### PR TITLE
chore(release): triple-cut engine 1.51.0 / dagster 1.48.0 / vscode 1.33.0

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.33.0] — 2026-06-08
+
+### Changed
+
+- Regenerated the `rocky-project` schema + TypeScript bindings for engine 1.51.0's state-schema deploy-safety work: the `state` output (`rocky state show`) gains `schema_version_supported` + `schema_version_on_disk`, and the config schema gains `[state] on_schema_mismatch`. (#865)
+
 ## [1.32.1] — 2026-06-06
 
 ### Changed

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocky",
-  "version": "1.32.1",
+  "version": "1.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocky",
-      "version": "1.32.1",
+      "version": "1.33.0",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.32.1",
+  "version": "1.33.0",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.51.0] — 2026-06-08
+
+### Added
+
+- **State-schema deploy safety for rolling upgrades.** A rolling engine upgrade that crosses a redb state-schema version no longer strands orchestrated runs (an old-binary pod that read newer state through a shared backend used to hard-fail deterministically, burning an orchestrator's retry budget for ~an hour before failing with no work done). Four parts:
+  - **Version-qualified remote state keys.** The tiered / S3 / GCS / Valkey state keys now carry the engine's *schema* version (`rocky:state:v9:…`, `rocky/state/v9/…`), so two engine versions that disagree on the schema never read or write each other's state through a shared backend. Qualified by **schema** version, not binary version — a patch bump that leaves the schema unchanged keeps sharing state, so watermarks are not reset on every upgrade. After a schema-changing bump the new version finds no state under its key and bootstraps once via the existing incremental path (one full refresh). (#865)
+  - **`[state] on_schema_mismatch` — `"recreate"` (default) `| "fail"`.** When the engine opens a state store whose schema is *newer* than it supports, `recreate` logs a single WARN, bootstraps fresh local state (one full refresh), and **never writes the downgraded state back** to the shared tier — so the newer state that already-upgraded pods depend on stays intact and an old-binary pod degrades gracefully instead of stranding the run. `"fail"` preserves the prior hard-abort. Backward-compatibility (a newer binary reading older state) still auto-migrates forward as before. (#865)
+  - **`rocky doctor --check state_schema`.** Returns `critical` (with both the supported and on-disk versions in the message) when the on-disk schema is newer than the binary supports — a deploy-time boot gate an orchestrator can add to its strict-startup checks so an incompatible pod fails fast and visibly at boot instead of mid-run. (#865)
+  - **`rocky state show --output json` schema versions.** Adds `schema_version_supported` and `schema_version_on_disk` so external tooling can make a compatibility decision structurally instead of parsing the human error string. (#865)
+
 ## [1.50.1] — 2026-06-06
 
 ### Changed

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "indexmap",
  "reqwest 0.12.28",
@@ -3842,7 +3842,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3887,7 +3887,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "redis",
  "serde",
@@ -3899,7 +3899,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3963,7 +3963,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -3990,7 +3990,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4030,7 +4030,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4056,7 +4056,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4075,7 +4075,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4124,7 +4124,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4149,7 +4149,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -4162,7 +4162,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "logos",
  "miette",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "rocky-server",
  "rustls",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4208,7 +4208,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4226,7 +4226,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -4283,7 +4283,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "miette",
  "regex",
@@ -4296,7 +4296,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4319,7 +4319,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.50.1"
+version = "1.51.0"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.50.1"
+version = "1.51.0"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.50.1"
+version = "1.51.0"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.50.1"
+version = "1.51.0"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.50.1"
+version = "1.51.0"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.50.1"
+version = "1.51.0"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.50.1"
+version = "1.51.0"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.50.1"
+version = "1.51.0"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.50.1"
+version = "1.51.0"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.50.1"
+version = "1.51.0"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.50.1"
+version = "1.51.0"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.50.1"
+version = "1.51.0"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.50.1"
+version = "1.51.0"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.50.1"
+version = "1.51.0"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.50.1"
+version = "1.51.0"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.50.1"
+version = "1.51.0"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.50.1"
+version = "1.51.0"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.50.1"
+version = "1.51.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.50.1"
+version = "1.51.0"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.50.1"
+version = "1.51.0"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.50.1"
+version = "1.51.0"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.50.1"
+version = "1.51.0"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.50.1"
+version = "1.51.0"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.50.1"
+version = "1.51.0"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.50.1"
+version = "1.51.0"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.50.1"
+version = "1.51.0"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.48.0] — 2026-06-08
+
+### Changed
+
+- Regenerated the Pydantic bindings for engine 1.51.0's state-schema deploy-safety work: `StateOutput` (`rocky state show`) gains `schema_version_supported` + `schema_version_on_disk`, and the `rocky-project` config schema gains `[state] on_schema_mismatch`. No integration code change is needed to use the new engine `state_schema` doctor check — a `RockyResource` with `strict_doctor_checks=["state_rw", "state_schema"]` matches the engine's critical check by name and blocks the run from launching when a pod meets forward-incompatible on-disk state. (#865)
+
 ## [1.47.0] — 2026-06-07
 
 ### Added

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.47.0"
+version = "1.48.0"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Triple-cut release for the state-schema deploy-safety work merged in #865.

| Artifact | Version | What ships |
|---|---|---|
| **engine** | 1.50.1 → **1.51.0** | Version-qualified remote state keys; `[state] on_schema_mismatch` (`recreate` default \| `fail`); `rocky doctor --check state_schema`; `schema_version_supported` + `schema_version_on_disk` on `rocky state show --output json`. |
| **dagster** | 1.47.0 → **1.48.0** | Regenerated Pydantic bindings for the new `StateOutput` fields + `on_schema_mismatch` config. `strict_doctor_checks=["state_rw", "state_schema"]` gates startup on the new engine check by name, no code change. |
| **vscode** | 1.32.1 → **1.33.0** | Regenerated `rocky-project` schema + TypeScript bindings for the new state output + config fields. |

Engine bump touches all 25 workspace crate `Cargo.toml` files + `Cargo.lock`. CHANGELOGs updated for all three artifacts.

After merge: tag + push `engine-v1.51.0`, `dagster-v1.48.0`, `vscode-v1.33.0` (watching the isLatest race on the coupled engine+dagster pushes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)