### PR TITLE
chore: triple-cut release — engine 1.52.0 / sdk 0.1.2 / dagster 1.50.0

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,10 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.52.0] — 2026-06-19
+
 ### Added
 
+- **Fixture-driven unit tests in `rocky test`.** A model sidecar can declare `[[test]]` blocks with mocked upstream inputs (`given`) and an `expect` table; `rocky test` seeds a fresh in-memory DuckDB, materializes the model against the fixtures, and compares the output (multiset comparison plus a row count). (#899)
+- **Named test definitions.** Define a data-quality assertion once in `models/test_definitions.toml` and apply it across models by name via `[[use_test]]`, overriding the column, severity, or row filter at the use site — the declarative analogue of dbt's generic tests. Inline `[[tests]]` keep working alongside. (#919)
+- **Config groups.** A `models/groups/<name>.toml` definition fans shared routing (`schema_template`, filled per model from its `[args]`) and strategy out to every model that opts in with `group = "<name>"`, so a one-line change flows to the whole group. (#917)
+- **Enforced config groups.** `enforce = true` makes a group's fields binding rather than defaults: a member that locally pins the group-controlled target schema or strategy fails the load instead of silently diverging from the group. (#918)
 - **Model-level `[tags]`, inheritable from config groups.** A model can declare a `[tags]` block of free-form governance attributes (`domain`, `tier`, `owner`, …), and a config group can declare `[tags]` that every member inherits as a shared baseline — a model's own tags override the group per key (sidecar > group). Resolved tags are surfaced on `rocky compile --output json` as `models_detail[].tags`, where orchestrators can read them. Merged at the shared `.sql` / `.rocky` resolution path so both model formats inherit. (#920)
 - **Config-group misplacement guard.** A group member that pins its own `target.schema` **and** supplies `[args]` now fails the load: the pin bypasses the group's `schema_template`, so the args could only fill a template that's never used — a contradiction that usually masks a routing mistake. Pinning a schema with no args (a legitimate override) and routing via args with no pin both stay valid. (#923)
+- **Deterministic surrogate keys.** A model sidecar can declare `[[surrogate_key]]` blocks (an output column name plus its input columns); `rocky run` injects each as a dialect-correct, dbt-value-identical MD5 hash column at materialization (DuckDB, Databricks, Snowflake, BigQuery), validates the spec at load, and treats a newly added key as a change so the model re-materializes rather than being skipped as unchanged. (#911, #913, #914)
+- **Per-column documentation.** Column descriptions declared in a model sidecar `[columns.<name>]` table now surface in `rocky docs` (the HTML catalog) and `rocky catalog --output json`. (#900)
+- **`rocky emit-sql` — a tested, dependency-ordered exit path.** Renders the runnable SQL each transformation model would produce, offline with no warehouse connection, either to stdout or as one `<model>.sql` file per model under `--out-dir`. A project always reduces to plain SQL, so adopting Rocky is never a one-way door. (#916)
 
 ### Changed
 

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.51.1"
+version = "1.52.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.51.1"
+version = "1.52.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.51.1"
+version = "1.52.0"
 dependencies = [
  "indexmap",
  "reqwest 0.12.28",
@@ -3842,7 +3842,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.51.1"
+version = "1.52.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.51.1"
+version = "1.52.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3887,7 +3887,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.51.1"
+version = "1.52.0"
 dependencies = [
  "redis",
  "serde",
@@ -3899,7 +3899,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.51.1"
+version = "1.52.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.51.1"
+version = "1.52.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3963,7 +3963,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.51.1"
+version = "1.52.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -3990,7 +3990,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.51.1"
+version = "1.52.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4030,7 +4030,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.51.1"
+version = "1.52.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4056,7 +4056,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.51.1"
+version = "1.52.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4075,7 +4075,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.51.1"
+version = "1.52.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.51.1"
+version = "1.52.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4124,7 +4124,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.51.1"
+version = "1.52.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4149,7 +4149,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.51.1"
+version = "1.52.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -4162,7 +4162,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.51.1"
+version = "1.52.0"
 dependencies = [
  "logos",
  "miette",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.51.1"
+version = "1.52.0"
 dependencies = [
  "rocky-server",
  "rustls",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.51.1"
+version = "1.52.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4208,7 +4208,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.51.1"
+version = "1.52.0"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4226,7 +4226,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.51.1"
+version = "1.52.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.51.1"
+version = "1.52.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -4283,7 +4283,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.51.1"
+version = "1.52.0"
 dependencies = [
  "miette",
  "regex",
@@ -4296,7 +4296,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.51.1"
+version = "1.52.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4319,7 +4319,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.51.1"
+version = "1.52.0"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.51.1"
+version = "1.52.0"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.51.1"
+version = "1.52.0"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.51.1"
+version = "1.52.0"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.51.1"
+version = "1.52.0"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.51.1"
+version = "1.52.0"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.51.1"
+version = "1.52.0"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.51.1"
+version = "1.52.0"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.51.1"
+version = "1.52.0"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.51.1"
+version = "1.52.0"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.51.1"
+version = "1.52.0"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.51.1"
+version = "1.52.0"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.51.1"
+version = "1.52.0"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.51.1"
+version = "1.52.0"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.51.1"
+version = "1.52.0"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.51.1"
+version = "1.52.0"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.51.1"
+version = "1.52.0"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.51.1"
+version = "1.52.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.51.1"
+version = "1.52.0"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.51.1"
+version = "1.52.0"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.51.1"
+version = "1.52.0"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.51.1"
+version = "1.52.0"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.51.1"
+version = "1.52.0"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.51.1"
+version = "1.52.0"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.51.1"
+version = "1.52.0"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.51.1"
+version = "1.52.0"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.50.0] — 2026-06-19
+
 ### Added
 
 - **Model governance tags on derived asset specs.** `RockyDagsterTranslator.get_model_tags` now projects a model's resolved `[tags]` (its own, inherited from its config group) as first-class Dagster tags — usable in asset selection (`tag:domain=finance`) — alongside the synthesized `rocky/*` metadata. Both keys **and values** are sanitized to Dagster's tag charset (Dagster validates values at `AssetSpec` construction too), and the synthesized keys keep their `/` so a governance tag can't clobber Rocky's own metadata. Requires `rocky-sdk` with `ModelDetail.tags`; older SDKs degrade to no governance tags. (#921, #924)

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.49.0"
+version = "1.50.0"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"
@@ -23,7 +23,7 @@ dependencies = [
     # package; RockyResource is a thin Dagster adapter over RockyClient. In-repo
     # dev/CI resolves this from the local path (see [tool.uv.sources]); the
     # published wheel floors on the released SDK.
-    "rocky-sdk>=0.1.0",
+    "rocky-sdk>=0.1.2",
     # Floor matches the version CI actually resolves and tests (uv.lock). The
     # RockyComponent path uses dagster.components.* APIs from preview namespaces,
     # so we advertise a tested floor rather than an older, never-exercised one.

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -220,7 +220,7 @@ wheels = [
 
 [[package]]
 name = "dagster-rocky"
-version = "1.49.0"
+version = "1.50.0"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },
@@ -910,7 +910,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "../../sdk/python" }
 dependencies = [
     { name = "pydantic" },

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] — 2026-06-19
+
 ### Added
 
 - **`ModelDetail.tags`** — model-level governance tags (`{key: value}` strings) resolved from a model's `[tags]` block and its config group, parsed from `rocky compile`'s `models_detail[].tags`. `None` when none are declared. (#921)

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rocky-sdk"
-version = "0.1.1"
+version = "0.1.2"
 description = "Typed Python client for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Consolidated release of the post-quad-cut delta (everything since engine 1.51.1 / sdk 0.1.1 / dagster 1.49.0). One PR, three scoped release commits; vscode is **not** cut (only a dev-dep bump + regenerated-but-unconsumed TS types since the last cut).

## Versions

| Artifact | From | To | Bump |
|---|---|---|---|
| engine | 1.51.1 | **1.52.0** | minor — new features, no breaking changes |
| rocky-sdk | 0.1.1 | **0.1.2** | additive field + a parse fix |
| dagster-rocky | 1.49.0 | **1.50.0** | minor; floors on `rocky-sdk>=0.1.2` |

## Headline (engine 1.52.0)

- Deterministic surrogate keys (`[[surrogate_key]]`, dbt-value-identical, injected at run)
- Config groups — shared routing + strategy fanned out to N models, with an `enforce` guardrail and a misplacement guard
- Model-level `[tags]`, inheritable from config groups, surfaced on `rocky compile`
- Named test definitions (`[[use_test]]`) + fixture-driven `[[test]]` unit tests in `rocky test`
- Per-column documentation in `rocky docs` / `rocky catalog`
- `rocky emit-sql` — offline, dependency-ordered runnable SQL (tested exit path)
- Self-review hardening (`deny_unknown_fields`, group-schema validation, emit-sql path guard)

**rocky-sdk 0.1.2:** `ModelDetail.tags`; `TestResult`/`CiResult` now parse their `failures` (object shape) and expose `model_results`/`declarative`/`unit_tests`.
**dagster-rocky 1.50.0:** governance tags projected onto derived asset specs (keys **and** values sanitized).

## ⚠️ Changelog backfill — please read the engine entries with care

The C/F-series PRs (#899, #900, #911–#919) did not add `[Unreleased]` changelog entries, so the engine `[1.52.0]` section **backfills** them. The wording was reconstructed from each PR's description (grounded via `gh pr view`), not skimmed — but it's new release copy, so it's the part of this PR most worth a close read.

## Tag-push sequence (after merge)

Order matters — the published `dagster-rocky` wheel resolves `rocky-sdk` from PyPI, and `dagster-rocky 1.50.0` floors on `rocky-sdk>=0.1.2`:

1. `sdk-v0.1.2` → PyPI (must land first)
2. `dagster-v1.50.0` → PyPI (after the SDK is live)
3. `engine-v1.52.0` → GitHub Releases (last, so it holds "Latest")

## Verification

- `cargo check --workspace` clean; engine fmt clean; `Cargo.lock` diff is the 25 member-version lines only.
- sdk + dagster `pytest` green; `ruff` + `ruff format` clean; both `uv.lock`s refreshed.
- `just codegen` clean (version is sentinelled in fixtures, so no fixture regen needed).
- No code asserts the old version string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)