### PR TITLE
fix(ci): give engine-weekly poc-smoke a git identity

### DIFF
--- a/.github/workflows/engine-weekly.yml
+++ b/.github/workflows/engine-weekly.yml
@@ -100,6 +100,15 @@ jobs:
           sudo unzip -o /tmp/duckdb.zip -d /usr/local/bin
           sudo chmod +x /usr/local/bin/duckdb
           duckdb --version
+      # The branch-approve POC (00-foundations/08) calls `rocky branch approve`,
+      # which records the approver from `git config user.email` and errors out
+      # if it's unset — and a fresh runner has no git identity. Set one (exactly
+      # what the CLI's own error message instructs) so the gated-promotion POC
+      # can sign its approval artifact.
+      - name: Configure git identity for rocky branch approve
+        run: |
+          git config --global user.email "engine-weekly@rocky.invalid"
+          git config --global user.name "rocky weekly CI"
       - name: Run POC smoke tests
         working-directory: ${{ github.workspace }}
         run: bash examples/playground/scripts/run-all-duckdb.sh


### PR DESCRIPTION
## Follow-up to #908

#908 fixed **39 of 40** POC smoke failures by installing the DuckDB CLI (the dispatched run went from `32 passed / 40 failed` → `71 passed / 1 failed`). The 40th was masked behind the duckdb-not-found failures and has a different, unrelated cause.

## The remaining failure
`pocs/00-foundations/08-branch-approve-promote` runs `rocky branch approve`, which records the approver from `git config user.email` and errors out if it's unset — by design (the CLI's own error message says to set it). A fresh CI runner has no git identity, so:

```
Error: `git config --get user.email` exited with status exit status: 1
```

It passes locally only because dev machines have a global git identity; POC 15 passes in CI because it sets a *local* identity inside its own throwaway repo, but POC 08 runs in the ambient checkout.

## Fix
Set a global git identity in the `poc-smoke` job — exactly what `rocky branch approve`'s error message instructs. Also future-proofs any other approval/sign POC.

## Validation
Reproduced the failure locally with `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null` (same `git config --get user.email exited with status 1`), then confirmed POC 08 runs to completion (exit 0) once an identity is provided. `actionlint` parses the workflow clean.

With this, all of `engine-weekly` should be green (audit already confirmed green on the #908 dispatch; coverage's `--all-targets` removal lands there too).