### PR TITLE
docs: lead README with concrete category + reconcile docs prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![VS Code CI](https://github.com/rocky-data/rocky/actions/workflows/vscode-ci.yml/badge.svg)](https://github.com/rocky-data/rocky/actions/workflows/vscode-ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
-**Rocky checks your SQL data pipelines and catches problems before they reach your warehouse.**
+**Rocky is a SQL transformation engine that type-checks your whole pipeline and catches breaking changes before they run.**
 
 Works with Databricks, Snowflake, BigQuery, and DuckDB. You keep your warehouse and your existing SQL. Apache 2.0.
 

--- a/ROCKY_EXPLAINED.md
+++ b/ROCKY_EXPLAINED.md
@@ -8,7 +8,7 @@ Everything Rocky does, from the outside in, with ASCII diagrams.
 
 Rocky is a **typed, compiled data platform**. You write SQL (or a SQL-like DSL). Rocky compiles it, checks it for mistakes, then runs it against your warehouse.
 
-The closest comparison is dbt — but Rocky has a real compiler. There's no Jinja templating, no string-substitution tricks. Rocky parses your SQL into a typed tree, checks types across the whole DAG at once, and only generates warehouse SQL after everything has been verified.
+The closest comparison is dbt Core — but Rocky has a real compiler. There's no Jinja templating, no string-substitution tricks. Rocky parses your SQL into a typed tree, checks types across the whole DAG at once, and only generates warehouse SQL after everything has been verified.
 
 ```
 You write this:            Rocky does this:              Warehouse gets this:

--- a/docs/src/content/docs/concepts/rocky-dsl.md
+++ b/docs/src/content/docs/concepts/rocky-dsl.md
@@ -5,7 +5,7 @@ sidebar:
   order: 8
 ---
 
-Rocky's DSL is a pipeline-oriented alternative to SQL for transformation models. `.rocky` files lower to standard SQL before execution; the warehouse only sees SQL.
+Rocky's DSL is a pipeline-oriented syntax for transformation models. `.rocky` files lower to standard SQL before execution; the warehouse only sees SQL.
 
 :::note[The DSL is optional]
 Rocky is **SQL-first**. Every feature works with plain `.sql` files. The DSL exists for teams that want a more readable shape for multi-step transformations. Mix and match freely: a DSL model can depend on a SQL model and vice versa.

--- a/docs/src/content/docs/guides/playground.mdx
+++ b/docs/src/content/docs/guides/playground.mdx
@@ -385,7 +385,7 @@ cd examples/playground/benchmarks
 make bench
 ```
 
-Headline (50k models): Rocky compiles in **10.5s**, **15x faster** than dbt-core, **21x faster** than dbt-fusion, with **5.3x less memory**.
+Headline (10k models): Rocky compiles in **1.00s**, **34x faster** than dbt-core and **38x faster** than dbt-fusion, with **4-7x less memory**. See [Benchmarks](/getting-started/benchmarks/) for the methodology and the 50k extrapolation.
 
 ## Next Steps
 

--- a/docs/src/content/docs/python-sdk/recipes.md
+++ b/docs/src/content/docs/python-sdk/recipes.md
@@ -45,7 +45,7 @@ except RockyCommandError as exc:
 
 ### Partial success
 
-`run()` returns its `RunResult` even when some tables fail — it does not raise —
+`run()` returns its `RunResult` even when some tables fail (it does not raise),
 so you can act on what landed and report the rest:
 
 ```python


### PR DESCRIPTION
## What

- **README hero** now leads with the concrete category: *"Rocky is a SQL transformation engine that type-checks your whole pipeline and catches breaking changes before they run."* A cold reader (GitHub search, HN, a "dbt alternatives" tab) files Rocky in the transformation-engine slot immediately and gets the wedge in the same sentence.
- **playground.mdx benchmark fix** (the one substantive defect): the "50k models" headline claimed 10.5s, 15x/21x faster, 5.3x less memory. Those figures were stale and roughly 2x off, and they contradicted the canonical `benchmarks.md` (10k at 1.00s, 34x/38x, 4-7x memory; 50k extrapolates to ~5.0s, not 10.5s). Replaced with the canonical 10k headline plus a link to the full methodology.
- **ROCKY_EXPLAINED.md**: qualified "dbt" to "dbt Core" so the "real compiler" contrast stays accurate now that dbt Fusion ships a Rust compiler.
- **rocky-dsl.md**: the DSL is "a pipeline-oriented syntax for transformation models", not an "alternative to SQL". Raw SQL stays first-class.
- **recipes.md**: de-dashed one parenthetical aside.

## Context

Out of a full re-review of the README and docs prose. The prose is otherwise in good shape across all content sections; these are the only fixes. The repo description, homepage, and topics were updated separately to match the README's concrete framing.

## Merge note

Docs-only, so the engine protect-main checks won't run. This will sit BLOCKED and needs an admin squash-merge.