### PR TITLE
docs(sdk): add Python SDK section to the docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 </p>
 
 [![Engine CI](https://github.com/rocky-data/rocky/actions/workflows/engine-ci.yml/badge.svg)](https://github.com/rocky-data/rocky/actions/workflows/engine-ci.yml)
+[![SDK CI](https://github.com/rocky-data/rocky/actions/workflows/sdk-ci.yml/badge.svg)](https://github.com/rocky-data/rocky/actions/workflows/sdk-ci.yml)
 [![Dagster CI](https://github.com/rocky-data/rocky/actions/workflows/dagster-ci.yml/badge.svg)](https://github.com/rocky-data/rocky/actions/workflows/dagster-ci.yml)
 [![VS Code CI](https://github.com/rocky-data/rocky/actions/workflows/vscode-ci.yml/badge.svg)](https://github.com/rocky-data/rocky/actions/workflows/vscode-ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
@@ -166,7 +167,7 @@ The trust primitives (compiler, branches, replay, lineage, contracts, cost attri
 - **AI is a growing surface, not a finished product.** The compile-validate loop (generate, type-check, auto-fix, then land) is shipped. The broader story (mass refactor across the DAG, auto-migration from a column-type change, schema-aware assertion generation) is on the roadmap.
 - **Iceberg.** REST-catalog source discovery is Beta. Content-addressed writes round-trip as Iceberg through Delta UniForm, shipped end-to-end. First-class Iceberg-native writes without the Delta intermediate are on the 2026 roadmap.
 - **No built-in semantic layer.** Rocky's typed IR is the right home for one. Today, integrate with Cube, the dbt Semantic Layer, or your existing metric store.
-- **Orchestration: Dagster is first-class.** A `rocky serve` standalone path exists; native Airflow and Prefect integrations are not yet shipped, so they're called from the CLI like any other binary.
+- **Orchestration: Dagster is first-class.** For other Python callers, the [`rocky-sdk`](sdk/python/) typed client drives Rocky from notebooks, scripts, or any orchestrator. A `rocky serve` standalone path exists too; native Airflow and Prefect integrations are not yet shipped, so they're called from the CLI like any other binary.
 
 If those gaps are blockers for your team, [open a discussion](https://github.com/rocky-data/rocky/discussions). The roadmap is shaped by where production pipelines are actually getting hurt.
 
@@ -192,7 +193,8 @@ dbt Core defined this category, and `rocky import-dbt` converts a vanilla dbt pr
 | Path | Artifact | Language | Description |
 |---|---|---|---|
 | [`engine/`](engine/) | `rocky` CLI binary | Rust | Core SQL transformation engine, 23-crate Cargo workspace |
-| [`integrations/dagster/`](integrations/dagster/) | `dagster-rocky` PyPI wheel | Python | Dagster resource and component wrapping the Rocky CLI |
+| [`sdk/python/`](sdk/python/) | `rocky-sdk` PyPI wheel | Python | Typed Python client (`RockyClient`) wrapping the Rocky CLI |
+| [`integrations/dagster/`](integrations/dagster/) | `dagster-rocky` PyPI wheel | Python | Dagster resource and component, built on `rocky-sdk` |
 | [`editors/vscode/`](editors/vscode/) | Rocky VSIX | TypeScript | VS Code extension; LSP client + commands for AI features |
 | [`examples/playground/`](examples/playground/) | (config only) | TOML / SQL | Self-contained DuckDB sample pipeline used for smoke tests and benchmarks |
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -55,6 +55,10 @@ export default defineConfig({
           items: [{ autogenerate: { directory: "reference" } }],
         },
         {
+          label: "Python SDK",
+          items: [{ autogenerate: { directory: "python-sdk" } }],
+        },
+        {
           label: "Dagster Integration",
           items: [{ autogenerate: { directory: "dagster" } }],
         },

--- a/docs/src/content/docs/dagster/introduction.md
+++ b/docs/src/content/docs/dagster/introduction.md
@@ -7,6 +7,8 @@ sidebar:
 
 `dagster-rocky` bridges Rocky's Rust binary with Dagster orchestration. Rocky is the **trust plane**: typed compiler, compile-time contracts, column-level lineage, schema drift detection, branches + replay, per-model cost. Dagster is the orchestrator: scheduling, retries, alerts, the asset-centric UI. The guarantees Rocky enforces at compile time surface as native Dagster events (asset checks, materializations, metadata) so the asset graph reflects the same trust contract.
 
+`RockyResource` is a thin adapter over [`rocky-sdk`](/python-sdk/introduction/)'s `RockyClient`, which it builds from your config and delegates each command to. To drive Rocky from a notebook, script, or non-Dagster orchestrator, use the [SDK](/python-sdk/introduction/) directly.
+
 ## Quick start
 
 Two ways to wire Rocky into Dagster. Start with the component; it auto-discovers your tables.

--- a/docs/src/content/docs/python-sdk/introduction.md
+++ b/docs/src/content/docs/python-sdk/introduction.md
@@ -1,0 +1,99 @@
+---
+title: Introduction
+description: rocky-sdk, the typed Python client for the Rocky engine
+sidebar:
+  order: 1
+---
+
+`rocky-sdk` is a typed Python client for the Rocky engine. `RockyClient` wraps the `rocky` binary (subprocess plus `--output json`) behind one method per CLI command, parses the output into Pydantic models, and raises typed errors. It is for human Python callers: notebooks, scripts, and orchestrators other than Dagster.
+
+It is also the foundation the [`dagster-rocky`](/dagster/introduction/) integration is built on. `RockyResource` is a thin Dagster adapter over `RockyClient` that translates its errors into `dagster.Failure`. For AI agents, use `rocky mcp`; to call Rocky from another language over HTTP, use `rocky serve`.
+
+## Install
+
+```bash
+pip install rocky-sdk
+```
+
+The `rocky` binary is not bundled. Install it separately and put it on `PATH`, or pass `binary_path=`. See the [releases page](https://github.com/rocky-data/rocky/releases). The SDK requires engine v1.34.0 or newer.
+
+## Quick start
+
+Every method returns a typed Pydantic model.
+
+```python
+from rocky_sdk import RockyClient
+
+client = RockyClient(config_path="rocky.toml")
+
+# Read-only inspection.
+compiled = client.compile()
+if compiled.has_errors:
+    for diag in compiled.diagnostics:
+        print(diag.severity, diag.message)
+
+lineage = client.lineage("customer_orders", column="email")
+catalog = client.catalog()
+
+# Execute a pipeline; stream live progress to any callback.
+run = client.run(filter="tenant=acme", log_callback=print)
+print(f"{run.tables_copied} copied, {run.tables_failed} failed, {run.duration_ms} ms")
+```
+
+## Errors
+
+Failures raise a `RockyError` subclass carrying structured fields, so you branch on the cause instead of parsing a message.
+
+```python
+from rocky_sdk import RockyClient
+from rocky_sdk.exceptions import RockyTimeoutError, RockyCommandError
+
+client = RockyClient(config_path="rocky.toml", timeout_seconds=600)
+try:
+    client.run(filter="tenant=acme")
+except RockyTimeoutError as exc:
+    print("timed out after", exc.timeout_seconds, "s")
+    print(exc.stderr_tail)
+except RockyCommandError as exc:
+    print("exit", exc.returncode)
+    print(exc.stderr_tail)
+```
+
+| Exception | Raised when |
+|---|---|
+| `RockyBinaryNotFoundError` | the `rocky` binary is missing |
+| `RockyVersionError` | the binary is older than the SDK minimum |
+| `RockyTimeoutError` | a command exceeds `timeout_seconds` |
+| `RockyCommandError` | a command exits non-zero |
+| `RockyPartialFailure` | a non-zero run still returned a parseable partial result |
+| `RockyOutputParseError` | stdout was not the expected JSON shape |
+| `RockyServerError` | a `rocky serve` HTTP request failed |
+| `RockyGovernanceError` | a `governance_override` would revoke every workspace binding |
+
+## Which Python surface to use
+
+| You want to | Use |
+|---|---|
+| Drive Rocky from a notebook, script, or non-Dagster orchestrator | `rocky-sdk` (`RockyClient`) |
+| Orchestrate Rocky as Dagster assets, checks, and materializations | [`dagster-rocky`](/dagster/introduction/), built on `rocky-sdk` |
+| Let an AI agent author and inspect models | `rocky mcp` |
+| Call Rocky from another language over HTTP | `rocky serve` |
+
+## Methods
+
+`RockyClient` exposes one method per Rocky CLI command:
+
+- **Pipeline:** `discover`, `plan`, `apply`, `run`, `run_model`, `resume_run`, `state`
+- **Modeling:** `compile`, `lineage`, `catalog`, `dag`, `test`, `ci`
+- **Observability:** `history`, `metrics`, `optimize`, `cost`
+- **AI:** `ai`, `ai_sync`, `ai_explain`, `ai_test`, `ai_contract`
+- **Governance and branches:** `compliance`, `retention_status`, `branch_approve`, `branch_promote`, `plan_promote`
+- **Diagnostics:** `doctor`, `validate_migration`, `test_adapter`, `hooks_list`, `hooks_test`
+
+`run()` accepts a `log_callback` that receives the engine's stderr line by line, so you can stream progress wherever you want. Setting `server_url` routes `compile`, `lineage`, and `metrics` through a running `rocky serve` instead of a subprocess.
+
+## Requirements
+
+- Python 3.11 or newer
+- `pydantic >= 2.0`
+- The `rocky` binary on `PATH` (engine v1.34.0 or newer), or a path passed via `binary_path`


### PR DESCRIPTION
## What

Adds public documentation for the new `rocky-sdk` Python client (shipped in #874). The docs site already has a 20-page Dagster Integration section but had no SDK presence, even though the SDK's audiences — notebooks, scripts, and non-Dagster orchestrators — are exactly who browses the site.

## Changes

- **New "Python SDK" sidebar section** with `docs/src/content/docs/python-sdk/introduction.md`: install, a typed quickstart (read-only inspection + `run(..., log_callback=...)`), the `RockyError` hierarchy, a "which Python surface" table (SDK vs dagster-rocky vs `rocky mcp` vs `rocky serve`), the method list, and requirements. Field names in the examples were verified against the real Pydantic models.
- **Cross-link** from the Dagster introduction noting `RockyResource` is a thin adapter over `RockyClient`.
- **README**: a `rocky-sdk` row in the Subprojects table, an SDK CI badge, and a one-line orchestration note.

Splittable into a fuller multi-page section (per-method reference, like Dagster) later if it grows; one page covers the surface for now.

## Verification

`npm run build` in `docs/` completes clean — 86 pages, the new SDK page included; `docs/dist/python-sdk/introduction/index.html` renders. `docs/dist` is gitignored, so only source is committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)