### PR TITLE
chore(release): quad-cut engine 1.51.1 / sdk 0.1.1 / dagster 1.49.0 / vscode 1.33.1

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.33.1] — 2026-06-14
+
+### Security
+
+- **Run and compile code lenses spawn `rocky` via argv instead of a shell command string.** A workspace path containing shell metacharacters can no longer trigger command execution when a code lens runs. (#889)
+
+### Changed
+
+- Bumped `vscode-languageclient` to 10 and `@vscode/test-electron` to 3.0.0, with CI on Node 22, plus assorted dev-dependency refreshes. (#882, #888)
+- Regenerated the `rocky-project` schema + TypeScript bindings for the `state.valkey_url` redaction. (#892)
+
 ## [1.33.0] — 2026-06-08
 
 ### Changed

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocky",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocky",
-      "version": "1.33.0",
+      "version": "1.33.1",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^10.0.0"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.51.1] — 2026-06-14
+
+### Security
+
+- **The BigQuery and DuckDB loaders validate SQL identifiers before interpolating them.** Table and column names that reach the bulk-load path are now checked against an allowlist rather than being formatted directly into the generated SQL. (#887)
+- **`state.valkey_url` is redacted from the plan snapshot.** The Valkey/Redis connection string (which can carry a password) is masked in serialized plan output, so the credential never lands in the snapshot on disk or in logs. (#892)
+- **`ci-diff`, `lineage-diff`, and `preview` reject an option-injecting `base_ref`.** A `base_ref` beginning with `-` can no longer be smuggled through to git as an option. (#893)
+
+### Fixed
+
+- **The LSP no longer panics on multi-byte UTF-8.** Truncation and indexing in the language server are now char-boundary-safe, so a document containing non-ASCII text doesn't crash `rocky lsp`. (#891)
+
+### Changed
+
+- **Compile and DAG model lookups are hash-map-backed.** Replacing the previous linear scans removes O(M²) behavior on large projects. (#890)
+
 ## [1.51.0] — 2026-06-08
 
 ### Added

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.51.0"
+version = "1.51.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.51.0"
+version = "1.51.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.51.0"
+version = "1.51.1"
 dependencies = [
  "indexmap",
  "reqwest 0.12.28",
@@ -3842,7 +3842,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.51.0"
+version = "1.51.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.51.0"
+version = "1.51.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3887,7 +3887,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.51.0"
+version = "1.51.1"
 dependencies = [
  "redis",
  "serde",
@@ -3899,7 +3899,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.51.0"
+version = "1.51.1"
 dependencies = [
  "async-trait",
  "serde",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.51.0"
+version = "1.51.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3963,7 +3963,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.51.0"
+version = "1.51.1"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -3990,7 +3990,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.51.0"
+version = "1.51.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4030,7 +4030,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.51.0"
+version = "1.51.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4056,7 +4056,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.51.0"
+version = "1.51.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4075,7 +4075,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.51.0"
+version = "1.51.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.51.0"
+version = "1.51.1"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4124,7 +4124,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.51.0"
+version = "1.51.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4149,7 +4149,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.51.0"
+version = "1.51.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -4162,7 +4162,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.51.0"
+version = "1.51.1"
 dependencies = [
  "logos",
  "miette",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.51.0"
+version = "1.51.1"
 dependencies = [
  "rocky-server",
  "rustls",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.51.0"
+version = "1.51.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4208,7 +4208,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.51.0"
+version = "1.51.1"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4226,7 +4226,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.51.0"
+version = "1.51.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.51.0"
+version = "1.51.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -4283,7 +4283,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.51.0"
+version = "1.51.1"
 dependencies = [
  "miette",
  "regex",
@@ -4296,7 +4296,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.51.0"
+version = "1.51.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4319,7 +4319,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.51.0"
+version = "1.51.1"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.51.0"
+version = "1.51.1"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.51.0"
+version = "1.51.1"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.51.0"
+version = "1.51.1"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.51.0"
+version = "1.51.1"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.51.0"
+version = "1.51.1"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.51.0"
+version = "1.51.1"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.51.0"
+version = "1.51.1"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.51.0"
+version = "1.51.1"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.51.0"
+version = "1.51.1"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.51.0"
+version = "1.51.1"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.51.0"
+version = "1.51.1"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.51.0"
+version = "1.51.1"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.51.0"
+version = "1.51.1"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.51.0"
+version = "1.51.1"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.51.0"
+version = "1.51.1"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.51.0"
+version = "1.51.1"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.51.0"
+version = "1.51.1"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.51.0"
+version = "1.51.1"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.51.0"
+version = "1.51.1"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.51.0"
+version = "1.51.1"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.51.0"
+version = "1.51.1"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.51.0"
+version = "1.51.1"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.51.0"
+version = "1.51.1"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.51.0"
+version = "1.51.1"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.51.0"
+version = "1.51.1"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.49.0] — 2026-06-14
+
+### Changed
+
+- **`dagster-rocky` now delegates to the standalone `rocky-sdk`.** The typed result models and the `RockyClient` they back moved into the `rocky-sdk` package; `dagster-rocky` is now a thin Dagster adapter over it and floors on `rocky-sdk>=0.1.0`. `dagster_rocky.types` and `dagster_rocky.types_generated` re-export the SDK's surface, so existing `from dagster_rocky import RunResult` / `parse_rocky_output` imports keep working unchanged. (#874)
+- Refreshed locked dependencies (dagster 1.13.9, ruff 0.15.17, structlog 26.1.0). (#884)
+
 ## [1.48.0] — 2026-06-08
 
 ### Changed

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.48.0"
+version = "1.49.0"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -220,7 +220,7 @@ wheels = [
 
 [[package]]
 name = "dagster-rocky"
-version = "1.48.0"
+version = "1.49.0"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },
@@ -910,7 +910,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "../../sdk/python" }
 dependencies = [
     { name = "pydantic" },

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1] — 2026-06-14
+
+### Added
+
+- **Runnable quickstart example** (`examples/quickstart.py`) plus a real-binary CI smoke test that exercises it against an actual `rocky` build. (#876)
+
+### Changed
+
+- Refreshed locked dev-dependencies (datamodel-code-generator 0.63.0, ruff 0.15.17). (#885)
+
+## [0.1.0] — 2026-06-12
+
+### Added
+
+- Initial release of `rocky-sdk` — a standalone, typed Python client (`RockyClient`) over the `rocky` CLI, owning the generated Pydantic result models and the `RockyError` hierarchy. `dagster-rocky` now delegates to it. (#874)
+
+See [GitHub Releases](https://github.com/rocky-data/rocky/releases) for detailed release notes.

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rocky-sdk"
-version = "0.1.0"
+version = "0.1.1"
 description = "Typed Python client for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Consolidated release of all four Rocky artifacts. Version bumps + changelogs only — no behavior changes beyond what already merged to `main` since the last cut.

## Engine → 1.51.1 (patch)
Security + robustness hardening, no new surface:
- **Security:** SQL-identifier validation in the BigQuery/DuckDB loaders (#887); `state.valkey_url` redacted from the plan snapshot (#892); `ci-diff`/`lineage-diff`/`preview` reject an option-injecting `base_ref` (#893).
- **Fixed:** LSP no longer panics on multi-byte UTF-8 (#891).
- **Changed:** compile/DAG model lookups are hash-map-backed, removing O(M²) behavior (#890).

## rocky-sdk → 0.1.1 (patch)
- Runnable quickstart example + real-binary CI smoke (#876); dev-dep refresh (#885). First `CHANGELOG.md` for the package.

## dagster-rocky → 1.49.0 (minor)
- `dagster-rocky` now delegates to the standalone `rocky-sdk` and floors on `rocky-sdk>=0.1.0`; `dagster_rocky.types` re-exports the SDK surface so existing imports are unchanged (#874). Dep refresh (#884).

## rocky VS Code extension → 1.33.1 (patch)
- **Security:** run/compile code lenses spawn `rocky` via argv instead of a shell string (#889).
- **Changed:** `vscode-languageclient` → 10, `@vscode/test-electron` → 3.0.0 (CI on Node 22), dep refreshes (#882, #888); regenerated bindings for the valkey_url redaction (#892).

## Release ordering
`rocky-sdk 0.1.0` is already on PyPI, so the `rocky-sdk>=0.1.0` floor for dagster-rocky is satisfied. After merge, tag the merged commit with all four namespaced tags (`engine-v1.51.1`, `sdk-v0.1.1`, `dagster-v1.49.0`, `vscode-v1.33.1`) — pushing `engine-v1.51.1` last (or `gh release edit --latest`) to win the isLatest race.

## Verification
- All 25 engine crate versions + `Cargo.lock` synced to 1.51.1 (`cargo update --workspace`); `uv.lock` relocked for sdk + dagster; both vscode `package-lock.json` self-version fields bumped.
- No hardcoded version strings in source/tests/fixtures; no codegen-affecting changes (schemas don't embed crate versions). CI (engine-ci / dagster-ci / sdk-ci / vscode + codegen-drift) gates the rest.