### PR TITLE
test(engine): gate on-disk state format (F1) + mixed-version no-clobber upload (F2)

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -3594,15 +3594,15 @@ pub async fn run(
     // Upload state to remote storage — unless this store was bootstrapped
     // fresh from a forward-incompatible on-disk schema. In that case the local
     // state is a downgrade; persisting it back would clobber the newer state
-    // that already-upgraded pods depend on, so we deliberately skip the upload.
-    if suppress_state_upload {
-        info!(
-            outcome = "skipped_forward_incompat_recreate",
-            "skipping end-of-run state upload: local state was recreated after a \
-             forward-incompatible schema mismatch (on_schema_mismatch = recreate); \
-             leaving the newer shared state intact"
-        );
-    } else if let Err(e) = rocky_core::state_sync::upload_state(&rocky_cfg.state, state_path).await {
+    // that already-upgraded pods depend on, so the upload is deliberately
+    // skipped (the periodic mid-run uploader above is gated by the same flag).
+    if let Err(e) = rocky_core::state_sync::upload_state_unless_recreated(
+        suppress_state_upload,
+        &rocky_cfg.state,
+        state_path,
+    )
+    .await
+    {
         warn!(error = %e, "state upload failed");
     }
 

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -6148,6 +6148,74 @@ mod tests {
         );
     }
 
+    /// F1 golden: pin the **on-disk state-schema format** — the schema version
+    /// plus the exact set of redb tables a fresh store materializes.
+    ///
+    /// The `state.redb` file is persisted and shared across pods (see
+    /// `state_sync`), so its layout is a compatibility contract. `init_db`
+    /// eagerly creates every table, so a fresh store's `list_tables()` is the
+    /// authoritative on-disk table set. Adding, removing, or renaming a table
+    /// — or bumping `CURRENT_SCHEMA_VERSION` — must be a deliberate, reviewed
+    /// change paired with the version-mismatch migration story (the
+    /// `open_with_policy_*` tests above). This test fails on any such change
+    /// until the golden below is updated **in the same PR**, making "no silent
+    /// breaking change to the consumed state format" mechanically true.
+    #[test]
+    fn on_disk_state_schema_format_is_pinned() {
+        use redb::TableHandle;
+
+        // The pinned format contract. Update DELIBERATELY: a table-set change
+        // is an on-disk break that needs a `CURRENT_SCHEMA_VERSION` bump + a
+        // migration path, not just an edit here.
+        const EXPECTED_VERSION: u32 = 9;
+        const EXPECTED_TABLES: &[&str] = &[
+            "branches",
+            "check_history",
+            "dag_snapshots",
+            "discover_snapshots",
+            "grace_periods",
+            "idempotency_keys",
+            "input_index",
+            "input_provenance",
+            "loaded_files",
+            "metadata",
+            "output_artifacts",
+            "partitions",
+            "quality_history",
+            "run_history",
+            "run_progress",
+            "run_progress_entries",
+            "schema_cache",
+            "watermarks",
+        ];
+
+        assert_eq!(
+            CURRENT_SCHEMA_VERSION, EXPECTED_VERSION,
+            "the on-disk state schema version changed. Update EXPECTED_VERSION here, and \
+             confirm the version-mismatch migration path (open_with_policy_* tests) handles \
+             the bump, in the same PR."
+        );
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("state.redb");
+        let store = StateStore::open(&path).unwrap();
+        let txn = store.db.begin_read().unwrap();
+        let mut actual: Vec<String> = txn
+            .list_tables()
+            .unwrap()
+            .map(|t| t.name().to_string())
+            .collect();
+        actual.sort_unstable();
+
+        assert_eq!(
+            actual, EXPECTED_TABLES,
+            "the on-disk state table set changed: a fresh `StateStore` now materializes a \
+             different set of redb tables than the pinned format contract. If intentional, \
+             update EXPECTED_TABLES (and bump CURRENT_SCHEMA_VERSION + add the migration) in \
+             the same PR."
+        );
+    }
+
     // -----------------------------------------------------------------------
     // VACUUM refcount (Phase 6) — refcount_for_hash + partition_vacuum_candidates
     // -----------------------------------------------------------------------

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -266,6 +266,39 @@ pub async fn upload_state(config: &StateConfig, local_path: &Path) -> Result<(),
         .await
 }
 
+/// End-of-run state upload, suppressed when the local store was recreated after
+/// a forward-incompatible schema mismatch.
+///
+/// This is the **no-clobber** half of the mixed-version safety invariant. When
+/// `recreated_for_forward_incompat` is true, the local `state.redb` was
+/// bootstrapped fresh under `on_schema_mismatch = recreate` because the on-disk
+/// state was written by a *newer* binary — so the local state is a downgrade.
+/// Uploading it back would overwrite the newer shared state that
+/// already-upgraded pods depend on, so the upload is deliberately skipped.
+/// Otherwise the local state is uploaded via [`upload_state`].
+///
+/// The open-time half of the invariant (refusing to *run* against
+/// forward-incompatible on-disk state, or recreating under policy) lives in
+/// [`crate::state`]'s `open_with_policy`. The periodic mid-run uploader in the
+/// CLI is gated by the same flag at spawn time (it is simply not started when
+/// the store was recreated), so both upload paths honor the suppression.
+pub async fn upload_state_unless_recreated(
+    recreated_for_forward_incompat: bool,
+    config: &StateConfig,
+    local_path: &Path,
+) -> Result<(), StateSyncError> {
+    if recreated_for_forward_incompat {
+        info!(
+            outcome = "skipped_forward_incompat_recreate",
+            "skipping end-of-run state upload: local state was recreated after a \
+             forward-incompatible schema mismatch (on_schema_mismatch = recreate); \
+             leaving the newer shared state intact"
+        );
+        return Ok(());
+    }
+    upload_state(config, local_path).await
+}
+
 /// Variant of [`upload_state`] that lets the caller override the list of
 /// redb tables stripped from the remote copy.
 ///
@@ -1575,5 +1608,54 @@ mod tests {
 
         let config = StateConfig::default();
         assert!(upload_state(&config, &src).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn upload_state_unless_recreated_suppresses_upload_when_recreated() {
+        // The "no-clobber" half of the mixed-version safety invariant: when the
+        // local store was recreated after a forward-incompatible schema
+        // mismatch, the end-of-run upload must NOT run — otherwise a downgraded
+        // pod overwrites the newer shared state.
+        //
+        // We prove the upload is *not attempted* (not just that a bool flipped)
+        // by pointing the config at a real upload backend that hard-errors the
+        // moment dispatch is reached — S3 with no bucket, under the `Fail`
+        // policy so the error propagates instead of being warn-swallowed:
+        //   recreated = true  → Ok                       (upload skipped, broken backend never touched)
+        //   recreated = false → Err(MissingConfig "s3")  (upload attempted, hit the broken S3 dispatch)
+        // Deleting the suppression guard would make the `true` case also reach
+        // the broken backend and fail — i.e. this test goes red, which is the
+        // regression we want to catch.
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("state.redb");
+        // The local state file must exist, else `upload_state` early-returns Ok
+        // and the `false` case would look "skipped" too.
+        seed_watermark_and_cache(&src);
+
+        let config = StateConfig {
+            backend: StateBackend::S3,
+            s3_bucket: None, // deliberately misconfigured → dispatch yields MissingConfig
+            on_upload_failure: StateUploadFailureMode::Fail, // propagate, don't warn-swallow
+            ..StateConfig::default()
+        };
+
+        // Recreated store: the upload is skipped entirely, so the broken
+        // backend is never reached.
+        assert!(
+            upload_state_unless_recreated(true, &config, &src)
+                .await
+                .is_ok(),
+            "a store recreated for forward-incompat must skip the end-of-run upload"
+        );
+
+        // Normal store: the upload runs and hits the (deliberately broken) S3
+        // dispatch — proving the gate let a real upload attempt through.
+        let err = upload_state_unless_recreated(false, &config, &src)
+            .await
+            .expect_err("an un-suppressed upload must actually attempt the backend");
+        assert!(
+            matches!(&err, StateSyncError::MissingConfig(backend, _) if backend == "s3"),
+            "expected the S3 dispatch to be reached (MissingConfig for the bucket); got {err:?}"
+        );
     }
 }


### PR DESCRIPTION
Two release-gate invariants for the consumed **state** surface — the buildable halves of F1 and F2 from the finite-work plan.

## F1 — on-disk state-schema format golden

There was no test pinning the on-disk state layout. The `state.redb` file is persisted and shared across pods (`state_sync`), so its layout is a compatibility contract. New test `on_disk_state_schema_format_is_pinned`:

- asserts `CURRENT_SCHEMA_VERSION == 9`, and
- asserts the exact set of redb tables a fresh store materializes (18), read back from `list_tables()` so the golden is **self-correcting** and **auto-detects** any table add/remove/rename (`init_db` eagerly creates every table).

Any such change now fails CI until the golden — and, for a table change, the version + migration — is updated in the same PR.

Scoped to table-set + version on purpose: record *values* are deliberately **not** byte-pinned, because the `*_forward_deserializes_*` tests exist to *allow* field evolution.

## F2 — mixed-version no-clobber upload

The **open-time** half of the mixed-version invariant was already gated: `open_with_policy_*` cover forward-incompat hard-fail/Fail/Recreate, backward auto-migrate, and same-version no-op, and run in engine-ci. This was **not** untested before — this PR adds the missing **run-time** half.

The catastrophic form of the 06-07 failure mode is a downgraded pod (recreated under `on_schema_mismatch = recreate`) uploading its state back and clobbering the newer shared state. The end-of-run skip decision was inline in the 3600-line `run` fn and untested. This PR:

- extracts it into `state_sync::upload_state_unless_recreated(recreated, cfg, path)` (behavior-preserving — the run path keeps its `warn!`-on-error), and
- tests it by pointing at a backend that hard-errors the moment dispatch is reached (S3 with no bucket, `on_upload_failure = Fail`): `recreated=true → Ok` (upload skipped), `recreated=false → Err(MissingConfig "s3")` (upload attempted). Deleting the guard turns the test **red** (verified).

Both upload sites honor the flag: the periodic mid-run uploader is gated at spawn time (not started when the store was recreated); the end-of-run upload goes through the new seam.

## Verification

`cargo test --all-features -p rocky-core -p rocky-cli` green (the new F1/F2 tests + 1361 rocky-core); `cargo fmt --check` + `clippy --all-targets --all-features` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)