### PR TITLE
ci(engine): harden against transient crates.io download flakes

### DIFF
--- a/.github/workflows/engine-ci.yml
+++ b/.github/workflows/engine-ci.yml
@@ -21,6 +21,11 @@ env:
   # Limit parallelism — DuckDB C++ compilation is extremely memory-intensive
   # and OOMs the GitHub Actions runner (~7GB RAM) at default parallelism
   CARGO_BUILD_JOBS: 4
+  # Survive transient crates.io download flakes on GitHub runners (seen as
+  # "[16] Error in the HTTP2 framing layer" mid-fetch): retry the download and
+  # force HTTP/1.1, which sidesteps the intermittent HTTP/2 framing bug.
+  CARGO_NET_RETRY: '10'
+  CARGO_HTTP_MULTIPLEXING: 'false'
 
 defaults:
   run:


### PR DESCRIPTION
## Problem

`engine-ci` (and the cargo-running jobs generally) intermittently fail during dependency fetch:

```
error: failed to get `recursive` as a dependency of package `sqlparser v0.62.0`
  ...
Caused by: [16] Error in the HTTP2 framing layer
```

This is a transient curl↔crates.io HTTP/2 hiccup on the GitHub runner, not a code or lockfile problem — a re-run clears it. But it fails PRs spuriously and costs a manual re-run each time.

## Fix

Add two env vars to the `engine-ci` workflow:
- `CARGO_NET_RETRY: 10` — cargo retries a failed registry download instead of aborting the job.
- `CARGO_HTTP_MULTIPLEXING: false` — forces HTTP/1.1, which sidesteps the intermittent HTTP/2 framing-layer bug entirely.

Workflow-level, so every job (test, clippy, fmt, codegen-drift's cargo step) is covered. No code or dependency changes.

If the same flake shows up in the other cargo workflows (`engine-weekly`, `engine-release`, `engine-bench`), the same two lines apply there — kept this PR scoped to the gate that actually flaked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)