### PR TITLE
feat(sdk): runnable quickstart example + real-binary CI smoke

### DIFF
--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -31,5 +31,21 @@ jobs:
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - run: uv sync --dev
       - run: uv run python -m pytest -v
-      - run: uv run python -m ruff check src/ tests/
-      - run: uv run python -m ruff format --check src/ tests/
+      - run: uv run python -m ruff check src/ tests/ examples/
+      - run: uv run python -m ruff format --check src/ tests/ examples/
+
+  smoke:
+    name: Example smoke (real binary)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - name: Install the rocky binary (latest engine release)
+        # The unit tests mock the binary; this job drives the SDK against a real
+        # rocky to catch breakage the mocks can't (argv, exit codes, JSON shapes).
+        run: |
+          bash "$GITHUB_WORKSPACE/engine/install.sh"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - run: uv sync
+      - name: Run the SDK quickstart against a generated playground
+        run: uv run python examples/quickstart.py

--- a/docs/src/content/docs/python-sdk/introduction.md
+++ b/docs/src/content/docs/python-sdk/introduction.md
@@ -40,6 +40,8 @@ run = client.run(filter="tenant=acme", log_callback=print)
 print(f"{run.tables_copied} copied, {run.tables_failed} failed, {run.duration_ms} ms")
 ```
 
+A complete runnable version lives in the repo at [`sdk/python/examples/quickstart.py`](https://github.com/rocky-data/rocky/blob/main/sdk/python/examples/quickstart.py). It spins up a throwaway DuckDB playground (no credentials) and walks through compile, lineage, a real run, and typed error handling.
+
 ## Errors
 
 Failures raise a `RockyError` subclass carrying structured fields, so you branch on the cause instead of parsing a message.

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -74,6 +74,16 @@ except RockyCommandError as exc:
 | `RockyServerError` | a `rocky serve` HTTP request failed |
 | `RockyGovernanceError` | a `governance_override` would silently full-revoke |
 
+## Example
+
+A runnable end-to-end script lives at [`examples/quickstart.py`](examples/quickstart.py). With the `rocky` binary on your `PATH`:
+
+```bash
+python examples/quickstart.py
+```
+
+It spins up a throwaway DuckDB playground (no credentials) and walks through compile, DAG, lineage, a real run, and typed error handling.
+
 ## License
 
 Apache-2.0

--- a/sdk/python/examples/quickstart.py
+++ b/sdk/python/examples/quickstart.py
@@ -1,0 +1,84 @@
+"""Drive the Rocky engine end-to-end with rocky-sdk.
+
+Run it with no arguments to spin up a throwaway, pre-seeded DuckDB playground
+(via ``rocky playground`` — no credentials) and exercise the client against it:
+
+    python quickstart.py
+
+Or point it at an existing project's ``rocky.toml``:
+
+    python quickstart.py path/to/rocky.toml
+
+Requires the ``rocky`` binary on PATH (engine v1.34.0+). The engine has DuckDB
+embedded, so the playground path needs nothing else installed.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from rocky_sdk import RockyClient
+from rocky_sdk.exceptions import RockyCommandError
+
+
+def bootstrap_playground() -> Path:
+    """Generate a throwaway, pre-seeded DuckDB playground; return its rocky.toml."""
+    project = Path(tempfile.mkdtemp(prefix="rocky-sdk-demo-")) / "playground"
+    subprocess.run(
+        ["rocky", "playground", str(project), "--template", "quickstart"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return project / "rocky.toml"
+
+
+def main() -> int:
+    config = Path(sys.argv[1]).resolve() if len(sys.argv) > 1 else bootstrap_playground()
+    # Run from the project directory so the relative paths in rocky.toml (the
+    # DuckDB file, models/, data/) resolve.
+    os.chdir(config.parent)
+
+    client = RockyClient(config_path=config.name)
+
+    # 1. Compile — type-check the models. Returns a typed CompileResult.
+    compiled = client.compile()
+    print(f"compile: {compiled.models} models, has_errors={compiled.has_errors}")
+    for diag in compiled.diagnostics:
+        print(f"  {diag.severity} {diag.code}: {diag.message}")
+
+    # 2. Inspect the dependency graph.
+    dag = client.dag()
+    print(f"dag: {len(dag.nodes)} nodes, {len(dag.edges)} edges")
+
+    # 3. Column-level lineage for one model.
+    lineage = client.lineage("revenue_summary")
+    print(f"lineage(revenue_summary): {type(lineage).__name__}")
+
+    # 4. Run the pipeline — materialize the model DAG against DuckDB. An empty
+    #    filter runs everything. For a transformation pipeline the signal is the
+    #    materialization count (tables_copied is a replication-only metric).
+    run = client.run(filter="")
+    print(
+        f"run: {len(run.materializations)} models materialized, "
+        f"{run.tables_failed} failed, {run.duration_ms} ms"
+    )
+    for m in run.materializations:
+        print(f"  materialized {'.'.join(m.asset_key)}")
+
+    # 5. Errors are typed — branch on the cause, not a string.
+    try:
+        client.lineage("does_not_exist")
+    except RockyCommandError as exc:
+        print(f"expected typed error: {type(exc).__name__} (exit {exc.returncode})")
+
+    print("ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Adds a runnable showcase for `rocky-sdk` and wires it into CI as the SDK's first **continuous real-binary** coverage.

`sdk/python/examples/quickstart.py` drives the client end-to-end against a throwaway, pre-seeded DuckDB playground (`rocky playground`, no credentials): `compile()`, `dag()`, `lineage()`, a real `run()` that materializes the model DAG, and a typed `RockyError` from a bad model. Run it with no arguments (it self-bootstraps) or point it at your own `rocky.toml`.

## Why the CI step

Every existing SDK unit test mocks the binary, so they can't catch breakage in argv construction, exit-code handling, or the JSON shapes the real engine emits. The new `sdk-ci` **`smoke`** job installs the latest released `rocky` and runs the example, so a regression against a real binary fails CI. `ruff` now also lints `examples/`.

## Verification

- The example runs locally against `rocky 1.51.0`: 3 models materialized, `RockyCommandError` raised on a nonexistent model, exit 0.
- SDK lint (src + tests + examples) + 30 unit tests pass; docs build clean (86 pages).
- Linked from the SDK README and the docs Python SDK page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)