### PR TITLE
feat(engine): graceful state-schema deploy safety

### DIFF
--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -2893,6 +2893,25 @@
       },
       "type": "object"
     },
+    "SchemaMismatchPolicy": {
+      "description": "Policy applied when the engine opens a state store whose schema version is **newer** than the binary supports (a *forward*-incompatibility).\n\nThis is the deploy-safety knob for rolling upgrades that cross a redb schema version. During a rolling bump, pods on the *old* binary can read state written by *already-upgraded* pods through a shared tiered backend. The default ([`Recreate`][Self::Recreate]) degrades that window instead of breaking it: the old pod does one full-refresh run and succeeds, rather than stranding the orchestrated run in an hour-long retry spiral.\n\nOnly the *forward* case (on-disk newer than binary) is governed here. *Backward*-compatibility — a newer binary reading older state — always auto-migrates forward as before; there is no knob for it.",
+      "oneOf": [
+        {
+          "description": "Treat a forward-incompatible store as cold: log a single `WARN`, bootstrap a fresh local state, and **never write the downgraded state back** to the shared tier (so the newer state upgraded pods depend on is left intact). The run proceeds as a full refresh. Default — it turns a hard, run-stranding failure into a graceful one-time full refresh during the mixed-version window of a schema-changing upgrade.",
+          "enum": [
+            "recreate"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Abort the open with a clear error (the historical behaviour). Appropriate when an operator would rather an incompatible pod fail loudly than do a full refresh against newer shared state.",
+          "enum": [
+            "fail"
+          ],
+          "type": "string"
+        }
+      ]
+    },
     "SchemaPatternConfig": {
       "additionalProperties": false,
       "description": "Schema pattern configuration from TOML, converted to [`SchemaPattern`] at runtime.",
@@ -3159,6 +3178,15 @@
           ],
           "default": "none",
           "description": "Per-pipeline / per-client state-file namespacing. Defaults to [`StateNamespacing::None`] (one global state file — byte-identical to a project that omits this key). Set `namespacing = \"pipeline\"` to give each pipeline its own `<models>/.rocky-state/<pipeline>.redb` so independent fan-out runs don't serialize on one advisory lock. The per-invocation `--state-namespace <key>` flag overrides this; an explicit `--state-path` disables namespacing for that run."
+        },
+        "on_schema_mismatch": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/SchemaMismatchPolicy"
+            }
+          ],
+          "default": "recreate",
+          "description": "What to do when the engine opens a state store whose schema version is **newer** than this binary supports (a forward-incompatibility, which happens during a rolling upgrade that crosses a redb schema version). Defaults to [`SchemaMismatchPolicy::Recreate`] — the old pod bootstraps fresh, does one full-refresh run, and never clobbers the newer shared state. Set to `fail` to keep the historical hard-abort behaviour. Only the run path honours this; inspection/branch commands still hard-fail on a forward-incompatible store. See [`SchemaMismatchPolicy`]."
         },
         "on_upload_failure": {
           "allOf": [
@@ -3915,6 +3943,7 @@
           "retention_days": 30
         },
         "namespacing": "none",
+        "on_schema_mismatch": "recreate",
         "on_upload_failure": "skip",
         "retention": {
           "applies_to": [

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -329,6 +329,14 @@ export type DedupPolicy = "success" | "any";
  */
 export type StateNamespacing = "none" | "pipeline";
 /**
+ * Policy applied when the engine opens a state store whose schema version is **newer** than the binary supports (a *forward*-incompatibility).
+ *
+ * This is the deploy-safety knob for rolling upgrades that cross a redb schema version. During a rolling bump, pods on the *old* binary can read state written by *already-upgraded* pods through a shared tiered backend. The default ([`Recreate`][Self::Recreate]) degrades that window instead of breaking it: the old pod does one full-refresh run and succeeds, rather than stranding the orchestrated run in an hour-long retry spiral.
+ *
+ * Only the *forward* case (on-disk newer than binary) is governed here. *Backward*-compatibility — a newer binary reading older state — always auto-migrates forward as before; there is no knob for it.
+ */
+export type SchemaMismatchPolicy = "recreate" | "fail";
+/**
  * Policy applied when state upload fails after retries + circuit-breaker are exhausted. See [`StateConfig::on_upload_failure`].
  */
 export type StateUploadFailureMode = "skip" | "fail";
@@ -1834,6 +1842,10 @@ export interface StateConfig {
    * Per-pipeline / per-client state-file namespacing. Defaults to [`StateNamespacing::None`] (one global state file — byte-identical to a project that omits this key). Set `namespacing = "pipeline"` to give each pipeline its own `<models>/.rocky-state/<pipeline>.redb` so independent fan-out runs don't serialize on one advisory lock. The per-invocation `--state-namespace <key>` flag overrides this; an explicit `--state-path` disables namespacing for that run.
    */
   namespacing?: StateNamespacing & string;
+  /**
+   * What to do when the engine opens a state store whose schema version is **newer** than this binary supports (a forward-incompatibility, which happens during a rolling upgrade that crosses a redb schema version). Defaults to [`SchemaMismatchPolicy::Recreate`] — the old pod bootstraps fresh, does one full-refresh run, and never clobbers the newer shared state. Set to `fail` to keep the historical hard-abort behaviour. Only the run path honours this; inspection/branch commands still hard-fail on a forward-incompatible store. See [`SchemaMismatchPolicy`].
+   */
+  on_schema_mismatch?: SchemaMismatchPolicy & string;
   /**
    * What to do when state upload exhausts retries + circuit-breaker. Defaults to `skip` — rocky continues the run and the next run re-derives state from target-table metadata. See [`StateUploadFailureMode`].
    */

--- a/editors/vscode/src/types/generated/state.ts
+++ b/editors/vscode/src/types/generated/state.ts
@@ -10,6 +10,14 @@
  */
 export interface StateOutput {
   command: string;
+  /**
+   * redb state-schema version stamped in the on-disk state file, or `null` when no state file exists yet or it predates schema versioning.
+   */
+  schema_version_on_disk?: number | null;
+  /**
+   * redb state-schema version this binary supports. Pair with `schema_version_on_disk` to make a compatibility decision without parsing a human error string: `on_disk > supported` means the file was written by a newer engine (forward-incompatible). See the state-schema-deploy-safety contract.
+   */
+  schema_version_supported: number;
   version: string;
   watermarks: WatermarkEntry[];
   [k: string]: unknown;

--- a/engine/crates/rocky-cli/src/commands/doctor.rs
+++ b/engine/crates/rocky-cli/src/commands/doctor.rs
@@ -220,6 +220,61 @@ async fn collect_health_checks(
         }
     }
 
+    // 2b. State-schema compatibility. A deploy-time gate for rolling upgrades
+    //     that cross a redb schema version: return Critical when the on-disk
+    //     state is *newer* than this binary supports (forward-incompatible), so
+    //     an orchestrator can put `state_schema` in its strict-startup checks
+    //     and fail an incompatible pod fast and visibly at boot — instead of
+    //     after a per-run, hour-long retry spiral. Uses `peek_schema_version`
+    //     so it reports the on-disk version precisely when it is newer (the
+    //     normal open path hard-fails there). A missing/unversioned store, or
+    //     one older than this binary (which auto-migrates forward), is healthy.
+    if should_run("state_schema", check_filter) {
+        let start = Instant::now();
+        let supported = rocky_core::state::current_schema_version();
+        match rocky_core::state::StateStore::peek_schema_version(state_path) {
+            Ok(on_disk) => {
+                let details = if verbose {
+                    vec![
+                        ("supported".into(), format!("v{supported}")),
+                        (
+                            "on_disk".into(),
+                            on_disk
+                                .map(|v| format!("v{v}"))
+                                .unwrap_or_else(|| "none".into()),
+                        ),
+                    ]
+                } else {
+                    Vec::new()
+                };
+                let (status, message) = classify_state_schema(on_disk, supported);
+                if matches!(status, HealthStatus::Critical) {
+                    suggestions.push(
+                        "state_schema: an incompatible pod met newer on-disk state — complete the \
+                         rollout or roll this pod forward to the newer engine"
+                            .into(),
+                    );
+                }
+                checks.push(HealthCheck {
+                    name: "state_schema".into(),
+                    status,
+                    message,
+                    duration_ms: start.elapsed().as_millis() as u64,
+                    details,
+                });
+            }
+            Err(e) => {
+                checks.push(HealthCheck {
+                    name: "state_schema".into(),
+                    status: HealthStatus::Warning,
+                    message: format!("Cannot read on-disk state schema version: {e}"),
+                    duration_ms: start.elapsed().as_millis() as u64,
+                    details: Vec::new(),
+                });
+            }
+        }
+    }
+
     // 3. Adapter configuration checks (without actual connectivity)
     if should_run("adapters", check_filter) {
         let start = Instant::now();
@@ -549,6 +604,37 @@ fn should_run(name: &str, filter: Option<&str>) -> bool {
     filter.is_none_or(|f| f == name)
 }
 
+/// Classify on-disk-vs-supported state-schema compatibility for the
+/// `state_schema` check.
+///
+/// `Critical` **iff** the on-disk schema is *newer* than this binary supports
+/// (forward-incompatible — the deploy-safety signal). An on-disk schema that is
+/// older (auto-migrates forward), exactly equal, or absent is `Healthy`.
+fn classify_state_schema(on_disk: Option<u32>, supported: u32) -> (HealthStatus, String) {
+    match on_disk {
+        Some(found) if found > supported => (
+            HealthStatus::Critical,
+            format!(
+                "on-disk state schema v{found} is newer than this binary supports \
+                 (v{supported}); this pod is forward-incompatible. Upgrade rocky, or \
+                 set [state] on_schema_mismatch = recreate to run a full refresh."
+            ),
+        ),
+        Some(found) if found < supported => (
+            HealthStatus::Healthy,
+            format!("on-disk state schema v{found} will auto-migrate forward to v{supported}"),
+        ),
+        Some(found) => (
+            HealthStatus::Healthy,
+            format!("state schema v{found} matches this binary"),
+        ),
+        None => (
+            HealthStatus::Healthy,
+            format!("no on-disk state schema (binary supports v{supported})"),
+        ),
+    }
+}
+
 /// Build a Critical `HealthCheck` for a check whose config could not be
 /// loaded, and record a remediation suggestion.
 ///
@@ -661,6 +747,71 @@ mod tests {
                 .any(|c| matches!(c.status, HealthStatus::Critical)),
             "doctor must report at least one Critical so it exits non-zero"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // state_schema check — forward-incompat is Critical, everything else OK
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn classify_state_schema_forward_incompat_is_critical() {
+        // On-disk NEWER than supported → Critical, with both versions named.
+        let (status, msg) = classify_state_schema(Some(9), 7);
+        assert!(matches!(status, HealthStatus::Critical));
+        assert!(msg.contains("v9") && msg.contains("v7"), "got: {msg}");
+    }
+
+    #[test]
+    fn classify_state_schema_older_equal_or_absent_is_healthy() {
+        // Older auto-migrates forward; equal matches; absent is fine.
+        assert!(matches!(
+            classify_state_schema(Some(6), 9).0,
+            HealthStatus::Healthy
+        ));
+        assert!(matches!(
+            classify_state_schema(Some(9), 9).0,
+            HealthStatus::Healthy
+        ));
+        assert!(matches!(
+            classify_state_schema(None, 9).0,
+            HealthStatus::Healthy
+        ));
+    }
+
+    #[tokio::test]
+    async fn state_schema_check_healthy_when_no_state_file() {
+        // A fresh pod (no state file yet) is healthy under `state_schema` — the
+        // check must not fail a pod merely because state hasn't been written.
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("rocky.toml");
+        let state_path = dir.path().join("state.redb"); // does not exist
+        let (checks, _suggestions) =
+            collect_health_checks(&config_path, &state_path, Some("state_schema"), false).await;
+        let check = checks
+            .iter()
+            .find(|c| c.name == "state_schema")
+            .expect("state_schema check must be emitted");
+        assert!(
+            matches!(check.status, HealthStatus::Healthy),
+            "missing state file must be healthy, got {:?}",
+            check.status
+        );
+    }
+
+    #[tokio::test]
+    async fn state_schema_check_healthy_on_current_version_store() {
+        // A freshly-created store stamped at the current version is healthy.
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("rocky.toml");
+        let state_path = dir.path().join("state.redb");
+        drop(rocky_core::state::StateStore::open(&state_path).unwrap());
+        let (checks, _suggestions) =
+            collect_health_checks(&config_path, &state_path, Some("state_schema"), true).await;
+        let check = checks
+            .iter()
+            .find(|c| c.name == "state_schema")
+            .expect("state_schema check must be emitted");
+        assert!(matches!(check.status, HealthStatus::Healthy));
     }
 
     #[test]

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -490,12 +490,16 @@ async fn try_claim_idempotency(
         | IdempotencyBackend::Valkey {
             mirror_to_redb: true,
             ..
-        } => Some(StateStore::open(state_path).with_context(|| {
-            format!(
-                "failed to open state store at {} for idempotency claim",
-                state_path.display()
-            )
-        })?),
+        } => Some(
+            StateStore::open_with_policy(state_path, state_cfg.on_schema_mismatch).with_context(
+                || {
+                    format!(
+                        "failed to open state store at {} for idempotency claim",
+                        state_path.display()
+                    )
+                },
+            )?,
+        ),
         _ => None,
     };
 
@@ -1097,7 +1101,11 @@ pub async fn run(
         // disabled state persistence (lost watermarks, missing run history)
         // whenever the state file was corrupted or unreadable.
         let state_store = Some(
-            rocky_core::state::StateStore::open(state_path).context(format!(
+            rocky_core::state::StateStore::open_with_policy(
+                state_path,
+                rocky_cfg.state.on_schema_mismatch,
+            )
+            .context(format!(
                 "failed to open state store at {}",
                 state_path.display()
             ))?,
@@ -1345,10 +1353,18 @@ pub async fn run(
     let governance_catalog_client: Option<std::sync::Arc<dyn GovernanceCatalogClient>> =
         adapter_registry.governance_catalog_client(&pipeline.target.adapter);
 
-    let state_store = StateStore::open(state_path).context(format!(
-        "failed to open state store at {}",
-        state_path.display()
-    ))?;
+    let state_store = StateStore::open_with_policy(state_path, rocky_cfg.state.on_schema_mismatch)
+        .context(format!(
+            "failed to open state store at {}",
+            state_path.display()
+        ))?;
+
+    // When the on-disk state was forward-incompatible (newer schema than this
+    // binary) and `on_schema_mismatch = recreate`, the store was bootstrapped
+    // fresh locally. We must NOT write that downgraded state back to a shared
+    // remote tier — doing so would clobber the newer state that already-upgraded
+    // pods depend on. Suppress both the periodic and the end-of-run upload.
+    let suppress_state_upload = state_store.was_recreated_for_forward_incompat();
 
     // Discover sources
     let discovery_result = async {
@@ -2179,7 +2195,7 @@ pub async fn run(
     // exposure for long runs. Runs shorter than ~1 minute skip it entirely.
     let estimated_run_secs =
         (tables_to_process.len() as u64).saturating_mul(3) / (concurrency.max(1) as u64);
-    let state_sync_handle = if estimated_run_secs < 60 {
+    let state_sync_handle = if estimated_run_secs < 60 || suppress_state_upload {
         None
     } else {
         // Target one upload per quarter of the estimated run, capped at 30s.
@@ -3571,8 +3587,18 @@ pub async fn run(
     )
     .await;
 
-    // Upload state to remote storage
-    if let Err(e) = rocky_core::state_sync::upload_state(&rocky_cfg.state, state_path).await {
+    // Upload state to remote storage — unless this store was bootstrapped
+    // fresh from a forward-incompatible on-disk schema. In that case the local
+    // state is a downgrade; persisting it back would clobber the newer state
+    // that already-upgraded pods depend on, so we deliberately skip the upload.
+    if suppress_state_upload {
+        info!(
+            outcome = "skipped_forward_incompat_recreate",
+            "skipping end-of-run state upload: local state was recreated after a \
+             forward-incompatible schema mismatch (on_schema_mismatch = recreate); \
+             leaving the newer shared state intact"
+        );
+    } else if let Err(e) = rocky_core::state_sync::upload_state(&rocky_cfg.state, state_path).await {
         warn!(error = %e, "state upload failed");
     }
 

--- a/engine/crates/rocky-cli/src/commands/state.rs
+++ b/engine/crates/rocky-cli/src/commands/state.rs
@@ -9,27 +9,59 @@ use rocky_core::state::StateStore;
 use crate::output::*;
 
 /// Execute `rocky state show`.
+///
+/// Reports the watermark set plus both schema versions (the version this
+/// binary supports and the version stamped in the on-disk file). The schema
+/// versions are read via [`StateStore::peek_schema_version`] so they are
+/// reported even when the on-disk store is **forward-incompatible** (newer
+/// than this binary) — that is exactly when an operator most needs the
+/// numbers. A forward-incompatible store still prints its versions with an
+/// empty watermark list and a warning, rather than failing outright.
 pub fn state_show(state_path: &Path, output_json: bool) -> Result<()> {
-    let store = StateStore::open_read_only(state_path).context(format!(
-        "failed to open state store at {}",
-        state_path.display()
-    ))?;
-    let watermarks = store
-        .list_watermarks()
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let schema_version_on_disk =
+        StateStore::peek_schema_version(state_path).map_err(|e| anyhow::anyhow!("{e}"))?;
 
-    let entries: Vec<WatermarkEntry> = watermarks
-        .into_iter()
-        .map(|(table, wm)| WatermarkEntry {
-            table,
-            last_value: wm.last_value,
-            updated_at: wm.updated_at,
-        })
-        .collect();
+    let entries: Vec<WatermarkEntry> = match StateStore::open_read_only(state_path) {
+        Ok(store) => store
+            .list_watermarks()
+            .map_err(|e| anyhow::anyhow!("{e}"))?
+            .into_iter()
+            .map(|(table, wm)| WatermarkEntry {
+                table,
+                last_value: wm.last_value,
+                updated_at: wm.updated_at,
+            })
+            .collect(),
+        // Forward-incompatible store: still report the version fields (the
+        // point of this command for an orchestrator startup hook) but skip the
+        // watermark read — this binary can't safely parse the newer layout.
+        Err(rocky_core::state::StateError::SchemaMismatch {
+            found, expected, ..
+        }) => {
+            eprintln!(
+                "warning: on-disk state schema v{found} is newer than this binary supports \
+                 (v{expected}); watermarks are not shown. Upgrade rocky to read this state."
+            );
+            Vec::new()
+        }
+        Err(e) => {
+            return Err(anyhow::anyhow!("{e}").context(format!(
+                "failed to open state store at {}",
+                state_path.display()
+            )));
+        }
+    };
 
     if output_json {
-        print_json(&StateOutput::new(entries))?;
+        print_json(&StateOutput::new(entries, schema_version_on_disk))?;
     } else {
+        println!(
+            "schema version: binary supports v{}, on disk {}",
+            rocky_core::state::current_schema_version(),
+            schema_version_on_disk
+                .map(|v| format!("v{v}"))
+                .unwrap_or_else(|| "none".to_string()),
+        );
         for e in &entries {
             println!("{} | {} | {}", e.table, e.last_value, e.updated_at);
         }
@@ -264,6 +296,39 @@ mod tests {
 
         // Must not have been created as a side effect.
         assert!(!path.exists(), "clear must not create state.redb");
+    }
+
+    #[test]
+    fn state_output_json_carries_both_schema_versions() {
+        // Acceptance (D): `rocky state show --output json` must carry both the
+        // supported and on-disk schema versions as structured fields, so an
+        // orchestrator startup hook never has to parse a human error string.
+        let out = StateOutput::new(Vec::new(), Some(9));
+        let json = serde_json::to_value(&out).unwrap();
+        assert_eq!(
+            json["schema_version_supported"],
+            serde_json::json!(rocky_core::state::current_schema_version())
+        );
+        assert_eq!(json["schema_version_on_disk"], serde_json::json!(9));
+
+        // A missing on-disk version serializes to null (not omitted).
+        let out_none = StateOutput::new(Vec::new(), None);
+        let json_none = serde_json::to_value(&out_none).unwrap();
+        assert!(json_none["schema_version_on_disk"].is_null());
+    }
+
+    #[test]
+    fn state_show_reports_versions_on_a_fresh_store() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("state.redb");
+        drop(StateStore::open(&path).unwrap());
+        // Both the human and JSON render paths succeed with the new fields.
+        state_show(&path, false).unwrap();
+        state_show(&path, true).unwrap();
+        assert_eq!(
+            StateStore::peek_schema_version(&path).unwrap(),
+            Some(rocky_core::state::current_schema_version())
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -2441,6 +2441,15 @@ pub struct StateOutput {
     pub version: String,
     pub command: String,
     pub watermarks: Vec<WatermarkEntry>,
+    /// redb state-schema version this binary supports. Pair with
+    /// `schema_version_on_disk` to make a compatibility decision without
+    /// parsing a human error string: `on_disk > supported` means the file was
+    /// written by a newer engine (forward-incompatible). See the
+    /// state-schema-deploy-safety contract.
+    pub schema_version_supported: u32,
+    /// redb state-schema version stamped in the on-disk state file, or `null`
+    /// when no state file exists yet or it predates schema versioning.
+    pub schema_version_on_disk: Option<u32>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -4128,11 +4137,13 @@ impl PlanOutput {
 }
 
 impl StateOutput {
-    pub fn new(watermarks: Vec<WatermarkEntry>) -> Self {
+    pub fn new(watermarks: Vec<WatermarkEntry>, schema_version_on_disk: Option<u32>) -> Self {
         StateOutput {
             version: VERSION.to_string(),
             command: "state".to_string(),
             watermarks,
+            schema_version_supported: rocky_core::state::current_schema_version(),
+            schema_version_on_disk,
         }
     }
 }

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -520,6 +520,45 @@ pub enum StateUploadFailureMode {
     Fail,
 }
 
+/// Policy applied when the engine opens a state store whose schema version is
+/// **newer** than the binary supports (a *forward*-incompatibility).
+///
+/// This is the deploy-safety knob for rolling upgrades that cross a redb
+/// schema version. During a rolling bump, pods on the *old* binary can read
+/// state written by *already-upgraded* pods through a shared tiered backend.
+/// The default ([`Recreate`][Self::Recreate]) degrades that window instead of
+/// breaking it: the old pod does one full-refresh run and succeeds, rather than
+/// stranding the orchestrated run in an hour-long retry spiral.
+///
+/// Only the *forward* case (on-disk newer than binary) is governed here.
+/// *Backward*-compatibility — a newer binary reading older state — always
+/// auto-migrates forward as before; there is no knob for it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SchemaMismatchPolicy {
+    /// Treat a forward-incompatible store as cold: log a single `WARN`,
+    /// bootstrap a fresh local state, and **never write the downgraded state
+    /// back** to the shared tier (so the newer state upgraded pods depend on is
+    /// left intact). The run proceeds as a full refresh. Default — it turns a
+    /// hard, run-stranding failure into a graceful one-time full refresh during
+    /// the mixed-version window of a schema-changing upgrade.
+    #[default]
+    Recreate,
+    /// Abort the open with a clear error (the historical behaviour).
+    /// Appropriate when an operator would rather an incompatible pod fail
+    /// loudly than do a full refresh against newer shared state.
+    Fail,
+}
+
+impl std::fmt::Display for SchemaMismatchPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SchemaMismatchPolicy::Recreate => write!(f, "recreate"),
+            SchemaMismatchPolicy::Fail => write!(f, "fail"),
+        }
+    }
+}
+
 /// Per-pipeline / per-client state-file namespacing policy.
 ///
 /// redb permits one writer per file, so fanning out one `rocky run` process
@@ -617,6 +656,16 @@ pub struct StateConfig {
     /// explicit `--state-path` disables namespacing for that run.
     #[serde(default)]
     pub namespacing: StateNamespacing,
+    /// What to do when the engine opens a state store whose schema version is
+    /// **newer** than this binary supports (a forward-incompatibility, which
+    /// happens during a rolling upgrade that crosses a redb schema version).
+    /// Defaults to [`SchemaMismatchPolicy::Recreate`] — the old pod bootstraps
+    /// fresh, does one full-refresh run, and never clobbers the newer shared
+    /// state. Set to `fail` to keep the historical hard-abort behaviour. Only
+    /// the run path honours this; inspection/branch commands still hard-fail on
+    /// a forward-incompatible store. See [`SchemaMismatchPolicy`].
+    #[serde(default)]
+    pub on_schema_mismatch: SchemaMismatchPolicy,
 }
 
 impl Default for StateConfig {
@@ -635,6 +684,7 @@ impl Default for StateConfig {
             idempotency: IdempotencyConfig::default(),
             retention: crate::retention::StateRetentionConfig::default(),
             namespacing: StateNamespacing::default(),
+            on_schema_mismatch: SchemaMismatchPolicy::default(),
         }
     }
 }

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -5,6 +5,7 @@ use fs4::FileExt;
 use redb::{Database, ReadableTable, TableDefinition};
 use thiserror::Error;
 
+use crate::config::SchemaMismatchPolicy;
 use crate::schema_cache::SchemaCacheEntry;
 use rocky_ir::WatermarkState;
 
@@ -270,6 +271,33 @@ pub struct StateStore {
     // Held exclusive advisory lock on `<path>.lock`. `None` for read-only opens.
     // Released automatically when the `File` is dropped.
     _lock_file: Option<File>,
+    // `true` when this store was opened against a forward-incompatible on-disk
+    // schema under [`SchemaMismatchPolicy::Recreate`] and the local file was
+    // bootstrapped fresh. The run path reads this via
+    // [`StateStore::was_recreated_for_forward_incompat`] to suppress the
+    // end-of-run upload, so a downgraded state is never written back over the
+    // newer state that upgraded pods depend on.
+    recreated_for_forward_incompat: bool,
+}
+
+/// The schema version this binary supports.
+///
+/// Exposed so callers (state-sync key qualification, `rocky doctor`,
+/// `rocky state show`) can reason about forward/backward compatibility without
+/// opening a store. See [`CURRENT_SCHEMA_VERSION`].
+pub fn current_schema_version() -> u32 {
+    CURRENT_SCHEMA_VERSION
+}
+
+/// Outcome of [`StateStore::init_db`].
+enum InitOutcome {
+    /// The version was stamped/upgraded and tables were created; the store is
+    /// ready to use.
+    Ready,
+    /// The on-disk schema is newer than this binary supports and the policy is
+    /// [`SchemaMismatchPolicy::Recreate`]; the caller must delete and recreate
+    /// the file. Carries the on-disk version for the WARN message.
+    RecreateForwardIncompat { found: u32 },
 }
 
 impl StateStore {
@@ -290,7 +318,26 @@ impl StateStore {
     /// binary (stored > current) an error is returned immediately so that the
     /// caller can surface a clear message rather than silently misreading data.
     pub fn open(path: &Path) -> Result<Self, StateError> {
-        Self::open_inner(path, true)
+        Self::open_inner(path, true, SchemaMismatchPolicy::Fail)
+    }
+
+    /// Opens or creates a state store for **writing** with an explicit
+    /// forward-incompatibility policy.
+    ///
+    /// Identical to [`StateStore::open`] except that the caller chooses what
+    /// happens when the on-disk schema is *newer* than this binary supports.
+    /// [`SchemaMismatchPolicy::Fail`] (what bare [`open`][Self::open] uses)
+    /// aborts with [`StateError::SchemaMismatch`]; [`SchemaMismatchPolicy::Recreate`]
+    /// logs a `WARN`, bootstraps a fresh local state, and sets the
+    /// [`was_recreated_for_forward_incompat`][Self::was_recreated_for_forward_incompat]
+    /// flag so the caller can suppress writing the downgraded state back to a
+    /// shared tier.
+    ///
+    /// Only the `rocky run` path threads a non-default policy here (from
+    /// `[state] on_schema_mismatch`); every other caller uses the hard-fail
+    /// default via [`open`][Self::open].
+    pub fn open_with_policy(path: &Path, policy: SchemaMismatchPolicy) -> Result<Self, StateError> {
+        Self::open_inner(path, true, policy)
     }
 
     /// Opens an existing state store for **read-only** access.
@@ -310,10 +357,68 @@ impl StateStore {
     /// millisecond-scale collisions the LSP creates on every debounced
     /// keystroke.
     pub fn open_read_only(path: &Path) -> Result<Self, StateError> {
-        Self::open_inner(path, false)
+        Self::open_inner(path, false, SchemaMismatchPolicy::Fail)
     }
 
-    fn open_inner(path: &Path, lock: bool) -> Result<Self, StateError> {
+    /// Reads the schema version stamped in an on-disk state file **without**
+    /// opening it for use, stamping it, creating tables, or recreating it.
+    ///
+    /// Returns:
+    /// - `Ok(None)` if the file does not exist, has no `metadata` table, or has
+    ///   no `schema_version` key (a pre-versioning store).
+    /// - `Ok(Some(v))` with the stored version otherwise.
+    ///
+    /// Unlike [`open`][Self::open] / [`open_read_only`][Self::open_read_only],
+    /// this never fails on a forward-incompatible store — it is the primitive
+    /// behind `rocky doctor --check state_schema` and the version fields in
+    /// `rocky state show`, both of which must report the on-disk version
+    /// precisely when it is newer than this binary supports. It takes redb's
+    /// shared open path (with the same lock-contention retry) but never Rocky's
+    /// advisory write lock.
+    pub fn peek_schema_version(path: &Path) -> Result<Option<u32>, StateError> {
+        // Side-effect-free for a missing file: do not let the redb open path
+        // create an empty database as a probe artifact.
+        if !path.exists() {
+            return Ok(None);
+        }
+        let db = open_redb_with_retry(path)?;
+        let txn = db.begin_read()?;
+        let metadata = match txn.open_table(METADATA) {
+            Ok(table) => table,
+            // A store written before the metadata table existed (or an empty
+            // freshly-created file) carries no version — treat as unversioned.
+            Err(redb::TableError::TableDoesNotExist(_)) => return Ok(None),
+            Err(e) => return Err(StateError::Table(e)),
+        };
+        match metadata.get("schema_version")? {
+            Some(guard) => {
+                let raw = guard.value().to_string();
+                let version = raw
+                    .parse::<u32>()
+                    .map_err(|_| StateError::VersionParse(raw))?;
+                Ok(Some(version))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Whether this store was bootstrapped fresh because the on-disk schema was
+    /// forward-incompatible (newer than this binary) and the open policy was
+    /// [`SchemaMismatchPolicy::Recreate`].
+    ///
+    /// When `true`, the caller must **not** persist this store back to a shared
+    /// remote tier — doing so would clobber the newer state that already-upgraded
+    /// pods depend on. The `rocky run` path checks this before its end-of-run
+    /// `upload_state`.
+    pub fn was_recreated_for_forward_incompat(&self) -> bool {
+        self.recreated_for_forward_incompat
+    }
+
+    fn open_inner(
+        path: &Path,
+        lock: bool,
+        policy: SchemaMismatchPolicy,
+    ) -> Result<Self, StateError> {
         // Acquire the advisory lock BEFORE opening the database — otherwise two
         // concurrent writers could both pass `Database::create` before either
         // of them reaches the lock check.
@@ -345,9 +450,82 @@ impl StateStore {
 
         let db = open_redb_with_retry(path)?;
 
-        // Single write transaction: check/write schema version AND ensure all
-        // tables exist. Committing them together means the version stamp and
-        // the table layout are always consistent.
+        match Self::init_db(&db, path, policy)? {
+            InitOutcome::Ready => Ok(StateStore {
+                db,
+                _lock_file: lock_file,
+                recreated_for_forward_incompat: false,
+            }),
+            InitOutcome::RecreateForwardIncompat { found } => {
+                // Forward-incompatible store under `SchemaMismatchPolicy::Recreate`.
+                // Treat it as cold: drop the handle, delete the local file, and
+                // bootstrap fresh. The caller (run path) reads the
+                // `recreated_for_forward_incompat` flag and skips the end-of-run
+                // upload, so the newer shared state is never clobbered.
+                tracing::warn!(
+                    target: "rocky::state",
+                    found,
+                    expected = CURRENT_SCHEMA_VERSION,
+                    path = %path.display(),
+                    "state schema version mismatch: database has v{found}, binary expects \
+                     v{CURRENT_SCHEMA_VERSION}. on_schema_mismatch = recreate: bootstrapping \
+                     fresh local state and running a full refresh. The newer shared state is \
+                     left intact (not overwritten) for already-upgraded pods."
+                );
+                drop(db);
+                // If we cannot remove the forward-incompatible file, reopening
+                // would just re-read the same newer version and loop. Degrade to
+                // the hard-fail error so the operator gets the actionable
+                // "delete or migrate" message rather than a silent spin.
+                if let Err(source) = std::fs::remove_file(path) {
+                    tracing::warn!(
+                        target: "rocky::state",
+                        error = %source,
+                        path = %path.display(),
+                        "could not delete forward-incompatible state file to recreate it; \
+                         falling back to hard failure"
+                    );
+                    return Err(StateError::SchemaMismatch {
+                        found,
+                        expected: CURRENT_SCHEMA_VERSION,
+                        path: path.display().to_string(),
+                    });
+                }
+                let db = open_redb_with_retry(path)?;
+                match Self::init_db(&db, path, policy)? {
+                    InitOutcome::Ready => Ok(StateStore {
+                        db,
+                        _lock_file: lock_file,
+                        recreated_for_forward_incompat: true,
+                    }),
+                    // A file we just created cannot carry a newer schema version.
+                    InitOutcome::RecreateForwardIncompat { found } => {
+                        Err(StateError::SchemaMismatch {
+                            found,
+                            expected: CURRENT_SCHEMA_VERSION,
+                            path: path.display().to_string(),
+                        })
+                    }
+                }
+            }
+        }
+    }
+
+    /// Stamp the schema version and ensure every table exists, in a single
+    /// write transaction so the version stamp and table layout always commit
+    /// together.
+    ///
+    /// Returns [`InitOutcome::RecreateForwardIncompat`] (without committing)
+    /// when the on-disk version is newer than this binary supports **and** the
+    /// policy is [`SchemaMismatchPolicy::Recreate`]; under
+    /// [`SchemaMismatchPolicy::Fail`] the same condition returns
+    /// [`StateError::SchemaMismatch`]. Otherwise stamps/upgrades the version,
+    /// creates the tables, commits, and returns [`InitOutcome::Ready`].
+    fn init_db(
+        db: &Database,
+        path: &Path,
+        policy: SchemaMismatchPolicy,
+    ) -> Result<InitOutcome, StateError> {
         let txn = db.begin_write()?;
         {
             let mut metadata = txn.open_table(METADATA)?;
@@ -365,11 +543,18 @@ impl StateStore {
                         .parse::<u32>()
                         .map_err(|_| StateError::VersionParse(version_str.clone()))?;
                     if found > CURRENT_SCHEMA_VERSION {
-                        return Err(StateError::SchemaMismatch {
-                            found,
-                            expected: CURRENT_SCHEMA_VERSION,
-                            path: path.display().to_string(),
-                        });
+                        // Dropping the uncommitted `txn` here aborts it, so no
+                        // partial stamp/table write survives the early return.
+                        return match policy {
+                            SchemaMismatchPolicy::Fail => Err(StateError::SchemaMismatch {
+                                found,
+                                expected: CURRENT_SCHEMA_VERSION,
+                                path: path.display().to_string(),
+                            }),
+                            SchemaMismatchPolicy::Recreate => {
+                                Ok(InitOutcome::RecreateForwardIncompat { found })
+                            }
+                        };
                     }
                     // Upgrade stamp so future migrations can branch on
                     // the actual version stored on disk.
@@ -402,11 +587,7 @@ impl StateStore {
             let _table = txn.open_table(DISCOVER_SNAPSHOTS)?;
         }
         txn.commit()?;
-
-        Ok(StateStore {
-            db,
-            _lock_file: lock_file,
-        })
+        Ok(InitOutcome::Ready)
     }
 
     /// Gets the watermark for a table (keyed by `catalog.schema.table`).
@@ -5763,6 +5944,162 @@ mod tests {
             .map(|g| g.value().to_string())
             .unwrap();
         assert_eq!(stored, CURRENT_SCHEMA_VERSION.to_string());
+    }
+
+    // -----------------------------------------------------------------------
+    // Forward-incompat / schema-mismatch policy (deploy safety)
+    // -----------------------------------------------------------------------
+
+    /// Stamp an arbitrary `schema_version` onto an existing store file, then
+    /// release the lock. Used to simulate a store written by a *newer* binary.
+    fn force_schema_version(path: &Path, version: &str) {
+        let store = StateStore::open(path).unwrap();
+        let txn = store.db.begin_write().unwrap();
+        {
+            let mut metadata = txn.open_table(METADATA).unwrap();
+            metadata.insert("schema_version", version).unwrap();
+        }
+        txn.commit().unwrap();
+        // `store` drops here, releasing the advisory lock.
+    }
+
+    fn sample_watermark() -> WatermarkState {
+        let now = Utc::now();
+        WatermarkState {
+            last_value: now,
+            updated_at: now,
+        }
+    }
+
+    #[test]
+    fn open_hard_fails_on_forward_incompat_by_default() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("state.redb");
+        drop(StateStore::open(&path).unwrap());
+        let future = (CURRENT_SCHEMA_VERSION + 1).to_string();
+        force_schema_version(&path, &future);
+
+        // Bare `open` keeps today's behaviour: a hard SchemaMismatch.
+        // (`StateStore` is not `Debug`, so match instead of `unwrap_err`.)
+        let err = match StateStore::open(&path) {
+            Ok(_) => panic!("expected SchemaMismatch on a forward-incompatible store"),
+            Err(e) => e,
+        };
+        assert!(
+            matches!(err, StateError::SchemaMismatch { found, expected, .. }
+                if found == CURRENT_SCHEMA_VERSION + 1 && expected == CURRENT_SCHEMA_VERSION),
+            "got {err:?}"
+        );
+        // Explicit `Fail` policy is identical.
+        let err = match StateStore::open_with_policy(&path, SchemaMismatchPolicy::Fail) {
+            Ok(_) => panic!("expected SchemaMismatch under Fail policy"),
+            Err(e) => e,
+        };
+        assert!(
+            matches!(err, StateError::SchemaMismatch { .. }),
+            "got {err:?}"
+        );
+        // The file still carries the newer stamp — Fail does not mutate it.
+        assert_eq!(
+            StateStore::peek_schema_version(&path).unwrap(),
+            Some(CURRENT_SCHEMA_VERSION + 1)
+        );
+    }
+
+    #[test]
+    fn open_with_policy_recreate_bootstraps_fresh_on_forward_incompat() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("state.redb");
+        // Seed a watermark, then stamp the file as written by a newer binary.
+        {
+            let store = StateStore::open(&path).unwrap();
+            store
+                .set_watermark("cat.sch.tbl", &sample_watermark())
+                .unwrap();
+        }
+        let future = (CURRENT_SCHEMA_VERSION + 2).to_string();
+        force_schema_version(&path, &future);
+
+        // Recreate: opens fresh, flags the recreate, and the old watermark is gone.
+        let store = StateStore::open_with_policy(&path, SchemaMismatchPolicy::Recreate).unwrap();
+        assert!(store.was_recreated_for_forward_incompat());
+        assert!(
+            store.list_watermarks().unwrap().is_empty(),
+            "recreate must discard the forward-incompatible state"
+        );
+        drop(store);
+        // The file is now re-stamped at the version this binary supports.
+        assert_eq!(
+            StateStore::peek_schema_version(&path).unwrap(),
+            Some(CURRENT_SCHEMA_VERSION)
+        );
+    }
+
+    #[test]
+    fn open_with_policy_recreate_is_noop_on_compatible_store() {
+        // A current-version store is never recreated; its data is preserved and
+        // the flag stays false even under the Recreate policy.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("state.redb");
+        {
+            let store = StateStore::open(&path).unwrap();
+            store
+                .set_watermark("cat.sch.tbl", &sample_watermark())
+                .unwrap();
+        }
+        let store = StateStore::open_with_policy(&path, SchemaMismatchPolicy::Recreate).unwrap();
+        assert!(!store.was_recreated_for_forward_incompat());
+        assert_eq!(store.list_watermarks().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn open_with_policy_recreate_upgrades_older_store_without_recreating() {
+        // Backward-compat (on-disk OLDER than binary) must still auto-migrate
+        // forward in place — Recreate is only for the forward case.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("state.redb");
+        {
+            let store = StateStore::open(&path).unwrap();
+            store
+                .set_watermark("cat.sch.tbl", &sample_watermark())
+                .unwrap();
+        }
+        force_schema_version(&path, "6");
+        let store = StateStore::open_with_policy(&path, SchemaMismatchPolicy::Recreate).unwrap();
+        assert!(
+            !store.was_recreated_for_forward_incompat(),
+            "an older store auto-migrates, it is not recreated"
+        );
+        assert_eq!(store.list_watermarks().unwrap().len(), 1, "data preserved");
+    }
+
+    #[test]
+    fn peek_schema_version_reports_on_disk_without_mutating() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("state.redb");
+        // Missing file → None, and peek must NOT create it as a side effect.
+        assert_eq!(StateStore::peek_schema_version(&path).unwrap(), None);
+        assert!(!path.exists(), "peek must not create a missing state file");
+
+        // Fresh store → the current version.
+        drop(StateStore::open(&path).unwrap());
+        assert_eq!(
+            StateStore::peek_schema_version(&path).unwrap(),
+            Some(CURRENT_SCHEMA_VERSION)
+        );
+
+        // A forward-stamped file is reported precisely (no error, no recreate).
+        let future = CURRENT_SCHEMA_VERSION + 3;
+        force_schema_version(&path, &future.to_string());
+        assert_eq!(
+            StateStore::peek_schema_version(&path).unwrap(),
+            Some(future)
+        );
+        // Peeking again leaves the stamp untouched.
+        assert_eq!(
+            StateStore::peek_schema_version(&path).unwrap(),
+            Some(future)
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -91,6 +91,39 @@ fn remote_state_key(local_path: &Path) -> String {
     STATE_FILE.to_string()
 }
 
+/// Schema-version path segment for remote state keys (e.g. `"v9"`).
+///
+/// Every remote state key is qualified by the engine's **schema** version so
+/// two engine versions that disagree on the redb schema never read or write
+/// each other's state through a shared tiered / object / Valkey backend. This
+/// is the durable fix for the rolling-upgrade strand: during a schema-changing
+/// bump, an old-binary pod resolves its keys under `vN` while already-upgraded
+/// pods use `vN+1`, so they never collide.
+///
+/// Qualifying by **schema** version, not binary version or hash, is
+/// deliberate: a patch bump that leaves the redb schema unchanged keeps the
+/// same segment and so keeps sharing state (no fleet-wide watermark reset).
+/// Only a schema-changing bump shifts the segment, after which the new version
+/// finds no state under its key and bootstraps once via the existing
+/// incremental-bootstrap path.
+fn schema_version_segment() -> String {
+    format!("v{}", crate::state::current_schema_version())
+}
+
+/// Schema-qualified object-store key: `v9/state.redb` (under the configured
+/// `<prefix>`). The version segment is a path component so the full object
+/// path reads `<prefix>/v9/state.redb`.
+fn object_store_state_key(remote_key: &str) -> String {
+    format!("{}/{remote_key}", schema_version_segment())
+}
+
+/// Schema-qualified Valkey key: `<prefix>v9:state.redb` (e.g.
+/// `rocky:state:v9:state.redb`). The version segment is colon-delimited to
+/// match the Valkey prefix convention.
+fn valkey_state_key(prefix: &str, remote_key: &str) -> String {
+    format!("{prefix}{}:{remote_key}", schema_version_segment())
+}
+
 /// Build an `ObjectStoreProvider` rooted at `<scheme>://<bucket>/<prefix>`.
 fn cloud_provider(
     scheme: &str,
@@ -473,7 +506,10 @@ async fn download_from_object_store(
     timeout: Duration,
 ) -> Result<(), StateSyncError> {
     let provider = cloud_provider(scheme, bucket, prefix)?;
-    let key = remote_state_key(local_path);
+    // Qualify the object key by schema version so a v7 pod and a v9 pod never
+    // collide on the same object — `<prefix>/v9/state.redb`, not
+    // `<prefix>/state.redb`.
+    let key = object_store_state_key(&remote_state_key(local_path));
     let span = info_span!(
         "state.download",
         backend = %provider.scheme(),
@@ -529,6 +565,10 @@ async fn upload_to_object_store(
     retry: &RetryConfig,
 ) -> Result<(), StateSyncError> {
     let provider = cloud_provider(scheme, bucket, prefix)?;
+    // Mirror `download_from_object_store`: qualify the object key by schema
+    // version so the upload lands at the same `<prefix>/v9/state.redb` the
+    // download reads, and never over a different version's object.
+    let key = object_store_state_key(key);
     let size_bytes = local_path.metadata().map(|m| m.len()).unwrap_or(0);
     let span = info_span!(
         "state.upload",
@@ -544,7 +584,7 @@ async fn upload_to_object_store(
         let retries = with_transfer_timeout(timeout, async {
             retry_transient(retry, "state.upload.object_store", || async {
                 provider
-                    .upload_file(local_path, key)
+                    .upload_file(local_path, &key)
                     .await
                     .map_err(StateSyncError::from)
             })
@@ -608,7 +648,9 @@ async fn download_from_valkey(
         .as_deref()
         .unwrap_or(DEFAULT_VALKEY_PREFIX)
         .to_string();
-    let key = format!("{prefix}{}", remote_state_key(local_path));
+    // Qualify by schema version: `rocky:state:v9:state.redb`, not
+    // `rocky:state:state.redb`, so a v7 reader and a v9 writer never share a key.
+    let key = valkey_state_key(&prefix, &remote_state_key(local_path));
     let local_path_owned = local_path.to_path_buf();
     let timeout = transfer_timeout(config);
 
@@ -681,7 +723,9 @@ async fn upload_to_valkey(
         .as_deref()
         .unwrap_or(DEFAULT_VALKEY_PREFIX)
         .to_string();
-    let key = format!("{prefix}{remote_key}");
+    // Mirror `download_from_valkey`: qualify by schema version so the upload
+    // key matches the download key (`rocky:state:v9:<remote_key>`).
+    let key = valkey_state_key(&prefix, remote_key);
     let data = std::fs::read(local_path)?;
     let size_bytes = data.len() as u64;
     let timeout = transfer_timeout(config);
@@ -1099,6 +1143,56 @@ mod tests {
         assert_ne!(remote_state_key(acme), remote_state_key(globex));
     }
 
+    // Schema-version qualification: remote keys carry the engine's *schema*
+    // version so two engine versions with different schemas never share a key.
+    #[test]
+    fn schema_version_segment_matches_current_schema() {
+        assert_eq!(
+            schema_version_segment(),
+            format!("v{}", crate::state::current_schema_version())
+        );
+    }
+
+    #[test]
+    fn object_store_key_is_schema_qualified() {
+        let seg = schema_version_segment();
+        // Global file → `v9/state.redb`; namespaced → `v9/acme.redb`.
+        assert_eq!(
+            object_store_state_key("state.redb"),
+            format!("{seg}/state.redb")
+        );
+        assert_eq!(
+            object_store_state_key("acme.redb"),
+            format!("{seg}/acme.redb")
+        );
+    }
+
+    #[test]
+    fn valkey_key_is_schema_qualified() {
+        let seg = schema_version_segment();
+        // Default prefix already ends in `:`, so the result is
+        // `rocky:state:v9:state.redb` — matching the FR's wire format.
+        assert_eq!(
+            valkey_state_key(DEFAULT_VALKEY_PREFIX, "state.redb"),
+            format!("rocky:state:{seg}:state.redb")
+        );
+    }
+
+    // Two engine versions with different schema versions must never resolve to
+    // the same remote key. We can't change `CURRENT_SCHEMA_VERSION` at runtime,
+    // so assert the version segment is load-bearing in the composed key: a key
+    // built with a different segment differs at the version position only.
+    #[test]
+    fn distinct_schema_versions_yield_distinct_keys() {
+        let here = object_store_state_key("state.redb");
+        let other = format!("v{}/state.redb", crate::state::current_schema_version() + 1);
+        assert_ne!(here, other);
+        // The local file stem maps to the same trailing object regardless of
+        // version — only the version segment changes — so a patch bump (same
+        // schema version) keeps sharing state.
+        assert!(here.ends_with("/state.redb") && other.ends_with("/state.redb"));
+    }
+
     // R8 (part 2) — no clobber. Two namespaced files round-trip through a real
     // object store at distinct keys and do not overwrite each other.
     #[tokio::test]
@@ -1175,12 +1269,21 @@ mod tests {
 
         test_support::clear();
 
-        // The namespaced object exists at `acme.redb`...
+        // The namespaced object exists at the schema-qualified key
+        // `v<N>/acme.redb` (the version segment keeps different-schema engines
+        // from sharing the object)...
+        let qualified = object_store_state_key("acme.redb");
         assert!(
-            provider.exists("acme.redb").await.unwrap(),
-            "{label} upload must land at the namespaced key `acme.redb`"
+            provider.exists(&qualified).await.unwrap(),
+            "{label} upload must land at the schema-qualified namespaced key `{qualified}`"
         );
-        // ...and the legacy shared key was NOT written (the clobber).
+        // ...and neither the *unqualified* namespaced key nor the legacy shared
+        // key was written (the version segment is load-bearing; the clobber is
+        // avoided).
+        assert!(
+            !provider.exists("acme.redb").await.unwrap(),
+            "{label} upload must NOT write the unqualified namespaced key `acme.redb`"
+        );
         assert!(
             !provider.exists("state.redb").await.unwrap(),
             "{label} upload must NOT write the shared legacy `state.redb` for a namespaced file"

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -1138,6 +1138,22 @@ class SchemaEvolutionConfig(BaseModel):
     """
 
 
+class SchemaMismatchPolicy1(StrEnum):
+    """
+    Treat a forward-incompatible store as cold: log a single `WARN`, bootstrap a fresh local state, and **never write the downgraded state back** to the shared tier (so the newer state upgraded pods depend on is left intact). The run proceeds as a full refresh. Default — it turns a hard, run-stranding failure into a graceful one-time full refresh during the mixed-version window of a schema-changing upgrade.
+    """
+
+    recreate = "recreate"
+
+
+class SchemaMismatchPolicy2(StrEnum):
+    """
+    Abort the open with a clear error (the historical behaviour). Appropriate when an operator would rather an incompatible pod fail loudly than do a full refresh against newer shared state.
+    """
+
+    fail = "fail"
+
+
 class SchemaPatternConfig(BaseModel):
     """
     Schema pattern configuration from TOML, converted to [`SchemaPattern`] at runtime.
@@ -2766,6 +2782,12 @@ class StateConfig(BaseModel):
     """
     Per-pipeline / per-client state-file namespacing. Defaults to [`StateNamespacing::None`] (one global state file — byte-identical to a project that omits this key). Set `namespacing = "pipeline"` to give each pipeline its own `<models>/.rocky-state/<pipeline>.redb` so independent fan-out runs don't serialize on one advisory lock. The per-invocation `--state-namespace <key>` flag overrides this; an explicit `--state-path` disables namespacing for that run.
     """
+    on_schema_mismatch: SchemaMismatchPolicy1 | SchemaMismatchPolicy2 | None = (
+        "recreate"
+    )
+    """
+    What to do when the engine opens a state store whose schema version is **newer** than this binary supports (a forward-incompatibility, which happens during a rolling upgrade that crosses a redb schema version). Defaults to [`SchemaMismatchPolicy::Recreate`] — the old pod bootstraps fresh, does one full-refresh run, and never clobbers the newer shared state. Set to `fail` to keep the historical hard-abort behaviour. Only the run path honours this; inspection/branch commands still hard-fail on a forward-incompatible store. See [`SchemaMismatchPolicy`].
+    """
     on_upload_failure: StateUploadFailureMode1 | StateUploadFailureMode2 | None = "skip"
     """
     What to do when state upload exhausts retries + circuit-breaker. Defaults to `skip` — rocky continues the run and the next run re-derives state from target-table metadata. See [`StateUploadFailureMode`].
@@ -3278,6 +3300,7 @@ class RockyConfig(BaseModel):
                 "retention_days": 30,
             },
             "namespacing": "none",
+            "on_schema_mismatch": "recreate",
             "on_upload_failure": "skip",
             "retention": {
                 "applies_to": ["history", "lineage", "audit"],

--- a/integrations/dagster/src/dagster_rocky/types_generated/state_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/state_schema.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from pydantic import AwareDatetime, BaseModel
+from pydantic import AwareDatetime, BaseModel, conint
 
 
 class WatermarkEntry(BaseModel):
@@ -18,5 +18,13 @@ class StateOutput(BaseModel):
     """
 
     command: str
+    schema_version_on_disk: conint(ge=0) | None = None
+    """
+    redb state-schema version stamped in the on-disk state file, or `null` when no state file exists yet or it predates schema versioning.
+    """
+    schema_version_supported: conint(ge=0)
+    """
+    redb state-schema version this binary supports. Pair with `schema_version_on_disk` to make a compatibility decision without parsing a human error string: `on_disk > supported` means the file was written by a newer engine (forward-incompatible). See the state-schema-deploy-safety contract.
+    """
     version: str
     watermarks: list[WatermarkEntry]

--- a/integrations/dagster/tests/fixtures_generated/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor.json
@@ -15,6 +15,12 @@
       "duration_ms": 0
     },
     {
+      "name": "state_schema",
+      "status": "healthy",
+      "message": "state schema v9 matches this binary",
+      "duration_ms": 0
+    },
+    {
       "name": "adapters",
       "status": "healthy",
       "message": "1 adapter(s) configured",

--- a/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
@@ -15,6 +15,12 @@
       "duration_ms": 0
     },
     {
+      "name": "state_schema",
+      "status": "healthy",
+      "message": "state schema v9 matches this binary",
+      "duration_ms": 0
+    },
+    {
       "name": "adapters",
       "status": "healthy",
       "message": "1 adapter(s) configured",

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
@@ -7,5 +7,7 @@
       "last_value": "2000-01-01T00:00:00Z",
       "updated_at": "2000-01-01T00:00:00Z"
     }
-  ]
+  ],
+  "schema_version_supported": 9,
+  "schema_version_on_disk": 9
 }

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
@@ -7,5 +7,7 @@
       "last_value": "2000-01-01T00:00:00Z",
       "updated_at": "2000-01-01T00:00:00Z"
     }
-  ]
+  ],
+  "schema_version_supported": 9,
+  "schema_version_on_disk": 9
 }

--- a/integrations/dagster/tests/fixtures_generated/state.json
+++ b/integrations/dagster/tests/fixtures_generated/state.json
@@ -7,5 +7,7 @@
       "last_value": "2000-01-01T00:00:00Z",
       "updated_at": "2000-01-01T00:00:00Z"
     }
-  ]
+  ],
+  "schema_version_supported": 9,
+  "schema_version_on_disk": 9
 }

--- a/integrations/dagster/tests/scenarios.py
+++ b/integrations/dagster/tests/scenarios.py
@@ -412,6 +412,11 @@ STATE: dict[str, Any] = {
             "updated_at": "2026-03-29T10:01:00Z",
         },
     ],
+    # State-schema deploy-safety: `rocky state show` reports both the version
+    # this binary supports and the version on disk so an orchestrator startup
+    # hook can decide compatibility structurally. In sync here (matching store).
+    "schema_version_supported": 9,
+    "schema_version_on_disk": 9,
 }
 
 # ---------------------------------------------------------------------------

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -2892,6 +2892,25 @@
       },
       "type": "object"
     },
+    "SchemaMismatchPolicy": {
+      "description": "Policy applied when the engine opens a state store whose schema version is **newer** than the binary supports (a *forward*-incompatibility).\n\nThis is the deploy-safety knob for rolling upgrades that cross a redb schema version. During a rolling bump, pods on the *old* binary can read state written by *already-upgraded* pods through a shared tiered backend. The default ([`Recreate`][Self::Recreate]) degrades that window instead of breaking it: the old pod does one full-refresh run and succeeds, rather than stranding the orchestrated run in an hour-long retry spiral.\n\nOnly the *forward* case (on-disk newer than binary) is governed here. *Backward*-compatibility — a newer binary reading older state — always auto-migrates forward as before; there is no knob for it.",
+      "oneOf": [
+        {
+          "description": "Treat a forward-incompatible store as cold: log a single `WARN`, bootstrap a fresh local state, and **never write the downgraded state back** to the shared tier (so the newer state upgraded pods depend on is left intact). The run proceeds as a full refresh. Default — it turns a hard, run-stranding failure into a graceful one-time full refresh during the mixed-version window of a schema-changing upgrade.",
+          "enum": [
+            "recreate"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Abort the open with a clear error (the historical behaviour). Appropriate when an operator would rather an incompatible pod fail loudly than do a full refresh against newer shared state.",
+          "enum": [
+            "fail"
+          ],
+          "type": "string"
+        }
+      ]
+    },
     "SchemaPatternConfig": {
       "additionalProperties": false,
       "description": "Schema pattern configuration from TOML, converted to [`SchemaPattern`] at runtime.",
@@ -3158,6 +3177,15 @@
           ],
           "default": "none",
           "description": "Per-pipeline / per-client state-file namespacing. Defaults to [`StateNamespacing::None`] (one global state file — byte-identical to a project that omits this key). Set `namespacing = \"pipeline\"` to give each pipeline its own `<models>/.rocky-state/<pipeline>.redb` so independent fan-out runs don't serialize on one advisory lock. The per-invocation `--state-namespace <key>` flag overrides this; an explicit `--state-path` disables namespacing for that run."
+        },
+        "on_schema_mismatch": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/SchemaMismatchPolicy"
+            }
+          ],
+          "default": "recreate",
+          "description": "What to do when the engine opens a state store whose schema version is **newer** than this binary supports (a forward-incompatibility, which happens during a rolling upgrade that crosses a redb schema version). Defaults to [`SchemaMismatchPolicy::Recreate`] — the old pod bootstraps fresh, does one full-refresh run, and never clobbers the newer shared state. Set to `fail` to keep the historical hard-abort behaviour. Only the run path honours this; inspection/branch commands still hard-fail on a forward-incompatible store. See [`SchemaMismatchPolicy`]."
         },
         "on_upload_failure": {
           "allOf": [
@@ -3914,6 +3942,7 @@
           "retention_days": 30
         },
         "namespacing": "none",
+        "on_schema_mismatch": "recreate",
         "on_upload_failure": "skip",
         "retention": {
           "applies_to": [

--- a/schemas/state.schema.json
+++ b/schemas/state.schema.json
@@ -28,6 +28,21 @@
     "command": {
       "type": "string"
     },
+    "schema_version_on_disk": {
+      "description": "redb state-schema version stamped in the on-disk state file, or `null` when no state file exists yet or it predates schema versioning.",
+      "format": "uint32",
+      "minimum": 0.0,
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "schema_version_supported": {
+      "description": "redb state-schema version this binary supports. Pair with `schema_version_on_disk` to make a compatibility decision without parsing a human error string: `on_disk > supported` means the file was written by a newer engine (forward-incompatible). See the state-schema-deploy-safety contract.",
+      "format": "uint32",
+      "minimum": 0.0,
+      "type": "integer"
+    },
     "version": {
       "type": "string"
     },
@@ -40,6 +55,7 @@
   },
   "required": [
     "command",
+    "schema_version_supported",
     "version",
     "watermarks"
   ],


### PR DESCRIPTION
## Problem

A rolling engine upgrade that crosses a redb **state-schema version** strands orchestrated runs. During the mixed-version window, a pod on the *old* binary reads state written by an *already-upgraded* pod through the shared tiered backend and hard-fails:

```
state schema version mismatch: database has v9, binary expects v7.
Delete or migrate the state file at .rocky-state.redb to continue.
```

Because the failure is deterministic, an orchestrator's op-level retry budget burns on it (retries at +9 / +19 / +36 min) before the run finally fails ~1h later having done no work. Runs launched after the rollout completes succeed normally. It's invisible to `rocky validate` and to build-time smoke tests — it only manifests when an old binary meets new on-disk state at run time.

The engine owns every lever (schema version, tiered backend keys, the open-or-fail decision), so the durable fix lives in the engine.

## What this lands (all four FR remedies)

**A — Version-qualify the remote state keys by *schema* version.** Valkey/S3/GCS keys now carry a `v<N>` segment (`rocky:state:v9:state.redb`, `rocky/state/v9/state.redb`). A v7 pod and a v9 pod resolve disjoint keys and never collide. Qualified by **schema** version, not binary version/hash, so a patch bump that leaves the schema unchanged keeps sharing state — no fleet-wide watermark reset. Applied only at the 4 key-construction leaves in `state_sync.rs` (the config prefixes are left untouched, so idempotency-key dedup is unaffected).

**B — Graceful forward-incompat handling.** New `[state] on_schema_mismatch = "recreate"` (default) `| "fail"`. On `recreate`, a binary that opens *newer* on-disk state logs a single WARN, bootstraps a fresh local state (full refresh), and **never writes the downgraded state back** to the shared tier — both the periodic and the end-of-run upload are suppressed, so the newer shared state upgraded pods depend on stays intact. `"fail"` preserves the historical hard-abort. Backward-compat (newer binary, older state) still auto-migrates as before. Threaded only through the `rocky run` opens; every other command keeps the hard-fail default.

**C — `rocky doctor --check state_schema`.** Returns **Critical** when the on-disk schema is newer than the binary supports (with both versions in the message), `Healthy` otherwise. A clean deploy-time boot gate: an orchestrator puts `state_schema` in its strict-startup checks and an incompatible pod fails fast and visibly instead of in an hour-long per-run retry spiral. Uses a non-mutating `peek_schema_version` so it reports the on-disk version precisely when the normal open path would hard-fail.

**D — Structured schema versions in `rocky state show --output json`.** Adds `{schema_version_supported, schema_version_on_disk}` so an external tool reads a compatibility decision cheaply instead of parsing the human error string. Reported via `peek` even on a forward-incompatible store (it degrades to an empty watermark list + a warning rather than failing).

## Acceptance criteria — status

- [x] **B/recreate:** old-binary `rocky run` against newer on-disk state completes (full refresh) with a WARN, writes no downgraded state to the shared tier, leaves the newer shared state intact. `= "fail"` preserves today's behaviour.
- [x] **A:** two engine versions with different schema versions never read each other's state on the same backend; a patch bump (same schema) keeps sharing state.
- [x] **C:** `doctor --check state_schema` returns `critical` (versions in message) for a forward-incompat store, `ok` otherwise; exit code reflects it.
- [x] **D:** `state show --output json` carries both schema-version fields.
- [x] Unit-tested across A/B/C/D; no change to steady-state single-version behaviour.

## Scope decision (deviation from the literal FR)

The FR also lists qualifying the **local** redb filename (`.rocky-state.v9.redb`). **Descoped.** The incident is the shared tiered backend; the local file is per-pod ephemeral with one binary version per pod, so qualifying the remote keys fixes the real problem. Qualifying the local filename would re-open the carefully-unified CLI/LSP `resolve_state_path` and need a one-time rename migration for no shared-tier benefit. **B** already makes any local forward-incompat open graceful, so the local case is covered.

## Operational note for the first deploy of A

On the deploy that introduces A, every pipeline looks for state under the new `…/v<N>/…` key, finds nothing at the old unqualified key, and **bootstraps once** (the existing incremental `bootstrap → record source MAX` path). This is a one-time, intended full refresh across all pipelines on the A-deploy — correct and cheap, but worth knowing it happens.

## Orchestrator wiring

`state_schema` needs no integration code — a Dagster resource with `strict_doctor_checks: ["state_rw", "state_schema"]` already matches the critical check by name and blocks the run from launching.

## Tests

- `state.rs`: `open_with_policy` recreate vs fail, recreate-is-noop on compatible/older stores, the recreate flag, `peek_schema_version` (missing → None without creating the file; forward-stamped reported precisely).
- `state_sync.rs`: schema-qualified object/Valkey key format; the end-to-end namespaced-upload test now asserts the object lands at the qualified key and **not** at the unqualified/legacy keys.
- `doctor.rs`: `classify_state_schema` (critical/healthy branches) + `state_schema` check healthy on missing/current store.
- `state.rs` (cmd): `StateOutput` JSON carries both version fields.

The run.rs upload-suppression wiring (`suppress_state_upload` reaching both upload sites) is verified by reading/grep, not a test — exercising it needs a full run against a forward-incompat store + mock remote, which is disproportionate; the `open_with_policy`-level behaviour is unit-tested.

Engine `cargo test` / `clippy --all-targets` / `fmt` green; dagster `ruff`/`pytest` (641) green; vscode `vitest` green. Bindings + fixtures regenerated via `just codegen` + `just regen-fixtures`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)