### PR TITLE
docs(sdk): Recipes page + clarify any-orchestrator integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The trust primitives (compiler, branches, replay, lineage, contracts, cost attri
 - **AI is a growing surface, not a finished product.** The compile-validate loop (generate, type-check, auto-fix, then land) is shipped. The broader story (mass refactor across the DAG, auto-migration from a column-type change, schema-aware assertion generation) is on the roadmap.
 - **Iceberg.** REST-catalog source discovery is Beta. Content-addressed writes round-trip as Iceberg through Delta UniForm, shipped end-to-end. First-class Iceberg-native writes without the Delta intermediate are on the 2026 roadmap.
 - **No built-in semantic layer.** Rocky's typed IR is the right home for one. Today, integrate with Cube, the dbt Semantic Layer, or your existing metric store.
-- **Orchestration: Dagster is first-class.** For other Python callers, the [`rocky-sdk`](sdk/python/) typed client drives Rocky from notebooks, scripts, or any orchestrator. A `rocky serve` standalone path exists too; native Airflow and Prefect integrations are not yet shipped, so they're called from the CLI like any other binary.
+- **Orchestration: Dagster is the one turnkey integration ([`dagster-rocky`](integrations/dagster/)).** Every other orchestrator — Airflow, Prefect, Flyte, a cron script — integrates by wrapping the typed [`rocky-sdk`](sdk/python/) client (`RockyClient`) in a task; a `rocky serve` HTTP path exists too. Prebuilt operators/hooks beyond Dagster aren't shipped yet, but the SDK is the building block for them.
 
 If those gaps are blockers for your team, [open a discussion](https://github.com/rocky-data/rocky/discussions). The roadmap is shaped by where production pipelines are actually getting hurt.
 

--- a/docs/src/content/docs/python-sdk/introduction.md
+++ b/docs/src/content/docs/python-sdk/introduction.md
@@ -7,7 +7,7 @@ sidebar:
 
 `rocky-sdk` is a typed Python client for the Rocky engine. `RockyClient` wraps the `rocky` binary (subprocess plus `--output json`) behind one method per CLI command, parses the output into Pydantic models, and raises typed errors. It is for human Python callers: notebooks, scripts, and orchestrators other than Dagster.
 
-It is also the foundation the [`dagster-rocky`](/dagster/introduction/) integration is built on. `RockyResource` is a thin Dagster adapter over `RockyClient` that translates its errors into `dagster.Failure`. For AI agents, use `rocky mcp`; to call Rocky from another language over HTTP, use `rocky serve`.
+It is also the foundation the [`dagster-rocky`](/dagster/introduction/) integration is built on: `RockyResource` is a thin Dagster adapter over `RockyClient`. Dagster is the one *turnkey* integration — every other orchestrator (Airflow, Prefect, Flyte, a cron script) integrates with Rocky by wrapping this client in a task. See [Recipes](/python-sdk/recipes/) for streaming, error handling, `rocky serve` mode, and Airflow/Prefect examples. For AI agents, use `rocky mcp`; to call Rocky from another language over HTTP, use `rocky serve`.
 
 ## Install
 
@@ -93,6 +93,8 @@ except RockyCommandError as exc:
 - **Diagnostics:** `doctor`, `validate_migration`, `test_adapter`, `hooks_list`, `hooks_test`
 
 `run()` accepts a `log_callback` that receives the engine's stderr line by line, so you can stream progress wherever you want. Setting `server_url` routes `compile`, `lineage`, and `metrics` through a running `rocky serve` instead of a subprocess.
+
+Each method's full signature, parameters, and return type are in the [`RockyResource` reference](/dagster/resource/) — `RockyClient` exposes the same methods and configuration, since the Dagster resource delegates to it. Output model shapes are in the [JSON output reference](/reference/json-output/), and the `filter=` syntax in [Filters](/reference/filters/).
 
 ## Requirements
 

--- a/docs/src/content/docs/python-sdk/recipes.md
+++ b/docs/src/content/docs/python-sdk/recipes.md
@@ -1,0 +1,121 @@
+---
+title: Recipes
+description: Common rocky-sdk patterns — streaming, error handling, server mode, and orchestrator integration
+sidebar:
+  order: 2
+---
+
+Patterns that go past the [quickstart](/python-sdk/introduction/). Each uses
+`RockyClient` from `rocky-sdk`.
+
+## Stream live progress
+
+`run()` takes a `log_callback` that receives the engine's stderr line by line as
+the run executes. Route it to `print`, a logger, or your orchestrator's logging:
+
+```python
+import logging
+
+from rocky_sdk import RockyClient
+
+log = logging.getLogger("my_pipeline")
+client = RockyClient(config_path="rocky.toml")
+client.run(filter="tenant=acme", log_callback=log.info)
+```
+
+The typed `RunResult` still comes back when the run finishes; the callback is
+purely for live visibility.
+
+## Handle failures
+
+Errors are typed, so you branch on the cause rather than parsing a message:
+
+```python
+from rocky_sdk import RockyClient
+from rocky_sdk.exceptions import RockyCommandError, RockyTimeoutError
+
+client = RockyClient(config_path="rocky.toml", timeout_seconds=900)
+try:
+    client.run(filter="tenant=acme")
+except RockyTimeoutError as exc:
+    print(f"timed out after {exc.timeout_seconds}s")  # retry, alert, ...
+except RockyCommandError as exc:
+    print(f"exit {exc.returncode}: {exc.stderr_tail}")
+```
+
+### Partial success
+
+`run()` returns its `RunResult` even when some tables fail — it does not raise —
+so you can act on what landed and report the rest:
+
+```python
+run = client.run(filter="tenant=acme")
+if run.tables_failed:
+    for err in run.errors:
+        print(f"{'/'.join(err.asset_key)} failed: {err.error}")
+    # decide: raise, alert, or proceed with the tables that did succeed
+```
+
+To make a non-zero run raise instead of returning a partial result, call the
+lower-level `run_cli(args, allow_partial=False)`, which raises
+`RockyPartialFailure` (the partial JSON is on `exc.stdout`).
+
+## Use a long-lived server
+
+For repeated read-only calls, point the client at a running `rocky serve` instead
+of spawning a subprocess per call. Only `compile`, `lineage`, and `metrics` honor
+`server_url`; `run()` and the write paths always use a subprocess.
+
+```python
+client = RockyClient(config_path="rocky.toml", server_url="http://localhost:8080")
+client.compile()                    # served over HTTP
+client.lineage("revenue_summary")
+```
+
+## Run inside any orchestrator
+
+`rocky-sdk` is how a non-Dagster orchestrator integrates with Rocky: construct a
+`RockyClient` in a task and branch on the typed result. (Dagster users get the
+turnkey [`dagster-rocky`](/dagster/introduction/) integration instead.)
+
+**Airflow** — wrap a run in a `@task`:
+
+```python
+from airflow.decorators import task
+
+from rocky_sdk import RockyClient
+
+
+@task
+def materialize(tenant: str) -> int:
+    client = RockyClient(config_path="rocky.toml")
+    run = client.run(filter=f"tenant={tenant}")
+    if run.tables_failed:
+        raise RuntimeError(f"{run.tables_failed} tables failed: {run.errors}")
+    return len(run.materializations)
+```
+
+**Prefect** — the same client inside a `@flow`:
+
+```python
+from prefect import flow, task
+
+from rocky_sdk import RockyClient
+
+
+@task
+def materialize(tenant: str):
+    client = RockyClient(config_path="rocky.toml")
+    return client.run(filter=f"tenant={tenant}")
+
+
+@flow
+def rocky_pipeline(tenants: list[str]):
+    for tenant in tenants:
+        materialize(tenant)
+```
+
+These are illustrative — they need `apache-airflow` / `prefect` installed and the
+`rocky` binary on `PATH`. The pattern holds for any framework: construct a
+`RockyClient`, call the method you need, and branch on the typed result or the
+typed exception.


### PR DESCRIPTION
## What

Follow-up to the Python SDK docs: a recipes/patterns page and a clearer "any orchestrator can integrate" message.

**New `python-sdk/recipes.md`** (snippet-driven, the example-rich docs that were missing):
- streaming live progress with `log_callback`
- typed error handling — timeout retry, and partial success via `RunResult.tables_failed` / `errors` (vs the strict `run_cli(allow_partial=False)` → `RockyPartialFailure` path)
- `rocky serve` (`server_url`) mode
- **orchestrator integration** — Airflow `@task` and Prefect `@flow` snippets

**Clarify the orchestration story** (it was only implied, and the README undersold it):
- README orchestration bullet: Dagster is the one *turnkey* integration; every other orchestrator wraps the typed `rocky-sdk` client — not "called from the CLI like any other binary."
- SDK intro: same framing + cross-links to the existing method/output/filter reference (`RockyClient` mirrors `RockyResource`, so `resource.md` doubles as the method reference — no duplicate reference written).

## Notes

Deliberately *not* duplicating `dagster/resource.md` as a separate SDK method reference (drift risk), and the orchestrator snippets are illustrative (need `apache-airflow`/`prefect`), not CI-run.

## Verification

All 6 code blocks `ast`-parse clean; SDK fields/signatures verified against the package; docs site builds (87 pages, recipes page included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)