### PR TITLE
feat(engine): config-group misplacement guard — reject incoherent args + pinned schema (C5)

### DIFF
--- a/docs/src/content/docs/reference/model-format.md
+++ b/docs/src/content/docs/reference/model-format.md
@@ -167,6 +167,8 @@ region = "emea"         # fills {region} -> schema "mart_emea"
 
 Precedence is **per-model sidecar > group > `_defaults.toml`**: a model can still pin its own `schema` or `strategy` to override the group, and the group in turn overrides directory defaults. A `group` that names no definition, or a `schema_template` placeholder the model doesn't supply, fails the load with a clear error rather than routing a model to the wrong place.
 
+A model that pins its own `schema` overrides the group's template entirely — so it must **not** also supply `[args]`, since the args could only fill a template that's now bypassed. That combination is a misplacement (the args silently do nothing, usually masking a routing mistake) and fails the load. Pin a schema *or* supply args, not both.
+
 #### Enforced groups
 
 Set `enforce = true` on a group to make its fields binding rather than defaults. A member model that locally pins a field the group controls — its target `schema` or its `strategy` — then fails the load instead of silently routing or materializing itself differently from the rest of the group:

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Model-level `[tags]`, inheritable from config groups.** A model can declare a `[tags]` block of free-form governance attributes (`domain`, `tier`, `owner`, …), and a config group can declare `[tags]` that every member inherits as a shared baseline — a model's own tags override the group per key (sidecar > group). Resolved tags are surfaced on `rocky compile --output json` as `models_detail[].tags`, where orchestrators can read them. Merged at the shared `.sql` / `.rocky` resolution path so both model formats inherit. (#920)
+- **Config-group misplacement guard.** A group member that pins its own `target.schema` **and** supplies `[args]` now fails the load: the pin bypasses the group's `schema_template`, so the args could only fill a template that's never used — a contradiction that usually masks a routing mistake. Pinning a schema with no args (a legitimate override) and routing via args with no pin both stay valid. (#923)
 
 ## [1.51.1] — 2026-06-14
 

--- a/engine/crates/rocky-compiler/src/project.rs
+++ b/engine/crates/rocky-compiler/src/project.rs
@@ -678,4 +678,41 @@ mod tests {
             Some("data-eng")
         );
     }
+
+    /// Regression: the C5 misplacement guard (a group member that supplies
+    /// `[args]` AND pins its own `target.schema`) fires for a `.rocky` DSL model
+    /// too, since it rides the shared `resolve_model_config` chokepoint — not
+    /// only the `.sql` `load_models_from_dir` path.
+    #[test]
+    fn rocky_model_args_with_pinned_schema_is_rejected() {
+        let _guard = crate::salsa_compile::tests::TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let dir = tempfile::tempdir().unwrap();
+        let d = dir.path();
+        std::fs::create_dir_all(d.join("groups")).unwrap();
+        std::fs::write(
+            d.join("groups/marts.toml"),
+            "schema_template = \"mart_{region}\"\n",
+        )
+        .unwrap();
+        std::fs::write(d.join("flow.rocky"), "from orders\nselect { id }\n").unwrap();
+        std::fs::write(
+            d.join("flow.toml"),
+            "group = \"marts\"\n\n[target]\ncatalog = \"wh\"\nschema = \"escape\"\n\n[args]\nregion = \"emea\"\n",
+        )
+        .unwrap();
+
+        let err = load_dir_models(d).unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                ProjectError::ModelLoad(rocky_core::models::ModelError::GroupArgsWithPinnedSchema {
+                    model,
+                    group,
+                }) if model == "flow" && group == "marts"
+            ),
+            "got {err:?}"
+        );
+    }
 }

--- a/engine/crates/rocky-core/src/models.rs
+++ b/engine/crates/rocky-core/src/models.rs
@@ -67,6 +67,11 @@ pub enum ModelError {
     },
 
     #[error(
+        "model '{model}' supplies [args] for config group '{group}'s schema_template but also pins its own target.schema; the pin overrides the template, so the [args] are dead. Remove the pinned schema to route via [args], or remove [args] if the pinned schema is intended."
+    )]
+    GroupArgsWithPinnedSchema { model: String, group: String },
+
+    #[error(
         "model '{model}' references unknown named test '{name}' (expected a [{name}] entry in test_definitions.toml)"
     )]
     UnknownTest { model: String, name: String },
@@ -928,6 +933,31 @@ fn resolve_model_config(
         }
     }
 
+    // Misplacement guard (C5): `[args]` exist solely to fill a group's
+    // `schema_template`. If a member also pins its own `target.schema`, the pin
+    // wins (sidecar > group) and the `[args]` become dead — an incoherent
+    // config that usually means the author believes `[args]` is routing the
+    // model when the pin actually sends it elsewhere. Hard-error regardless of
+    // `enforce` (this is a coherence check, not enforcement): an enforced group
+    // already rejects the pin above, so this only adds the non-enforced case. A
+    // legitimate non-enforced override pins a schema with NO `[args]`, which
+    // stays allowed. (`[args]` is template-only; if a future feature consumes
+    // args elsewhere, revisit this guard.)
+    if let Some(g) = group
+        && g.schema_template.is_some()
+        && !raw.args.is_empty()
+        && raw
+            .target
+            .as_ref()
+            .and_then(|t| t.schema.as_ref())
+            .is_some()
+    {
+        return Err(ModelError::GroupArgsWithPinnedSchema {
+            model: name.clone(),
+            group: raw.group.as_deref().unwrap_or_default().to_string(),
+        });
+    }
+
     // Precedence: per-model sidecar > group > directory defaults.
     let strategy = raw
         .strategy
@@ -962,14 +992,25 @@ fn resolve_model_config(
     // Group routing: when the sidecar doesn't pin a schema, fall back to the
     // group's `schema_template` (filled from the model's `args`) before the
     // directory default — keeping the sidecar > group > defaults precedence.
-    let group_schema = match group.and_then(|g| g.schema_template.as_deref()) {
-        Some(template) => Some(resolve_group_schema(
-            template,
-            &raw.args,
-            &name,
-            raw.group.as_deref().unwrap_or_default(),
-        )?),
-        None => None,
+    //
+    // Resolution is lazy: a model that pins its own `target.schema` overrides
+    // the group, so the template is skipped entirely. This keeps a legitimate
+    // pin-without-args override from erroring on an unfilled placeholder for a
+    // template it never uses. (Pin *with* `[args]` is rejected by the
+    // misplacement guard above; this branch handles the allowed pin-without-args
+    // case and the no-pin routing case.)
+    let group_schema = if raw_target.schema.is_some() {
+        None
+    } else {
+        match group.and_then(|g| g.schema_template.as_deref()) {
+            Some(template) => Some(resolve_group_schema(
+                template,
+                &raw.args,
+                &name,
+                raw.group.as_deref().unwrap_or_default(),
+            )?),
+            None => None,
+        }
     };
     let schema = raw_target
         .schema
@@ -2966,7 +3007,10 @@ columns = ["order_id"]
         std::fs::write(
             dir.path().join("orders.toml"),
             // Sidecar pins both schema and strategy — the group must not override.
-            "group = \"daily_marts\"\n\n[target]\ncatalog = \"wh\"\nschema = \"custom\"\n\n[args]\nregion = \"emea\"\n\n[strategy]\ntype = \"full_refresh\"\n",
+            // No `[args]`: pinning the schema is a legitimate override, but pairing
+            // it with `[args]` would trip the misplacement guard (the args could
+            // only fill the now-bypassed template).
+            "group = \"daily_marts\"\n\n[target]\ncatalog = \"wh\"\nschema = \"custom\"\n\n[strategy]\ntype = \"full_refresh\"\n",
         )
         .unwrap();
         std::fs::write(dir.path().join("orders.sql"), "SELECT id, v FROM upstream").unwrap();
@@ -3158,7 +3202,8 @@ columns = ["order_id"]
         let m = &load_models_from_dir(dir.path()).unwrap()[0];
         assert_eq!(m.config.target.schema, "mart_emea");
 
-        // The same override under a NON-enforced group is allowed.
+        // The same override under a NON-enforced group is allowed (pin a schema
+        // with no `[args]` — the template is bypassed, not filled).
         let dir2 = tempfile::tempdir().unwrap();
         write_group(
             dir2.path(),
@@ -3167,7 +3212,7 @@ columns = ["order_id"]
         );
         std::fs::write(
             dir2.path().join("orders.toml"),
-            "group = \"flexible\"\n\n[target]\ncatalog = \"wh\"\nschema = \"escape\"\n\n[args]\nregion = \"emea\"\n",
+            "group = \"flexible\"\n\n[target]\ncatalog = \"wh\"\nschema = \"escape\"\n",
         )
         .unwrap();
         std::fs::write(dir2.path().join("orders.sql"), "SELECT id, v FROM upstream").unwrap();
@@ -3175,6 +3220,52 @@ columns = ["order_id"]
         assert_eq!(
             m2.config.target.schema, "escape",
             "non-enforced group allows override"
+        );
+    }
+
+    /// C5 misplacement guard: a group member that supplies `[args]` (which only
+    /// fill the group's `schema_template`) AND pins its own `target.schema` is
+    /// an incoherent config — the pin bypasses the template, leaving the args
+    /// dead. It is a hard error regardless of `enforce`.
+    #[test]
+    fn group_args_with_pinned_schema_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        // Non-enforced group with a placeholder template.
+        write_group(dir.path(), "marts", "schema_template = \"mart_{region}\"\n");
+        std::fs::write(
+            dir.path().join("orders.toml"),
+            // Pins schema AND supplies args → the args can never route anything.
+            "group = \"marts\"\n\n[target]\ncatalog = \"wh\"\nschema = \"escape\"\n\n[args]\nregion = \"emea\"\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("orders.sql"), "SELECT 1 AS id").unwrap();
+
+        let err = load_models_from_dir(dir.path()).unwrap_err();
+        assert!(
+            matches!(err, ModelError::GroupArgsWithPinnedSchema { ref model, ref group }
+                if model == "orders" && group == "marts"),
+            "got {err:?}"
+        );
+    }
+
+    /// The allowed companion to the guard: a group member may pin its own schema
+    /// as long as it supplies no `[args]` — the placeholder template is bypassed
+    /// (and never resolved), so an unfilled `{region}` is not an error.
+    #[test]
+    fn group_member_pins_schema_without_args_is_allowed() {
+        let dir = tempfile::tempdir().unwrap();
+        write_group(dir.path(), "marts", "schema_template = \"mart_{region}\"\n");
+        std::fs::write(
+            dir.path().join("orders.toml"),
+            "group = \"marts\"\n\n[target]\ncatalog = \"wh\"\nschema = \"escape\"\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("orders.sql"), "SELECT 1 AS id").unwrap();
+
+        let m = &load_models_from_dir(dir.path()).unwrap()[0];
+        assert_eq!(
+            m.config.target.schema, "escape",
+            "a pin without args overrides the group, bypassing the template"
         );
     }
 


### PR DESCRIPTION
## What

The buildable remainder of **C5**. Most of C5 — *"a model's target schema derives from its location/metadata"* — was **already delivered by C4**: config groups derive a member's schema from `schema_template` + per-model `[args]`, and `enforce = true` hard-blocks an override for enforced groups. This PR adds the one piece that was missing: the **misplacement guard** for the incoherent config the plan calls "a misplaced model fails compile."

A group's `[args]` exist *solely* to fill its `schema_template`. If a member also pins its own `target.schema`, the pin wins (`sidecar > group`), so the template is bypassed and the args are **dead**. That's never a valid override — it usually masks a routing mistake ("I thought `[args]` routed this model, but the pin sends it elsewhere"). It now fails the load:

```toml
# group marts: schema_template = "mart_{region}"
group = "marts"
[target]
schema = "escape"     # pins schema → bypasses the template
[args]
region = "emea"       # ...so this can never route anything → ERROR
```

`ModelError::GroupArgsWithPinnedSchema`. Pin a schema *or* supply args, not both.

## How

- Detected in the shared `resolve_model_config` chokepoint, next to the existing `enforce` check — so it covers **both `.sql` and `.rocky`** for free (`.rocky` regression included). No `ModelConfig` churn, no new warning channel; a load error fails compile, the same path `GroupOverride` already uses.
- **Group-schema resolution is now lazy**: a model that pins its own schema skips the template entirely. Without this, a legitimate *pin-without-args* override would error on an unfilled `{region}` placeholder for a template it never uses. (`[args]` is template-only — verified no other consumer — and unreleased, so no existing project changes behavior.)

## Allowed cases (unchanged)

- Pin a schema, no args → override (template bypassed).
- Supply args, no pin → route via template.
- Enforced group + pin → already `GroupOverride`.

Only the contradiction (group with a template + args + pin) is rejected. Two existing tests that encoded the now-forbidden args+pin pattern were updated to the coherent override (pin, no args).

## Verification

`cargo test --all-features -p rocky-core -p rocky-compiler` green (incl. the guard, the allowed companion, and the `.rocky` regression); `cargo fmt --check` + `clippy --all-targets --all-features` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)