### PR TITLE
fix(rocky-core): redact state.valkey_url so the redis credential never leaks into the plan snapshot

### DIFF
--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -3263,11 +3263,15 @@
           ]
         },
         "valkey_url": {
-          "description": "Valkey/Redis URL for state persistence",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RedactedString"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Valkey/Redis URL for state persistence. May embed credentials, so the value is redacted in serialized config and logs."
         }
       },
       "type": "object"

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -1875,9 +1875,9 @@ export interface StateConfig {
    */
   valkey_prefix?: string | null;
   /**
-   * Valkey/Redis URL for state persistence
+   * Valkey/Redis URL for state persistence. May embed credentials, so the value is redacted in serialized config and logs.
    */
-  valkey_url?: string | null;
+  valkey_url?: RedactedString | null;
 }
 /**
  * Config for `rocky run --idempotency-key` dedup.

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -607,10 +607,13 @@ pub struct StateConfig {
     pub gcs_bucket: Option<String>,
     /// GCS key prefix (default: "rocky/state/")
     pub gcs_prefix: Option<String>,
-    /// Valkey/Redis URL for state persistence
-    // SECURITY: may embed credentials (`redis://:password@host`). Never log
-    // this value; redact it if it ever reaches an error/trace message.
-    pub valkey_url: Option<String>,
+    // Wrapped in `RedactedString`: serializes to "***" (e.g. in the plan
+    // config snapshot) and prints as `***` in Debug/logs, so the embedded
+    // credential never lands in the on-disk plan or a trace. Call `.expose()`
+    // at the point of use (state sync / idempotency) for the real URL.
+    /// Valkey/Redis URL for state persistence. May embed credentials, so the
+    /// value is redacted in serialized config and logs.
+    pub valkey_url: Option<RedactedString>,
     /// Valkey key prefix (default: "rocky:state:")
     pub valkey_prefix: Option<String>,
     /// Wall-clock budget (seconds) for each state transfer operation
@@ -7322,6 +7325,42 @@ pat = "pat_LEAKED_HERE"
         assert!(
             serialized.contains("client_123"),
             "client_id missing from snapshot"
+        );
+    }
+
+    /// Companion guard for the `config_snapshot` leak: a populated
+    /// `[state].valkey_url` (which may embed a redis password) must serialize
+    /// to `"***"` through the same `serde_json` path `rocky plan` snapshots
+    /// into the replication plan. Regression for the field being a plain
+    /// `String` outside the redaction model — that left the credential
+    /// cleartext in the on-disk plan file and in `Debug` output.
+    #[test]
+    fn rocky_config_serde_json_redacts_state_valkey_url() {
+        let cfg = parse(
+            r#"
+[adapter.default]
+type = "duckdb"
+path = ":memory:"
+
+[state]
+backend = "valkey"
+valkey_url = "rediss://default:VALKEY_PASSWORD_SECRET@valkey.example:6379"
+"#,
+        );
+
+        let serialized =
+            serde_json::to_string(&cfg).expect("RockyConfig must serialize via serde_json");
+        assert!(
+            !serialized.contains("VALKEY_PASSWORD_SECRET"),
+            "state.valkey_url password leaked into serde_json output: {serialized}"
+        );
+        assert!(serialized.contains("***"), "missing *** in {serialized}");
+
+        // Debug must also redact (StateConfig derives Debug).
+        let dbg = format!("{:?}", cfg.state);
+        assert!(
+            !dbg.contains("VALKEY_PASSWORD_SECRET"),
+            "state.valkey_url password leaked into Debug: {dbg}"
         );
     }
 

--- a/engine/crates/rocky-core/src/idempotency.rs
+++ b/engine/crates/rocky-core/src/idempotency.rs
@@ -227,7 +227,11 @@ impl IdempotencyBackend {
         match state_config.backend {
             StateBackend::Local => IdempotencyBackend::Local,
             StateBackend::Valkey => IdempotencyBackend::Valkey {
-                url: state_config.valkey_url.clone().unwrap_or_default(),
+                url: state_config
+                    .valkey_url
+                    .as_ref()
+                    .map(|s| s.expose().to_string())
+                    .unwrap_or_default(),
                 prefix: state_config
                     .valkey_prefix
                     .clone()
@@ -235,7 +239,11 @@ impl IdempotencyBackend {
                 mirror_to_redb: false,
             },
             StateBackend::Tiered => IdempotencyBackend::Valkey {
-                url: state_config.valkey_url.clone().unwrap_or_default(),
+                url: state_config
+                    .valkey_url
+                    .as_ref()
+                    .map(|s| s.expose().to_string())
+                    .unwrap_or_default(),
                 prefix: state_config
                     .valkey_prefix
                     .clone()
@@ -1097,7 +1105,9 @@ mod tests {
     fn tiered_backend_mirrors_to_redb() {
         let sc = StateConfig {
             backend: StateBackend::Tiered,
-            valkey_url: Some("redis://localhost:6379".into()),
+            valkey_url: Some(crate::redacted::RedactedString::new(
+                "redis://localhost:6379".into(),
+            )),
             ..StateConfig::default()
         };
         let backend = IdempotencyBackend::from_state_config(&sc);

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -17,6 +17,7 @@ use tracing::{Instrument, debug, info, info_span, warn};
 use crate::circuit_breaker::TransitionOutcome;
 use crate::config::{RetryConfig, StateBackend, StateConfig, StateUploadFailureMode};
 use crate::object_store::{ObjectStoreError, ObjectStoreProvider};
+use crate::redacted::RedactedString;
 use crate::retry::compute_backoff;
 use crate::retry_budget::RetryBudget;
 
@@ -640,7 +641,8 @@ async fn download_from_valkey(
 ) -> Result<(), StateSyncError> {
     let url = config
         .valkey_url
-        .as_deref()
+        .as_ref()
+        .map(RedactedString::expose)
         .ok_or_else(|| StateSyncError::MissingConfig("valkey".into(), "state.valkey_url".into()))?
         .to_string();
     let prefix = config
@@ -715,7 +717,8 @@ async fn upload_to_valkey(
 ) -> Result<(), StateSyncError> {
     let url = config
         .valkey_url
-        .as_deref()
+        .as_ref()
+        .map(RedactedString::expose)
         .ok_or_else(|| StateSyncError::MissingConfig("valkey".into(), "state.valkey_url".into()))?
         .to_string();
     let prefix = config
@@ -881,7 +884,8 @@ async fn probe_object_store(
 async fn probe_valkey(config: &StateConfig) -> Result<(), StateSyncError> {
     let url = config
         .valkey_url
-        .as_deref()
+        .as_ref()
+        .map(RedactedString::expose)
         .ok_or_else(|| StateSyncError::MissingConfig("valkey".into(), "state.valkey_url".into()))?
         .to_string();
     let prefix = config

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -3262,11 +3262,15 @@
           ]
         },
         "valkey_url": {
-          "description": "Valkey/Redis URL for state persistence",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RedactedString"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Valkey/Redis URL for state persistence. May embed credentials, so the value is redacted in serialized config and logs."
         }
       },
       "type": "object"

--- a/sdk/python/src/rocky_sdk/types_generated/rocky_project_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/rocky_project_schema.py
@@ -2839,7 +2839,7 @@ class StateConfig(BaseModel):
     """
     valkey_url: str | None = None
     """
-    Valkey/Redis URL for state persistence
+    Valkey/Redis URL for state persistence. May embed credentials, so the value is redacted in serialized config and logs.
     """
 
 


### PR DESCRIPTION
## What

`StateConfig.valkey_url` was a plain `String`. The redis connection URL can embed a password (`rediss://default:pw@host`), and `rocky plan` snapshots the whole `RockyConfig` into `ReplicationPlan.config_snapshot` via `serde_json::to_value` (written to the on-disk plan file). A plain `String` serializes cleartext, and `StateConfig` derives `Debug`, so the credential also printed cleartext in `{:?}`. The existing redaction guard test (`rocky_config_serde_json_redacts_adapter_secrets`) never set `[state].valkey_url`, so it stayed green while the field leaked.

## Fix

Wrap the field in `RedactedString` — the engine's secret type, already used for every adapter credential. It serializes to `"***"` through the **default** scope (which is exactly the scope `plan.rs` uses; `with_unredacted_scope` is only for config-file writers), and its `Debug`/`Display` are `***`. Consumers in `state_sync` and `idempotency` call `.expose()` at the point of use to get the real URL for the redis client.

## Codegen

`config.rs` backs `rocky-project.schema.json`. `RedactedString` delegates its `JsonSchema` to `String`, so the regenerated bindings keep the downstream Python type as `str | None` and the TS as the existing `RedactedString` (= string) alias — no breaking shape change. Schema + SDK + VS Code bindings regenerated via `just codegen` and committed (codegen-drift gate).

## Testing

Extends the `config_snapshot` guard test to set `[state].valkey_url` to a password-bearing URL and assert the secret is absent from **both** the `serde_json` output and `Debug`. `cargo test -p rocky-core` (1343), `clippy --all-targets -- -D warnings`, and `fmt --check` pass.

## Follow-ups (same class, out of scope here)

The `[adapter.*.cache] valkey_url` fields (4, ripple into `rocky-fivetran`) and the webhook `url`/`headers` (the header `HashMap` needs bespoke key-masking) are the same config-snapshot leak and are deferred to keep this change contained to `rocky-core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)