### PR TITLE
docs: fix compiler stage counts + diagnostic codes (source-verified)

### DIFF
--- a/ROCKY_EXPLAINED.md
+++ b/ROCKY_EXPLAINED.md
@@ -165,12 +165,11 @@ If there's a cycle (A depends on B depends on A), Rocky reports it clearly and s
 The compiler is a 9-stage pipeline. It reads your models and produces a typed project description plus any diagnostics (errors/warnings).
 
 ```
-Stage 1: Load project
-  .sql + .toml files from disk → parsed models
+Stage 1: Load + resolve project
+  .sql + .toml files from disk → parsed models, DAG edges resolved
          ↓
 Stage 2: Build semantic graph
-  Parse SQL → extract table references → build DAG edges
-  Track column lineage: which col flows where
+  Parse SQL → extract table references → column lineage map
          ↓
 Stage 3: Type check
   Propagate types through the DAG
@@ -182,14 +181,14 @@ Stage 4: Contract validation
   Check column types match declared types
   Check protected columns aren't removed
          ↓
-Stage 5: Blast-radius lint
-  "You're changing orders.id — 4 downstream models use it"
+Stage 5: Blast-radius lint (P002)
+  Warn when a SELECT * model feeds consumers that read specific columns
          ↓
-Stage 6: Breaking-change classification
-  16 kinds of breaking change (E011: type narrowed, E013: col removed, ...)
+Stage 6: Classification-tag completeness (W004)
+  Warn on a [classification] tag with no matching [mask] strategy
          ↓
-Stage 7: Freshness coverage
-  Check that incremental models have freshness SLAs defined
+Stage 7: Freshness coverage (W005)
+  Warn on a model with temporal columns but no freshness block in scope
          ↓
 Stage 8: Merge diagnostics
   Collect all errors + warnings into a single list
@@ -211,13 +210,13 @@ error[E011]: column 'id' type mismatch
 
 Every diagnostic has: `code`, `severity` (Error/Warning/Info), `message`, `span` (file + line + col), `model`, and `suggestion`.
 
-**Key codes:**
-- `E001–E009` — Type errors (mismatch, incompatible join keys)
-- `E010` — Required contract column missing
-- `E011` — Column type doesn't match contract
-- `E012` — Nullability violation
-- `E013` — Protected column removed
-- `W001–W012` — Warnings (type widening, loose checks, etc.)
+**Key codes** (the full set spans E001–E033, W001–W012, P001–P002):
+- `E001` — Type-checking error (unresolved reference, type mismatch)
+- `E010`–`E013` — Contract violations (missing / retyped / nullability / protected-column removed)
+- `E020`–`E027` — Time-interval placeholders and budget ceiling
+- `E030` / `E033` — Cross-team import-contract violations
+- `W001`–`W012` — Warnings (unused model, duplicate column, classification + freshness gaps, …)
+- `P001` / `P002` — Dialect-portability and blast-radius lints
 
 ---
 
@@ -542,10 +541,10 @@ Rocky has a safety gate for AI-generated changes. An AI can propose a plan, but 
 
 **Rocky refuses `rocky apply` on AI-authored plans without an approval marker.** This is enforced in the engine — not a convention.
 
-The breaking-change classifier knows 16 kinds of breaking change:
-- Column removed, column renamed, type narrowed, type changed incompatibly
-- Required contract column removed, protected column dropped
-- Upstream model deleted, join key type changed, etc.
+The breaking-change classifier lives in `rocky-core` (consumed by `rocky review` and `rocky plan`, not the compiler) and knows 16 kinds of change:
+- Model added or removed; column dropped, added, retyped (narrowing flagged), nullability flipped, or reordered
+- Materialization strategy or key changed, partition-by changed, replication columns changed
+- Target renamed, source rebound, column mask changed, lakehouse format changed, SQL body changed
 
 ---
 
@@ -1088,4 +1087,3 @@ Everything Rocky does, in one ASCII map:
 | Health check everything | `rocky doctor -c rocky.toml` |
 | Generate a model with AI | `rocky ai "create a daily revenue summary by region"` |
 | Test models locally (no warehouse) | `rocky test --models models/` |
-```

--- a/docs/src/content/docs/concepts/compiler.md
+++ b/docs/src/content/docs/concepts/compiler.md
@@ -9,7 +9,7 @@ Rocky includes a full compiler (`rocky-compiler` crate) that performs static ana
 
 ## Compile pipeline
 
-The compiler runs five stages in sequence:
+The compiler runs as a sequence of stages. The first five do the core work (load, resolve, build the graph, type-check, validate contracts); three more lint passes run afterward, before the diagnostics are merged into the result:
 
 ```
  ┌──────────────────────────────────────┐
@@ -43,6 +43,12 @@ The compiler runs five stages in sequence:
           └──────────┬──────────┘
                      │
           ┌──────────▼──────────┐
+          │ 6. Lint passes      │   blast-radius (P002),
+          │    + merge          │   classification (W004),
+          │                     │   freshness (W005)
+          └──────────┬──────────┘
+                     │
+          ┌──────────▼──────────┐
           │  CompileResult      │   models, diagnostics,
           │                     │   semantic_graph, timings
           └─────────────────────┘
@@ -64,16 +70,7 @@ Explicit `depends_on` entries in the model config are merged with auto-resolved 
 
 ### 3. Build semantic graph
 
-The semantic graph is a cross-DAG column lineage map. It tracks which source columns flow through which models to which final outputs.
-
-For each model (processed in topological order), the compiler:
-
-- Extracts column-level lineage from the SQL AST
-- Resolves table aliases to real model or source names
-- Records lineage edges with transform types (Direct, Cast, Expression, Aggregation)
-- Expands `SELECT *` by inheriting columns from upstream models or known source schemas
-
-The result is a `SemanticGraph` containing per-model schemas, upstream/downstream relationships, and all cross-model lineage edges.
+Walking each model in topological order, the compiler extracts column-level lineage from the SQL AST, resolves table aliases to real model or source names, and expands `SELECT *` against upstream schemas. The result is a `SemanticGraph` of per-model schemas, upstream/downstream relationships, and cross-model lineage edges. The [Semantic graph](#semantic-graph) section below covers it in detail.
 
 ### 4. Type check
 
@@ -95,16 +92,9 @@ Each model receives a typed schema: a list of `TypedColumn` entries with name, `
 
 If a contracts directory exists, `.contract.toml` files are loaded and validated against the inferred schemas. See the [Testing and Contracts](/concepts/testing) page for details on the contract format.
 
-## Diagnostic format
+### 6. Lint passes and merge
 
-Diagnostics render in a format inspired by `rustc`, with machine-readable codes and actionable suggestions:
-
-```
-error[E011]: column 'id' type mismatch: contract expects Int64, got String
- --> models/orders.sql:3:8
- in model: orders_summary
- = help: add CAST(id AS BIGINT) to fix the type
-```
+After contract validation, three always-on lint passes run against the typed models. The blast-radius lint (`P002`) flags a `SELECT *` model whose downstream consumers read specific columns. The classification-tag check (`W004`) flags a `[classification]` tag with no matching `[mask]` strategy. The freshness-coverage check (`W005`) flags a model with temporal columns but no `freshness` declaration in scope. Their diagnostics are merged with the type-checker and contract diagnostics into the final `CompileResult`.
 
 ## The type system
 
@@ -189,14 +179,27 @@ The compiler produces structured diagnostics with codes, severity levels, source
 
 | Code | Meaning |
 |------|---------|
-| `E001`--`E009` | Type checking errors (type mismatch, incompatible join keys) |
+| `E001` | Type-checking error (unresolved reference, type mismatch) |
 | `E010` | Required column missing from model output |
 | `E011` | Column type mismatch against contract |
 | `E012` | Nullability violation against contract |
 | `E013` | Protected column removed |
-| `W001`--`W009` | Type checking warnings |
-| `W010` | Contract column not found in model output |
-| `W011` | Contract exists for unknown model |
+| `E020`--`E026` | `time_interval` validation (`@start_date`/`@end_date` placeholders, `time_column` presence/type/nullability/granularity) |
+| `E027` | Budget exceeded -- projected spend over the model's `[budget]` ceiling |
+| `E030` | Imported producer dropped a column this project reads (cross-team contract) |
+| `E033` | Imported snapshot's recipe hash does not match the configured `pin` |
+| `W001` | Unused model (no downstream consumers) |
+| `W002` | Duplicate column in model output |
+| `W003` | `time_column` is TIMESTAMP where DATE is preferred for the granularity |
+| `W004` | Classification tag with no matching `[mask]` strategy |
+| `W005` | Temporal column present but no `freshness` declaration in scope |
+| `W010` | Contract defines a column not in model output (not required) |
+| `W011` | Contract exists for a model not found in the project |
+| `W012` | An `[imports.<name>]` snapshot could not be loaded; `E030`/`E033` checks skipped |
+| `I001` | Model dependency inferred from SQL |
+| `I002` | Model compiled with `SELECT *` |
+| `P001` | Construct not portable to the target dialect (opt-in via `--target-dialect`) |
+| `P002` | `SELECT *` model has downstream consumers that read specific columns |
 
 ### Format
 


### PR DESCRIPTION
A source-verified pass over the docs added in #925 found two pages disagreeing about the compiler and listing diagnostic codes that don't exist. Every claim here was checked against `rocky-compiler` / `rocky-core`.

## Fixes

1. **Stage-count contradiction.** `ROCKY_EXPLAINED.md` said the compiler is a 9-stage pipeline; `compiler.md` said five. The source's `compile_project()` has nine numbered steps. `compiler.md` no longer hard-claims "five" (it stopped at contract validation and omitted the lint passes), and its diagram + a new subsection now cover the post-contract passes.
2. **Misattributed stage.** `ROCKY_EXPLAINED.md` listed "breaking-change classification" as compiler stage 6. That classifier lives in `rocky-core` (`breaking_change.rs`) and is consumed by `rocky review` / `rocky plan`, not the compiler. Stage 6 is now the real pass: classification-tag completeness (`W004`).
3. **"16 kinds of breaking change."** The count is right (the `BreakingChange` enum has 16 variants) but was illustrated with the wrong vocabulary (`E011`/`E013` are compiler diagnostics, not diff variants). The list now matches the actual enum variants.
4. **Stale diagnostic-code tables.** Both docs claimed an `E001–E009` / `W001–W009` band; only `E001` exists there. Both lists now enumerate the real codes (`E001`, `E010`–`E013`, `E020`–`E027`, `E030`/`E033`, `W001`–`W005`/`W010`–`W012`, `I001`/`I002`, `P001`/`P002`).
5. **Stray code fence.** Removed an unmatched closing ` ``` ` after the Quick Reference table in `ROCKY_EXPLAINED.md`.
6. **Duplication in `compiler.md`.** The semantic graph and the rustc-style diagnostic example each appeared twice; collapsed to one home apiece.

## Test plan

Docs only. Verified fence balance, that the rustc example now appears once, and that the `#semantic-graph` cross-link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)