### PR TITLE
fix(vscode): run/compile code lenses spawn argv instead of a shell command string

### DIFF
--- a/editors/vscode/src/__tests__/codeLensModelArgs.test.ts
+++ b/editors/vscode/src/__tests__/codeLensModelArgs.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// VS Code mock — codeLens.ts only touches `vscode.EventEmitter` at module load
+// (a provider class field). The arg-builders under test are pure.
+// ---------------------------------------------------------------------------
+vi.mock("vscode", () => {
+  class EventEmitter {
+    event = (): { dispose(): void } => ({ dispose: (): void => undefined });
+    fire(): void {}
+    dispose(): void {}
+  }
+  return { EventEmitter };
+});
+
+vi.mock("../config", () => ({
+  getConfig: (): { serverPath: string } => ({ serverPath: "rocky" }),
+}));
+
+import { buildCompileModelArgs, buildRunModelArgs } from "../codeLens";
+
+// A model file name an attacker could plant in a cloned repo, packed with
+// shell metacharacters (PowerShell `$(...)`, backtick, quotes, `;`, `~`). The
+// security invariant is that this string travels as ONE literal argv element to
+// ProcessExecution, where no shell ever parses it — not concatenated into a
+// command string the way the old `Terminal.sendText` path did.
+const MALICIOUS = "$(calc); rm -rf ~ '\"`evil";
+
+describe("codeLens model task argv", () => {
+  it("run: model name is a single literal argv element", () => {
+    expect(buildRunModelArgs(MALICIOUS)).toEqual([
+      "run",
+      "--filter",
+      `name=${MALICIOUS}`,
+      "--output",
+      "json",
+    ]);
+  });
+
+  it("compile: model name is a single literal argv element", () => {
+    expect(buildCompileModelArgs(MALICIOUS)).toEqual([
+      "compile",
+      "--model",
+      MALICIOUS,
+      "--output",
+      "json",
+    ]);
+  });
+
+  it("never emits a joined shell string for the model name", () => {
+    // No argv element is the model name spliced together with the flags — the
+    // dangerous payload is always isolated in its own slot.
+    for (const args of [
+      buildRunModelArgs(MALICIOUS),
+      buildCompileModelArgs(MALICIOUS),
+    ]) {
+      expect(args.some((a) => a.includes(" --output "))).toBe(false);
+      expect(args).toContain("json");
+    }
+  });
+});

--- a/editors/vscode/src/codeLens.ts
+++ b/editors/vscode/src/codeLens.ts
@@ -1,7 +1,6 @@
 import * as path from "path";
 import * as vscode from "vscode";
 import { getConfig } from "./config";
-import { shellQuote } from "./shell";
 
 const SUPPORTED_EXTENSIONS = new Set([".rocky", ".sql"]);
 
@@ -130,34 +129,63 @@ function makeLens(
 }
 
 /**
- * Runs `rocky run --filter name=<model>` in the integrated terminal.
+ * Build the argv for `rocky run --filter name=<model> --output json`.
+ *
+ * The model name is a discrete argv element, never spliced into a shell command
+ * string. Exported so the security invariant (the model name reaches the CLI as
+ * one literal argument, with zero shell interpretation) can be unit-tested.
  */
-function runModelInTerminal(modelName: string): void {
-  const cfg = getConfig();
-  // Quote the entire `name=<model>` token together so the `name=` prefix sits
-  // inside the same shell-quoted argv slot as the value — keeps it a single
-  // argv element even if the model name contains shell metacharacters.
-  const cmd = `${shellQuote(cfg.serverPath)} run --filter ${shellQuote(`name=${modelName}`)} --output json`;
-  const terminal = vscode.window.createTerminal({
-    name: `Rocky: run ${modelName}`,
-    iconPath: new vscode.ThemeIcon("play"),
-  });
-  terminal.show();
-  terminal.sendText(cmd);
+export function buildRunModelArgs(modelName: string): string[] {
+  return ["run", "--filter", `name=${modelName}`, "--output", "json"];
 }
 
 /**
- * Runs `rocky compile --model <model>` in the integrated terminal.
+ * Build the argv for `rocky compile --model <model> --output json`. See
+ * [`buildRunModelArgs`] for the literal-argv-element invariant.
+ */
+export function buildCompileModelArgs(modelName: string): string[] {
+  return ["compile", "--model", modelName, "--output", "json"];
+}
+
+/**
+ * Execute a model-scoped rocky command as a VS Code task.
+ *
+ * Uses [`vscode.ProcessExecution`] with an argv array rather than a shell
+ * command string passed to `Terminal.sendText`, so the model name (derived from
+ * a workspace file name an attacker could control via a cloned repo) is passed
+ * as a single literal argument the shell never parses. Mirrors `taskProvider.ts`.
+ * The task terminal still streams live output, matching the previous UX.
+ */
+function runModelTask(args: string[], label: string): void {
+  const cfg = getConfig();
+  const exec = new vscode.ProcessExecution(cfg.serverPath, args);
+  const task = new vscode.Task(
+    { type: "rocky", command: args[0] },
+    vscode.TaskScope.Workspace,
+    label,
+    "rocky",
+    exec,
+  );
+  task.presentationOptions = {
+    reveal: vscode.TaskRevealKind.Always,
+    panel: vscode.TaskPanelKind.Dedicated,
+    clear: true,
+  };
+  void vscode.tasks.executeTask(task);
+}
+
+/**
+ * Runs `rocky run --filter name=<model>` as a task (argv, no shell).
+ */
+function runModelInTerminal(modelName: string): void {
+  runModelTask(buildRunModelArgs(modelName), `run ${modelName}`);
+}
+
+/**
+ * Runs `rocky compile --model <model>` as a task (argv, no shell).
  */
 function compileModelInTerminal(modelName: string): void {
-  const cfg = getConfig();
-  const cmd = `${shellQuote(cfg.serverPath)} compile --model ${shellQuote(modelName)} --output json`;
-  const terminal = vscode.window.createTerminal({
-    name: `Rocky: compile ${modelName}`,
-    iconPath: new vscode.ThemeIcon("file-code"),
-  });
-  terminal.show();
-  terminal.sendText(cmd);
+  runModelTask(buildCompileModelArgs(modelName), `compile ${modelName}`);
 }
 
 export function registerCodeLensProvider(


### PR DESCRIPTION
## What

The **Run Model** and **Compile Model** code lenses built a shell command string from the model file basename and fed it to `Terminal.sendText`:

```ts
const cmd = `${shellQuote(cfg.serverPath)} run --filter ${shellQuote(`name=${modelName}`)} --output json`;
terminal.sendText(cmd);
```

`shellQuote` emits cmd.exe-style quoting that does **not** neutralize PowerShell expansion on Windows, where the integrated terminal is PowerShell by default. A model file named e.g. `$(...).sql` in a cloned repo could turn one click on the inline lens into command execution. The model name is workspace-controlled (it is `path.basename(document.fileName)`).

## Fix

Build the invocation as a `vscode.Task` with `vscode.ProcessExecution(serverPath, args)` — an argv array, the pattern `taskProvider.ts` already uses — so the model name reaches the CLI as a **single literal argument** with zero shell interpretation. The task terminal still streams live output, matching the prior UX. `shellQuote` is no longer used by the code lenses (it remains for `info.ts`, whose only interpolated token is a hardcoded subcommand).

## Testing

New `codeLensModelArgs.test.ts` asserts that a model name packed with shell metacharacters (`$(calc); rm -rf ~ '\"\``) is carried as one discrete argv element, never spliced into a joined command string. `npm run compile`, `eslint`, and the host vitest suite (179 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)