### PR TITLE
docs: document the 1.52.0 feature wave (reference, concepts, dagster)

### DIFF
--- a/docs/src/content/docs/concepts/data-quality-checks.md
+++ b/docs/src/content/docs/concepts/data-quality-checks.md
@@ -101,6 +101,8 @@ Row count and freshness checks use batched `UNION ALL` queries in groups of 200 
 
 Declarative assertions are defined as repeated `[[assertions]]` (or `[[tests]]` in a model sidecar) blocks. Each one declares a `type`, optional `column`, optional `severity`, optional `filter`, and type-specific parameters.
 
+**Don't confuse `[[tests]]` with `[[test]]`.** They differ by one letter and run on different paths. The plural `[[tests]]` (and the equivalent `[[assertions]]`) are the declarative assertions on this page. Assertions written under `[pipeline.<name>.checks]` run inline against the warehouse during `rocky run`/`apply`; the model-sidecar `[[tests]]` form runs standalone with `rocky test --declarative`, which executes each assertion against the configured warehouse adapter. The singular `[[test]]` is a separate surface: fixture-driven unit tests that mock upstream inputs (`given`) and assert expected output rows (`expect`), run locally on DuckDB by plain `rocky test`. The assertions check rows already in the warehouse; the unit tests check the model's SQL against fixtures, with no warehouse connection.
+
 ```toml
 [[assertions]]
 type = "not_null"

--- a/docs/src/content/docs/concepts/schema-patterns.md
+++ b/docs/src/content/docs/concepts/schema-patterns.md
@@ -198,6 +198,27 @@ catalog_template = "{environment}_analytics"
 schema_template = "{department}__{system}"
 ```
 
+## Config groups vs schema patterns
+
+Schema patterns route at the pipeline level: they parse a source schema *name* into components, then fill a target `catalog_template` / `schema_template` from those parsed values. The values come from the schema name itself, and a `...` component can be multi-valued.
+
+Rocky has a separate model-level routing feature that shares the same template grammar but takes its values from a different place. A **config group** lives in `models/groups/<name>.toml` and defines a `schema_template` once. Each model opts in with `group = "<name>"` and fills the template's placeholders from its own `[args]` block:
+
+```toml
+# models/groups/daily_marts.toml
+schema_template = "mart_{region}"
+
+# models/fct_orders.toml
+group = "daily_marts"
+
+[args]
+region = "emea"   # fills {region} -> schema "mart_emea"
+```
+
+A group's `schema_template` uses the same `{name}` / `{name:SEP}` placeholder grammar as the target templates on this page, and resolves through the same engine code. The difference is the input: a config group substitutes the explicit single-valued strings a model declares under `[args]`, not components parsed out of a source schema name. Use schema patterns when the routing information is encoded in source schema names; use config groups when a fan-out of models shares one routing and materialization that you set by hand.
+
+See [Config groups](/reference/model-format/#config-groups) in the model format reference for the full `[args]` rules, precedence, enforced groups, and shared tags.
+
 ## Filtering by parsed component
 
 Once your sources are parsed into components, you can scope `rocky plan` and `rocky compare` (and the `rocky run` alias) to a subset via the `--filter` flag. The filter key is one of the component names you declared above (or the reserved `id`), and the value is matched against the parsed value, with containment semantics for multi-valued (`...`) components:

--- a/docs/src/content/docs/concepts/sql-generation.md
+++ b/docs/src/content/docs/concepts/sql-generation.md
@@ -88,6 +88,47 @@ User-defined SQL is wrapped in the appropriate statement depending on the materi
 - **Dynamic Table**: `CREATE OR REPLACE DYNAMIC TABLE ... TARGET_LAG = '<lag>' AS <user_sql>` (Snowflake)
 - **Time Interval**: Per-partition `INSERT OVERWRITE` with `@start_date`/`@end_date` substitution
 
+## Surrogate Key Columns
+
+A model declares deterministic surrogate keys with `[[surrogate_key]]` blocks in its `.toml` sidecar:
+
+```toml
+[[surrogate_key]]
+name = "order_key"
+columns = ["order_id"]
+```
+
+At `rocky run` and `rocky emit-sql`, Rocky wraps the model's SELECT and appends each key as a top-level column (DuckDB shown):
+
+```sql
+SELECT *, CAST(md5(cast(coalesce(cast(order_id as VARCHAR), '_dbt_utils_surrogate_key_null_') as VARCHAR)) AS VARCHAR) AS order_key
+FROM (
+<user_sql>
+) AS __rocky_keyed
+```
+
+The hash expression follows dbt-utils' `generate_surrogate_key`: each input is cast to text, NULL-coalesced to the `_dbt_utils_surrogate_key_null_` sentinel, joined with a `-` separator, and MD5-hashed. Most warehouses concatenate with `||` and differ only in the text type they cast to:
+
+- **DuckDB / Snowflake** cast to `VARCHAR`:
+
+  ```sql
+  md5(cast(coalesce(cast(a as VARCHAR), '_dbt_utils_surrogate_key_null_') || '-' || coalesce(cast(b as VARCHAR), '_dbt_utils_surrogate_key_null_') as VARCHAR))
+  ```
+
+- **Databricks** casts to `STRING` (Spark SQL rejects an unsized `VARCHAR`):
+
+  ```sql
+  md5(cast(coalesce(cast(a as STRING), '_dbt_utils_surrogate_key_null_') || '-' || coalesce(cast(b as STRING), '_dbt_utils_surrogate_key_null_') as STRING))
+  ```
+
+- **BigQuery** wraps the hash in `to_hex(...)` (its `MD5()` returns `BYTES`) and concatenates with `concat(...)` instead of `||`, casting to `STRING`:
+
+  ```sql
+  to_hex(md5(cast(concat(coalesce(cast(a as STRING), '_dbt_utils_surrogate_key_null_'), '-', coalesce(cast(b as STRING), '_dbt_utils_surrogate_key_null_')) as STRING)))
+  ```
+
+The hash digest is the same one dbt-utils' `generate_surrogate_key` produces for the same columns, so a key Rocky computes joins against the same key in an upstream dbt model.
+
 ## Materialized View (Databricks)
 
 ```sql

--- a/docs/src/content/docs/concepts/testing.md
+++ b/docs/src/content/docs/concepts/testing.md
@@ -129,11 +129,146 @@ Testing 12 models...
   "passed": 10,
   "failed": 2,
   "failures": [
-    ["orders_summary", "column 'revenue' type mismatch"],
-    ["customer_ltv", "required column 'customer_id' missing"]
+    { "name": "orders_summary", "error": "column 'revenue' type mismatch" },
+    { "name": "customer_ltv", "error": "required column 'customer_id' missing" }
   ]
 }
 ```
+
+## Unit tests (`[[test]]`)
+
+A unit test feeds a model mocked input rows and asserts on the rows it produces. This is the same approach dbt 1.8 ships as unit tests: you exercise the model's logic in isolation, against fixtures you control, without touching the warehouse. Rocky runs unit tests on the default `rocky test` path via DuckDB, alongside the local model-execution check above.
+
+Unit tests live in a model's `.toml` sidecar as singular `[[test]]` blocks. Each block names the test, declares one or more mocked inputs under `[[test.given]]`, and declares the expected output under `[test.expect]`:
+
+```toml
+# models/orders_summary.toml
+
+[[test]]
+name = "high_value_orders"
+description = "Orders over $100 should be flagged as high value"
+
+[[test.given]]
+ref = "orders"
+rows = [
+    { id = 1, amount = 150.0, status = "completed" },
+    { id = 2, amount = 50.0, status = "completed" },
+    { id = 3, amount = 200.0, status = "cancelled" },
+]
+
+[test.expect]
+rows = [
+    { id = 1, amount = 150.0, is_high_value = true },
+    { id = 3, amount = 200.0, is_high_value = true },
+]
+```
+
+The runner seeds DuckDB with each `[[test.given]]` fixture as a table named after its `ref`, executes the model's compiled SQL against those fixtures, and compares the result to `[test.expect]`.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Test name, unique within the model. |
+| `description` | No | Documentation for human readers. |
+| `[[test.given]]` | No | A mocked upstream input. `ref` is the model or source name to stand in for (matches the model's `from` / `depends_on` references); `rows` is an inline list of input rows. Repeat the block to mock more than one input. |
+| `[test.expect]` | Yes | The expected output. `rows` is an inline list of expected rows; `ordered` is an optional boolean. |
+
+Comparison rules:
+
+- **Multiset by default.** Rows are compared as a multiset (order does not matter, but duplicate counts do), implemented as `EXCEPT ALL` in both directions so a missing row and an unexpected row are both reported.
+- **Ordered comparison.** Set `ordered = true` under `[test.expect]` to compare rows positionally, in the model's output order against the declaration order of the expected rows.
+- **Only asserted columns are compared.** The comparison uses the columns present in the expected rows. Extra columns in the model's output are ignored, so you assert on the columns you care about.
+- **Empty `rows` asserts zero output.** An empty `[test.expect]` `rows` list asserts that the model produces no rows for the given inputs.
+
+```bash
+# Unit tests run automatically on the default test path
+rocky test --models models/
+
+# Scope to one model
+rocky test --models models/ --model orders_summary
+```
+
+When a project declares any `[[test]]` blocks, `rocky test` reports a unit-test summary after the model results, and the `--output json` payload gains a `unit_tests` object:
+
+```json
+{
+  "version": "1.6.0",
+  "command": "test",
+  "total": 12,
+  "passed": 12,
+  "failed": 0,
+  "failures": [],
+  "unit_tests": {
+    "total": 3,
+    "passed": 2,
+    "failed": 1,
+    "results": [
+      {
+        "model": "orders_summary",
+        "test": "high_value_orders",
+        "passed": false,
+        "error": "output mismatch: 1 expected row(s) missing, 0 unexpected row(s)"
+      }
+    ]
+  }
+}
+```
+
+A failed unit test also carries a `mismatches` array of row-level diagnostics (each entry naming a missing, extra, or value-differing row), omitted above for brevity. A unit-test failure fails the `rocky test` run with a non-zero exit code, the same as a model-execution failure.
+
+## Declarative tests (`[[tests]]`)
+
+Declarative tests are assertions about the data already in your warehouse: not-null columns, uniqueness, accepted values, referential integrity, row-count ranges, and more. They share the assertion vocabulary of pipeline-level data quality checks. See [Data quality checks](/concepts/data-quality-checks/) for the full catalog of assertion kinds, severity, and quarantine behavior.
+
+Declarative tests use the plural `[[tests]]` array in a model's `.toml` sidecar. Each entry declares a `type`, an optional `column`, an optional `severity`, an optional `filter`, and type-specific parameters:
+
+```toml
+# models/orders_summary.toml
+
+[[tests]]
+type = "not_null"
+column = "customer_id"
+
+[[tests]]
+type = "unique"
+column = "order_id"
+
+[[tests]]
+type = "accepted_values"
+column = "status"
+values = ["pending", "shipped", "delivered"]
+severity = "warning"
+```
+
+Run them with `--declarative`. Unlike unit tests, declarative tests execute against the configured warehouse adapter rather than DuckDB, so they need a `rocky.toml` and a reachable warehouse:
+
+```bash
+# Run declarative assertions against the warehouse
+rocky test --declarative
+
+# Pick a pipeline when the config defines more than one
+rocky test --declarative --pipeline silver
+
+# Scope to one model
+rocky test --declarative --model orders_summary
+```
+
+Each assertion compiles to a SQL query in the adapter's dialect, runs against the model's target table, and reports `pass`, `fail`, or `error`. An assertion with `severity = "error"` (the default) that fails causes a non-zero exit; `severity = "warning"` reports without failing the run. The `--output json` payload carries a `declarative` summary with per-assertion results and the SQL that ran.
+
+### Reusable named tests
+
+To apply the same assertion across many models, define it once in `models/test_definitions.toml` and reference it by name with a `[[use_test]]` block. Inline `[[tests]]` and `[[use_test]]` references coexist in a sidecar, and references resolve into ordinary assertions at load. See the [Reusable named tests](/concepts/data-quality-checks/#reusable-named-tests) section of the data quality checks page for the full syntax.
+
+### `[[test]]` vs `[[tests]]`
+
+The singular and plural keys are two different test mechanisms. The names are close, so keep the distinction in mind:
+
+| | `[[test]]` (singular) | `[[tests]]` (plural) |
+|---|---|---|
+| What it tests | Model logic against mocked inputs | Data already in the warehouse |
+| Inputs | `[[test.given]]` fixtures you supply | The model's real target table |
+| Executes against | DuckDB, locally | The configured warehouse adapter |
+| How to run | `rocky test` (default path) | `rocky test --declarative` |
+| Analogous to | dbt 1.8 unit tests | dbt / DQX data tests and assertions |
 
 ## rocky ci
 

--- a/docs/src/content/docs/dagster/derived-models.md
+++ b/docs/src/content/docs/dagster/derived-models.md
@@ -47,7 +47,12 @@ Each derived-model asset gets:
   group, which usually corresponds to a logical layer (`raw` /
   `staging` / `marts`).
 - **Tags:** `rocky/strategy`, `rocky/target_catalog`,
-  `rocky/target_schema`, `rocky/model_name`.
+  `rocky/target_schema`, `rocky/model_name`, plus the model's resolved
+  `[tags]` (its own block merged over any config-group baseline)
+  projected as first-class Dagster tags via
+  `RockyDagsterTranslator.get_model_tags`, so a governance tag is usable
+  in asset selection (`dagster asset materialize --select
+  tag:domain=finance`).
 - **Kinds:** `{"rocky", "model"}` for UI badges.
 - **Freshness policy:** from `model.freshness` (`[freshness]
   max_lag_seconds` in the model's TOML frontmatter).

--- a/docs/src/content/docs/dagster/resource.md
+++ b/docs/src/content/docs/dagster/resource.md
@@ -158,6 +158,8 @@ Runs `rocky lineage` and returns the dependency graph for a model or a single co
 
 Runs `rocky test` to execute models locally via DuckDB without warehouse credentials.
 
+`TestResult` is an import-compatible alias of the generated `TestOutput`. Its `.failures` field is a list of `TestFailure` objects, each with a `name` and an `error` field.
+
 **Wraps**: `rocky test --models <models_dir> --output json`
 
 | Parameter | Type | Default | Description |
@@ -167,6 +169,8 @@ Runs `rocky test` to execute models locally via DuckDB without warehouse credent
 ### `ci() -> CiResult`
 
 Runs `rocky ci` (compile + test) and returns the combined result.
+
+`CiResult` is an import-compatible alias of the generated `CiOutput`. Its `.failures` field is a list of `TestFailure` objects, each with a `name` and an `error` field.
 
 **Wraps**: `rocky ci --models <models_dir> --output json`
 

--- a/docs/src/content/docs/dagster/translator.md
+++ b/docs/src/content/docs/dagster/translator.md
@@ -27,6 +27,34 @@ Returns tags to attach to the asset.
 
 **Default:** `rocky/source_type` plus one tag per string component (`rocky/<component_name>`)
 
+### `get_model_tags(model) -> dict[str, str]`
+
+The derived-model counterpart to `get_tags`. It takes a `ModelDetail` rather than a source and table, and projects the model's resolved `[tags]` (its own tags merged over any config-group baseline) onto the derived-model `AssetSpec` as first-class Dagster tags, so a governance tag is usable in asset selection (for example `tag:domain=finance`). Both keys and values are sanitized to Dagster's tag charset `[A-Za-z0-9_.-]`: any other character (whitespace, `@`, `:`, `/`, and so on) collapses to `_`, and each is truncated to 63 characters. A key that sanitizes to empty is dropped; an empty value is kept.
+
+Rocky also synthesizes its own metadata tags: `rocky/model_name`, `rocky/target_catalog`, `rocky/target_schema`, plus `rocky/strategy` when the model declares a materialization strategy. The synthesized keys always contain a `/`, and a sanitized governance key never can (its `/` collapses to `_`), so a governance tag can never clobber Rocky's metadata. A governance key written as `rocky/owner` sanitizes to `rocky_owner`, clear of the synthesized `rocky/*` keys.
+
+**Default:** the model's sanitized `[tags]` plus `rocky/model_name`, `rocky/target_catalog`, `rocky/target_schema`, and (when present) `rocky/strategy`
+
+For a model named `customers` materialized into `analytics.marts.customers` with the default `full_refresh` strategy and these resolved tags:
+
+```python
+# model.tags
+{"domain": "finance", "owner": "data-eng@corp.com"}
+```
+
+`get_model_tags(model)` returns:
+
+```python
+{
+    "domain": "finance",
+    "owner": "data-eng_corp.com",          # @ collapsed to _; the . and - survive
+    "rocky/model_name": "customers",
+    "rocky/target_catalog": "analytics",
+    "rocky/target_schema": "marts",
+    "rocky/strategy": "full_refresh",
+}
+```
+
 ### `get_metadata(source, table) -> dict[str, str]`
 
 Returns metadata to attach to the asset.

--- a/docs/src/content/docs/dagster/types.md
+++ b/docs/src/content/docs/dagster/types.md
@@ -8,7 +8,7 @@ sidebar:
 All data returned by `RockyResource` methods is parsed into Pydantic v2 models. These models provide type safety, validation, and IDE autocompletion.
 
 :::tip[Source of truth]
-These types are generated from the engine's JSON schemas via `just codegen`; the generated [`dagster_rocky.types_generated`](https://github.com/rocky-data/rocky/tree/main/integrations/dagster/src/dagster_rocky/types_generated) module is the canonical, complete definition, and `dagster_rocky.types` re-exports it with Python-flavored names. This page documents the types you consume most (discover, run, compile, doctor) plus `parse_rocky_output`. For any type not shown here, consult the generated module or the [JSON Output reference](/reference/json-output/).
+These types are generated from the engine's JSON schemas via `just codegen`; the generated [`dagster_rocky.types_generated`](https://github.com/rocky-data/rocky/tree/main/integrations/dagster/src/dagster_rocky/types_generated) module is the canonical, complete definition, and `dagster_rocky.types` re-exports it with Python-flavored names. This page documents the types you consume most (discover, run, compile, test, ci, doctor) plus `parse_rocky_output`. For any type not shown here, consult the generated module or the [JSON Output reference](/reference/json-output/).
 :::
 
 ## Discover types
@@ -279,7 +279,7 @@ Top-level result from `rocky compile`.
 | `execution_layers` | `int` | Number of execution layers in the DAG |
 | `diagnostics` | `list[Diagnostic]` | Compiler diagnostics (errors, warnings, info) |
 | `has_errors` | `bool` | Whether any diagnostics are errors |
-| `models_detail` | `list[ModelDetail]` | Per-model detail (strategy, target, freshness) |
+| `models_detail` | `list[ModelDetail]` | Per-model detail (strategy, target, freshness, tags) |
 
 ### `Diagnostic`
 
@@ -304,6 +304,89 @@ Per-model summary from compilation.
 | `strategy` | `dict` | Strategy configuration (tagged union) |
 | `target` | `dict[str, str]` | Target catalog/schema/table |
 | `freshness` | `ModelFreshnessConfig \| None` | Per-model freshness config |
+| `tags` | `dict[str, str] \| None` | Model governance tags (own + group-inherited), projected onto Dagster asset tags |
+
+---
+
+## Test and CI types
+
+`TestResult` and `CiResult` are import-compatible aliases for the generated `TestOutput` and `CiOutput`. `parse_rocky_output` dispatches the `"test"` command to `TestOutput` and the `"ci"` command to `CiOutput`. Both share the same `TestFailure` shape for the `failures` list. The nested sub-types (`ModelTestResult`, `DeclarativeTestSummary`, `UnitTestSummary`, and their per-item types) are not re-exported at the top level; import them from `rocky_sdk.types_generated.test_schema` when you need to type-annotate those fields.
+
+### `TestOutput`
+
+Top-level result from `rocky test`. Also exported as `TestResult`.
+
+| Field | Type | Description |
+|---|---|---|
+| `version` | `str` | Output schema version |
+| `command` | `str` | Command that produced this output |
+| `total` | `int` | Total tests run |
+| `passed` | `int` | Tests that passed |
+| `failed` | `int` | Tests that failed |
+| `failures` | `list[TestFailure]` | Failed tests, each a `{name, error}` object |
+| `model_results` | `list[ModelTestResult] \| None` | Per-model outcomes from the model-execution test, passes included. Empty when only declarative tests ran; filtered to `--model` when that flag is set |
+| `declarative` | `DeclarativeTestSummary \| None` | Results from declarative `[[tests]]` in model sidecars. Present only when `--declarative` is used |
+| `unit_tests` | `UnitTestSummary \| None` | Results from fixture-driven `[[test]]` unit tests. Present only when at least one model declares a `[[test]]` block |
+
+### `TestFailure`
+
+A single failed test. The `failures` field carries these as objects, not positional tuples.
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | `str` | Test name |
+| `error` | `str` | Failure message |
+
+### `ModelTestResult`
+
+One per-model outcome from the model-execution test.
+
+| Field | Type | Description |
+|---|---|---|
+| `model` | `str` | Model name |
+| `status` | `str` | `"pass"` or `"fail"` |
+| `error` | `str \| None` | Failure message, set only when `status` is `"fail"` |
+
+### `DeclarativeTestSummary`
+
+Summary of declarative test execution from `[[tests]]` in model sidecars.
+
+| Field | Type | Description |
+|---|---|---|
+| `total` | `int` | Total declarative assertions run |
+| `passed` | `int` | Assertions that passed |
+| `failed` | `int` | Assertions that failed |
+| `warned` | `int` | Assertions that failed at `warning` severity |
+| `errored` | `int` | Assertions that raised an execution error |
+| `results` | `list[DeclarativeTestResult]` | Per-assertion detail |
+
+### `UnitTestSummary`
+
+Summary of fixture-driven unit-test execution from `[[test]]` blocks in model sidecars.
+
+| Field | Type | Description |
+|---|---|---|
+| `total` | `int` | Total unit tests run |
+| `passed` | `int` | Unit tests that passed |
+| `failed` | `int` | Unit tests that failed |
+| `results` | `list[UnitTestResult]` | Per-test detail, including row-level mismatches |
+
+### `CiOutput`
+
+Top-level result from `rocky ci`. Also exported as `CiResult`.
+
+| Field | Type | Description |
+|---|---|---|
+| `version` | `str` | Output schema version |
+| `command` | `str` | Command that produced this output |
+| `compile_ok` | `bool` | Whether compilation succeeded |
+| `models_compiled` | `int` | Number of models compiled |
+| `diagnostics` | `list[Diagnostic]` | Compiler diagnostics (errors, warnings, info) |
+| `tests_ok` | `bool` | Whether all tests passed |
+| `tests_passed` | `int` | Tests that passed |
+| `tests_failed` | `int` | Tests that failed |
+| `failures` | `list[TestFailure]` | Failed tests, each a `{name, error}` object |
+| `exit_code` | `int` | Process exit code |
 
 ---
 

--- a/docs/src/content/docs/guides/migrate-from-dbt.md
+++ b/docs/src/content/docs/guides/migrate-from-dbt.md
@@ -430,6 +430,19 @@ For migrations that lean on `{{ var() }}` or `{{ target.* }}` to drive per-model
 
 For each failed model, check the error message and rewrite the SQL manually. Most Jinja macros exist to work around SQL limitations that Rocky handles differently (incremental logic, schema naming, environment branching).
 
+### `generate_surrogate_key`
+
+`{{ dbt_utils.generate_surrogate_key([...]) }}` is a common one. The importer does not auto-convert it: it surfaces as an `UnsupportedMacro` warning and the call is replaced with a `/* TODO: unsupported macro */` marker in the emitted SQL. Rewrite it by hand as a `[[surrogate_key]]` block in the model sidecar. The block names the output column and the input columns; `rocky run` injects the hash column at materialization time:
+
+```toml
+# models/fct_orders.toml
+[[surrogate_key]]
+name = "order_key"
+columns = ["order_id", "customer_id"]
+```
+
+Drop the `{{ ... }}` expression from the model SQL and let the sidecar add the column. Rocky's hash matches what dbt-utils produces on the same warehouse: each input is cast to text, NULL-coalesced to the same `_dbt_utils_surrogate_key_null_` sentinel, joined with a `-` separator, and MD5-hashed. The expression is dialect-correct on DuckDB, Databricks, Snowflake, and BigQuery, so the hash values are identical to the dbt output for the matching warehouse.
+
 ## 4. Configure rocky.toml
 
 Create a `rocky.toml` in your project root. Rocky uses **named adapters** plus **named pipelines**. Define one adapter for the source and one for the warehouse, then a pipeline that wires them together. If you were using dbt with Databricks, your settings map directly:
@@ -485,6 +498,39 @@ export DATABRICKS_TOKEN="dapi..."
 | `catalog` | `[pipeline.<name>.target] catalog_template` |
 | `schema` | `[pipeline.<name>.target] schema_template` |
 | `threads` | `[pipeline.<name>.execution] concurrency` |
+
+### Folder-level config (`+materialized`, `+schema`)
+
+dbt's `dbt_project.yml` sets per-directory defaults like `marts: +materialized: table` and `+schema: marts`. Rocky's equivalent is a **config group**: define the shared routing and strategy once in `models/groups/<name>.toml`, then have each member model opt in with `group = "<name>"` in its sidecar. The mapping is direct:
+
+| dbt folder-level | Rocky config group (`models/groups/<name>.toml`) |
+|---|---|
+| `+materialized: table` (or `incremental`, etc.) | `[strategy]` block |
+| `+schema: marts` | `schema_template = "marts"` (a literal is a template with no placeholders) |
+
+```toml
+# models/groups/daily_marts.toml
+schema_template = "mart_{region}"
+
+[strategy]
+type = "merge"
+unique_key = ["id"]
+
+[tags]
+domain = "finance"
+```
+
+```toml
+# models/fct_orders.toml
+group = "daily_marts"
+
+[args]
+region = "emea"
+```
+
+The groups differ from dbt's folder defaults in one way. dbt's folder defaults apply automatically to every model in the directory; a Rocky config group applies only to models that name it with `group = "<name>"`. Precedence is per-model sidecar over group over `models/_defaults.toml`, so a member can still override anything the group sets.
+
+Rocky adds a knob dbt has no equivalent for. Set `enforce = true` on a group and a member model that locally pins a field the group controls (its target schema or its strategy) fails to load instead of silently diverging. Enforced groups are Rocky-only: they turn the group from an overridable default into a governance guarantee that the whole fan-out routes and materializes the same way.
 
 ## 5. Compile the Imported Models
 
@@ -561,6 +607,8 @@ rocky plan --filter tenant=acme
 ```
 
 This shows the SQL Rocky will generate for each model. Compare it against `dbt compile` output for the same models.
+
+For a connection-free side-by-side, `rocky emit-sql --models ./rocky-models` renders the compiled SQL for every transformation model without a warehouse, the same shape `dbt compile` writes to `target/`. It also doubles as the exit door: the SQL it produces is plain runnable SQL you keep if you ever step away from the engine. See [No lock-in](/guides/no-lock-in/) for the full walkthrough.
 
 ### Run on a test catalog
 
@@ -660,6 +708,34 @@ column = "customer_id"
 
 Anything else (`dbt_utils.*`, `dbt_expectations.*`, project-defined generics, model-level tests) is surfaced as an `UnsupportedTest` warning with the model, column, and test name. Rewrite those as a Rocky `expression` test or a quality-pipeline check; the importer does not stub them in the emitted TOML.
 
+#### Consolidating repeated tests into named definitions
+
+The importer writes one inline `[[tests]]` block per column, so a `not_null` you apply across twelve models lands as twelve identical blocks. To get dbt's generic-test parity (define a test once, apply it by name), define each test once in `models/test_definitions.toml` and reference it from each sidecar with `[[use_test]]`. This is a post-import authoring step, not a conversion the importer performs.
+
+```toml
+# models/test_definitions.toml
+[positive_amount]
+type = "expression"
+expression = "amount > 0"
+
+[known_status]
+type = "accepted_values"
+values = ["pending", "shipped", "delivered"]
+```
+
+```toml
+# models/fct_orders.toml
+[[use_test]]
+name = "positive_amount"
+column = "total_amount"
+
+[[use_test]]
+name = "known_status"
+column = "status"
+```
+
+`test_definitions.toml` is a table of named entries (`[name]`, not an array of `[[...]]` blocks); each entry is the test type plus its parameters. A `[[use_test]]` reference binds the named test to a column at the use site and may override the column, `severity`, or row `filter`. An unknown name is a hard error at load. These resolve into the same `[[tests]]` the importer would emit inline, so they run under `rocky test --declarative` against the configured warehouse the same way.
+
 ### dbt unit tests (manifest path)
 
 If your dbt project has compiled to a `manifest.json` and declares `unit_tests:` blocks (dbt 1.8+), `rocky import-dbt --manifest target/manifest.json` walks `manifest.unit_tests` and emits each entry as a `[[test]]` block in the matching model's sidecar TOML. `ref('upstream_model')` / `source('s', 't')` wrappers on `given.input` are stripped to bare references.
@@ -704,7 +780,7 @@ The importer also surfaces three new counters on the `--output json` payload and
 - `OrphanUnitTest`: the unit test targets a model the importer didn't pick up. Skipped and counted as skipped.
 - `UnsupportedUnitTestFormat`: `expect.format = "csv"` or `"sql"`, fixture references, or any other shape Rocky's `UnitTestDef` doesn't yet model. Skipped.
 
-CSV / SQL fixtures and `overrides:` blocks are deferred until Rocky's runtime test runner grows the matching surface; emitted `[[test]]` blocks deserialize through Rocky today but aren't yet wired into `rocky test` execution.
+CSV / SQL fixtures and `overrides:` blocks are deferred until Rocky's runtime test runner grows the matching surface. Emitted given/expect `[[test]]` blocks now execute under `rocky test` as of engine-v1.52.0: the runner seeds a fresh in-memory DuckDB with each `given` fixture, materializes the model against it, and compares the output to `expect` (a multiset comparison by default, positional when `expect.ordered` is set).
 
 ### Column-level contracts (manual)
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -8,7 +8,7 @@ sidebar:
 Rocky provides a single binary with subcommands for the full pipeline lifecycle. Commands are organized into categories:
 
 - **Core Pipeline**: `init`, `validate`, `discover`, `plan`, `apply`, `state`, `branch` (single-step alias: `run`)
-- **Modeling**: `compile`, `lineage`, `lineage-diff`, `test`, `ci`, `ci-diff`, `preview`
+- **Modeling**: `compile`, `lineage`, `lineage-diff`, `test`, `ci`, `ci-diff`, `preview`, `emit-sql`, `catalog`
 - **Data**: `seed`, `snapshot`, `docs`
 - **AI**: `ai`, `ai-sync`, `ai-explain`, `ai-test`
 - **Development**: `playground`, `shell`, `watch`, `fmt`, `list`, `serve`, `lsp`, `import-dbt`, `init-adapter`, `adapter`, `hooks`, `validate-migration`, `test-adapter`
@@ -636,6 +636,68 @@ rocky docs --models models/ --output site/api.html  # Custom paths
   "duration_ms": 15
 }
 ```
+
+---
+
+### `rocky emit-sql`
+
+Render the runnable SQL each transformation model would produce, without a warehouse connection and without running anything. This is the tested exit path: a Rocky project always reduces to plain SQL files you can run directly or hand to a dbt / hand-SQL fallback, so adopting Rocky is never a one-way door. See [No lock-in](/guides/no-lock-in/) for the full workflow.
+
+```bash
+rocky emit-sql                                   # Print SQL for every model to stdout
+rocky emit-sql --out-dir build/sql/              # Write one <model>.sql file per model
+rocky emit-sql --model stg_orders --out-dir sql/ # Emit a single model
+```
+
+**Flags:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--models <PATH>` | `models` | Models directory to compile. |
+| `--model <NAME>` | (all) | Restrict output to a single model by name. |
+| `--out-dir <PATH>` | (stdout) | Write one `<model>.sql` file per model into this directory, in dependency order. When omitted, the concatenated SQL is printed to stdout, also in dependency order. |
+
+**Behavior:**
+
+- Compiles the project offline and generates SQL through the same path `rocky run` uses, including declared surrogate-key columns, so the emitted statements match what a run executes.
+- The dialect is the project's configured target adapter type, resolved from `rocky.toml` without credentials. With no resolvable config it defaults to DuckDB. All models render in this one resolved dialect, so for a project whose models target more than one adapter, the emitted SQL matches `rocky run` only for the models whose target uses that dialect.
+- **Full-refresh models.** Emit a complete `CREATE OR REPLACE TABLE … AS …` that runs as-is against a fresh warehouse and matches what a run executes in the resolved dialect.
+- **Incremental and merge models.** Emit their steady-state statement (a bare `INSERT` / `MERGE` against an existing target). `rocky run` bootstraps the target table on first build and threads the incremental watermark from state, neither of which a static emit can reproduce, so each such file carries a leading `-- NOTE:` comment to that effect.
+- Models that produce no standalone SQL are reported on stderr rather than silently dropped. This covers ephemeral models (inlined as CTEs) and strategies that cannot render offline, such as Snowflake dynamic tables, which need a live compute-warehouse name.
+
+This command prints SQL or writes files; it has no JSON output mode.
+
+---
+
+### `rocky catalog`
+
+Emit a project-wide column-level lineage snapshot as a persisted catalog artifact, so any non-Rocky consumer can read column-level lineage without invoking the engine.
+
+```bash
+rocky catalog                              # Write all artifacts to ./.rocky/catalog/
+rocky catalog --out build/catalog/         # Custom output directory
+rocky catalog --format json               # Emit only catalog.json
+rocky catalog --catalog acme_warehouse     # Scope to a single warehouse catalog
+```
+
+**Flags:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--models <PATH>` | `models` | Models directory to compile. |
+| `--out <PATH>` | `./.rocky/catalog/` | Output directory for the catalog artifacts. |
+| `--format <FORMAT>` | `both` | Which artefact family to emit. `json` writes only `catalog.json`; `parquet` writes only `edges.parquet` and `assets.parquet`; `both` writes all three. |
+| `--catalog <NAME>` | (all) | Scope the snapshot to a single warehouse catalog. Only assets whose fully-qualified name sits in the named catalog are emitted, and edges referencing dropped assets are pruned. Mirrors `compact --catalog` and `archive --catalog`. |
+
+**Artifacts:**
+
+- `catalog.json` is the single-file front door for the snapshot.
+- `edges.parquet` holds one row per column-lineage edge.
+- `assets.parquet` holds one row per asset column.
+
+**Behavior:**
+
+- JSON output is [`CatalogOutput`](/reference/json-output/). Under `--output json` the same `CatalogOutput` is mirrored to stdout, independent of `--format`, so a consumer can pipe it without re-reading the written files.
 
 ---
 

--- a/docs/src/content/docs/reference/commands/modeling.md
+++ b/docs/src/content/docs/reference/commands/modeling.md
@@ -45,9 +45,34 @@ rocky compile
   "has_errors": false,
   "diagnostics": [],
   "compile_timings": { "load_ms": 8, "resolve_ms": 2, "typecheck_ms": 42 },
-  "models_detail": [ /* one entry per model */ ]
+  "models_detail": [
+    {
+      "name": "fct_revenue",
+      "strategy": { "type": "full_refresh" },
+      "target": { "catalog": "acme_warehouse", "schema": "gold", "table": "fct_revenue" },
+      "freshness": { "max_lag_seconds": 86400, "time_column": "order_date", "severity": "warning" },
+      "contract_source": "auto",
+      "incrementality_hint": {
+        "is_candidate": true,
+        "recommended_column": "order_date",
+        "confidence": "medium",
+        "signals": ["column name 'order_date' ends with '_date' (timestamp pattern)"]
+      },
+      "cost_hint": {
+        "estimated_rows": 10000,
+        "estimated_bytes": 2560000,
+        "estimated_cost_usd": 0.0000228,
+        "confidence": "high"
+      },
+      "depends_on": ["stg_orders", "stg_refunds"],
+      "tags": { "domain": "finance", "tier": "gold", "owner": "analytics", "region": "emea" }
+    }
+    /* one entry per model */
+  ]
 }
 ```
+
+`models_detail` carries the stable, declarative shape of each compiled model: its name, materialization `strategy` (the wire form `{"type": "..."}`), `target` coordinates, and direct `depends_on` list. Optional fields appear only when present: `freshness` when the model declares a freshness expectation, `contract_source` (`"auto"` for a sibling `.contract.toml`, `"explicit"` for one passed via `--contracts`) when a contract applies, `incrementality_hint` when a `full_refresh` model has a monotonic-looking column, and `cost_hint` when upstream statistics support a heuristic estimate. The `tags` object holds the model's `[tags]` block merged over any config-group baseline (sidecar wins), so a governed key like `domain` or `owner` declared once on a group is visible to consumers such as `dagster-rocky`. Empty `tags`, `depends_on`, and absent optional fields are omitted from the JSON.
 
 Compile a single model with contracts, showing a warning diagnostic:
 
@@ -284,7 +309,7 @@ rocky catalog [flags]
 
 The artifact contains:
 
-- `assets` — one entry per model or upstream source, with columns (name plus inferred type and nullability when known), upstream / downstream lists, and the model's intent description when supplied.
+- `assets` — one entry per model or upstream source, with columns (name plus inferred type and nullability when known, and a per-column `description` from the sidecar `[columns]` table when set), upstream / downstream lists, and the model's intent description when supplied.
 - `edges` — one entry per column-level lineage edge: source column, target column, transform kind (`direct`, `cast`, `expression`, `aggregation: <fn>`), and a confidence grade (`High` for explicit projections, `Medium` for star-expanded edges, `Low` reserved for future use).
 - `stats` — aggregate counts (`asset_count`, `edge_count`, `column_count`, `assets_with_star`, `orphan_columns`, `duration_ms`).
 - A `config_hash` fingerprint of `rocky.toml` so consumers can tell whether the catalog was built against the current configuration.
@@ -329,6 +354,87 @@ rocky catalog --out build/catalog
 
 - [`rocky lineage`](#rocky-lineage) -- per-model lineage exploration with `--column` traces
 - [`rocky compile`](#rocky-compile) -- build the semantic graph that the catalog reads
+
+---
+
+## `rocky emit-sql`
+
+Render the runnable SQL each transformation model would emit, without a warehouse connection and without running anything. This is Rocky's tested exit path: a project can always be reduced to plain, dialect-correct SQL files that feed a hand-SQL or dbt fallback, so adopting Rocky is never a one-way door. The SQL is generated through the same path `rocky run` uses, including declared surrogate-key columns wrapped exactly as they are at materialization.
+
+```bash
+rocky emit-sql [flags]
+```
+
+### Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--models <PATH>` | `PathBuf` | `models` | Directory containing `.sql` and `.toml` model files. |
+| `--model <NAME>` | `string` | | Render a single model by name instead of the whole project. |
+| `--out-dir <PATH>` | `PathBuf` | | Write one `<model>.sql` file per model into this directory, in dependency order. When omitted, the concatenated SQL is printed to stdout (also in dependency order). |
+
+### Dialect and the runnable guarantee
+
+The dialect is the project's configured target adapter type, resolved from `rocky.toml` without credentials. With no resolvable config it defaults to DuckDB. All models render in this one resolved dialect, so for a project whose models target more than one adapter, the emitted SQL matches `rocky run` only for the models whose target uses that dialect.
+
+Full-refresh models emit a complete `CREATE OR REPLACE TABLE … AS …` that runs as-is against a fresh warehouse and matches what a run executes in the resolved dialect. Incremental and merge models emit their steady-state statement instead: a bare `INSERT` or `MERGE` that operates on an existing target. `rocky run` bootstraps the target table on first build and threads the incremental watermark from state, neither of which a static emit can reproduce, so those files carry a leading note to that effect:
+
+```sql
+-- NOTE: incremental/merge statement — operates on an existing target.
+-- `rocky run` bootstraps the table on first build and threads the
+-- incremental watermark from state; this static SQL does neither.
+MERGE INTO ...
+```
+
+Models that produce no standalone SQL are reported on stderr rather than silently dropped, so you never mistake the emitted set for the complete project. Two cases are skipped this way: ephemeral models (inlined as CTEs upstream, so they have no statement of their own) and strategies that cannot render offline, such as a Snowflake dynamic table that needs a live compute-warehouse name.
+
+### Examples
+
+Print the whole project's SQL to stdout in dependency order:
+
+```bash
+rocky emit-sql
+```
+
+```sql
+-- model: stg_orders
+CREATE OR REPLACE TABLE main.stg_orders AS
+SELECT order_id, customer_id, total_amount FROM raw.orders;
+
+-- model: fct_revenue
+CREATE OR REPLACE TABLE main.fct_revenue AS
+SELECT customer_id, SUM(total_amount) AS revenue_amount FROM main.stg_orders GROUP BY customer_id;
+```
+
+Write one file per model, ready to commit or hand to another tool:
+
+```bash
+rocky emit-sql --out-dir build/sql/
+```
+
+```text
+emit-sql: wrote 2 model(s) to build/sql/ in dependency order
+```
+
+Render a single model, and capture the project-wide SQL into one file:
+
+```bash
+rocky emit-sql --model fct_revenue
+rocky emit-sql > build/all.sql
+```
+
+When some models cannot be emitted as standalone SQL, the skip report goes to stderr:
+
+```text
+emit-sql: 1 model(s) not emitted:
+  - dim_session (ephemeral — inlined as a CTE)
+```
+
+### Related Commands
+
+- `rocky dag` -- inspect the dependency order `emit-sql` renders in
+- [`rocky catalog`](#rocky-catalog) -- the same compiled graph, exported as a lineage snapshot rather than runnable SQL
+- [No lock-in](/guides/no-lock-in/) -- the full fallback recipe for stepping away from the engine
 
 ---
 
@@ -387,7 +493,39 @@ rocky test --model fct_revenue --contracts contracts/
 }
 ```
 
-`--declarative` adds a `declarative` block summarising `[[tests]]` declared in model sidecars; see [Testing and Contracts](/concepts/testing/) for that surface.
+The default `rocky test` path also runs fixture-driven `[[test]]` unit tests declared in model sidecars. Each `[[test]]` block mocks upstream inputs with inline rows (`given`) and asserts the model's output rows (`expect`), executed in-memory against DuckDB. When at least one model declares a `[[test]]` block, the JSON output gains a `unit_tests` summary; the key is omitted entirely when no model declares one. A failing unit test makes `rocky test` exit non-zero, the same as a failing model assertion.
+
+```json
+{
+  "version": "1.11.0",
+  "command": "test",
+  "total": 3,
+  "passed": 3,
+  "failed": 0,
+  "failures": [],
+  "unit_tests": {
+    "total": 2,
+    "passed": 1,
+    "failed": 1,
+    "results": [
+      { "model": "fct_revenue", "test": "discount_caps_at_total", "passed": true, "error": null, "mismatches": [] },
+      {
+        "model": "fct_revenue",
+        "test": "refunds_subtract",
+        "passed": false,
+        "error": "ordered output mismatch (1 expected vs 1 actual row(s))",
+        "mismatches": [
+          { "row_index": 0, "expected": "customer_id=7, revenue_amount=80", "actual": "customer_id=7, revenue_amount=100", "kind": "value_diff" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Each `results` entry carries the model name, the `[[test]]` block's `test` name, a `passed` flag, an `error` message (`null` when the test passed), and the `mismatches` array of row-level diffs. Each mismatch renders its row as `col=val, col=val`. A mismatch `kind` is `missing` (expected but not produced), `extra` (produced but not expected), or `value_diff` (same positional row, differing values, from an `ordered` expectation).
+
+`--declarative` is a separate surface: it adds a `declarative` block summarising `[[tests]]` (plural) declared in model sidecars, run against the configured warehouse adapter rather than DuckDB. See [Testing and Contracts](/concepts/testing/) for both surfaces.
 
 ### Related Commands
 

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -382,6 +382,8 @@ Given `source=shopify`:
 
 For multi-tenant setups with per-tenant catalogs, use `{component}` placeholders in `catalog_template`. See [Schema Patterns](/concepts/schema-patterns/) for the full pattern reference (e.g. `catalog_template = "{tenant}_warehouse"` with `components = ["tenant", "regions...", "source"]`).
 
+This `schema_template` routes replication targets, and its `{component}` placeholders are filled from the parsed source-schema components defined in `[pipeline.NAME.source.schema_pattern]`. It is a different feature from the config-group `schema_template`, which fills its `{placeholder}` values from a model's `[args]` to route a fan-out of transformation models. See [Config groups](/reference/model-format/#config-groups) for that one.
+
 ### `[pipeline.NAME.target.governance]`
 
 Catalog/schema lifecycle, tagging, grants, and isolation. Tagging, grants, and workspace isolation are implemented against Databricks Unity Catalog APIs and apply only when the target adapter is Databricks. The two `auto_create_*` lifecycle flags work on every adapter that emits `CREATE SCHEMA` SQL.

--- a/docs/src/content/docs/reference/glossary.md
+++ b/docs/src/content/docs/reference/glossary.md
@@ -31,6 +31,10 @@ A data-quality assertion that runs inline during a run (row counts, column match
 
 A schema agreement Rocky enforces before any row is written. A missing required column or an unsafe type change becomes a compile error (`E010`, `E013`) that blocks the PR. See [Testing and contracts](/concepts/testing/).
 
+### Config group
+
+A `models/groups/<name>.toml` definition that a fan-out of models opts into by name (`group = "<name>"` in the sidecar). The group supplies shared routing (a `schema_template` filled per model from its `[args]`), a shared `strategy`, and shared `[tags]`. Precedence is per-model sidecar over group over `_defaults.toml`, so a model can still override what the group sets unless the group is enforced. See [Config groups](/reference/model-format/#config-groups) and [Enforced group](#enforced-group).
+
 ### Content-addressed
 
 Identified by the hash of its contents rather than a name or timestamp. Rocky records each run's inputs, code, and outputs this way, which is what lets [replay](#replay) verify a past run against its record. See [Content-addressed writes](/concepts/content-addressed/).
@@ -42,6 +46,10 @@ A stable identifier for a compiler finding: errors (`E###`), warnings (`W###`), 
 ### Drift
 
 A mismatch between what your code expects and what the warehouse actually has, usually because a source column changed type or was added or dropped. Rocky detects it on every run and either recreates the target or blocks the PR. See [Schema drift](/concepts/schema-drift/).
+
+### Enforced group
+
+A [config group](#config-group) with `enforce = true`. The group's fields become binding rather than defaults: a member model that locally pins a field the group controls (its target `schema` or its `strategy`) fails the load instead of quietly routing or materializing itself differently from the rest of the group. Enforcement is opt-in; without it, groups stay overridable defaults. See [Enforced groups](/reference/model-format/#enforced-groups).
 
 ### IR (intermediate representation)
 
@@ -82,6 +90,10 @@ The transformation layer: SQL (or `.rocky` DSL) models that build on the bronze 
 ### State store
 
 The embedded database (`redb`) where Rocky keeps run records, watermarks, and plans, with optional S3 or Valkey sync. There is no `manifest.json`. See [State management](/concepts/state-management/).
+
+### Surrogate key
+
+A computed column whose value is a deterministic MD5 hash over a set of input columns, declared in a `[[surrogate_key]]` sidecar block (`name` plus `columns`). Modeled on dbt-utils' `generate_surrogate_key`: each input is coerced to text and NULL-coalesced to a fixed sentinel before hashing, so on a given warehouse the output matches dbt-utils over the same columns. Rocky injects the hash into the model's SELECT at `rocky run` and on the emit-SQL path, so you don't hand-write it. See [`[[surrogate_key]]`](/reference/model-format/#surrogate_key).
 
 ### Trust plane
 

--- a/docs/src/content/docs/reference/json-output.md
+++ b/docs/src/content/docs/reference/json-output.md
@@ -311,3 +311,29 @@ Additional fields vary by check type:
 - **Machine-readable schemas:** [`schemas/*.schema.json`](https://github.com/rocky-data/rocky/tree/main/schemas), one per command, exported via `rocky export-schemas`. These generate the Dagster Pydantic models and the VS Code TypeScript types, so they are the contract to validate against.
 - **Per-command examples:** each command's entry in the [CLI Reference](/reference/cli/) and the category pages under [Reference → Commands](/reference/commands/core-pipeline/) shows a worked JSON example.
 
+The shapes below are the ones consumers tend to get wrong; the full, authoritative shape for each still lives in the generated schemas.
+
+### `test` unit-test results
+
+When a model declares a fixture-driven `[[test]]` block, `rocky test --output json` carries a `unit_tests` object alongside the top-level `total` / `passed` / `failed` counts. It's present only when at least one model declares such a block, and is distinct from `declarative` (the `[[tests]]` summary, present only under `--declarative`).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `unit_tests.total` | integer | Number of fixture-driven unit tests run. |
+| `unit_tests.passed` | integer | Number that passed. |
+| `unit_tests.failed` | integer | Number that failed. |
+| `unit_tests.results` | array | Per-test outcomes. |
+| `unit_tests.results[].model` | string | Model under test. |
+| `unit_tests.results[].test` | string | Test name. |
+| `unit_tests.results[].passed` | boolean | Whether the test passed. |
+| `unit_tests.results[].error` | string or null | Failure message. Null when the test passed. |
+| `unit_tests.results[].mismatches` | array | Row-level diffs between expected and actual output, for diagnosing a failure. Empty on pass. See the generated schema for the per-row shape. |
+
+### `test` and `ci` failures
+
+On both `rocky test` and `rocky ci`, the top-level `failures` field is an array of objects, each `{ "name": "...", "error": "..." }`, not positional `[name, error]` tuples. JSON Schema can't represent positional tuples cleanly, so the engine emits named fields. See [`test.schema.json`](https://github.com/rocky-data/rocky/blob/main/schemas/test.schema.json) and [`ci.schema.json`](https://github.com/rocky-data/rocky/blob/main/schemas/ci.schema.json) for the exact shape.
+
+### `compile` model tags
+
+`rocky compile --output json` includes a `models_detail[]` array, one entry per compiled model. Each entry's `tags` object carries the model's **resolved** governance tags: the model's own sidecar `[tags]` merged over its config-group `[tags]` baseline, with the sidecar winning per key. So a `domain` set once on a config group is visible on every member model's `models_detail[].tags` without being repeated. The authoritative `models_detail[]` shape lives in [`compile.schema.json`](https://github.com/rocky-data/rocky/blob/main/schemas/compile.schema.json), and the tag-resolution rules are documented under [Group tags](/reference/model-format/#group-tags).
+

--- a/docs/src/content/docs/reference/model-format.md
+++ b/docs/src/content/docs/reference/model-format.md
@@ -54,7 +54,14 @@ The `.toml` file specifies the model name, dependencies, materialization strateg
 |-------|------|----------|-------------|
 | `name` | string | Yes | Model identifier. Must be unique across all models. |
 | `depends_on` | list of strings | No | Names of upstream models that must run before this one. Defaults to `[]`. |
+| `group` | string | No | Name of a [config group](#config-groups) (`models/groups/<name>.toml`) this model opts into for shared routing and materialization. |
 | `retention` | string | No | Data retention policy for this model. Grammar `^\d+[dy]$` — e.g. `"90d"` or `"1y"`. See [Retention](#retention). |
+
+**`[args]`** -- Placeholder values for a config group's `schema_template` (only meaningful when the model declares a `group`):
+
+| Key pattern | Value type | Description |
+|---|---|---|
+| `<placeholder>` | string | Fills a `{placeholder}` in the group's `schema_template` (e.g. `region = "emea"` resolves `mart_{region}` to `mart_emea`). Ignored when the model declares no `group`. See [Config groups](#config-groups). |
 
 **`[strategy]`** -- Materialization configuration:
 
@@ -247,6 +254,180 @@ owner = "data-eng"
 | `<tag_name>` | string | Free-form governance attribute. Merged over any [config-group `[tags]`](#group-tags) baseline (sidecar > group). |
 
 Resolved tags are emitted on `rocky compile --output json` as `models_detail[].tags`. The `dagster-rocky` integration projects them onto the derived asset's Dagster tags, so the same attribute drives both Rocky's view of the model and the orchestrator's. Tags are inherited from a model's config group when it belongs to one — see [Group tags](#group-tags).
+
+### `[[surrogate_key]]`
+
+Declares a computed surrogate-key column. Rocky injects a deterministic hash of the listed input columns into the materialized SELECT, so you don't hand-write the hash expression in your SQL.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | Yes | Output column name for the injected key. Must be a valid SQL identifier (`^[a-zA-Z0-9_]+$`). |
+| `columns` | list of strings | Yes | Input columns to hash. At least one, each a valid SQL identifier. |
+
+```toml
+# models/dim_customers.toml
+name = "dim_customers"
+
+[[surrogate_key]]
+name = "customer_sk"
+columns = ["tenant_id", "customer_id"]
+
+[target]
+catalog = "warehouse"
+schema = "marts"
+table = "dim_customers"
+```
+
+At `rocky run` (and on the emit-SQL path), Rocky appends `CAST(md5(...) AS <string_type>) AS <name>` to the model's projection, computed over the input columns. The hash expression is dialect-correct: it uses the warehouse's variable-length string type (`STRING` on Databricks and BigQuery, `VARCHAR` on Snowflake, DuckDB, and Trino) and BigQuery's `to_hex(...)` / `concat(...)` form where the default `||` concatenation doesn't apply. On a given warehouse the hash value is the same one `dbt_utils.generate_surrogate_key` produces over the same columns, so a surrogate key keeps the same values whether it was built by Rocky or a prior dbt project and a key Rocky computes joins against the same key in an upstream dbt model. NULL inputs coalesce to a fixed sentinel before hashing, matching dbt-utils.
+
+A `[[surrogate_key]]` block uses `deny_unknown_fields`: a typo such as `colums = [...]` fails the load rather than silently hashing nothing. An empty `columns` list or a `name` / column that isn't a valid identifier is rejected at load with a clear diagnostic. Declare multiple blocks to inject more than one key column.
+
+### `[[tests]]`
+
+Inline declarative data-quality assertions. Each `[[tests]]` block is one assertion that runs against the model's target table. Tests are declarative TOML, not SQL macros. Rocky generates the assertion SQL for the active dialect.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `type` | string | Yes | Assertion kind. Common types: `not_null`, `unique`, `accepted_values`, `relationships`, `expression`, `row_count_range`. (More are available, including `in_range`, `regex_match`, `aggregate`, and composite-key uniqueness.) |
+| `column` | string | Sometimes | Column under test. Required for `not_null`, `unique`, `accepted_values`, `relationships`. Ignored for `expression` and `row_count_range`. |
+| `severity` | string | No | `"error"` (default) fails the run; `"warning"` records the failure and continues. |
+| `filter` | string | No | SQL boolean predicate that scopes the assertion to a subset of rows. Only rows where the filter is `TRUE` are checked; rows where it's `FALSE` or `NULL` pass unconditionally. |
+
+Type-specific fields: `accepted_values` takes `values` (a list of allowed string literals), `relationships` takes `to_table` and `to_column` (referential integrity against another table), `expression` takes an `expression` (a SQL boolean that must hold for every row), and `row_count_range` takes `min` and/or `max` (inclusive bounds on the total row count).
+
+```toml
+# models/fct_orders.toml
+name = "fct_orders"
+
+[[tests]]
+type = "not_null"
+column = "order_id"
+
+[[tests]]
+type = "unique"
+column = "order_id"
+
+[[tests]]
+type = "accepted_values"
+column = "status"
+values = ["pending", "shipped", "delivered"]
+severity = "warning"
+
+[[tests]]
+type = "expression"
+expression = "amount >= 0"
+filter = "status != 'cancelled'"
+
+[[tests]]
+type = "row_count_range"
+min = 1
+```
+
+`filter` and `expression` are user-supplied SQL passed through verbatim, so treat them with the same trust as any SQL you run against the warehouse.
+
+### `[[use_test]]`
+
+References a reusable test defined once in `models/test_definitions.toml` and applies it to this model by name. Use this when several models share the same assertion and you don't want to repeat it as inline `[[tests]]`.
+
+A named definition lives in `models/test_definitions.toml`, keyed by name, carrying the test `type` and its parameters plus an optional default `column`:
+
+```toml
+# models/test_definitions.toml
+[positive_amount]
+type = "expression"
+expression = "amount > 0"
+
+[known_status]
+type = "accepted_values"
+values = ["pending", "shipped", "delivered"]
+column = "status"
+```
+
+A model applies one with a `[[use_test]]` reference:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | Yes | Name of the definition in `test_definitions.toml`. An unknown name fails the load. |
+| `column` | string | No | Column to bind the test to. Overrides the definition's own `column` at this use site. |
+| `severity` | string | No | Failure severity here. Defaults to `error`. |
+| `filter` | string | No | Row-scoping SQL predicate, same contract as an inline test's `filter`. |
+
+```toml
+# models/fct_orders.toml
+name = "fct_orders"
+
+[[use_test]]
+name = "positive_amount"
+severity = "warning"
+
+[[use_test]]
+name = "known_status"
+column = "order_status"   # override the definition's default column
+```
+
+Resolved references are appended to the model's `[[tests]]` at load. A `[[use_test]]` block uses `deny_unknown_fields`, so a mistyped key (`colum =`, `filer =`) is rejected at load rather than silently applying the test with the wrong binding.
+
+### `[[test]]`
+
+A fixture-driven unit test. Where `[[tests]]` asserts properties of materialized output, a `[[test]]` checks the model's SQL logic against hand-written inputs: it seeds mock upstream tables, runs the model SQL, and compares the result to an expected set of rows. The block name is singular (`[[test]]`), unlike the plural `[[tests]]` used for declarative assertions.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | Yes | Test name. Unique within the model. |
+| `description` | string | No | Free-form note describing what the test covers. |
+
+Each test declares one or more input fixtures and one expected output:
+
+- **`[[test.given]]`** — a mocked upstream model or source. `ref` is the name to mock (matches a `depends_on` or `from` reference); `rows` is an inline list of TOML tables seeded as that table's contents.
+- **`[test.expect]`** — the expected output. `rows` is the list of expected output rows. Set `ordered = true` to require the output in exactly this order; the default is a multiset comparison where row order doesn't matter.
+
+```toml
+# models/high_value_orders.toml
+name = "high_value_orders"
+
+[[test]]
+name = "flags_orders_over_100"
+description = "Orders over $100 should be flagged as high value"
+
+[[test.given]]
+ref = "orders"
+rows = [
+    { id = 1, amount = 150.0, status = "completed" },
+    { id = 2, amount = 50.0, status = "completed" },
+    { id = 3, amount = 200.0, status = "cancelled" },
+]
+
+[test.expect]
+rows = [
+    { id = 1, amount = 150.0, is_high_value = true },
+    { id = 3, amount = 200.0, is_high_value = true },
+]
+```
+
+The runner seeds DuckDB with each `given` fixture, executes the model SQL, and asserts the result matches `expect`. A test may declare several `[[test.given]]` blocks to mock more than one upstream, and a model may declare several `[[test]]` blocks.
+
+### `[columns.<name>]`
+
+Per-column documentation. Each `[columns.<name>]` table attaches a description to one output column:
+
+| Field | Type | Description |
+|---|---|---|
+| `description` | string | Natural-language description of the column. |
+
+```toml
+# models/fct_orders.toml
+name = "fct_orders"
+
+[columns.order_id]
+description = "Unique order identifier"
+
+[columns.amount]
+description = "Order total in USD"
+```
+
+Descriptions surface in `rocky catalog --output json` as each asset's `CatalogColumn.description`. A description is attached only when its `<name>` matches a column the model actually projects; a description for a column the SELECT doesn't produce is silently dropped, so keep the key in sync with your output columns. The `rocky docs` HTML catalog does not emit per-column detail (it has no warehouse connection to introspect the column list), so column descriptions reach consumers through `rocky catalog`, not the generated HTML.
+
+The singular `[columns.<name>]` table documents columns, and is distinct from the plural `[[columns]]` array used to declare a contract's column schema. The two look similar but do different jobs.
 
 ### Retention
 


### PR DESCRIPTION
PR 1 of a 3-part sweep documenting the engine 1.52.0 feature wave, which shipped after the last docs overhaul and was almost entirely undocumented (found by a coverage audit). This PR covers the **reference, concept, and dagster** pages; a follow-up covers discovery/positioning pages, and a third adds runnable POCs.

## Correctness fixes (these were wrong on `main`)

- **`guides/migrate-from-dbt.md`** — removed the stale claim that emitted `[[test]]` blocks "aren't yet wired into rocky test execution." They execute as of engine-v1.52.0 (#899). The still-true "CSV / SQL fixtures deferred" clause is preserved.
- **`concepts/testing.md`** — the `failures` example showed the obsolete positional-tuple shape; it's now `[{name, error}]` objects (#924), matching the generated `TestOutput` schema and the other reference pages.

## Reference

- **`model-format.md`** — five new sidecar-block sections: `[[surrogate_key]]`, `[[tests]]`, `[[use_test]]`, `[[test]]`, `[columns.<name>]`, plus `group`/`[args]` rows in the Fields table. Per-column docs are scoped to `rocky catalog --output json` (not the `rocky docs` HTML, which has no column introspection).
- **`cli.md` + `commands/modeling.md`** — the new `rocky emit-sql` verb (+ backfilled `rocky catalog`), the `rocky test` `unit_tests` summary, the per-column `description` in catalog output, and a populated `rocky compile` `models_detail` example with a `tags` object.
- **`json-output.md`, `configuration.md`, `glossary.md`** — `unit_tests`/`tags`/failures-shape notes, a config-groups cross-reference, and surrogate-key + config-group glossary entries.

## Concepts & Dagster

- `testing.md` (declarative + unit-test sections), `data-quality-checks.md` (`[[test]]` vs `[[tests]]` callout), `sql-generation.md` (surrogate-key SQL + dbt_utils parity), `schema-patterns.md` (config-groups distinction).
- `dagster/{translator,derived-models,types,resource}` — the model-tag projection (`get_model_tags`), `ModelDetail.tags`, and the `TestOutput`/`CiOutput` aliases.

## How this was produced & verified

15 files, one agent per file, each draft adversarially verified against the source (accuracy + de-AI prose standard), then a cross-link/terminology sweep. The verify pass caught real issues — e.g. a draft wrongly claimed `rocky catalog` has no JSON mode (it does; `emit-sql` doesn't), and the `compile` example's `signals` string was checked verbatim against the live dagster fixture. **+826 / −10** across 15 files (deletions are the two correctness rewrites + a couple of hedge phrasings).

- `astro build` green (89 pages, no frontmatter/MDX/link errors).
- GOLD/proprietary grep clean — the only `gold` matches are medallion-layer (`schema: "gold"`, `tier: "gold"`), consistent with the existing `bronze-layer`/`silver-layer` docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)