### PR TITLE
feat(engine): execute fixture-driven unit tests in `rocky test`

### DIFF
--- a/editors/vscode/src/types/generated/test.ts
+++ b/editors/vscode/src/types/generated/test.ts
@@ -6,6 +6,11 @@
  */
 
 /**
+ * Type of row mismatch.
+ */
+export type MismatchKind = "missing" | "extra" | "value_diff";
+
+/**
  * JSON output for `rocky test`.
  */
 export interface TestOutput {
@@ -22,6 +27,10 @@ export interface TestOutput {
   model_results?: ModelTestResult[];
   passed: number;
   total: number;
+  /**
+   * Results from fixture-driven `[[test]]` unit tests in model sidecars. Present only when at least one model declares a `[[test]]` block.
+   */
+  unit_tests?: UnitTestSummary | null;
   version: string;
   [k: string]: unknown;
 }
@@ -95,5 +104,51 @@ export interface ModelTestResult {
    * `"pass"` or `"fail"`.
    */
   status: string;
+  [k: string]: unknown;
+}
+/**
+ * Summary of fixture-driven unit-test execution (from `[[test]]` blocks in model sidecars). The per-test `results` reuse the engine's [`rocky_core::unit_test::UnitTestResult`] shape (model, test, passed, error, and row-level mismatches).
+ */
+export interface UnitTestSummary {
+  failed: number;
+  passed: number;
+  results: UnitTestResult[];
+  total: number;
+  [k: string]: unknown;
+}
+/**
+ * Result of running a single unit test.
+ */
+export interface UnitTestResult {
+  /**
+   * Error message if failed.
+   */
+  error?: string | null;
+  /**
+   * Mismatched rows (for diagnostics).
+   */
+  mismatches?: RowMismatch[];
+  /**
+   * Model name.
+   */
+  model: string;
+  /**
+   * Whether the test passed.
+   */
+  passed: boolean;
+  /**
+   * Test name.
+   */
+  test: string;
+  [k: string]: unknown;
+}
+/**
+ * A single row mismatch between expected and actual output.
+ */
+export interface RowMismatch {
+  actual?: string | null;
+  expected: string;
+  kind: MismatchKind;
+  row_index: number;
   [k: string]: unknown;
 }

--- a/engine/crates/rocky-cli/src/commands/test.rs
+++ b/engine/crates/rocky-cli/src/commands/test.rs
@@ -12,7 +12,7 @@ use rocky_core::traits::WarehouseAdapter;
 
 use crate::output::{
     DeclarativeTestResult, DeclarativeTestSummary, ModelTestResult, TestFailure, TestOutput,
-    print_json,
+    UnitTestSummary, print_json,
 };
 use crate::registry::{self, AdapterRegistry};
 
@@ -32,6 +32,20 @@ fn to_output_results(
             error: r.error.clone(),
         })
         .collect()
+}
+
+/// Build the JSON-output unit-test summary from the engine runner, or `None`
+/// when the project declares no `[[test]]` blocks.
+fn unit_summary(run: &rocky_engine::test_runner::UnitTestRun) -> Option<UnitTestSummary> {
+    if run.results.is_empty() {
+        return None;
+    }
+    Some(UnitTestSummary {
+        total: run.total(),
+        passed: run.passed(),
+        failed: run.total() - run.passed(),
+        results: run.results.clone(),
+    })
 }
 
 /// Side-effect-free core of `rocky test` (DuckDB-based local tests): run the
@@ -56,7 +70,13 @@ pub fn test_output(
         })
         .collect();
     let model_results = to_output_results(&result.model_results);
-    Ok(TestOutput::new(result.total, result.passed, failures).with_model_results(model_results))
+    let mut output =
+        TestOutput::new(result.total, result.passed, failures).with_model_results(model_results);
+    let unit_run = rocky_engine::test_runner::run_unit_tests(models_dir, model_filter)?;
+    if let Some(summary) = unit_summary(&unit_run) {
+        output = output.with_unit_tests(summary);
+    }
+    Ok(output)
 }
 
 /// Execute `rocky test` (DuckDB-based local tests).
@@ -67,6 +87,8 @@ pub fn run_test(
     output_json: bool,
 ) -> Result<()> {
     let result = rocky_engine::test_runner::run_tests(models_dir, contracts_dir, model_filter)?;
+    let unit_run = rocky_engine::test_runner::run_unit_tests(models_dir, model_filter)?;
+    let unit_failed = unit_run.total() - unit_run.passed();
 
     if output_json {
         let failures: Vec<TestFailure> = result
@@ -78,8 +100,11 @@ pub fn run_test(
             })
             .collect();
         let model_results = to_output_results(&result.model_results);
-        let output = TestOutput::new(result.total, result.passed, failures)
+        let mut output = TestOutput::new(result.total, result.passed, failures)
             .with_model_results(model_results);
+        if let Some(summary) = unit_summary(&unit_run) {
+            output = output.with_unit_tests(summary);
+        }
         print_json(&output)?;
     } else {
         let scope = match model_filter {
@@ -114,9 +139,27 @@ pub fn run_test(
             result.passed,
             result.failures.len()
         );
+
+        if unit_run.total() > 0 {
+            println!();
+            println!(
+                "  Unit tests: {} passed, {unit_failed} failed",
+                unit_run.passed()
+            );
+            for r in &unit_run.results {
+                if !r.passed {
+                    println!(
+                        "  \u{2717} {}::{} — {}",
+                        r.model,
+                        r.test,
+                        r.error.as_deref().unwrap_or("output mismatch")
+                    );
+                }
+            }
+        }
     }
 
-    if !result.failures.is_empty() {
+    if !result.failures.is_empty() || unit_failed > 0 {
         anyhow::bail!("test failures detected");
     }
 

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -1476,6 +1476,10 @@ pub struct TestOutput {
     /// Present only when `--declarative` is used.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub declarative: Option<DeclarativeTestSummary>,
+    /// Results from fixture-driven `[[test]]` unit tests in model sidecars.
+    /// Present only when at least one model declares a `[[test]]` block.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unit_tests: Option<UnitTestSummary>,
 }
 
 /// One failed test, mirroring the (name, error) tuple in
@@ -1536,6 +1540,18 @@ pub struct DeclarativeTestResult {
     pub sql: String,
 }
 
+/// Summary of fixture-driven unit-test execution (from `[[test]]` blocks in
+/// model sidecars). The per-test `results` reuse the engine's
+/// [`rocky_core::unit_test::UnitTestResult`] shape (model, test, passed,
+/// error, and row-level mismatches).
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct UnitTestSummary {
+    pub total: usize,
+    pub passed: usize,
+    pub failed: usize,
+    pub results: Vec<rocky_core::unit_test::UnitTestResult>,
+}
+
 impl TestOutput {
     pub fn new(total: usize, passed: usize, failures: Vec<TestFailure>) -> Self {
         TestOutput {
@@ -1547,6 +1563,7 @@ impl TestOutput {
             failures,
             model_results: Vec::new(),
             declarative: None,
+            unit_tests: None,
         }
     }
 
@@ -1554,6 +1571,12 @@ impl TestOutput {
     /// so callers can chain it onto `new(...)`.
     pub fn with_model_results(mut self, results: Vec<ModelTestResult>) -> Self {
         self.model_results = results;
+        self
+    }
+
+    /// Attach fixture-driven unit-test results. Returns `self` for chaining.
+    pub fn with_unit_tests(mut self, summary: UnitTestSummary) -> Self {
+        self.unit_tests = Some(summary);
         self
     }
 }

--- a/engine/crates/rocky-core/src/models.rs
+++ b/engine/crates/rocky-core/src/models.rs
@@ -10,6 +10,7 @@ use crate::config::{ModelBudgetConfig, substitute_env_vars};
 use crate::lakehouse::{LakehouseFormat, LakehouseOptions};
 use crate::retention::{RetentionParseError, RetentionPolicy};
 use crate::tests::TestDecl;
+use crate::unit_test::UnitTestDef;
 use rocky_ir::dag::DagNode;
 use rocky_ir::{
     CostBudget, GovernanceConfig, MaterializationStrategy, ModelIr, SourceRef, TargetRef, TimeGrain,
@@ -1010,6 +1011,71 @@ pub fn load_models_from_dir(dir: &Path) -> Result<Vec<Model>, ModelError> {
 
     models.sort_unstable_by(|a, b| a.config.name.cmp(&b.config.name));
     Ok(models)
+}
+
+/// Minimal sidecar view capturing only the model `name` and its fixture-driven
+/// unit tests (`[[test]]` blocks), ignoring all other config keys.
+#[derive(Deserialize)]
+struct UnitTestSidecar {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    test: Vec<UnitTestDef>,
+}
+
+/// Load fixture-driven unit tests (`[[test]]` blocks) declared across a models
+/// directory, keyed by model name.
+///
+/// Loaded independently of [`load_models_from_dir`] — but matching its flat,
+/// sidecar-preferred discovery — so the test runner can pair each model's unit
+/// tests with its compiled SQL without threading them through the compiler IR.
+/// A model's name is its sidecar `name` field, or the file stem. Files that
+/// declare no `[[test]]` blocks are omitted from the map.
+pub fn load_unit_tests_from_dir(
+    dir: &Path,
+) -> Result<std::collections::HashMap<String, Vec<UnitTestDef>>, ModelError> {
+    let mut out = std::collections::HashMap::new();
+    if !dir.exists() {
+        return Ok(out);
+    }
+    for entry in std::fs::read_dir(dir)? {
+        let path = entry?.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("sql") {
+            continue;
+        }
+        let stem = path
+            .file_stem()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_default();
+
+        // Sidecar `.toml` is preferred; fall back to inline `---toml` frontmatter.
+        let toml_path = path.with_extension("toml");
+        let toml_src = if toml_path.exists() {
+            std::fs::read_to_string(&toml_path)?
+        } else {
+            let content = std::fs::read_to_string(&path)?;
+            match split_frontmatter(&content) {
+                Some((frontmatter, _)) => frontmatter.to_string(),
+                None => continue,
+            }
+        };
+
+        let substituted =
+            substitute_env_vars(&toml_src).map_err(|source| ModelError::EnvSubstitution {
+                path: path.display().to_string(),
+                source: Box::new(source),
+            })?;
+        let sidecar: UnitTestSidecar =
+            toml::from_str(&substituted).map_err(|e| ModelError::ParseFrontmatter {
+                path: path.display().to_string(),
+                source: e,
+            })?;
+        if sidecar.test.is_empty() {
+            continue;
+        }
+        out.insert(sidecar.name.unwrap_or(stem), sidecar.test);
+    }
+    Ok(out)
 }
 
 fn split_frontmatter(content: &str) -> Option<(&str, &str)> {

--- a/engine/crates/rocky-core/src/unit_test.rs
+++ b/engine/crates/rocky-core/src/unit_test.rs
@@ -17,7 +17,7 @@
 //!     { id = 3, amount = 200.0, status = "cancelled" },
 //! ]
 //!
-//! [[test.expect]]
+//! [test.expect]
 //! rows = [
 //!     { id = 1, amount = 150.0, is_high_value = true },
 //!     { id = 3, amount = 200.0, is_high_value = true },
@@ -99,6 +99,21 @@ pub enum MismatchKind {
     Extra,
     /// Row exists in both but values differ.
     ValueDiff,
+}
+
+/// Render a JSON scalar to a DuckDB SQL literal.
+///
+/// Strings are single-quote escaped; numbers and bools pass through their
+/// canonical text form; anything else (including `null`, arrays, objects) is
+/// rendered as `NULL`. Shared by [`fixture_to_sql`] and the unit-test runner's
+/// expected-table builder so both stringify values identically.
+pub fn json_to_sql_literal(value: &JsonValue) -> String {
+    match value {
+        JsonValue::String(s) => format!("'{}'", s.replace('\'', "''")),
+        JsonValue::Number(n) => n.to_string(),
+        JsonValue::Bool(b) => b.to_string(),
+        _ => "NULL".to_string(),
+    }
 }
 
 /// Generate DuckDB SQL to create a temporary table from fixture rows.

--- a/engine/crates/rocky-engine/src/test_runner.rs
+++ b/engine/crates/rocky-engine/src/test_runner.rs
@@ -7,7 +7,12 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use rocky_compiler::compile::CompilerConfig;
+use rocky_core::models::load_unit_tests_from_dir;
+use rocky_core::unit_test::{
+    MismatchKind, RowMismatch, UnitTestDef, UnitTestResult, fixture_to_sql, json_to_sql_literal,
+};
 use rocky_duckdb::DuckDbConnector;
+use rocky_sql::validation::validate_identifier;
 use tracing::info;
 
 /// Per-model outcome of a local test run.
@@ -173,6 +178,359 @@ fn include_model(filter: Option<&str>, model: &str) -> bool {
     }
 }
 
+/// Outcome of running all fixture-driven unit tests (`[[test]]` blocks) in a
+/// project. Each [`UnitTestResult`] records one test's pass/fail against its
+/// mock-input → expected-output expectation.
+#[derive(Debug)]
+pub struct UnitTestRun {
+    pub results: Vec<UnitTestResult>,
+}
+
+impl UnitTestRun {
+    /// Total unit tests executed.
+    pub fn total(&self) -> usize {
+        self.results.len()
+    }
+
+    /// Unit tests that passed.
+    pub fn passed(&self) -> usize {
+        self.results.iter().filter(|r| r.passed).count()
+    }
+}
+
+/// Run every fixture-driven unit test (`[[test]]` blocks) declared in the
+/// project's model sidecars.
+///
+/// For each test a fresh in-memory DuckDB is seeded with the `given` fixtures,
+/// the model's compiled SQL is materialized against them, and the output is
+/// compared to `expect` — a multiset comparison by default, positional when
+/// `expect.ordered` is set. Models are filtered by `model_filter` when set;
+/// models declaring no `[[test]]` blocks are skipped entirely (no compile).
+pub fn run_unit_tests(
+    models_dir: &Path,
+    model_filter: Option<&str>,
+) -> anyhow::Result<UnitTestRun> {
+    let unit_tests = load_unit_tests_from_dir(models_dir)?;
+    if unit_tests.is_empty() {
+        return Ok(UnitTestRun {
+            results: Vec::new(),
+        });
+    }
+
+    let config = CompilerConfig {
+        models_dir: models_dir.to_path_buf(),
+        ..Default::default()
+    };
+    let compile_result = rocky_compiler::compile::compile(&config)?;
+
+    // Stable, name-sorted iteration so output order is deterministic.
+    let mut names: Vec<&String> = unit_tests.keys().collect();
+    names.sort();
+
+    let mut results = Vec::new();
+    for name in names {
+        if !include_model(model_filter, name) {
+            continue;
+        }
+        let compiled_sql = compile_result.project.model(name).map(|m| m.sql.clone());
+        for test in &unit_tests[name] {
+            match &compiled_sql {
+                Some(sql) => results.push(run_one_unit_test(name, sql, test)),
+                None => results.push(UnitTestResult {
+                    model: name.clone(),
+                    test: test.name.clone(),
+                    passed: false,
+                    error: Some(format!(
+                        "model '{name}' did not compile — cannot run its unit tests"
+                    )),
+                    mismatches: Vec::new(),
+                }),
+            }
+        }
+    }
+
+    info!(
+        total = results.len(),
+        passed = results.iter().filter(|r| r.passed).count(),
+        "unit test run complete"
+    );
+    Ok(UnitTestRun { results })
+}
+
+/// Execute one unit test: seed `given` fixtures, materialize the model against
+/// them, and compare the output to `expect`.
+fn run_one_unit_test(model: &str, compiled_sql: &str, test: &UnitTestDef) -> UnitTestResult {
+    let fail = |msg: String, mismatches: Vec<RowMismatch>| UnitTestResult {
+        model: model.to_string(),
+        test: test.name.clone(),
+        passed: false,
+        error: Some(msg),
+        mismatches,
+    };
+    let pass = || UnitTestResult {
+        model: model.to_string(),
+        test: test.name.clone(),
+        passed: true,
+        error: None,
+        mismatches: Vec::new(),
+    };
+
+    let db = match DuckDbConnector::in_memory() {
+        Ok(d) => d,
+        Err(e) => return fail(format!("DuckDB init failed: {e}"), Vec::new()),
+    };
+
+    // Seed the mock input fixtures.
+    for fx in &test.given {
+        if validate_identifier(&fx.model_ref).is_err() {
+            return fail(
+                format!("invalid fixture ref '{}'", fx.model_ref),
+                Vec::new(),
+            );
+        }
+        if let Some(sql) = fixture_to_sql(fx)
+            && let Err(e) = db.execute_statement(&sql)
+        {
+            return fail(
+                format!("failed to seed fixture '{}': {e}", fx.model_ref),
+                Vec::new(),
+            );
+        }
+    }
+
+    // Materialize the model output against the mocked inputs.
+    let sql = compiled_sql.trim().trim_end_matches(';');
+    if let Err(e) =
+        db.execute_statement(&format!("CREATE OR REPLACE TABLE __rocky_actual AS\n{sql}"))
+    {
+        return fail(format!("model execution failed: {e}"), Vec::new());
+    }
+
+    // Empty expectation ⇒ the model must produce no rows.
+    if test.expect.rows.is_empty() {
+        return match query_scalar_u64(&db, "SELECT COUNT(*) AS n FROM __rocky_actual") {
+            Ok(0) => pass(),
+            Ok(n) => fail(format!("expected 0 rows, got {n}"), Vec::new()),
+            Err(e) => fail(format!("row count query failed: {e}"), Vec::new()),
+        };
+    }
+
+    // Comparison columns come from the expected rows — only the columns the
+    // author asserts on are compared (extra model columns are ignored).
+    let cols: Vec<String> = match test.expect.rows[0].as_object() {
+        Some(obj) => obj.keys().cloned().collect(),
+        None => {
+            return fail(
+                "expect rows must be tables (key = value)".into(),
+                Vec::new(),
+            );
+        }
+    };
+    for c in &cols {
+        if validate_identifier(c).is_err() {
+            return fail(format!("invalid column name in expect: '{c}'"), Vec::new());
+        }
+    }
+    if let Err(e) = db.execute_statement(&expected_table_sql(&test.expect.rows, &cols)) {
+        return fail(format!("failed to build expected table: {e}"), Vec::new());
+    }
+    let col_list = cols.join(", ");
+
+    if test.expect.ordered {
+        // Positional comparison: actual in the model's output order (re-run as a
+        // subquery so its ORDER BY survives), expected by declaration order.
+        let actual =
+            match db.execute_sql(&format!("SELECT {col_list} FROM (\n{sql}\n) AS __rocky_m")) {
+                Ok(r) => r.rows,
+                Err(e) => return fail(format!("actual query failed: {e}"), Vec::new()),
+            };
+        let expected = match db.execute_sql(&format!(
+            "SELECT {col_list} FROM __rocky_expected ORDER BY __rocky_ord"
+        )) {
+            Ok(r) => r.rows,
+            Err(e) => return fail(format!("expected query failed: {e}"), Vec::new()),
+        };
+        if actual == expected {
+            return pass();
+        }
+        let mismatches = ordered_mismatches(&cols, &expected, &actual);
+        return fail(
+            format!(
+                "ordered output mismatch ({} expected vs {} actual row(s))",
+                expected.len(),
+                actual.len()
+            ),
+            mismatches,
+        );
+    }
+
+    // Default: multiset comparison via EXCEPT ALL both directions.
+    let missing = match query_scalar_u64(
+        &db,
+        &format!(
+            "SELECT COUNT(*) AS n FROM (SELECT {col_list} FROM __rocky_expected \
+             EXCEPT ALL SELECT {col_list} FROM __rocky_actual)"
+        ),
+    ) {
+        Ok(n) => n,
+        Err(e) => return fail(format!("diff query failed: {e}"), Vec::new()),
+    };
+    let extra = match query_scalar_u64(
+        &db,
+        &format!(
+            "SELECT COUNT(*) AS n FROM (SELECT {col_list} FROM __rocky_actual \
+             EXCEPT ALL SELECT {col_list} FROM __rocky_expected)"
+        ),
+    ) {
+        Ok(n) => n,
+        Err(e) => return fail(format!("diff query failed: {e}"), Vec::new()),
+    };
+
+    if missing == 0 && extra == 0 {
+        return pass();
+    }
+    let mismatches = unordered_mismatches(&db, &cols, &col_list);
+    fail(
+        format!("output mismatch: {missing} expected row(s) missing, {extra} unexpected row(s)"),
+        mismatches,
+    )
+}
+
+/// Build a `CREATE TABLE __rocky_expected` statement from the expected rows,
+/// carrying a `__rocky_ord` ordinal so ordered comparison can recover the
+/// declaration order. Values are rendered identically to the `given` fixtures.
+fn expected_table_sql(rows: &[serde_json::Value], cols: &[String]) -> String {
+    let selects: Vec<String> = rows
+        .iter()
+        .enumerate()
+        .map(|(i, row)| {
+            let obj = row.as_object();
+            let vals: Vec<String> = cols
+                .iter()
+                .map(|c| {
+                    let lit = obj
+                        .and_then(|o| o.get(c))
+                        .map_or_else(|| "NULL".to_string(), json_to_sql_literal);
+                    format!("{lit} AS {c}")
+                })
+                .collect();
+            format!("SELECT {i} AS __rocky_ord, {}", vals.join(", "))
+        })
+        .collect();
+    format!(
+        "CREATE OR REPLACE TABLE __rocky_expected AS\n{}",
+        selects.join("\nUNION ALL\n")
+    )
+}
+
+/// Run a single-cell `COUNT(*)`-style query and parse the result as `u64`.
+fn query_scalar_u64(db: &DuckDbConnector, sql: &str) -> Result<u64, String> {
+    let r = db.execute_sql(sql).map_err(|e| e.to_string())?;
+    let cell = r
+        .rows
+        .first()
+        .and_then(|row| row.first())
+        .ok_or_else(|| "query returned no rows".to_string())?;
+    // `execute_sql` returns every cell stringified, so a `COUNT(*)` comes back
+    // as e.g. `"0"`; accept both the string and native-number forms.
+    let text = match cell {
+        serde_json::Value::String(s) => s.clone(),
+        other => other.to_string(),
+    };
+    text.trim()
+        .parse::<u64>()
+        .map_err(|e| format!("expected an integer count, got '{text}': {e}"))
+}
+
+/// Render a single result cell for diagnostics (strings unquoted, null as NULL).
+fn value_to_display(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Null => "NULL".to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Render a result row as `col=val, col=val` for diagnostics.
+fn render_row(cols: &[String], row: &[serde_json::Value]) -> String {
+    cols.iter()
+        .zip(row.iter())
+        .map(|(c, v)| format!("{c}={}", value_to_display(v)))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Sample up to 10 missing + 10 unexpected rows for an unordered mismatch.
+fn unordered_mismatches(db: &DuckDbConnector, cols: &[String], col_list: &str) -> Vec<RowMismatch> {
+    let mut out = Vec::new();
+    if let Ok(r) = db.execute_sql(&format!(
+        "SELECT * FROM (SELECT {col_list} FROM __rocky_expected \
+         EXCEPT ALL SELECT {col_list} FROM __rocky_actual) AS __d LIMIT 10"
+    )) {
+        for row in &r.rows {
+            let row_index = out.len();
+            out.push(RowMismatch {
+                row_index,
+                expected: render_row(cols, row),
+                actual: None,
+                kind: MismatchKind::Missing,
+            });
+        }
+    }
+    if let Ok(r) = db.execute_sql(&format!(
+        "SELECT * FROM (SELECT {col_list} FROM __rocky_actual \
+         EXCEPT ALL SELECT {col_list} FROM __rocky_expected) AS __d LIMIT 10"
+    )) {
+        for row in &r.rows {
+            let row_index = out.len();
+            out.push(RowMismatch {
+                row_index,
+                expected: String::new(),
+                actual: Some(render_row(cols, row)),
+                kind: MismatchKind::Extra,
+            });
+        }
+    }
+    out
+}
+
+/// Build positional mismatches for an ordered comparison (up to 10).
+fn ordered_mismatches(
+    cols: &[String],
+    expected: &[Vec<serde_json::Value>],
+    actual: &[Vec<serde_json::Value>],
+) -> Vec<RowMismatch> {
+    let mut out = Vec::new();
+    for i in 0..expected.len().max(actual.len()) {
+        match (expected.get(i), actual.get(i)) {
+            (Some(e), Some(a)) if e == a => {}
+            (Some(e), Some(a)) => out.push(RowMismatch {
+                row_index: i,
+                expected: render_row(cols, e),
+                actual: Some(render_row(cols, a)),
+                kind: MismatchKind::ValueDiff,
+            }),
+            (Some(e), None) => out.push(RowMismatch {
+                row_index: i,
+                expected: render_row(cols, e),
+                actual: None,
+                kind: MismatchKind::Missing,
+            }),
+            (None, Some(a)) => out.push(RowMismatch {
+                row_index: i,
+                expected: String::new(),
+                actual: Some(render_row(cols, a)),
+                kind: MismatchKind::Extra,
+            }),
+            (None, None) => {}
+        }
+        if out.len() >= 10 {
+            break;
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -239,5 +597,77 @@ mod tests {
         assert_eq!(result.model_results.len(), 1);
         assert_eq!(result.model_results[0].model, "good_mart");
         assert_eq!(result.model_results[0].status, ModelTestStatus::Pass);
+    }
+
+    /// Scaffold a project where `flagged` filters an upstream `orders` model
+    /// and a `[[test]]` mocks `orders` with fixture rows. `expect_match`
+    /// toggles whether the asserted output matches the model's real output.
+    fn scaffold_unit_test_project(expect_match: bool) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let models = dir.path().join("models");
+        std::fs::create_dir_all(&models).unwrap();
+        // Upstream model the unit test mocks.
+        std::fs::write(models.join("orders.sql"), "SELECT 0 AS id, 0 AS amount").unwrap();
+        std::fs::write(
+            models.join("orders.toml"),
+            "[strategy]\ntype = \"full_refresh\"\n[target]\ncatalog=\"wh\"\nschema=\"main\"\n",
+        )
+        .unwrap();
+        // Model under test: keep only high-value orders.
+        std::fs::write(
+            models.join("flagged.sql"),
+            "SELECT id, amount, true AS is_high FROM orders WHERE amount > 100",
+        )
+        .unwrap();
+        let expected_amount = if expect_match { 150 } else { 999 };
+        std::fs::write(
+            models.join("flagged.toml"),
+            format!(
+                "[strategy]\ntype = \"full_refresh\"\n\
+                 [target]\ncatalog = \"wh\"\nschema = \"main\"\n\n\
+                 [[test]]\nname = \"flags_high_value\"\n\n\
+                 [[test.given]]\nref = \"orders\"\n\
+                 rows = [ {{ id = 1, amount = 150 }}, {{ id = 2, amount = 50 }} ]\n\n\
+                 [test.expect]\n\
+                 rows = [ {{ id = 1, amount = {expected_amount}, is_high = true }} ]\n"
+            ),
+        )
+        .unwrap();
+        (dir, models)
+    }
+
+    /// A unit test passes when the model's output against the mocked inputs
+    /// matches the expectation (the high-value filter keeps only `id = 1`).
+    #[test]
+    fn unit_test_passes_when_output_matches() {
+        let (_tmp, models) = scaffold_unit_test_project(true);
+        let run = run_unit_tests(&models, None).unwrap();
+        assert_eq!(run.total(), 1);
+        assert_eq!(run.passed(), 1, "error: {:?}", run.results[0].error);
+        assert!(run.results[0].passed);
+    }
+
+    /// A unit test fails and reports row-level diagnostics when the model's
+    /// output diverges from the expectation.
+    #[test]
+    fn unit_test_fails_and_reports_mismatch() {
+        let (_tmp, models) = scaffold_unit_test_project(false);
+        let run = run_unit_tests(&models, None).unwrap();
+        assert_eq!(run.total(), 1);
+        assert_eq!(run.passed(), 0);
+        assert!(!run.results[0].passed);
+        assert!(
+            !run.results[0].mismatches.is_empty(),
+            "expected mismatch diagnostics"
+        );
+    }
+
+    /// A project whose models declare no `[[test]]` blocks runs zero unit
+    /// tests (and skips compilation entirely).
+    #[test]
+    fn unit_tests_empty_when_none_declared() {
+        let (_tmp, models) = scaffold_two_model_project();
+        let run = run_unit_tests(&models, None).unwrap();
+        assert_eq!(run.total(), 0);
     }
 }

--- a/schemas/test.schema.json
+++ b/schemas/test.schema.json
@@ -98,6 +98,32 @@
       ],
       "type": "object"
     },
+    "MismatchKind": {
+      "description": "Type of row mismatch.",
+      "oneOf": [
+        {
+          "description": "Row exists in expected but not in actual.",
+          "enum": [
+            "missing"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Row exists in actual but not in expected.",
+          "enum": [
+            "extra"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Row exists in both but values differ.",
+          "enum": [
+            "value_diff"
+          ],
+          "type": "string"
+        }
+      ]
+    },
     "ModelTestResult": {
       "description": "One per-model outcome from the local model-execution test.\n\n`status` is `\"pass\"` or `\"fail\"`. `error` is set only when `status = \"fail\"`. Mirrors `rocky_engine::test_runner::ModelTestResult` with the status flattened to a string so consumers (Pydantic, TypeScript) get a stable, JSON-Schema-friendly shape.",
       "properties": {
@@ -121,6 +147,34 @@
       ],
       "type": "object"
     },
+    "RowMismatch": {
+      "description": "A single row mismatch between expected and actual output.",
+      "properties": {
+        "actual": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "expected": {
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/definitions/MismatchKind"
+        },
+        "row_index": {
+          "format": "uint",
+          "minimum": 0.0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "expected",
+        "kind",
+        "row_index"
+      ],
+      "type": "object"
+    },
     "TestFailure": {
       "description": "One failed test, mirroring the (name, error) tuple in `rocky_engine::test_runner::TestResult::failures` but with named fields because schemars/JSON Schema can't represent positional tuples cleanly.",
       "properties": {
@@ -134,6 +188,78 @@
       "required": [
         "error",
         "name"
+      ],
+      "type": "object"
+    },
+    "UnitTestResult": {
+      "description": "Result of running a single unit test.",
+      "properties": {
+        "error": {
+          "default": null,
+          "description": "Error message if failed.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "mismatches": {
+          "default": [],
+          "description": "Mismatched rows (for diagnostics).",
+          "items": {
+            "$ref": "#/definitions/RowMismatch"
+          },
+          "type": "array"
+        },
+        "model": {
+          "description": "Model name.",
+          "type": "string"
+        },
+        "passed": {
+          "description": "Whether the test passed.",
+          "type": "boolean"
+        },
+        "test": {
+          "description": "Test name.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "model",
+        "passed",
+        "test"
+      ],
+      "type": "object"
+    },
+    "UnitTestSummary": {
+      "description": "Summary of fixture-driven unit-test execution (from `[[test]]` blocks in model sidecars). The per-test `results` reuse the engine's [`rocky_core::unit_test::UnitTestResult`] shape (model, test, passed, error, and row-level mismatches).",
+      "properties": {
+        "failed": {
+          "format": "uint",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "passed": {
+          "format": "uint",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "results": {
+          "items": {
+            "$ref": "#/definitions/UnitTestResult"
+          },
+          "type": "array"
+        },
+        "total": {
+          "format": "uint",
+          "minimum": 0.0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "failed",
+        "passed",
+        "results",
+        "total"
       ],
       "type": "object"
     }
@@ -182,6 +308,17 @@
       "format": "uint",
       "minimum": 0.0,
       "type": "integer"
+    },
+    "unit_tests": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/UnitTestSummary"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Results from fixture-driven `[[test]]` unit tests in model sidecars. Present only when at least one model declares a `[[test]]` block."
     },
     "version": {
       "type": "string"

--- a/sdk/python/src/rocky_sdk/types_generated/test_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/test_schema.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from enum import StrEnum
+
 from pydantic import BaseModel, Field, conint
 
 
@@ -58,6 +60,30 @@ class DeclarativeTestSummary(BaseModel):
     warned: conint(ge=0)
 
 
+class MismatchKind1(StrEnum):
+    """
+    Row exists in expected but not in actual.
+    """
+
+    missing = "missing"
+
+
+class MismatchKind2(StrEnum):
+    """
+    Row exists in actual but not in expected.
+    """
+
+    extra = "extra"
+
+
+class MismatchKind3(StrEnum):
+    """
+    Row exists in both but values differ.
+    """
+
+    value_diff = "value_diff"
+
+
 class ModelTestResult(BaseModel):
     """
     One per-model outcome from the local model-execution test.
@@ -73,6 +99,20 @@ class ModelTestResult(BaseModel):
     """
 
 
+class RowMismatch(BaseModel):
+    """
+    A single row mismatch between expected and actual output.
+    """
+
+    actual: str | None = None
+    expected: str
+    kind: MismatchKind1 | MismatchKind2 | MismatchKind3
+    """
+    Type of row mismatch.
+    """
+    row_index: conint(ge=0)
+
+
 class TestFailure(BaseModel):
     """
     One failed test, mirroring the (name, error) tuple in `rocky_engine::test_runner::TestResult::failures` but with named fields because schemars/JSON Schema can't represent positional tuples cleanly.
@@ -80,6 +120,44 @@ class TestFailure(BaseModel):
 
     error: str
     name: str
+
+
+class UnitTestResult(BaseModel):
+    """
+    Result of running a single unit test.
+    """
+
+    error: str | None = None
+    """
+    Error message if failed.
+    """
+    mismatches: list[RowMismatch] | None = Field([], validate_default=True)
+    """
+    Mismatched rows (for diagnostics).
+    """
+    model: str
+    """
+    Model name.
+    """
+    passed: bool
+    """
+    Whether the test passed.
+    """
+    test: str
+    """
+    Test name.
+    """
+
+
+class UnitTestSummary(BaseModel):
+    """
+    Summary of fixture-driven unit-test execution (from `[[test]]` blocks in model sidecars). The per-test `results` reuse the engine's [`rocky_core::unit_test::UnitTestResult`] shape (model, test, passed, error, and row-level mismatches).
+    """
+
+    failed: conint(ge=0)
+    passed: conint(ge=0)
+    results: list[UnitTestResult]
+    total: conint(ge=0)
 
 
 class TestOutput(BaseModel):
@@ -100,4 +178,8 @@ class TestOutput(BaseModel):
     """
     passed: conint(ge=0)
     total: conint(ge=0)
+    unit_tests: UnitTestSummary | None = None
+    """
+    Results from fixture-driven `[[test]]` unit tests in model sidecars. Present only when at least one model declares a `[[test]]` block.
+    """
     version: str


### PR DESCRIPTION
## What

Wires Rocky's `[[test]]` unit-test types into an **executing** runner. The types (`UnitTestDef`, `fixture_to_sql`) existed but nothing consumed them — `rocky test` now actually runs fixture-driven (mock-input → expected-output) unit tests.

## How

For each `[[test]]` block in a model sidecar:
1. A fresh in-memory DuckDB is seeded with the test's `given` fixtures (one table per mocked upstream).
2. The model's compiled SQL is materialized against them.
3. The output is compared to `expect`:
   - **default** — multiset comparison via `EXCEPT ALL` both directions + a count check;
   - **`ordered = true`** — positional comparison preserving the model's output order.

Only the columns named in `expect` are compared (extra model columns are ignored). Results surface in a new optional `TestOutput.unit_tests` summary and gate the command's exit code.

## Notes

- `load_unit_tests_from_dir` (rocky-core) loads `[[test]]` blocks independently of the full model load — flat, sidecar-preferred discovery mirroring `load_models_from_dir` — so unit tests aren't threaded through the compiler IR and no `Model`/`ModelConfig` constructors change.
- Reuses the existing `JsonSchema`-deriving `UnitTestResult` for the output shape.
- Schema + Pydantic + TS bindings regenerated via `just codegen`; dagster fixtures unaffected.

## Test

- New runner tests: pass, fail-with-row-diagnostics, and no-`[[test]]` cases.
- `cargo fmt` + `clippy --all-targets` clean; rocky-core / rocky-engine / rocky-cli suites green.