### PR TITLE
fix: address self-review findings across engine, rocky-sdk, and dagster

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Model-level `[tags]`, inheritable from config groups.** A model can declare a `[tags]` block of free-form governance attributes (`domain`, `tier`, `owner`, …), and a config group can declare `[tags]` that every member inherits as a shared baseline — a model's own tags override the group per key (sidecar > group). Resolved tags are surfaced on `rocky compile --output json` as `models_detail[].tags`, where orchestrators can read them. Merged at the shared `.sql` / `.rocky` resolution path so both model formats inherit. (#920)
 - **Config-group misplacement guard.** A group member that pins its own `target.schema` **and** supplies `[args]` now fails the load: the pin bypasses the group's `schema_template`, so the args could only fill a template that's never used — a contradiction that usually masks a routing mistake. Pinning a schema with no args (a legitimate override) and routing via args with no pin both stay valid. (#923)
 
+### Changed
+
+- **A config group's `schema_template` is validated as a SQL identifier once resolved against a model's `[args]`.** A bad `[args]` value (e.g. one carrying a hyphen) now fails at load with a clear message instead of surfacing later as broken SQL — the same `validate_identifier` the table-reference builder applies, so load and run agree. (#924)
+- **Typos in a `[[surrogate_key]]` or `[[use_test]]` sidecar block now fail the load** (`deny_unknown_fields`) instead of being silently ignored. (#924)
+
+### Fixed
+
+- **`emit-sql --out-dir` skips a model whose name is not a safe filename** (reporting it) rather than joining the name into the output path. (#924)
+
 ## [1.51.1] — 2026-06-14
 
 ### Security

--- a/engine/crates/rocky-cli/src/commands/emit_sql.rs
+++ b/engine/crates/rocky-cli/src/commands/emit_sql.rs
@@ -11,7 +11,8 @@
 //! ## Scope of the runnable guarantee
 //!
 //! Full-refresh models emit a complete `CREATE OR REPLACE TABLE … AS …` that
-//! runs as-is against a fresh warehouse and is identical to what a run executes.
+//! runs as-is against a fresh warehouse and matches what a run executes in the
+//! resolved dialect (see the dialect note below).
 //! Incremental and merge models emit their **steady-state** statement (a bare
 //! `INSERT` / `MERGE` that operates on an existing target); `rocky run`
 //! bootstraps the target table on first build and threads the incremental
@@ -20,7 +21,10 @@
 //!
 //! The dialect is the project's configured target adapter type (resolved from
 //! `rocky.toml` without credentials); with no resolvable config it defaults to
-//! DuckDB. Output is one `<model>.sql` file per model when `--out-dir` is given,
+//! DuckDB. All models render in this one resolved dialect, so for a project
+//! whose models target more than one adapter, the emitted SQL matches
+//! `rocky run` only for the models whose target uses that dialect. Output is
+//! one `<model>.sql` file per model when `--out-dir` is given,
 //! otherwise the concatenated SQL is printed to stdout, both in dependency
 //! order. Models that produce no standalone SQL — ephemeral (inlined as CTEs)
 //! or strategies that cannot render offline (e.g. Snowflake `DynamicTable`,
@@ -217,6 +221,20 @@ fn emit_models(
     })
 }
 
+/// True when `name` is safe to use as a single `<name>.sql` filename component:
+/// non-empty, no path separators, no parent-/absolute-path escape. Model names
+/// are normally plain identifiers; a name that fails this is anomalous, so the
+/// `--out-dir` path skips it with a report rather than risking a `std::fs::write`
+/// outside `out_dir` via a traversing join.
+fn is_safe_file_stem(name: &str) -> bool {
+    !name.is_empty()
+        && !name.contains('/')
+        && !name.contains('\\')
+        && !Path::new(name).is_absolute()
+        && Path::new(name).components().count() == 1
+        && Path::new(name).file_name().and_then(|n| n.to_str()) == Some(name)
+}
+
 /// `rocky emit-sql` entry point. Writes one `<model>.sql` per model into
 /// `out_dir` when given, otherwise prints the concatenated SQL to stdout.
 pub fn run_emit_sql(
@@ -225,7 +243,10 @@ pub fn run_emit_sql(
     model_filter: Option<&str>,
     out_dir: Option<&Path>,
 ) -> Result<()> {
-    let EmitResult { models, skipped } = emit_models(config_path, models_dir, model_filter)?;
+    let EmitResult {
+        models,
+        mut skipped,
+    } = emit_models(config_path, models_dir, model_filter)?;
 
     if models.is_empty() {
         println!("emit-sql: no transformation SQL to emit.");
@@ -237,14 +258,22 @@ pub fn run_emit_sql(
         Some(dir) => {
             std::fs::create_dir_all(dir)
                 .with_context(|| format!("failed to create out-dir {}", dir.display()))?;
+            let mut written = 0usize;
             for m in &models {
+                if !is_safe_file_stem(&m.name) {
+                    skipped.push(format!(
+                        "{} (unsafe model name for a file path; not written)",
+                        m.name
+                    ));
+                    continue;
+                }
                 let path = dir.join(format!("{}.sql", m.name));
                 std::fs::write(&path, format!("{}\n", file_body(m)))
                     .with_context(|| format!("failed to write {}", path.display()))?;
+                written += 1;
             }
             println!(
-                "emit-sql: wrote {} model(s) to {} in dependency order",
-                models.len(),
+                "emit-sql: wrote {written} model(s) to {} in dependency order",
                 dir.display()
             );
         }
@@ -420,5 +449,25 @@ mod tests {
             .expect("query materialized table");
         assert_eq!(r.rows.len(), 1);
         assert_eq!(r.rows[0][0].as_str(), Some("ok"));
+    }
+
+    #[test]
+    fn is_safe_file_stem_rejects_path_traversal() {
+        // Plain identifiers and dotted names are fine.
+        assert!(is_safe_file_stem("stg_orders"));
+        assert!(is_safe_file_stem("orders.v2"));
+        // Anything that could escape `out_dir` via the join is rejected.
+        for bad in [
+            "",
+            "..",
+            ".",
+            "../evil",
+            "a/b",
+            "a\\b",
+            "/abs",
+            "/etc/passwd",
+        ] {
+            assert!(!is_safe_file_stem(bad), "expected {bad:?} to be rejected");
+        }
     }
 }

--- a/engine/crates/rocky-core/src/models.rs
+++ b/engine/crates/rocky-core/src/models.rs
@@ -736,7 +736,12 @@ pub struct NamedTest {
 /// A `[[use_test]]` reference in a model sidecar: apply the named test `name`
 /// (from `test_definitions.toml`) to this model, optionally binding/overriding
 /// the column, severity, and row filter at the use site.
+///
+/// `deny_unknown_fields` so a mistyped key in a `[[use_test]]` block (e.g.
+/// `colum =` or `filer =`) is rejected at load instead of being silently
+/// ignored, which would apply the test with the wrong binding.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TestRef {
     /// Name of the definition in `test_definitions.toml`.
     pub name: String,
@@ -835,6 +840,20 @@ fn resolve_group_schema(
             reason: format!(
                 "group '{group}' schema_template '{template}' has unfilled placeholder(s); \
                  supply them under the model's [args]"
+            ),
+        });
+    }
+    // The resolved schema flows into `format_table_ref`, which validates every
+    // component with `validate_identifier`. Validate here too — with the same
+    // validator — so an `[args]` value carrying a bad character (e.g. a hyphen
+    // or quote) fails at load with a clear message instead of at SQL-gen, and
+    // load/run never disagree on what's acceptable.
+    if rocky_sql::validation::validate_identifier(&resolved).is_err() {
+        return Err(ModelError::InvalidGroup {
+            model: model.to_string(),
+            reason: format!(
+                "group '{group}' schema_template resolved to '{resolved}', which is not a valid \
+                 SQL identifier; check the model's [args] values"
             ),
         });
     }
@@ -1612,7 +1631,12 @@ pub fn load_column_docs_from_dir(
 /// A surrogate-key computed column declared in a model sidecar
 /// `[[surrogate_key]]` block: an output column `name` whose value is a
 /// deterministic hash of `columns`, injected into the materialized SELECT.
+///
+/// `deny_unknown_fields` so a typo in a `[[surrogate_key]]` block (e.g.
+/// `colums = [...]`) fails the load loudly rather than silently dropping the
+/// columns and computing the hash over nothing.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SurrogateKeySpec {
     pub name: String,
     pub columns: Vec<String>,
@@ -1745,6 +1769,15 @@ fn validate_surrogate_key_spec(spec: &SurrogateKeySpec, model: &str) -> Result<(
 /// A no-op when `specs` is empty. Used by both the materialization path and the
 /// skip-gate IR, so a model that *gains* a key re-materializes rather than being
 /// skipped as unchanged.
+///
+/// # Precondition
+///
+/// Every spec must already be validated by [`validate_surrogate_key_spec`] —
+/// [`load_surrogate_keys_from_dir`] does this at load. The spec's `name` and
+/// `columns` are interpolated into SQL without re-escaping (per the
+/// validate-before-interpolation rule), so passing an unvalidated spec is a
+/// SQL-injection vector. A `debug_assert!` re-checks the precondition in debug
+/// builds.
 pub fn apply_surrogate_keys(
     model_ir: &mut rocky_ir::ModelIr,
     specs: &[SurrogateKeySpec],
@@ -1753,6 +1786,14 @@ pub fn apply_surrogate_keys(
     if specs.is_empty() {
         return;
     }
+    debug_assert!(
+        specs
+            .iter()
+            .all(|s| validate_surrogate_key_spec(s, "").is_ok()),
+        "apply_surrogate_keys received an unvalidated SurrogateKeySpec — callers must validate \
+         via validate_surrogate_key_spec (load_surrogate_keys_from_dir does) before its fields \
+         are interpolated into SQL"
+    );
     let additions = surrogate_key_metadata_columns(specs, dialect)
         .iter()
         .map(|m| format!("CAST({} AS {}) AS {}", m.value, m.data_type, m.name))
@@ -2962,6 +3003,28 @@ columns = ["order_id"]
         }
     }
 
+    #[test]
+    fn load_surrogate_keys_rejects_unknown_field() {
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("m.toml"),
+            "[target]\ncatalog = \"wh\"\nschema = \"main\"\n\n\
+             [[surrogate_key]]\nname = \"order_key\"\ncolumns = [\"order_id\"]\n\
+             algoritm = \"sha256\"\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("m.sql"), "SELECT order_id FROM upstream").unwrap();
+
+        // A mistyped key in a [[surrogate_key]] block (deny_unknown_fields) fails
+        // the load loudly instead of silently dropping the misspelled setting.
+        let err = load_surrogate_keys_from_dir(dir.path()).unwrap_err();
+        assert!(
+            matches!(err, ModelError::ParseFrontmatter { .. }),
+            "expected ParseFrontmatter for unknown [[surrogate_key]] field, got {err:?}"
+        );
+    }
+
     // ----- config groups (models/groups/<name>.toml) -----
 
     /// Write a `groups/<name>.toml` group definition under `dir`.
@@ -3269,6 +3332,30 @@ columns = ["order_id"]
         );
     }
 
+    /// A group `schema_template` that resolves to a non-identifier (because an
+    /// `[args]` value carries an illegal character) is rejected at load with the
+    /// same `validate_identifier` `format_table_ref` applies at SQL-gen — so the
+    /// failure surfaces early with a clear message instead of as broken SQL.
+    #[test]
+    fn group_schema_resolving_to_invalid_identifier_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        write_group(dir.path(), "marts", "schema_template = \"mart_{region}\"\n");
+        std::fs::write(
+            dir.path().join("orders.toml"),
+            // `us-west` has a hyphen → resolved schema `mart_us-west` is not a
+            // valid SQL identifier (no pinned schema, so the template resolves).
+            "group = \"marts\"\n\n[target]\ncatalog = \"wh\"\n\n[args]\nregion = \"us-west\"\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("orders.sql"), "SELECT 1 AS id").unwrap();
+
+        let err = load_models_from_dir(dir.path()).unwrap_err();
+        assert!(
+            matches!(err, ModelError::InvalidGroup { ref model, .. } if model == "orders"),
+            "got {err:?}"
+        );
+    }
+
     // ----- named test definitions (test_definitions.toml + [[use_test]]) -----
 
     /// A `[[use_test]]` reference resolves a named definition onto a column,
@@ -3327,6 +3414,31 @@ columns = ["order_id"]
         assert_eq!(m.config.tests.len(), 2, "inline test + resolved reference");
         // The reference's column overrides the definition default ("id").
         assert_eq!(m.config.tests[1].column.as_deref(), Some("email"));
+    }
+
+    /// A mistyped key in a `[[use_test]]` block (deny_unknown_fields) is a hard
+    /// error, so a typo like `colum =` can't silently drop the column binding.
+    #[test]
+    fn use_test_rejects_unknown_field() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("test_definitions.toml"),
+            "[not_empty]\ntype = \"not_null\"\ncolumn = \"id\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("orders.toml"),
+            "[target]\ncatalog = \"wh\"\nschema = \"main\"\n\n\
+             [[use_test]]\nname = \"not_empty\"\ncolum = \"email\"\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("orders.sql"), "SELECT 1 AS id").unwrap();
+
+        let err = load_models_from_dir(dir.path()).unwrap_err();
+        assert!(
+            matches!(err, ModelError::ParseFrontmatter { .. }),
+            "expected ParseFrontmatter for unknown [[use_test]] field, got {err:?}"
+        );
     }
 
     /// An unknown `[[use_test]]` name is a hard error (typo protection).

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -568,6 +568,13 @@ impl StateStore {
                 }
             }
 
+            // Eagerly open every table so a freshly-created DB materializes the
+            // full set up front. This is what makes the on-disk format
+            // deterministic and lets the `on_disk_state_schema_format_is_pinned`
+            // golden enumerate it via `list_tables()`. When adding a table:
+            // register it HERE (eager creation) *and* in that golden's
+            // EXPECTED_TABLES. A table created lazily on first write would not
+            // appear in a fresh DB and would silently escape the golden.
             let _table = txn.open_table(WATERMARKS)?;
             let _table = txn.open_table(CHECK_HISTORY)?;
             let _table = txn.open_table(RUN_HISTORY)?;

--- a/engine/crates/rocky-engine/src/executor.rs
+++ b/engine/crates/rocky-engine/src/executor.rs
@@ -24,6 +24,18 @@ pub struct ExecutionResult {
 ///
 /// Models are executed in DAG layer order. Each model's compiled SQL
 /// is run against the DuckDB instance.
+///
+/// # Divergence: surrogate keys are not applied here
+///
+/// Unlike `rocky run` and `rocky emit-sql` — which call
+/// [`rocky_core::models::apply_surrogate_keys`] — this path materializes each
+/// model from its compiled SQL alone. A model that declares a `[[surrogate_key]]`
+/// block is built here *without* the surrogate column. This backs `rocky test`'s
+/// model-execution check ([`crate::test_runner::run_tests`]), so a test that
+/// depends on a surrogate column (e.g. a `unique` assertion on it) would behave
+/// differently from a real run. Aligning the two would change existing
+/// `rocky test` outcomes, so it is left as a known divergence pending a decision
+/// on whether `rocky test` should mirror run-time surrogate keys.
 pub fn execute_locally(compile_result: &CompileResult, db: &DuckDbConnector) -> ExecutionResult {
     let mut result = ExecutionResult {
         succeeded: Vec::new(),

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Model governance tags on derived asset specs.** `RockyDagsterTranslator.get_model_tags` now projects a model's resolved `[tags]` (its own, inherited from its config group) as first-class Dagster tags — usable in asset selection (`tag:domain=finance`) — alongside the synthesized `rocky/*` metadata. Keys are sanitized to Dagster's tag charset; the synthesized keys keep their `/` so a governance tag can't clobber Rocky's own metadata. Requires `rocky-sdk` with `ModelDetail.tags`; older SDKs degrade to no governance tags. (#921)
+- **Model governance tags on derived asset specs.** `RockyDagsterTranslator.get_model_tags` now projects a model's resolved `[tags]` (its own, inherited from its config group) as first-class Dagster tags — usable in asset selection (`tag:domain=finance`) — alongside the synthesized `rocky/*` metadata. Both keys **and values** are sanitized to Dagster's tag charset (Dagster validates values at `AssetSpec` construction too), and the synthesized keys keep their `/` so a governance tag can't clobber Rocky's own metadata. Requires `rocky-sdk` with `ModelDetail.tags`; older SDKs degrade to no governance tags. (#921, #924)
 
 ## [1.49.0] — 2026-06-14
 

--- a/integrations/dagster/src/dagster_rocky/translator.py
+++ b/integrations/dagster/src/dagster_rocky/translator.py
@@ -14,7 +14,12 @@ if TYPE_CHECKING:
     from .types import DagNodeOutput
 
 _INVALID_CHARS = re.compile(r"[^A-Za-z0-9_]")
-_INVALID_TAG_KEY_CHARS = re.compile(r"[^A-Za-z0-9_.\-]")
+# Dagster's strict tag charset is identical for key segments and strict values:
+# ``[A-Za-z0-9_.-]`` (dagster._utils.tags ``VALID_TAG_KEY_REGEX`` /
+# ``VALID_STRICT_TAG_VALUE_REGEX``). A single complement class drives both the
+# key and value sanitizers below; if Dagster ever diverges the two charsets,
+# split this into separate constants.
+_INVALID_TAG_CHARS = re.compile(r"[^A-Za-z0-9_.\-]")
 
 
 def _sanitize_key_part(s: str) -> str:
@@ -34,7 +39,22 @@ def _sanitize_tag_key(s: str) -> str:
     so this is rare. Returns ``""`` only for an empty input, in which case the
     caller drops the tag.
     """
-    return _INVALID_TAG_KEY_CHARS.sub("_", s)[:63]
+    return _INVALID_TAG_CHARS.sub("_", s)[:63]
+
+
+def _sanitize_tag_value(s: str) -> str:
+    """Coerce an arbitrary governance tag value into a Dagster-valid strict value.
+
+    Dagster validates tag *values* against ``^[A-Za-z0-9_.-]{0,63}$`` at
+    ``AssetSpec`` construction (``normalize_tags(strict=True)``). Disallowed
+    characters — ``@``, ``:``, ``/``, whitespace, etc. — collapse to ``_`` and
+    the result is truncated to 63 characters. Unlike keys, an empty value is
+    valid in Dagster and is preserved as-is. This is the value-side counterpart
+    of :func:`_sanitize_tag_key`; without it, a governance value like
+    ``data-eng@corp.com`` would raise at spec construction rather than degrade
+    gracefully.
+    """
+    return _INVALID_TAG_CHARS.sub("_", s)[:63]
 
 
 def strip_tenant_component(source: SourceInfo, tenant_component: str) -> SourceInfo:
@@ -221,8 +241,10 @@ class RockyDagsterTranslator:
           from its config group, projected as *first-class* Dagster tags so
           they're usable in asset selection (e.g. ``tag:domain=finance``).
           Keys are sanitized to the Dagster-valid charset via
-          :func:`_sanitize_tag_key` and values stringified; a key that
-          sanitizes to empty is dropped.
+          :func:`_sanitize_tag_key` and values via :func:`_sanitize_tag_value`
+          (both required — Dagster validates keys *and* values at ``AssetSpec``
+          construction); a key that sanitizes to empty is dropped, an empty
+          value is kept.
         * **Synthesized metadata tags** — ``rocky/model_name``,
           ``rocky/target_catalog``, ``rocky/target_schema``, and
           ``rocky/strategy`` (the materialization type).
@@ -239,13 +261,16 @@ class RockyDagsterTranslator:
         for key, value in (getattr(model, "tags", None) or {}).items():
             sanitized = _sanitize_tag_key(str(key))
             if sanitized:
-                tags[sanitized] = str(value)
-        tags["rocky/model_name"] = model.name
-        tags["rocky/target_catalog"] = str(model.target.get("catalog", ""))
-        tags["rocky/target_schema"] = str(model.target.get("schema", ""))
+                tags[sanitized] = _sanitize_tag_value(str(value))
+        # Synthesized values are warehouse identifiers / strategy enums and are
+        # virtually always already valid, but sanitize them too so an
+        # unexpected value can never raise at AssetSpec construction.
+        tags["rocky/model_name"] = _sanitize_tag_value(model.name)
+        tags["rocky/target_catalog"] = _sanitize_tag_value(str(model.target.get("catalog", "")))
+        tags["rocky/target_schema"] = _sanitize_tag_value(str(model.target.get("schema", "")))
         strategy_type = model.strategy.get("type") if isinstance(model.strategy, dict) else None
         if strategy_type:
-            tags["rocky/strategy"] = str(strategy_type)
+            tags["rocky/strategy"] = _sanitize_tag_value(str(strategy_type))
         return tags
 
     def get_model_metadata(self, model: ModelDetail) -> dict[str, str]:

--- a/integrations/dagster/tests/scenarios.py
+++ b/integrations/dagster/tests/scenarios.py
@@ -497,8 +497,25 @@ TEST_RESULT: dict[str, Any] = {
     "total": 3,
     "passed": 2,
     "failed": 1,
+    # `failures` is an array of {name, error} objects on the wire — the engine
+    # maps its (name, error) tuples to the `TestFailure` struct. Captured from
+    # `rocky test --output json` against examples/test-declarative.
     "failures": [
-        ["revenue_summary", "type mismatch: expected INT64 but got STRING for column 'order_id'"],
+        {
+            "name": "revenue_summary",
+            "error": "type mismatch: expected INT64 but got STRING for column 'order_id'",
+        },
+    ],
+    # Per-model outcomes (passes too, not just failures) — the C-series field
+    # consumed by the VS Code Inspector Tests tab and dagster.
+    "model_results": [
+        {
+            "model": "revenue_summary",
+            "status": "fail",
+            "error": "type mismatch: expected INT64 but got STRING for column 'order_id'",
+        },
+        {"model": "daily_active_users", "status": "pass"},
+        {"model": "customer_ltv", "status": "pass"},
     ],
 }
 
@@ -526,7 +543,10 @@ CI: dict[str, Any] = {
         },
     ],
     "failures": [
-        ["revenue_summary", "DuckDB execution error: column 'order_id' type mismatch"],
+        {
+            "name": "revenue_summary",
+            "error": "DuckDB execution error: column 'order_id' type mismatch",
+        },
     ],
 }
 

--- a/integrations/dagster/tests/test_derived_models.py
+++ b/integrations/dagster/tests/test_derived_models.py
@@ -251,6 +251,35 @@ def test_build_model_specs_gnarly_tag_keys_pass_dagster_validation():
     assert all(len(k) <= 63 for k in specs[0].tags)
 
 
+def test_build_model_specs_gnarly_tag_values_pass_dagster_validation():
+    # The value-side counterpart of the gnarly-keys test: Dagster validates tag
+    # *values* (charset [A-Za-z0-9_.-], ≤63 chars) at AssetSpec construction,
+    # not just keys. Governance values inherited from a config group can carry
+    # `@`, `/`, whitespace, or exceed 63 chars. Push such values — under *clean*
+    # keys, to isolate the value path — through build_model_specs and prove
+    # they're accepted, not rejected. Without value sanitization this raises
+    # DagsterInvalidDefinitionError at spec construction.
+    long_value = "x" * 80
+    result = _compile_result(
+        _model(
+            "orders",
+            tags={
+                "team": "data-eng@corp.com",
+                "domain": "growth marketing",
+                "region": "finance/emea",
+                "note": long_value,
+            },
+        ),
+    )
+    specs = build_model_specs(result, translator=RockyDagsterTranslator())
+
+    assert specs[0].tags["team"] == "data-eng_corp.com"
+    assert specs[0].tags["domain"] == "growth_marketing"
+    assert specs[0].tags["region"] == "finance_emea"
+    assert specs[0].tags["note"] == "x" * 63
+    assert all(len(v) <= 63 for v in specs[0].tags.values())
+
+
 # ---------------------------------------------------------------------------
 # split_model_specs_by_partition_shape
 # ---------------------------------------------------------------------------

--- a/integrations/dagster/tests/test_types.py
+++ b/integrations/dagster/tests/test_types.py
@@ -566,7 +566,17 @@ def test_parse_test_result(test_result_json: str):
     assert result.passed == 2
     assert result.failed == 1
     assert len(result.failures) == 1
-    assert result.failures[0][0] == "revenue_summary"
+    # `failures` entries are {name, error} objects, not positional [name, error]
+    # tuples — the old hand-written `list[list[str]]` shadow could not parse this
+    # wire shape and raised on any non-empty failure list.
+    assert result.failures[0].name == "revenue_summary"
+    assert "type mismatch" in result.failures[0].error
+    # Per-model outcomes (C-series) round-trip too, including passes.
+    assert {(m.model, m.status) for m in result.model_results} == {
+        ("revenue_summary", "fail"),
+        ("daily_active_users", "pass"),
+        ("customer_ltv", "pass"),
+    }
 
 
 def test_parse_ci_result(ci_json: str):

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`ModelDetail.tags`** — model-level governance tags (`{key: value}` strings) resolved from a model's `[tags]` block and its config group, parsed from `rocky compile`'s `models_detail[].tags`. `None` when none are declared. (#921)
 
+### Fixed
+
+- **`rocky test` / `rocky ci` output now parses its `failures` correctly.** `TestResult` and `CiResult` are now aliases of the generated `TestOutput` / `CiOutput`. The previous hand-written shapes declared `failures` as positional `[name, error]` lists and raised on any non-empty failure list — the engine emits `{name, error}` objects. Per-model outcomes (`model_results`) and the `declarative` / `unit_tests` summaries are now exposed too. (#924)
+
 ## [0.1.1] — 2026-06-14
 
 ### Added

--- a/sdk/python/src/rocky_sdk/types.py
+++ b/sdk/python/src/rocky_sdk/types.py
@@ -616,41 +616,13 @@ class ColumnLineageResult(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# Test output (v0.1.0)
+# Test / CI output (v0.1.0)
 # ---------------------------------------------------------------------------
-
-
-class TestResult(BaseModel):
-    """Output of ``rocky test --json``."""
-
-    __test__ = False  # Prevent pytest collection
-
-    version: str
-    command: str
-    total: int
-    passed: int
-    failed: int
-    failures: list[list[str]]
-
-
-# ---------------------------------------------------------------------------
-# CI output (v0.1.0)
-# ---------------------------------------------------------------------------
-
-
-class CiResult(BaseModel):
-    """Output of ``rocky ci --json``."""
-
-    version: str
-    command: str
-    compile_ok: bool
-    tests_ok: bool
-    models_compiled: int
-    tests_passed: int
-    tests_failed: int
-    exit_code: int
-    diagnostics: list[Diagnostic]
-    failures: list[list[str]]
+# ``TestResult`` and ``CiResult`` were hand-written shadows that diverged from
+# the engine's real wire format (``failures`` is ``[{"name", "error"}]``, not
+# positional ``[[name, error]]``). They are now soft-swapped to the generated
+# ``TestOutput`` / ``CiOutput`` — see the alias block near the bottom of this
+# module, alongside the ``HistoryResult`` / ``ModelHistoryResult`` swap.
 
 
 # ---------------------------------------------------------------------------
@@ -1178,6 +1150,19 @@ DagEdge = DagEdgeOutput
 # exports so external consumers don't break.
 HistoryResult = HistoryOutput
 ModelHistoryResult = ModelHistoryOutput
+
+# ``TestResult`` / ``CiResult`` had the same drift: both declared
+# ``failures: list[list[str]]`` (positional tuples), but the engine serializes
+# ``failures`` as ``[{"name", "error"}]`` objects (``TestFailure``) — so the
+# hand-written shape only ever parsed the empty (all-pass) case and raised on
+# any real failure. They also lacked ``model_results`` / ``declarative`` /
+# ``unit_tests``. The generated outputs are the source of truth; keep the
+# Result names as aliases for import compatibility.
+TestResult = TestOutput
+CiResult = CiOutput
+# ``TestResult``/``TestOutput`` start with "Test"; without this guard pytest
+# tries to collect the alias as a test class wherever a test module imports it.
+TestOutput.__test__ = False
 
 # ``rocky ai-contract`` has no hand-written legacy class; the generated model
 # is the source of truth. Expose a Python-flavored alias for symmetry with the

--- a/sdk/python/tests/test_types.py
+++ b/sdk/python/tests/test_types.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import pytest
 
-from rocky_sdk import CompileResult, DiscoverResult, parse_rocky_output
+from rocky_sdk import CiResult, CompileResult, DiscoverResult, TestResult, parse_rocky_output
 from rocky_sdk.client import _parse_rocky_json, _parse_run_or_apply
 from rocky_sdk.exceptions import RockyOutputParseError
 
@@ -45,6 +45,45 @@ def test_parse_compile_model_without_tags_defaults_none():
     )
     result = parse_rocky_output(payload)
     assert result.models_detail[0].tags is None
+
+
+def test_parse_test_result_failures_are_objects():
+    # `rocky test --output json` serializes `failures` as [{name, error}]
+    # objects (the engine maps its (name, error) tuples to the `TestFailure`
+    # struct), and carries `model_results` (per-model outcomes, passes too).
+    # The old hand-written `TestResult` declared `failures: list[list[str]]`
+    # and lacked `model_results` — it could not parse this payload at all and
+    # raised on the first failing test. Captured shape from the live binary.
+    payload = (
+        '{"version": "1.0.0", "command": "test", "total": 2, "passed": 1, '
+        '"failed": 1, "failures": [{"name": "fct_orders", "error": '
+        '"DuckDB error: Binder Error"}], "model_results": ['
+        '{"model": "fct_orders", "status": "fail", "error": "DuckDB error: Binder Error"}, '
+        '{"model": "stg_orders", "status": "pass"}]}'
+    )
+    result = parse_rocky_output(payload)
+    assert isinstance(result, TestResult)
+    assert result.failures[0].name == "fct_orders"
+    assert "Binder Error" in result.failures[0].error
+    assert {(m.model, m.status) for m in result.model_results} == {
+        ("fct_orders", "fail"),
+        ("stg_orders", "pass"),
+    }
+
+
+def test_parse_ci_result_failures_are_objects():
+    # `rocky ci` shares the same `failures` shape: [{name, error}] objects, not
+    # positional tuples. Same drift as `TestResult`; same soft-swap fix.
+    payload = (
+        '{"version": "1.0.0", "command": "ci", "compile_ok": true, '
+        '"tests_ok": false, "models_compiled": 2, "tests_passed": 1, '
+        '"tests_failed": 1, "exit_code": 1, "diagnostics": [], '
+        '"failures": [{"name": "fct_orders", "error": "type mismatch"}]}'
+    )
+    result = parse_rocky_output(payload)
+    assert isinstance(result, CiResult)
+    assert result.failures[0].name == "fct_orders"
+    assert result.failures[0].error == "type mismatch"
 
 
 def test_parse_rocky_output_rejects_non_object():


### PR DESCRIPTION
Self-review of the unreleased delta (the tags → Dagster fan-out, config-group guard, surrogate keys, and state-format goldens). Each finding was traced consumer-first and fixed with a discriminating test that fails without the fix.

## High

- **dagster: sanitize Dagster tag *values*, not just keys.** `get_model_tags` sanitized governance tag keys but passed values through verbatim. Dagster validates values too (`^[A-Za-z0-9_.-]{0,63}$`) at `AssetSpec` construction, so a governance value carrying `@`, `/`, whitespace, or exceeding 63 chars raised `DagsterInvalidDefinitionError` when building the derived-model specs. Added `_sanitize_tag_value` (same charset as the key sanitizer; empty values preserved, since Dagster allows them) applied to governance and synthesized `rocky/*` values. New test pushes gnarly values through `build_model_specs` (fails on `main`).

## Medium

- **rocky-sdk: `TestResult` / `CiResult` couldn't parse real failure output.** Both hand-written shadows declared `failures: list[list[str]]` (positional tuples), but the engine serializes `failures` as `[{name, error}]` objects — so the shadow parsed only the all-pass case and raised on any real failure, and also lacked `model_results` / `declarative` / `unit_tests`. Soft-swapped both names to the generated `TestOutput` / `CiOutput`, matching the existing `HistoryResult` / `ModelHistoryResult` precedent in the same module; kept the `Result` names as aliases for import compatibility. Real wire shape captured from `rocky test --output json`; discriminating round-trip tests added on both the SDK and dagster sides (the old fixtures + assertions were stale-positional, internally consistent with the broken shadow).
- **engine: `deny_unknown_fields` on `SurrogateKeySpec` and `TestRef`.** A typo'd key in a `[[surrogate_key]]` or `[[use_test]]` block was silently dropped; it now fails the load loudly.

## Low / hardening

- **engine: `resolve_group_schema` validates the resolved schema** with the same `validate_identifier` `format_table_ref` applies at SQL-gen, so a bad `[args]` value fails at load with a clear message instead of as broken SQL (load/run stay consistent).
- **engine: `emit-sql` guards the per-model output filename against path traversal** (skip-with-report on an unsafe name) and the module doc no longer over-claims "identical to a run" for multi-adapter projects (one dialect is resolved for all models).
- **engine: `apply_surrogate_keys`** documents its validate-before-interpolation precondition and re-checks it with a `debug_assert`.
- **engine: `init_db`** notes the eager-table registration contract that keeps the on-disk-format golden complete.

## Open decision (documented, not changed)

`rocky test`'s model-execution path (`execute_locally`) does **not** apply declared surrogate keys, unlike `rocky run` and `rocky emit-sql`. A model with a `[[surrogate_key]]` is materialized without the surrogate column under `rocky test`, so a test depending on that column behaves differently from a real run. Left as a documented divergence rather than changed here, because aligning it would flip existing `rocky test` outcomes — flagging for a call on whether `rocky test` should mirror run-time surrogate keys.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets --all-features`, `cargo test` (rocky-core/engine/duckdb/cli) — green.
- SDK + dagster `pytest` (incl. `-W error::pytest.PytestCollectionWarning`) and `ruff check` / `ruff format --check` — green.
- `just codegen` and `just regen-fixtures` — no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)