### PR TITLE
fix(ci): repair the three broken engine-weekly jobs

### DIFF
--- a/.github/workflows/engine-weekly.yml
+++ b/.github/workflows/engine-weekly.yml
@@ -29,8 +29,12 @@ jobs:
         # Pin to a specific version + --locked so a regression in a newer
         # cargo-audit release can't silently change the weekly CI signal.
         # Bump deliberately alongside any MSRV or advisory-db change.
-        run: cargo install cargo-audit --version 0.21.1 --locked
+        # 0.21.1 could no longer parse newer advisory-db entries (the TOML
+        # schema drifted under it); 0.22.x reads the current database.
+        run: cargo install cargo-audit --version 0.22.2 --locked
       - name: Run cargo audit
+        # Advisory ignores (with rationale) live in engine/.cargo/audit.toml,
+        # which cargo-audit reads from this working directory.
         run: cargo audit
 
   coverage:
@@ -51,7 +55,13 @@ jobs:
         # Pinned + --locked for the same reason as cargo-audit above.
         run: cargo install cargo-tarpaulin --version 0.31.2 --locked
       - name: Run coverage
-        run: cargo tarpaulin --all-targets --timeout 600 --out xml --output-dir coverage/
+        # No --all-targets: that pulls the criterion benches into the run, and
+        # the `binary_startup` bench shells out to `cargo run` on every
+        # iteration. Under tarpaulin's ptrace instrumentation that subprocess
+        # never returns (it contends on the target/ lock) and the bench blows
+        # the --timeout, failing the whole job. tarpaulin's default target set
+        # (lib + bins + tests) is what we want coverage for anyway.
+        run: cargo tarpaulin --timeout 600 --out xml --output-dir coverage/
       - name: Upload coverage report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -77,6 +87,19 @@ jobs:
         run: cargo build --release
       - name: Add rocky binary to PATH
         run: echo "$GITHUB_WORKSPACE/engine/target/release" >> $GITHUB_PATH
+      # The playground POC run.sh scripts shell out to the standalone `duckdb`
+      # CLI to seed data and inspect Parquet companions. The runner doesn't
+      # ship it, so without this step every DuckDB-seeding POC fails with
+      # `duckdb: command not found`. Pin to 1.5.3 to match the DuckDB version
+      # the engine bundles (libduckdb-sys 1.10503.1) so seeded .duckdb files
+      # round-trip through `rocky`.
+      - name: Install DuckDB CLI
+        working-directory: ${{ github.workspace }}
+        run: |
+          curl -fsSL https://github.com/duckdb/duckdb/releases/download/v1.5.3/duckdb_cli-linux-amd64.zip -o /tmp/duckdb.zip
+          sudo unzip -o /tmp/duckdb.zip -d /usr/local/bin
+          sudo chmod +x /usr/local/bin/duckdb
+          duckdb --version
       - name: Run POC smoke tests
         working-directory: ${{ github.workspace }}
         run: bash examples/playground/scripts/run-all-duckdb.sh

--- a/engine/.cargo/audit.toml
+++ b/engine/.cargo/audit.toml
@@ -1,0 +1,14 @@
+# cargo-audit configuration — read from the working directory's
+# `.cargo/audit.toml` when `cargo audit` runs (the weekly security audit in
+# `../.github/workflows/engine-weekly.yml` runs with `working-directory: engine`).
+
+[advisories]
+# RUSTSEC-2023-0071 — "Marvin Attack" timing sidechannel in the `rsa` crate.
+# No fixed upgrade is available (the maintainers have no constant-time fix yet),
+# so there is nothing to bump to. It reaches us transitively through
+# `rocky-snowflake`, which uses `rsa` only to sign RS256 key-pair JWTs for
+# Snowflake auth — a client-side signing operation, not a server decrypting
+# attacker-supplied ciphertext, so the timing oracle the advisory describes is
+# not reachable in our usage. Re-evaluate (and drop this entry) once `rsa`
+# ships a patched release. See crates/rocky-snowflake/src/auth.rs.
+ignore = ["RUSTSEC-2023-0071"]


### PR DESCRIPTION
## Why

[`engine-weekly`](https://github.com/rocky-data/rocky/actions/workflows/engine-weekly.yml) has been red on **every** run for months. It's the advisory weekly lane (coverage + audit + POC smoke) and doesn't gate PRs, so three *independent* breakages piled up unnoticed. This fixes all three.

## What was broken

### 1. POC Smoke Tests — `duckdb: command not found` *(gates the run, exit 40)*
All **40 of 40** failures were the same: the playground POC `run.sh` scripts shell out to the standalone **DuckDB CLI** to seed data and inspect Parquet, but the runner only installed `cmake`, never `duckdb`. The 32 passing POCs are `rocky`-only (the engine bundles DuckDB via the crate).

**Fix:** add an *Install DuckDB CLI* step, pinned to **v1.5.3** to match the DuckDB the engine bundles (`libduckdb-sys 1.10503.1`) so seeded `.duckdb` files round-trip through `rocky`.

### 2. Coverage — bench run to timeout *(gates the run, exit 1)*
`cargo tarpaulin --all-targets` pulled the criterion benches into the run. The `binary_startup` bench (`crates/rocky-cli/benches/compile.rs:583`) shells out to `cargo run` every iteration; under tarpaulin's ptrace instrumentation that subprocess never returns (it contends on the `target/` lock) and the bench blew `--timeout` → `Timed out waiting for test response`.

**Fix:** drop `--all-targets`. tarpaulin's default target set (lib + bins + tests) is what we want coverage for anyway.

### 3. Security Audit — couldn't even run *(advisory, but permanently red)*
Pinned `cargo-audit 0.21.1` could no longer parse newer advisory-db entries (`RUSTSEC-2026-0124.md`, TOML schema drift) and exited before scanning. Bumping to **0.22.2** fixes that — and surfaces a real finding underneath: `rsa 0.9.10` / **RUSTSEC-2023-0071 (Marvin Attack)**, *no fixed upgrade available*, transitive via `rocky-snowflake`'s RS256 key-pair JWT auth.

**Fix:** bump the pin **and** add `engine/.cargo/audit.toml` ignoring `RUSTSEC-2023-0071` with a documented rationale (client-side JWT signing, not a server timing oracle; re-evaluate when `rsa` ships a patch).

## Validation
- **poc-smoke:** ran a sample of the previously-failing POCs locally with `duckdb v1.5.3` on PATH → all PASS.
- **audit:** `cargo audit` from `engine/` with the shipped `audit.toml` exits **0** (no parse error, advisory ignored, only the 2 unmaintained `paste`/`rustls-pemfile` warnings remain).
- **coverage:** reasoned (a full tarpaulin run is ~1h); dropping `--all-targets` removes the benches that timed out.
- `actionlint` parses the workflow cleanly; DuckDB v1.5.3 download URL returns HTTP 200.