### PR TITLE
feat(engine): add dbt-compatible surrogate-key dialect primitive

### DIFF
--- a/engine/crates/rocky-bigquery/src/dialect.rs
+++ b/engine/crates/rocky-bigquery/src/dialect.rs
@@ -212,6 +212,30 @@ impl SqlDialect for BigQueryDialect {
         "STRING"
     }
 
+    fn surrogate_key_expr(&self, columns: &[&str]) -> String {
+        // BigQuery's `MD5()` returns BYTES, so dbt-bigquery wraps it in
+        // `to_hex(...)`; it also concatenates with `concat(...)` rather than the
+        // `||` operator. Otherwise identical to the trait default.
+        let str_type = self.string_type_name();
+        let fields: Vec<String> = columns
+            .iter()
+            .map(|c| format!("coalesce(cast({c} as {str_type}), '_dbt_utils_surrogate_key_null_')"))
+            .collect();
+        let concatenated = if fields.is_empty() {
+            "''".to_string()
+        } else {
+            let mut args = Vec::with_capacity(fields.len() * 2 - 1);
+            for (i, f) in fields.into_iter().enumerate() {
+                if i > 0 {
+                    args.push("'-'".to_string());
+                }
+                args.push(f);
+            }
+            format!("concat({})", args.join(", "))
+        };
+        format!("to_hex(md5(cast({concatenated} as {str_type})))")
+    }
+
     fn ground_table_ref(&self, parts: &[&str]) -> AdapterResult<String> {
         // BigQuery refs are `project.dataset.table`. The project (catalog)
         // segment allows hyphens — every real GCP project ID has them — so it
@@ -491,6 +515,20 @@ mod tests {
         let d = BigQueryDialect;
         let sql = d.create_schema_sql("project", "dataset").unwrap().unwrap();
         assert_eq!(sql, "CREATE SCHEMA IF NOT EXISTS `project`.`dataset`");
+    }
+
+    #[test]
+    fn surrogate_key_uses_to_hex_md5_and_concat() {
+        let d = BigQueryDialect;
+        assert_eq!(
+            d.surrogate_key_expr(&["a", "b"]),
+            "to_hex(md5(cast(concat(coalesce(cast(a as STRING), '_dbt_utils_surrogate_key_null_'), '-', coalesce(cast(b as STRING), '_dbt_utils_surrogate_key_null_')) as STRING)))"
+        );
+        // Single column: still wrapped in concat(...).
+        assert_eq!(
+            d.surrogate_key_expr(&["id"]),
+            "to_hex(md5(cast(concat(coalesce(cast(id as STRING), '_dbt_utils_surrogate_key_null_')) as STRING)))"
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -1008,6 +1008,34 @@ pub trait SqlDialect: Send + Sync {
         "VARCHAR"
     }
 
+    /// Build a deterministic surrogate-key SQL expression over `columns`,
+    /// modeled on dbt-utils' `generate_surrogate_key`: each input is coerced to
+    /// text and NULL-coalesced to a fixed sentinel, the inputs are joined with a
+    /// `-` separator, and the concatenation is MD5-hashed.
+    ///
+    /// The default form — `md5(cast(coalesce(cast(c as <str>), '<sentinel>') ||
+    /// '-' || … as <str>))` — matches dbt's default adapter (Databricks,
+    /// Snowflake, DuckDB, Trino all concatenate with `||`). BigQuery overrides
+    /// this to wrap the hash in `to_hex(...)` and concatenate with `concat(...)`.
+    /// Byte-exact parity with a specific dbt project's output is validated by
+    /// the SQL parity harness, which is the source of truth for case/spacing.
+    ///
+    /// Column references are interpolated as given; the caller is responsible
+    /// for validating them.
+    fn surrogate_key_expr(&self, columns: &[&str]) -> String {
+        let str_type = self.string_type_name();
+        let fields: Vec<String> = columns
+            .iter()
+            .map(|c| format!("coalesce(cast({c} as {str_type}), '_dbt_utils_surrogate_key_null_')"))
+            .collect();
+        let concatenated = if fields.is_empty() {
+            "''".to_string()
+        } else {
+            fields.join(" || '-' || ")
+        };
+        format!("md5(cast({concatenated} as {str_type}))")
+    }
+
     /// Build a validated, dialect-correct table reference for the
     /// data-grounding tools from an already-split list of name segments.
     ///

--- a/engine/crates/rocky-databricks/src/dialect.rs
+++ b/engine/crates/rocky-databricks/src/dialect.rs
@@ -283,6 +283,20 @@ mod tests {
     }
 
     #[test]
+    fn surrogate_key_uses_dbt_form_with_string_cast() {
+        let d = dialect();
+        assert_eq!(
+            d.surrogate_key_expr(&["a", "b"]),
+            "md5(cast(coalesce(cast(a as STRING), '_dbt_utils_surrogate_key_null_') || '-' || coalesce(cast(b as STRING), '_dbt_utils_surrogate_key_null_') as STRING))"
+        );
+        // Single column: no separator.
+        assert_eq!(
+            d.surrogate_key_expr(&["id"]),
+            "md5(cast(coalesce(cast(id as STRING), '_dbt_utils_surrogate_key_null_') as STRING))"
+        );
+    }
+
+    #[test]
     fn test_create_table_as() {
         let d = dialect();
         let sql = d.create_table_as("cat.sch.tbl", "SELECT * FROM src");

--- a/engine/crates/rocky-duckdb/src/dialect.rs
+++ b/engine/crates/rocky-duckdb/src/dialect.rs
@@ -286,6 +286,15 @@ mod tests {
     }
 
     #[test]
+    fn surrogate_key_uses_dbt_default_form() {
+        let d = dialect();
+        assert_eq!(
+            d.surrogate_key_expr(&["a", "b"]),
+            "md5(cast(coalesce(cast(a as VARCHAR), '_dbt_utils_surrogate_key_null_') || '-' || coalesce(cast(b as VARCHAR), '_dbt_utils_surrogate_key_null_') as VARCHAR))"
+        );
+    }
+
+    #[test]
     fn test_create_table_as() {
         let d = dialect();
         let sql = d.create_table_as("sch.tbl", "SELECT * FROM src");


### PR DESCRIPTION
## What

Adds `SqlDialect::surrogate_key_expr` — a deterministic, dbt-compatible surrogate-key SQL builder. This is the primitive behind the upcoming governed-materialization key column (the config-injected key we agreed on) and the SQL parity harness.

## How

Models dbt-utils' `generate_surrogate_key`: each input is `cast` to the dialect's string type, `coalesce`d to a fixed sentinel (`_dbt_utils_surrogate_key_null_`), joined with `-`, then MD5-hashed.

- **Trait default:** `md5(cast(coalesce(cast(c as <str>), '<sentinel>') || '-' || … as <str>))` — the `||` form used by Databricks, Snowflake, DuckDB, Trino. Reuses the existing per-dialect `string_type_name()` for the cast type.
- **BigQuery override:** wraps the hash in `to_hex(...)` and concatenates with `concat(...)` (its `MD5()` returns BYTES).

## Test

Per-dialect parity tests pin the exact emitted SQL (VARCHAR default via DuckDB, STRING via Databricks, `to_hex`/`concat` via BigQuery). Byte-exact parity against a specific dbt project's output (case/spacing) is validated by the SQL parity harness — the source of truth — so this lands the structure and the harness tunes the final form.

## Note

Standalone primitive — not yet wired to a config surface. The next PR (governed-materialization config) declares a key column that calls this and injects it via the existing `metadata_columns` IR path.