### PR TITLE
feat(engine): enforced config groups — opt-in governance guardrail

### DIFF
--- a/docs/src/content/docs/reference/model-format.md
+++ b/docs/src/content/docs/reference/model-format.md
@@ -167,9 +167,25 @@ region = "emea"         # fills {region} -> schema "mart_emea"
 
 Precedence is **per-model sidecar > group > `_defaults.toml`**: a model can still pin its own `schema` or `strategy` to override the group, and the group in turn overrides directory defaults. A `group` that names no definition, or a `schema_template` placeholder the model doesn't supply, fails the load with a clear error rather than routing a model to the wrong place.
 
+#### Enforced groups
+
+Set `enforce = true` on a group to make its fields binding rather than defaults. A member model that locally pins a field the group controls — its target `schema` or its `strategy` — then fails the load instead of silently routing or materializing itself differently from the rest of the group:
+
+```toml
+# models/groups/regulated.toml
+enforce = true
+schema_template = "mart_{region}"
+
+[strategy]
+type = "merge"
+unique_key = ["id"]
+```
+
+Enforcement is strictly opt-in: without `enforce`, groups stay overridable defaults. A model under an enforced group still supplies its own `[args]` (and any field the group doesn't set, like `target.catalog`); it just can't override what the group owns. Use this when a set of models must share routing and materialization as a governance guarantee.
+
 The model loader does not recurse into subdirectories, so `models/groups/` is never mistaken for model files.
 
-A group currently carries `schema_template` and `strategy`. Shared tags and per-model computed keys are planned additions; until then, an unrecognized key in a group file is rejected at load so typos surface immediately.
+A group currently carries `schema_template`, `strategy`, and `enforce`. Shared tags and per-model computed keys are planned additions; until then, an unrecognized key in a group file is rejected at load so typos surface immediately.
 
 ### `[classification]`
 

--- a/engine/crates/rocky-core/src/models.rs
+++ b/engine/crates/rocky-core/src/models.rs
@@ -57,6 +57,15 @@ pub enum ModelError {
     #[error("model '{model}' has an invalid config group: {reason}")]
     InvalidGroup { model: String, reason: String },
 
+    #[error(
+        "model '{model}' overrides '{field}', which its enforced group '{group}' controls; remove the local override or set the group's enforce = false"
+    )]
+    GroupOverride {
+        model: String,
+        group: String,
+        field: String,
+    },
+
     #[error("failed to substitute env vars in '{path}': {source}")]
     EnvSubstitution {
         path: String,
@@ -593,6 +602,15 @@ pub struct GroupConfig {
     /// Shared materialization strategy for every model in the group.
     #[serde(default)]
     pub strategy: Option<StrategyConfig>,
+    /// When `true`, the group's fields are **enforced**, not just defaulted: a
+    /// member model that locally pins a field the group also sets (its target
+    /// `schema`, or its `strategy`) fails the load with
+    /// [`ModelError::GroupOverride`]. This is the governance guarantee — a model
+    /// in an enforced group cannot quietly route or materialize itself
+    /// differently from the rest of the group. Defaults to `false` (groups are
+    /// overridable defaults unless the author opts in).
+    #[serde(default)]
+    pub enforce: bool,
 }
 
 /// Load config groups from `<models_dir>/groups/*.toml`. Each file defines one
@@ -713,6 +731,36 @@ fn resolve_model_config(
                 })?,
         ),
     };
+
+    // Enforcement: when the group sets `enforce = true`, a member model may not
+    // locally override a field the group controls. Checked here, before the
+    // fields are consumed by the resolution chain below, using sidecar
+    // provenance (`raw.<field>.is_some()` ⇒ the model set it locally).
+    if let Some(g) = group
+        && g.enforce
+    {
+        let group_name = raw.group.as_deref().unwrap_or_default();
+        if g.strategy.is_some() && raw.strategy.is_some() {
+            return Err(ModelError::GroupOverride {
+                model: name.clone(),
+                group: group_name.to_string(),
+                field: "strategy".into(),
+            });
+        }
+        if g.schema_template.is_some()
+            && raw
+                .target
+                .as_ref()
+                .and_then(|t| t.schema.as_ref())
+                .is_some()
+        {
+            return Err(ModelError::GroupOverride {
+                model: name.clone(),
+                group: group_name.to_string(),
+                field: "target.schema".into(),
+            });
+        }
+    }
 
     // Precedence: per-model sidecar > group > directory defaults.
     let strategy = raw
@@ -2833,6 +2881,79 @@ columns = ["order_id"]
         assert!(
             matches!(err, ModelError::InvalidGroup { .. }),
             "got {err:?}"
+        );
+    }
+
+    /// An `enforce = true` group rejects a member model that locally overrides
+    /// a field the group controls (its strategy, or its routing schema).
+    #[test]
+    fn enforced_group_rejects_local_override() {
+        for (override_block, field) in [
+            ("[strategy]\ntype = \"full_refresh\"\n", "strategy"),
+            (
+                "[target]\ncatalog = \"wh\"\nschema = \"escape\"\n",
+                "target.schema",
+            ),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            write_group(
+                dir.path(),
+                "locked",
+                "enforce = true\nschema_template = \"mart_{region}\"\n\n[strategy]\ntype = \"merge\"\nunique_key = [\"id\"]\nupdate_columns = [\"v\"]\n",
+            );
+            std::fs::write(
+                dir.path().join("orders.toml"),
+                format!("group = \"locked\"\n\n[args]\nregion = \"emea\"\n\n{override_block}"),
+            )
+            .unwrap();
+            std::fs::write(dir.path().join("orders.sql"), "SELECT id, v FROM upstream").unwrap();
+
+            let err = load_models_from_dir(dir.path()).unwrap_err();
+            assert!(
+                matches!(&err, ModelError::GroupOverride { field: f, .. } if f == field),
+                "expected GroupOverride for {field}, got {err:?}"
+            );
+        }
+    }
+
+    /// An `enforce = true` group accepts a model that takes everything from the
+    /// group (only supplies its `[args]`), and a non-enforced group still allows
+    /// local overrides (enforcement is strictly opt-in).
+    #[test]
+    fn enforcement_is_opt_in_and_allows_conforming_models() {
+        // Conforming model under an enforced group: OK.
+        let dir = tempfile::tempdir().unwrap();
+        write_group(
+            dir.path(),
+            "locked",
+            "enforce = true\nschema_template = \"mart_{region}\"\n\n[strategy]\ntype = \"merge\"\nunique_key = [\"id\"]\nupdate_columns = [\"v\"]\n",
+        );
+        std::fs::write(
+            dir.path().join("orders.toml"),
+            "group = \"locked\"\n\n[target]\ncatalog = \"wh\"\n\n[args]\nregion = \"emea\"\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("orders.sql"), "SELECT id, v FROM upstream").unwrap();
+        let m = &load_models_from_dir(dir.path()).unwrap()[0];
+        assert_eq!(m.config.target.schema, "mart_emea");
+
+        // The same override under a NON-enforced group is allowed.
+        let dir2 = tempfile::tempdir().unwrap();
+        write_group(
+            dir2.path(),
+            "flexible",
+            "schema_template = \"mart_{region}\"\n\n[strategy]\ntype = \"merge\"\nunique_key = [\"id\"]\nupdate_columns = [\"v\"]\n",
+        );
+        std::fs::write(
+            dir2.path().join("orders.toml"),
+            "group = \"flexible\"\n\n[target]\ncatalog = \"wh\"\nschema = \"escape\"\n\n[args]\nregion = \"emea\"\n",
+        )
+        .unwrap();
+        std::fs::write(dir2.path().join("orders.sql"), "SELECT id, v FROM upstream").unwrap();
+        let m2 = &load_models_from_dir(dir2.path()).unwrap()[0];
+        assert_eq!(
+            m2.config.target.schema, "escape",
+            "non-enforced group allows override"
         );
     }
 


### PR DESCRIPTION
## What

Adds `enforce = true` to a config group (built on #917). When set, the group's fields become **binding rather than defaults**: a member model that locally pins a field the group controls — its target `schema` or its `strategy` — fails the load with `ModelError::GroupOverride`, instead of silently routing or materializing itself differently from the rest of the group.

```toml
# models/groups/regulated.toml
enforce = true
schema_template = "mart_{region}"
[strategy]
type = "merge"
unique_key = ["id"]
```

A member that tries to escape:

```
Error: model 'orders' overrides 'target.schema', which its enforced group
'regulated' controls; remove the local override or set the group's enforce = false
```

## Design

- The check rides in the shared `resolve_model_config` using **sidecar provenance** (`raw.<field>.is_some()` ⇒ the model set it locally) — no provenance plumbing, no new compiler pass.
- Because it's in the shared resolver, **both** the `.sql` loader and the `.rocky` salsa loader enforce with no extra wiring — verified end-to-end through `rocky emit-sql` (the `compile` path) rejecting an override.
- **Strictly opt-in:** without `enforce`, groups stay overridable defaults (existing behavior unchanged). A model under an enforced group still supplies its own `[args]` and any field the group doesn't set (e.g. `target.catalog`).

## Tests

`enforced_group_rejects_local_override` (both `strategy` and `target.schema`); `enforcement_is_opt_in_and_allows_conforming_models` (conforming model under an enforced group loads; the same override under a non-enforced group is allowed).

## Context

This is the governance "teeth" of the config-groups keystone (C4): a set of models can be made to share routing + materialization *by construction*. Framed neutrally — it's "a model can't silently escape its group's config," with no domain-specific invariants. Shared tags (→ Dagster) and per-mode computed keys remain follow-ups.

cargo fmt + clippy `--all-targets` clean; no codegen/schema drift.