### PR TITLE
fix(engine): robust Windows install + ship rocky-lsp alongside rocky

### DIFF
--- a/engine/install.ps1
+++ b/engine/install.ps1
@@ -146,8 +146,31 @@ try {
         exit 1
     }
 
-    # Install
-    Copy-Item -Path $BinaryPath -Destination (Join-Path $InstallDir "rocky.exe") -Force
+    # Install. On Windows a running executable is locked, so overwriting rocky.exe
+    # in place fails when a process is running it — most often the VS Code Rocky
+    # extension, which spawns `rocky lsp`. Renaming an in-use binary IS allowed (the
+    # running process keeps its handle to the renamed file), so this mirrors what
+    # install.sh does with `mv`: try a normal copy first, and on a locked overwrite,
+    # move the old binary aside and drop the new one into its place. The running LSP
+    # keeps using the renamed copy until VS Code (or the extension) restarts.
+    $Dest = Join-Path $InstallDir "rocky.exe"
+
+    # Clear leftover .old binaries from previous in-use updates (now unlocked).
+    Get-ChildItem -Path $InstallDir -Filter "rocky.exe.old*" -ErrorAction SilentlyContinue |
+        Remove-Item -Force -ErrorAction SilentlyContinue
+
+    try {
+        Copy-Item -Path $BinaryPath -Destination $Dest -Force -ErrorAction Stop
+    }
+    catch {
+        if (-not (Test-Path $Dest)) { throw }
+        # A unique name avoids colliding with a still-locked .old from an earlier
+        # in-use update in the same session.
+        $Stale = "$Dest.old-$(Get-Random)"
+        Move-Item -Path $Dest -Destination $Stale -Force
+        Copy-Item -Path $BinaryPath -Destination $Dest -Force
+        Write-Host "  Replaced an in-use rocky.exe. Restart VS Code (or the Rocky extension) to use the new version." -ForegroundColor Yellow
+    }
 }
 finally {
     Remove-Item -Path $TmpDir -Recurse -Force -ErrorAction SilentlyContinue

--- a/engine/install.ps1
+++ b/engine/install.ps1
@@ -18,6 +18,36 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $ProgressPreference = 'SilentlyContinue'
 
+# Install a binary with rename-then-replace. On Windows a running executable is
+# locked, so overwriting it in place fails when a process is running it (most
+# often the VS Code Rocky extension). Renaming an in-use binary IS allowed — the
+# running process keeps its handle to the renamed file until it restarts — so try
+# a normal copy first and, on a locked overwrite, move the old binary aside and
+# drop the new one into place. Mirrors what install.sh does with `mv`.
+function Install-RockyBinary {
+    param(
+        [Parameter(Mandatory)] [string]$Source,
+        [Parameter(Mandatory)] [string]$Dest
+    )
+    $Name = [System.IO.Path]::GetFileName($Dest)
+    $Dir = Split-Path -Path $Dest -Parent
+    # Sweep leftover .old binaries from previous in-use updates (now unlocked).
+    Get-ChildItem -Path $Dir -Filter "$Name.old*" -ErrorAction SilentlyContinue |
+        Remove-Item -Force -ErrorAction SilentlyContinue
+    try {
+        Copy-Item -Path $Source -Destination $Dest -Force -ErrorAction Stop
+    }
+    catch {
+        if (-not (Test-Path $Dest)) { throw }
+        # A unique name avoids colliding with a still-locked .old from an earlier
+        # in-use update in the same session.
+        $Stale = "$Dest.old-$(Get-Random)"
+        Move-Item -Path $Dest -Destination $Stale -Force
+        Copy-Item -Path $Source -Destination $Dest -Force
+        Write-Host "  Replaced an in-use $Name. Restart VS Code (or the Rocky extension) to use the new version." -ForegroundColor Yellow
+    }
+}
+
 # Check for 32-bit Windows
 if (-not [Environment]::Is64BitProcess) {
     Write-Error "Rocky does not support 32-bit Windows."
@@ -146,30 +176,38 @@ try {
         exit 1
     }
 
-    # Install. On Windows a running executable is locked, so overwriting rocky.exe
-    # in place fails when a process is running it — most often the VS Code Rocky
-    # extension, which spawns `rocky lsp`. Renaming an in-use binary IS allowed (the
-    # running process keeps its handle to the renamed file), so this mirrors what
-    # install.sh does with `mv`: try a normal copy first, and on a locked overwrite,
-    # move the old binary aside and drop the new one into its place. The running LSP
-    # keeps using the renamed copy until VS Code (or the extension) restarts.
-    $Dest = Join-Path $InstallDir "rocky.exe"
+    # Install rocky.exe (rename-then-replace handles a locked, in-use binary).
+    Install-RockyBinary -Source $BinaryPath -Dest (Join-Path $InstallDir "rocky.exe")
 
-    # Clear leftover .old binaries from previous in-use updates (now unlocked).
-    Get-ChildItem -Path $InstallDir -Filter "rocky.exe.old*" -ErrorAction SilentlyContinue |
-        Remove-Item -Force -ErrorAction SilentlyContinue
-
+    # Best-effort: also install the standalone rocky-lsp binary. The VS Code
+    # extension prefers a sibling rocky-lsp for the language server; when it's
+    # present the extension never runs rocky.exe as the LSP, so rocky.exe is never
+    # locked in the first place. Optional — if the archive is missing (older
+    # release) or fails verification we skip it and the extension falls back to
+    # `rocky lsp`, which the rename-then-replace install above already handles.
+    $LspArchive = "rocky-lsp-x86_64-pc-windows-msvc.zip"
+    $LspZip = Join-Path $TmpDir $LspArchive
     try {
-        Copy-Item -Path $BinaryPath -Destination $Dest -Force -ErrorAction Stop
+        Invoke-WebRequest -Uri "https://github.com/$Repo/releases/download/$ResolvedVersion/$LspArchive" -OutFile $LspZip -UseBasicParsing -ErrorAction Stop
+        if ($null -ne $ChecksumsResponse) {
+            $LspHash = (Get-FileHash -Path $LspZip -Algorithm SHA256).Hash.ToLower()
+            $LspLine = ($ChecksumsText -split "`n") |
+                Where-Object { $_ -match [regex]::Escape($LspArchive) } |
+                Select-Object -First 1
+            $LspExpected = if ($LspLine) { ($LspLine.Trim() -split '\s+')[0].ToLower() } else { "" }
+            if ($LspExpected -ne $LspHash) {
+                throw "rocky-lsp checksum missing or mismatched; skipping."
+            }
+        }
+        Expand-Archive -Path $LspZip -DestinationPath $TmpDir -Force
+        $LspBin = Join-Path $TmpDir "rocky-lsp.exe"
+        if (Test-Path $LspBin) {
+            Install-RockyBinary -Source $LspBin -Dest (Join-Path $InstallDir "rocky-lsp.exe")
+            Write-Host "  Installed rocky-lsp (the VS Code extension prefers it for the language server)."
+        }
     }
     catch {
-        if (-not (Test-Path $Dest)) { throw }
-        # A unique name avoids colliding with a still-locked .old from an earlier
-        # in-use update in the same session.
-        $Stale = "$Dest.old-$(Get-Random)"
-        Move-Item -Path $Dest -Destination $Stale -Force
-        Copy-Item -Path $BinaryPath -Destination $Dest -Force
-        Write-Host "  Replaced an in-use rocky.exe. Restart VS Code (or the Rocky extension) to use the new version." -ForegroundColor Yellow
+        Write-Host "  (Optional rocky-lsp not installed; the VS Code extension will use 'rocky lsp'.)"
     }
 }
 finally {

--- a/engine/install.sh
+++ b/engine/install.sh
@@ -190,6 +190,32 @@ fi
 mv "${TMP}/rocky" "${INSTALL_DIR}/rocky"
 chmod +x "${INSTALL_DIR}/rocky"
 
+# Best-effort: also install the standalone rocky-lsp binary. The VS Code
+# extension prefers a sibling rocky-lsp for the language server (a startup
+# optimization), so install it alongside rocky when the release ships it.
+# Optional — skipped silently if the archive is missing (older release) or
+# fails verification; the extension then falls back to `rocky lsp`.
+LSP_ARCHIVE="rocky-lsp-${TARGET}.tar.gz"
+if download_file "https://github.com/${REPO}/releases/download/${ROCKY_VERSION}/${LSP_ARCHIVE}" "${TMP}/${LSP_ARCHIVE}" 2>/dev/null; then
+    LSP_OK=1
+    if [[ -n "${ACTUAL_HASH}" && -f "${TMP}/checksums.txt" ]]; then
+        if command -v sha256sum >/dev/null 2>&1; then
+            LSP_ACTUAL="$(sha256sum "${TMP}/${LSP_ARCHIVE}" | cut -d' ' -f1)"
+        else
+            LSP_ACTUAL="$(shasum -a 256 "${TMP}/${LSP_ARCHIVE}" | cut -d' ' -f1)"
+        fi
+        LSP_EXPECTED="$(grep "${LSP_ARCHIVE}" "${TMP}/checksums.txt" | cut -d' ' -f1 || true)"
+        if [[ -z "${LSP_EXPECTED}" || "${LSP_ACTUAL}" != "${LSP_EXPECTED}" ]]; then
+            LSP_OK=0
+        fi
+    fi
+    if [[ "${LSP_OK}" == "1" ]] && tar xzf "${TMP}/${LSP_ARCHIVE}" -C "${TMP}" 2>/dev/null && [[ -f "${TMP}/rocky-lsp" ]]; then
+        mv "${TMP}/rocky-lsp" "${INSTALL_DIR}/rocky-lsp"
+        chmod +x "${INSTALL_DIR}/rocky-lsp"
+        echo "  Installed rocky-lsp (the VS Code extension prefers it for the language server)."
+    fi
+fi
+
 echo ""
 
 # Verify installation


### PR DESCRIPTION
## The bug

Running the Windows install one-liner while VS Code is open fails:

```
Copy-Item: The process cannot access the file
'C:\Users\…\AppData\Local\rocky\bin\rocky.exe' because it is being used by another process.
```

## Why

Two things combine:
1. `install.ps1` overwrote `rocky.exe` in place with `Copy-Item -Force`. On Windows a **running** executable is locked, so the overwrite fails.
2. Neither installer ships the standalone `rocky-lsp`. The VS Code extension prefers `rocky-lsp` for the language server but, not finding it, falls back to spawning `rocky lsp` — so it runs `rocky.exe`, locking the exact file the installer is replacing.

`install.sh` (macOS/Linux) didn't hit this because it uses `mv` (atomic rename, fine over a running binary on Unix). This was Windows-only.

## The fix (two complementary changes)

**1. Rename-then-replace on Windows.** Renaming an in-use binary is allowed on Windows (the running process keeps its handle), so `install.ps1` now mirrors `install.sh`'s `mv`: try a normal copy, and on a locked overwrite move the old binary aside (`rocky.exe.old-<rand>`) and drop the new one in. Stale `.old` files are swept on the next run. **The install now succeeds while VS Code is open.**

**2. Ship `rocky-lsp` alongside `rocky` (both installers).** This removes the root cause: when `rocky-lsp` is present the extension uses it for the LSP and never runs `rocky.exe`, so `rocky.exe` is never locked. Both installers best-effort download `rocky-lsp-<target>`, verify it against the same `checksums.txt`, and place it with the same mechanism as `rocky`. The Windows rename-replace is factored into an `Install-RockyBinary` helper so both binaries get identical robust install (and `rocky-lsp`'s own future updates are covered too).

Best-effort and **non-fatal**: if the `rocky-lsp` archive is missing (older release) or fails verification, it's skipped and the extension falls back to `rocky lsp`. The core `rocky` install is unchanged.

No release needed — the one-liners fetch the scripts from `main`, so this takes effect on merge.

## Verification
- `bash -n` + `shellcheck -S error` clean on `install.sh`.
- `install.ps1` hand-verified (no `pwsh` on the build host): `-ErrorAction Stop` makes the lock error terminating so the `catch` fires; non-lock failures rethrow; the unique `.old-<rand>` name avoids colliding with a still-locked prior `.old`; `Install-RockyBinary` is defined before its call sites; the `rocky-lsp` block reuses the already-fetched `checksums.txt` and is wrapped so any failure is non-fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)