### PR TITLE
feat(engine): validate surrogate-key config and fix skip-gate for keyed models

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -4406,8 +4406,10 @@ pub(crate) async fn execute_models(
     // results, contract diagnostics) ride on this struct without further
     // signature churn.
     // Per-model surrogate-key specs, loaded once and threaded via the context.
-    let surrogate_keys =
-        rocky_core::models::load_surrogate_keys_from_dir(models_dir).unwrap_or_default();
+    // Surface a malformed key spec (bad output name, empty/invalid input
+    // columns) as a hard run failure rather than silently emitting broken SQL.
+    let surrogate_keys = rocky_core::models::load_surrogate_keys_from_dir(models_dir)
+        .context("invalid surrogate_key configuration")?;
     let exec_ctx = ExecutionContext {
         typed_models: &compile_result.type_check.typed_models,
         model_timings: &compile_result.model_timings,
@@ -4461,7 +4463,12 @@ pub(crate) async fn execute_models(
                 // mirroring `project_ir_from_compile`) so `skip_hash()` can
                 // canonicalise. An empty `typed_columns` ⇒ `skip_hash()` is
                 // `None` ⇒ the gate builds.
-                let typed_ir = typed_model_ir(model, exec_ctx.typed_models);
+                let typed_ir = typed_model_ir(
+                    model,
+                    exec_ctx.typed_models,
+                    exec_ctx.surrogate_keys,
+                    dialect,
+                );
                 match gate
                     .evaluate(model, &typed_ir, warehouse, state_store)
                     .await
@@ -5254,10 +5261,18 @@ pub(crate) fn is_plain_strategy(model: &rocky_core::models::Model) -> bool {
 fn typed_model_ir(
     model: &rocky_core::models::Model,
     typed_models: &indexmap::IndexMap<String, Vec<rocky_compiler::types::TypedColumn>>,
+    surrogate_keys: &HashMap<String, Vec<rocky_core::models::SurrogateKeySpec>>,
+    dialect: &dyn rocky_core::traits::SqlDialect,
 ) -> rocky_ir::ModelIr {
     let mut ir = model.to_model_ir();
     if let Some(cols) = typed_models.get(&model.config.name) {
         ir.typed_columns = cols.clone();
+    }
+    // Mirror the materialization-time SQL wrap so the skip-hash reflects a
+    // declared surrogate key: a model that *gains* a key changes its IR and
+    // re-materializes instead of being skipped as unchanged.
+    if let Some(specs) = surrogate_keys.get(&model.config.name) {
+        rocky_core::models::apply_surrogate_keys(&mut ir, specs, dialect);
     }
     ir
 }
@@ -5288,22 +5303,12 @@ async fn execute_one_plain_model(
     exec_ctx: ExecutionContext<'_>,
 ) -> Result<MaterializationOutput> {
     let mut model_ir = model.to_model_ir();
-    // Inject declared surrogate-key columns (config-driven, dialect-resolved) by
-    // wrapping the model's SELECT:
-    //   `SELECT *, CAST(<hash> AS <str>) AS <name> FROM (<sql>) __rocky_keyed`.
-    // Transformation models materialize their raw SQL directly (it never flows
-    // through the replication-only metadata-column path), so wrapping is what
-    // surfaces the computed column into the CTAS / merge-source schema.
-    if let Some(specs) = exec_ctx.surrogate_keys.get(model_name)
-        && !specs.is_empty()
-    {
-        let additions = rocky_core::models::surrogate_key_metadata_columns(specs, dialect)
-            .iter()
-            .map(|m| format!("CAST({} AS {}) AS {}", m.value, m.data_type, m.name))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let inner = model_ir.sql.trim().trim_end_matches(';');
-        model_ir.sql = format!("SELECT *, {additions}\nFROM (\n{inner}\n) AS __rocky_keyed");
+    // Inject declared surrogate-key columns by wrapping the model's SELECT.
+    // Transformation models materialize their raw SQL directly (never the
+    // replication-only metadata-column path), so the wrap is what surfaces the
+    // computed column into the CTAS / merge-source schema.
+    if let Some(specs) = exec_ctx.surrogate_keys.get(model_name) {
+        rocky_core::models::apply_surrogate_keys(&mut model_ir, specs, dialect);
     }
     let target_ref = dialect
         .format_table_ref(

--- a/engine/crates/rocky-core/src/models.rs
+++ b/engine/crates/rocky-core/src/models.rs
@@ -46,6 +46,9 @@ pub enum ModelError {
         reason: String,
     },
 
+    #[error("model '{model}' has an invalid surrogate_key: {reason}")]
+    InvalidSurrogateKey { model: String, reason: String },
+
     #[error("failed to substitute env vars in '{path}': {source}")]
     EnvSubstitution {
         path: String,
@@ -1223,7 +1226,11 @@ pub fn load_surrogate_keys_from_dir(
         if sidecar.surrogate_key.is_empty() {
             continue;
         }
-        out.insert(sidecar.name.unwrap_or(stem), sidecar.surrogate_key);
+        let model_name = sidecar.name.unwrap_or(stem);
+        for spec in &sidecar.surrogate_key {
+            validate_surrogate_key_spec(spec, &model_name)?;
+        }
+        out.insert(model_name, sidecar.surrogate_key);
     }
     Ok(out)
 }
@@ -1248,6 +1255,60 @@ pub fn surrogate_key_metadata_columns(
             }
         })
         .collect()
+}
+
+/// Validate a surrogate-key spec: a non-empty, valid-identifier output `name`
+/// and at least one valid-identifier input column. These are the compile-time
+/// invariants for the injected column, enforced at load so malformed config
+/// fails loudly rather than emitting broken SQL.
+fn validate_surrogate_key_spec(spec: &SurrogateKeySpec, model: &str) -> Result<(), ModelError> {
+    let invalid = |reason: String| ModelError::InvalidSurrogateKey {
+        model: model.to_string(),
+        reason,
+    };
+    if rocky_sql::validation::validate_identifier(&spec.name).is_err() {
+        return Err(invalid(format!(
+            "output column name '{}' is not a valid SQL identifier",
+            spec.name
+        )));
+    }
+    if spec.columns.is_empty() {
+        return Err(invalid(format!(
+            "key '{}' must list at least one input column",
+            spec.name
+        )));
+    }
+    for col in &spec.columns {
+        if rocky_sql::validation::validate_identifier(col).is_err() {
+            return Err(invalid(format!(
+                "key '{}' references invalid column identifier '{col}'",
+                spec.name
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Wrap a transformation model's SELECT to append the declared surrogate-key
+/// columns: `SELECT *, CAST(<hash> AS <str>) AS <name> FROM (<sql>) __rocky_keyed`.
+/// A no-op when `specs` is empty. Used by both the materialization path and the
+/// skip-gate IR, so a model that *gains* a key re-materializes rather than being
+/// skipped as unchanged.
+pub fn apply_surrogate_keys(
+    model_ir: &mut rocky_ir::ModelIr,
+    specs: &[SurrogateKeySpec],
+    dialect: &dyn crate::traits::SqlDialect,
+) {
+    if specs.is_empty() {
+        return;
+    }
+    let additions = surrogate_key_metadata_columns(specs, dialect)
+        .iter()
+        .map(|m| format!("CAST({} AS {}) AS {}", m.value, m.data_type, m.name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let inner = model_ir.sql.trim().trim_end_matches(';');
+    model_ir.sql = format!("SELECT *, {additions}\nFROM (\n{inner}\n) AS __rocky_keyed");
 }
 
 fn split_frontmatter(content: &str) -> Option<(&str, &str)> {
@@ -2388,14 +2449,14 @@ catalog = "wh"
 schema = "main"
 
 [[surrogate_key]]
-name = "permission_key"
-columns = ["advertiser_id"]
+name = "order_key"
+columns = ["order_id"]
 "#,
         )
         .unwrap();
         std::fs::write(
             dir.path().join("keyed.sql"),
-            "SELECT advertiser_id FROM upstream",
+            "SELECT order_id FROM upstream",
         )
         .unwrap();
         // A model with no `[[surrogate_key]]` block is omitted from the map.
@@ -2410,9 +2471,44 @@ columns = ["advertiser_id"]
         assert_eq!(specs.len(), 1);
         let keyed = specs.get("keyed").unwrap();
         assert_eq!(keyed.len(), 1);
-        assert_eq!(keyed[0].name, "permission_key");
-        assert_eq!(keyed[0].columns, vec!["advertiser_id".to_string()]);
+        assert_eq!(keyed[0].name, "order_key");
+        assert_eq!(keyed[0].columns, vec!["order_id".to_string()]);
         assert!(!specs.contains_key("plain"));
+    }
+
+    /// A malformed `[[surrogate_key]]` block fails the load with
+    /// [`ModelError::InvalidSurrogateKey`] rather than emitting broken SQL.
+    /// Covers all three guard arms: an empty column list, a non-identifier
+    /// output name, and a non-identifier input column.
+    #[test]
+    fn load_surrogate_keys_rejects_malformed_config() {
+        use tempfile::tempdir;
+        let cases = [
+            // empty input columns
+            ("order_key", "columns = []"),
+            // output name with a SQL-injecting character
+            ("bad name; DROP", "columns = [\"order_id\"]"),
+            // input column with an injecting character
+            ("order_key", "columns = [\"order_id); DROP\"]"),
+        ];
+        for (name, columns_line) in cases {
+            let dir = tempdir().unwrap();
+            std::fs::write(
+                dir.path().join("m.toml"),
+                format!(
+                    "[target]\ncatalog = \"wh\"\nschema = \"main\"\n\n\
+                     [[surrogate_key]]\nname = \"{name}\"\n{columns_line}\n"
+                ),
+            )
+            .unwrap();
+            std::fs::write(dir.path().join("m.sql"), "SELECT order_id FROM upstream").unwrap();
+
+            let err = load_surrogate_keys_from_dir(dir.path()).unwrap_err();
+            assert!(
+                matches!(err, ModelError::InvalidSurrogateKey { .. }),
+                "expected InvalidSurrogateKey for name={name:?} {columns_line}, got {err:?}"
+            );
+        }
     }
 
     /// FR-001 Option A: `${VAR}` and `${VAR:-default}` placeholders in a

--- a/engine/crates/rocky-duckdb/src/dialect.rs
+++ b/engine/crates/rocky-duckdb/src/dialect.rs
@@ -298,16 +298,48 @@ mod tests {
     fn surrogate_key_metadata_columns_resolves_via_dialect() {
         let d = dialect();
         let specs = vec![rocky_core::models::SurrogateKeySpec {
-            name: "permission_key".into(),
-            columns: vec!["advertiser_id".into()],
+            name: "order_key".into(),
+            columns: vec!["order_id".into()],
         }];
         let cols = rocky_core::models::surrogate_key_metadata_columns(&specs, &d);
         assert_eq!(cols.len(), 1);
-        assert_eq!(cols[0].name, "permission_key");
+        assert_eq!(cols[0].name, "order_key");
         assert_eq!(cols[0].data_type, "VARCHAR");
         assert_eq!(
             cols[0].value,
-            "md5(cast(coalesce(cast(advertiser_id as VARCHAR), '_dbt_utils_surrogate_key_null_') as VARCHAR))"
+            "md5(cast(coalesce(cast(order_id as VARCHAR), '_dbt_utils_surrogate_key_null_') as VARCHAR))"
+        );
+    }
+
+    #[test]
+    fn apply_surrogate_keys_wraps_select_via_dialect() {
+        let d = dialect();
+        let mut ir = rocky_core::models::parse_model_inline(
+            "---toml\n[target]\ncatalog = \"wh\"\nschema = \"marts\"\n---\n\nSELECT order_id FROM upstream",
+            "fct_orders.sql",
+            None,
+        )
+        .unwrap()
+        .to_model_ir();
+
+        // No specs ⇒ the SQL is left byte-for-byte unchanged (preserves the
+        // unkeyed model's skip-hash).
+        let original = ir.sql.clone();
+        rocky_core::models::apply_surrogate_keys(&mut ir, &[], &d);
+        assert_eq!(ir.sql, original);
+
+        // One spec ⇒ the SELECT is wrapped and the dbt-form hash appended as a
+        // top-level column.
+        let specs = vec![rocky_core::models::SurrogateKeySpec {
+            name: "order_key".into(),
+            columns: vec!["order_id".into()],
+        }];
+        rocky_core::models::apply_surrogate_keys(&mut ir, &specs, &d);
+        assert_eq!(
+            ir.sql,
+            "SELECT *, CAST(md5(cast(coalesce(cast(order_id as VARCHAR), \
+             '_dbt_utils_surrogate_key_null_') as VARCHAR)) AS VARCHAR) AS order_key\n\
+             FROM (\nSELECT order_id FROM upstream\n) AS __rocky_keyed"
         );
     }
 


### PR DESCRIPTION
## What

Two related correctness fixes for config-declared surrogate keys (the column-injection feature added in #913):

1. **Validation at load.** A malformed `[[surrogate_key]]` block now fails the run with `ModelError::InvalidSurrogateKey` instead of emitting broken SQL. Guards: empty column list, non-identifier output `name`, non-identifier input column (all checked via `rocky_sql::validation::validate_identifier`). The loader error is propagated as a hard run failure rather than swallowed.

2. **Skip-gate correctness.** The injected key columns are now mirrored into the typed IR that feeds `skip_hash()`. Previously a model that *gained* a surrogate key could be skipped as "unchanged" because the skip-hash was computed from the un-wrapped SQL. The SELECT-wrapping is extracted into a shared `apply_surrogate_keys` helper used by **both** the materialization path and the skip-gate IR, so the two stay byte-identical by construction.

## Tests

- `load_surrogate_keys_rejects_malformed_config` (rocky-core) — all three guard arms.
- `apply_surrogate_keys_wraps_select_via_dialect` (rocky-duckdb) — wrap structure + no-op-when-empty.
- Existing `surrogate_key_column_is_materialized` e2e still green against the refactored helper.

## Notes

Surrogate-key test examples use a generic `order` / `order_id` shape.

cargo fmt + clippy `--all-targets` clean; affected-crate tests green.