### PR TITLE
docs: represent rocky-sdk in README + CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,11 @@
 # Contributing to Rocky
 
-Rocky is a monorepo. The four subprojects share one repository, one issue tracker, and one pull-request flow, but each has its own build system.
+Rocky is a monorepo. The five subprojects share one repository, one issue tracker, and one pull-request flow, but each has its own build system.
 
 | Subproject | Path | Language | Build |
 |---|---|---|---|
 | Rocky CLI engine | `engine/` | Rust (23-crate Cargo workspace) | `cargo` |
+| Python SDK | `sdk/python/` | Python | `uv` |
 | Dagster integration | `integrations/dagster/` | Python | `uv` |
 | VS Code extension | `editors/vscode/` | TypeScript | `npm` |
 | Sample project | `examples/playground/` | TOML / SQL config | none |
@@ -21,7 +22,7 @@ cd rocky
 Each subproject is built and tested independently. From the repo root, the top-level `justfile` orchestrates common tasks across all of them. Install [`just`](https://github.com/casey/just) and then:
 
 ```bash
-just build       # build engine + dagster wheel + vscode extension
+just build       # build engine + sdk + dagster wheels + vscode extension
 just test        # run all test suites
 just lint        # cargo clippy/fmt + ruff + eslint
 just --list      # see all available recipes
@@ -40,6 +41,17 @@ cargo fmt --check
 ```
 
 The engine is a Cargo workspace with 25 members — 23 library crates plus the `rocky` and `rocky-lsp` binaries (Rust edition 2024, MSRV 1.88). Run a single crate's tests with `cargo test -p rocky-core`. End-to-end tests in `crates/rocky-core/tests/e2e.rs` use DuckDB and need no credentials.
+
+### Python SDK (`sdk/python/`)
+
+```bash
+cd sdk/python
+uv sync --dev
+uv run pytest -v
+uv run ruff check src/ tests/ examples/ && uv run ruff format --check src/ tests/ examples/
+```
+
+`rocky-sdk` is the standalone typed client (`RockyClient`) that `dagster-rocky` is built on. Unit tests mock the binary and need no credentials; `examples/quickstart.py` runs against a real `rocky` (the `sdk-ci` smoke job installs one). The generated Pydantic models in `src/rocky_sdk/types_generated/` come from `just codegen` — don't hand-edit them.
 
 ### Dagster integration (`integrations/dagster/`)
 
@@ -76,12 +88,12 @@ The single biggest reason Rocky is a monorepo: changes to the engine's CLI JSON 
 1. Edit the typed `*Output` struct in `engine/crates/rocky-cli/src/output.rs` (or `engine/crates/rocky-cli/src/commands/doctor.rs` for the doctor types).
 2. From the repo root, run `just codegen`. This regenerates:
    - `schemas/<command>.schema.json` (canonical JSON Schema)
-   - `integrations/dagster/src/dagster_rocky/types_generated/` (Pydantic v2 models)
+   - `sdk/python/src/rocky_sdk/types_generated/` (Pydantic v2 models)
    - `editors/vscode/src/types/generated/` (TypeScript interfaces)
 3. Commit the regenerated bindings together with your Rust change.
 4. The `codegen-drift` CI workflow will fail any PR where the committed bindings don't match what the engine produces, so this is enforced.
 
-The hand-written `integrations/dagster/src/dagster_rocky/types.py` and `editors/vscode/src/types/rockyJson.ts` are now re-export shims over the generated modules, providing backward-compat aliases for the renamed Python/TypeScript class names.
+The generated Pydantic models live in the `rocky-sdk` package. `dagster_rocky.types` (and `dagster_rocky.types_generated`) re-export them from `rocky_sdk`, and `editors/vscode/src/types/rockyJson.ts` is a re-export shim over the generated TypeScript — both providing backward-compat aliases for the renamed class names.
 
 **When modifying Rocky DSL syntax** (`.rocky` files), update in lockstep:
 1. `engine/crates/rocky-lang/` (parser + lexer)
@@ -96,8 +108,11 @@ Each artifact is released independently using a tag-namespaced scheme. Releases 
 | Artifact | Tag pattern | CI workflow (on tag push) |
 |---|---|---|
 | Rocky CLI binary | `engine-v*` | `engine-release.yml` — full 5-target matrix (macOS ARM64/Intel, Linux x86_64/ARM64, Windows x86_64), all attached to the GitHub Release |
+| rocky-sdk wheel | `sdk-v*` | `sdk-release.yml` — build + PyPI publish via OIDC |
 | dagster-rocky wheel | `dagster-v*` | `dagster-release.yml` — build + PyPI publish via OIDC |
 | Rocky VSIX | `vscode-v*` | `vscode-release.yml` — build + VS Code Marketplace publish |
+
+`dagster-rocky` depends on `rocky-sdk`, so when a `dagster-v*` release raises its `rocky-sdk` floor, publish the `sdk-v*` tag first — the published dagster wheel resolves the SDK from PyPI, not the monorepo path source.
 
 Canonical flow for each artifact:
 
@@ -141,7 +156,7 @@ Avoid the third option (create a merge commit) for normal PRs — it adds a bran
 Each subproject follows its language's idioms; the linter is the source of truth.
 
 - **Rust** (`engine/`): edition 2024, `cargo fmt`, `cargo clippy --all-targets -- -D warnings`. Use `tracing` for logs. Use `thiserror` for library errors and `anyhow` for binary/CLI errors. SQL identifiers must be validated via `rocky-sql/validation.rs` before interpolation.
-- **Python** (`integrations/dagster/`): Python 3.11+, `from __future__ import annotations`, Pydantic for all data structures. Line length 100. Ruff rules: E, F, I, N, UP, B, SIM.
+- **Python** (`sdk/python/`, `integrations/dagster/`): Python 3.11+, `from __future__ import annotations`, Pydantic for all data structures. Line length 100. Ruff rules: E, F, I, N, UP, B, SIM.
 - **TypeScript** (`editors/vscode/`): ES2022 target, strict mode, `cp.execFile()` (never `cp.exec()`), escape HTML in webview content.
 
 ## Reporting issues

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Building a warehouse Rocky doesn't ship in-tree (ClickHouse, Redshift, …)? See
 ```bash
 git clone https://github.com/rocky-data/rocky.git
 cd rocky
-just build       # builds engine + dagster wheel + vscode extension
+just build       # builds engine + sdk + dagster wheels + vscode extension
 just test        # runs all test suites
 just lint        # cargo clippy/fmt + ruff + eslint
 ```
@@ -233,6 +233,7 @@ just lint        # cargo clippy/fmt + ruff + eslint
 Each artifact is released independently using a tag-namespaced scheme:
 
 - `engine-v*` → Rocky CLI binary (cross-compiled, on GitHub Releases)
+- `sdk-v*` → `rocky-sdk` wheel (publish before a `dagster-v*` that raises its `rocky-sdk` floor)
 - `dagster-v*` → `dagster-rocky` wheel
 - `vscode-v*` → Rocky VSIX
 
@@ -240,7 +241,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md#releases) for the full release flow.
 
 ## Documentation
 
-Full documentation lives at **[rocky-data.dev](https://rocky-data.dev)**: concepts, guides, CLI reference, Dagster integration, and the adapter SDK.
+Full documentation lives at **[rocky-data.dev](https://rocky-data.dev)**: concepts, guides, CLI reference, the Python SDK, Dagster integration, and the adapter SDK.
 
 ## Contributing
 


### PR DESCRIPTION
## What

The Python SDK shipped as a first-class artifact (#874–#876), but the repo-meta docs lagged. This fixes the stale and missing spots.

**README.md**
- `just build` now builds the sdk wheel (it was wired into the `build` aggregate).
- Add `sdk-v*` → `rocky-sdk` wheel to the Releases list, with the publish-before-`dagster-v*` ordering note.
- Name the Python SDK under Documentation.

**CONTRIBUTING.md**
- "four" → "five" subprojects; add a `rocky-sdk` table row and a per-subproject build section (matching Engine/Dagster/VS Code).
- **Correct the codegen output path** to `sdk/python/src/rocky_sdk/types_generated/` — it still pointed at the old `integrations/dagster/...` location the codegen cascade moved.
- Update the shim note: `dagster_rocky.types` re-exports the generated models from `rocky_sdk`.
- Add the `rocky-sdk` wheel / `sdk-v*` row to the release table, with the SDK-before-dagster ordering note.

No code changes; docs/repo-meta only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)