### PR TITLE
chore(vscode): bump @vscode/test-electron to 3.0.0 + CI Node 22

### DIFF
--- a/.github/workflows/vscode-ci.yml
+++ b/.github/workflows/vscode-ci.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: editors/vscode/package-lock.json
       - run: npm ci
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: editors/vscode/package-lock.json
       - run: npm ci

--- a/.github/workflows/vscode-release.yml
+++ b/.github/workflows/vscode-release.yml
@@ -54,7 +54,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: editors/vscode/package-lock.json
 

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -22,7 +22,7 @@
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@types/vscode": "1.120.0",
-        "@vscode/test-electron": "^2.5.2",
+        "@vscode/test-electron": "^3.0.0",
         "@vscode/vsce": "^3.9.1",
         "@xyflow/react": "^12.11.0",
         "esbuild": "^0.28.1",
@@ -3121,9 +3121,9 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
-      "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.0.0.tgz",
+      "integrity": "sha512-TY5mC7aAjxSLDXsyjhrG8cJHgc/HLdiE5lvtW7hABYQrY24Qwozzr5UoO3HiuAM4Hzz4b7K/eZlwrCILj94CcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3134,7 +3134,7 @@
         "semver": "^7.6.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@vscode/vsce": {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -999,7 +999,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@types/vscode": "1.120.0",
-    "@vscode/test-electron": "^2.5.2",
+    "@vscode/test-electron": "^3.0.0",
     "@vscode/vsce": "^3.9.1",
     "@xyflow/react": "^12.11.0",
     "esbuild": "^0.28.1",


### PR DESCRIPTION
`@vscode/test-electron` 2.5.2 → 3.0.0 (major). 3.0.0 requires **node>=22**, so this moves the vscode-ci `Test` job (`xvfb-run npm test`) and `vscode-release` from Node 20 → 22 in lockstep. `runTest.ts` uses the stable `runTests()` API — no code change needed.

Verified locally on Node 22: the Electron suite downloads VS Code 1.120.0, launches the extension host, and runs **14 passing**. CI's `Test` job re-verifies on Node 22.

Scope note: other workflows that `npm install` the vscode devDeps (codegen-drift, poc-counts) stay on Node 20 — there's no project `.npmrc engine-strict`, so the node>=22 devDep is a harmless install warning there, not a failure.