### PR TITLE
docs(playground): runnable POCs for the 1.52.0 feature wave

### DIFF
--- a/examples/playground/README.md
+++ b/examples/playground/README.md
@@ -38,11 +38,11 @@ cd pocs/02-performance/01-incremental-watermark
 
 **Prerequisites:** Rocky CLI on PATH. Most POCs only need the [DuckDB CLI](https://duckdb.org) for seeding (`brew install duckdb`).
 
-**76 of 88 POCs run with no external credentials.** See each POC's README for prerequisites.
+**82 of 94 POCs run with no external credentials.** See each POC's README for prerequisites.
 
 ## The catalog
 
-### 00 — Foundations (14 POCs · DuckDB)
+### 00 — Foundations (16 POCs · DuckDB)
 
 DSL syntax, materialization basics, playground baseline, the trust-arc 1 storage primitives, file-format ingest and per-tenant routing, plus the plan/apply deployment workflow and project scaffolding.
 
@@ -62,8 +62,10 @@ DSL syntax, materialization basics, playground baseline, the trust-arc 1 storage
 | [10-route-by-tenant](pocs/00-foundations/10-route-by-tenant) | One Parquet file with mixed-account rows is loaded then fanned out to per-tenant schemas (`account_acme.events`, `account_beta.events`, …) via per-model `target.schema` overrides |
 | [11-plan-apply-workflow](pocs/00-foundations/11-plan-apply-workflow) | `rocky plan` persists a content-addressed plan to `.rocky/plans/<id>.json`; `rocky apply <id>` executes it. Re-planning the same intent yields the same `plan_id` |
 | [12-init-scaffolding](pocs/00-foundations/12-init-scaffolding) | `rocky init --template duckdb` scaffolds a project that validates + compiles out of the box; `--template snowflake` shows the layout changes per warehouse |
+| [13-surrogate-keys](pocs/00-foundations/13-surrogate-keys) | A model sidecar `[[surrogate_key]]` block injects a deterministic, dbt_utils-identical MD5 hash column into the materialized table at `rocky run` |
+| [14-config-groups](pocs/00-foundations/14-config-groups) | One `models/groups/*.toml` fans `schema_template` + strategy + tags to N members via per-model `[args]`; `broken/` siblings show the `enforce` and pinned-schema-plus-args load guards |
 
-### 01 — Quality (8 POCs · DuckDB)
+### 01 — Quality (10 POCs · DuckDB)
 
 Contracts, inline checks, anomaly detection, local testing, SCD-2 snapshots, standalone quality pipeline, freshness SLAs, cross-source overlap.
 
@@ -77,6 +79,8 @@ Contracts, inline checks, anomaly detection, local testing, SCD-2 snapshots, sta
 | [06-quality-pipeline-standalone](pocs/01-quality/06-quality-pipeline-standalone) | `type = "quality"` pipeline — standalone checks (row_count, freshness, null_rate) with `depends_on` chaining |
 | [07-freshness-sla](pocs/01-quality/07-freshness-sla) | Per-model + project `[freshness]` SLAs (`expected_lag_seconds` alias); the **W005** coverage diagnostic fires on a temporal-output model with no freshness declaration (`compile --with-seed`), suppressed by a per-model block or a project default; also surfaces in the editor with an AI fix |
 | [08-cross-source-overlap](pocs/01-quality/08-cross-source-overlap) | The same data arriving via two sibling sources — `cross_source_overlap` flags a business key shared across siblings (which per-table `unique` can't see) + `unique_expr` catches a derived-key duplicate, both at replication time |
+| [09-named-tests](pocs/01-quality/09-named-tests) | Define a check once in `test_definitions.toml`, apply it across models via `[[use_test]]` (column/severity overrides) alongside inline `[[tests]]` |
+| [10-unit-tests](pocs/01-quality/10-unit-tests) | Fixture-driven `[[test]]` blocks (`given` rows → `expect` rows) run by `rocky test` — multiset by default, positional with `ordered` |
 
 ### 02 — Performance (14 POCs · DuckDB)
 
@@ -112,7 +116,7 @@ AI-powered model generation, intent extraction, schema sync, test generation, sc
 | [05-schema-grounded-validation](pocs/03-ai/05-schema-grounded-validation) | **Trust arc 5** — `ValidationContext` schema grounding + compile-verify retry loop |
 | [06-mcp-grounding](pocs/03-ai/06-mcp-grounding) | `rocky mcp` server — a schema-only model compiles but reconciles wrong; sampling the data via the MCP tools fixes it (creds-free `run.sh`) |
 
-### 04 — Governance (8 POCs · Databricks / DuckDB)
+### 04 — Governance (9 POCs · Databricks / DuckDB)
 
 Unity Catalog grants, schema patterns, workspace isolation, tagging, classification + masking, retention, auto-create schemas.
 
@@ -126,6 +130,7 @@ Unity Catalog grants, schema patterns, workspace isolation, tagging, classificat
 | [06-retention-policies](pocs/04-governance/06-retention-policies) | Declarative `retention = "<N>[dy]"` sidecars + `rocky retention-status --drift` | none |
 | [07-auto-create-schemas](pocs/04-governance/07-auto-create-schemas) | `[…target.governance] auto_create_schemas = true` on a transformation pipeline targeting a fresh schema (v1.29.0 parity fix) | none |
 | [08-cross-team-contracts](pocs/04-governance/08-cross-team-contracts) | Consumer imports a producer's published IR snapshot via `[imports.<name>]`; `rocky compile` fails with E030 when the producer drops a column the consumer reads (E033 on pin mismatch) | none |
+| [09-model-tags-inheritance](pocs/04-governance/09-model-tags-inheritance) | A config-group `[tags]` baseline inherited by members and overridden per-key by a model's own `[tags]`, surfaced on `rocky compile --output json` as `models_detail[].tags` | none |
 
 ### 05 — Orchestration (11 POCs · DuckDB / docker)
 
@@ -145,7 +150,7 @@ Hooks, webhooks, remote state, checkpoint/resume, Valkey cache, Dagster DAG mode
 | [10-state-retention-sweep](pocs/05-orchestration/10-state-retention-sweep) | `[state.retention]` + `rocky state retention sweep` — manual + end-of-run auto-sweep of run history / lineage / audit domains |
 | [11-state-namespacing](pocs/05-orchestration/11-state-namespacing) | `rocky --state-namespace <key>` routes each pipeline/client to its own `<models>/.rocky-state/<key>.redb` (own single-writer lock) — opt-in, byte-identical when off |
 
-### 06 — Developer Experience (20 POCs · DuckDB)
+### 06 — Developer Experience (21 POCs · DuckDB)
 
 Lineage, HTTP API, dbt import, shadow mode, CI, hybrid workflows, trace Gantt, portability lint, SQL types, PR-preview, lineage-diff, run-watch, dbt-import failure modes, view strategy, dbt unit-test import.
 
@@ -171,6 +176,7 @@ Lineage, HTTP API, dbt import, shadow mode, CI, hybrid workflows, trace Gantt, p
 | [18-view-strategy](pocs/06-developer-experience/18-view-strategy) | `[strategy] type = "view"` — model compiles to `CREATE OR REPLACE VIEW <target>` on every warehouse |
 | [19-import-dbt-unit-tests](pocs/06-developer-experience/19-import-dbt-unit-tests) | `rocky import-dbt --manifest` walks `manifest.unit_tests` into Rocky `[[test]]` sidecars; `data_tests:` accepted as alias for `tests:` on column tests (dbt 1.7+) |
 | [20-defer-against-prod](pocs/06-developer-experience/20-defer-against-prod) | `rocky run --model <name> --defer --defer-to <schema>` — build only the changed model locally, resolve its unbuilt upstream `ref()`s against a production schema (default-off dev convenience) |
+| [21-emit-sql-exit-path](pocs/06-developer-experience/21-emit-sql-exit-path) | `rocky emit-sql --out-dir` renders the model DAG to plain `.sql`, then runs it through DuckDB with no Rocky — the tested no-lock-in exit path |
 
 ### 07 — Adapters (7 POCs · mixed)
 

--- a/examples/playground/pocs/00-foundations/13-surrogate-keys/README.md
+++ b/examples/playground/pocs/00-foundations/13-surrogate-keys/README.md
@@ -1,0 +1,118 @@
+# 13-surrogate-keys — Inject a dbt_utils-compatible surrogate key from a sidecar
+
+> **Category:** 00-foundations
+> **Credentials:** none (DuckDB)
+> **Runtime:** < 5s
+> **Rocky features:** `[[surrogate_key]]` sidecar block, deterministic hash injection, dbt_utils parity
+
+## What it shows
+
+A transformation model whose `.toml` sidecar declares a `[[surrogate_key]]` block.
+You don't hand-write the hash expression in your SQL: Rocky appends a deterministic
+md5 of the listed input columns to the model's projection at materialization time.
+
+```toml
+# models/order_keys.toml
+[[surrogate_key]]
+name = "order_key"
+columns = ["order_id", "customer_id"]
+```
+
+The SQL stays a plain `SELECT` over the seeded source. After `rocky run`, the
+materialized `poc.main.order_keys` table carries an extra `order_key` column
+holding a 32-character md5 hash, computed over `(order_id, customer_id)`.
+
+## Why it's distinctive
+
+- **The hash lives in config, not SQL.** The surrogate key is declared once in the
+  sidecar; the `.sql` file never mentions `md5(...)`. Rename or re-key without
+  editing the query.
+- **Byte-identical to `dbt_utils.generate_surrogate_key`.** On a given warehouse the
+  value Rocky computes is exactly the value `dbt_utils.generate_surrogate_key` produces
+  over the same columns, so a key Rocky computes joins against the same key in an
+  upstream dbt model. This makes incremental dbt-to-Rocky migrations safe: a fact
+  table re-keyed by Rocky still joins against dimensions keyed by the old dbt project.
+- **The POC proves it twice.** `run.sh` first asserts the column matches `^[0-9a-f]{32}$`
+  in the real materialized table, then asserts every row equals the hand-written
+  dbt-utils form — 0 mismatches.
+
+## How the hash is built (dbt_utils parity)
+
+Rocky appends `CAST(md5(...) AS <string_type>) AS order_key` to the projection.
+The expression is dialect-correct. On DuckDB (this POC) it resolves to:
+
+```sql
+md5(cast(
+    coalesce(cast(order_id    as VARCHAR), '_dbt_utils_surrogate_key_null_') || '-' ||
+    coalesce(cast(customer_id as VARCHAR), '_dbt_utils_surrogate_key_null_')
+as VARCHAR))
+```
+
+Matching the dbt-utils contract exactly:
+
+- each input is cast to the warehouse's variable-length string type
+  (`VARCHAR` on DuckDB, Snowflake, and Trino; `STRING` on Databricks and BigQuery),
+- inputs are concatenated in **declared column order** with a `'-'` separator,
+- a NULL input coalesces to the fixed sentinel `_dbt_utils_surrogate_key_null_`
+  **before** hashing — so a row with a NULL `customer_id` still gets a stable,
+  collision-resistant key. (The seed includes one such row to exercise this.)
+
+BigQuery uses `to_hex(...)` / `concat(...)` where the `||` form doesn't apply, but the
+resulting value is the same one dbt-utils produces there.
+
+## Layout
+
+```
+.
+├── README.md
+├── rocky.toml              # transformation pipeline over poc.duckdb
+├── data/
+│   └── seed.sql            # seeds raw__orders.orders (one row has a NULL customer_id)
+├── models/
+│   ├── order_keys.sql      # plain SELECT — no hash expression
+│   └── order_keys.toml     # [[surrogate_key]] name="order_key" columns=["order_id","customer_id"]
+└── run.sh                  # seed → run → assert hash present + dbt_utils parity
+```
+
+## Prerequisites
+
+- `rocky` CLI on PATH
+- `duckdb` CLI (`brew install duckdb`)
+
+## Run
+
+```bash
+./run.sh
+# or, by hand:
+duckdb poc.duckdb < data/seed.sql                                   # seed the source
+rocky run                                                           # materialize order_keys with the injected key
+duckdb -noheader -list poc.duckdb "SELECT order_key FROM main.order_keys LIMIT 5"
+```
+
+## Expected output
+
+```text
+materialized in poc.main:
+order_keys
+=== query the injected surrogate key ===
+9a9311b626de39f67f9f2e67f40353fc
+6498e323aaf8bf05a7bb8ce6a6a876ac
+...
+PASS: order_key holds a 32-char md5 surrogate key
+PASS: every order_key matches the dbt_utils.generate_surrogate_key form (0 mismatches)
+```
+
+## What happened
+
+1. `duckdb … < data/seed.sql` seeds `raw__orders.orders`.
+2. `rocky run` materializes `order_keys` into `poc.main`, appending
+   `CAST(md5(...) AS VARCHAR) AS order_key` to the model's SELECT.
+3. The first assert confirms the column exists and every sampled value is a
+   32-char md5 hex string.
+4. The second assert confirms each `order_key` equals the dbt-utils hash form
+   computed independently in SQL — the byte-identical-parity proof.
+
+## Related
+
+- [`reference/model-format`](https://github.com/rocky-data/rocky/blob/main/docs/src/content/docs/reference/model-format.md) — the `[[surrogate_key]]` sidecar field reference.
+- [`00-playground-default`](../00-playground-default) — the baseline transformation pipeline this POC's structure mirrors.

--- a/examples/playground/pocs/00-foundations/13-surrogate-keys/data/seed.sql
+++ b/examples/playground/pocs/00-foundations/13-surrogate-keys/data/seed.sql
@@ -1,0 +1,25 @@
+-- Seed data for the surrogate-keys POC.
+--
+-- `rocky test` auto-loads this file into an in-memory DuckDB before executing
+-- models, so the POC is runnable end-to-end with no manual setup.
+--
+-- For the `rocky run` flow you need to seed the persistent file referenced by
+-- `path` in rocky.toml first:
+--   duckdb poc.duckdb < data/seed.sql
+
+CREATE SCHEMA IF NOT EXISTS raw__orders;
+
+-- A small orders table keyed by (order_id, customer_id). The surrogate key the
+-- model injects hashes exactly those two columns. One row deliberately leaves
+-- customer_id NULL to exercise the dbt-utils NULL sentinel coalesce.
+CREATE OR REPLACE TABLE raw__orders.orders AS
+SELECT * FROM (VALUES
+    (1001,  42, 'acme',   'emea',    129.50, DATE '2026-01-03'),
+    (1002,  42, 'acme',   'emea',    310.00, DATE '2026-01-05'),
+    (1003,  17, 'globex', 'us_west',  58.25, DATE '2026-01-06'),
+    (1004,  17, 'globex', 'us_west', 442.10, DATE '2026-01-09'),
+    (1005,   8, 'acme',   'emea',     12.00, DATE '2026-01-11'),
+    (1006,   8, 'acme',   'us_west', 199.99, DATE '2026-01-12'),
+    (1007,  91, 'globex', 'emea',    777.00, DATE '2026-01-15'),
+    (1008, NULL, 'globex', 'us_west', 64.40, DATE '2026-01-18')
+) AS t(order_id, customer_id, owner, region, amount, order_date);

--- a/examples/playground/pocs/00-foundations/13-surrogate-keys/models/order_keys.sql
+++ b/examples/playground/pocs/00-foundations/13-surrogate-keys/models/order_keys.sql
@@ -1,0 +1,8 @@
+SELECT
+    order_id,
+    customer_id,
+    owner,
+    region,
+    amount,
+    order_date
+FROM raw__orders.orders

--- a/examples/playground/pocs/00-foundations/13-surrogate-keys/models/order_keys.toml
+++ b/examples/playground/pocs/00-foundations/13-surrogate-keys/models/order_keys.toml
@@ -1,0 +1,17 @@
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "poc"
+schema = "main"
+
+# Rocky appends `CAST(md5(...) AS VARCHAR) AS order_key` to the model's
+# projection, hashing the listed input columns. The columns must be produced
+# by the SELECT above. The hash is byte-identical to
+# dbt_utils.generate_surrogate_key('order_id', 'customer_id') on this dialect.
+[[surrogate_key]]
+name = "order_key"
+columns = ["order_id", "customer_id"]
+
+[columns.order_key]
+description = "Deterministic md5 surrogate key over (order_id, customer_id), dbt_utils-compatible."

--- a/examples/playground/pocs/00-foundations/13-surrogate-keys/rocky.toml
+++ b/examples/playground/pocs/00-foundations/13-surrogate-keys/rocky.toml
@@ -1,0 +1,27 @@
+# 13-surrogate-keys — a transformation model that injects a deterministic
+# surrogate-key column via a [[surrogate_key]] sidecar block. No credentials.
+#
+# Seed the local DuckDB once, then materialize the model:
+#   duckdb poc.duckdb < data/seed.sql
+#   rocky run
+#
+# The materialized `poc.main.order_keys` table carries an `order_key` column
+# that holds a 32-char md5 hash, byte-identical to what
+# dbt_utils.generate_surrogate_key('order_id', 'customer_id') produces.
+
+[adapter]
+type = "duckdb"
+path = "poc.duckdb"
+
+[pipeline.surrogate_keys]
+type = "transformation"
+models = "models/**"
+
+# The model targets the database's default schema (`poc.main`), so the
+# materialized table resolves the same way under `rocky run` and the
+# in-memory `rocky test` run.
+[pipeline.surrogate_keys.target.governance]
+auto_create_schemas = true
+
+[pipeline.surrogate_keys.execution]
+concurrency = 4

--- a/examples/playground/pocs/00-foundations/13-surrogate-keys/run.sh
+++ b/examples/playground/pocs/00-foundations/13-surrogate-keys/run.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# 13-surrogate-keys — inject a deterministic, dbt_utils-compatible surrogate
+# key via a [[surrogate_key]] sidecar block, then prove the hash column is
+# present and populated in the real materialized table.
+set -euo pipefail
+
+export ROCKY_SUPPRESS_DEPRECATION=1
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+mkdir -p expected
+# State lands under models/ for this transformation pipeline; clean it (plus the
+# root path the template uses) so every run starts from a fresh redb + DuckDB.
+rm -f poc.duckdb .rocky-state.redb models/.rocky-state.redb*
+
+echo "=== seed ==="
+duckdb poc.duckdb < data/seed.sql
+
+echo "=== run (materialize order_keys; Rocky injects the order_key hash) ==="
+rocky run > expected/run.json
+echo "materialized in poc.main:"
+duckdb -noheader -list poc.duckdb \
+    "SELECT table_name FROM information_schema.tables WHERE table_schema='main' ORDER BY table_name"
+
+echo "=== query the injected surrogate key ==="
+duckdb -noheader -list poc.duckdb \
+    "SELECT order_key FROM main.order_keys LIMIT 5"
+
+echo "=== assert: order_key is present and holds a 32-char md5 hash ==="
+if duckdb -noheader -list poc.duckdb \
+        "SELECT order_key FROM main.order_keys LIMIT 5" \
+        | grep -qE '^[0-9a-f]{32}$'; then
+    echo "PASS: order_key holds a 32-char md5 surrogate key"
+else
+    echo "FAIL: order_key missing or not a 32-char md5 hash" >&2
+    exit 1
+fi
+
+echo "=== assert: byte-identical to dbt_utils.generate_surrogate_key ==="
+# Rocky's injected hash must equal the dbt-utils form hand-written here:
+# md5( coalesce(cast(c as varchar), '_dbt_utils_surrogate_key_null_') joined by '-' ),
+# in declared column order (order_id, customer_id). A NULL input coalesces to
+# the fixed sentinel before hashing, exactly as dbt-utils does.
+MISMATCHES=$(duckdb -noheader -list poc.duckdb "
+    SELECT COUNT(*) FROM main.order_keys
+    WHERE order_key <> md5(
+        coalesce(cast(order_id as varchar),    '_dbt_utils_surrogate_key_null_') || '-' ||
+        coalesce(cast(customer_id as varchar), '_dbt_utils_surrogate_key_null_')
+    )")
+if [ "$MISMATCHES" = "0" ]; then
+    echo "PASS: every order_key matches the dbt_utils.generate_surrogate_key form (0 mismatches)"
+else
+    echo "FAIL: ${MISMATCHES} row(s) diverge from the dbt_utils surrogate-key hash" >&2
+    exit 1
+fi
+
+echo "POC complete: order_key materialized as a 32-char md5 surrogate key, byte-identical to dbt_utils.generate_surrogate_key."

--- a/examples/playground/pocs/00-foundations/14-config-groups/README.md
+++ b/examples/playground/pocs/00-foundations/14-config-groups/README.md
@@ -1,0 +1,149 @@
+# 14-config-groups — governed materialization fan-out
+
+> **Category:** 00-foundations
+> **Credentials:** none (DuckDB)
+> **Runtime:** < 5s
+> **Rocky features:** config groups (`models/groups/<name>.toml`), `schema_template` + `[args]` routing, group `[strategy]`, group `[tags]` inheritance, `enforce`, the misplacement guard
+
+## What it shows
+
+When many models share the same routing and materialization, you define a
+**config group** once and have each model opt in by name. The group lives in
+`models/groups/<name>.toml` (the file stem is the group name) and supplies:
+
+- a **`schema_template`** like `mart_{region}` — each member fills the
+  `{region}` placeholder from its own `[args]`, so one definition fans out
+  across distinct target schemas;
+- a shared **`[strategy]`** — one materialization for the whole group;
+- a **`[tags]`** baseline — a governance attribute applied once on the group
+  lands on every member.
+
+This POC has one group, `daily_marts`, and three members that each opt in
+with `group = "daily_marts"` and a different `[args] region`:
+
+| Model | `[args] region` | Resolved schema |
+|---|---|---|
+| `fct_orders_emea` | `emea` | `mart_emea` |
+| `fct_orders_us_west` | `us_west` | `mart_us_west` |
+| `fct_orders_apac` | `apac` | `mart_apac` |
+
+`run.sh` compiles them with `rocky compile --output json` and asserts the
+members resolved to **three distinct target schemas** and **inherited the
+group's `[tags]`** (`domain = "sales"`). `fct_orders_us_west` also overrides
+one tag (`tier = "silver"`) to show the per-key merge: it keeps the
+inherited `domain` while pinning its own `tier`.
+
+## The two load-time guards
+
+A config group makes routing *easy* — and routing mistakes *loud*. Two
+deliberately-broken siblings under `broken/` show the guards that fail the
+load instead of silently misrouting a model. `run.sh` runs each and asserts
+the expected error.
+
+### Guard A — misplaced `[args]` (`broken/misplaced-args/`)
+
+`[args]` exist only to fill a group's `schema_template`. If a member also
+pins its own `target.schema`, the pin wins (sidecar > group), the template is
+bypassed, and the `[args]` become dead — usually masking a routing mistake.
+Rocky fails the load:
+
+```
+model 'fct_orders_broken' supplies [args] for config group 'daily_marts's
+schema_template but also pins its own target.schema; the pin overrides the
+template, so the [args] are dead. ...
+```
+
+Fix it one way or the other: pin a schema (drop `[args]`), **or** route via
+`[args]` (drop the pinned schema). Not both.
+
+### Guard B — overriding an enforced group (`broken/enforce-override/`)
+
+By default a group is an overridable **default**: a member may pin its own
+schema or strategy to diverge. Set `enforce = true` to make the group's
+fields **binding** — a governance guarantee that the whole fan-out shares
+routing and materialization. A member that then pins a field the enforced
+group owns (its target `schema` or its `strategy`) fails the load:
+
+```
+model 'fct_ledger_broken' overrides 'target.schema', which its enforced
+group 'regulated' controls; remove the local override or set the group's
+enforce = false
+```
+
+Enforcement is strictly opt-in. Without `enforce`, the same pin is allowed.
+
+## Why it's distinctive
+
+- One group definition routes a fan-out across many schemas with no codegen
+  or templating step — the dbt analogue would be a macro + per-model config
+  sprawl.
+- Governance attributes (`[tags]`) declared once on the group land on every
+  member, and `dagster-rocky` projects them onto each derived asset's Dagster
+  tags, so the governed fan-out is visible to the orchestrator end-to-end.
+- `enforce = true` turns the group from a convenience default into a binding
+  contract: a regulated set of models *cannot* quietly route or materialize
+  itself differently from the rest. That's enforcement, not just a lint.
+
+## Layout
+
+```
+.
+├── README.md
+├── rocky.toml                         pipeline + adapter (DuckDB)
+├── run.sh                             fan-out asserts + both broken-sibling asserts
+├── models/
+│   ├── groups/
+│   │   └── daily_marts.toml           the group: schema_template + [strategy] + [tags]
+│   ├── fct_orders_emea.sql + .toml    member, [args] region = "emea"
+│   ├── fct_orders_us_west.sql + .toml member, [args] region = "us_west" (+ tier override)
+│   └── fct_orders_apac.sql + .toml    member, [args] region = "apac"
+└── broken/
+    ├── misplaced-args/models/         Guard A: pins schema AND supplies [args]
+    │   ├── groups/daily_marts.toml              (non-enforced)
+    │   └── fct_orders_broken.sql + .toml
+    └── enforce-override/models/       Guard B: pins schema under an enforced group
+        ├── groups/regulated.toml               (enforce = true)
+        └── fct_ledger_broken.sql + .toml
+```
+
+> The broken siblings are plain `models/` trees, not standalone pipelines —
+> `run.sh` compiles each with `rocky compile --models broken/<case>/models`,
+> and the parent `rocky.toml` auto-loads from the POC dir. Each carries its
+> own copy of `models/groups/` because a group resolves relative to the
+> compiled models directory (`<models_dir>/groups/`). The model loader does
+> not recurse into subdirectories, so `models/groups/` is never mistaken for
+> model files. They live under `broken/` (not the main `models/` tree)
+> because a group guard is a *load* error that aborts the whole load — it
+> can't sit beside the good fan-out the way a per-model contract diagnostic
+> can.
+
+## Run
+
+```bash
+./run.sh
+```
+
+## Precedence rules
+
+Per-model sidecar **>** group **>** `_defaults.toml`:
+
+1. A member can still pin its own `schema` / `strategy` to override the group
+   (unless the group is enforced).
+2. Otherwise the group's `schema_template` (filled from `[args]`) and
+   `[strategy]` apply.
+3. Otherwise directory defaults from `_defaults.toml`.
+
+Tags merge per key (sidecar wins per key, the rest of the group's tags stay).
+An unknown group name, an unfilled `schema_template` placeholder, a pinned
+schema alongside `[args]`, or overriding an enforced field all fail the load
+with a clear error rather than routing a model to the wrong place.
+
+## Related
+
+- Model format reference — Config groups:
+  `docs/src/content/docs/reference/model-format.md` (`#config-groups`).
+- The three-layer config + env-var story:
+  `examples/playground/pocs/00-foundations/07-config-layering/`.
+- The group loader + guards live at
+  `engine/crates/rocky-core/src/models.rs` (`load_groups_from_dir`,
+  `resolve_model_config`).

--- a/examples/playground/pocs/00-foundations/14-config-groups/broken/enforce-override/models/fct_ledger_broken.sql
+++ b/examples/playground/pocs/00-foundations/14-config-groups/broken/enforce-override/models/fct_ledger_broken.sql
@@ -1,0 +1,1 @@
+SELECT 1 AS entry_id, 'acme' AS account, 500 AS balance

--- a/examples/playground/pocs/00-foundations/14-config-groups/broken/enforce-override/models/fct_ledger_broken.toml
+++ b/examples/playground/pocs/00-foundations/14-config-groups/broken/enforce-override/models/fct_ledger_broken.toml
@@ -1,0 +1,19 @@
+# DELIBERATELY BROKEN — the enforced-group guard.
+#
+# This member belongs to the ENFORCED `regulated` group, which OWNS the
+# target schema (via schema_template). The member tries to pin its own
+# target.schema — routing itself away from the rest of the group. Under an
+# enforced group that is a governance violation, so Rocky FAILS the load
+# instead of letting one regulated model drift to a different schema.
+#
+# Fix: remove the pinned schema and route via [args] like every other
+# member, or (if the divergence is intended) set enforce = false on the group.
+
+group = "regulated"
+
+[target]
+catalog = "warehouse"
+schema  = "rogue_schema"   # the enforced group controls schema -> load error
+
+[args]
+region  = "emea"

--- a/examples/playground/pocs/00-foundations/14-config-groups/broken/enforce-override/models/groups/regulated.toml
+++ b/examples/playground/pocs/00-foundations/14-config-groups/broken/enforce-override/models/groups/regulated.toml
@@ -1,0 +1,17 @@
+# ENFORCED config group.
+#
+# `enforce = true` makes the group's fields BINDING, not just defaults. A
+# member may still supply its own [args] and any field the group doesn't set
+# (like target.catalog) — it just cannot override what the group OWNS
+# (target.schema, strategy). Use this when a set of models must share routing
+# and materialization as a governance guarantee.
+
+enforce = true
+schema_template = "mart_{region}"
+
+[strategy]
+type = "full_refresh"
+
+[tags]
+domain = "finance"
+tier = "gold"

--- a/examples/playground/pocs/00-foundations/14-config-groups/broken/misplaced-args/models/fct_orders_broken.sql
+++ b/examples/playground/pocs/00-foundations/14-config-groups/broken/misplaced-args/models/fct_orders_broken.sql
@@ -1,0 +1,1 @@
+SELECT 1 AS order_id, 'acme' AS customer, 100 AS amount

--- a/examples/playground/pocs/00-foundations/14-config-groups/broken/misplaced-args/models/fct_orders_broken.toml
+++ b/examples/playground/pocs/00-foundations/14-config-groups/broken/misplaced-args/models/fct_orders_broken.toml
@@ -1,0 +1,18 @@
+# DELIBERATELY BROKEN — the misplacement guard.
+#
+# This member pins its own target.schema AND supplies [args]. The pin wins
+# (sidecar > group), so the schema_template is bypassed and the [args] can
+# never fill anything — they are dead. That combination usually masks a
+# routing mistake, so Rocky FAILS the load rather than silently misrouting.
+#
+# Fix one way or the other: pin a schema (drop [args]), OR route via [args]
+# (drop the pinned schema). Not both.
+
+group = "daily_marts"
+
+[target]
+catalog = "warehouse"
+schema  = "manual_override"   # pin overrides the group template...
+
+[args]
+region  = "emea"              # ...so this is dead — load-time error.

--- a/examples/playground/pocs/00-foundations/14-config-groups/broken/misplaced-args/models/groups/daily_marts.toml
+++ b/examples/playground/pocs/00-foundations/14-config-groups/broken/misplaced-args/models/groups/daily_marts.toml
@@ -1,0 +1,12 @@
+# Same NON-enforced group as the parent POC. Without `enforce`, a member may
+# legitimately pin its own schema to override the template — but it must NOT
+# also supply [args], since the pin bypasses the template the args would fill.
+
+schema_template = "mart_{region}"
+
+[strategy]
+type = "full_refresh"
+
+[tags]
+domain = "sales"
+tier = "gold"

--- a/examples/playground/pocs/00-foundations/14-config-groups/models/fct_orders_apac.sql
+++ b/examples/playground/pocs/00-foundations/14-config-groups/models/fct_orders_apac.sql
@@ -1,0 +1,1 @@
+SELECT 5 AS order_id, 'hooli' AS customer, 90 AS amount

--- a/examples/playground/pocs/00-foundations/14-config-groups/models/fct_orders_apac.toml
+++ b/examples/playground/pocs/00-foundations/14-config-groups/models/fct_orders_apac.toml
@@ -1,0 +1,12 @@
+# Member of the daily_marts group, APAC region.
+#
+# A third [args] value -> a third DISTINCT schema (mart_apac). Inherits the
+# group's strategy and full [tags] baseline unchanged.
+
+group = "daily_marts"
+
+[target]
+catalog = "warehouse"
+
+[args]
+region = "apac"         # fills {region} -> schema "mart_apac"

--- a/examples/playground/pocs/00-foundations/14-config-groups/models/fct_orders_emea.sql
+++ b/examples/playground/pocs/00-foundations/14-config-groups/models/fct_orders_emea.sql
@@ -1,0 +1,1 @@
+SELECT 1 AS order_id, 'acme' AS customer, 100 AS amount

--- a/examples/playground/pocs/00-foundations/14-config-groups/models/fct_orders_emea.toml
+++ b/examples/playground/pocs/00-foundations/14-config-groups/models/fct_orders_emea.toml
@@ -1,0 +1,13 @@
+# Member of the daily_marts group, EMEA region.
+#
+# The sidecar pins only `target.catalog`. The schema comes from the group's
+# schema_template, filled by [args]: region = "emea" -> schema "mart_emea".
+# strategy + [tags] are inherited from the group.
+
+group = "daily_marts"
+
+[target]
+catalog = "warehouse"   # schema comes from the group's schema_template
+
+[args]
+region = "emea"         # fills {region} -> schema "mart_emea"

--- a/examples/playground/pocs/00-foundations/14-config-groups/models/fct_orders_us_west.sql
+++ b/examples/playground/pocs/00-foundations/14-config-groups/models/fct_orders_us_west.sql
@@ -1,0 +1,1 @@
+SELECT 3 AS order_id, 'initech' AS customer, 175 AS amount

--- a/examples/playground/pocs/00-foundations/14-config-groups/models/fct_orders_us_west.toml
+++ b/examples/playground/pocs/00-foundations/14-config-groups/models/fct_orders_us_west.toml
@@ -1,0 +1,16 @@
+# Member of the daily_marts group, US-West region.
+#
+# Same group, different [args] -> a DISTINCT target schema (mart_us_west).
+# This member also overrides ONE tag (tier = "silver") to show per-key
+# merge: it keeps the group's `domain = "sales"` but pins its own tier.
+
+group = "daily_marts"
+
+[target]
+catalog = "warehouse"
+
+[args]
+region = "us_west"      # fills {region} -> schema "mart_us_west"
+
+[tags]
+tier = "silver"         # overrides the group's tier; domain stays inherited

--- a/examples/playground/pocs/00-foundations/14-config-groups/models/groups/daily_marts.toml
+++ b/examples/playground/pocs/00-foundations/14-config-groups/models/groups/daily_marts.toml
@@ -1,0 +1,20 @@
+# Config group: daily_marts
+#
+# Defined ONCE; every member opts in with `group = "daily_marts"`.
+#   * schema_template — each member fills {region} from its own [args],
+#     so the fan-out lands in distinct schemas (mart_emea, mart_us_west, …).
+#   * [strategy]      — one shared materialization for the whole group.
+#   * [tags]          — a governance baseline inherited by every member.
+#
+# This group is an overridable DEFAULT (no `enforce`): a member may still
+# pin its own schema/strategy. The enforced sibling under broken/ shows the
+# governance-guarantee variant.
+
+schema_template = "mart_{region}"
+
+[strategy]
+type = "full_refresh"
+
+[tags]
+domain = "sales"
+tier = "gold"

--- a/examples/playground/pocs/00-foundations/14-config-groups/rocky.toml
+++ b/examples/playground/pocs/00-foundations/14-config-groups/rocky.toml
@@ -1,0 +1,21 @@
+# 14-config-groups — governed materialization fan-out via a config group
+#
+# A config group (models/groups/<name>.toml) defines a schema_template,
+# a shared [strategy], and a [tags] baseline once. Each member model opts
+# in with `group = "<name>"` and fills the template's {placeholder}s from
+# its own [args] — so one definition fans out across many target schemas.
+
+[adapter]
+type = "duckdb"
+path = "poc.duckdb"
+
+[pipeline.marts]
+type = "transformation"
+
+# Transformation pipelines defer catalog/schema/table to per-model sidecars
+# and (here) to the config group's schema_template. The adapter reference is
+# all that's needed at the pipeline level.
+[pipeline.marts.target]
+
+[pipeline.marts.target.governance]
+auto_create_schemas = true

--- a/examples/playground/pocs/00-foundations/14-config-groups/run.sh
+++ b/examples/playground/pocs/00-foundations/14-config-groups/run.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# 14-config-groups — governed materialization fan-out + the two load-time guards
+#
+# No `set -e`: the broken siblings are SUPPOSED to fail, and we assert on those
+# failures. Unexpected failures are caught explicitly and exit non-zero.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+mkdir -p expected
+rm -f .rocky-state.redb poc.duckdb
+
+fail() { echo "ASSERT FAILED: $1" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Part 1 — the good fan-out: one group definition, three distinct schemas.
+# ---------------------------------------------------------------------------
+echo "=== Part 1: fan-out — three members of group 'daily_marts' ==="
+echo "    schema_template = \"mart_{region}\"; each member fills {region} from [args]"
+echo
+rocky compile --models models --output json > expected/compile.json 2>/dev/null
+rc=$?
+[ "$rc" -eq 0 ] || fail "good fan-out compile exited $rc (expected 0)"
+
+echo "Resolved member targets + inherited tags:"
+python3 -c "
+import json
+d = json.load(open('expected/compile.json'))
+for m in sorted(d.get('models_detail', []), key=lambda x: x['name']):
+    t = m['target']
+    tags = ','.join(f'{k}={v}' for k, v in sorted(m.get('tags', {}).items()))
+    print(f\"  {m['name']:20s} -> {t['catalog']}.{t['schema']}.{t['table']:18s} [{tags}]\")
+"
+
+# Assert the three members resolved to THREE DISTINCT target schemas.
+distinct_schemas=$(python3 -c "
+import json
+d = json.load(open('expected/compile.json'))
+schemas = sorted({m['target']['schema'] for m in d['models_detail']})
+print(' '.join(schemas))
+")
+echo
+echo "Distinct schemas: $distinct_schemas"
+[ "$distinct_schemas" = "mart_apac mart_emea mart_us_west" ] \
+    || fail "expected schemas 'mart_apac mart_emea mart_us_west', got '$distinct_schemas'"
+
+# Assert every member inherited the group's [tags] domain=sales baseline,
+# and that the per-key override took (us_west tier=silver, others tier=gold).
+python3 -c "
+import json, sys
+d = json.load(open('expected/compile.json'))
+by = {m['name']: m.get('tags', {}) for m in d['models_detail']}
+def need(model, key, val):
+    got = by.get(model, {}).get(key)
+    if got != val:
+        sys.exit(f'tag {key}={val} expected on {model}, got {got!r}')
+# domain=sales inherited from the group by every member:
+for m in ('fct_orders_emea', 'fct_orders_us_west', 'fct_orders_apac'):
+    need(m, 'domain', 'sales')
+# tier: group baseline gold, except us_west which overrides to silver,
+# while still keeping the inherited domain (per-key merge, sidecar > group):
+need('fct_orders_emea',    'tier', 'gold')
+need('fct_orders_apac',    'tier', 'gold')
+need('fct_orders_us_west', 'tier', 'silver')
+print('OK: group [tags] inherited by all members; us_west tier override merged per-key')
+" || fail "group [tags] inheritance / override assertion failed"
+
+# ---------------------------------------------------------------------------
+# Part 2 — guard A: misplacement (pin target.schema AND supply [args]).
+# ---------------------------------------------------------------------------
+echo
+echo "=== Part 2: load-time guard A — misplaced [args] (non-enforced group) ==="
+echo "    broken/misplaced-args pins target.schema AND supplies [args] -> the"
+echo "    pin bypasses the template, so the [args] are dead. Expect load FAILURE."
+echo
+if rocky compile \
+        --models broken/misplaced-args/models \
+        --output json > /dev/null 2> expected/err-misplaced.txt; then
+    echo "--- stderr ---"; cat expected/err-misplaced.txt
+    fail "broken/misplaced-args compiled successfully (expected a load error)"
+fi
+echo "    -> failed as expected. Error:"
+msg=$(grep -m1 -E "the \[args\] are dead" expected/err-misplaced.txt) \
+    || fail "expected misplacement error ('the [args] are dead') not found"
+echo "      ${msg#Error: }"
+
+# ---------------------------------------------------------------------------
+# Part 3 — guard B: enforced group overridden (pin a group-controlled field).
+# ---------------------------------------------------------------------------
+echo
+echo "=== Part 3: load-time guard B — overriding an ENFORCED group ==="
+echo "    broken/enforce-override pins target.schema under an enforced group"
+echo "    that OWNS the schema. Expect load FAILURE (governance guarantee)."
+echo
+if rocky compile \
+        --models broken/enforce-override/models \
+        --output json > /dev/null 2> expected/err-enforce.txt; then
+    echo "--- stderr ---"; cat expected/err-enforce.txt
+    fail "broken/enforce-override compiled successfully (expected a load error)"
+fi
+echo "    -> failed as expected. Error:"
+msg=$(grep -m1 -E "which its enforced group 'regulated' controls" expected/err-enforce.txt) \
+    || fail "expected enforcement error ('enforced group ... controls') not found"
+echo "      ${msg#Error: }"
+
+echo
+echo "POC complete:"
+echo "  - one config group fanned out to 3 distinct schemas (mart_emea / mart_us_west / mart_apac)"
+echo "  - every member inherited the group [tags] baseline; us_west overrode tier per-key"
+echo "  - misplacement guard rejected pin-schema + [args]"
+echo "  - enforcement guard rejected overriding an enforced group's schema"

--- a/examples/playground/pocs/01-quality/09-named-tests/README.md
+++ b/examples/playground/pocs/01-quality/09-named-tests/README.md
@@ -1,0 +1,98 @@
+# 09-named-tests — reusable named tests via `[[use_test]]`
+
+> **Category:** 01-quality
+> **Credentials:** none (DuckDB)
+> **Runtime:** < 5s
+> **Rocky features:** `models/test_definitions.toml`, `[[use_test]]`, inline `[[tests]]`, `rocky test --declarative`
+
+## What it shows
+
+Define a data-quality assertion once, apply it to many models. A named test
+lives in `models/test_definitions.toml` carrying its type, parameters, and an
+optional default column. Any model references it by name with `[[use_test]]`
+and can override the column, severity, or filter at that call site. This is
+Rocky's equivalent of a dbt generic test.
+
+This POC ships two reusable definitions and exercises every way a model can
+apply them:
+
+- `positive_amount` — an `expression` test (`amount > 0`).
+- `known_status` — an `accepted_values` test with a default column of `status`.
+
+Across two marts (`orders_mart`, `shipments_mart`) the POC demonstrates:
+
+| Application | Where | What it shows |
+|---|---|---|
+| Default-column use | `orders_mart` ← `known_status` | binds to the definition's own `status` column |
+| Column-bind override | `shipments_mart` ← `known_status` | re-points the same test at `fulfilment_state` |
+| Severity override | `orders_mart` ← `positive_amount` | downgrades the default `error` to `warning` |
+| Inline coexistence | `orders_mart` | a one-off `[[tests]] not_null` sits beside the named tests |
+
+## Why it's distinctive
+
+- **One definition, many call sites.** Change the accepted status vocabulary
+  in `test_definitions.toml` once and every `[[use_test]]` reference picks it
+  up — no copy-paste drift across models.
+- **Per-use overrides.** The same named test binds to a different column on
+  one model and runs at a different severity on another, all without forking
+  the definition.
+- **Named and inline tests coexist.** Shared assertions go in
+  `test_definitions.toml`; a genuinely one-off check stays inline as
+  `[[tests]]` on the model.
+- **No warehouse required.** Everything runs against in-memory / file-backed
+  DuckDB.
+
+## Mapping to dbt generic tests
+
+| dbt | Rocky |
+|---|---|
+| A generic test (`tests/generic/positive_amount.sql`) or a built-in (`accepted_values`) | A named entry in `models/test_definitions.toml` |
+| `tests:` block under a column in `schema.yml` applying the generic test | `[[use_test]]` on the model sidecar |
+| `column_name:` the generic test attaches to | `column = "…"` on `[[use_test]]` (or the definition's default) |
+| `config: severity: warn` on the test | `severity = "warning"` on `[[use_test]]` |
+| `where:` test config | `filter = "…"` on `[[use_test]]` |
+| A bespoke `tests/singular/*.sql` assertion | inline `[[tests]]` on the model |
+
+In dbt, a generic test is a SQL macro plus a `schema.yml` reference. In Rocky
+it's a declarative TOML definition plus a `[[use_test]]` reference — Rocky
+generates the assertion SQL for the active dialect.
+
+## Layout
+
+```
+.
+├── README.md
+├── rocky.toml
+├── run.sh
+├── data/seed.sql
+└── models/
+    ├── test_definitions.toml   # the named tests
+    ├── orders_mart.sql / .toml # default-column + severity override + inline test
+    └── shipments_mart.sql / .toml  # column-bind override
+```
+
+## Run
+
+```bash
+./run.sh
+```
+
+The script materializes both marts on DuckDB, runs `rocky test --models models`
+(every model compiles + executes), then runs `rocky test --declarative` to
+execute and **name** each resolved assertion. It asserts all four applications
+landed with the right binding: default column, column override, severity
+override, and the coexisting inline test.
+
+## Expected output
+
+`rocky test --declarative` names every resolved assertion:
+
+```
+  - orders_mart: not_null(order_id) [error]
+  - orders_mart: expression(—) [warning]          # positive_amount, downgraded
+  - orders_mart: accepted_values(status) [error]  # known_status, default column
+  - shipments_mart: accepted_values(fulfilment_state) [error]  # known_status, re-bound
+```
+
+All four pass (`declarative.total = 4, failed = 0`), and `rocky test` reports
+both models green.

--- a/examples/playground/pocs/01-quality/09-named-tests/data/seed.sql
+++ b/examples/playground/pocs/01-quality/09-named-tests/data/seed.sql
@@ -1,0 +1,22 @@
+CREATE SCHEMA IF NOT EXISTS seeds;
+
+-- Orders: amount > 0 and status in {pending, shipped, delivered}.
+CREATE OR REPLACE TABLE seeds.orders AS
+SELECT
+    CAST(i AS BIGINT)                                            AS order_id,
+    CAST(1 + (i % 12) AS BIGINT)                                AS customer_id,
+    ROUND(CAST(5.0 + random() * 95.0 AS DECIMAL(10,2)), 2)      AS amount,
+    (CASE WHEN i % 3 = 0 THEN 'shipped'
+          WHEN i % 3 = 1 THEN 'pending'
+          ELSE 'delivered' END)                                 AS status
+FROM generate_series(1, 60) AS t(i);
+
+-- Shipments: a `fulfilment_state` column carrying the same vocabulary as
+-- `status`, so the same named test can be re-bound to a differently-named
+-- column at the use site.
+CREATE OR REPLACE TABLE seeds.shipments AS
+SELECT
+    CAST(i AS BIGINT)                                            AS shipment_id,
+    CAST(1 + (i % 12) AS BIGINT)                                AS customer_id,
+    (CASE WHEN i % 2 = 0 THEN 'shipped' ELSE 'delivered' END)   AS fulfilment_state
+FROM generate_series(1, 40) AS t(i);

--- a/examples/playground/pocs/01-quality/09-named-tests/models/orders_mart.sql
+++ b/examples/playground/pocs/01-quality/09-named-tests/models/orders_mart.sql
@@ -1,0 +1,2 @@
+SELECT order_id, customer_id, amount, status
+FROM seeds.orders

--- a/examples/playground/pocs/01-quality/09-named-tests/models/orders_mart.toml
+++ b/examples/playground/pocs/01-quality/09-named-tests/models/orders_mart.toml
@@ -1,0 +1,25 @@
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "poc"
+schema = "demo"
+
+# Inline assertion — coexists with the named tests below. Shows that
+# [[tests]] (one-off, declared in place) and [[use_test]] (shared, declared
+# once in test_definitions.toml) live side by side on the same model.
+[[tests]]
+type = "not_null"
+column = "order_id"
+
+# Named test with a severity override: the shared `positive_amount`
+# definition fails the run by default (error); here it's downgraded to a
+# warning at this call site only.
+[[use_test]]
+name = "positive_amount"
+severity = "warning"
+
+# Named test using its definition's default column. `known_status` binds to
+# `status` (declared in test_definitions.toml) without restating it here.
+[[use_test]]
+name = "known_status"

--- a/examples/playground/pocs/01-quality/09-named-tests/models/shipments_mart.sql
+++ b/examples/playground/pocs/01-quality/09-named-tests/models/shipments_mart.sql
@@ -1,0 +1,2 @@
+SELECT shipment_id, customer_id, fulfilment_state
+FROM seeds.shipments

--- a/examples/playground/pocs/01-quality/09-named-tests/models/shipments_mart.toml
+++ b/examples/playground/pocs/01-quality/09-named-tests/models/shipments_mart.toml
@@ -1,0 +1,14 @@
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "poc"
+schema = "demo"
+
+# Named test with a column-bind override: the same `known_status`
+# definition (whose default column is `status`) is re-pointed at this
+# model's differently-named `fulfilment_state` column. One definition,
+# applied to a column it was never written for.
+[[use_test]]
+name = "known_status"
+column = "fulfilment_state"

--- a/examples/playground/pocs/01-quality/09-named-tests/models/test_definitions.toml
+++ b/examples/playground/pocs/01-quality/09-named-tests/models/test_definitions.toml
@@ -1,0 +1,13 @@
+# Reusable named tests — defined once here, applied by name from any model
+# via [[use_test]]. This is Rocky's answer to a dbt generic test: one
+# definition, many call sites, each free to override the column, severity,
+# or filter at the point of use.
+
+[positive_amount]
+type = "expression"
+expression = "amount > 0"
+
+[known_status]
+type = "accepted_values"
+values = ["pending", "shipped", "delivered"]
+column = "status"

--- a/examples/playground/pocs/01-quality/09-named-tests/rocky.toml
+++ b/examples/playground/pocs/01-quality/09-named-tests/rocky.toml
@@ -1,0 +1,20 @@
+# 09-named-tests — reusable named tests applied across models via [[use_test]]
+#
+# A transformation pipeline that materializes two marts into poc.demo on
+# DuckDB, so the declarative [[tests]] / [[use_test]] assertions have real
+# tables to run against — no warehouse credentials required.
+
+[adapter]
+type = "duckdb"
+path = "poc.duckdb"
+
+[pipeline.poc]
+type = "transformation"
+models = "models/**"
+
+[pipeline.poc.target]
+
+# Lets `rocky run` auto-create poc.demo on first invocation so the POC needs
+# no manual `CREATE SCHEMA` step.
+[pipeline.poc.target.governance]
+auto_create_schemas = true

--- a/examples/playground/pocs/01-quality/09-named-tests/run.sh
+++ b/examples/playground/pocs/01-quality/09-named-tests/run.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# 09-named-tests — reusable named tests applied via [[use_test]]
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+mkdir -p expected
+rm -f .rocky-state.redb poc.duckdb models/.rocky-state.redb models/.rocky-state.redb.lock
+
+# Seed + materialize the two marts so the declarative assertions have real
+# target tables to run against.
+duckdb poc.duckdb < data/seed.sql
+rocky validate > /dev/null
+rocky -c rocky.toml -o json run --pipeline poc > expected/run.json
+
+echo "=== rocky test --models models (compile + execute every model) ==="
+# The literal local-test path: compiles and executes each model against
+# in-memory DuckDB. Must pass.
+rocky test --models models > expected/test.json
+TOTAL=$(jq '.total'  expected/test.json)
+PASSED=$(jq '.passed' expected/test.json)
+FAILED=$(jq '.failed' expected/test.json)
+echo "models tested: total=$TOTAL passed=$PASSED failed=$FAILED"
+[ "$FAILED" -eq 0 ] || { echo "FAIL: rocky test reported $FAILED model failures"; exit 1; }
+[ "$TOTAL"  -eq 2 ] || { echo "FAIL: expected 2 models, got $TOTAL"; exit 1; }
+
+echo
+echo "=== rocky test --declarative (run + name the resolved named tests) ==="
+# The declarative surface runs the [[tests]] and [[use_test]] assertions
+# against the materialized tables and names each one it applied. This is the
+# surface that proves the named definitions resolved.
+rocky test --models models --declarative --pipeline poc > expected/test_declarative.json
+
+D_TOTAL=$(jq '.declarative.total'  expected/test_declarative.json)
+D_PASSED=$(jq '.declarative.passed' expected/test_declarative.json)
+D_FAILED=$(jq '.declarative.failed' expected/test_declarative.json)
+echo "assertions: total=$D_TOTAL passed=$D_PASSED failed=$D_FAILED"
+[ "$D_FAILED" -eq 0 ] || { echo "FAIL: $D_FAILED declarative assertions failed"; exit 1; }
+[ "$D_TOTAL"  -eq 4 ] || { echo "FAIL: expected 4 resolved assertions, got $D_TOTAL"; exit 1; }
+
+echo
+echo "Applied assertions (model / type / column / severity):"
+jq -r '.declarative.results[]
+       | "  - \(.model): \(.test_type)(\(.column // "—")) [\(.severity)]"' \
+  expected/test_declarative.json
+
+# Assert each named test resolved with the right binding. We key on the
+# resolved (type, column, severity) tuple + inlined SQL, because that is what
+# proves the named definition was looked up and applied — the definition name
+# itself is consumed at load time and does not appear in the output.
+
+# 1. inline not_null coexists on orders_mart
+jq -e '.declarative.results
+       | any(.model=="orders_mart" and .test_type=="not_null" and .column=="order_id")' \
+  expected/test_declarative.json > /dev/null \
+  || { echo "FAIL: inline not_null(order_id) not applied to orders_mart"; exit 1; }
+
+# 2. positive_amount resolved with the severity override (warning, not error)
+#    and inlined its expression SQL
+jq -e '.declarative.results
+       | any(.model=="orders_mart" and .test_type=="expression"
+             and .severity=="warning" and (.sql | contains("amount > 0")))' \
+  expected/test_declarative.json > /dev/null \
+  || { echo "FAIL: positive_amount severity override (warning) not resolved"; exit 1; }
+
+# 3. known_status applied to its default column (status) on orders_mart
+jq -e '.declarative.results
+       | any(.model=="orders_mart" and .test_type=="accepted_values" and .column=="status")' \
+  expected/test_declarative.json > /dev/null \
+  || { echo "FAIL: known_status default-column (status) not applied to orders_mart"; exit 1; }
+
+# 4. known_status re-bound to fulfilment_state on shipments_mart (column override)
+jq -e '.declarative.results
+       | any(.model=="shipments_mart" and .test_type=="accepted_values"
+             and .column=="fulfilment_state")' \
+  expected/test_declarative.json > /dev/null \
+  || { echo "FAIL: known_status column-bind override (fulfilment_state) not applied"; exit 1; }
+
+echo
+echo "POC complete: 2 models, 1 inline test + 3 [[use_test]] references resolved"
+echo "(default column, column-bind override, severity override) — all 4 assertions pass."

--- a/examples/playground/pocs/01-quality/10-unit-tests/README.md
+++ b/examples/playground/pocs/01-quality/10-unit-tests/README.md
@@ -1,0 +1,71 @@
+# 10-unit-tests — fixture-driven `[[test]]` unit tests
+
+> **Category:** 01-quality
+> **Credentials:** none (DuckDB)
+> **Runtime:** < 5s
+> **Rocky features:** `[[test]]` / `[[test.given]]` / `[test.expect]`, `rocky test`, multiset vs `ordered = true` comparison, auto-loaded `data/seed.sql`
+
+## What it shows
+
+A model unit test in the dbt 1.8 sense: hand-written input rows in, expected
+output rows out, no warehouse. `flag_orders` reads from `raw_orders` and flags
+each order with `amount >= 100`. Two `[[test]]` blocks in
+`models/flag_orders.toml` check its logic against mocked upstream rows:
+
+1. **Default multiset comparison.** `flags_orders_at_or_above_100` mocks
+   `raw_orders` with three rows and asserts the `is_high_value` flag on each.
+   Row order does not matter, and only the columns named in `expect.rows`
+   (`order_id`, `is_high_value`) are compared — `region` and `amount` are
+   ignored.
+2. **Ordered comparison (`ordered = true`).** `sorts_by_amount_descending`
+   pins the exact output order. The model ends in `ORDER BY amount DESC`, so
+   the expected rows are listed largest-amount first. Reorder them and the
+   test fails with `ordered output mismatch` — the regression a positional
+   assertion is meant to catch.
+
+`rocky test --models models` runs both, and `run.sh` parses the JSON
+`unit_tests` field to assert `passed == total` and `failed == 0`.
+
+## `[[test]]` (unit tests) vs `[[tests]]` (declarative assertions)
+
+These two blocks look alike but do different jobs. The singular/plural
+distinction is load-bearing — read the `s`.
+
+| | `[[test]]` (singular) | `[[tests]]` (plural) |
+|---|---|---|
+| **Kind** | Fixture-driven **unit test** | Declarative data-quality **assertion** |
+| **Checks** | The model's SQL **logic** | Properties of **materialized output** |
+| **Inputs** | Hand-written `[[test.given]]` rows | The real target table |
+| **Output** | Compared to `[test.expect]` rows | `not_null`, `unique`, `accepted_values`, `expression`, … |
+| **Command** | `rocky test` (this POC, **default path**) | `rocky test --declarative` |
+| **Warehouse** | None — in-memory DuckDB | Runs against the configured adapter |
+
+Plural `[[tests]]` and the `--declarative` path are covered in a separate POC.
+This one is purely the singular `[[test]]` unit-test surface.
+
+This mirrors dbt 1.8's `unit_tests:` (`given` / `expect`) for SQL-logic tests
+versus dbt's long-standing `tests:` for schema/data assertions — Rocky reaches
+the same parity with one `rocky test` invocation and no Jinja, no manifest, no
+seed-CSV scaffolding.
+
+## Layout
+
+```
+.
+├── README.md
+├── rocky.toml
+├── run.sh
+├── data/seed.sql          # backs the local model-execution pass
+└── models/
+    ├── raw_orders.sql/.toml    # mocked upstream
+    └── flag_orders.sql/.toml   # model under test + two [[test]] blocks
+```
+
+## Run
+
+```bash
+./run.sh
+```
+
+Expected: `2/2 fixture-driven unit tests passed` and the captured
+`expected/test.json` carries `unit_tests.total = 2`, `passed = 2`, `failed = 0`.

--- a/examples/playground/pocs/01-quality/10-unit-tests/data/seed.sql
+++ b/examples/playground/pocs/01-quality/10-unit-tests/data/seed.sql
@@ -1,0 +1,8 @@
+CREATE SCHEMA IF NOT EXISTS seeds;
+
+CREATE OR REPLACE TABLE seeds.orders AS
+SELECT
+    CAST(i AS BIGINT) AS order_id,
+    CASE WHEN i % 2 = 0 THEN 'emea' ELSE 'us_west' END AS region,
+    ROUND(CAST(10.0 + (i * 7) % 300 AS DECIMAL(10, 2)), 2) AS amount
+FROM generate_series(1, 50) AS t(i);

--- a/examples/playground/pocs/01-quality/10-unit-tests/models/flag_orders.sql
+++ b/examples/playground/pocs/01-quality/10-unit-tests/models/flag_orders.sql
@@ -1,0 +1,7 @@
+SELECT
+    order_id,
+    region,
+    amount,
+    amount >= 100 AS is_high_value
+FROM raw_orders
+ORDER BY amount DESC

--- a/examples/playground/pocs/01-quality/10-unit-tests/models/flag_orders.toml
+++ b/examples/playground/pocs/01-quality/10-unit-tests/models/flag_orders.toml
@@ -1,0 +1,61 @@
+depends_on = ["raw_orders"]
+
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "poc"
+schema = "marts"
+
+# ---------------------------------------------------------------------------
+# Fixture-driven unit tests. Singular [[test]] (NOT plural [[tests]]).
+#
+# Each block seeds a mock upstream with hand-written rows ([[test.given]]),
+# runs flag_orders.sql against it, and compares the result to [test.expect].
+# Default comparison is a multiset (row order ignored). Set ordered = true to
+# pin the exact output order — useful here because the model sorts amount DESC.
+# ---------------------------------------------------------------------------
+
+# Case 1 — DEFAULT multiset comparison (order does not matter).
+# Only the columns named in expect.rows are compared; `region` is ignored.
+[[test]]
+name = "flags_orders_at_or_above_100"
+description = "amount >= 100 is flagged high-value; the < 100 row is not"
+
+[[test.given]]
+ref = "raw_orders"
+rows = [
+    { order_id = 1, region = "emea",    amount = 150.0 },
+    { order_id = 2, region = "us_west", amount = 50.0 },
+    { order_id = 3, region = "emea",    amount = 100.0 },
+]
+
+[test.expect]
+rows = [
+    { order_id = 1, is_high_value = true },
+    { order_id = 2, is_high_value = false },
+    { order_id = 3, is_high_value = true },
+]
+
+# Case 2 — ORDERED comparison (ordered = true). The model sorts amount DESC,
+# so the expected rows must appear in descending-amount order. Reorder them
+# and the test fails — exactly the regression a positional assertion guards.
+[[test]]
+name = "sorts_by_amount_descending"
+description = "output is ordered by amount DESC; ordered = true pins the order"
+
+[[test.given]]
+ref = "raw_orders"
+rows = [
+    { order_id = 10, region = "emea",    amount = 25.0 },
+    { order_id = 11, region = "us_west", amount = 300.0 },
+    { order_id = 12, region = "emea",    amount = 175.0 },
+]
+
+[test.expect]
+ordered = true
+rows = [
+    { order_id = 11, amount = 300.0 },
+    { order_id = 12, amount = 175.0 },
+    { order_id = 10, amount = 25.0 },
+]

--- a/examples/playground/pocs/01-quality/10-unit-tests/models/raw_orders.sql
+++ b/examples/playground/pocs/01-quality/10-unit-tests/models/raw_orders.sql
@@ -1,0 +1,1 @@
+SELECT order_id, region, amount FROM seeds.orders

--- a/examples/playground/pocs/01-quality/10-unit-tests/models/raw_orders.toml
+++ b/examples/playground/pocs/01-quality/10-unit-tests/models/raw_orders.toml
@@ -1,0 +1,6 @@
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "poc"
+schema = "staging"

--- a/examples/playground/pocs/01-quality/10-unit-tests/rocky.toml
+++ b/examples/playground/pocs/01-quality/10-unit-tests/rocky.toml
@@ -1,0 +1,14 @@
+[adapter]
+type = "duckdb"
+
+[pipeline.poc]
+strategy = "full_refresh"
+
+[pipeline.poc.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.poc.target]
+catalog_template = "poc"
+schema_template = "demo"

--- a/examples/playground/pocs/01-quality/10-unit-tests/run.sh
+++ b/examples/playground/pocs/01-quality/10-unit-tests/run.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Fixture-driven unit tests — singular [[test]] blocks (dbt 1.8 unit-test parity)
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+mkdir -p expected
+rm -f .rocky-state.redb poc.duckdb
+
+rocky validate > /dev/null
+
+echo "=== Run fixture-driven unit tests ([[test]] blocks) ==="
+# `rocky test` runs BOTH local model tests and the fixture-driven [[test]]
+# blocks. The unit-test outcome lands in the JSON `unit_tests` field.
+rocky test --models models --output json > expected/test.json
+
+echo
+echo "=== Unit-test summary ==="
+jq '.unit_tests | { total, passed, failed,
+  cases: [ .results[] | { model, test, passed } ] }' expected/test.json
+
+# Assert the unit_tests field reports every case passing.
+TOTAL=$(jq '.unit_tests.total'  expected/test.json)
+PASSED=$(jq '.unit_tests.passed' expected/test.json)
+FAILED=$(jq '.unit_tests.failed' expected/test.json)
+
+if [ "$TOTAL" -lt 2 ]; then
+  echo "FAIL: expected at least 2 unit tests (multiset + ordered), got $TOTAL" >&2
+  exit 1
+fi
+if [ "$FAILED" -ne 0 ] || [ "$PASSED" -ne "$TOTAL" ]; then
+  echo "FAIL: unit_tests not all passing — passed=$PASSED failed=$FAILED total=$TOTAL" >&2
+  exit 1
+fi
+
+echo
+echo "POC complete: $PASSED/$TOTAL fixture-driven unit tests passed"
+echo "  (default multiset comparison + ordered=true positional comparison)."

--- a/examples/playground/pocs/04-governance/09-model-tags-inheritance/README.md
+++ b/examples/playground/pocs/04-governance/09-model-tags-inheritance/README.md
@@ -1,0 +1,120 @@
+# 09-model-tags-inheritance — governance tags: group baseline + per-key override
+
+> **Category:** 04-governance
+> **Credentials:** none (DuckDB)
+> **Runtime:** < 5s
+> **Rocky features:** model `[tags]`, config-group `[tags]` baseline, per-key tag merge (sidecar > group), `models_detail[].tags` on `rocky compile --output json`, dagster-rocky asset-tag projection
+
+## What it shows
+
+Model-level `[tags]` are free-form governance attributes that describe a model
+as a whole — `domain`, `tier`, `owner`, whatever your governance model needs.
+Unlike `[classification]` (keyed by column, drives masking), tags travel with
+the model itself.
+
+When a set of models shares a governance baseline, you declare the `[tags]`
+once on a **config group** and every member inherits it. A member can then
+override a single key from its own `[tags]` without dropping the rest of the
+baseline — the merge is **per key**, sidecar **>** group.
+
+This POC has one group, `finance`, that carries the baseline and two members:
+
+| Model | Own `[tags]` | Resolved tags |
+|---|---|---|
+| `fct_revenue` | `tier = "gold"` | `domain = "finance"`, `tier = "gold"` |
+| `dim_account` | _(none)_ | `domain = "finance"`, `tier = "silver"` |
+
+The group declares `domain = "finance"`, `tier = "silver"` once. `fct_revenue`
+overrides only `tier` (to `gold`) and still inherits `domain = "finance"` —
+the override does **not** replace the whole tag set. `dim_account` declares no
+tags of its own, so it inherits the full baseline verbatim.
+
+`run.sh` compiles both with `rocky compile --output json` and asserts each
+model's `models_detail[].tags` matches the table above.
+
+## The dagster asset-tag projection
+
+Resolved tags don't just live in Rocky's view of the model — `dagster-rocky`
+projects them onto each derived asset so the same governance attribute drives
+both Rocky and the orchestrator.
+
+`RockyDagsterTranslator.get_model_tags()` reads `models_detail[].tags` and
+emits each one as a **first-class Dagster tag**, so the governed set is usable
+in asset selection directly — for example `tag:domain=finance` selects every
+model in the `finance` group, and `tag:tier=gold` narrows to just the
+gold-tier members. Alongside the governance tags it synthesizes namespaced
+metadata tags (`rocky/model_name`, `rocky/target_catalog`,
+`rocky/target_schema`, `rocky/strategy`). The synthesized keys always contain a
+`/` and the governance keys never do, so a governance tag can never clobber
+Rocky's own metadata.
+
+The net effect: a `tier` baseline set once on the `finance` group, with one
+model bumped to `gold`, shows up as `tier=silver` / `tier=gold` Dagster tags on
+the corresponding assets — no per-asset tagging code, no drift between the two
+systems.
+
+## Why it's distinctive
+
+- A governance attribute applied **once** on a config group lands on the whole
+  set of members, and a single member can diverge on one key without losing the
+  rest of the baseline. That's inheritance with per-key precedence, not
+  copy-paste-per-model.
+- The same resolved tags reach the orchestrator: `dagster-rocky` turns them
+  into first-class, selectable Dagster tags. Governance declared in the model
+  layer is enforced and queryable in the asset graph end-to-end.
+
+## Layout
+
+```
+.
+├── README.md
+├── rocky.toml                    pipeline + adapter (DuckDB)
+├── run.sh                        compile + per-model tag assertions
+└── models/
+    ├── _defaults.toml            shared target (catalog + schema)
+    ├── groups/
+    │   └── finance.toml          the group: [tags] baseline + shared [strategy]
+    ├── fct_revenue.sql + .toml    member, overrides tier -> gold (keeps domain)
+    └── dim_account.sql + .toml    member, inherits the full baseline
+```
+
+## Run
+
+```bash
+./run.sh
+```
+
+## Expected output
+
+```text
+Resolved governance tags per model (models_detail[].tags):
+  dim_account    -> {domain=finance, tier=silver}
+  fct_revenue    -> {domain=finance, tier=gold}
+```
+
+## Precedence rules
+
+For each tag key, **sidecar > group**:
+
+1. A member model's own `[tags]` value for a key wins.
+2. Otherwise the config-group `[tags]` value for that key applies.
+
+The merge is per key — overriding one key keeps every other key inherited from
+the group. A model that belongs to no group simply carries its own `[tags]`.
+
+## Related
+
+- Routing fan-out via a config group's `schema_template` + `[args]`, plus the
+  enforced-group load guards:
+  `examples/playground/pocs/00-foundations/14-config-groups/`.
+- Per-column classification tags that drive masking (the column-keyed sibling
+  of model `[tags]`):
+  `examples/playground/pocs/04-governance/05-classification-masking-compliance/`.
+- Model format reference — `[tags]` and Group tags:
+  `docs/src/content/docs/reference/model-format.md` (`#tags`, `#group-tags`).
+- The dagster tag projection lives at
+  `integrations/dagster/src/dagster_rocky/translator.py`
+  (`RockyDagsterTranslator.get_model_tags`).
+- The group loader + tag merge live at
+  `engine/crates/rocky-core/src/models.rs` (`resolve_model_config`).
+```

--- a/examples/playground/pocs/04-governance/09-model-tags-inheritance/models/_defaults.toml
+++ b/examples/playground/pocs/04-governance/09-model-tags-inheritance/models/_defaults.toml
@@ -1,0 +1,8 @@
+# Directory-level target defaults.
+#
+# Both members share one catalog + schema and differ only by table name
+# (the filename stem). This POC is about tag inheritance, not routing — so the
+# target is kept deliberately uniform across the group.
+[target]
+catalog = "warehouse"
+schema = "marts"

--- a/examples/playground/pocs/04-governance/09-model-tags-inheritance/models/dim_account.sql
+++ b/examples/playground/pocs/04-governance/09-model-tags-inheritance/models/dim_account.sql
@@ -1,0 +1,1 @@
+SELECT 1 AS account_id, 'acme' AS account, 'emea' AS region

--- a/examples/playground/pocs/04-governance/09-model-tags-inheritance/models/dim_account.toml
+++ b/examples/playground/pocs/04-governance/09-model-tags-inheritance/models/dim_account.toml
@@ -1,0 +1,8 @@
+# Member 2 — inherits the FULL group baseline, overrides nothing.
+#
+# Joins the `finance` group with no [tags] of its own, so it inherits the
+# group's baseline verbatim.
+#
+# Resolved tags: domain = "finance", tier = "silver".
+
+group = "finance"

--- a/examples/playground/pocs/04-governance/09-model-tags-inheritance/models/fct_revenue.sql
+++ b/examples/playground/pocs/04-governance/09-model-tags-inheritance/models/fct_revenue.sql
@@ -1,0 +1,1 @@
+SELECT 1 AS account_id, 'acme' AS account, 1000 AS revenue

--- a/examples/playground/pocs/04-governance/09-model-tags-inheritance/models/fct_revenue.toml
+++ b/examples/playground/pocs/04-governance/09-model-tags-inheritance/models/fct_revenue.toml
@@ -1,0 +1,15 @@
+# Member 1 — OVERRIDES one tag, inherits the rest.
+#
+# Joins the `finance` group, so it inherits the group's [tags] baseline
+# (domain = "finance", tier = "silver") and its [strategy].
+#
+# Its own [tags] pins tier = "gold". The merge is PER KEY: tier is overridden,
+# but domain = "finance" is still inherited from the group — the override does
+# NOT replace the whole tag set.
+#
+# Resolved tags: domain = "finance", tier = "gold".
+
+group = "finance"
+
+[tags]
+tier = "gold"

--- a/examples/playground/pocs/04-governance/09-model-tags-inheritance/models/groups/finance.toml
+++ b/examples/playground/pocs/04-governance/09-model-tags-inheritance/models/groups/finance.toml
@@ -1,0 +1,16 @@
+# Config group: finance
+#
+# This group exists purely to carry a governance baseline — no schema_template,
+# no fan-out routing (see 00-foundations/14-config-groups for that). It supplies:
+#   * [tags]     — a governance baseline (domain + tier) inherited by every member.
+#   * [strategy] — one shared materialization for the whole group.
+#
+# Every member opts in with `group = "finance"`. A member's own [tags] override
+# the group PER KEY (sidecar > group) without dropping the rest of the baseline.
+
+[tags]
+domain = "finance"
+tier = "silver"
+
+[strategy]
+type = "full_refresh"

--- a/examples/playground/pocs/04-governance/09-model-tags-inheritance/rocky.toml
+++ b/examples/playground/pocs/04-governance/09-model-tags-inheritance/rocky.toml
@@ -1,0 +1,22 @@
+# 09-model-tags-inheritance — governance tags: group baseline + per-key override
+#
+# A config group declares a [tags] baseline once; every member model inherits
+# it, and a member can override a single key from its own [tags] without
+# dropping the rest (sidecar > group, merged per key). The resolved tags land
+# on `rocky compile --output json` as models_detail[].tags, which dagster-rocky
+# projects onto each derived asset's Dagster tags.
+
+[adapter]
+type = "duckdb"
+path = "poc.duckdb"
+
+[pipeline.marts]
+type = "transformation"
+
+# Transformation pipelines defer catalog/schema/table to per-model sidecars
+# (here, to models/_defaults.toml). The adapter reference is all that's needed
+# at the pipeline level.
+[pipeline.marts.target]
+
+[pipeline.marts.target.governance]
+auto_create_schemas = true

--- a/examples/playground/pocs/04-governance/09-model-tags-inheritance/run.sh
+++ b/examples/playground/pocs/04-governance/09-model-tags-inheritance/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# 09-model-tags-inheritance — governance tags: group baseline + per-key override
+#
+# Compiles two members of the `finance` config group and asserts each model's
+# resolved governance tags (models_detail[].tags):
+#   * fct_revenue  -> domain=finance, tier=gold    (overrides tier, inherits domain)
+#   * dim_account  -> domain=finance, tier=silver  (inherits the full baseline)
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+mkdir -p expected
+rm -f .rocky-state.redb poc.duckdb
+
+fail() { echo "ASSERT FAILED: $1" >&2; exit 1; }
+
+echo "=== Config group 'finance' declares a [tags] baseline: domain=finance, tier=silver ==="
+echo "    fct_revenue overrides tier=gold (keeps inherited domain); dim_account inherits both."
+echo
+
+rocky compile --models models --output json > expected/compile.json 2>/dev/null
+
+echo "Resolved governance tags per model (models_detail[].tags):"
+# House convention: assert with python3, not jq (jq may not be on the PATH).
+# The jq form would be:  jq -r '.models_detail[] | "\(.name) \(.tags)"' expected/compile.json
+python3 -c "
+import json
+d = json.load(open('expected/compile.json'))
+for m in sorted(d.get('models_detail', []), key=lambda x: x['name']):
+    tags = ', '.join(f'{k}={v}' for k, v in sorted(m.get('tags', {}).items()))
+    print(f'  {m[\"name\"]:14s} -> {{{tags}}}')
+"
+echo
+
+# Assert the inherited + overridden tags appear per model.
+python3 -c "
+import json, sys
+d = json.load(open('expected/compile.json'))
+by = {m['name']: m.get('tags', {}) for m in d['models_detail']}
+
+def need(model, key, val):
+    got = by.get(model, {}).get(key)
+    if got != val:
+        sys.exit(f'tag {key}={val} expected on {model}, got {got!r}')
+
+# Member 1: overrides tier=gold, still inherits domain=finance (per-key merge).
+need('fct_revenue', 'domain', 'finance')
+need('fct_revenue', 'tier',   'gold')
+# Member 2: inherits the full baseline, overrides nothing.
+need('dim_account', 'domain', 'finance')
+need('dim_account', 'tier',   'silver')
+
+# The override is per KEY, not whole-set: fct_revenue keeps exactly two tags.
+if sorted(by['fct_revenue']) != ['domain', 'tier']:
+    sys.exit(f'fct_revenue should keep domain+tier, got {sorted(by[\"fct_revenue\"])}')
+
+print('OK: group [tags] baseline inherited; fct_revenue overrode tier per-key (domain stayed inherited)')
+" || fail "tag inheritance / per-key override assertion failed"
+
+echo
+echo "POC complete:"
+echo "  - config group 'finance' declared the baseline domain=finance, tier=silver once"
+echo "  - fct_revenue inherited domain=finance and overrode tier -> gold (per-key merge)"
+echo "  - dim_account inherited the full baseline -> domain=finance, tier=silver"
+echo "  - dagster-rocky projects these onto each derived asset's Dagster tags"

--- a/examples/playground/pocs/06-developer-experience/12-catalog-emit/README.md
+++ b/examples/playground/pocs/06-developer-experience/12-catalog-emit/README.md
@@ -5,7 +5,7 @@
 > **Category:** 06-developer-experience
 > **Credentials:** none (DuckDB)
 > **Runtime:** < 5s
-> **Rocky features:** `rocky catalog`, `--format json|parquet|both`, `--out`, state-store enrichment
+> **Rocky features:** `rocky catalog`, `--format json|parquet|both`, `--out`, state-store enrichment, per-column docs (`[columns.<name>]` → `CatalogColumn.description`)
 
 ## What it shows
 
@@ -17,7 +17,8 @@ self-contained, machine-consumable lineage artefact under
   `last_run_id`, an `assets[]` array (one per model with its columns +
   upstream/downstream models), and an `edges[]` array of column-level
   lineage edges including transform kind (`direct`, `aggregation: sum`,
-  …) and confidence.
+  …) and confidence. Each asset column carries a `description` field when
+  the model's sidecar documents it via a `[columns.<name>]` table.
 - `edges.parquet` — flat table of column-lineage edges. Any Parquet
   reader (DuckDB, Polars, Spark, BigQuery external table, Athena…) can
   query it without going through the engine.
@@ -36,6 +37,11 @@ self-contained, machine-consumable lineage artefact under
   table-to-table edges only.
 - **No engine on the read path.** Once the catalog is written, lineage
   consumers (Looker, Superset, custom dashboards) read Parquet directly.
+- **Per-column docs ride along.** A `[columns.<name>]` table in a model's
+  sidecar attaches a description to one *projected* output column, and it
+  surfaces as `CatalogColumn.description` in `rocky catalog --output json`.
+  A description keyed to a column the SELECT doesn't produce is silently
+  dropped, so the keys stay honest about the real output schema.
 
 ## Layout
 
@@ -49,7 +55,8 @@ self-contained, machine-consumable lineage artefact under
     ├── _defaults.toml      catalog=poc, schema=demo
     ├── raw_orders.sql      SELECT … FROM raw__orders.orders
     ├── stg_orders.sql      filter cancelled
-    └── fct_revenue.sql     group by customer_id → SUM(amount), COUNT(order_id)
+    ├── fct_revenue.sql     group by customer_id → SUM(amount), COUNT(order_id)
+    └── fct_revenue.toml    [columns.total] / [columns.orders] docs the SUM/COUNT outputs
 ```
 
 ## Prerequisites
@@ -74,6 +81,11 @@ self-contained, machine-consumable lineage artefact under
    shows each asset's columns + upstream models, then queries
    `edges.parquet` directly via DuckDB to prove the artefact is
    tool-agnostic.
+4. **Per-column docs** — `fct_revenue.toml` carries `[columns.total]` and
+   `[columns.orders]` descriptions (keyed to the aggregated output columns,
+   not the raw inputs). The demo re-emits `catalog.json`, prints every
+   column with a description, then asserts `fct_revenue.total.description`
+   is populated in `rocky catalog --output json`.
 
 ## Related
 

--- a/examples/playground/pocs/06-developer-experience/12-catalog-emit/models/fct_revenue.toml
+++ b/examples/playground/pocs/06-developer-experience/12-catalog-emit/models/fct_revenue.toml
@@ -1,2 +1,13 @@
 [strategy]
 type = "full_refresh"
+
+# Per-column documentation. Each [columns.<name>] table attaches a description
+# to one *projected* output column. fct_revenue projects the aliases
+# customer_id, total, orders — NOT the raw inputs amount/order_id (those are
+# aggregated away), so the keys below are the SUM/COUNT result columns. A
+# description keyed to a column the SELECT does not produce is silently dropped.
+[columns.total]
+description = "Completed revenue per customer (SUM of order amount, cancelled orders excluded)."
+
+[columns.orders]
+description = "Count of completed orders per customer (COUNT of order_id)."

--- a/examples/playground/pocs/06-developer-experience/12-catalog-emit/run.sh
+++ b/examples/playground/pocs/06-developer-experience/12-catalog-emit/run.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$HERE"
 
-rm -rf .rocky-state.redb poc.duckdb .rocky/catalog
+rm -rf .rocky-state.redb models/.rocky-state.redb poc.duckdb .rocky/catalog
 mkdir -p expected
 
 echo "==> 1. Compile the 3-model DAG (the catalog walks the SemanticGraph; no warehouse needed)"
@@ -45,6 +45,30 @@ FROM read_parquet('.rocky/catalog/edges.parquet')
 ORDER BY target_model, target_column
 LIMIT 6;
 SQL
+
+echo
+echo "==> 3. Per-column docs: [columns.<name>] sidecar descriptions surface as CatalogColumn.description"
+echo "    (fct_revenue.toml documents the projected output columns 'total' and 'orders')"
+rocky catalog --models models --format json --output json > expected/catalog_columns.json
+jq -r '
+  .assets[] | select(.model_name=="fct_revenue") | .columns[]
+  | select(.description != null)
+  | "  fct_revenue.\(.name): \(.description)"
+' expected/catalog_columns.json
+
+echo
+echo "==> Assert the description landed on a projected column (a description on a"
+echo "    non-projected column is silently dropped, so this proves the key is in sync):"
+desc="$(jq -r '
+  .assets[] | select(.model_name=="fct_revenue") | .columns[]
+  | select(.name=="total") | .description
+' expected/catalog_columns.json)"
+if [ -n "$desc" ] && [ "$desc" != "null" ]; then
+  echo "  OK: fct_revenue.total.description = \"$desc\""
+else
+  echo "  FAIL: fct_revenue.total.description is missing or null" >&2
+  exit 1
+fi
 
 echo
 echo "POC complete: catalog.json + edges.parquet + assets.parquet under .rocky/catalog/."

--- a/examples/playground/pocs/06-developer-experience/21-emit-sql-exit-path/README.md
+++ b/examples/playground/pocs/06-developer-experience/21-emit-sql-exit-path/README.md
@@ -1,0 +1,125 @@
+# 21-emit-sql-exit-path — the tested no-lock-in exit path
+
+> **Category:** 06-developer-experience
+> **Credentials:** none (DuckDB)
+> **Runtime:** < 5s
+> **Rocky features:** `rocky emit-sql --out-dir`, `rocky dag` execution order, surrogate-key injection on the emit path
+
+## What it shows
+
+Adopting Rocky is not a one-way door. `rocky emit-sql` compiles the whole
+model DAG offline (no warehouse, no engine to run it) and writes one
+dialect-correct `<model>.sql` file per model — the exact SQL `rocky run`
+would execute, surrogate keys included.
+
+This POC then **proves** those files run Rocky-free. It seeds a fresh DuckDB
+and replays the emitted SQL in dependency order through the plain `duckdb`
+CLI. There is no `rocky run` anywhere in `run.sh`: the final tables are built
+by vanilla DuckDB from the emitted SQL.
+
+```
+rocky emit-sql --out-dir build/sql      # Rocky → plain .sql files (offline)
+duckdb poc.duckdb < data/seed.sql       # fresh DuckDB, seeded source
+for m in $(rocky dag …); do             # replay in dependency order
+    duckdb poc.duckdb < build/sql/$m.sql #   ← plain DuckDB, no rocky run
+done
+```
+
+The feature proof is a table built by plain DuckDB from emitted SQL — and a
+surrogate key that survives the trip.
+
+## Why it's distinctive
+
+- **The proof is execution, not inspection.** Most "export your SQL" stories
+  stop at "here are the files." This one runs them: the assertion is
+  `SELECT count(*) FROM poc.main.revenue_by_region` against a database Rocky
+  never touched.
+- **Rocky's value-add survives the exit.** `stg_orders` declares a
+  `[[surrogate_key]]`. On the emit path Rocky injects
+  `CAST(md5(…) AS VARCHAR) AS order_key` into the SELECT, so the 32-char hash
+  key is rebuilt by plain DuckDB's `md5()` — not by `rocky run`. The exit path
+  carries the modeling, not just the raw SELECT.
+- **The DSL reduces too.** `customer_orders` is a Rocky DSL group-by, yet it
+  emits ordinary `GROUP BY … HAVING …` SQL that DuckDB runs unaided.
+- **Dependency order is audited, not guessed.** Replay order comes from
+  `rocky dag --output json` (`execution_layers`), not a fragile alphabetical
+  glob — `customer_orders.sql` would otherwise sort before its upstream
+  `stg_orders.sql`.
+
+## How it resolves with zero gymnastics
+
+The emitted SQL mixes fully-qualified write targets
+(`CREATE OR REPLACE TABLE poc.main.stg_orders`) with bare upstream references
+(`FROM stg_orders`). Both resolve in vanilla DuckDB because the catalog name
+(`poc`) matches the DuckDB file stem (`poc.duckdb`): opening `poc.duckdb`
+makes `poc` the default catalog and `main` the default schema, so
+`poc.main.stg_orders` and bare `FROM stg_orders` point at the same table. No
+`ATTACH`, no `SET search_path`.
+
+## Layout
+
+```
+.
+├── README.md                  this file
+├── rocky.toml                 transformation pipeline, catalog=poc, schema=main
+├── run.sh                     emit-sql → seed → replay → assert (no rocky run)
+├── data/
+│   └── seed.sql               seeds raw__sales.orders (acme / globex, emea / us_west)
+└── models/
+    ├── stg_orders.sql         FROM raw__sales.orders
+    ├── stg_orders.toml        [[surrogate_key]] order_key = md5(tenant, order_id)
+    ├── customer_orders.rocky  Rocky DSL group-by over stg_orders
+    ├── customer_orders.toml   depends_on = ["stg_orders"]
+    ├── revenue_by_region.sql  GROUP BY tenant, region over stg_orders
+    └── revenue_by_region.toml depends_on = ["stg_orders"]
+```
+
+## Prerequisites
+
+- `rocky` CLI on PATH
+- `duckdb` CLI (`brew install duckdb`)
+- `jq` (to read `rocky dag` JSON)
+
+## Run
+
+```bash
+./run.sh
+# or, by hand:
+rocky emit-sql --models models --out-dir build/sql   # Rocky → plain .sql files
+duckdb poc.duckdb < data/seed.sql                     # seed the source
+duckdb poc.duckdb < build/sql/stg_orders.sql          # replay in dep order…
+duckdb poc.duckdb < build/sql/customer_orders.sql
+duckdb poc.duckdb < build/sql/revenue_by_region.sql
+duckdb poc.duckdb "SELECT * FROM poc.main.revenue_by_region"  # built Rocky-free
+```
+
+## Expected output
+
+```text
+emit-sql: wrote 3 model(s) to build/sql in dependency order
+OK: build/sql/stg_orders.sql builds order_key with md5()
+poc.main.revenue_by_region rows: 4
+poc.main.stg_orders.order_key length: 32
+POC complete: 3 models reduced to plain SQL via emit-sql; a fresh DuckDB built
+revenue_by_region (and a 32-char md5 order_key) with no rocky run.
+```
+
+## What happened
+
+1. `rocky emit-sql --out-dir build/sql` compiles the DAG offline and writes
+   `stg_orders.sql`, `customer_orders.sql`, `revenue_by_region.sql` — each a
+   `CREATE OR REPLACE TABLE poc.main.<model> AS …` statement.
+2. `rocky dag --output json` yields the replay order (`stg_orders` →
+   `customer_orders`, `revenue_by_region`).
+3. `duckdb poc.duckdb < data/seed.sql` seeds `raw__sales.orders` into the same
+   file the emitted SQL writes into.
+4. Each emitted file is replayed through the plain `duckdb` CLI. No `rocky run`.
+5. `run.sh` asserts `poc.main.revenue_by_region` has rows and that
+   `order_key` is a 32-char md5 — both produced by DuckDB alone.
+6. `rocky test` runs the same models in-memory for parity, confirming the SQL
+   you just proved is the SQL Rocky would have executed.
+
+## Related
+
+- [`00-foundations/00-playground-default`](../../00-foundations/00-playground-default) — the same DAG shape, materialized the normal way with `rocky run`.
+- [`08-portability-lint`](../08-portability-lint) — the other half of "your SQL travels": compile-time rejection of dialect-divergent constructs before they ever reach a warehouse.

--- a/examples/playground/pocs/06-developer-experience/21-emit-sql-exit-path/data/seed.sql
+++ b/examples/playground/pocs/06-developer-experience/21-emit-sql-exit-path/data/seed.sql
@@ -1,0 +1,22 @@
+-- Seed data for the emit-sql exit-path POC.
+--
+-- `rocky test` auto-loads this file into an in-memory DuckDB. The exit-path
+-- replay in run.sh loads it into the persistent `poc.duckdb` (the same file
+-- the emitted SQL writes into) before replaying the emitted `<model>.sql`
+-- files:
+--   duckdb poc.duckdb < data/seed.sql
+
+CREATE SCHEMA IF NOT EXISTS raw__sales;
+
+CREATE OR REPLACE TABLE raw__sales.orders AS
+SELECT
+    CASE WHEN i % 2 = 0 THEN 'acme' ELSE 'globex' END AS tenant,
+    i AS order_id,
+    1 + (i % 40) AS customer_id,
+    CASE WHEN i % 3 = 0 THEN 'emea' ELSE 'us_west' END AS region,
+    ROUND(CAST(5.0 + (i * 7 % 490) AS DECIMAL(10,2)), 2) AS amount,
+    CASE WHEN i % 19 = 0 THEN 'cancelled'
+         WHEN i % 11 = 0 THEN 'pending'
+         ELSE 'completed' END AS status,
+    CAST(DATE '2025-06-01' + CAST(i % 90 AS INTEGER) AS DATE) AS order_date
+FROM generate_series(1, 300) AS t(i);

--- a/examples/playground/pocs/06-developer-experience/21-emit-sql-exit-path/models/customer_orders.rocky
+++ b/examples/playground/pocs/06-developer-experience/21-emit-sql-exit-path/models/customer_orders.rocky
@@ -1,0 +1,10 @@
+-- Customer order rollup (Rocky DSL group-by) — proves the DSL also reduces to
+-- plain SQL on the emit-sql exit path, not just hand-written SQL models.
+from stg_orders
+where status != "cancelled"
+group customer_id {
+    total_revenue: sum(amount),
+    order_count: count(),
+    first_order: min(order_date)
+}
+where total_revenue > 0

--- a/examples/playground/pocs/06-developer-experience/21-emit-sql-exit-path/models/customer_orders.toml
+++ b/examples/playground/pocs/06-developer-experience/21-emit-sql-exit-path/models/customer_orders.toml
@@ -1,0 +1,8 @@
+depends_on = ["stg_orders"]
+
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "poc"
+schema = "main"

--- a/examples/playground/pocs/06-developer-experience/21-emit-sql-exit-path/models/revenue_by_region.sql
+++ b/examples/playground/pocs/06-developer-experience/21-emit-sql-exit-path/models/revenue_by_region.sql
@@ -1,0 +1,9 @@
+SELECT
+    tenant,
+    region,
+    COUNT(*) AS order_count,
+    SUM(amount) AS total_revenue,
+    ROUND(AVG(amount), 2) AS avg_order_value
+FROM stg_orders
+WHERE status = 'completed'
+GROUP BY tenant, region

--- a/examples/playground/pocs/06-developer-experience/21-emit-sql-exit-path/models/revenue_by_region.toml
+++ b/examples/playground/pocs/06-developer-experience/21-emit-sql-exit-path/models/revenue_by_region.toml
@@ -1,0 +1,8 @@
+depends_on = ["stg_orders"]
+
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "poc"
+schema = "main"

--- a/examples/playground/pocs/06-developer-experience/21-emit-sql-exit-path/models/stg_orders.sql
+++ b/examples/playground/pocs/06-developer-experience/21-emit-sql-exit-path/models/stg_orders.sql
@@ -1,0 +1,9 @@
+SELECT
+    tenant,
+    order_id,
+    customer_id,
+    region,
+    amount,
+    status,
+    order_date
+FROM raw__sales.orders

--- a/examples/playground/pocs/06-developer-experience/21-emit-sql-exit-path/models/stg_orders.toml
+++ b/examples/playground/pocs/06-developer-experience/21-emit-sql-exit-path/models/stg_orders.toml
@@ -1,0 +1,13 @@
+[strategy]
+type = "full_refresh"
+
+# Rocky injects CAST(md5(tenant || order_id) AS VARCHAR) AS order_key into the
+# emitted SELECT — so the surrogate key survives the exit path and is rebuilt
+# by plain DuckDB, not by rocky run.
+[[surrogate_key]]
+name = "order_key"
+columns = ["tenant", "order_id"]
+
+[target]
+catalog = "poc"
+schema = "main"

--- a/examples/playground/pocs/06-developer-experience/21-emit-sql-exit-path/rocky.toml
+++ b/examples/playground/pocs/06-developer-experience/21-emit-sql-exit-path/rocky.toml
@@ -1,0 +1,26 @@
+# 21-emit-sql-exit-path — prove the no-lock-in exit path.
+#
+# `rocky emit-sql --out-dir build/sql` compiles the model DAG offline and
+# writes one dialect-correct `<model>.sql` file per model — the exact SQL
+# `rocky run` would execute, surrogate keys included. This POC then PROVES
+# those files run Rocky-free: it seeds a fresh DuckDB and replays the emitted
+# SQL in dependency order through the plain `duckdb` CLI, with no `rocky run`.
+#
+# The catalog name (`poc`) matches the DuckDB file stem (`poc.duckdb`), so the
+# emitted `CREATE OR REPLACE TABLE poc.main.<model>` targets and the bare
+# `FROM <upstream>` references both resolve in vanilla DuckDB with no ATTACH
+# and no search_path fiddling.
+
+[adapter]
+type = "duckdb"
+path = "poc.duckdb"
+
+[pipeline.exit_path]
+type = "transformation"
+models = "models/**"
+
+[pipeline.exit_path.target.governance]
+auto_create_schemas = true
+
+[pipeline.exit_path.execution]
+concurrency = 4

--- a/examples/playground/pocs/06-developer-experience/21-emit-sql-exit-path/run.sh
+++ b/examples/playground/pocs/06-developer-experience/21-emit-sql-exit-path/run.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# 21-emit-sql-exit-path — prove the no-lock-in exit path.
+#
+# `rocky emit-sql` reduces the whole model DAG to plain `<model>.sql` files,
+# then this script PROVES those files run Rocky-free: it seeds a fresh DuckDB
+# and replays the emitted SQL in dependency order through the `duckdb` CLI.
+# There is no `rocky run` anywhere below — the final tables are built by plain
+# DuckDB from emitted SQL.
+set -euo pipefail
+
+export ROCKY_SUPPRESS_DEPRECATION=1
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+mkdir -p expected
+rm -rf build
+rm -f .rocky-state.redb poc.duckdb
+
+echo "=== validate ==="
+rocky validate > expected/validate.json
+
+echo "=== emit-sql (compile DAG offline → one <model>.sql per model) ==="
+rocky emit-sql --models models --out-dir build/sql
+echo "emitted SQL files:"
+ls build/sql
+
+# Confirm the value-add survives the exit path: the surrogate key is a real
+# md5() expression in the emitted SQL, computed by plain SQL, not by rocky run.
+echo "=== surrogate key is plain SQL in the emitted file ==="
+grep -q "md5(" build/sql/stg_orders.sql \
+    && echo "OK: build/sql/stg_orders.sql builds order_key with md5()"
+
+# Dependency order comes from Rocky, not from a fragile alphabetical glob.
+# (emit-sql already writes in dep order; we use `rocky dag` to drive the
+# replay explicitly so the order is auditable.)
+echo "=== resolve replay order from rocky dag ==="
+ORDER="$(rocky dag --models models --output json 2>/dev/null \
+    | jq -r '.execution_layers[][]' \
+    | sed 's/^transformation://')"
+echo "replay order: $(echo "$ORDER" | tr '\n' ' ')"
+
+echo "=== seed a fresh DuckDB (the same file the emitted SQL writes into) ==="
+duckdb poc.duckdb < data/seed.sql
+
+echo "=== replay emitted SQL through plain duckdb — NO rocky run ==="
+while IFS= read -r model; do
+    [ -n "$model" ] || continue
+    echo "  duckdb poc.duckdb < build/sql/${model}.sql"
+    duckdb poc.duckdb < "build/sql/${model}.sql"
+done <<< "$ORDER"
+
+echo "=== assert the final table materialized via plain DuckDB ==="
+ROWS="$(duckdb -noheader -list poc.duckdb \
+    "SELECT count(*) FROM poc.main.revenue_by_region")"
+echo "poc.main.revenue_by_region rows: $ROWS"
+if [ "$ROWS" -lt 1 ]; then
+    echo "FAIL: revenue_by_region is empty — emitted SQL did not materialize it" >&2
+    exit 1
+fi
+
+echo "=== assert the surrogate key was rebuilt by plain DuckDB (32-char md5) ==="
+KEYLEN="$(duckdb -noheader -list poc.duckdb \
+    "SELECT length(order_key) FROM poc.main.stg_orders LIMIT 1")"
+echo "poc.main.stg_orders.order_key length: $KEYLEN"
+if [ "$KEYLEN" != "32" ]; then
+    echo "FAIL: order_key is not a 32-char md5 hash" >&2
+    exit 1
+fi
+
+echo "tables built by plain DuckDB from emitted SQL:"
+duckdb poc.duckdb \
+    "SELECT table_name FROM information_schema.tables WHERE table_schema='main' ORDER BY table_name"
+
+# Sanity: the same models also pass Rocky's in-memory test path (auto-loads
+# data/seed.sql), so the emitted SQL we just proved is the same SQL Rocky runs.
+echo "=== rocky test (in-memory, for parity) ==="
+rocky test --models models > expected/test.json
+
+echo "POC complete: 3 models reduced to plain SQL via emit-sql; a fresh DuckDB built revenue_by_region (and a 32-char md5 order_key) with no rocky run."


### PR DESCRIPTION
PR 3 (final) of the docs/POC sweep (after #930 reference docs, #934 discovery docs). The audit found **no runnable POC natively authored any of the 1.52.0 features** — this adds them.

## Six new credential-free DuckDB POCs

Each has a `run.sh` I re-ran end-to-end against the built **1.52.0** binary (EXIT 0), and each was independently verified to *genuinely* exercise its feature (not a vacuous pass):

| POC | Feature | Proof |
|---|---|---|
| `00-foundations/13-surrogate-keys` | `[[surrogate_key]]` | injects a 32-char MD5 hash column into the materialized table; **byte-identical to `dbt_utils.generate_surrogate_key`** (recomputed over the full table, incl. the NULL-sentinel path) |
| `00-foundations/14-config-groups` | config groups | fans `schema_template`+strategy+tags to 3 members → 3 distinct schemas; `broken/` siblings prove the `enforce` and pinned-schema+`[args]` **load guards** (with negation tests) |
| `01-quality/09-named-tests` | `[[use_test]]` | one `test_definitions.toml` applied across models with column/severity overrides, alongside inline `[[tests]]` |
| `01-quality/10-unit-tests` | `[[test]]` | fixture `given`→`expect` unit tests; `unit_tests` summary reports all passing (multiset + `ordered`) |
| `04-governance/09-model-tags-inheritance` | model `[tags]` | group baseline inherited, overridden per-key by a model's own `[tags]`; visible in `rocky compile --output json` |
| `06-developer-experience/21-emit-sql-exit-path` | `rocky emit-sql` | renders a 3-model DAG to plain `.sql`, then **runs it through DuckDB with no Rocky** — the no-lock-in exit path |

Plus **`06-developer-experience/12-catalog-emit`** extended with a `[columns.<name>]` description on a *projected* column, surfaced as `CatalogColumn.description` in `rocky catalog --output json`.

## Cascade + hygiene
- `scripts/update-poc-counts.sh` run: README catalog rows added + counts updated (**94 total / 82 credential-free**), idempotent — satisfies `poc-counts-drift.yml`.
- All run.sh: `set -euo pipefail` (the config-groups one uses `set -uo pipefail` deliberately, matching the broken-sibling precedent), bare `rocky`, credential-free, state cleaned.
- No build artifacts committed (`poc.duckdb` / `*.redb` / `.rocky/` / `expected/` are gitignored). GOLD/proprietary grep clean.

Docs-only/examples PR — like #930/#934 it'll sit BLOCKED on engine checks that never run; merge with `gh pr merge --squash --admin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)