### PR TITLE
docs: rewrite README in plain English, remove jargon

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 [![VS Code CI](https://github.com/rocky-data/rocky/actions/workflows/vscode-ci.yml/badge.svg)](https://github.com/rocky-data/rocky/actions/workflows/vscode-ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
-**Rocky is a tool that checks and runs your SQL data pipelines — and catches problems before they reach your warehouse.**
+**Rocky checks your SQL data pipelines and runs them, so problems get caught before they reach your warehouse.**
 
-It works with Databricks, Snowflake, BigQuery, and DuckDB. You keep your warehouse and your existing SQL. Rocky reads your pipeline, understands what every column does, and tells you when something is wrong — before running anything. Apache 2.0.
+It works with Databricks, Snowflake, BigQuery, and DuckDB. You keep your warehouse and your existing SQL. Rocky reads your pipeline, figures out what every column does, and tells you when something's wrong before it runs anything. Apache 2.0.
 
-The problems that cost data teams the most are the ones nobody notices until it's too late: a source table's columns change and break something downstream, a column gets renamed and three other models silently stop working, a query that works in dev fails in prod because it uses a function the production database doesn't support. Rocky catches all of these at the "check" step — before any data moves.
+Most of the expensive failures in data work are the quiet ones. A source table changes its columns and breaks a model downstream. Someone renames a column and three other models stop working without a peep. A query runs fine in dev, then fails in prod because it uses a function the production database doesn't have. Rocky catches all of these when you check the pipeline, before any data moves.
 
 <p align="center">
   <img src="docs/public/demo-quickstart.gif" alt="Rocky quickstart: create a project, compile, and run 3 models in under 15s" width="900" />
@@ -37,23 +37,23 @@ cd my-first-project
 rocky compile && rocky test && rocky run
 ```
 
-No credentials needed — the playground runs entirely on a local database (DuckDB) so you can try everything offline.
+No credentials needed. The playground runs entirely on a local database (DuckDB), so you can try everything offline.
 
-`rocky run` runs your whole pipeline in one command, which is fine for local development and automation. For production or code-review deploys, you can split it into two steps: `rocky plan` (which saves a record of exactly what will change) followed by `rocky apply <plan-id>` (which executes it). This gives you a clear audit trail and a chance to review before anything runs.
+`rocky run` does the whole pipeline in one command, which is what you want for local work and automation. For production or PR-gated deploys, split it in two: `rocky plan` saves a record of exactly what will change, then `rocky apply <plan-id>` carries it out. You get an audit trail and a chance to look things over before anything runs.
 
 ## Who Rocky is for
 
-Rocky is built first for **data engineers running critical, multi-tenant pipelines on Databricks** where silent failures cost real money and Dagster is already the scheduler. That's the primary audience, and where Rocky is most thoroughly tested.
+Rocky was built first for **data engineers running critical, multi-tenant pipelines on Databricks**, where a silent failure costs real money and Dagster is already doing the scheduling. That's who it's built around, and it's where Rocky is most battle-tested.
 
-The next group: **Snowflake and BigQuery teams** who want problems caught before pipelines run rather than after. Those adapters are in Beta today — see [Where Rocky is today](#where-rocky-is-today) below.
+After that come **Snowflake and BigQuery teams** who'd rather catch problems before a pipeline runs than after. Those adapters are in Beta today; see [Where Rocky is today](#where-rocky-is-today) below.
 
 ## See it in action
 
 Each demo is a self-contained example in [`examples/playground/pocs/`](examples/playground/). `cd` in, run `./run.sh`, and reproduce it yourself.
 
-### See what breaks before you merge — with `rocky lineage-diff`
+### See what breaks before you merge, with `rocky lineage-diff`
 
-Compare two versions of your project and get a report of which downstream tables and columns are affected by each change. The output drops straight into a GitHub PR comment, so reviewers can see the impact without having to dig through code.
+Compare two versions of your project and Rocky tells you which downstream tables and columns each change affects. The output drops straight into a GitHub PR comment, so reviewers can see the impact without digging through code.
 
 <p align="center">
   <img src="docs/public/demo-lineage-diff.gif" alt="rocky lineage-diff main lists added and removed columns across two models with downstream consumers per change" width="900" />
@@ -63,20 +63,20 @@ Compare two versions of your project and get a report of which downstream tables
 
 ### More demos
 
-- [Schema drift recovery](examples/playground/pocs/02-performance/06-schema-drift-recover/): a source column's type changes upstream; Rocky detects it and rebuilds the affected table safely instead of letting it silently corrupt.
-- [Data contracts at check time](examples/playground/pocs/01-quality/01-data-contracts-strict/): required columns that go missing, protected columns that get removed, or type changes that aren't safe all surface as errors (`E010` / `E013`) before a single row is written.
-- [Native BigQuery, cost to the byte](examples/playground/pocs/07-adapters/05-bigquery-native-queries/): the same models run live against BigQuery; the run receipt's `bytes_scanned` matches BigQuery's own billing number exactly (requires credentials).
-- [Named branches + replay](examples/playground/pocs/00-foundations/06-branches-replay-lineage/): run your pipeline against an isolated copy of your schema, inspect the results, then drop it or promote it to production.
-- [Column-level lineage](examples/playground/pocs/06-developer-experience/01-lineage-column-level/): trace a single column in a downstream report back to the original source it came from.
-- [Incremental loads](examples/playground/pocs/02-performance/01-incremental-watermark/): set `strategy = "incremental"` and a timestamp column; Rocky only processes new rows since the last run.
-- [Data masking and compliance](examples/playground/pocs/04-governance/05-classification-masking-compliance/): tag columns that contain personal data, choose a masking strategy per environment, and fail the pipeline check if sensitive data would be exposed unmasked.
-- [AI model generation](examples/playground/pocs/03-ai/01-model-generation/): describe what you want in plain English; Rocky generates the SQL, checks it, and retries automatically if there's a problem.
+- [Schema drift recovery](examples/playground/pocs/02-performance/06-schema-drift-recover/): a source column's type changes upstream. Rocky notices and rebuilds the affected table safely instead of letting it corrupt quietly.
+- [Data contracts at check time](examples/playground/pocs/01-quality/01-data-contracts-strict/): a required column goes missing, a protected column gets dropped, or a type change isn't safe. Each one shows up as an error (`E010` / `E013`) before a single row is written.
+- [Native BigQuery, cost to the byte](examples/playground/pocs/07-adapters/05-bigquery-native-queries/): the models run live against BigQuery, and the run receipt's `bytes_scanned` matches BigQuery's own billing number exactly (requires credentials).
+- [Named branches + replay](examples/playground/pocs/00-foundations/06-branches-replay-lineage/): run your pipeline against an isolated copy of your schema, look at the results, then drop it or promote it to production.
+- [Column-level lineage](examples/playground/pocs/06-developer-experience/01-lineage-column-level/): trace one column in a downstream report all the way back to the source it came from.
+- [Incremental loads](examples/playground/pocs/02-performance/01-incremental-watermark/): set `strategy = "incremental"` and a timestamp column, and Rocky only processes the rows that are new since the last run.
+- [Data masking and compliance](examples/playground/pocs/04-governance/05-classification-masking-compliance/): tag the columns that hold personal data, pick a masking strategy per environment, and fail the check if sensitive data would go out unmasked.
+- [AI model generation](examples/playground/pocs/03-ai/01-model-generation/): describe what you want in plain English. Rocky writes the SQL, checks it, and tries again on its own if something's off.
 
 ## In your editor
 
-The same checker that runs in CI also runs as a language server inside VS Code. That means you see problems — column type mismatches, broken references, violated rules — while you're writing the code, not hours later in CI. Your `.rocky` model files produce SQL live as you type, with column types shown on hover and go-to-definition across all your models.
+The same checker that runs in CI also runs as a language server inside VS Code. So you see the problems (a column type mismatch, a broken reference, a rule you've violated) while you're writing the code, not hours later in a failed CI run. Your `.rocky` files compile to SQL live as you type, with column types on hover and go-to-definition across all your models.
 
-The Rocky Inspector shows you everything about a model in one place: its columns, where each column came from, what tests it has, how much it costs to run, and which columns contain sensitive data.
+The Rocky Inspector puts everything about a model in one place: its columns, where each one came from, what tests it has, what it costs to run, and which columns hold sensitive data.
 
 <p align="center">
   <img src="editors/vscode/media/demo-inspector.gif" alt="The Rocky Inspector's Overview as a model trust dashboard, its Governance card flagging two classified columns with one left unmasked" width="900" />
@@ -86,42 +86,42 @@ The Rocky Inspector shows you everything about a model in one place: its columns
 
 ## Where Rocky is today
 
-The core features (the checker, named pipeline branches, replay, column lineage tracking, rules enforcement, cost tracking per model) are production-ready on Databricks. Everything else is in progress:
+The core features are production-ready on Databricks: the checker, named pipeline branches, replay, column lineage, rule enforcement, and per-model cost tracking. The rest is still in progress.
 
-- **Databricks is the main focus for 2026.** Snowflake, BigQuery, and Trino adapters work for connecting, running queries, and the core pipeline loop — but they haven't reached the same level of thoroughness as the Databricks adapter yet. If you need Snowflake or BigQuery in production today, [talk to us](https://github.com/rocky-data/rocky/discussions).
-- **AI features are early.** The generate → check → fix loop is shipped. Bigger AI features — mass refactoring across your whole pipeline, automatic migration when a column type changes, auto-generated data quality assertions — are on the roadmap.
-- **Iceberg support.** Reading from an Iceberg catalog works in Beta. Writing directly as Iceberg (without going through Delta format first) is planned for 2026.
-- **No built-in metrics layer.** Rocky understands your columns and where they come from, but it doesn't define business metrics. For that, integrate with Cube, the dbt Semantic Layer, or whatever metrics tool you already use.
-- **Dagster is the one built-in scheduler integration ([`dagster-rocky`](integrations/dagster/)).** Every other scheduler — Airflow, Prefect, Flyte, a cron script — can use the [`rocky-sdk`](sdk/python/) Python client to wrap Rocky in a task. There's also a `rocky serve` HTTP mode. Pre-built integrations for other schedulers aren't shipped yet, but the Python client is the building block.
+- **Databricks is the main focus for 2026.** The Snowflake, BigQuery, and Trino adapters connect, run queries, and handle the core pipeline loop, but they aren't as thoroughly tested as the Databricks one yet. If you need Snowflake or BigQuery in production today, [talk to us](https://github.com/rocky-data/rocky/discussions).
+- **AI features are early.** The generate → check → fix loop is shipped. The bigger stuff is on the roadmap: refactoring across a whole pipeline at once, auto-migrating when a column type changes, and generating data-quality assertions for you.
+- **Iceberg support.** Reading from an Iceberg catalog works in Beta. Writing straight to Iceberg, without going through Delta format first, is planned for 2026.
+- **No built-in metrics layer.** Rocky knows your columns and where they come from, but it won't define business metrics for you. Use Cube, the dbt Semantic Layer, or whatever metrics tool you already have.
+- **Dagster is the one built-in scheduler integration ([`dagster-rocky`](integrations/dagster/)).** For anything else (Airflow, Prefect, Flyte, a cron script), the [`rocky-sdk`](sdk/python/) Python client lets you wrap Rocky in a task, and there's a `rocky serve` HTTP mode too. We haven't shipped pre-built integrations for other schedulers yet, but you can build one on the SDK.
 
-If any of these gaps are a problem for your team, [open a discussion](https://github.com/rocky-data/rocky/discussions). The roadmap is driven by where real pipelines are actually breaking.
+If one of these gaps is a blocker for your team, [open a discussion](https://github.com/rocky-data/rocky/discussions). What gets built next depends on where real pipelines are actually breaking.
 
 ## How it compares to dbt Core
 
 | Problem | What dbt Core does | What Rocky does |
 |---|---|---|
-| A source table's column type changes | Silent; shows up as a failure later in a downstream model | Caught at check time as error `E013` — blocks the PR |
-| A required column disappears | Caught at build time if you've opted into `contract: enforced` | Caught at check time as error `E010` — blocks the PR |
+| A source table's column type changes | Silent; shows up as a failure later in a downstream model | Caught at check time as error `E013`, blocks the PR |
+| A required column disappears | Caught at build time if you've opted into `contract: enforced` | Caught at check time as error `E010`, blocks the PR |
 | A column gets renamed and you don't know what breaks | `dbt docs` shows table-level lineage after the fact; dbt Cloud Enterprise adds column lineage in the UI, also after the fact | `rocky lineage-diff` at PR time shows exactly which downstream columns are affected, by name |
-| `SELECT *` pulls in a new column you didn't ask for | Silent | Warning `P002` — names the downstream models that are affected |
+| `SELECT *` pulls in a new column you didn't ask for | Silent | Warning `P002`, naming the downstream models it touches |
 | SQL that only works on Snowflake gets written for a Databricks project | No check; works in dev, fails in prod | `P001` database-portability warning at check time |
 | A run costs twice as much as last week and no one knows which model | No per-model cost; you'd have to dig through warehouse query history | `RunOutput.cost_summary` gives you the cost per model, every run |
 | An auditor asks who changed `fct_revenue.amount`, when, and why | Run history in dbt Cloud, but no record of the exact code that produced a given output | `rocky replay <run_id>` gives you a complete record of the code and the output it produced |
-| A pipeline fails at 3 AM and half the models already ran | `dbt retry` resumes from the failed model | `rocky run --resume-latest` picks up from the last checkpoint; models that already succeeded are not re-run |
+| A pipeline fails at 3 AM and half the models already ran | `dbt retry` resumes from the failed model | `rocky run --resume-latest` picks up from the last checkpoint and skips the models that already succeeded |
 
-dbt Core created this category, and `rocky import-dbt` converts a vanilla dbt project in one command. In June 2026 dbt Labs open-sourced a new Rust-based runtime called Fusion as dbt Core v2.0 (Apache 2.0, alpha). Fusion adds SQL type-checking and column-level lineage, though it still uses Jinja templates and its safety checks are opt-in rather than enforced.
+dbt Core created this category, and `rocky import-dbt` converts a vanilla dbt project in one command. In June 2026 dbt Labs open-sourced a new Rust-based runtime called Fusion as dbt Core v2.0 (Apache 2.0, alpha). Fusion adds SQL type-checking and column-level lineage, but it still uses Jinja templates, and its safety checks are opt-in rather than enforced.
 
-What neither dbt Core v2.0 nor Fusion includes: named pipeline branches, a record of the exact code and output for each run, cost per model as a built-in field, a cross-database SQL portability check, or declarative data access rules and masking. dbt's governance and cost features are part of its paid platform; Rocky's are all Apache 2.0.
+A few things neither dbt Core v2.0 nor Fusion has: named pipeline branches, a record of the exact code and output for each run, per-model cost as a built-in field, a cross-database SQL portability check, and declarative data-access rules with masking. dbt keeps its governance and cost features in the paid platform; Rocky's are all Apache 2.0.
 
 ## Subprojects
 
 | Path | What ships | Language | What it does |
 |---|---|---|---|
-| [`engine/`](engine/) | `rocky` CLI binary | Rust | The core engine — SQL checking, schema drift detection, incremental loads, warehouse adapters. 23 Rust crates. |
-| [`sdk/python/`](sdk/python/) | `rocky-sdk` (PyPI) | Python | A Python client that wraps the Rocky CLI — use it in notebooks, scripts, and custom schedulers |
-| [`integrations/dagster/`](integrations/dagster/) | `dagster-rocky` (PyPI) | Python | Dagster resource that uses `rocky-sdk` under the hood; maps results to Dagster assets and checks |
-| [`editors/vscode/`](editors/vscode/) | Rocky VS Code extension | TypeScript | VS Code extension — live checking, syntax highlighting, AI commands |
-| [`examples/playground/`](examples/playground/) | (config only) | TOML / SQL | A self-contained sample pipeline on DuckDB — no credentials needed; used for testing and demos |
+| [`engine/`](engine/) | `rocky` CLI binary | Rust | The core engine: SQL checking, schema drift detection, incremental loads, warehouse adapters. 23 Rust crates. |
+| [`sdk/python/`](sdk/python/) | `rocky-sdk` (PyPI) | Python | A Python client that wraps the Rocky CLI, for use in notebooks, scripts, and custom schedulers |
+| [`integrations/dagster/`](integrations/dagster/) | `dagster-rocky` (PyPI) | Python | Dagster resource built on `rocky-sdk`; maps results to Dagster assets and checks |
+| [`editors/vscode/`](editors/vscode/) | Rocky VS Code extension | TypeScript | VS Code extension: live checking, syntax highlighting, AI commands |
+| [`examples/playground/`](examples/playground/) | (config only) | TOML / SQL | A self-contained sample pipeline on DuckDB, no credentials needed, used for testing and demos |
 
 Each subproject has its own README with more detail. [`engine/README.md`](engine/README.md) is the main reference for the Rocky CLI.
 
@@ -139,7 +139,7 @@ Each subproject has its own README with more detail. [`engine/README.md`](engine
 | Source | Iceberg | Beta | REST catalog — discovers namespaces and tables |
 | Source | Manual | Production | List schemas and tables directly in `rocky.toml` |
 
-Building a connector for a warehouse Rocky doesn't support yet (ClickHouse, Redshift, …)? See the [Adapter SDK guide](https://rocky-data.dev/guides/adapter-sdk/) and the [example skeleton POC](examples/playground/pocs/07-adapters/06-rust-native-adapter-skeleton/).
+Need a warehouse Rocky doesn't ship yet, like ClickHouse or Redshift? You can build your own connector. See the [Adapter SDK guide](https://rocky-data.dev/guides/adapter-sdk/) and the [example skeleton POC](examples/playground/pocs/07-adapters/06-rust-native-adapter-skeleton/).
 
 ## Building from source
 
@@ -151,7 +151,7 @@ just test        # runs all test suites
 just lint        # cargo clippy/fmt + ruff + eslint
 ```
 
-`just` is optional — you can build each subproject on its own too. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for per-subproject build commands.
+`just` is optional; you can build each subproject on its own too. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for per-subproject build commands.
 
 ## Releases
 
@@ -168,11 +168,11 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md#releases) for the full release process.
 
 Full documentation is at **[rocky-data.dev](https://rocky-data.dev)**: concepts, guides, CLI reference, the Python SDK, Dagster integration, and the adapter SDK.
 
-New to Rocky and want the whole thing explained in plain English? **[`ROCKY_EXPLAINED.md`](ROCKY_EXPLAINED.md)** is a single file that walks through every part of Rocky from the ground up — the checker, the pipeline model, how adapters work, incremental watermarks, data contracts, masking, column lineage, and more — with diagrams throughout.
+New to Rocky and want the whole thing explained in plain English? **[`ROCKY_EXPLAINED.md`](ROCKY_EXPLAINED.md)** is a single file that walks through every part of Rocky from the ground up: the checker, the pipeline model, how adapters work, incremental watermarks, data contracts, masking, column lineage, and the rest, with diagrams throughout.
 
 ## Contributing
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md). Before opening a PR, read the cross-project change guidance: changes to the output format or the Rocky DSL language need to update all the dependent pieces at the same time.
+See [`CONTRIBUTING.md`](CONTRIBUTING.md). Before you open a PR, read the cross-project change guidance: a change to the output format or the Rocky DSL needs to update all the dependent pieces at once.
 
 ## Sponsoring
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 [![VS Code CI](https://github.com/rocky-data/rocky/actions/workflows/vscode-ci.yml/badge.svg)](https://github.com/rocky-data/rocky/actions/workflows/vscode-ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
-**Rocky is the typed graph between your code and whichever warehouse, table format, or query engine you've chosen.**
+**Rocky is a tool that checks and runs your SQL data pipelines — and catches problems before they reach your warehouse.**
 
-It's a typed compiler over your existing Databricks, Snowflake, BigQuery, or DuckDB: named branches, content-addressed run records, column-level lineage, compile-time contracts, and per-model cost. Storage and compute stay where they are, and Rocky works on the SQL you already have. The `.rocky` DSL is there when you want it. Apache 2.0.
+It works with Databricks, Snowflake, BigQuery, and DuckDB. You keep your warehouse and your existing SQL. Rocky reads your pipeline, understands what every column does, and tells you when something is wrong — before running anything. Apache 2.0.
 
-The failures that cost data teams the most are invisible to the warehouse and out of scope for the templating layer above it: schema drift, column-rename blast radius, dialect divergence, cost spikes nobody can attribute. Rocky turns them into compile errors and blocked PRs.
+The problems that cost data teams the most are the ones nobody notices until it's too late: a source table's columns change and break something downstream, a column gets renamed and three other models silently stop working, a query that works in dev fails in prod because it uses a function the production database doesn't support. Rocky catches all of these at the "check" step — before any data moves.
 
 <p align="center">
   <img src="docs/public/demo-quickstart.gif" alt="Rocky quickstart: create a project, compile, and run 3 models in under 15s" width="900" />
@@ -37,23 +37,23 @@ cd my-first-project
 rocky compile && rocky test && rocky run
 ```
 
-No credentials needed; the playground runs end-to-end on local DuckDB.
+No credentials needed — the playground runs entirely on a local database (DuckDB) so you can try everything offline.
 
-`rocky run` is the one-step path for local iteration and automation. For production or PR-gated deploys, split it into `rocky plan` (persists an auditable plan to `.rocky/plans/<id>.json`) followed by `rocky apply <plan-id>`.
+`rocky run` runs your whole pipeline in one command, which is fine for local development and automation. For production or code-review deploys, you can split it into two steps: `rocky plan` (which saves a record of exactly what will change) followed by `rocky apply <plan-id>` (which executes it). This gives you a clear audit trail and a chance to review before anything runs.
 
 ## Who Rocky is for
 
-Rocky is built first for **data platform engineers running production-critical, multi-tenant pipelines on Databricks**, where silent failures cost real money and Dagster is already the orchestrator. That is the launch wedge, and where Rocky is most battle-tested.
+Rocky is built first for **data engineers running critical, multi-tenant pipelines on Databricks** where silent failures cost real money and Dagster is already the scheduler. That's the primary audience, and where Rocky is most thoroughly tested.
 
-The next ring out: **Snowflake and BigQuery shops** evaluating SQLMesh, who want correctness in the compiler rather than the planner and prefer SQL by default. Adapters are Beta today; see [Where Rocky is today](#where-rocky-is-today) below.
+The next group: **Snowflake and BigQuery teams** who want problems caught before pipelines run rather than after. Those adapters are in Beta today — see [Where Rocky is today](#where-rocky-is-today) below.
 
 ## See it in action
 
-Each demo is a self-contained POC in [`examples/playground/pocs/`](examples/playground/): `cd` in, run `./run.sh`, reproduce it locally.
+Each demo is a self-contained example in [`examples/playground/pocs/`](examples/playground/). `cd` in, run `./run.sh`, and reproduce it yourself.
 
-### PR-time blast-radius with `rocky lineage-diff`
+### See what breaks before you merge — with `rocky lineage-diff`
 
-Compare two git refs and get a per-changed-column readout of downstream consumers; the pre-rendered Markdown drops straight into a GitHub PR comment. CODEOWNERS-style review tooling can't reach this granularity without a compiled engine.
+Compare two versions of your project and get a report of which downstream tables and columns are affected by each change. The output drops straight into a GitHub PR comment, so reviewers can see the impact without having to dig through code.
 
 <p align="center">
   <img src="docs/public/demo-lineage-diff.gif" alt="rocky lineage-diff main lists added and removed columns across two models with downstream consumers per change" width="900" />
@@ -63,20 +63,20 @@ Compare two git refs and get a per-changed-column readout of downstream consumer
 
 ### More demos
 
-- [Schema drift recovery](examples/playground/pocs/02-performance/06-schema-drift-recover/): a source column type changes upstream; Rocky diffs source against target and recreates it, no silent corruption.
-- [Data contracts at compile time](examples/playground/pocs/01-quality/01-data-contracts-strict/): missing required columns, removed protected columns, or unsafe type changes surface as `E010` / `E013` before a row is written.
-- [Native BigQuery, cost to the byte](examples/playground/pocs/07-adapters/05-bigquery-native-queries/): the same models materialize live; the run receipt's `bytes_scanned` matches BigQuery's own `totalBytesBilled`, to the byte (live path requires credentials).
-- [Named branches + replay](examples/playground/pocs/00-foundations/06-branches-replay-lineage/): run against an isolated schema, inspect, then drop or promote.
-- [Column-level lineage](examples/playground/pocs/06-developer-experience/01-lineage-column-level/): trace a single column from a downstream fact back to the seed.
-- [Incremental loads with watermark state](examples/playground/pocs/02-performance/01-incremental-watermark/): set `strategy = "incremental"` and a `timestamp_column`; run 2 copies only the delta.
-- [Classification, masking, CI gate](examples/playground/pocs/04-governance/05-classification-masking-compliance/): tag PII columns, bind mask strategies per environment, fail CI on unmasked data.
-- [AI model generation with a compile-validate loop](examples/playground/pocs/03-ai/01-model-generation/): describe a model in plain English; Rocky generates it, compiles, and retries on parse failure.
+- [Schema drift recovery](examples/playground/pocs/02-performance/06-schema-drift-recover/): a source column's type changes upstream; Rocky detects it and rebuilds the affected table safely instead of letting it silently corrupt.
+- [Data contracts at check time](examples/playground/pocs/01-quality/01-data-contracts-strict/): required columns that go missing, protected columns that get removed, or type changes that aren't safe all surface as errors (`E010` / `E013`) before a single row is written.
+- [Native BigQuery, cost to the byte](examples/playground/pocs/07-adapters/05-bigquery-native-queries/): the same models run live against BigQuery; the run receipt's `bytes_scanned` matches BigQuery's own billing number exactly (requires credentials).
+- [Named branches + replay](examples/playground/pocs/00-foundations/06-branches-replay-lineage/): run your pipeline against an isolated copy of your schema, inspect the results, then drop it or promote it to production.
+- [Column-level lineage](examples/playground/pocs/06-developer-experience/01-lineage-column-level/): trace a single column in a downstream report back to the original source it came from.
+- [Incremental loads](examples/playground/pocs/02-performance/01-incremental-watermark/): set `strategy = "incremental"` and a timestamp column; Rocky only processes new rows since the last run.
+- [Data masking and compliance](examples/playground/pocs/04-governance/05-classification-masking-compliance/): tag columns that contain personal data, choose a masking strategy per environment, and fail the pipeline check if sensitive data would be exposed unmasked.
+- [AI model generation](examples/playground/pocs/03-ai/01-model-generation/): describe what you want in plain English; Rocky generates the SQL, checks it, and retries automatically if there's a problem.
 
 ## In your editor
 
-The same compiler runs as a language server inside VS Code, so you catch drift, type errors, and contract violations where you write the code, not just in CI. Your `.rocky` models compile to SQL live as you type, with type-aware hover, inline column types, and go-to-definition across the graph.
+The same checker that runs in CI also runs as a language server inside VS Code. That means you see problems — column type mismatches, broken references, violated rules — while you're writing the code, not hours later in CI. Your `.rocky` model files produce SQL live as you type, with column types shown on hover and go-to-definition across all your models.
 
-The Inspector turns any model into a trust dashboard: schema, column-level lineage, tests, per-model cost, and a governance card that flags classified columns and unmasked PII.
+The Rocky Inspector shows you everything about a model in one place: its columns, where each column came from, what tests it has, how much it costs to run, and which columns contain sensitive data.
 
 <p align="center">
   <img src="editors/vscode/media/demo-inspector.gif" alt="The Rocky Inspector's Overview as a model trust dashboard, its Governance card flagging two classified columns with one left unmasked" width="900" />
@@ -86,62 +86,60 @@ The Inspector turns any model into a trust dashboard: schema, column-level linea
 
 ## Where Rocky is today
 
-The trust primitives (compiler, branches, replay, lineage, contracts, cost attribution) are production-grade on Databricks. The rest is in progress:
+The core features (the checker, named pipeline branches, replay, column lineage tracking, rules enforcement, cost tracking per model) are production-ready on Databricks. Everything else is in progress:
 
-- **Databricks is the production target for 2026.** Snowflake, BigQuery, and Trino adapters are Beta: connection, execution, and the core run loop work, but conformance coverage is still growing. If your enterprise warehouse is Snowflake or BigQuery and you need it production-grade today, talk to us.
-- **AI is an early surface.** The compile-validate loop (generate, type-check, auto-fix, then land) is shipped. The broader story (mass refactor across the DAG, auto-migration from a column-type change, schema-aware assertion generation) is on the roadmap.
-- **Iceberg.** REST-catalog source discovery is Beta. Content-addressed writes round-trip as Iceberg through Delta UniForm, shipped end-to-end. First-class Iceberg-native writes without the Delta intermediate are on the 2026 roadmap.
-- **No built-in semantic layer.** Rocky's typed IR is the right home for one. Today, integrate with Cube, the dbt Semantic Layer, or your existing metric store.
-- **Orchestration: Dagster is the one turnkey integration ([`dagster-rocky`](integrations/dagster/)).** Every other orchestrator — Airflow, Prefect, Flyte, a cron script — integrates by wrapping the typed [`rocky-sdk`](sdk/python/) client (`RockyClient`) in a task; a `rocky serve` HTTP path exists too. Prebuilt operators/hooks beyond Dagster aren't shipped yet, but the SDK is the building block for them.
+- **Databricks is the main focus for 2026.** Snowflake, BigQuery, and Trino adapters work for connecting, running queries, and the core pipeline loop — but they haven't reached the same level of thoroughness as the Databricks adapter yet. If you need Snowflake or BigQuery in production today, [talk to us](https://github.com/rocky-data/rocky/discussions).
+- **AI features are early.** The generate → check → fix loop is shipped. Bigger AI features — mass refactoring across your whole pipeline, automatic migration when a column type changes, auto-generated data quality assertions — are on the roadmap.
+- **Iceberg support.** Reading from an Iceberg catalog works in Beta. Writing directly as Iceberg (without going through Delta format first) is planned for 2026.
+- **No built-in metrics layer.** Rocky understands your columns and where they come from, but it doesn't define business metrics. For that, integrate with Cube, the dbt Semantic Layer, or whatever metrics tool you already use.
+- **Dagster is the one built-in scheduler integration ([`dagster-rocky`](integrations/dagster/)).** Every other scheduler — Airflow, Prefect, Flyte, a cron script — can use the [`rocky-sdk`](sdk/python/) Python client to wrap Rocky in a task. There's also a `rocky serve` HTTP mode. Pre-built integrations for other schedulers aren't shipped yet, but the Python client is the building block.
 
-If those gaps are blockers for your team, [open a discussion](https://github.com/rocky-data/rocky/discussions). The roadmap is shaped by where production pipelines are actually getting hurt.
+If any of these gaps are a problem for your team, [open a discussion](https://github.com/rocky-data/rocky/discussions). The roadmap is driven by where real pipelines are actually breaking.
 
 ## How it compares to dbt Core
 
-| Disaster | What dbt Core does | What Rocky does |
+| Problem | What dbt Core does | What Rocky does |
 |---|---|---|
-| Upstream changes a column type | Silent; surfaces as a downstream failure later | `E013` at compile, blocks the PR |
-| Required column dropped from a contract | Caught at build time via `contract: enforced` | `E010` at compile, blocks the PR |
-| Column rename with unknown blast radius | `dbt docs` is post-hoc and table-level; dbt Cloud Enterprise adds column lineage in the UI, also post-hoc and not PR-blocking | `rocky lineage-diff` at PR time, column-level, downstream consumers listed, blocks the merge |
-| `SELECT *` pulls a new column you didn't expect | Silent | `P002` warning, downstream consumers named |
-| Snowflake-only function written for a Databricks project | No dialect-portability lint; runs in dev, fails in prod | `P001` dialect-portability lint at compile |
-| Run cost doubles, no one knows which model | No per-model cost attribution; reconstruct it from warehouse query history | `RunOutput.cost_summary` per model, every run |
-| Auditor asks: who changed `fct_revenue.amount`, when, and why? | Run history in dbt Cloud, but no content-addressed record of code and output | `rocky replay <run_id>`: a content-addressed record of the exact code and the output it produced |
-| Sev-2 at 3 AM, half the pipeline already ran | `dbt retry` resumes from the failed model; no within-run checkpoint or circuit breaker | `rocky run --resume-latest`: checkpoint, three-state circuit breaker, skip what succeeded |
+| A source table's column type changes | Silent; shows up as a failure later in a downstream model | Caught at check time as error `E013` — blocks the PR |
+| A required column disappears | Caught at build time if you've opted into `contract: enforced` | Caught at check time as error `E010` — blocks the PR |
+| A column gets renamed and you don't know what breaks | `dbt docs` shows table-level lineage after the fact; dbt Cloud Enterprise adds column lineage in the UI, also after the fact | `rocky lineage-diff` at PR time shows exactly which downstream columns are affected, by name |
+| `SELECT *` pulls in a new column you didn't ask for | Silent | Warning `P002` — names the downstream models that are affected |
+| SQL that only works on Snowflake gets written for a Databricks project | No check; works in dev, fails in prod | `P001` database-portability warning at check time |
+| A run costs twice as much as last week and no one knows which model | No per-model cost; you'd have to dig through warehouse query history | `RunOutput.cost_summary` gives you the cost per model, every run |
+| An auditor asks who changed `fct_revenue.amount`, when, and why | Run history in dbt Cloud, but no record of the exact code that produced a given output | `rocky replay <run_id>` gives you a complete record of the code and the output it produced |
+| A pipeline fails at 3 AM and half the models already ran | `dbt retry` resumes from the failed model | `rocky run --resume-latest` picks up from the last checkpoint; models that already succeeded are not re-run |
 
-Each row is a real failure mode and a Rocky command that turns it into a non-event. The same primitives back every row: typed compiler, content-addressed state, column-level lineage, per-model cost.
+dbt Core created this category, and `rocky import-dbt` converts a vanilla dbt project in one command. In June 2026 dbt Labs open-sourced a new Rust-based runtime called Fusion as dbt Core v2.0 (Apache 2.0, alpha). Fusion adds SQL type-checking and column-level lineage, though it still uses Jinja templates and its safety checks are opt-in rather than enforced.
 
-dbt Core defined this category, and `rocky import-dbt` converts a vanilla dbt project in one command. In June 2026 dbt Labs open-sourced the Fusion runtime as dbt Core v2.0 (Rust, Apache 2.0, alpha); the **Fusion** distribution adds SQL type-checking and column-level lineage, though it still templates with Jinja and its build-failing checks are opt-in.
-
-What neither dbt Core v2.0 nor Fusion ships: named branches, a content-addressed run record, per-model cost as a first-class column, a cross-warehouse dialect lint, or declarative RBAC and masking. dbt's governance and cost features live in its paid platform; Rocky's are Apache 2.0.
+What neither dbt Core v2.0 nor Fusion includes: named pipeline branches, a record of the exact code and output for each run, cost per model as a built-in field, a cross-database SQL portability check, or declarative data access rules and masking. dbt's governance and cost features are part of its paid platform; Rocky's are all Apache 2.0.
 
 ## Subprojects
 
-| Path | Artifact | Language | Description |
+| Path | What ships | Language | What it does |
 |---|---|---|---|
-| [`engine/`](engine/) | `rocky` CLI binary | Rust | Core SQL transformation engine, 23-crate Cargo workspace |
-| [`sdk/python/`](sdk/python/) | `rocky-sdk` PyPI wheel | Python | Typed Python client (`RockyClient`) wrapping the Rocky CLI |
-| [`integrations/dagster/`](integrations/dagster/) | `dagster-rocky` PyPI wheel | Python | Dagster resource and component, built on `rocky-sdk` |
-| [`editors/vscode/`](editors/vscode/) | Rocky VSIX | TypeScript | VS Code extension; LSP client + commands for AI features |
-| [`examples/playground/`](examples/playground/) | (config only) | TOML / SQL | Self-contained DuckDB sample pipeline used for smoke tests and benchmarks |
+| [`engine/`](engine/) | `rocky` CLI binary | Rust | The core engine — SQL checking, schema drift detection, incremental loads, warehouse adapters. 23 Rust crates. |
+| [`sdk/python/`](sdk/python/) | `rocky-sdk` (PyPI) | Python | A Python client that wraps the Rocky CLI — use it in notebooks, scripts, and custom schedulers |
+| [`integrations/dagster/`](integrations/dagster/) | `dagster-rocky` (PyPI) | Python | Dagster resource that uses `rocky-sdk` under the hood; maps results to Dagster assets and checks |
+| [`editors/vscode/`](editors/vscode/) | Rocky VS Code extension | TypeScript | VS Code extension — live checking, syntax highlighting, AI commands |
+| [`examples/playground/`](examples/playground/) | (config only) | TOML / SQL | A self-contained sample pipeline on DuckDB — no credentials needed; used for testing and demos |
 
-Each subproject has its own README with detailed usage. The [`engine/README.md`](engine/README.md) is the canonical product reference for the Rocky CLI.
+Each subproject has its own README with more detail. [`engine/README.md`](engine/README.md) is the main reference for the Rocky CLI.
 
 ## Adapters
 
 | Role | Adapter | Status | Notes |
 |------|---------|--------|-------|
-| Warehouse | Databricks | Production | SQL Statement API · Unity Catalog · schema-prefix branches (`SHALLOW CLONE` is a follow-up) |
-| Warehouse | Snowflake | Beta | REST connector · GRANT/REVOKE reconciliation · schema-prefix branches (zero-copy `CLONE` is a follow-up) |
+| Warehouse | Databricks | Production | SQL Statement API · Unity Catalog · schema-prefix branches |
+| Warehouse | Snowflake | Beta | REST connector · permission reconciliation · schema-prefix branches |
 | Warehouse | BigQuery | Beta | REST connector · schema-prefix branches |
-| Warehouse | DuckDB | Local / Testing | Embedded · powers `rocky playground` (no credentials needed) |
-| Warehouse | Trino | Beta | REST `/v1/statement` polling client · Basic + JWT auth · Docker conformance harness behind `trino-conformance` feature |
+| Warehouse | DuckDB | Local / Testing | Embedded database · powers `rocky playground` (no credentials needed) |
+| Warehouse | Trino | Beta | REST polling client · Basic + JWT auth |
 | Source | Fivetran | Production | REST connector + table discovery |
 | Source | Airbyte | Beta | Catalog discovery |
-| Source | Iceberg | Beta | REST catalog discovery of namespaces and tables |
-| Source | Manual | Production | Schema/table lists inline in `rocky.toml` |
+| Source | Iceberg | Beta | REST catalog — discovers namespaces and tables |
+| Source | Manual | Production | List schemas and tables directly in `rocky.toml` |
 
-Building a warehouse Rocky doesn't ship in-tree (ClickHouse, Redshift, …)? See the [Adapter SDK guide](https://rocky-data.dev/guides/adapter-sdk/) and the [Rust-native skeleton POC](examples/playground/pocs/07-adapters/06-rust-native-adapter-skeleton/).
+Building a connector for a warehouse Rocky doesn't support yet (ClickHouse, Redshift, …)? See the [Adapter SDK guide](https://rocky-data.dev/guides/adapter-sdk/) and the [example skeleton POC](examples/playground/pocs/07-adapters/06-rust-native-adapter-skeleton/).
 
 ## Building from source
 
@@ -153,28 +151,28 @@ just test        # runs all test suites
 just lint        # cargo clippy/fmt + ruff + eslint
 ```
 
-`just` is optional; you can also build each subproject directly. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for per-subproject build commands.
+`just` is optional — you can build each subproject on its own too. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for per-subproject build commands.
 
 ## Releases
 
-Each artifact is released independently using a tag-namespaced scheme:
+Each piece ships independently, tagged separately:
 
-- `engine-v*` → Rocky CLI binary (cross-compiled, on GitHub Releases)
-- `sdk-v*` → `rocky-sdk` wheel (publish before a `dagster-v*` that raises its `rocky-sdk` floor)
-- `dagster-v*` → `dagster-rocky` wheel
-- `vscode-v*` → Rocky VSIX
+- `engine-v*` → Rocky CLI binary (built for macOS, Linux, and Windows, available on GitHub Releases)
+- `sdk-v*` → `rocky-sdk` Python package on PyPI
+- `dagster-v*` → `dagster-rocky` Python package on PyPI
+- `vscode-v*` → Rocky VS Code extension on the Marketplace
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md#releases) for the full release flow.
+See [`CONTRIBUTING.md`](CONTRIBUTING.md#releases) for the full release process.
 
 ## Documentation
 
-Full documentation lives at **[rocky-data.dev](https://rocky-data.dev)**: concepts, guides, CLI reference, the Python SDK, Dagster integration, and the adapter SDK.
+Full documentation is at **[rocky-data.dev](https://rocky-data.dev)**: concepts, guides, CLI reference, the Python SDK, Dagster integration, and the adapter SDK.
 
-New to Rocky and want the whole thing explained from first principles? **[`ROCKY_EXPLAINED.md`](ROCKY_EXPLAINED.md)** is a single-file, plain-English tour of every feature — the compiler, the IR, the DAG, adapters, incremental watermarks, contracts, masking, lineage, and more — with ASCII diagrams throughout.
+New to Rocky and want the whole thing explained in plain English? **[`ROCKY_EXPLAINED.md`](ROCKY_EXPLAINED.md)** is a single file that walks through every part of Rocky from the ground up — the checker, the pipeline model, how adapters work, incremental watermarks, data contracts, masking, column lineage, and more — with diagrams throughout.
 
 ## Contributing
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md). Before opening a PR, please read the cross-project change guidance: schema and DSL changes must update consumers atomically.
+See [`CONTRIBUTING.md`](CONTRIBUTING.md). Before opening a PR, read the cross-project change guidance: changes to the output format or the Rocky DSL language need to update all the dependent pieces at the same time.
 
 ## Sponsoring
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md#releases) for the full release flow.
 
 Full documentation lives at **[rocky-data.dev](https://rocky-data.dev)**: concepts, guides, CLI reference, the Python SDK, Dagster integration, and the adapter SDK.
 
+New to Rocky and want the whole thing explained from first principles? **[`ROCKY_EXPLAINED.md`](ROCKY_EXPLAINED.md)** is a single-file, plain-English tour of every feature — the compiler, the IR, the DAG, adapters, incremental watermarks, contracts, masking, lineage, and more — with ASCII diagrams throughout.
+
 ## Contributing
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md). Before opening a PR, please read the cross-project change guidance: schema and DSL changes must update consumers atomically.

--- a/ROCKY_EXPLAINED.md
+++ b/ROCKY_EXPLAINED.md
@@ -295,27 +295,32 @@ For time-interval models, `@start_date` and `@end_date` placeholders in your SQL
 
 ## 9. The State Store
 
-Rocky keeps a small embedded database (redb, a key-value store built into the binary) alongside your project. No external database needed.
+Rocky keeps a small embedded database (redb, a key-value store built into the binary) alongside your project. No external database needed. It holds a number of named tables; the ones that matter most for a run:
 
 ```
-.rocky-state/
-└── state.redb
-    ├── WATERMARKS        key: "catalog.schema.orders_summary"
-    │                     val: "2024-01-15 12:34:56"
+redb state file
+    ├── watermarks            key: "catalog.schema.orders_summary"
+    │                         val: "2024-01-15 12:34:56"
     │
-    ├── RUN_PROGRESS      key: run_id + model_name
-    │                     val: "Completed" | "Failed" | "Skipped"
+    ├── run_progress          key: run_id
+    │                         val: run header (started_at, total_tables)
     │
-    ├── PARTITIONS        key: model + partition_key
-    │                     val: partition metadata (start, end, status)
+    ├── run_progress_entries  key: "run_id|table"
+    │                         val: per-table status (drives --resume)
     │
-    └── IDEMPOTENCY       key: run_id
-                          val: list of statements already executed
+    ├── partitions            key: model + partition_key
+    │                         val: partition metadata (start, end, status)
+    │
+    └── idempotency_keys      key: "run_id|model|file"
+                              val: statement-completion marker
+
+    (plus run_history, quality_history, schema_cache, branches,
+     check_history, dag_snapshots, … — same file, one table each)
 ```
 
 **Watermarks** answer "where did I leave off?" The watermark is read *from the target table* (not the source), using `SELECT MAX(updated_at) FROM target.orders_summary`. Reading from the target prevents a race condition: if the source gets new data while we're running, we don't accidentally move the watermark past data we haven't processed.
 
-**IDEMPOTENCY** makes runs resumable. If a run is interrupted, Rocky can skip statements that already completed (the IDEMPOTENCY table records each statement's success). `rocky run --resume-latest` uses this.
+**run_progress_entries + idempotency_keys** make runs resumable. If a run is interrupted, Rocky can skip the models that already completed. `rocky run --resume-latest` uses this.
 
 ---
 
@@ -325,7 +330,7 @@ When you type `rocky run`, here's what happens inside, step by step:
 
 ```
 Step 1: Mint a run_id
-  "run_20240115_1234"
+  "run-20240115-123456-789"   (run-%Y%m%d-%H%M%S-%3f)
   (stored in state — every action is tagged with it)
 
 Step 2: Validate config
@@ -372,7 +377,7 @@ Step 7: Commit watermarks (batch, after layer completes)
   (If any model failed, no watermarks are committed for that layer)
 
 Step 8: Fire post-run hooks
-  Shell commands or webhooks on "run_complete" / "run_failed" events
+  Shell commands or webhooks on "pipeline_complete" / "pipeline_error" events
 
 Step 9: Emit JSON output
   { tables_copied, materializations, check_results, drift, anomalies }
@@ -927,27 +932,26 @@ This is extracted from the SQL AST by `rocky-sql::lineage` — no runtime execut
 
 ## 25. Hooks and Webhooks
 
-Rocky can fire shell commands or HTTP calls on 18 different lifecycle events.
+Rocky can fire shell commands or HTTP calls on 18 different lifecycle events. The event names below are the exact strings you put in `event = "..."` (the `HookEvent` enum, serialized as snake_case).
 
-**Lifecycle events:**
+**The 18 lifecycle events:**
 
 ```
-Pipeline events:           Model events:              Quality events:
-──────────────────         ──────────────             ──────────────
-run_start                  model_start                check_passed
-run_complete               model_complete             check_failed
-run_failed                 model_skipped              drift_detected
-run_partial                model_failed               anomaly_detected
-plan_created               watermark_updated
-review_approved            schema_altered
-apply_start                catalog_created
-apply_complete
+Pipeline lifecycle:        Materialize / model:       Checks & signals:
+──────────────────         ────────────────────       ─────────────────
+pipeline_start             before_materialize         before_checks
+discover_complete          after_materialize          check_result
+compile_complete           materialize_error          after_checks
+pipeline_complete          before_model_run           drift_detected
+pipeline_error             after_model_run            anomaly_detected
+                           model_error                state_synced
+                                                      budget_breach
 ```
 
 **Command hook (shell):**
 ```toml
 [[hooks]]
-event = "run_failed"
+event = "pipeline_error"
 command = "python scripts/alert.py --model {{model}} --error {{error}}"
 on_failure = "warn"   # or "abort" or "ignore"
 ```
@@ -955,7 +959,7 @@ on_failure = "warn"   # or "abort" or "ignore"
 **Webhook hook (HTTP):**
 ```toml
 [[hooks]]
-event = "run_complete"
+event = "pipeline_complete"
 url   = "https://hooks.slack.com/services/..."
 preset = "slack"   # pre-built template for Slack's JSON format
 async = true       # don't wait for the response
@@ -972,8 +976,7 @@ Rocky run complete ✓
   Models skipped: 3 (unchanged)
 ```
 
-Hook context variables (available as `{{var}}` in templates and commands):
-`run_id`, `model`, `table`, `error`, `duration_ms`, `rows_written`, `watermark`, `environment`, `git_sha`, `trigger`, `plan_id`
+Hooks receive a context payload (rendered into command args and webhook templates via `{{var}}` placeholders) carrying the run and model details — `run_id`, the model/table, error info, timings, and the active environment.
 
 ---
 

--- a/ROCKY_EXPLAINED.md
+++ b/ROCKY_EXPLAINED.md
@@ -1,0 +1,1088 @@
+# Rocky Explained — Plain English, No Jargon
+
+Everything Rocky does, from the outside in, with ASCII diagrams.
+
+---
+
+## 1. What Is Rocky?
+
+Rocky is a **typed, compiled data platform**. You write SQL (or a SQL-like DSL). Rocky compiles it, checks it for mistakes, then runs it against your warehouse.
+
+The closest comparison is dbt — but Rocky has a real compiler. There's no Jinja templating, no string-substitution tricks. Rocky parses your SQL into a typed tree, checks types across the whole DAG at once, and only generates warehouse SQL after everything has been verified.
+
+```
+You write this:            Rocky does this:              Warehouse gets this:
+─────────────────          ──────────────────────────    ──────────────────────
+SELECT                     1. Parse SQL → typed AST      INSERT INTO
+  order_id,                2. Resolve deps (DAG)           orders_summary
+  SUM(amount) AS total     3. Type-check columns         SELECT
+FROM raw_orders            4. Validate contracts           order_id,
+GROUP BY order_id          5. Generate dialect SQL         SUM(amount) AS total
+                           6. Run against warehouse       FROM raw_orders
+                                                         WHERE updated_at > '...'
+                                                         GROUP BY order_id
+```
+
+Key idea: **Rocky is a program that compiles other programs** (your SQL models). The output of compilation is verified, typed SQL that gets sent to the warehouse. If there's a type mismatch, a missing column, or a broken dependency — you hear about it before anything runs.
+
+---
+
+## 2. Rocky's Key Features at a Glance
+
+| Feature | What it means |
+|---|---|
+| **Typed compiler** | Catches type mismatches and missing columns before any SQL runs |
+| **DAG-aware** | Knows which models depend on which; runs them in the right order |
+| **Multiple materialization strategies** | Table, view, incremental, merge, snapshot, partitioned, content-addressed |
+| **Incremental loads** | Only processes new rows since the last run (watermark-based) |
+| **Schema drift detection** | Notices when a source column changed type and handles it automatically |
+| **Data contracts** | Declare what columns must exist and what types they must be; enforced at compile time |
+| **Data masking** | Hash, redact, or partially mask sensitive columns per environment |
+| **Role graph & permissions** | Declare who gets what; Rocky reconciles GRANT/REVOKE to match |
+| **Hooks & webhooks** | Fire shell commands or HTTP calls on 18 lifecycle events |
+| **Column lineage** | Trace any output column back to its origin, through every transformation |
+| **Cost model** | Recommends the cheapest materialization strategy based on usage patterns |
+| **Dagster integration** | First-class orchestration via RockyResource and Dagster Pipes |
+| **VS Code extension** | Full LSP: hover types, go-to-definition, inline diagnostics, completion |
+| **AI intent layer** | Generate models from a plain-English description (`rocky ai "..."`) |
+
+---
+
+## 3. The Engine: How the Crates Fit Together
+
+Rocky's engine is a 23-crate Rust workspace. Each crate has one job.
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│                        rocky (binary)                          │
+│                    main.rs — wires it all                      │
+└───────────────────────────┬────────────────────────────────────┘
+                            │
+              ┌─────────────▼──────────────┐
+              │         rocky-cli          │
+              │  35+ commands, JSON output │
+              │  Dagster Pipes emitter     │
+              └──────┬──────────┬──────────┘
+                     │          │
+         ┌───────────▼──┐  ┌───▼────────────┐
+         │ rocky-compiler│  │  rocky-server  │
+         │ type checking │  │  HTTP + LSP    │
+         └──────┬────────┘  └───────────────┘
+                │
+         ┌──────▼────────┐
+         │  rocky-core   │  ← The main engine room
+         │  SQL gen      │    DAG, checks, contracts,
+         │  state store  │    state, schema patterns,
+         │  drift detect │    masking, permissions
+         └──────┬────────┘
+                │
+    ┌───────────▼────────────┐
+    │       rocky-ir         │  ← Typed blueprint of every model
+    │  ModelIr, Strategy,    │    (no runtime traits, no logic,
+    │  PartitionWindow       │     just data)
+    └───────────┬────────────┘
+                │
+   ┌────────────▼────────────────────────────┐
+   │           rocky-adapter-sdk             │
+   │   WarehouseAdapter / SqlDialect /       │
+   │   DiscoveryAdapter / GovernanceAdapter  │
+   └──┬──────────┬─────────────┬────────────┘
+      │          │             │
+  ┌───▼────┐ ┌──▼────────┐ ┌──▼─────────┐
+  │Databr. │ │ Snowflake │ │   DuckDB   │   ... + BigQuery, Trino
+  └────────┘ └───────────┘ └────────────┘
+
+  ┌──────────────────────────────────────────┐
+  │  rocky-lang     rocky-sql   rocky-ai     │
+  │  (.rocky DSL)   (SQL AST)   (Claude API) │
+  └──────────────────────────────────────────┘
+```
+
+**The chain:** CLI command → compile config + models → produce IR → topological sort → generate SQL per adapter → execute against warehouse → update state store.
+
+---
+
+## 4. The Intermediate Representation (IR)
+
+The IR (`ModelIr`) is Rocky's internal "recipe card" for a single model. It's produced by the compiler and consumed by the SQL generator. Neither the compiler nor the SQL generator knows about the other — they just read and write IR.
+
+```
+ModelIr (one per model)
+┌─────────────────────────────────────────────────────┐
+│  name:         "orders_summary"                     │
+│  source:       { catalog, schema, table }           │
+│  target:       { catalog, schema, table }           │
+│  strategy:     Incremental                          │
+│  watermark_col: "updated_at"                        │
+│  columns:      [ { name, rocky_type, nullable } ]   │
+│  depends_on:   [ "raw_orders" ]                     │
+│  checks:       [ not_null(order_id), ... ]          │
+│  contracts:    { required: [...], protected: [...] }│
+│  tags:         { team: "analytics", pii: "false" }  │
+│  recipe_hash:  blake3(canonical JSON of all above)  │
+└─────────────────────────────────────────────────────┘
+```
+
+**Why IR?** Because it means you can swap warehouses (Databricks → Snowflake) by swapping the SQL dialect adapter. The IR is the same; only the SQL output changes.
+
+**recipe_hash** is a blake3 fingerprint of the entire model definition. If nothing changed, the hash is the same → the model can be skipped. This is the "skip-unchanged gate" (section 14).
+
+---
+
+## 5. The DAG: How Models Know Their Order
+
+Every Rocky project is a directed acyclic graph (DAG). Each model is a node; "depends on" edges point upstream.
+
+```
+raw_orders ──────┐
+                 ▼
+raw_customers ──▶ orders_with_customers ──▶ orders_summary
+                                                  │
+raw_products ──▶ product_stats ──────────────────▶│
+```
+
+Rocky runs a **topological sort** (Kahn's algorithm) to find the right execution order, then groups models into **execution layers** — models in the same layer can run in parallel.
+
+```
+Layer 0 (no deps, run in parallel):
+  [ raw_orders, raw_customers, raw_products ]
+
+Layer 1 (deps all in layer 0):
+  [ orders_with_customers, product_stats ]
+
+Layer 2 (deps in layer 1):
+  [ orders_summary ]
+```
+
+If you have a typo in a `depends_on`, Rocky finds the closest real name and suggests it: "did you mean `raw_orders`?" (Levenshtein distance).
+
+If there's a cycle (A depends on B depends on A), Rocky reports it clearly and stops.
+
+---
+
+## 6. The Compiler: Catching Bugs Before They Run
+
+The compiler is a 9-stage pipeline. It reads your models and produces a typed project description plus any diagnostics (errors/warnings).
+
+```
+Stage 1: Load project
+  .sql + .toml files from disk → parsed models
+         ↓
+Stage 2: Build semantic graph
+  Parse SQL → extract table references → build DAG edges
+  Track column lineage: which col flows where
+         ↓
+Stage 3: Type check
+  Propagate types through the DAG
+  INT + FLOAT → FLOAT
+  String + INT → ERROR E001
+         ↓
+Stage 4: Contract validation
+  Check required columns exist
+  Check column types match declared types
+  Check protected columns aren't removed
+         ↓
+Stage 5: Blast-radius lint
+  "You're changing orders.id — 4 downstream models use it"
+         ↓
+Stage 6: Breaking-change classification
+  16 kinds of breaking change (E011: type narrowed, E013: col removed, ...)
+         ↓
+Stage 7: Freshness coverage
+  Check that incremental models have freshness SLAs defined
+         ↓
+Stage 8: Merge diagnostics
+  Collect all errors + warnings into a single list
+         ↓
+Stage 9: Assemble result
+  CompileResult { models, diagnostics, semantic_graph, timings }
+```
+
+Each diagnostic looks like this:
+
+```
+error[E011]: column 'id' type mismatch
+  --> models/orders.sql:3:8
+  in model: orders_summary
+  contract expects: Int64
+  got: String
+  help: add CAST(id AS BIGINT) to fix the type
+```
+
+Every diagnostic has: `code`, `severity` (Error/Warning/Info), `message`, `span` (file + line + col), `model`, and `suggestion`.
+
+**Key codes:**
+- `E001–E009` — Type errors (mismatch, incompatible join keys)
+- `E010` — Required contract column missing
+- `E011` — Column type doesn't match contract
+- `E012` — Nullability violation
+- `E013` — Protected column removed
+- `W001–W012` — Warnings (type widening, loose checks, etc.)
+
+---
+
+## 7. Adapters: Talking to Different Warehouses
+
+Rocky separates *what to do* (IR) from *how to talk to a specific warehouse* (adapters). There are three adapter types:
+
+```
+SOURCE ADAPTERS (discovery only — "what exists?")
+─────────────────────────────────────────────────
+Fivetran REST API ──▶ rocky-fivetran ──▶ list of tables
+DuckDB info_schema ─▶ rocky-duckdb  ──▶ list of tables
+Manual rocky.toml  ─▶ (built-in)   ──▶ list of tables
+
+No data is extracted. The data is already in the warehouse.
+Source adapters only find out what's there.
+
+
+WAREHOUSE ADAPTERS (execution — "write the results")
+─────────────────────────────────────────────────────
+rocky-core (SQL gen) ──▶ rocky-databricks ──▶ Databricks SQL API
+                     ──▶ rocky-snowflake  ──▶ Snowflake REST API
+                     ──▶ rocky-duckdb     ──▶ DuckDB in-process
+                     ──▶ rocky-bigquery   ──▶ BigQuery REST API
+                     ──▶ rocky-trino      ──▶ Trino /v1/statement
+```
+
+Each warehouse adapter implements the `WarehouseAdapter` trait:
+- `execute_statement(sql)` — run DDL/DML
+- `execute_query(sql)` — run a SELECT and get rows back
+- `describe_table(catalog, schema, table)` — get column names + types
+- `table_exists(...)` — check before creating
+- `dialect()` — return the SQL dialect object
+
+**SQL Dialect:** The same logical SQL operation looks different across warehouses. The `SqlDialect` trait handles the translation:
+
+```
+Same operation:          Databricks:              Snowflake:
+─────────────────        ──────────────────────   ─────────────────────
+Upsert rows      →       MERGE INTO t USING ...   MERGE INTO t USING ...
+                         WHEN MATCHED THEN         (same, but different
+                         UPDATE SET ...            IDENTIFIER quoting)
+
+Create partition →       INSERT OVERWRITE          Not supported natively;
+-keyed table             PARTITION(dt='2024-01')   Rocky uses DELETE+INSERT
+
+Materialized view →      CREATE OR REPLACE          CREATE OR REPLACE
+                         MATERIALIZED VIEW          DYNAMIC TABLE
+                                                    TARGET_LAG = '1 hour'
+```
+
+---
+
+## 8. SQL Generation
+
+Given an IR and a dialect, `rocky-core::sql_gen` generates the actual SQL string.
+
+```
+ModelIr { strategy: Incremental, watermark_col: "updated_at", ... }
+                    ↓
+sql_gen::generate_insert_sql(ir, dialect, watermark_value)
+                    ↓
+"INSERT INTO target.orders_summary
+ SELECT order_id, SUM(amount) AS total
+ FROM source.raw_orders
+ WHERE updated_at > '2024-01-15 12:34:56'
+ GROUP BY order_id"
+```
+
+The watermark value (`2024-01-15 12:34:56`) comes from the state store at SQL-generation time. It's injected as a literal into the SQL string. The IR doesn't carry it — keeping the IR clean means the recipe hash stays deterministic (runtime state doesn't affect the hash).
+
+For time-interval models, `@start_date` and `@end_date` placeholders in your SQL are replaced with the concrete partition timestamps before the SQL is sent to the warehouse.
+
+---
+
+## 9. The State Store
+
+Rocky keeps a small embedded database (redb, a key-value store built into the binary) alongside your project. No external database needed.
+
+```
+.rocky-state/
+└── state.redb
+    ├── WATERMARKS        key: "catalog.schema.orders_summary"
+    │                     val: "2024-01-15 12:34:56"
+    │
+    ├── RUN_PROGRESS      key: run_id + model_name
+    │                     val: "Completed" | "Failed" | "Skipped"
+    │
+    ├── PARTITIONS        key: model + partition_key
+    │                     val: partition metadata (start, end, status)
+    │
+    └── IDEMPOTENCY       key: run_id
+                          val: list of statements already executed
+```
+
+**Watermarks** answer "where did I leave off?" The watermark is read *from the target table* (not the source), using `SELECT MAX(updated_at) FROM target.orders_summary`. Reading from the target prevents a race condition: if the source gets new data while we're running, we don't accidentally move the watermark past data we haven't processed.
+
+**IDEMPOTENCY** makes runs resumable. If a run is interrupted, Rocky can skip statements that already completed (the IDEMPOTENCY table records each statement's success). `rocky run --resume-latest` uses this.
+
+---
+
+## 10. Execution Flow: What `rocky run` Actually Does
+
+When you type `rocky run`, here's what happens inside, step by step:
+
+```
+Step 1: Mint a run_id
+  "run_20240115_1234"
+  (stored in state — every action is tagged with it)
+
+Step 2: Validate config
+  Parse rocky.toml. Check env vars. Ping adapters.
+
+Step 3: Discover sources
+  Call DiscoveryAdapter → get list of tables available
+
+Step 4: Compile
+  Load .sql + .toml → type check → produce ProjectIr
+  (or error out with diagnostics if compilation fails)
+
+Step 5: Topological sort
+  Order models by dependency; group into parallel layers
+
+Step 6: For each model in each layer (in parallel within layer):
+
+  6a. Drift detection
+      describe_table(target) → compare with source schema
+      If a column type changed unsafely → DROP + recreate target
+      If a column was added → ALTER TABLE ADD COLUMN
+
+  6b. Skip-unchanged gate
+      blake3(model definition) == stored hash?
+      If yes AND no schema drift → SKIP this model entirely
+
+  6c. Read watermark (incremental only)
+      SELECT MAX(ts_col) FROM target_table
+
+  6d. Generate SQL
+      ir + dialect + watermark → SQL string
+
+  6e. Execute SQL
+      Send to WarehouseAdapter
+
+  6f. Run quality checks
+      SELECT COUNT(*) ... (row count, null rate, custom assertions)
+
+  6g. Defer watermark write
+      Don't write yet — wait until the whole layer succeeds
+
+Step 7: Commit watermarks (batch, after layer completes)
+  Write all watermarks for the layer in one transaction
+  (If any model failed, no watermarks are committed for that layer)
+
+Step 8: Fire post-run hooks
+  Shell commands or webhooks on "run_complete" / "run_failed" events
+
+Step 9: Emit JSON output
+  { tables_copied, materializations, check_results, drift, anomalies }
+  Exit code 0 (all good) or 2 (partial success — some tables failed)
+```
+
+The key insight in step 6g: watermarks are committed *after* the layer succeeds, not after each individual model. This means if two models in the same layer both run, but one fails, neither gets its watermark committed. Safe to re-run.
+
+---
+
+## 11. Incremental Loads and Watermarks
+
+Most production tables are too big to rebuild from scratch every time. Incremental loads solve this by only processing *new* rows.
+
+```
+First run (watermark = null):
+─────────────────────────────
+SELECT * FROM source.orders
+WHERE updated_at > NULL          ← null means "everything"
+INSERT INTO target.orders_summary ...
+
+State store: watermarks["orders_summary"] = "2024-01-10 23:59:59"
+
+
+Second run (watermark = "2024-01-10 23:59:59"):
+────────────────────────────────────────────────
+SELECT * FROM source.orders
+WHERE updated_at > '2024-01-10 23:59:59'  ← only new rows
+INSERT INTO target.orders_summary ...
+
+State store: watermarks["orders_summary"] = "2024-01-15 08:22:11"
+```
+
+**Why read the watermark from the target, not the state store?**
+
+```
+Race condition scenario (if you read from source):
+─────────────────────────────────────────────────
+T=0   Rocky starts. Source MAX(ts) = 10:00
+T=1   New rows arrive in source. ts = 10:01
+T=2   Rocky inserts rows where ts > 10:00 (gets rows up to 10:00)
+T=3   Rocky records watermark = 10:00
+T=4   Next run: WHERE ts > 10:00 → misses rows at 10:01 ✗
+
+Safe approach (read watermark from target):
+───────────────────────────────────────────
+After INSERT, rocky reads MAX(ts) FROM *target*
+Target only contains what was inserted → watermark = 10:00
+Next run: WHERE ts > 10:00 → correctly gets 10:01 rows ✓
+```
+
+---
+
+## 12. Time-Interval Partitioning
+
+For models where data is naturally chunked by time (daily reports, monthly aggregations), Rocky can materialize one partition at a time.
+
+```
+Your SQL:                       Rocky runs this for each partition:
+─────────────────────────────   ────────────────────────────────────────
+SELECT                          Partition: 2024-01-01 to 2024-01-02
+  DATE(@start_date) AS dt,      → INSERT INTO target
+  SUM(revenue) AS rev              SELECT DATE('2024-01-01') AS dt,
+FROM orders                              SUM(revenue) AS rev
+WHERE order_date >= @start_date         FROM orders
+  AND order_date <  @end_date           WHERE order_date >= '2024-01-01'
+                                          AND order_date < '2024-01-02'
+
+                                Partition: 2024-01-02 to 2024-01-03
+                                → INSERT INTO target
+                                   SELECT DATE('2024-01-02') AS dt, ...
+                                   WHERE order_date >= '2024-01-02'
+                                     AND order_date < '2024-01-03'
+```
+
+CLI flags for time-interval models:
+- `--partition 2024-01-15` — run exactly one partition
+- `--from 2024-01-01 --to 2024-01-31` — run a range
+- `--latest` — run the most recent unfilled partition
+- `--missing` — find and run all partitions that have no data yet
+
+---
+
+## 13. SCD-2 Snapshots (Slowly Changing Dimensions)
+
+Sometimes you want to track *history* — not just the current state, but every change over time. Rocky's snapshot strategy implements SCD Type 2 automatically.
+
+```
+Source table (current state):          Target table (history):
+─────────────────────────────          ─────────────────────────────────────
+customer_id │ name    │ tier           customer_id │ name    │ tier   │ valid_from          │ valid_to            │ is_current │ snapshot_id
+────────────┼─────────┼────────        ────────────┼─────────┼────────┼─────────────────────┼─────────────────────┼────────────┼─────────────
+42          │ Alice   │ Gold           42          │ Alice   │ Silver │ 2024-01-01 00:00:00 │ 2024-06-01 00:00:00 │ false      │ abc123
+                                       42          │ Alice   │ Gold   │ 2024-06-01 00:00:00 │ 9999-12-31          │ true       │ def456
+```
+
+When a row changes (Alice went from Silver → Gold), Rocky:
+1. Finds the old row in the target (`is_current = true`)
+2. Closes it: sets `valid_to = now()`, `is_current = false`
+3. Inserts the new row: `valid_from = now()`, `is_current = true`
+
+New rows (no prior history) just get inserted with `valid_from = now()`.
+
+The change detection uses `IS DISTINCT FROM` (NULL-safe comparison) on the key columns. If nothing changed, Rocky does nothing — no spurious new history rows.
+
+---
+
+## 14. The Skip-Unchanged Gate
+
+If a model's definition hasn't changed and the source schema hasn't changed, Rocky skips it entirely — no SQL sent to the warehouse.
+
+```
+Every run:
+───────────────────────────────────────────────────────────────────
+Compute blake3(normalize(SQL) + typed_columns + strategy + config)
+                    ↓
+Compare with stored hash in state store
+                    ↓
+  Same hash?              Different hash?
+      │                         │
+      ▼                         ▼
+  SKIP (no SQL run)       Run the model, store new hash
+```
+
+**Normalization matters:** `SELECT a,b` and `SELECT a, b` (extra space) would hash differently without normalization. Rocky normalizes whitespace and sorts order-independent clauses before hashing.
+
+**Fail-safe:** If the SQL contains non-deterministic functions (`RAND()`, `NOW()`, `UUID()`), Rocky marks it as *volatile* and never skips it. The list of volatile functions is a compile-time constant; any unknown function is assumed volatile (fail-safe).
+
+---
+
+## 15. The Plan / Review / Apply Safety Gate
+
+Rocky has a safety gate for AI-generated changes. An AI can propose a plan, but it can't apply it without a human signing off.
+
+```
+1. AI proposes change
+   ─────────────────
+   rocky plan → generates SQL plan → stores as "AI-authored plan"
+   plan_id = "plan_abc123"
+
+2. Review (automated diff)
+   ────────────────────────
+   rocky review plan_abc123
+   → compiles old version + new version
+   → runs breaking-change classifier
+   → reports:
+       ⚠ BREAKING: column 'id' type changed Int32 → String
+       ✓ ADDITIVE: new column 'region' added
+       ~ RETYPED: column 'amount' widened Int32 → Int64 (safe)
+
+3. Human approves
+   ───────────────
+   rocky review plan_abc123 --approve
+   → writes approval marker (who, when)
+
+4. Apply (only possible after approval)
+   ─────────────────────────────────────
+   rocky apply plan_abc123
+   → checks approval marker exists
+   → executes the plan
+```
+
+**Rocky refuses `rocky apply` on AI-authored plans without an approval marker.** This is enforced in the engine — not a convention.
+
+The breaking-change classifier knows 16 kinds of breaking change:
+- Column removed, column renamed, type narrowed, type changed incompatibly
+- Required contract column removed, protected column dropped
+- Upstream model deleted, join key type changed, etc.
+
+---
+
+## 16. Data Contracts
+
+A data contract is a promise about what a model will always contain. Other teams can depend on this promise.
+
+```
+contracts/orders_summary.contract.toml
+───────────────────────────────────────
+[required]
+columns = ["order_id", "total"]    # These must always exist
+
+[required.types]
+order_id = "Int64"                 # And must be these types
+total    = "Decimal"
+
+[protected]
+columns = ["order_id"]             # This column can never be removed
+
+[allowed_type_changes]
+total = ["Int64 → Decimal"]        # Widening is OK; narrowing is not
+```
+
+At compile time, Rocky checks every model against its contract:
+
+```
+Compile time check:
+───────────────────
+orders_summary outputs: { order_id: String, total: Decimal }
+contract requires:       { order_id: Int64,  total: Decimal }
+
+E011: column 'order_id' type mismatch
+      contract expects Int64, got String
+      → compilation fails
+```
+
+The "validate → promote" workflow:
+```
+Staging model (no contract) → validate shape → promote to prod (contract enforced)
+```
+Once a model has a contract, any PR that breaks it fails at compile time — no warehouse run needed.
+
+---
+
+## 17. Data Masking
+
+Rocky can mask sensitive columns differently per environment (prod vs. staging vs. dev).
+
+Four strategies:
+
+```
+Strategy: Hash (SHA-256)
+────────────────────────
+Input:  "alice@example.com"
+Output: "2cf24dba5fb0a30e..."
+Use when: you need consistent tokens (same email → same hash)
+
+
+Strategy: Redact
+─────────────────
+Input:  "alice@example.com"
+Output: "***"
+Use when: the value must never appear in any environment
+
+
+Strategy: Partial (first + last 2 chars)
+─────────────────────────────────────────
+Input:  "alice@example.com"
+Output: "al...om"
+Use when: you need enough context to identify the column but not the real value
+
+
+Strategy: None
+───────────────
+Input:  "alice@example.com"
+Output: "alice@example.com"
+Use when: this environment gets full access (e.g., prod)
+```
+
+Masking generates actual SQL expressions applied at the column level — not application-level filtering, but warehouse-level column masking (using Dynamic Data Masking on Databricks/Snowflake, or a `CASE/WHEN` expression on DuckDB).
+
+---
+
+## 18. Role Graph and Permissions
+
+Rocky manages warehouse permissions declaratively. You declare who should have what, and Rocky figures out the minimum set of GRANT/REVOKE statements needed to get there.
+
+```
+rocky.toml:
+───────────
+[roles.analyst]
+permissions = ["SELECT"]
+on = ["catalog.analytics.*"]
+
+[roles.senior_analyst]
+inherits = ["analyst"]          # gets everything analyst has
+permissions = ["INSERT"]        # plus this
+on = ["catalog.analytics.staging.*"]
+
+[roles.lead]
+inherits = ["senior_analyst"]   # transitively gets analyst too
+permissions = ["CREATE", "DROP"]
+on = ["catalog.analytics.*"]
+```
+
+**The role graph is flattened to a union of all inherited permissions:**
+
+```
+analyst:         { SELECT on analytics.* }
+senior_analyst:  { SELECT on analytics.* } ∪ { INSERT on analytics.staging.* }
+lead:            { SELECT on analytics.* } ∪ { INSERT on analytics.staging.* } ∪ { CREATE, DROP on analytics.* }
+```
+
+**Reconciliation (desired vs current):**
+
+```
+Desired (from rocky.toml):          Current (from SHOW GRANTS in warehouse):
+analyst → SELECT on analytics.*     analyst → SELECT on analytics.*
+                                    analyst → INSERT on analytics.* ← extra!
+                                    
+Diff:
+  + nothing to add
+  - REVOKE INSERT ON analytics.* FROM analyst   ← Rocky removes the excess
+```
+
+Rocky only touches the minimum delta — it never rebuilds all grants from scratch.
+
+---
+
+## 19. The VS Code Extension and LSP
+
+Rocky ships a Language Server Protocol (LSP) server (`rocky lsp`). VS Code's Rocky extension spawns it as a child process and communicates over stdio.
+
+```
+VS Code                              rocky lsp (child process)
+──────────────────────────────       ──────────────────────────────────
+User opens orders.sql
+  → extension sends: textDocument/didOpen
+                     ──────────────────────▶
+                                            Parse SQL
+                                            Compile project
+                                            (300ms debounce — waits for
+                                             the user to stop typing)
+                     ◀──────────────────────
+                       publishDiagnostics:
+                       [ E011 at line 3:8 ]
+Red squiggly appears ←
+
+User hovers over "amount"
+  → textDocument/hover request
+                     ──────────────────────▶
+                                            Look up 'amount' in semantic graph
+                                            → type: Decimal(18,2), nullable: false
+                     ◀──────────────────────
+                       hover response:
+                       "amount: Decimal(18,2)"
+Tooltip appears ←
+```
+
+**What the LSP server provides:**
+- Hover: column names → show inferred type
+- Go to definition: jump to where a model or column is defined
+- Find references: all places a model is used
+- Rename symbol: rename a model everywhere at once
+- Completion: suggest column names and model names as you type
+- Inline diagnostics: red/yellow squiggles for E001-E033, W001-W012
+- Inlay hints: show inferred types inline next to expressions
+- Semantic tokens: syntax highlighting that understands your schema
+- Code actions: "quick fix" suggestions from diagnostic hints
+
+The extension also adds custom commands: "Preview SQL" (runs `rocky plan`), "View Lineage", "Run Model", etc.
+
+---
+
+## 20. The Rocky DSL
+
+Rocky supports a higher-level DSL for people who prefer it over raw SQL. It's a pipeline-oriented syntax that compiles down to SQL.
+
+```
+File: models/orders_summary.rocky
+──────────────────────────────────
+source orders from raw.orders
+  filter status = "completed"         # WHERE status = 'completed'
+  select order_id, customer_id, amount
+
+transform total_by_customer from orders
+  group by customer_id
+  aggregate total = sum(amount)
+
+target customer_totals
+  from total_by_customer
+  materialize incremental(watermark: updated_at)
+```
+
+This compiles to:
+
+```sql
+-- CTE for orders (ephemeral — inlined)
+WITH orders AS (
+  SELECT order_id, customer_id, amount
+  FROM raw.orders
+  WHERE status = 'completed'
+),
+-- CTE for total_by_customer (ephemeral — inlined)
+total_by_customer AS (
+  SELECT customer_id, SUM(amount) AS total
+  FROM orders
+  GROUP BY customer_id
+)
+-- Final INSERT
+INSERT INTO customer_totals
+SELECT * FROM total_by_customer
+WHERE updated_at > '2024-01-15 12:34:56'
+```
+
+**One important detail:** The DSL compiles `!=` to `IS DISTINCT FROM` (NULL-safe not-equal). In SQL, `NULL != 'foo'` evaluates to `NULL` (not `true`). `IS DISTINCT FROM` treats `NULL` as a value: `NULL IS DISTINCT FROM 'foo'` → `true`. Rocky's DSL always does the right thing.
+
+**The compilation chain:**
+```
+.rocky file
+    ↓ lexer (logos crate) → token stream
+    ↓ parser (recursive descent) → typed AST
+    ↓ lowering (lower.rs) → SQL string
+    ↓ fed into compiler just like a .sql file
+```
+
+---
+
+## 21. The Dagster Integration
+
+Rocky plugs into Dagster as a `ConfigurableResource`. You configure it once, then use it to run Rocky commands from Dagster ops or assets.
+
+```python
+from dagster_rocky import RockyResource, load_rocky_assets
+
+rocky = RockyResource(config_path="rocky.toml")
+
+# Load all Rocky models as Dagster assets (auto-detected from compile output)
+defs = Definitions(assets=load_rocky_assets(rocky))
+```
+
+**Three execution modes:**
+
+```
+Mode 1: run()  — buffered
+──────────────────────────
+subprocess.run(["rocky", "run", ...])
+Rocky runs to completion, returns full output at once.
+No Dagster context needed. Good for simple ops.
+
+
+Mode 2: run_streaming()  — stderr streaming
+────────────────────────────────────────────
+subprocess.Popen(["rocky", "run", ...])
+Rocky's stderr is streamed line-by-line to context.log.
+You see progress in Dagster's UI in real time.
+stdout is buffered and parsed at the end.
+
+
+Mode 3: run_pipes()  — full Dagster Pipes
+──────────────────────────────────────────
+PipesSubprocessClient launches rocky with two env vars:
+  DAGSTER_PIPES_CONTEXT  = base64-encoded context payload
+  DAGSTER_PIPES_MESSAGES = path to a temp file for messages
+
+Rocky detects these env vars at startup (pipes.rs).
+Rocky emits structured messages (asset materialization events,
+check results, metadata) to the messages file as JSON lines.
+Dagster reads them back in real time.
+
+This mode lets Rocky report asset-level metadata
+(rows written, schema, quality check results)
+directly into the Dagster asset catalog.
+```
+
+**Exit code handling:** Rocky exits with code 2 on partial success (some models ran fine, some failed). Dagster integration explicitly handles this with `allow_partial=True` — it reads the JSON output to see which assets succeeded/failed rather than treating the exit code as a binary pass/fail.
+
+---
+
+## 22. The Python SDK
+
+`rocky-sdk` is a pure Python client that wraps the Rocky CLI via subprocess. No Rust dependency needed at runtime.
+
+```python
+from rocky_sdk import RockyClient
+
+client = RockyClient(config_path="rocky.toml")
+
+# Each method maps to a CLI command:
+result = client.run(filter={"source": "shopify"})
+print(result.tables_copied)   # typed Pydantic model
+
+discovery = client.discover()
+for connector in discovery.connectors:
+    print(connector.id, connector.tables)
+```
+
+**Under the hood — the 3-thread subprocess model:**
+
+```
+Main thread                   Subprocess (rocky CLI)
+────────────────              ────────────────────────────────
+client.run(...)
+  → spawn subprocess
+  → start thread 1:   ◀──── stdout (JSON) ─────────────────────
+    reads stdout line by line
+    accumulates JSON
+  → start thread 2:   ◀──── stderr (logs) ─────────────────────
+    reads stderr line by line
+    logs to Python logger
+  → start watchdog:
+    kills subprocess if
+    no progress for 30s
+  → join all threads
+  → parse JSON → RunOutput (Pydantic)
+  → return typed result
+```
+
+All 60+ output types (`RunOutput`, `DiscoverOutput`, `CompileOutput`, etc.) are Pydantic v2 models auto-generated from Rocky's Rust JSON schemas. When a Rust `*Output` struct changes, `just codegen` regenerates the Pydantic models. You always get the right shape.
+
+---
+
+## 23. Cost Model and Optimization
+
+Rocky can recommend the cheapest materialization strategy for each model based on how often it's queried vs. how expensive it is to compute.
+
+```
+rocky optimize -c rocky.toml
+
+Model: orders_summary
+  Compute cost:  $0.82 / run   (takes 40s on Databricks)
+  Storage cost:  $0.003 / GB·month
+  Queries/day:   150
+  Runs/day:      24
+
+Decision tree:
+──────────────────────────────────────────────────────────
+Is compute cost > threshold AND query_count > 10/day?
+  YES → keep as Table (results cached in warehouse)
+
+Is the model cheap to compute AND rarely queried?
+  YES → recommend Ephemeral (inlined as CTE, zero storage)
+
+Is the model always up to date via CDC?
+  YES → recommend View (no materialization overhead)
+
+Is the model a huge historical table with low daily query rate?
+  YES → recommend Incremental (only new rows each run)
+──────────────────────────────────────────────────────────
+
+Recommendation: Table (current strategy is already optimal)
+Estimated monthly cost: $19.20 compute + $0.09 storage
+```
+
+---
+
+## 24. Column Lineage
+
+Rocky can trace any output column back through the entire DAG to its original source column.
+
+```
+rocky lineage orders_summary --column total
+
+Lineage for: orders_summary.total
+──────────────────────────────────────────────────────────
+orders_summary.total
+  ← [Aggregation: SUM] orders_enriched.amount
+      ← [Cast: DECIMAL] raw_orders.amount_cents
+          ← [Direct] source.fivetran_shopify.orders.amount_cents
+```
+
+Each edge in the lineage graph has a **TransformKind**:
+- **Direct** — column passed through unchanged (`SELECT a`)
+- **Cast** — explicit type conversion (`CAST(a AS BIGINT)`)
+- **Aggregation(name)** — aggregate function applied (`SUM(a)`, `COUNT(a)`)
+- **Expression** — derived from an expression (`a + b`, `COALESCE(a, 0)`)
+
+This is extracted from the SQL AST by `rocky-sql::lineage` — no runtime execution needed, purely static analysis.
+
+`rocky lineage-diff` is the PR-friendly version: it finds columns that changed between your branch and main, then shows the downstream impact. Useful as an automated PR comment.
+
+---
+
+## 25. Hooks and Webhooks
+
+Rocky can fire shell commands or HTTP calls on 18 different lifecycle events.
+
+**Lifecycle events:**
+
+```
+Pipeline events:           Model events:              Quality events:
+──────────────────         ──────────────             ──────────────
+run_start                  model_start                check_passed
+run_complete               model_complete             check_failed
+run_failed                 model_skipped              drift_detected
+run_partial                model_failed               anomaly_detected
+plan_created               watermark_updated
+review_approved            schema_altered
+apply_start                catalog_created
+apply_complete
+```
+
+**Command hook (shell):**
+```toml
+[[hooks]]
+event = "run_failed"
+command = "python scripts/alert.py --model {{model}} --error {{error}}"
+on_failure = "warn"   # or "abort" or "ignore"
+```
+
+**Webhook hook (HTTP):**
+```toml
+[[hooks]]
+event = "run_complete"
+url   = "https://hooks.slack.com/services/..."
+preset = "slack"   # pre-built template for Slack's JSON format
+async = true       # don't wait for the response
+retries = 3
+```
+
+**5 built-in presets:** `slack`, `pagerduty`, `datadog`, `teams`, `generic`
+
+The Slack preset automatically formats a message like:
+```
+Rocky run complete ✓
+  Tables copied: 12
+  Duration: 4m 32s
+  Models skipped: 3 (unchanged)
+```
+
+Hook context variables (available as `{{var}}` in templates and commands):
+`run_id`, `model`, `table`, `error`, `duration_ms`, `rows_written`, `watermark`, `environment`, `git_sha`, `trigger`, `plan_id`
+
+---
+
+## 26. The Complete Picture
+
+Everything Rocky does, in one ASCII map:
+
+```
+ YOU WRITE                 ROCKY PROCESSES            WAREHOUSE GETS
+ ─────────                 ───────────────            ──────────────
+
+ rocky.toml                ┌─────────────┐
+ (config)     ──────────▶  │  Config +   │
+                           │  Discovery  │ ◀── Fivetran API / DuckDB info_schema
+ models/*.sql              └──────┬──────┘
+ models/*.toml ──────────▶        │
+                           ┌──────▼──────┐
+ contracts/*.toml ───────▶ │  Compiler   │ ── diagnostics (E001–E033, W001–W012)
+                           │  9 stages   │    ↓ errors → stop here
+                           └──────┬──────┘    ↓ clean → continue
+                                  │
+                           ┌──────▼──────┐
+                           │  ProjectIr  │  ModelIr × N
+                           │  (all typed)│
+                           └──────┬──────┘
+                                  │
+                           ┌──────▼──────────────────────┐
+                           │  DAG: topological sort       │
+                           │  Layer 0: [raw_a, raw_b]    │
+                           │  Layer 1: [enriched]        │
+                           │  Layer 2: [summary]         │
+                           └──────┬──────────────────────┘
+                                  │
+                     ┌────────────▼────────────────────────┐
+                     │    Per-model execution loop         │
+                     │                                     │
+                     │  drift detect → skip gate           │
+                     │  → read watermark → SQL gen         │
+                     │  → execute → quality checks         │
+                     │  → defer watermark write            │
+                     └────────────┬────────────────────────┘
+                                  │
+                           ┌──────▼──────┐
+              Databricks ◀─┤ Warehouse   ├─▶ Snowflake
+              DuckDB     ◀─┤ Adapter     ├─▶ BigQuery
+                           └──────┬──────┘
+                                  │
+                           ┌──────▼──────┐
+                           │ State Store │  watermarks, run history,
+                           │ (redb)      │  partitions, idempotency
+                           └──────┬──────┘
+                                  │
+                           ┌──────▼──────┐
+                           │    Hooks    │  shell + webhooks (18 events)
+                           └──────┬──────┘
+                                  │
+                           JSON output (exit 0 / 2)
+
+
+ OBSERVABILITY LAYER (always on):
+ ─────────────────────────────────
+ Column lineage ──▶ rocky lineage <model> [--column <col>]
+ Cost model     ──▶ rocky optimize
+ Schema drift   ──▶ rocky drift
+ Health checks  ──▶ rocky doctor
+ Run history    ──▶ rocky history [--model <name>]
+ Metrics        ──▶ rocky metrics <model>
+
+
+ INTEGRATIONS:
+ ─────────────
+ Dagster ──▶ RockyResource (3 modes: run / run_streaming / run_pipes)
+             ↳ Pipes: real-time asset events back to Dagster UI
+
+ Python  ──▶ RockyClient (3-thread subprocess: stdout + stderr + watchdog)
+             ↳ Typed Pydantic results auto-generated from Rust schemas
+
+ VS Code ──▶ rocky lsp (child process over stdio)
+             ↳ hover types, diagnostics, completion, go-to-def, rename
+
+
+ SAFETY GATES:
+ ─────────────
+ AI plans:   propose → review (breaking-change classifier) → human approve → apply
+ Contracts:  staging → validate types/columns → promote to prod
+ SQL safety: all identifiers validated via regex before interpolation (no SQL injection)
+ Watermarks: read from target (not source) to prevent TOCTOU race
+ Skips:      volatile functions (RAND, NOW, UUID) are never skipped — fail-safe
+```
+
+---
+
+## Quick Reference
+
+| You want to... | Command |
+|---|---|
+| Check everything is valid (no API calls) | `rocky validate -c rocky.toml` |
+| Type-check your models | `rocky compile --models models/` |
+| See what SQL will run | `rocky plan -c rocky.toml` |
+| Run the pipeline | `rocky run -c rocky.toml` |
+| Run only changed models | `rocky run -c rocky.toml --filter source=shopify` |
+| Resume a failed run | `rocky run -c rocky.toml --resume-latest` |
+| Run a single partition | `rocky run -c rocky.toml --partition 2024-01-15` |
+| Check watermark state | `rocky state -c rocky.toml` |
+| See run history | `rocky history` |
+| Check schema drift | `rocky drift -c rocky.toml` |
+| Get optimization suggestions | `rocky optimize -c rocky.toml` |
+| Trace column lineage | `rocky lineage orders_summary --column total` |
+| Health check everything | `rocky doctor -c rocky.toml` |
+| Generate a model with AI | `rocky ai "create a daily revenue summary by region"` |
+| Test models locally (no warehouse) | `rocky test --models models/` |
+```

--- a/docs/src/content/docs/advanced/contributing.md
+++ b/docs/src/content/docs/advanced/contributing.md
@@ -5,6 +5,44 @@ sidebar:
   order: 1
 ---
 
+## Where to start
+
+The right entry point depends on what you want to change. Use this table to orient yourself before diving into the code.
+
+| You want to change | Start here |
+|---|---|
+| How a warehouse executes SQL | `engine/crates/rocky-<name>/` — the adapter crate. Implement `WarehouseAdapter` / `SqlDialect` from `rocky-adapter-sdk`. |
+| How SQL is generated from the IR | `engine/crates/rocky-core/src/sql_gen.rs` |
+| What the IR looks like (model shape) | `engine/crates/rocky-ir/src/ir.rs` |
+| The type checker or semantic graph | `engine/crates/rocky-compiler/src/` |
+| A diagnostic code (error/warning) | `engine/crates/rocky-compiler/src/diagnostic.rs` |
+| Incremental / watermark logic | `engine/crates/rocky-core/src/state.rs` + `sql_gen.rs` |
+| The `rocky run` execution loop | `engine/crates/rocky-cli/src/commands/run.rs` |
+| DAG / dependency resolution | `engine/crates/rocky-ir/src/dag.rs` |
+| Data contracts enforcement | `engine/crates/rocky-core/src/contracts.rs` |
+| Schema drift detection | `engine/crates/rocky-core/src/drift.rs` |
+| Masking strategies | `engine/crates/rocky-core/src/masking.rs` |
+| Permission / role graph | `engine/crates/rocky-core/src/role_graph.rs` |
+| SCD-2 snapshot logic | `engine/crates/rocky-core/src/snapshots.rs` |
+| Quality checks | `engine/crates/rocky-core/src/checks.rs` |
+| Hooks / webhooks | `engine/crates/rocky-core/src/hooks/` |
+| Column lineage extraction | `engine/crates/rocky-sql/src/lineage.rs` |
+| Skip-unchanged gate / hashing | `engine/crates/rocky-sql/src/determinism.rs` + `rocky-ir/src/ir.rs::skip_hash()` |
+| CLI JSON output shape | `engine/crates/rocky-cli/src/output.rs` — then run `just codegen` |
+| A new CLI subcommand | See the `rocky-new-cli-command` skill in `.claude/skills/` |
+| The Rocky DSL (`.rocky` files) | `engine/crates/rocky-lang/src/` — then update VS Code grammar too |
+| The LSP server | `engine/crates/rocky-server/src/lsp.rs` |
+| The Dagster integration | `integrations/dagster/src/dagster_rocky/` |
+| The Python SDK | `sdk/python/src/rocky_sdk/client.py` |
+| The VS Code extension | `editors/vscode/src/` |
+
+### Key invariants before you commit
+
+- **Never** commit a Rust `*Output` change without running `just codegen` — `codegen-drift.yml` CI will fail.
+- **Never** `format!()` untrusted input into SQL — use `rocky-sql/validation.rs` to validate identifiers first.
+- **Never** hand-edit files under `*/types_generated/` or `*/types/generated/` — those are codegen outputs.
+- **Never** skip hooks (`--no-verify`). Fix the underlying issue instead.
+
 ## Monorepo Structure
 
 Rocky is a monorepo with four subprojects:

--- a/docs/src/content/docs/concepts/architecture.mdx
+++ b/docs/src/content/docs/concepts/architecture.mdx
@@ -9,6 +9,47 @@ import pocCounts from "../../../data/poc-counts.json";
 
 Rocky is a Cargo workspace composed of several crates, each with a focused responsibility. This page describes what each crate does and how they connect.
 
+## How data flows
+
+A `rocky run` touches every layer of the stack. From config file to warehouse result:
+
+```
+rocky.toml
+    │  parse config + env-var substitution
+    ▼
+Config struct
+    │  call DiscoveryAdapter
+    ▼
+Source metadata  ◀── Fivetran REST API / DuckDB info_schema / manual config
+    │  compile .sql + .toml models
+    ▼
+rocky-compiler  →  diagnostics (E001–E033 / W001–W012)
+    │  produces typed ProjectIr on success
+    ▼
+ProjectIr  (one ModelIr per model, fully typed and validated)
+    │  topological sort → execution layers
+    ▼
+Layer 0: [raw_a, raw_b]   ← run in parallel
+Layer 1: [enriched]
+Layer 2: [summary]
+    │  per model: drift detect → skip gate → SQL gen → execute → checks
+    ▼
+WarehouseAdapter
+    ├── rocky-databricks  →  Databricks SQL Statement API
+    ├── rocky-snowflake   →  Snowflake REST API
+    ├── rocky-bigquery    →  BigQuery REST API
+    ├── rocky-trino       →  Trino /v1/statement
+    └── rocky-duckdb      →  DuckDB in-process
+    │  write results to warehouse; update state store
+    ▼
+State store (redb, embedded)
+    │  watermarks, run progress, partitions, idempotency
+    ▼
+Hooks + JSON output on stdout
+```
+
+For a detailed walkthrough of each step, see [Execution Flow](/concepts/execution-flow/).
+
 ## Adapter model
 
 Rocky separates concerns through two adapter types:

--- a/docs/src/content/docs/concepts/compiler.md
+++ b/docs/src/content/docs/concepts/compiler.md
@@ -12,7 +12,40 @@ Rocky includes a full compiler (`rocky-compiler` crate) that performs static ana
 The compiler runs five stages in sequence:
 
 ```
-Load models → Resolve dependencies → Build semantic graph → Type check → Validate contracts
+ ┌──────────────────────────────────────┐
+ │  .sql files   .toml sidecars         │
+ │  .rocky files  contracts/*.toml      │
+ └───────────────────┬──────────────────┘
+                     │
+          ┌──────────▼──────────┐
+          │   1. Load models    │   parse SQL + TOML from disk
+          └──────────┬──────────┘
+                     │
+          ┌──────────▼──────────┐
+          │ 2. Resolve deps     │   bare name → DAG edge
+          │    (build DAG)      │   schema.table → external ref
+          └──────────┬──────────┘
+                     │
+          ┌──────────▼──────────┐
+          │ 3. Semantic graph   │   track column lineage across DAG
+          │    (column lineage) │   a.id ──Direct──▶ b.id
+          └──────────┬──────────┘
+                     │
+          ┌──────────▼──────────┐
+          │  4. Type check      │   propagate types through graph
+          │                     │   INT + FLOAT → FLOAT
+          │                     │   String + INT → E001 error
+          └──────────┬──────────┘
+                     │
+          ┌──────────▼──────────┐
+          │ 5. Validate         │   required columns present?
+          │    contracts        │   types match declarations?
+          └──────────┬──────────┘
+                     │
+          ┌──────────▼──────────┐
+          │  CompileResult      │   models, diagnostics,
+          │                     │   semantic_graph, timings
+          └─────────────────────┘
 ```
 
 ### 1. Load models
@@ -62,6 +95,17 @@ Each model receives a typed schema: a list of `TypedColumn` entries with name, `
 
 If a contracts directory exists, `.contract.toml` files are loaded and validated against the inferred schemas. See the [Testing and Contracts](/concepts/testing) page for details on the contract format.
 
+## Diagnostic format
+
+Diagnostics render in a format inspired by `rustc`, with machine-readable codes and actionable suggestions:
+
+```
+error[E011]: column 'id' type mismatch: contract expects Int64, got String
+ --> models/orders.sql:3:8
+ in model: orders_summary
+ = help: add CAST(id AS BIGINT) to fix the type
+```
+
 ## The type system
 
 `RockyType` is Rocky's unified type representation. All warehouse-specific types map to and from `RockyType` via a `TypeMapper` trait, so the compiler works identically regardless of the target warehouse.
@@ -98,6 +142,19 @@ Incompatible types (e.g., `String` + `Int64`) produce an error diagnostic.
 The `is_assignable` function determines whether a value of one type can be written to a column of another type. It allows widening conversions (e.g., `Int32` into `Int64`) but rejects narrowing conversions (e.g., `Int64` into `Int32`).
 
 ## Semantic graph
+
+The semantic graph is a cross-model column lineage map. It tracks every column's origin and transformation kind through the entire DAG.
+
+```
+raw_orders                  orders_enriched              orders_summary
+──────────                  ───────────────              ──────────────
+order_id  ──[Direct]──────▶ order_id  ──[Direct]───────▶ order_id
+amount    ──[Cast:DECIMAL]─▶ amount   ──[Agg:SUM]────────▶ total
+customer_id──[Direct]──────▶ customer_id
+                            region    ◀──[Direct]── raw_customers.region
+```
+
+The graph is built in topological order, so downstream models always see the full column list of their upstreams (including `SELECT *` expansions).
 
 The semantic graph is the foundation for several compiler features:
 

--- a/docs/src/content/docs/concepts/execution-flow.md
+++ b/docs/src/content/docs/concepts/execution-flow.md
@@ -1,0 +1,237 @@
+---
+title: Execution Flow
+description: What happens inside rocky run, step by step
+sidebar:
+  order: 3
+---
+
+This page traces what happens inside the engine from the moment you type `rocky run` to the moment the warehouse is updated and JSON is emitted. The goal is to make the execution model concrete enough that you can reason about failures, retries, and performance.
+
+## The high-level flow
+
+```
+rocky run -c rocky.toml
+      │
+      ▼
+1. Mint run_id
+      │
+      ▼
+2. Validate config + ping adapters
+      │
+      ▼
+3. Discover sources (DiscoveryAdapter)
+      │
+      ▼
+4. Compile models (rocky-compiler)
+      │   produces: ProjectIr (typed, validated)
+      │   error here → emit diagnostics, exit 1
+      ▼
+5. Topological sort → execution layers
+      │   Layer 0: [ raw_a, raw_b ]  (parallel)
+      │   Layer 1: [ enriched ]      (parallel within layer)
+      │   Layer 2: [ summary ]
+      ▼
+6. Execute each layer (layers are sequential; models within a layer are parallel)
+      │
+      ▼
+7. Batch-commit watermarks for the completed layer
+      │
+      ▼
+8. Fire post-run hooks
+      │
+      ▼
+9. Emit JSON output → exit 0 (all good) or 2 (partial success)
+```
+
+## Step 1: Mint a run_id
+
+Every run gets a unique `run_id` (a ULIDv2 — sortable, monotonic, collision-free). Every subsequent state-store write is tagged with this ID. This is what makes `--resume-latest` work: Rocky looks up the most recent `run_id` in the state store and finds which tables already completed.
+
+## Step 2: Validate config + ping adapters
+
+Rocky parses `rocky.toml`, substitutes environment variables (`${VAR:-default}`), and validates the config struct. Then it calls `ping()` on each declared adapter — a lightweight connection check that fails fast before any expensive work starts.
+
+## Step 3: Discover sources
+
+Rocky calls `DiscoveryAdapter::discover()` on the declared source. For Fivetran, this calls the Fivetran REST API to list connectors and their enabled tables. For DuckDB, it queries `information_schema`. For manual sources, it reads the `rocky.toml` directly.
+
+This step is metadata-only. No data moves. The result is a list of available schemas and tables that models can reference as sources.
+
+## Step 4: Compile
+
+Rocky runs the full compiler pipeline:
+
+1. Load `.sql` + `.toml` model files
+2. Resolve dependencies → build the DAG
+3. Build the semantic graph (column lineage map)
+4. Type-check columns (propagate types through the DAG)
+5. Validate contracts (required columns, type constraints, protected columns)
+6. Run lints (blast radius, freshness coverage, breaking-change classification)
+7. Merge diagnostics
+
+If any `Error`-severity diagnostic is produced, Rocky emits all diagnostics as JSON and exits with code 1. No SQL has run yet.
+
+The compile result is a `ProjectIr` — a typed, validated snapshot of the entire project.
+
+## Step 5: Topological sort → execution layers
+
+Rocky runs Kahn's algorithm on the dependency graph to produce a topological ordering. It then groups models into execution layers: a model goes in the earliest layer where all its upstream dependencies are in earlier layers.
+
+Models in the same layer have no dependency on each other and can run in parallel (bounded by the concurrency setting in `rocky.toml`).
+
+If a model name in `depends_on` doesn't match any known model, Rocky reports `UnknownDependency` and suggests the closest real name (Levenshtein distance). If there's a cycle, Rocky reports `CyclicDependency` and stops.
+
+## Step 6: Per-model execution
+
+This is the core loop. For each model in each layer (in parallel within the layer):
+
+### 6a. Drift detection
+
+Rocky calls `describe_table(target)` to get the current column list and types from the warehouse. It compares this against the source schema.
+
+```
+Source column: amount  type: BIGINT
+Target column: amount  type: INT     ← type narrowed
+
+Is this a safe widening? No → DROP target table, let it be recreated.
+
+Source column: region  (new, not in target yet)
+→ ALTER TABLE target ADD COLUMN region STRING
+```
+
+Safe widening allowlist (no recreate needed): `INT → BIGINT`, `FLOAT → DOUBLE`, `DATE → TIMESTAMP`, and a few others. Everything else triggers a full recreate.
+
+If the target doesn't exist yet, it's created from scratch on first run.
+
+### 6b. Skip-unchanged gate
+
+Rocky computes a `blake3` hash over:
+- The normalized SQL text
+- The typed column list
+- The materialization strategy + config
+
+If this hash matches the hash stored in the state store **and** no schema drift was detected, Rocky marks the model as `Skipped` and moves on. No SQL sent to the warehouse.
+
+Fail-safe: if the SQL contains non-deterministic functions (`NOW()`, `RAND()`, `UUID()`, etc.), the model is never skipped, regardless of the hash.
+
+### 6c. Read watermark (incremental only)
+
+For `Incremental` and `Microbatch` strategies, Rocky reads the current watermark from the **target table**:
+
+```sql
+SELECT MAX(updated_at) FROM target.orders_summary
+```
+
+Reading from the target (not the source) prevents a TOCTOU race: if new source rows arrive while the current run is in progress, the target's `MAX` only reflects what was already written.
+
+The watermark value is passed to the SQL generator, not carried in the IR. This keeps the IR's `recipe_hash` deterministic (runtime state doesn't affect it).
+
+### 6d. Generate SQL
+
+`rocky-core::sql_gen` takes the `ModelIr`, the `SqlDialect` for the target warehouse, and (where applicable) the watermark value or partition timestamps, and produces a SQL string.
+
+For `TimeInterval` models, `@start_date` and `@end_date` placeholders in the user's SQL are replaced with concrete partition timestamps from the `PartitionWindow`.
+
+### 6e. Execute SQL
+
+Rocky calls `WarehouseAdapter::execute_statement(sql)`. The adapter handles connection pooling, retries on transient errors, and warehouse-specific quirks.
+
+For Databricks, this calls `POST /api/2.0/sql/statements` and polls for the result. Adaptive concurrency control (AIMD: additive increase on success, multiplicative decrease on 429/throttle) prevents overloading the warehouse.
+
+Failed execution produces a `failure_kind` (one of: `Transient`, `AuthFailed`, `QueryRejected`, `QuotaExceeded`, `SchemaConflict`, etc.). Rocky branches on this:
+- `Transient` → retry with backoff
+- `AuthFailed` → stop immediately, surface the error
+- `QuotaExceeded` → surface the error with `cooldown_seconds` hint
+
+### 6f. Quality checks
+
+After the SQL executes, Rocky runs the model's declared quality checks (from the model's `.toml` sidecar):
+
+```toml
+[[checks]]
+type = "not_null"
+column = "order_id"
+
+[[checks]]
+type = "row_count"
+min = 1
+
+[[checks]]
+type = "accepted_values"
+column = "status"
+values = ["completed", "cancelled", "pending"]
+```
+
+Each check runs a `SELECT` against the freshly written target table. Failed checks are collected into `check_results` in the JSON output and may trigger `check_failed` hooks.
+
+### 6g. Defer watermark write
+
+Rocky does **not** immediately write the watermark to the state store after a model succeeds. Instead, it queues the write. Only when the entire layer completes successfully does Rocky commit all watermarks in that layer in a single transaction.
+
+If any model in the layer fails, no watermarks are committed for that layer. This means a partial layer failure is fully safe to re-run: every model in the layer will start from its previous watermark.
+
+## Step 7: Batch-commit watermarks
+
+After a layer completes (all models succeeded, or the run is in partial mode), Rocky commits the deferred watermarks in one redb transaction. Atomic: all-or-nothing.
+
+## Step 8: Fire post-run hooks
+
+Rocky fires the appropriate lifecycle hooks:
+- `run_complete` if all models succeeded
+- `run_failed` if all models failed
+- `run_partial` if some succeeded and some failed (exit code 2)
+
+Command hooks are executed as shell subprocesses. Webhook hooks fire as HTTP POSTs (async if configured). Hook failures are handled per the `on_failure` setting (`abort`, `warn`, or `ignore`).
+
+## Step 9: Emit JSON output
+
+Rocky serializes the `RunOutput` struct to JSON on stdout:
+
+```json
+{
+  "version": "1.28.0",
+  "command": "run",
+  "tables_copied": 3,
+  "materializations": [
+    { "model": "orders_summary", "status": "completed", "rows_written": 14203, "duration_ms": 1840 },
+    { "model": "product_stats",  "status": "skipped",   "reason": "unchanged" },
+    { "model": "customer_totals","status": "failed",    "error": "...", "failure_kind": "QueryRejected" }
+  ],
+  "check_results": [...],
+  "drift": [...],
+  "anomalies": [...]
+}
+```
+
+Exit code:
+- `0` — all models succeeded
+- `1` — hard failure (config error, adapter unreachable, compile error)
+- `2` — partial success — some models succeeded, some failed. **JSON is still valid and fully emitted.** The Dagster integration handles this via `allow_partial=True`.
+
+## Checkpoint and resume
+
+If a run is interrupted mid-layer (process killed, network failure, etc.), Rocky can resume from the last successful checkpoint.
+
+The `IDEMPOTENCY` table in the state store records each statement that completed. `rocky run --resume-latest` looks up the most recent `run_id` in the state store, checks which models completed, and skips them. Models whose watermarks were not committed (because the layer didn't finish) are re-run from their last committed watermark.
+
+```bash
+# Resume the most recent run:
+rocky run -c rocky.toml --resume-latest
+
+# Resume a specific run:
+rocky run -c rocky.toml --resume run_20240115_1234
+```
+
+## AIMD adaptive concurrency
+
+When running against Databricks or other rate-limited warehouses, Rocky uses an AIMD (Additive Increase, Multiplicative Decrease) algorithm to find the maximum safe concurrency level:
+
+```
+Start: concurrency = 1
+
+Each successful statement:  concurrency = min(concurrency + 1, max_concurrency)
+Each 429 / throttle error:  concurrency = max(concurrency / 2, 1)
+                            back off for cooldown_seconds
+```
+
+This converges quickly to the warehouse's actual throughput capacity without requiring manual tuning.

--- a/docs/src/content/docs/concepts/execution-flow.md
+++ b/docs/src/content/docs/concepts/execution-flow.md
@@ -45,7 +45,7 @@ rocky run -c rocky.toml
 
 ## Step 1: Mint a run_id
 
-Every run gets a unique `run_id` (a ULIDv2 — sortable, monotonic, collision-free). Every subsequent state-store write is tagged with this ID. This is what makes `--resume-latest` work: Rocky looks up the most recent `run_id` in the state store and finds which tables already completed.
+Every run gets a unique `run_id` — a timestamp-based string of the form `run-%Y%m%d-%H%M%S-%3f` (e.g. `run-20240115-123456-789`), so IDs sort lexicographically in chronological order. Every subsequent state-store write is tagged with this ID. This is what makes `--resume-latest` work: Rocky looks up the most recent `run_id` in the state store and finds which tables already completed.
 
 ## Step 2: Validate config + ping adapters
 
@@ -99,7 +99,7 @@ Source column: region  (new, not in target yet)
 → ALTER TABLE target ADD COLUMN region STRING
 ```
 
-Safe widening allowlist (no recreate needed): `INT → BIGINT`, `FLOAT → DOUBLE`, `DATE → TIMESTAMP`, and a few others. Everything else triggers a full recreate.
+Safe widening allowlist (no recreate needed): integer widenings (`TINYINT`/`SMALLINT`/`INT`/`INTEGER → BIGINT`), `FLOAT → DOUBLE`, widening to `STRING` (`BIGINT → STRING`, `DOUBLE → STRING`), `DECIMAL` precision widening, and `VARCHAR` length widening. Everything else triggers a full recreate. (The default lives in `default_is_safe_type_widening`; a dialect can override `SqlDialect::is_safe_type_widening`.)
 
 If the target doesn't exist yet, it's created from scratch on first run.
 
@@ -138,10 +138,10 @@ Rocky calls `WarehouseAdapter::execute_statement(sql)`. The adapter handles conn
 
 For Databricks, this calls `POST /api/2.0/sql/statements` and polls for the result. Adaptive concurrency control (AIMD: additive increase on success, multiplicative decrease on 429/throttle) prevents overloading the warehouse.
 
-Failed execution produces a `failure_kind` (one of: `Transient`, `AuthFailed`, `QueryRejected`, `QuotaExceeded`, `SchemaConflict`, etc.). Rocky branches on this:
+Failed execution produces a `failure_kind` (the `FailureKind` enum in `output.rs`: `AuthFailed`, `ConnectionFailed`, `QueryRejected`, `QuotaExceeded`, `NotFound`, `Transient`, `Unknown`). Rocky branches on this:
 - `Transient` → retry with backoff
 - `AuthFailed` → stop immediately, surface the error
-- `QuotaExceeded` → surface the error with `cooldown_seconds` hint
+- `QuotaExceeded` → surface the error and back off (a 429 or tripped circuit breaker maps here)
 
 ### 6f. Quality checks
 
@@ -176,16 +176,13 @@ After a layer completes (all models succeeded, or the run is in partial mode), R
 
 ## Step 8: Fire post-run hooks
 
-Rocky fires the appropriate lifecycle hooks:
-- `run_complete` if all models succeeded
-- `run_failed` if all models failed
-- `run_partial` if some succeeded and some failed (exit code 2)
+Rocky fires the appropriate lifecycle hooks — `pipeline_complete` on success, `pipeline_error` on failure (the `HookEvent` enum is serialized as snake_case; the full set of 18 events runs from `pipeline_start` through `after_model_run`, `check_result`, `drift_detected`, and `budget_breach`).
 
 Command hooks are executed as shell subprocesses. Webhook hooks fire as HTTP POSTs (async if configured). Hook failures are handled per the `on_failure` setting (`abort`, `warn`, or `ignore`).
 
 ## Step 9: Emit JSON output
 
-Rocky serializes the `RunOutput` struct to JSON on stdout:
+Rocky serializes the `RunOutput` struct to JSON on stdout. Illustrative shape (top-level fields are stable; per-entry fields shown for orientation):
 
 ```json
 {
@@ -193,12 +190,13 @@ Rocky serializes the `RunOutput` struct to JSON on stdout:
   "command": "run",
   "tables_copied": 3,
   "materializations": [
-    { "model": "orders_summary", "status": "completed", "rows_written": 14203, "duration_ms": 1840 },
-    { "model": "product_stats",  "status": "skipped",   "reason": "unchanged" },
-    { "model": "customer_totals","status": "failed",    "error": "...", "failure_kind": "QueryRejected" }
+    { "model": "orders_summary",  "status": "completed", "reason": "..." },
+    { "model": "product_stats",   "status": "skipped",   "reason": "unchanged" },
+    { "model": "customer_totals", "status": "failed",    "failure_kind": "QueryRejected" }
   ],
   "check_results": [...],
   "drift": [...],
+  "permissions": [...],
   "anomalies": [...]
 }
 ```
@@ -212,14 +210,14 @@ Exit code:
 
 If a run is interrupted mid-layer (process killed, network failure, etc.), Rocky can resume from the last successful checkpoint.
 
-The `IDEMPOTENCY` table in the state store records each statement that completed. `rocky run --resume-latest` looks up the most recent `run_id` in the state store, checks which models completed, and skips them. Models whose watermarks were not committed (because the layer didn't finish) are re-run from their last committed watermark.
+The state store records which models completed via the `run_progress_entries` table (one entry per `run_id` + table) and the `idempotency_keys` table (keyed by `run_id` + model + file). `rocky run --resume-latest` looks up the most recent `run_id`, checks which models already completed, and skips them. Models whose watermarks were not committed (because the layer didn't finish) are re-run from their last committed watermark.
 
 ```bash
 # Resume the most recent run:
 rocky run -c rocky.toml --resume-latest
 
 # Resume a specific run:
-rocky run -c rocky.toml --resume run_20240115_1234
+rocky run -c rocky.toml --resume run-20240115-123456-789
 ```
 
 ## AIMD adaptive concurrency


### PR DESCRIPTION
## Summary

Rewrites the root `README.md` to remove jargon and explain Rocky in plain, simple terms accessible to someone encountering the project for the first time. The structure is unchanged (badges → try it → who it's for → demos → editor → status → dbt comparison → subprojects → adapters → building → releases → docs → contributing); only the wording is simplified.

Follow-up to #925 (now merged), which added the `ROCKY_EXPLAINED.md` link — that link is preserved here in the Documentation section.

## What changed

- **Tagline** — "the typed graph between your code and whichever warehouse" → "a tool that checks and runs your SQL data pipelines and catches problems before they reach your warehouse"
- **Opening** — dropped "content-addressed run records", "column-level lineage", "compile-time contracts", "dialect divergence" in favor of plain descriptions of the actual failures
- **Who it's for** — removed "multi-tenant" / "launch wedge" framing
- **Demos** — reworded each item to describe what the feature does, not how it's built internally
- **Editor / Inspector** — plain explanation instead of "trust dashboard", "governance card"
- **Status section** — removed "conformance coverage", "Delta UniForm", "content-addressed writes round-trip" jargon
- **dbt comparison** — each row reworded so the problem reads in plain terms
- **Subprojects / adapters tables** — plain descriptions instead of "LSP client", "schema-prefix branches" internals where they added noise
- **ROCKY_EXPLAINED.md link** preserved in Documentation

## Test plan

N/A — documentation only.
