### PR TITLE
docs: distinguish Rocky's semantic lints from SQL style linters

### DIFF
--- a/docs/src/content/docs/concepts/linters.md
+++ b/docs/src/content/docs/concepts/linters.md
@@ -14,6 +14,16 @@ Rocky ships two built-in lints that catch the two most common silent-breakage cl
 
 ---
 
+## Semantic lints, not style lints
+
+A SQL style linter such as SQLFluff checks the text of a query: indentation, alias conventions, ambiguous references, unused columns. It runs before the warehouse executes anything and reasons only about the SQL as written. That work is worth doing, and Rocky doesn't replace it. Run a style linter alongside Rocky if you want consistent formatting.
+
+Rocky's lints answer a different question. P001 and P002 are **semantic**: they read the compiled model graph, not a single query in isolation, so they catch breakage a style linter can't see. P001 knows a construct won't run on your target warehouse. P002 knows a `SELECT *` will silently propagate an upstream schema change to a specific downstream consumer. A query can be perfectly well-formatted and still fail both.
+
+These compile-time lints are the first of three layers. Beyond them, Rocky enforces at run time: [data-quality checks](/concepts/data-quality-checks/) and [schema-drift detection](/concepts/schema-drift/) verify that a model's actual output still matches what it declared. A style linter checks that the SQL is well-formed. Rocky's lints check it won't break the graph. The contract layer checks the data itself is what you promised.
+
+---
+
 ## P001 — dialect portability
 
 Rejects SQL constructs that don't exist on the chosen warehouse dialect. Detection is AST-based (sqlparser visitor over each model's SQL), using the same catalog that backs Rocky's SQL transpiler.


### PR DESCRIPTION
## What

Adds a **"Semantic lints, not style lints"** section to `concepts/linters.md`. The page documented P001/P002 but never related them to SQLFluff-style text linters, so a reader couldn't place where Rocky's lints sit.

## The distinction

Three layers, Rocky owns the last two:

- **Text-style lint** (SQLFluff and similar) — formatting, aliasing, ambiguous references. Rocky doesn't replace it; run one alongside.
- **Semantic compile-time lint** (Rocky `P001`/`P002`) — reads the compiled model graph; catches non-portable constructs and blast-radius `SELECT *`.
- **Runtime enforcement** (data-quality checks + schema-drift) — verifies a model's output still matches what it declared.

Evergreen by design: the dbt-Fusion `dbt lint` comparison stays on the dated `getting-started/comparison.md` page, which already handles it.

## Verification

- `npm run build` (astro): 89 pages, no errors, `/concepts/linters/` renders.
- Internal links resolve to existing `/concepts/data-quality-checks/` and `/concepts/schema-drift/` pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)