### PR TITLE
feat(dagster): project model governance tags onto derived asset specs

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Model-level `[tags]`, inheritable from config groups.** A model can declare a `[tags]` block of free-form governance attributes (`domain`, `tier`, `owner`, …), and a config group can declare `[tags]` that every member inherits as a shared baseline — a model's own tags override the group per key (sidecar > group). Resolved tags are surfaced on `rocky compile --output json` as `models_detail[].tags`, where orchestrators can read them. Merged at the shared `.sql` / `.rocky` resolution path so both model formats inherit. (#920)
+
 ## [1.51.1] — 2026-06-14
 
 ### Security

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Model governance tags on derived asset specs.** `RockyDagsterTranslator.get_model_tags` now projects a model's resolved `[tags]` (its own, inherited from its config group) as first-class Dagster tags — usable in asset selection (`tag:domain=finance`) — alongside the synthesized `rocky/*` metadata. Keys are sanitized to Dagster's tag charset; the synthesized keys keep their `/` so a governance tag can't clobber Rocky's own metadata. Requires `rocky-sdk` with `ModelDetail.tags`; older SDKs degrade to no governance tags. (#921)
+
 ## [1.49.0] — 2026-06-14
 
 ### Changed

--- a/integrations/dagster/src/dagster_rocky/translator.py
+++ b/integrations/dagster/src/dagster_rocky/translator.py
@@ -14,11 +14,27 @@ if TYPE_CHECKING:
     from .types import DagNodeOutput
 
 _INVALID_CHARS = re.compile(r"[^A-Za-z0-9_]")
+_INVALID_TAG_KEY_CHARS = re.compile(r"[^A-Za-z0-9_.\-]")
 
 
 def _sanitize_key_part(s: str) -> str:
     """Replace characters invalid in Dagster names with underscores."""
     return _INVALID_CHARS.sub("_", s)
+
+
+def _sanitize_tag_key(s: str) -> str:
+    """Coerce an arbitrary governance tag key into a Dagster-valid tag key.
+
+    Dagster tag keys allow ``[A-Za-z0-9_.-]`` plus one optional ``/``
+    namespace separator (which this never introduces). Disallowed characters
+    — including ``/`` and whitespace — collapse to ``_``, and the result is
+    truncated to Dagster's 63-character key limit. Two keys that differ only
+    in disallowed characters therefore collapse to the same sanitized key
+    (last write wins); governance keys are expected to be simple identifiers,
+    so this is rare. Returns ``""`` only for an empty input, in which case the
+    caller drops the tag.
+    """
+    return _INVALID_TAG_KEY_CHARS.sub("_", s)[:63]
 
 
 def strip_tenant_component(source: SourceInfo, tenant_component: str) -> SourceInfo:
@@ -199,15 +215,34 @@ class RockyDagsterTranslator:
     def get_model_tags(self, model: ModelDetail) -> dict[str, str]:
         """Returns Dagster tags for a derived model asset.
 
-        Default tags: ``rocky/strategy`` (the materialization type),
-        ``rocky/target_catalog``, ``rocky/target_schema``,
-        ``rocky/model_name``.
+        Two kinds of tag are emitted:
+
+        * **Governance tags** — the model's own ``[tags]`` block, inherited
+          from its config group, projected as *first-class* Dagster tags so
+          they're usable in asset selection (e.g. ``tag:domain=finance``).
+          Keys are sanitized to the Dagster-valid charset via
+          :func:`_sanitize_tag_key` and values stringified; a key that
+          sanitizes to empty is dropped.
+        * **Synthesized metadata tags** — ``rocky/model_name``,
+          ``rocky/target_catalog``, ``rocky/target_schema``, and
+          ``rocky/strategy`` (the materialization type).
+
+        The synthesized keys always contain a ``/``; sanitized governance
+        keys never do, so a governance tag can never clobber Rocky's own
+        metadata. Override this method to namespace governance tags
+        differently or drop the synthesized ones.
         """
-        tags: dict[str, str] = {
-            "rocky/model_name": model.name,
-            "rocky/target_catalog": str(model.target.get("catalog", "")),
-            "rocky/target_schema": str(model.target.get("schema", "")),
-        }
+        tags: dict[str, str] = {}
+        # `getattr` (not `model.tags`) so an older rocky-sdk without the field
+        # degrades to "no governance tags" instead of crashing — same defensive
+        # access the rest of this module uses for newer ModelDetail fields.
+        for key, value in (getattr(model, "tags", None) or {}).items():
+            sanitized = _sanitize_tag_key(str(key))
+            if sanitized:
+                tags[sanitized] = str(value)
+        tags["rocky/model_name"] = model.name
+        tags["rocky/target_catalog"] = str(model.target.get("catalog", ""))
+        tags["rocky/target_schema"] = str(model.target.get("schema", ""))
         strategy_type = model.strategy.get("type") if isinstance(model.strategy, dict) else None
         if strategy_type:
             tags["rocky/strategy"] = str(strategy_type)

--- a/integrations/dagster/tests/test_derived_models.py
+++ b/integrations/dagster/tests/test_derived_models.py
@@ -30,12 +30,14 @@ def _model(
     target: dict[str, str] | None = None,
     freshness: ModelFreshnessConfig | None = None,
     depends_on: list[str] | None = None,
+    tags: dict[str, str] | None = None,
 ) -> ModelDetail:
     detail = ModelDetail(
         name=name,
         strategy=strategy or {"type": "full_refresh"},
         target=target or {"catalog": "warehouse", "schema": "marts", "table": name},
         freshness=freshness,
+        tags=tags,
     )
     # depends_on isn't a field on ModelDetail; the helper reads it via
     # getattr so a custom attribute on the dict is fine for tests. We
@@ -185,6 +187,68 @@ def test_build_model_specs_kinds_includes_rocky_and_model():
 
     assert "rocky" in specs[0].kinds
     assert "model" in specs[0].kinds
+
+
+def test_build_model_specs_projects_governance_tags():
+    # Governance tags (from the model's [tags], inherited from its config
+    # group) land as first-class Dagster tags alongside the synthesized
+    # rocky/* metadata — the engine→orchestrator end of the C4 fan-out.
+    result = _compile_result(
+        _model("orders", tags={"domain": "finance", "tier": "gold"}),
+    )
+    specs = build_model_specs(result, translator=RockyDagsterTranslator())
+
+    assert specs[0].tags["domain"] == "finance"
+    assert specs[0].tags["tier"] == "gold"
+    # synthesized metadata still present and untouched
+    assert specs[0].tags["rocky/model_name"] == "orders"
+
+
+def test_build_model_specs_no_tags_when_model_has_none():
+    result = _compile_result(_model("orders"))
+    specs = build_model_specs(result, translator=RockyDagsterTranslator())
+
+    # only the synthesized rocky/* tags, no governance keys
+    assert all("/" in k for k in specs[0].tags)
+
+
+def test_get_model_tags_sanitizes_keys_and_cannot_clobber_metadata():
+    translator = RockyDagsterTranslator()
+    # A `/` in a governance key would be a second namespace separator (invalid
+    # for Dagster) and could otherwise impersonate a synthesized rocky/* tag;
+    # whitespace is also disallowed. Both collapse to `_`, so the resulting
+    # key can never equal a synthesized `rocky/...` key.
+    model = _model(
+        "orders",
+        tags={"rocky/model_name": "hijack", "cost center": "kpi", "": "dropped"},
+    )
+    tags = translator.get_model_tags(model)
+
+    assert tags["rocky/model_name"] == "orders"  # synthesized wins, not "hijack"
+    assert tags["rocky_model_name"] == "hijack"  # the sanitized governance key
+    assert tags["cost_center"] == "kpi"
+    assert "" not in tags  # empty key dropped
+
+
+def test_build_model_specs_gnarly_tag_keys_pass_dagster_validation():
+    # The real test of sanitization: Dagster validates tag keys at AssetSpec
+    # construction (charset [A-Za-z0-9_.-], ≤63 chars, no second `/`). Push
+    # keys that would be rejected raw — whitespace, an extra slash, an
+    # over-long key — through build_model_specs and prove they're accepted,
+    # not just that our regex produced what we expected.
+    long_key = "x" * 100
+    result = _compile_result(
+        _model(
+            "orders",
+            tags={"cost center": "kpi", "a/b/c": "v", long_key: "w"},
+        ),
+    )
+    # Would raise DagsterInvalidDefinitionError here if any key were invalid.
+    specs = build_model_specs(result, translator=RockyDagsterTranslator())
+
+    assert specs[0].tags["cost_center"] == "kpi"
+    assert specs[0].tags["a_b_c"] == "v"
+    assert all(len(k) <= 63 for k in specs[0].tags)
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`ModelDetail.tags`** — model-level governance tags (`{key: value}` strings) resolved from a model's `[tags]` block and its config group, parsed from `rocky compile`'s `models_detail[].tags`. `None` when none are declared. (#921)
+
 ## [0.1.1] — 2026-06-14
 
 ### Added

--- a/sdk/python/src/rocky_sdk/types.py
+++ b/sdk/python/src/rocky_sdk/types.py
@@ -527,6 +527,12 @@ class ModelDetail(BaseModel):
     strategy: dict[str, object]
     target: dict[str, str]
     freshness: ModelFreshnessConfig | None = None
+    #: Model-level governance tags — the model's own ``[tags]`` block merged
+    #: over any config-group ``[tags]`` baseline (sidecar > group). Free-form
+    #: ``{key: value}`` strings describing the model as a whole (``domain``,
+    #: ``tier``, ``owner``, …). ``None`` when none are declared. ``dagster-rocky``
+    #: projects these onto the derived asset's Dagster tags.
+    tags: dict[str, str] | None = None
 
 
 class CompileResult(BaseModel):

--- a/sdk/python/tests/test_types.py
+++ b/sdk/python/tests/test_types.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import pytest
 
-from rocky_sdk import DiscoverResult, parse_rocky_output
+from rocky_sdk import CompileResult, DiscoverResult, parse_rocky_output
 from rocky_sdk.client import _parse_rocky_json, _parse_run_or_apply
 from rocky_sdk.exceptions import RockyOutputParseError
 
@@ -17,6 +17,34 @@ def test_parse_rocky_output_dispatches_discover():
     result = parse_rocky_output(DISCOVER_JSON)
     assert isinstance(result, DiscoverResult)
     assert result.sources == []
+
+
+def test_parse_compile_surfaces_model_governance_tags():
+    # A model's resolved [tags] (own + inherited from its config group) ride
+    # on `models_detail[].tags` — the seam dagster-rocky reads to project
+    # governance tags onto the derived asset.
+    payload = (
+        '{"version": "1.0.0", "command": "compile", "models": 1, '
+        '"execution_layers": 1, "diagnostics": [], "has_errors": false, '
+        '"models_detail": [{"name": "fct_orders", '
+        '"strategy": {"type": "full_refresh"}, '
+        '"target": {"catalog": "wh", "schema": "mart_emea", "table": "fct_orders"}, '
+        '"tags": {"domain": "finance", "tier": "silver"}}]}'
+    )
+    result = parse_rocky_output(payload)
+    assert isinstance(result, CompileResult)
+    assert result.models_detail[0].tags == {"domain": "finance", "tier": "silver"}
+
+
+def test_parse_compile_model_without_tags_defaults_none():
+    payload = (
+        '{"version": "1.0.0", "command": "compile", "models": 1, '
+        '"execution_layers": 1, "diagnostics": [], "has_errors": false, '
+        '"models_detail": [{"name": "stg", "strategy": {"type": "full_refresh"}, '
+        '"target": {"catalog": "wh", "schema": "s", "table": "stg"}}]}'
+    )
+    result = parse_rocky_output(payload)
+    assert result.models_detail[0].tags is None
 
 
 def test_parse_rocky_output_rejects_non_object():


### PR DESCRIPTION
## What

Completes the C4 governed-materialization fan-out **end-to-end**. Engine PR #920 made a model's resolved `[tags]` (its own + inherited from its config group) available on `rocky compile --output json`; this PR carries them through the SDK and projects them onto the Dagster asset.

A config group declares a governance attribute once → every member model inherits it → it lands on the derived Dagster asset, usable in selection (`tag:domain=finance`).

## How

- **sdk:** add `tags: dict[str, str] | None` to the hand-written `rocky_sdk.types.ModelDetail` — the curated model `parse_rocky_output` builds and `dagster-rocky` consumes (the generated `compile_schema.ModelDetail` already carries it, but that's not the one on the consumer path). Populated automatically from the engine JSON.
- **dagster:** `RockyDagsterTranslator.get_model_tags` projects governance tags as **first-class** Dagster tags (alongside the synthesized `rocky/*` metadata), matching how `dagster-dbt` surfaces model tags. Keys are sanitized to Dagster's tag charset (`[A-Za-z0-9_.-]`, ≤63 chars, no second `/`); the synthesized keys keep their `/`, so a governance tag can **never** clobber Rocky's own metadata. Read via `getattr` so an older `rocky-sdk` degrades to "no governance tags" rather than crashing.

## Verification

- sdk: 32 tests (incl. compile-parse with/without tags), ruff check + format clean.
- dagster: 644 tests, ruff check + format clean.
- **Sanitization proven against Dagster's *actual* rules**, not just the regex: a test pushes gnarly keys (whitespace, extra `/`, 100-char) through `build_model_specs` → `dg.AssetSpec`, which validates tag keys at construction — confirming sanitized output is accepted (and that a governance key can't impersonate `rocky/model_name`).

## Release ordering

`rocky-sdk` `0.1.1` is already published **without** this field, so the next cut needs an **sdk version bump** (0.1.2+) containing `tags`, released **before** the `dagster-rocky` cut that floors on it. Because the translator reads via `getattr`, a mismatch degrades silently (tags absent) rather than erroring — track it on the release checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)