### PR TITLE
feat(engine): inject config-declared surrogate-key columns at materialization

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -366,6 +366,10 @@ pub(crate) struct ExecutionContext<'a> {
     /// Per-model compile cost (currently `typecheck_ms` only).
     pub model_timings:
         &'a std::collections::HashMap<String, rocky_compiler::compile::ModelCompileTimings>,
+    /// Per-model surrogate-key specs (`[[surrogate_key]]` sidecar blocks),
+    /// resolved into injected metadata columns at materialization time.
+    pub surrogate_keys:
+        &'a std::collections::HashMap<String, Vec<rocky_core::models::SurrogateKeySpec>>,
 }
 
 impl<'a> ExecutionContext<'a> {
@@ -4401,9 +4405,13 @@ pub(crate) async fn execute_models(
     // execution path. Future compile-time fields (semantic info, optimize
     // results, contract diagnostics) ride on this struct without further
     // signature churn.
+    // Per-model surrogate-key specs, loaded once and threaded via the context.
+    let surrogate_keys =
+        rocky_core::models::load_surrogate_keys_from_dir(models_dir).unwrap_or_default();
     let exec_ctx = ExecutionContext {
         typed_models: &compile_result.type_check.typed_models,
         model_timings: &compile_result.model_timings,
+        surrogate_keys: &surrogate_keys,
     };
 
     // Intra-layer concurrency is strictly opt-in via `--parallel N`.
@@ -5279,7 +5287,24 @@ async fn execute_one_plain_model(
     // breaks the `Send` bound on the boxed `run()` future.
     exec_ctx: ExecutionContext<'_>,
 ) -> Result<MaterializationOutput> {
-    let model_ir = model.to_model_ir();
+    let mut model_ir = model.to_model_ir();
+    // Inject declared surrogate-key columns (config-driven, dialect-resolved) by
+    // wrapping the model's SELECT:
+    //   `SELECT *, CAST(<hash> AS <str>) AS <name> FROM (<sql>) __rocky_keyed`.
+    // Transformation models materialize their raw SQL directly (it never flows
+    // through the replication-only metadata-column path), so wrapping is what
+    // surfaces the computed column into the CTAS / merge-source schema.
+    if let Some(specs) = exec_ctx.surrogate_keys.get(model_name)
+        && !specs.is_empty()
+    {
+        let additions = rocky_core::models::surrogate_key_metadata_columns(specs, dialect)
+            .iter()
+            .map(|m| format!("CAST({} AS {}) AS {}", m.value, m.data_type, m.name))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let inner = model_ir.sql.trim().trim_end_matches(';');
+        model_ir.sql = format!("SELECT *, {additions}\nFROM (\n{inner}\n) AS __rocky_keyed");
+    }
     let target_ref = dialect
         .format_table_ref(
             &model_ir.target.catalog,
@@ -7130,9 +7155,11 @@ mod tests {
             },
         );
 
+        let surrogate_keys = HashMap::new();
         let ctx = ExecutionContext {
             typed_models: &typed_models,
             model_timings: &model_timings,
+            surrogate_keys: &surrogate_keys,
         };
 
         assert_eq!(ctx.column_count_for("fct_orders"), Some(3));
@@ -7150,9 +7177,11 @@ mod tests {
 
         let typed_models = IndexMap::new();
         let model_timings: HashMap<String, ModelCompileTimings> = HashMap::new();
+        let surrogate_keys = HashMap::new();
         let ctx = ExecutionContext {
             typed_models: &typed_models,
             model_timings: &model_timings,
+            surrogate_keys: &surrogate_keys,
         };
 
         assert_eq!(ctx.column_count_for("raw__shopify__orders"), None);
@@ -8663,6 +8692,34 @@ merge_keys = ["id"]
             "[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"\"\nschema = \"main\"\n",
         )
         .expect("write model toml");
+    }
+
+    /// End-to-end: a model declaring a `[[surrogate_key]]` block materializes a
+    /// table that carries the injected, dialect-resolved hash column.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn surrogate_key_column_is_materialized() {
+        let dir = tempfile::tempdir().unwrap();
+        let models = dir.path().join("models");
+        std::fs::create_dir_all(&models).unwrap();
+        std::fs::write(models.join("keyed.sql"), "SELECT 1 AS id\n").unwrap();
+        std::fs::write(
+            models.join("keyed.toml"),
+            "[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"\"\nschema = \"main\"\n\n[[surrogate_key]]\nname = \"sk\"\ncolumns = [\"id\"]\n",
+        )
+        .unwrap();
+        let db_path = dir.path().join("t.duckdb");
+        let (_out, result) = run_models_against_duckdb(&models, &db_path, false, 1).await;
+        result.expect("run should succeed");
+
+        // The materialized table carries the injected surrogate-key column.
+        let conn = rocky_duckdb::DuckDbConnector::open(&db_path).expect("open db");
+        let r = conn
+            .execute_sql("SELECT sk FROM main.keyed")
+            .expect("query sk");
+        assert_eq!(r.rows.len(), 1);
+        let sk = r.rows[0][0].as_str().unwrap_or_default();
+        assert_eq!(sk.len(), 32, "md5 hex should be 32 chars, got {sk:?}");
     }
 
     /// Materialize all models in `models_dir` against a fresh DuckDB file,

--- a/engine/crates/rocky-core/src/models.rs
+++ b/engine/crates/rocky-core/src/models.rs
@@ -1155,6 +1155,101 @@ pub fn load_column_docs_from_dir(
     Ok(out)
 }
 
+/// A surrogate-key computed column declared in a model sidecar
+/// `[[surrogate_key]]` block: an output column `name` whose value is a
+/// deterministic hash of `columns`, injected into the materialized SELECT.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SurrogateKeySpec {
+    pub name: String,
+    pub columns: Vec<String>,
+}
+
+/// Minimal sidecar view capturing the model `name` and its `[[surrogate_key]]`
+/// blocks, ignoring all other config keys.
+#[derive(Deserialize)]
+struct SurrogateKeySidecar {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    surrogate_key: Vec<SurrogateKeySpec>,
+}
+
+/// Load surrogate-key specs (`[[surrogate_key]]` blocks) declared across a
+/// models directory, keyed by model name.
+///
+/// Loaded independently of [`load_models_from_dir`] — matching its flat,
+/// sidecar-preferred discovery — so the materialization path can pair each
+/// model with its key columns without threading them through the compiler IR.
+/// A model's name is its sidecar `name` field, or the file stem. Files that
+/// declare no `[[surrogate_key]]` blocks are omitted from the map.
+pub fn load_surrogate_keys_from_dir(
+    dir: &Path,
+) -> Result<std::collections::HashMap<String, Vec<SurrogateKeySpec>>, ModelError> {
+    let mut out = std::collections::HashMap::new();
+    if !dir.exists() {
+        return Ok(out);
+    }
+    for entry in std::fs::read_dir(dir)? {
+        let path = entry?.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("sql") {
+            continue;
+        }
+        let stem = path
+            .file_stem()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_default();
+
+        let toml_path = path.with_extension("toml");
+        let toml_src = if toml_path.exists() {
+            std::fs::read_to_string(&toml_path)?
+        } else {
+            let content = std::fs::read_to_string(&path)?;
+            match split_frontmatter(&content) {
+                Some((frontmatter, _)) => frontmatter.to_string(),
+                None => continue,
+            }
+        };
+
+        let substituted =
+            substitute_env_vars(&toml_src).map_err(|source| ModelError::EnvSubstitution {
+                path: path.display().to_string(),
+                source: Box::new(source),
+            })?;
+        let sidecar: SurrogateKeySidecar =
+            toml::from_str(&substituted).map_err(|e| ModelError::ParseFrontmatter {
+                path: path.display().to_string(),
+                source: e,
+            })?;
+        if sidecar.surrogate_key.is_empty() {
+            continue;
+        }
+        out.insert(sidecar.name.unwrap_or(stem), sidecar.surrogate_key);
+    }
+    Ok(out)
+}
+
+/// Resolve surrogate-key specs into dialect-correct [`rocky_ir::MetadataColumn`]s
+/// for injection into a model's SELECT. Each spec becomes a metadata column
+/// whose value is the dialect's `surrogate_key_expr` over the spec columns and
+/// whose type is the dialect's string type — rendered by `select_clause` as
+/// `CAST(<hash> AS <str>) AS <name>`.
+pub fn surrogate_key_metadata_columns(
+    specs: &[SurrogateKeySpec],
+    dialect: &dyn crate::traits::SqlDialect,
+) -> Vec<rocky_ir::MetadataColumn> {
+    specs
+        .iter()
+        .map(|spec| {
+            let cols: Vec<&str> = spec.columns.iter().map(String::as_str).collect();
+            rocky_ir::MetadataColumn {
+                name: spec.name.clone(),
+                data_type: dialect.string_type_name().to_string(),
+                value: dialect.surrogate_key_expr(&cols),
+            }
+        })
+        .collect()
+}
+
 fn split_frontmatter(content: &str) -> Option<(&str, &str)> {
     let content = content.trim_start();
 
@@ -2279,6 +2374,45 @@ description = "Order total in USD"
             Some("Order total in USD")
         );
         assert!(!docs.contains_key("plain"));
+    }
+
+    #[test]
+    fn load_surrogate_keys_reads_sidecar_blocks() {
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("keyed.toml"),
+            r#"
+[target]
+catalog = "wh"
+schema = "main"
+
+[[surrogate_key]]
+name = "permission_key"
+columns = ["advertiser_id"]
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("keyed.sql"),
+            "SELECT advertiser_id FROM upstream",
+        )
+        .unwrap();
+        // A model with no `[[surrogate_key]]` block is omitted from the map.
+        std::fs::write(
+            dir.path().join("plain.toml"),
+            "[target]\ncatalog = \"wh\"\nschema = \"main\"\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("plain.sql"), "SELECT 1 AS x").unwrap();
+
+        let specs = load_surrogate_keys_from_dir(dir.path()).unwrap();
+        assert_eq!(specs.len(), 1);
+        let keyed = specs.get("keyed").unwrap();
+        assert_eq!(keyed.len(), 1);
+        assert_eq!(keyed[0].name, "permission_key");
+        assert_eq!(keyed[0].columns, vec!["advertiser_id".to_string()]);
+        assert!(!specs.contains_key("plain"));
     }
 
     /// FR-001 Option A: `${VAR}` and `${VAR:-default}` placeholders in a

--- a/engine/crates/rocky-duckdb/src/dialect.rs
+++ b/engine/crates/rocky-duckdb/src/dialect.rs
@@ -295,6 +295,23 @@ mod tests {
     }
 
     #[test]
+    fn surrogate_key_metadata_columns_resolves_via_dialect() {
+        let d = dialect();
+        let specs = vec![rocky_core::models::SurrogateKeySpec {
+            name: "permission_key".into(),
+            columns: vec!["advertiser_id".into()],
+        }];
+        let cols = rocky_core::models::surrogate_key_metadata_columns(&specs, &d);
+        assert_eq!(cols.len(), 1);
+        assert_eq!(cols[0].name, "permission_key");
+        assert_eq!(cols[0].data_type, "VARCHAR");
+        assert_eq!(
+            cols[0].value,
+            "md5(cast(coalesce(cast(advertiser_id as VARCHAR), '_dbt_utils_surrogate_key_null_') as VARCHAR))"
+        );
+    }
+
+    #[test]
     fn test_create_table_as() {
         let d = dialect();
         let sql = d.create_table_as("sch.tbl", "SELECT * FROM src");


### PR DESCRIPTION
## What

The first governed-materialization increment. A model sidecar declares `[[surrogate_key]]` blocks, and `rocky run` injects each as a **dialect-correct, dbt-value-identical hash column** into the materialized table — config-injected computed columns, no Jinja, building on the C2 `surrogate_key_expr` primitive.

```toml
# mart.toml
[[surrogate_key]]
name = "permission_key"
columns = ["advertiser_id"]
```

## How

- **`SurrogateKeySpec` + `load_surrogate_keys_from_dir`** (rocky-core) — a flat side-loader for `[[surrogate_key]]` blocks, mirroring the C1/C6 loaders, so there's **zero `ModelConfig`/`ModelIr` constructor churn**.
- **`surrogate_key_metadata_columns(specs, dialect)`** — resolves each spec to a column whose value is the dialect's surrogate-key expression and whose type is the dialect string type.
- The spec map **rides on `ExecutionContext`** (its doc explicitly invites compile-time fields). At the transformation materialization path, the model SELECT is wrapped: `SELECT *, CAST(<hash> AS <str>) AS <name> FROM (<sql>) __rocky_keyed`. Transformation models materialize their raw SQL, so the replication-only metadata-column path doesn't apply — the e2e test caught exactly that.

## Test

- Loader, dialect resolver (DuckDB), and an **end-to-end run** asserting the materialized DuckDB table carries the injected 32-char-md5 column.
- fmt + `clippy --all-targets --features duckdb` clean; rocky-core / rocky-duckdb / run-module suites green.

## Follow-ups (documented, separate)

- Skip-gate IR (so a model gaining a key isn't wrongly skip-unchanged); `content_addressed` / `time_interval` strategy paths.
- **C4b:** the profile fan-out (`[profile.<name>]` + per-model args) + compile-time invariant validation (E0xx) + tags → `dagster-rocky`.