### PR TITLE
feat(dagster): opt-in empty-output signalling for subset/tenant runs

### DIFF
--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`RockyComponent.satisfy_empty_outputs`.** Opt-in (default `False`) mode for subset / partition runs. Rocky runs at source granularity, so a partition run (e.g. a tenant-collapse `rocky run --filter client=<X>`) copies only the tables that have data for that partition. Dagster treats a *selected* output that yields no event as skipped, and `can_subset=True` does **not** prune — a single unyielded dependency makes the executor wholesale-skip any *same-run* downstream `@multi_asset` that depends on it, so the consolidation layer for a sparse `(partition × connector)` never materialised while the run still reported SUCCESS (silent data loss). With the flag on, the op additionally emits a zero-row `MaterializeResult` (marked `rocky/empty_for_partition=True`, exported as `EMPTY_FOR_PARTITION_METADATA_KEY`) for every selected-but-uncopied key, so the dependency is satisfied and the downstream runs and applies its own subset logic. **Failed** tables are excluded — a copy that errored keeps its downstream skipped so the failure stays visible and retriable rather than being papered over with a fake-green zero. Supported only on the default `execution_mode="streaming"`, non-`dag_mode` path; `build_defs` raises a clear error if combined with `execution_mode="pipes"` (can't distinguish absent from failed over the Pipes wire) or `dag_mode=True` (separate emission path).
+
 ## [1.46.1] — 2026-06-06
 
 ### Added

--- a/integrations/dagster/src/dagster_rocky/__init__.py
+++ b/integrations/dagster/src/dagster_rocky/__init__.py
@@ -16,7 +16,13 @@ from .checks import (
     emit_materializations,
 )
 from .column_lineage import build_column_lineage
-from .component import RockyComponent, RockyMetadataSet, RockyTableProps, TenantConfig
+from .component import (
+    EMPTY_FOR_PARTITION_METADATA_KEY,
+    RockyComponent,
+    RockyMetadataSet,
+    RockyTableProps,
+    TenantConfig,
+)
 from .contracts import (
     CONTRACT_COLUMN_CONSTRAINTS_CHECK,
     CONTRACT_PROTECTED_COLUMNS_CHECK,
@@ -160,6 +166,7 @@ __all__ = [
     "RockyMetadataSet",
     "RockyTableProps",
     "TenantConfig",
+    "EMPTY_FOR_PARTITION_METADATA_KEY",
     "RockyResource",
     "MIN_ROCKY_VERSION",
     "Resolver",

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -159,7 +159,16 @@ def _engine_schema_mismatch_failure(command: str, exc: ValidationError) -> dg.Fa
 
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterable, Iterator
+
+#: Metadata key stamped on the zero-row ``MaterializeResult`` that the
+#: ``satisfy_empty_outputs`` mode emits for a *selected* output Rocky did
+#: not copy in a subset / partition run. ``True`` marks the materialization
+#: as a dependency-satisfying placeholder — the table was absent or empty
+#: for this partition, not really copied — so downstream consumers (and the
+#: Dagster UI) can tell it apart from a genuine copy. See
+#: :attr:`RockyComponent.satisfy_empty_outputs`.
+EMPTY_FOR_PARTITION_METADATA_KEY: str = "rocky/empty_for_partition"
 
 #: Built-in Rocky check names. Pre-declared as ``AssetCheckSpec`` so the
 #: Dagster UI knows about them before any execution happens. The
@@ -661,6 +670,41 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
     #: ``None`` (default) is byte-identical to today's one-spec-per-source
     #: behaviour. See :class:`TenantConfig`.
     tenant: TenantConfig | None = None
+    #: When ``True``, a subset / partition run that copies only *some* of the
+    #: selected outputs additionally emits a lightweight zero-row
+    #: :class:`dg.MaterializeResult` for every *selected-but-uncopied* asset
+    #: key (marked with ``rocky/empty_for_partition=True``).
+    #:
+    #: **Why this exists.** Rocky runs at source granularity, so a single
+    #: ``rocky run --filter <tenant>`` materialises only the tables that have
+    #: data for that partition. Dagster's executor treats a selected output
+    #: that yields no event as *skipped*, and ``can_subset=True`` does **not**
+    #: prune: a single unyielded dependency makes the executor wholesale-skip
+    #: any *same-run* downstream ``@multi_asset`` that depends on it — its own
+    #: ``can_subset`` + runtime filter never get to run. For a sparse
+    #: ``(partition × connector)`` whose data is a strict subset of the
+    #: connector's table set, the downstream consolidation layer then never
+    #: materialises and the run still reports SUCCESS — silent data loss.
+    #:
+    #: Emitting a zero-row result for the absent keys *produces* the output,
+    #: so the dependency is satisfied and the downstream step runs and applies
+    #: its own subset logic. **Failed** tables are deliberately *excluded*
+    #: from this — a copy that errored keeps skipping its downstream so the
+    #: failure stays visible and retriable, rather than being papered over
+    #: with a fake-green zero.
+    #:
+    #: **Trade-off.** Producing an output emits an ``ASSET_MATERIALIZATION``
+    #: event, so a sparse partition records many zero-row materialisations per
+    #: run. They are clearly marked via ``rocky/empty_for_partition`` and give
+    #: per-partition table-presence visibility, but they are noise — hence
+    #: opt-in, default ``False`` (behaviour byte-for-byte unchanged when off).
+    #:
+    #: Only the default ``execution_mode="streaming"`` non-``dag_mode`` path
+    #: is supported: over Dagster Pipes the integration cannot distinguish an
+    #: absent table from a failed one, and ``dag_mode`` uses a separate
+    #: emission path. ``build_defs`` raises if the flag is combined with
+    #: either, rather than silently no-op'ing or masking a failure.
+    satisfy_empty_outputs: bool = False
 
     @property
     def defs_state_config(self) -> DefsStateConfig:
@@ -931,11 +975,56 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
         ``surface_column_lineage``) and default to off, so the fast path
         is unchanged from :meth:`StateBackedComponent.build_defs`.
         """
+        self._validate_satisfy_empty_outputs()
         self._maybe_cold_start_discover(context)
         defs = super().build_defs(context)
         if self.surface_column_lineage:
             defs = self._attach_column_lineage(defs)
         return defs
+
+    def _validate_satisfy_empty_outputs(self) -> None:
+        """Fail fast on ``satisfy_empty_outputs`` in an unsupported mode.
+
+        The empty-output emission only lives on the streaming
+        ``_emit_results`` path and depends on telling an *absent* table
+        apart from a *failed* one (``RunResult.errors`` carries the failed
+        keys). Neither holds for:
+
+        * ``execution_mode="pipes"`` — the engine reports only what it
+          copied over the Pipes wire, so the integration cannot exclude a
+          failed table from the empty-emit, and a zero-row success on a
+          table that actually errored is *worse* than today's skip.
+        * ``dag_mode=True`` — the connected-graph assets are built by
+          :func:`dag_assets.build_dag_multi_assets`, a separate emission
+          path the flag is not wired into, so it would silently no-op.
+
+        The flag is opt-in and new, so raising here cannot regress an
+        existing deployment — and a clear load-time error beats a silent
+        no-op (footgun) or a masked failure (the very thing the flag
+        exists to prevent).
+        """
+        if not self.satisfy_empty_outputs:
+            return
+        if self.execution_mode == "pipes":
+            raise dg.DagsterInvalidConfigError(
+                "satisfy_empty_outputs=True is not supported with "
+                'execution_mode="pipes": over Dagster Pipes the integration '
+                "cannot distinguish a table that was absent for the partition "
+                "from one that failed to copy, so it would stamp a zero-row "
+                'success on a failed table. Use execution_mode="streaming" '
+                "(the default).",
+                errors=[],
+                config_value="pipes",
+            )
+        if self.dag_mode:
+            raise dg.DagsterInvalidConfigError(
+                "satisfy_empty_outputs=True is not supported with dag_mode=True: "
+                "the connected-graph assets are built by a separate emission "
+                "path that the empty-output mode is not wired into. Unset one "
+                "of the two.",
+                errors=[],
+                config_value=True,
+            )
 
     def _maybe_cold_start_discover(self, context: dg.ComponentLoadContext) -> None:
         """Run :meth:`write_state_to_path` synchronously when state is absent.
@@ -1198,6 +1287,7 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
                 execution_mode=self.execution_mode,
                 surface_compliance=self.surface_compliance,
                 surface_retention_status=self.surface_retention_status,
+                satisfy_empty_outputs=self.satisfy_empty_outputs,
                 op_tags=self.op_tags or None,
             )
             for group in groups
@@ -2159,6 +2249,7 @@ def _make_rocky_asset(
     execution_mode: Literal["streaming", "pipes"] = "streaming",
     surface_compliance: bool = False,
     surface_retention_status: bool = False,
+    satisfy_empty_outputs: bool = False,
     op_tags: dict[str, str] | None = None,
 ) -> dg.AssetsDefinition:
     """Create a multi-asset that executes ``rocky run`` for one group.
@@ -2292,6 +2383,7 @@ def _make_rocky_asset(
                 rocky_key_to_dagster_key=group.rocky_key_to_dagster_key,
                 extra_yielded_checks=compliance_yielded,
                 collapsed_key_by_table=group.collapsed_key_by_table or None,
+                satisfy_empty_outputs=satisfy_empty_outputs,
             )
 
             # If a filter surfaced the Fivetran-storm signal, raise the
@@ -2678,6 +2770,7 @@ def _emit_results(
     rocky_key_to_dagster_key: dict[tuple[str, ...], dg.AssetKey],
     extra_yielded_checks: set[tuple[dg.AssetKey, str]] | None = None,
     collapsed_key_by_table: dict[str, dg.AssetKey] | None = None,
+    satisfy_empty_outputs: bool = False,
 ) -> Iterator[dg.MaterializeResult | dg.AssetCheckResult | dg.AssetObservation]:
     """Yield Dagster events for every materialization, check, drift event and anomaly.
 
@@ -2702,6 +2795,17 @@ def _emit_results(
     * :class:`dg.AssetObservation` — one per drift action (ALTER COLUMN,
       DROP+RECREATE, etc.). Drift is a structural change, not pass/fail,
       so observation is the right primitive.
+
+    When ``satisfy_empty_outputs`` is set, a final pass emits a zero-row
+    :class:`dg.MaterializeResult` (marked
+    :data:`EMPTY_FOR_PARTITION_METADATA_KEY`) for every *selected* key that
+    got neither a real materialization nor an error — i.e. a table that was
+    absent or empty for this partition. This *produces* the output so a
+    same-run downstream that depends on it is not wholesale-skipped by the
+    executor (``can_subset`` does not prune unyielded deps). **Errored**
+    keys are excluded so a failed copy keeps its downstream skipped — a
+    failure must stay visible, not be masked by a fake-green zero. See
+    :attr:`RockyComponent.satisfy_empty_outputs`.
     """
 
     def remap(raw_key: list[str]) -> dg.AssetKey:
@@ -2836,12 +2940,71 @@ def _emit_results(
             yielded_checks.add(spec_key)
             yield anomaly_result
 
+    # Empty-output satisfaction (opt-in). For a subset / partition run, emit
+    # a zero-row MaterializeResult for every selected key that was neither
+    # copied nor errored, so a same-run downstream depending on it isn't
+    # wholesale-skipped by the executor. Errored keys are subtracted so a
+    # failed copy stays a visible, retriable skip rather than a fake-green
+    # zero. Computed AFTER the dedup'd materialization loop, so it only ever
+    # covers keys with no real result (preserving the first-wins guard).
+    #
+    # Safety guard: the no-fake-green guarantee rests on the engine itemising
+    # *every* failed table in ``errors`` (with an ``asset_key``) so it can be
+    # subtracted — the current engine sets ``tables_failed = errors.len()``
+    # from one source (run.rs). If a result reports more failures than it
+    # itemises (e.g. an older binary that emits the ``tables_failed`` count
+    # but not per-table ``errors``), we cannot tell which absent key is
+    # actually a hidden failure — so we skip the empty-emit for that whole
+    # batch and let the downstream skip exactly as today. A visible skip
+    # beats a zero-row success that masks a failure.
+    if satisfy_empty_outputs:
+        unattributable = any(r.tables_failed > len(r.errors) for r in results)
+        if unattributable:
+            _log.warning(
+                "satisfy_empty_outputs: a rocky run reported more failures "
+                "(tables_failed) than it itemised in `errors`, so failed tables "
+                "cannot be excluded from the empty-output emission. Skipping the "
+                "empty-output pass for this op — same-run downstreams will skip "
+                "as before — rather than risk stamping a zero-row success on a "
+                "table that actually failed. Upgrade the rocky engine to a build "
+                "that itemises every failed table."
+            )
+        else:
+            errored_keys = {remap(err.asset_key) for r in results for err in r.errors}
+            empty_keys = selected_keys - materialized_keys - errored_keys
+            yield from _empty_output_results(empty_keys)
+
     yield from _emit_placeholder_checks(
         check_specs=check_specs,
         selected_keys=selected_keys,
         yielded_checks=yielded_checks,
         materialized_keys=materialized_keys,
     )
+
+
+def _empty_output_results(
+    empty_keys: Iterable[dg.AssetKey],
+) -> Iterator[dg.MaterializeResult]:
+    """Yield a zero-row, dependency-satisfying result per absent key.
+
+    Each carries :data:`EMPTY_FOR_PARTITION_METADATA_KEY` ``=True`` (and a
+    human-readable reason) so consumers and the Dagster UI can tell it apart
+    from a real copy, plus ``dagster/row_count=0`` for Insights. Keys are
+    yielded in a deterministic (sorted) order so the emitted event stream
+    doesn't depend on set-iteration order. The caller is responsible for
+    having already removed copied and errored keys from ``empty_keys``.
+    """
+    for key in sorted(empty_keys, key=lambda k: k.to_user_string()):
+        yield dg.MaterializeResult(
+            asset_key=key,
+            metadata={
+                EMPTY_FOR_PARTITION_METADATA_KEY: dg.MetadataValue.bool(True),
+                "rocky/reason": dg.MetadataValue.text(
+                    "no rows copied for this partition (table absent or empty in the filtered run)"
+                ),
+                "dagster/row_count": dg.MetadataValue.int(0),
+            },
+        )
 
 
 def _build_table_resolver(

--- a/integrations/dagster/tests/test_empty_outputs.py
+++ b/integrations/dagster/tests/test_empty_outputs.py
@@ -1,0 +1,471 @@
+"""Tests for ``satisfy_empty_outputs`` — empty-output signalling for subset runs.
+
+A Rocky multi-asset (especially the tenant-collapse op) runs at source
+granularity, so a partition / subset run copies only the tables that have
+data for that partition. Dagster treats a *selected* output that yields no
+event as skipped, and ``can_subset=True`` does **not** prune — a single
+unyielded dependency makes the executor wholesale-skip any *same-run*
+downstream that depends on it. ``satisfy_empty_outputs`` makes the op emit a
+zero-row, dependency-satisfying ``MaterializeResult`` for the absent keys so
+the downstream runs and applies its own subset logic.
+
+Covered here:
+
+* **End-to-end** — the minimal ``dg.materialize([up, down])`` repro from the
+  FR: with the flag the downstream produces its subset instead of skipping
+  wholesale; without it, the downstream is skipped (the bug).
+* **Error exclusion** — a *failed* table is NOT given a fake-green empty
+  result; it keeps skipping so the failure stays visible and retriable.
+* **Metadata + off-by-default** — absent keys carry
+  ``rocky/empty_for_partition=True``; the flag off is byte-for-byte unchanged.
+* **Build-time guards** — the flag is rejected with ``execution_mode="pipes"``
+  and with ``dag_mode=True``.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import dagster as dg
+import pytest
+
+from dagster_rocky import EMPTY_FOR_PARTITION_METADATA_KEY, RockyResource, TenantConfig
+from dagster_rocky.component import RockyComponent, _emit_results
+from dagster_rocky.types import RunResult
+
+
+def _run_result(
+    *,
+    materializations: list[dict] | None = None,
+    errors: list[dict] | None = None,
+    tables_failed: int | None = None,
+) -> RunResult:
+    mats = materializations or []
+    errs = errors or []
+    # tables_failed defaults to len(errors) — the engine invariant (run.rs sets
+    # both from the same Vec). Overridable so a test can pin the divergence
+    # case (count without itemisation) instead of enforcing the invariant.
+    return RunResult.model_validate(
+        {
+            "version": "0.3.0",
+            "command": "run",
+            "filter": "client=sw",
+            "duration_ms": 100,
+            "tables_copied": len(mats),
+            "tables_failed": len(errs) if tables_failed is None else tables_failed,
+            "materializations": mats,
+            "check_results": [],
+            "errors": errs,
+            "permissions": {
+                "grants_added": 0,
+                "grants_revoked": 0,
+                "catalogs_created": 0,
+                "schemas_created": 0,
+            },
+            "drift": {"tables_checked": 0, "tables_drifted": 0, "actions_taken": []},
+        }
+    )
+
+
+def _mat(name: str, rows: int = 10) -> dict:
+    return {
+        "asset_key": [name],
+        "rows_copied": rows,
+        "duration_ms": 5,
+        "metadata": {"strategy": "full_refresh"},
+    }
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end: the FR minimal repro, driven through _emit_results
+# --------------------------------------------------------------------------- #
+
+
+def _build_repro_assets(*, satisfy_empty_outputs: bool):
+    """Mirror the FR repro: ``up`` declares a/b/c_raw but only copies a/b_raw.
+
+    ``up`` routes its emission through the real :func:`_emit_results` so the
+    test exercises production code, not a hand-rolled stand-in. ``down``
+    declares per-spec deps a<-a_raw, b<-b_raw, c<-c_raw (the consolidation-layer
+    shape: a downstream multi-asset with per-table deps on the raw union) and
+    is ``can_subset=True``.
+    """
+    a_raw, b_raw, c_raw = (dg.AssetKey([x]) for x in ("a_raw", "b_raw", "c_raw"))
+    mapping = {("a_raw",): a_raw, ("b_raw",): b_raw, ("c_raw",): c_raw}
+    run_result = _run_result(materializations=[_mat("a_raw"), _mat("b_raw")])
+
+    @dg.multi_asset(
+        specs=[dg.AssetSpec("a_raw"), dg.AssetSpec("b_raw"), dg.AssetSpec("c_raw")],
+        can_subset=True,
+        name="up",
+    )
+    def up(context):
+        yield from _emit_results(
+            results=[run_result],
+            check_specs=[],
+            selected_keys=set(context.selected_asset_keys),
+            rocky_key_to_dagster_key=mapping,
+            satisfy_empty_outputs=satisfy_empty_outputs,
+        )
+
+    @dg.multi_asset(
+        specs=[
+            dg.AssetSpec("a", deps=["a_raw"]),
+            dg.AssetSpec("b", deps=["b_raw"]),
+            dg.AssetSpec("c", deps=["c_raw"]),
+        ],
+        can_subset=True,
+        name="down",
+    )
+    def down(context):
+        for k in context.selected_asset_keys:
+            yield dg.MaterializeResult(asset_key=k)
+
+    return up, down
+
+
+def test_satisfy_empty_outputs_unblocks_same_run_downstream():
+    """With the flag, ``down`` runs instead of being wholesale-skipped."""
+    up, down = _build_repro_assets(satisfy_empty_outputs=True)
+
+    result = dg.materialize([up, down], raise_on_error=False)
+    assert result.success
+
+    mats = list(result.get_asset_materialization_events())
+    by_key = {e.asset_key.to_user_string(): e for e in mats}
+
+    # up: real copies for a_raw/b_raw + a zero-row empty for the absent c_raw.
+    assert {"a_raw", "b_raw", "c_raw"} <= set(by_key)
+    c_meta = by_key["c_raw"].materialization.metadata
+    assert c_meta[EMPTY_FOR_PARTITION_METADATA_KEY].value is True
+    assert c_meta["dagster/row_count"].value == 0
+    # The copied tables are NOT marked empty.
+    assert EMPTY_FOR_PARTITION_METADATA_KEY not in by_key["a_raw"].materialization.metadata
+
+    # down: the whole point — it materialized instead of skipping wholesale.
+    down_keys = {e.asset_key.to_user_string() for e in mats} & {"a", "b", "c"}
+    assert down_keys == {"a", "b", "c"}
+
+
+def test_without_flag_same_run_downstream_is_skipped():
+    """Baseline / criterion-2: off by default, ``down`` is skipped (the bug),
+    and ``up`` emits no empty markers."""
+    up, down = _build_repro_assets(satisfy_empty_outputs=False)
+
+    result = dg.materialize([up, down], raise_on_error=False)
+    assert result.success  # the run still reports SUCCESS — the silent-loss trap
+
+    mats = list(result.get_asset_materialization_events())
+    keys = {e.asset_key.to_user_string() for e in mats}
+
+    # up only copied a_raw/b_raw; no empty c_raw; down produced nothing.
+    assert keys == {"a_raw", "b_raw"}
+    assert all(EMPTY_FOR_PARTITION_METADATA_KEY not in e.materialization.metadata for e in mats)
+
+
+# --------------------------------------------------------------------------- #
+# Error exclusion — a failed table must NOT get a fake-green empty result
+# --------------------------------------------------------------------------- #
+
+
+def test_satisfy_empty_outputs_excludes_errored_keys():
+    """A selected key that *errored* keeps skipping; only the genuinely
+    absent key gets an empty result."""
+    a_raw, b_raw, c_raw = (dg.AssetKey([x]) for x in ("a_raw", "b_raw", "c_raw"))
+    mapping = {("a_raw",): a_raw, ("b_raw",): b_raw, ("c_raw",): c_raw}
+    # a_raw copied, c_raw errored, b_raw absent (neither copied nor errored).
+    run_result = _run_result(
+        materializations=[_mat("a_raw")],
+        errors=[{"asset_key": ["c_raw"], "error": "boom", "failure_kind": "query-rejected"}],
+    )
+
+    events = list(
+        _emit_results(
+            results=[run_result],
+            check_specs=[],
+            selected_keys={a_raw, b_raw, c_raw},
+            rocky_key_to_dagster_key=mapping,
+            satisfy_empty_outputs=True,
+        )
+    )
+
+    empty_keys = {
+        e.asset_key
+        for e in events
+        if isinstance(e, dg.MaterializeResult)
+        and e.metadata.get(EMPTY_FOR_PARTITION_METADATA_KEY)
+        and e.metadata[EMPTY_FOR_PARTITION_METADATA_KEY].value is True
+    }
+    real_keys = {
+        e.asset_key
+        for e in events
+        if isinstance(e, dg.MaterializeResult)
+        and not e.metadata.get(EMPTY_FOR_PARTITION_METADATA_KEY)
+    }
+    # b_raw (absent) is satisfied; c_raw (failed) is NOT — it stays skipped.
+    assert empty_keys == {b_raw}
+    assert real_keys == {a_raw}
+
+
+def test_satisfy_empty_outputs_skips_emit_on_unattributable_failures(caplog):
+    """If a result reports more failures than it itemises in ``errors`` (e.g.
+    an older engine that emits the ``tables_failed`` count but no per-table
+    ``errors``), the empty-output pass is skipped entirely — we can't tell
+    which absent key is a hidden failure, so we let the downstream skip rather
+    than risk a fake-green zero. Pins the invariant the safety rests on instead
+    of enforcing it by construction."""
+    import logging
+
+    a_raw, b_raw, c_raw = (dg.AssetKey([x]) for x in ("a_raw", "b_raw", "c_raw"))
+    mapping = {("a_raw",): a_raw, ("b_raw",): b_raw, ("c_raw",): c_raw}
+    # One table copied, TWO failures reported but NONE itemised — exactly the
+    # opaque-accounting shape. b_raw/c_raw absent could each be a hidden failure.
+    run_result = _run_result(materializations=[_mat("a_raw")], errors=[], tables_failed=2)
+
+    with caplog.at_level(logging.WARNING, logger="dagster_rocky.component"):
+        events = list(
+            _emit_results(
+                results=[run_result],
+                check_specs=[],
+                selected_keys={a_raw, b_raw, c_raw},
+                rocky_key_to_dagster_key=mapping,
+                satisfy_empty_outputs=True,
+            )
+        )
+
+    # No empty results emitted at all — only the one real copy.
+    empties = [
+        e
+        for e in events
+        if isinstance(e, dg.MaterializeResult) and e.metadata.get(EMPTY_FOR_PARTITION_METADATA_KEY)
+    ]
+    assert empties == []
+    real = {e.asset_key for e in events if isinstance(e, dg.MaterializeResult)}
+    assert real == {a_raw}
+    assert any("more failures" in r.message for r in caplog.records)
+
+
+def test_satisfy_empty_outputs_off_emits_no_empties():
+    """Flag off ⇒ no empty results at all (only the real copy)."""
+    a_raw, b_raw = dg.AssetKey(["a_raw"]), dg.AssetKey(["b_raw"])
+    mapping = {("a_raw",): a_raw, ("b_raw",): b_raw}
+    run_result = _run_result(materializations=[_mat("a_raw")])
+
+    events = list(
+        _emit_results(
+            results=[run_result],
+            check_specs=[],
+            selected_keys={a_raw, b_raw},
+            rocky_key_to_dagster_key=mapping,
+            satisfy_empty_outputs=False,
+        )
+    )
+    mats = [e for e in events if isinstance(e, dg.MaterializeResult)]
+    assert {m.asset_key for m in mats} == {a_raw}
+    assert all(EMPTY_FOR_PARTITION_METADATA_KEY not in m.metadata for m in mats)
+
+
+def test_empty_output_coexists_with_declared_check_on_absent_key():
+    """An absent key with a declared check gets BOTH the empty MaterializeResult
+    and the placeholder check (the existing "table not materialized" WARN). The
+    two are different output types on the same key — no invariant is violated."""
+    b_raw = dg.AssetKey(["b_raw"])
+    mapping = {("a_raw",): dg.AssetKey(["a_raw"]), ("b_raw",): b_raw}
+    check_specs = [dg.AssetCheckSpec(name="row_count", asset=b_raw)]
+    run_result = _run_result(materializations=[_mat("a_raw")])  # b_raw absent
+
+    events = list(
+        _emit_results(
+            results=[run_result],
+            check_specs=check_specs,
+            selected_keys={dg.AssetKey(["a_raw"]), b_raw},
+            rocky_key_to_dagster_key=mapping,
+            satisfy_empty_outputs=True,
+        )
+    )
+
+    empty_for_b = [
+        e
+        for e in events
+        if isinstance(e, dg.MaterializeResult)
+        and e.asset_key == b_raw
+        and e.metadata.get(EMPTY_FOR_PARTITION_METADATA_KEY)
+    ]
+    check_for_b = [
+        e
+        for e in events
+        if isinstance(e, dg.AssetCheckResult)
+        and e.asset_key == b_raw
+        and e.check_name == "row_count"
+    ]
+    assert len(empty_for_b) == 1
+    assert len(check_for_b) == 1
+    # The placeholder reflects the absent table — not passed (no data to check).
+    assert check_for_b[0].passed is False
+
+
+# --------------------------------------------------------------------------- #
+# Acceptance criterion #1 — partitioned tenant-collapse, end-to-end
+# --------------------------------------------------------------------------- #
+
+
+def test_tenant_collapse_sparse_partition_emits_partitioned_empty(tmp_path):
+    """The literal FR acceptance scenario: a tenant-collapse run for a
+    partition missing some of the connector's tables, through the full
+    build_defs_from_state → partitioned materialize → _emit_results path.
+
+    ``pepsi`` has only ``orders``; ``coca_cola`` also has ``leads``. The
+    collapsed graph carries a spec for both (union across tenants). Running
+    partition ``pepsi`` with the flag on must:
+
+    * materialise ``orders`` for real, and
+    * emit a zero-row empty for the absent ``leads`` — **stamped with the
+      ``pepsi`` partition key**, the same way real results are — so a same-run
+      downstream depending on ``leads`` is unblocked instead of skipped.
+    """
+    discover = {
+        "version": "0.3.0",
+        "command": "discover",
+        "sources": [
+            {
+                "id": "src_coca_cola",
+                "source_type": "fivetran",
+                "components": {"client": "coca_cola", "region": "usa", "source": "facebookads"},
+                "tables": [{"name": "orders"}, {"name": "leads"}],
+            },
+            {
+                "id": "src_pepsi",
+                "source_type": "fivetran",
+                "components": {"client": "pepsi", "region": "usa", "source": "facebookads"},
+                "tables": [{"name": "orders"}],
+            },
+        ],
+    }
+    state_file = tmp_path / "state.json"
+    state_file.write_text(json.dumps({"discover": discover}))
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        tenant=TenantConfig(component="client", partitions_name="rocky_clients"),
+        satisfy_empty_outputs=True,
+    )
+    defs = component.build_defs_from_state(context=None, state_path=state_file)
+
+    orders_key = dg.AssetKey(["fivetran", "usa", "facebookads", "orders"])
+    leads_key = dg.AssetKey(["fivetran", "usa", "facebookads", "leads"])
+    asset_defs = [a for a in (defs.assets or []) if isinstance(a, dg.AssetsDefinition)]
+    all_keys = {k for a in asset_defs for k in a.keys}
+    assert {orders_key, leads_key} <= all_keys
+
+    # Engine RunResult for --filter client=pepsi: only orders has data; the
+    # materialization key carries the tenant. leads is absent for pepsi.
+    run_result = RunResult.model_validate(
+        {
+            "version": "0.3.0",
+            "command": "run",
+            "filter": "client=pepsi",
+            "duration_ms": 100,
+            "tables_copied": 1,
+            "tables_failed": 0,
+            "materializations": [
+                {
+                    "asset_key": ["fivetran", "pepsi", "usa", "facebookads", "orders"],
+                    "rows_copied": 10,
+                    "duration_ms": 50,
+                    "metadata": {"strategy": "full_refresh"},
+                }
+            ],
+            "check_results": [],
+            "errors": [],
+            "permissions": {
+                "grants_added": 0,
+                "grants_revoked": 0,
+                "catalogs_created": 0,
+                "schemas_created": 0,
+            },
+            "drift": {"tables_checked": 1, "tables_drifted": 0, "actions_taken": []},
+        }
+    )
+
+    instance = dg.DagsterInstance.ephemeral()
+    instance.add_dynamic_partitions("rocky_clients", ["coca_cola", "pepsi"])
+
+    with (
+        patch.object(RockyResource, "run", return_value=run_result),
+        patch.object(RockyResource, "run_streaming", return_value=run_result),
+    ):
+        result = dg.materialize(
+            asset_defs,
+            resources={"rocky": RockyResource(config_path="rocky.toml")},
+            selection=[orders_key, leads_key],
+            partition_key="pepsi",
+            instance=instance,
+            raise_on_error=False,
+        )
+
+    assert result.success
+    mats = list(result.get_asset_materialization_events())
+    by_key = {e.asset_key: e for e in mats}
+
+    # orders: real copy, pepsi partition, NOT marked empty.
+    assert orders_key in by_key
+    assert by_key[orders_key].materialization.partition == "pepsi"
+    assert EMPTY_FOR_PARTITION_METADATA_KEY not in by_key[orders_key].materialization.metadata
+
+    # leads: zero-row empty, stamped with the SAME partition key (the whole
+    # point — a partitioned empty mat satisfies the partitioned downstream).
+    assert leads_key in by_key
+    leads_mat = by_key[leads_key].materialization
+    assert leads_mat.partition == "pepsi"
+    assert leads_mat.metadata[EMPTY_FOR_PARTITION_METADATA_KEY].value is True
+    assert leads_mat.metadata["dagster/row_count"].value == 0
+
+
+# --------------------------------------------------------------------------- #
+# Build-time guards
+# --------------------------------------------------------------------------- #
+
+
+def test_satisfy_empty_outputs_rejects_pipes_mode():
+    component = RockyComponent(
+        config_path="rocky.toml",
+        satisfy_empty_outputs=True,
+        execution_mode="pipes",
+    )
+    with pytest.raises(dg.DagsterInvalidConfigError, match="pipes"):
+        component._validate_satisfy_empty_outputs()
+
+
+def test_satisfy_empty_outputs_rejects_dag_mode():
+    component = RockyComponent(
+        config_path="rocky.toml",
+        satisfy_empty_outputs=True,
+        dag_mode=True,
+    )
+    with pytest.raises(dg.DagsterInvalidConfigError, match="dag_mode"):
+        component._validate_satisfy_empty_outputs()
+
+
+def test_satisfy_empty_outputs_streaming_non_dag_ok():
+    """The supported configuration validates cleanly (no raise)."""
+    component = RockyComponent(
+        config_path="rocky.toml",
+        satisfy_empty_outputs=True,
+    )
+    component._validate_satisfy_empty_outputs()  # must not raise
+
+
+def test_default_off_is_unvalidated_noop():
+    """Default (flag off) skips the guard regardless of mode."""
+    component = RockyComponent(config_path="rocky.toml", execution_mode="pipes", dag_mode=True)
+    component._validate_satisfy_empty_outputs()  # must not raise
+
+
+def test_satisfy_empty_outputs_resolves_from_yaml():
+    """The deployment path: a host sets the flag in defs.yaml. Plain bool field,
+    so it resolves without a custom Resolver."""
+    on = RockyComponent.resolve_from_yaml("config_path: rocky.toml\nsatisfy_empty_outputs: true\n")
+    assert on.satisfy_empty_outputs is True
+    off = RockyComponent.resolve_from_yaml("config_path: rocky.toml\n")
+    assert off.satisfy_empty_outputs is False

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -267,7 +267,7 @@ wheels = [
 
 [[package]]
 name = "dagster-rocky"
-version = "1.46.0"
+version = "1.46.1"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },


### PR DESCRIPTION
## Problem

Rocky runs at source granularity, so a partition/subset run — e.g. a tenant-collapse `rocky run --filter client=<X>` — copies only the tables that have data for that partition. Dagster treats a *selected* output that yields no event as **skipped**, and `can_subset=True` does **not** prune: a single unyielded dependency makes the executor wholesale-skip any *same-run* downstream `@multi_asset` that depends on it. Its own `can_subset` + runtime filter never get to run.

For a sparse `(partition × connector)` whose data is a strict subset of the connector's table set, the downstream consolidation layer then **never materialises** — yet the run still reports **SUCCESS**. Silent data loss.

This is general to any `can_subset` subset run, not just the tenant-collapse op.

## Fix

Add `RockyComponent.satisfy_empty_outputs` (opt-in, default `False`). When on, after the real materialisations, `_emit_results` emits a lightweight zero-row `MaterializeResult` for every *selected-but-uncopied* key — marked `rocky/empty_for_partition=True` (exported as `EMPTY_FOR_PARTITION_METADATA_KEY`) with `dagster/row_count=0`. That *produces* the output, so the dependency is satisfied and the same-run downstream runs and applies its own subset logic.

Key correctness property: **failed tables are excluded** (`selected − materialized − errored`). A copy that errored keeps its downstream skipped so the failure stays visible and retriable, rather than being papered over with a fake-green zero. The exclusion rests on the engine itemising every failure in `errors[]` (verified against the run command, which sets `tables_failed = errors.len()` from one source); as defence in depth, if a result reports more failures than it itemises (e.g. an older binary), the empty-emit is skipped entirely for that batch and the downstream skips as before.

## Scope / guards

- **Component-level**, not scoped to `TenantConfig` — the skip is general to any subset run.
- Supported only on the default `execution_mode="streaming"`, non-`dag_mode` path. `build_defs` raises a clear error if combined with `execution_mode="pipes"` (can't distinguish absent from failed over the Pipes wire) or `dag_mode=True` (separate emission path) — no silent no-op.
- Flag **off** (default) is byte-for-byte unchanged.

The semantically-clean fix (a Dagster-core change so a `can_subset` downstream prunes unyielded deps from a `can_subset` upstream instead of skipping the whole step) lives upstream; this opt-in is the shippable fix under our control until/unless that lands.

## Tests

`tests/test_empty_outputs.py` (12 tests):
- End-to-end `dg.materialize([up, down])` proving the downstream produces its subset *with* the flag and is wholesale-skipped *without* it.
- Partitioned tenant-collapse end-to-end: a sparse partition's empty mat lands on the right partition key.
- Error exclusion + the unattributable-failures fallback guard.
- Empty-mat / declared-check coexistence, off-by-default no-op, build-time guards, YAML resolution.

Full suite: 641 passed; ruff lint + format clean. Pure Python feature — no CLI output schema touched, so no codegen/schema drift.