### PR TITLE
chore(deps): bump astro + @astrojs/starlight in /docs

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,8 +8,8 @@
       "name": "rocky-docs",
       "version": "0.0.1",
       "dependencies": {
-        "@astrojs/starlight": "^0.39.2",
-        "astro": "^6.4.2",
+        "@astrojs/starlight": "^0.39.3",
+        "astro": "^6.4.4",
         "sharp": "^0.34.5"
       }
     },
@@ -108,9 +108,9 @@
       }
     },
     "node_modules/@astrojs/starlight": {
-      "version": "0.39.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.39.2.tgz",
-      "integrity": "sha512-vlw+bwnjtf5buCTUtLU7JfV6D3knslxqnspr6LKs6hfRuFZiyr5hT44F7GyDqR9FKANUqFxnIzWM81F1k/kOUA==",
+      "version": "0.39.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.39.3.tgz",
+      "integrity": "sha512-uvAweA2DwhmLgFVfBT9NqG38Ey14k1ck3+y78XNJbceT1pMdzxCCX69RoBajb1QzTJviufsXzSc1xswgRxJfig==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/markdown-remark": "^7.1.1",
@@ -133,7 +133,7 @@
         "mdast-util-directive": "^3.1.0",
         "mdast-util-to-markdown": "^2.1.2",
         "mdast-util-to-string": "^4.0.0",
-        "pagefind": "^1.3.0",
+        "pagefind": "^1.5.2",
         "rehype": "^13.0.2",
         "rehype-format": "^5.0.1",
         "remark-directive": "^4.0.0",
@@ -1978,9 +1978,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.3.tgz",
-      "integrity": "sha512-heArIk8zLcxuoj1WgBH2zGdAD8zKSU1mEcBvS6hYMEHRPlbtvB+4Y8ri9Z27hzeryvGaFgrH32zjghEfV2y07g==",
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.6.tgz",
+      "integrity": "sha512-48OBTBKR9ctbf+DQxpOuxGl8ebfn59zTuNQMBzptmG/Mi/H8IdfMSbJgGuX1I/4U6g9yazG1p4BHlf4+2hWU4Q==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,8 +13,8 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/starlight": "^0.39.2",
-    "astro": "^6.4.2",
+    "@astrojs/starlight": "^0.39.3",
+    "astro": "^6.4.4",
     "sharp": "^0.34.5"
   },
   "overrides": {


### PR DESCRIPTION
Combines Dependabot #869 (astro → ^6.4.4) and #867 (@astrojs/starlight → ^0.39.3), which share `docs/package-lock.json` and have no CI gate. Single `npm install` (resolved astro 6.4.6 / starlight 0.39.3) + `npm run build` verified locally: 86 pages built, search index + sitemap clean. Supersedes #869 and #867.