### PR TITLE
fix(rocky-cli): reject option-injecting base_ref in ci-diff/lineage-diff/preview

### DIFF
--- a/engine/crates/rocky-cli/src/commands/ci_diff.rs
+++ b/engine/crates/rocky-cli/src/commands/ci_diff.rs
@@ -34,6 +34,28 @@ struct ChangedFile {
     status: char,
 }
 
+/// Reject a `base_ref` that git would interpret as an option rather than a
+/// revision.
+///
+/// `base_ref` is operator- or CI-supplied (commonly wired from a PR/branch
+/// variable such as `${{ github.base_ref }}`). The diff helpers below pass it
+/// to `git diff` / `git ls-tree` / `git show` as a positional argument, so a
+/// value beginning with `-` could smuggle flags into those invocations
+/// (argument injection). Refs that begin with `-` are never valid revisions,
+/// and an empty ref is meaningless here, so rejecting both fully closes the
+/// vector without constraining legitimate refs (`origin/main`, `HEAD~3`, a SHA).
+pub(crate) fn validate_base_ref(base_ref: &str) -> Result<()> {
+    if base_ref.is_empty() {
+        anyhow::bail!("base ref must not be empty");
+    }
+    if base_ref.starts_with('-') {
+        anyhow::bail!(
+            "invalid base ref '{base_ref}': must not begin with '-' (git would read it as an option)"
+        );
+    }
+    Ok(())
+}
+
 /// Run `git diff --name-status` between `base_ref` and HEAD to find changed files.
 ///
 /// Uses three-dot syntax (`base...HEAD`) for merge-base semantics — this matches
@@ -480,6 +502,8 @@ pub(crate) fn compute_ci_diff(
     models_dir: &Path,
     cache_ttl_override: Option<u64>,
 ) -> Result<CiDiffData> {
+    validate_base_ref(base_ref)?;
+
     // Load cached source schemas once and seed both compiles (current
     // tree + base ref) with the same map so the resulting per-model
     // type diffs measure real schema drift rather than
@@ -724,6 +748,19 @@ pub fn run_ci_diff(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn validate_base_ref_rejects_option_injection() {
+        // A leading-dash ref would otherwise smuggle flags into the git
+        // invocations (e.g. via ${{ github.base_ref }} in CI).
+        assert!(validate_base_ref("--upload-pack=touch /tmp/pwned").is_err());
+        assert!(validate_base_ref("-foo").is_err());
+        assert!(validate_base_ref("").is_err());
+        // Legitimate revisions still pass.
+        assert!(validate_base_ref("origin/main").is_ok());
+        assert!(validate_base_ref("HEAD~3").is_ok());
+        assert!(validate_base_ref("abc1234").is_ok());
+    }
 
     // -----------------------------------------------------------------------
     // parse_name_status

--- a/engine/crates/rocky-cli/src/commands/preview.rs
+++ b/engine/crates/rocky-cli/src/commands/preview.rs
@@ -83,6 +83,10 @@ pub async fn run_preview_create(
 ) -> Result<()> {
     let start = Instant::now();
 
+    // `base_ref` is operator-/CI-supplied and flows into `git` as a positional
+    // argument; reject option-looking values before any git invocation.
+    crate::commands::ci_diff::validate_base_ref(base_ref)?;
+
     let head_ref = git_head_sha().unwrap_or_else(|_| "HEAD".to_string());
 
     // Step 1+2: identify changed model files between base and HEAD.


### PR DESCRIPTION
## What

`base_ref` is operator- or CI-supplied — commonly wired from a PR/branch variable such as `${{ github.base_ref }}` — and the diff helpers pass it straight to `git diff` / `git ls-tree` / `git show` as a **positional argument**. A value beginning with `-` would be read by git as an option, so an attacker-influenced base ref could smuggle flags into those invocations (argument injection). There was no validation or `--` separator.

## Fix

Validate `base_ref` at the two entry points where it arrives from the CLI:
- `compute_ci_diff` — shared by `rocky ci --diff` **and** `rocky lineage-diff`, so one guard covers both.
- `run_preview_create` — the `rocky preview` diff path.

The guard rejects an empty ref and any ref beginning with `-`. That fully closes the option-injection vector (a leading-dash string is never a valid revision) without constraining legitimate refs — `origin/main`, `HEAD~3`, a bare SHA all pass. Validation is portable, unlike `--end-of-options` (which needs a recent git).

## Testing

`validate_base_ref_rejects_option_injection` asserts `--upload-pack=…`, `-foo`, and `""` error while `origin/main` / `HEAD~3` / a SHA pass. `cargo test -p rocky-cli`, `clippy --all-targets -- -D warnings`, and `fmt --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)