### PR TITLE
perf(engine): replace O(M²) model lookups with HashMaps on the compile/DAG paths

### DIFF
--- a/engine/crates/rocky-cli/src/commands/dag.rs
+++ b/engine/crates/rocky-cli/src/commands/dag.rs
@@ -128,16 +128,25 @@ fn build_dag_output(
 
     let seed_map: HashMap<&str, &SeedFile> = seeds.iter().map(|s| (s.name.as_str(), s)).collect();
 
+    // Index incoming edges by target node once. The per-node
+    // `UnifiedDag::incoming_edges` call scanned every edge (O(nodes × edges));
+    // a single pass builds the same lookup in O(nodes + edges). Edge order
+    // within a node is preserved, so `depends_on` ordering is unchanged.
+    let mut incoming_by_node: HashMap<&unified_dag::NodeId, Vec<&unified_dag::UnifiedEdge>> =
+        HashMap::new();
+    for edge in &dag.edges {
+        incoming_by_node.entry(&edge.to).or_default().push(edge);
+    }
+
     // Project nodes.
     let nodes: Vec<DagNodeOutput> = dag
         .nodes
         .iter()
         .map(|node| {
-            let depends_on: Vec<String> = dag
-                .incoming_edges(&node.id)
-                .iter()
-                .map(|e| e.from.0.clone())
-                .collect();
+            let depends_on: Vec<String> = incoming_by_node
+                .get(&node.id)
+                .map(|edges| edges.iter().map(|e| e.from.0.clone()).collect())
+                .unwrap_or_default();
 
             let (target, strategy, freshness, partition_shape) = match node.kind {
                 NodeKind::Transformation => {

--- a/engine/crates/rocky-compiler/src/semantic.rs
+++ b/engine/crates/rocky-compiler/src/semantic.rs
@@ -245,10 +245,21 @@ pub fn build_semantic_graph(
         }
     }
 
+    // Index models by name once. `build_semantic_graph` runs on every compile
+    // (and every LSP recompile); resolving each model with the linear
+    // `Project::model` scan inside this per-model loop made the phase O(M²) in
+    // the project's model count — the `cold_compile` bench exercises it at 10k
+    // models. Mirrors the lookup map in `typecheck.rs`.
+    let model_by_name: HashMap<&str, &rocky_core::models::Model> = project
+        .models
+        .iter()
+        .map(|m| (m.config.name.as_str(), m))
+        .collect();
+
     // Process models in topological order
     for model_name in &project.execution_order {
-        let model = match project.model(model_name) {
-            Some(m) => m,
+        let model = match model_by_name.get(model_name.as_str()) {
+            Some(m) => *m,
             None => continue,
         };
 


### PR DESCRIPTION
## What

Two hot-path quadratic scans, both fixed by building a lookup map once instead of repeating a linear scan per item.

### `build_semantic_graph` (rocky-compiler) — the headline fix
The per-model loop resolved each model with `Project::model`, which is a linear `self.models.iter().find(...)`. Called once per model in `execution_order`, the semantic-graph phase was **O(M²)** in the project's model count. This phase runs on every `compile` / `plan` / `run` and every LSP recompile; the repo's own `cold_compile` bench exercises it at 10k models. Now a `HashMap<&str, &Model>` is built once before the loop (mirrors the existing pattern in `typecheck.rs`), collapsing it to O(M).

### `rocky dag` output builder (rocky-cli)
Building `DagOutput` called `UnifiedDag::incoming_edges(&node.id)` per node, and that helper scans **every** edge — O(nodes × edges). Now an incoming-edges-by-node map is built in one pass (O(nodes + edges)). Edge order within a node is preserved, so `depends_on` output is byte-identical.

## Testing

Behavior-preserving — no output changes. `cargo test -p rocky-compiler` (323) and the `rocky-cli` dag tests (11) pass; `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)