### PR TITLE
fix(engine): validate SQL identifiers in BigQuery/DuckDB loaders before interpolation

### DIFF
--- a/engine/crates/rocky-bigquery/src/loader.rs
+++ b/engine/crates/rocky-bigquery/src/loader.rs
@@ -44,6 +44,7 @@ use rocky_core::arrow_loader::{
     CsvBatchReader, RowBatch, generate_batch_insert_sql, infer_column_types,
 };
 use rocky_core::traits::WarehouseAdapter;
+use rocky_sql::validation::{validate_gcp_project_id, validate_identifier};
 
 use crate::BigQueryAdapter;
 use crate::connector::{
@@ -86,14 +87,24 @@ fn resolve_format(source: &LoadSource, options: &LoadOptions) -> AdapterResult<F
 
 /// Render a BigQuery target as `` `project`.`dataset`.`table` `` for the
 /// SQL (INSERT-fallback) path. Mirrors how the connector formats refs.
-fn format_target(target: &TableRef) -> String {
+///
+/// Every segment is validated before interpolation — the dataset and table as
+/// SQL identifiers, the project (catalog) as a GCP project id — so a malicious
+/// target (e.g. a discovered filename stem containing a backtick) can never
+/// break out of the identifier. Backtick-wrapping alone does not escape an
+/// embedded backtick, so validation is the guard, matching the Databricks and
+/// Snowflake loaders.
+fn format_target(target: &TableRef) -> AdapterResult<String> {
+    validate_identifier(&target.schema).map_err(AdapterError::new)?;
+    validate_identifier(&target.table).map_err(AdapterError::new)?;
     if target.catalog.is_empty() {
-        format!("`{}`.`{}`", target.schema, target.table)
+        Ok(format!("`{}`.`{}`", target.schema, target.table))
     } else {
-        format!(
+        validate_gcp_project_id(&target.catalog).map_err(AdapterError::new)?;
+        Ok(format!(
             "`{}`.`{}`.`{}`",
             target.catalog, target.schema, target.table
-        )
+        ))
     }
 }
 
@@ -127,9 +138,9 @@ fn build_create_table_sql(
     target_ref: &str,
     column_names: &[String],
     batches: &[RowBatch],
-) -> Option<String> {
+) -> AdapterResult<Option<String>> {
     if column_names.is_empty() {
-        return None;
+        return Ok(None);
     }
 
     // Inferred types keyed by column name; absent columns (e.g. a
@@ -139,18 +150,24 @@ fn build_create_table_sql(
         .map(|c| (c.name, c.data_type))
         .collect();
 
+    // Validate every header-derived column name before backtick-wrapping it.
+    // CSV headers are file content (the most plausibly untrusted input on this
+    // path), and a backtick in a header would otherwise break out of the
+    // identifier into arbitrary DDL — the Databricks and Snowflake CSV loaders
+    // validate here too.
     let col_defs: Vec<String> = column_names
         .iter()
         .map(|name| {
+            validate_identifier(name).map_err(AdapterError::new)?;
             let generic = inferred.get(name).map_or("STRING", String::as_str);
-            format!("`{name}` {}", bq_column_type(generic))
+            Ok(format!("`{name}` {}", bq_column_type(generic)))
         })
-        .collect();
+        .collect::<AdapterResult<Vec<String>>>()?;
 
-    Some(format!(
+    Ok(Some(format!(
         "CREATE TABLE IF NOT EXISTS {target_ref} ({})",
         col_defs.join(", ")
-    ))
+    )))
 }
 
 /// Map the SDK [`FileFormat`] to the BigQuery load-job source format.
@@ -269,7 +286,7 @@ impl LoaderAdapter for BigQueryLoaderAdapter {
                     )));
                 }
 
-                let target_ref = format_target(target);
+                let target_ref = format_target(target)?;
                 let file_size = std::fs::metadata(local_path)
                     .map(|m| m.len())
                     .unwrap_or_default();
@@ -307,7 +324,7 @@ impl LoaderAdapter for BigQueryLoaderAdapter {
                 // declared `id INT64`. Idempotent via IF NOT EXISTS — no
                 // DESCRIBE / existence round-trip.
                 if options.create_table
-                    && let Some(sql) = build_create_table_sql(&target_ref, &column_names, &batches)
+                    && let Some(sql) = build_create_table_sql(&target_ref, &column_names, &batches)?
                 {
                     debug!(sql = %sql, "ensuring target table exists with inferred types");
                     self.adapter
@@ -364,11 +381,11 @@ mod tests {
     #[test]
     fn test_format_target_fully_qualified() {
         let t = TableRef {
-            catalog: "proj".into(),
+            catalog: "my-proj".into(),
             schema: "ds".into(),
             table: "tbl".into(),
         };
-        assert_eq!(format_target(&t), "`proj`.`ds`.`tbl`");
+        assert_eq!(format_target(&t).unwrap(), "`my-proj`.`ds`.`tbl`");
     }
 
     #[test]
@@ -378,7 +395,29 @@ mod tests {
             schema: "ds".into(),
             table: "tbl".into(),
         };
-        assert_eq!(format_target(&t), "`ds`.`tbl`");
+        assert_eq!(format_target(&t).unwrap(), "`ds`.`tbl`");
+    }
+
+    #[test]
+    fn format_target_rejects_backtick_injection() {
+        // A discovered filename stem like `t`); DROP TABLE x; --` must not
+        // break out of the backtick-quoted identifier.
+        let t = TableRef {
+            catalog: String::new(),
+            schema: "ds".into(),
+            table: "t`); DROP TABLE x; --".into(),
+        };
+        assert!(format_target(&t).is_err());
+    }
+
+    #[test]
+    fn format_target_rejects_bad_project() {
+        let t = TableRef {
+            catalog: "proj`.`evil".into(),
+            schema: "ds".into(),
+            table: "tbl".into(),
+        };
+        assert!(format_target(&t).is_err());
     }
 
     #[test]
@@ -524,7 +563,9 @@ mod tests {
             row_count: 2,
         }];
         let cols = batches[0].column_names.clone();
-        let sql = build_create_table_sql("`p`.`d`.`t`", &cols, &batches).unwrap();
+        let sql = build_create_table_sql("`p`.`d`.`t`", &cols, &batches)
+            .unwrap()
+            .unwrap();
         assert_eq!(
             sql,
             "CREATE TABLE IF NOT EXISTS `p`.`d`.`t` \
@@ -548,7 +589,9 @@ mod tests {
         // nothing, so every column falls back to STRING — but all columns
         // are still present (no regression from the old header-derived path).
         let cols = vec!["id".to_string(), "name".to_string()];
-        let sql = build_create_table_sql("`p`.`d`.`t`", &cols, &[]).unwrap();
+        let sql = build_create_table_sql("`p`.`d`.`t`", &cols, &[])
+            .unwrap()
+            .unwrap();
         assert_eq!(
             sql,
             "CREATE TABLE IF NOT EXISTS `p`.`d`.`t` (`id` STRING, `name` STRING)"
@@ -557,7 +600,19 @@ mod tests {
 
     #[test]
     fn build_create_table_sql_no_columns_is_none() {
-        assert!(build_create_table_sql("`p`.`d`.`t`", &[], &[]).is_none());
+        assert!(
+            build_create_table_sql("`p`.`d`.`t`", &[], &[])
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn build_create_table_sql_rejects_backtick_header() {
+        // A CSV header column containing a backtick would otherwise break out
+        // of the `col` identifier into arbitrary DDL.
+        let cols = vec!["id".to_string(), "x` STRING); DROP TABLE y; --".to_string()];
+        assert!(build_create_table_sql("`p`.`d`.`t`", &cols, &[]).is_err());
     }
 
     #[test]

--- a/engine/crates/rocky-core/src/arrow_loader.rs
+++ b/engine/crates/rocky-core/src/arrow_loader.rs
@@ -56,6 +56,9 @@ pub enum BatchLoaderError {
 
     #[error("batch is empty — cannot generate INSERT SQL")]
     EmptyBatch,
+
+    #[error("invalid column name in CSV header: {0}")]
+    InvalidColumnName(String),
 }
 
 // ---------------------------------------------------------------------------
@@ -253,6 +256,16 @@ pub fn generate_batch_insert_sql(
 ) -> Result<String, BatchLoaderError> {
     if batch.rows.is_empty() {
         return Err(BatchLoaderError::EmptyBatch);
+    }
+
+    // Column names come from the CSV header (file content). Validate each as a
+    // SQL identifier before interpolating it into the column list, so a header
+    // like `id) VALUES (1); DROP TABLE x; --` cannot inject. This is the shared
+    // INSERT generator for the local-file fallback paths (e.g. BigQuery), so
+    // guarding here covers every caller.
+    for name in &batch.column_names {
+        rocky_sql::validation::validate_identifier(name)
+            .map_err(|e| BatchLoaderError::InvalidColumnName(format!("{name:?}: {e}")))?;
     }
 
     let col_list = batch.column_names.join(", ");
@@ -700,6 +713,20 @@ mod tests {
         assert!(sql.starts_with("INSERT INTO cat.sch.tbl (id, name) VALUES"));
         assert!(sql.contains("(1, 'Alice')"));
         assert!(sql.contains("(2, 'Bob')"));
+    }
+
+    #[test]
+    fn insert_sql_rejects_injecting_column_name() {
+        // A CSV header column that tries to break out of the column list must
+        // be rejected rather than interpolated.
+        let batch = RowBatch {
+            column_names: vec!["id".into(), "x) VALUES (1); DROP TABLE y; --".into()],
+            rows: vec![vec!["1".into(), "2".into()]],
+            row_count: 1,
+        };
+
+        let err = generate_batch_insert_sql(&batch, "t", &TestDialect).unwrap_err();
+        assert!(matches!(err, BatchLoaderError::InvalidColumnName(_)));
     }
 
     #[test]

--- a/engine/crates/rocky-duckdb/src/adapter.rs
+++ b/engine/crates/rocky-duckdb/src/adapter.rs
@@ -164,11 +164,11 @@ impl WarehouseAdapter for DuckDbWarehouseAdapter {
     }
 
     async fn describe_table(&self, table: &TableRef) -> AdapterResult<Vec<ColumnInfo>> {
-        let table_ref = if table.catalog.is_empty() {
-            format!("{}.{}", table.schema, table.table)
-        } else {
-            format!("{}.{}.{}", table.catalog, table.schema, table.table)
-        };
+        // Route through the dialect's validated formatter so identifiers are
+        // checked before interpolation, rather than building the ref inline.
+        let table_ref =
+            self.dialect()
+                .format_table_ref(&table.catalog, &table.schema, &table.table)?;
 
         let conn = Arc::clone(&self.connector);
         spawn_blocking(move || {

--- a/engine/crates/rocky-duckdb/src/loader.rs
+++ b/engine/crates/rocky-duckdb/src/loader.rs
@@ -23,6 +23,7 @@ use rocky_adapter_sdk::{
     AdapterError, AdapterResult, FileFormat, LoadOptions, LoadResult, LoadSource, LoaderAdapter,
     TableRef,
 };
+use rocky_sql::validation::validate_identifier;
 
 use crate::DuckDbConnector;
 
@@ -71,11 +72,18 @@ fn resolve_format(source: &LoadSource, options: &LoadOptions) -> AdapterResult<F
 
 /// Build a two-part DuckDB table reference (`schema.table`), falling back to
 /// just the table name when schema is empty.
-fn format_target(target: &TableRef) -> String {
+///
+/// Both identifiers are validated before interpolation. The target table is
+/// derived from `--table`, config, or a discovered filename stem, so a file
+/// named e.g. `evil; DROP TABLE x; --.csv` must not be able to drive arbitrary
+/// SQL. Matches the validation the Databricks and Snowflake loaders apply.
+fn format_target(target: &TableRef) -> AdapterResult<String> {
+    validate_identifier(&target.table).map_err(AdapterError::new)?;
     if target.schema.is_empty() {
-        target.table.clone()
+        Ok(target.table.clone())
     } else {
-        format!("{}.{}", target.schema, target.table)
+        validate_identifier(&target.schema).map_err(AdapterError::new)?;
+        Ok(format!("{}.{}", target.schema, target.table))
     }
 }
 
@@ -88,6 +96,36 @@ fn source_path_str(source: &LoadSource) -> String {
     }
 }
 
+/// Reject a `FROM '<path>'` literal that would break out of the surrounding
+/// `'...'` SQL string literal. Used for both local paths and cloud URIs.
+/// Rocky never escapes embedded quotes — instead we refuse to build the SQL,
+/// matching the Databricks and Snowflake loaders.
+fn validate_sql_path_literal(path: &str) -> AdapterResult<&str> {
+    if path.is_empty() {
+        return Err(AdapterError::msg("load source path cannot be empty"));
+    }
+    if path.contains(['\'', '\n', '\r', '\\']) {
+        return Err(AdapterError::msg(format!(
+            "invalid load source path {path:?}: must not contain quotes, backslashes, or newlines"
+        )));
+    }
+    Ok(path)
+}
+
+/// Reject CSV delimiters that would break out of the `'...'` SQL string
+/// literal. Allows printable ASCII plus tab; rejects quotes, backslash, and
+/// control characters. Matches the Databricks and Snowflake loaders.
+fn validate_csv_delimiter(c: char) -> AdapterResult<char> {
+    let ok = c == '\t' || (c.is_ascii() && !c.is_ascii_control() && c != '\'' && c != '\\');
+    if ok {
+        Ok(c)
+    } else {
+        Err(AdapterError::msg(format!(
+            "invalid CSV delimiter {c:?}: must be a printable ASCII char (or tab), not a quote, backslash, or control character"
+        )))
+    }
+}
+
 /// Build the COPY/read SQL for loading a source into a target table.
 ///
 /// The caller is responsible for handling `create_table` and `truncate_first`
@@ -97,8 +135,9 @@ fn load_sql(
     target_ref: &str,
     format: FileFormat,
     options: &LoadOptions,
-) -> String {
+) -> AdapterResult<String> {
     let path_str = source_path_str(source);
+    let path_str = validate_sql_path_literal(&path_str)?;
     match format {
         FileFormat::Csv => {
             let header = if options.csv_has_header {
@@ -106,34 +145,43 @@ fn load_sql(
             } else {
                 "HEADER false"
             };
-            let delim = options.csv_delimiter;
-            format!("COPY {target_ref} FROM '{path_str}' (DELIMITER '{delim}', {header})")
+            let delim = validate_csv_delimiter(options.csv_delimiter)?;
+            Ok(format!(
+                "COPY {target_ref} FROM '{path_str}' (DELIMITER '{delim}', {header})"
+            ))
         }
-        FileFormat::Parquet => {
-            format!("COPY {target_ref} FROM '{path_str}' (FORMAT PARQUET)")
-        }
+        FileFormat::Parquet => Ok(format!(
+            "COPY {target_ref} FROM '{path_str}' (FORMAT PARQUET)"
+        )),
         FileFormat::JsonLines => {
             // COPY ... FROM does not support JSONL; use read_json_auto which
             // handles newline-delimited JSON natively.
-            format!("INSERT INTO {target_ref} SELECT * FROM read_json_auto('{path_str}')")
+            Ok(format!(
+                "INSERT INTO {target_ref} SELECT * FROM read_json_auto('{path_str}')"
+            ))
         }
     }
 }
 
 /// Build a `CREATE TABLE ... AS SELECT` statement that infers the schema from
 /// the source itself, used when `create_table` is true.
-fn create_table_sql(source: &LoadSource, target_ref: &str, format: FileFormat) -> String {
+fn create_table_sql(
+    source: &LoadSource,
+    target_ref: &str,
+    format: FileFormat,
+) -> AdapterResult<String> {
     let path_str = source_path_str(source);
+    let path_str = validate_sql_path_literal(&path_str)?;
     match format {
-        FileFormat::Csv => {
-            format!("CREATE TABLE {target_ref} AS SELECT * FROM read_csv_auto('{path_str}')")
-        }
-        FileFormat::Parquet => {
-            format!("CREATE TABLE {target_ref} AS SELECT * FROM read_parquet('{path_str}')")
-        }
-        FileFormat::JsonLines => {
-            format!("CREATE TABLE {target_ref} AS SELECT * FROM read_json_auto('{path_str}')")
-        }
+        FileFormat::Csv => Ok(format!(
+            "CREATE TABLE {target_ref} AS SELECT * FROM read_csv_auto('{path_str}')"
+        )),
+        FileFormat::Parquet => Ok(format!(
+            "CREATE TABLE {target_ref} AS SELECT * FROM read_parquet('{path_str}')"
+        )),
+        FileFormat::JsonLines => Ok(format!(
+            "CREATE TABLE {target_ref} AS SELECT * FROM read_json_auto('{path_str}')"
+        )),
     }
 }
 
@@ -146,7 +194,7 @@ impl LoaderAdapter for DuckDbLoaderAdapter {
         options: &LoadOptions,
     ) -> AdapterResult<LoadResult> {
         let format = resolve_format(source, options)?;
-        let target_ref = format_target(target);
+        let target_ref = format_target(target)?;
         // Only local files have filesystem metadata; cloud sources report 0.
         let file_size = match source {
             LoadSource::LocalFile(p) => std::fs::metadata(p).map(|m| m.len()).unwrap_or_default(),
@@ -178,7 +226,7 @@ impl LoaderAdapter for DuckDbLoaderAdapter {
 
             if !table_exists && create_table {
                 // Let DuckDB infer the schema from the source.
-                let sql = create_table_sql(&source, &target_ref, format);
+                let sql = create_table_sql(&source, &target_ref, format)?;
                 debug!(sql = %sql, "creating table from source");
                 conn.execute_statement(&sql).map_err(AdapterError::new)?;
             } else {
@@ -189,7 +237,7 @@ impl LoaderAdapter for DuckDbLoaderAdapter {
                     conn.execute_statement(&sql).map_err(AdapterError::new)?;
                 }
 
-                let sql = load_sql(&source, &target_ref, format, &options);
+                let sql = load_sql(&source, &target_ref, format, &options)?;
                 debug!(sql = %sql, "loading source into existing table");
                 conn.execute_statement(&sql).map_err(AdapterError::new)?;
             }
@@ -476,7 +524,7 @@ mod tests {
             schema: "main".into(),
             table: "tbl".into(),
         };
-        assert_eq!(format_target(&t), "main.tbl");
+        assert_eq!(format_target(&t).unwrap(), "main.tbl");
     }
 
     #[test]
@@ -486,13 +534,35 @@ mod tests {
             schema: String::new(),
             table: "tbl".into(),
         };
-        assert_eq!(format_target(&t), "tbl");
+        assert_eq!(format_target(&t).unwrap(), "tbl");
+    }
+
+    #[test]
+    fn format_target_rejects_injecting_table_name() {
+        // A discovered filename stem like `evil; DROP TABLE x; --` must error,
+        // not flow into the table reference.
+        let t = TableRef {
+            catalog: String::new(),
+            schema: "main".into(),
+            table: "evil; DROP TABLE x; --".into(),
+        };
+        assert!(format_target(&t).is_err());
+    }
+
+    #[test]
+    fn format_target_rejects_injecting_schema_name() {
+        let t = TableRef {
+            catalog: String::new(),
+            schema: "main; DROP SCHEMA s".into(),
+            table: "tbl".into(),
+        };
+        assert!(format_target(&t).is_err());
     }
 
     #[test]
     fn test_load_sql_csv() {
         let src = LoadSource::LocalFile(PathBuf::from("/tmp/data.csv"));
-        let sql = load_sql(&src, "main.t", FileFormat::Csv, &LoadOptions::default());
+        let sql = load_sql(&src, "main.t", FileFormat::Csv, &LoadOptions::default()).unwrap();
         assert!(sql.contains("COPY main.t FROM '/tmp/data.csv'"));
         assert!(sql.contains("HEADER"));
         assert!(sql.contains("DELIMITER ','"));
@@ -501,7 +571,7 @@ mod tests {
     #[test]
     fn test_load_sql_parquet() {
         let src = LoadSource::LocalFile(PathBuf::from("/tmp/data.parquet"));
-        let sql = load_sql(&src, "main.t", FileFormat::Parquet, &LoadOptions::default());
+        let sql = load_sql(&src, "main.t", FileFormat::Parquet, &LoadOptions::default()).unwrap();
         assert_eq!(sql, "COPY main.t FROM '/tmp/data.parquet' (FORMAT PARQUET)");
     }
 
@@ -513,7 +583,8 @@ mod tests {
             "main.t",
             FileFormat::JsonLines,
             &LoadOptions::default(),
-        );
+        )
+        .unwrap();
         assert!(sql.contains("read_json_auto"));
         assert!(sql.contains("INSERT INTO main.t"));
     }
@@ -521,7 +592,7 @@ mod tests {
     #[test]
     fn test_load_sql_cloud_uri() {
         let src = LoadSource::CloudUri("s3://bucket/data.parquet".into());
-        let sql = load_sql(&src, "main.t", FileFormat::Parquet, &LoadOptions::default());
+        let sql = load_sql(&src, "main.t", FileFormat::Parquet, &LoadOptions::default()).unwrap();
         assert_eq!(
             sql,
             "COPY main.t FROM 's3://bucket/data.parquet' (FORMAT PARQUET)"
@@ -529,24 +600,47 @@ mod tests {
     }
 
     #[test]
+    fn load_sql_rejects_quote_bearing_path() {
+        // A path containing a single quote would break out of the '...' literal.
+        let src = LoadSource::LocalFile(PathBuf::from("/tmp/a'); DROP TABLE x; --.csv"));
+        assert!(load_sql(&src, "main.t", FileFormat::Csv, &LoadOptions::default()).is_err());
+    }
+
+    #[test]
+    fn load_sql_rejects_quote_bearing_delimiter() {
+        let src = LoadSource::LocalFile(PathBuf::from("/tmp/data.csv"));
+        let opts = LoadOptions {
+            csv_delimiter: '\'',
+            ..Default::default()
+        };
+        assert!(load_sql(&src, "main.t", FileFormat::Csv, &opts).is_err());
+    }
+
+    #[test]
     fn test_create_table_sql_csv() {
         let src = LoadSource::LocalFile(PathBuf::from("/tmp/d.csv"));
-        let sql = create_table_sql(&src, "main.t", FileFormat::Csv);
+        let sql = create_table_sql(&src, "main.t", FileFormat::Csv).unwrap();
         assert!(sql.contains("CREATE TABLE main.t AS SELECT * FROM read_csv_auto"));
     }
 
     #[test]
     fn test_create_table_sql_parquet() {
         let src = LoadSource::LocalFile(PathBuf::from("/tmp/d.parquet"));
-        let sql = create_table_sql(&src, "main.t", FileFormat::Parquet);
+        let sql = create_table_sql(&src, "main.t", FileFormat::Parquet).unwrap();
         assert!(sql.contains("read_parquet"));
     }
 
     #[test]
     fn test_create_table_sql_jsonl() {
         let src = LoadSource::LocalFile(PathBuf::from("/tmp/d.jsonl"));
-        let sql = create_table_sql(&src, "main.t", FileFormat::JsonLines);
+        let sql = create_table_sql(&src, "main.t", FileFormat::JsonLines).unwrap();
         assert!(sql.contains("read_json_auto"));
+    }
+
+    #[test]
+    fn create_table_sql_rejects_quote_bearing_path() {
+        let src = LoadSource::LocalFile(PathBuf::from("/tmp/a'.csv"));
+        assert!(create_table_sql(&src, "main.t", FileFormat::Csv).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## What

The BigQuery and DuckDB local-file loaders built SQL by interpolating target identifiers, CSV-header column names, source paths, and the CSV delimiter via `format!` **without** the validation the Databricks and Snowflake loaders already apply. This violates the engine invariant (CLAUDE.md): *SQL identifiers must be validated via `rocky-sql/validation` before interpolation — never use `format!()` to build SQL with untrusted input.* Backtick/quote wrapping alone does not escape an embedded backtick or quote, so validation is the guard.

## Changes

- **rocky-bigquery loader** — `format_target` validates dataset/table as identifiers and the project as a GCP project id; `build_create_table_sql` validates every CSV-header column name before backtick-wrapping.
- **rocky-core `arrow_loader`** — `generate_batch_insert_sql` (the shared INSERT generator for the local-file fallback paths) validates every column name. Fixing it here covers every caller.
- **rocky-duckdb loader** — `format_target` validates schema/table; source paths and the CSV delimiter are rejected when they contain quote/backslash/newline characters that would break out of the SQL string literal (mirrors `validate_sql_path_literal` / `validate_csv_delimiter` in the sibling loaders).
- **rocky-duckdb `describe_table`** — routes through the dialect's validated `format_table_ref` instead of building the reference inline.

## Testing

Each path gains a regression test asserting the previously-injectable input now **errors** (backtick-bearing column name, injecting table/schema name, quote-bearing path, quote-bearing delimiter). `cargo test` (rocky-core / rocky-bigquery / rocky-duckdb), `cargo clippy --all-targets -- -D warnings`, and `cargo fmt --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)