### PR TITLE
docs: note rocky-lsp preference in ide-setup + changelog the installer fix

### DIFF
--- a/docs/src/content/docs/guides/ide-setup.md
+++ b/docs/src/content/docs/guides/ide-setup.md
@@ -83,7 +83,7 @@ This avoids rebuilding a VSIX on every change. Run `npm run compile` after editi
 
 ## 2. Configure the Rocky Binary Path
 
-The extension launches the Rocky language server by running `rocky lsp`. By default, it looks for `rocky` on your `PATH`. If Rocky is installed elsewhere, configure the path:
+The extension runs the Rocky language server. It prefers a standalone `rocky-lsp` binary when one is available (the install scripts place `rocky-lsp` next to `rocky`), and otherwise falls back to running `rocky lsp`. By default it resolves both from your `PATH`. If Rocky is installed elsewhere, configure the path:
 
 1. Open VS Code Settings (**Cmd+,** / **Ctrl+,**)
 2. Search for `rocky.server.path`

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The installers now also install the standalone `rocky-lsp` binary** next to `rocky`, and the Windows installer replaces an in-use `rocky.exe` (rename-then-replace) instead of failing the overwrite. The VS Code extension prefers `rocky-lsp` for the language server, so updating `rocky` no longer fails because the editor is running it. (#931)
+
 ## [1.52.0] — 2026-06-19
 
 ### Added


### PR DESCRIPTION
Two small follow-ups after #931 (installers now ship `rocky-lsp` + Windows rename-then-replace):

- **`guides/ide-setup.md`** — the "Configure the Rocky Binary Path" section said the extension runs `rocky lsp` and looks for `rocky` on PATH. It now notes the extension *prefers* a standalone `rocky-lsp` (which the install scripts place next to `rocky`) and falls back to `rocky lsp` — matching the extension's actual resolution and the reason `rocky.exe` no longer gets locked on Windows updates.
- **`engine/CHANGELOG.md` `[Unreleased]`** — records the #931 installer fix so the next engine release notes mention it. The fix itself is already live (the install one-liners fetch from `main`); this is release-notes hygiene, not a code change.

No binary/wheel/extension source changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)