### PR TITLE
feat(engine): per-column documentation in `rocky docs` and `rocky catalog`

### DIFF
--- a/editors/vscode/src/types/generated/catalog.ts
+++ b/editors/vscode/src/types/generated/catalog.ts
@@ -83,6 +83,10 @@ export interface CatalogColumn {
    * Declared or inferred type of the column, when known.
    */
   data_type?: string | null;
+  /**
+   * Human-readable description from the sidecar `[columns]` table, when set.
+   */
+  description?: string | null;
   name: string;
   /**
    * Whether the column accepts nulls, when known.

--- a/engine/crates/rocky-cli/src/commands/catalog.rs
+++ b/engine/crates/rocky-cli/src/commands/catalog.rs
@@ -192,6 +192,9 @@ pub fn compute_catalog_output(
     };
     let result = compile::compile(&config).context("compile failed")?;
 
+    // Per-column descriptions from sidecar `[columns]` tables (best-effort).
+    let column_docs = rocky_core::models::load_column_docs_from_dir(models_dir).unwrap_or_default();
+
     // 3. Resolve project name from the config (first pipeline if multi).
     let project_name = match &rocky_cfg {
         Some(cfg) => resolve_pipeline(cfg, None)
@@ -272,6 +275,10 @@ pub fn compute_catalog_output(
                     name: col.name.clone(),
                     data_type,
                     nullable,
+                    description: column_docs
+                        .get(name)
+                        .and_then(|cols| cols.get(&col.name))
+                        .cloned(),
                 }
             })
             .collect();

--- a/engine/crates/rocky-cli/src/commands/docs.rs
+++ b/engine/crates/rocky-cli/src/commands/docs.rs
@@ -39,8 +39,10 @@ pub fn run_docs(
         "generating documentation"
     );
 
+    // Per-column descriptions from sidecar `[columns]` tables (best-effort).
+    let column_docs = rocky_core::models::load_column_docs_from_dir(models_dir).unwrap_or_default();
     // Build the documentation index (no column map — would need warehouse connection).
-    let index = build_doc_index(&models, &rocky_cfg, None);
+    let index = build_doc_index(&models, &rocky_cfg, None, Some(&column_docs));
 
     // Render HTML.
     let html = generate_index_html(&index);

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -2400,6 +2400,9 @@ pub struct CatalogColumn {
     /// Whether the column accepts nulls, when known.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable: Option<bool>,
+    /// Human-readable description from the sidecar `[columns]` table, when set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }
 
 /// A single column-level lineage edge.

--- a/engine/crates/rocky-core/src/docs.rs
+++ b/engine/crates/rocky-core/src/docs.rs
@@ -28,6 +28,9 @@ pub struct DocColumn {
     pub data_type: String,
     /// Whether the column accepts NULLs.
     pub nullable: bool,
+    /// Human-readable description from the sidecar `[columns]` table.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }
 
 /// A single model entry in the documentation catalog.
@@ -91,6 +94,9 @@ pub fn build_doc_index(
     models: &[Model],
     config: &RockyConfig,
     column_map: Option<&std::collections::HashMap<String, Vec<ColumnInfo>>>,
+    column_docs: Option<
+        &std::collections::HashMap<String, std::collections::HashMap<String, String>>,
+    >,
 ) -> DocIndex {
     let mut doc_models: Vec<DocModel> = models
         .iter()
@@ -99,6 +105,7 @@ pub fn build_doc_index(
                 "{}.{}.{}",
                 m.config.target.catalog, m.config.target.schema, m.config.target.table
             );
+            let model_docs = column_docs.and_then(|cd| cd.get(&m.config.name));
             let columns = column_map
                 .and_then(|cm| cm.get(&m.config.name))
                 .map(|cols| {
@@ -107,6 +114,7 @@ pub fn build_doc_index(
                             name: c.name.clone(),
                             data_type: c.data_type.clone(),
                             nullable: c.nullable,
+                            description: model_docs.and_then(|md| md.get(&c.name)).cloned(),
                         })
                         .collect()
                 })
@@ -306,9 +314,16 @@ pub fn generate_index_html(index: &DocIndex) -> String {
 "#,
             );
             for col in &model.columns {
+                let desc = col.description.as_deref().map_or_else(String::new, |d| {
+                    format!(
+                        "<div style=\"color:#8b949e;font-size:12px;\">{}</div>",
+                        html_escape(d)
+                    )
+                });
                 html.push_str(&format!(
-                    "            <tr><td>{}</td><td class=\"col-type\">{}</td><td class=\"col-nullable\">{}</td></tr>\n",
+                    "            <tr><td>{}{}</td><td class=\"col-type\">{}</td><td class=\"col-nullable\">{}</td></tr>\n",
                     html_escape(&col.name),
+                    desc,
                     html_escape(&col.data_type),
                     if col.nullable { "yes" } else { "no" },
                 ));
@@ -438,16 +453,19 @@ mod tests {
                             name: "order_id".into(),
                             data_type: "BIGINT".into(),
                             nullable: false,
+                            description: None,
                         },
                         DocColumn {
                             name: "customer_id".into(),
                             data_type: "BIGINT".into(),
                             nullable: true,
+                            description: None,
                         },
                         DocColumn {
                             name: "status".into(),
                             data_type: "STRING".into(),
                             nullable: false,
+                            description: None,
                         },
                     ],
                     tests: vec![
@@ -786,7 +804,7 @@ mod tests {
             },
         ];
 
-        let index = build_doc_index(&models, &config, None);
+        let index = build_doc_index(&models, &config, None, None);
         assert_eq!(index.models[0].name, "a_model");
         assert_eq!(index.models[1].name, "z_model");
     }
@@ -866,14 +884,28 @@ mod tests {
             ],
         );
 
-        let index = build_doc_index(&models, &config, Some(&col_map));
+        let mut column_docs = HashMap::new();
+        column_docs.insert(
+            "my_model".to_string(),
+            HashMap::from([("id".to_string(), "Primary key".to_string())]),
+        );
+
+        let index = build_doc_index(&models, &config, Some(&col_map), Some(&column_docs));
         assert_eq!(index.models.len(), 1);
         assert_eq!(index.models[0].columns.len(), 2);
         assert_eq!(index.models[0].columns[0].name, "id");
         assert_eq!(index.models[0].columns[1].data_type, "STRING");
         assert!(!index.models[0].columns[0].nullable);
         assert!(index.models[0].columns[1].nullable);
+        // Per-column description flows onto the matching column only.
+        assert_eq!(
+            index.models[0].columns[0].description.as_deref(),
+            Some("Primary key")
+        );
+        assert!(index.models[0].columns[1].description.is_none());
         assert_eq!(index.models[0].description.as_deref(), Some("Test model"));
+        // The rendered HTML surfaces the per-column description.
+        assert!(generate_index_html(&index).contains("Primary key"));
     }
 
     #[test]
@@ -903,7 +935,7 @@ mod tests {
             reuse: Default::default(),
         };
 
-        let index = build_doc_index(&[], &config, None);
+        let index = build_doc_index(&[], &config, None, None);
         assert_eq!(index.pipeline_count, 0);
         assert_eq!(index.adapter_count, 0);
         assert!(index.models.is_empty());

--- a/engine/crates/rocky-core/src/models.rs
+++ b/engine/crates/rocky-core/src/models.rs
@@ -1078,6 +1078,83 @@ pub fn load_unit_tests_from_dir(
     Ok(out)
 }
 
+/// Per-column documentation entry from a sidecar `[columns.<name>]` table.
+#[derive(Deserialize)]
+struct ColumnDoc {
+    #[serde(default)]
+    description: Option<String>,
+}
+
+/// Minimal sidecar view capturing only the model `name` and its per-column
+/// `[columns]` documentation, ignoring all other config keys.
+#[derive(Deserialize)]
+struct ColumnDocsSidecar {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    columns: std::collections::HashMap<String, ColumnDoc>,
+}
+
+/// Load per-column documentation (`[columns.<name>] description = "…"`) declared
+/// across a models directory, keyed by model name then column name.
+///
+/// Loaded independently of [`load_models_from_dir`] — matching its flat,
+/// sidecar-preferred discovery — so `rocky docs` / `rocky catalog` can attach
+/// descriptions without threading them through the compiler IR. A model's name
+/// is its sidecar `name` field, or the file stem. Files declaring no column
+/// descriptions are omitted from the map.
+pub fn load_column_docs_from_dir(
+    dir: &Path,
+) -> Result<std::collections::HashMap<String, std::collections::HashMap<String, String>>, ModelError>
+{
+    let mut out = std::collections::HashMap::new();
+    if !dir.exists() {
+        return Ok(out);
+    }
+    for entry in std::fs::read_dir(dir)? {
+        let path = entry?.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("sql") {
+            continue;
+        }
+        let stem = path
+            .file_stem()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_default();
+
+        let toml_path = path.with_extension("toml");
+        let toml_src = if toml_path.exists() {
+            std::fs::read_to_string(&toml_path)?
+        } else {
+            let content = std::fs::read_to_string(&path)?;
+            match split_frontmatter(&content) {
+                Some((frontmatter, _)) => frontmatter.to_string(),
+                None => continue,
+            }
+        };
+
+        let substituted =
+            substitute_env_vars(&toml_src).map_err(|source| ModelError::EnvSubstitution {
+                path: path.display().to_string(),
+                source: Box::new(source),
+            })?;
+        let sidecar: ColumnDocsSidecar =
+            toml::from_str(&substituted).map_err(|e| ModelError::ParseFrontmatter {
+                path: path.display().to_string(),
+                source: e,
+            })?;
+        let descriptions: std::collections::HashMap<String, String> = sidecar
+            .columns
+            .into_iter()
+            .filter_map(|(col, doc)| doc.description.map(|d| (col, d)))
+            .collect();
+        if descriptions.is_empty() {
+            continue;
+        }
+        out.insert(sidecar.name.unwrap_or(stem), descriptions);
+    }
+    Ok(out)
+}
+
 fn split_frontmatter(content: &str) -> Option<(&str, &str)> {
     let content = content.trim_start();
 
@@ -2156,6 +2233,52 @@ ssn = "confidential"
             m.config.classification.get("ssn"),
             Some(&"confidential".to_string())
         );
+    }
+
+    #[test]
+    fn load_column_docs_reads_sidecar_columns_table() {
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("orders.toml"),
+            r#"
+[target]
+catalog = "wh"
+schema = "main"
+
+[columns.order_id]
+description = "Unique order identifier"
+
+[columns.amount]
+description = "Order total in USD"
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("orders.sql"),
+            "SELECT order_id, amount FROM upstream",
+        )
+        .unwrap();
+        // A model with no `[columns]` table is omitted from the map.
+        std::fs::write(
+            dir.path().join("plain.toml"),
+            "[target]\ncatalog = \"wh\"\nschema = \"main\"\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("plain.sql"), "SELECT 1 AS x").unwrap();
+
+        let docs = load_column_docs_from_dir(dir.path()).unwrap();
+        assert_eq!(docs.len(), 1);
+        let orders = docs.get("orders").unwrap();
+        assert_eq!(
+            orders.get("order_id").map(String::as_str),
+            Some("Unique order identifier")
+        );
+        assert_eq!(
+            orders.get("amount").map(String::as_str),
+            Some("Order total in USD")
+        );
+        assert!(!docs.contains_key("plain"));
     }
 
     /// FR-001 Option A: `${VAR}` and `${VAR:-default}` placeholders in a

--- a/schemas/catalog.schema.json
+++ b/schemas/catalog.schema.json
@@ -91,6 +91,13 @@
             "null"
           ]
         },
+        "description": {
+          "description": "Human-readable description from the sidecar `[columns]` table, when set.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "name": {
           "type": "string"
         },

--- a/sdk/python/src/rocky_sdk/types_generated/catalog_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/catalog_schema.py
@@ -28,6 +28,10 @@ class CatalogColumn(BaseModel):
     """
     Declared or inferred type of the column, when known.
     """
+    description: str | None = None
+    """
+    Human-readable description from the sidecar `[columns]` table, when set.
+    """
     name: str
     nullable: bool | None = None
     """


### PR DESCRIPTION
## What

Adds per-column documentation to Rocky (GAP-8). Column descriptions are declared in a model sidecar `[columns.<name>]` table and surfaced in both `rocky docs` (HTML) and `rocky catalog --output json` (structured) — closing "no per-column description field; docs/catalog have no column description output."

## How

```toml
# orders.toml
[columns.order_id]
description = "Unique order identifier"
```

- `DocColumn` / `CatalogColumn` gain a `description` field.
- `load_column_docs_from_dir` reads `[columns]` tables via the same flat, sidecar-preferred discovery as the unit-test loader — keeps it off the heavily-constructed `ModelConfig`, so **zero churn** to existing constructors.
- `build_doc_index` attaches descriptions to columns and the docs HTML renders them under the column name; the catalog builder populates `CatalogColumn.description`.
- Catalog schema + Pydantic + TS bindings regenerated via `just codegen`.

## Test

- Loader test (parses `[columns]`, keys by model name, omits models with none).
- Doc-index wiring test (description flows onto the matching column only, and renders in the HTML).
- `fmt` + `clippy --all-targets` clean; rocky-core / rocky-cli suites green.

## Follow-up

`import-dbt` parses dbt column descriptions today but drops them — a fast-follow can emit them into the `[columns]` table.