### PR TITLE
feat(engine): roll `rocky cost` up by tenant or model

### DIFF
--- a/editors/vscode/src/types/generated/cost.ts
+++ b/editors/vscode/src/types/generated/cost.ts
@@ -26,6 +26,10 @@ export interface CostOutput {
   command: string;
   duration_ms: number;
   finished_at: string;
+  /**
+   * Grouped cost rollup, present only when `--by <dimension>` is passed. `--by model` produces one group per model; `--by tenant` produces one group per tenant (models with no recorded tenant land in an `"<unattributed>"` bucket). `None` (and omitted from JSON) for a plain `rocky cost` invocation, so the default output shape is unchanged. `per_model` is always present regardless of grouping.
+   */
+  groups?: CostGroup[] | null;
   per_model: PerModelCostHistorical[];
   run_id: string;
   started_at: string;
@@ -48,6 +52,42 @@ export interface CostOutput {
   total_duration_ms: number;
   trigger: string;
   version: string;
+  [k: string]: unknown;
+}
+/**
+ * One grouped row in [`CostOutput::groups`], emitted when `rocky cost` is run with `--by <dimension>`.
+ *
+ * Each group sums the per-model figures of the executions that share the grouping key (a tenant, or a model name). The cost roll-up uses the same `compute_observed_cost_usd` figures as [`PerModelCostHistorical`], so a `--by tenant` total equals the sum of its members' `cost_usd`.
+ */
+export interface CostGroup {
+  /**
+   * Dimension the grouping was performed on: `"tenant"` or `"model"`.
+   */
+  dimension: string;
+  /**
+   * The grouping key's value — the tenant name, the model name, or the literal `"<unattributed>"` for the `--by tenant` bucket that collects executions with no recorded tenant.
+   */
+  key: string;
+  /**
+   * Number of model executions rolled into this group.
+   */
+  model_count: number;
+  /**
+   * Sum of the group's member `bytes_scanned`. `None` when no member reported bytes scanned.
+   */
+  total_bytes_scanned?: number | null;
+  /**
+   * Sum of the group's member `bytes_written`. `None` when no member reported bytes written.
+   */
+  total_bytes_written?: number | null;
+  /**
+   * Sum of every member's `cost_usd` that produced a number. `None` when no member produced a cost.
+   */
+  total_cost_usd?: number | null;
+  /**
+   * Wall-clock time summed across the group's member executions.
+   */
+  total_duration_ms: number;
   [k: string]: unknown;
 }
 /**
@@ -74,5 +114,9 @@ export interface PerModelCostHistorical {
   model_name: string;
   rows_affected?: number | null;
   status: string;
+  /**
+   * Tenant this execution was attributed to, read back from the persisted `rocky_core::state::ModelExecution::tenant`. Present only for replication executions whose source schema declared a `{tenant}` component; `None` (and omitted from JSON) otherwise.
+   */
+  tenant?: string | null;
   [k: string]: unknown;
 }

--- a/editors/vscode/src/types/generated/run.ts
+++ b/editors/vscode/src/types/generated/run.ts
@@ -356,6 +356,10 @@ export interface MaterializationOutput {
    * Wall-clock timestamp captured at the moment the engine began executing this model. Used by `RunOutput::to_run_record` to build accurate per-model windows on the persisted `ModelExecution` — replaces the prior lossy reconstruction (`finished_at - duration`) that mis-ordered parallel runs. `finished_at` is derived as `started_at + duration_ms`; keeping one source of truth avoids drift between the two.
    */
   started_at: string;
+  /**
+   * Tenant this materialization is attributed to, taken from the discover-time schema-pattern `{tenant}` component. Present only for replication pipelines whose schema pattern declares a `{tenant}` placeholder; transformation / `time_interval` models and non-tenant patterns leave it `None`. Carried onto the persisted `rocky_core::state::ModelExecution` by [`RunOutput::to_run_record`] so `rocky cost --by tenant` can roll per-model cost up to a tenant dimension. Omitted from JSON when `None` so non-tenant outputs stay byte-identical.
+   */
+  tenant?: string | null;
   [k: string]: unknown;
 }
 export interface MaterializationMetadata {

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`rocky cost --by tenant` (and `--by model`) — grouped cost rollups.** `rocky cost <run|latest>` can now roll its per-model cost attribution up by a dimension: `--by tenant` groups executions by the discover-time schema-pattern `{tenant}` component (replication models with no recorded tenant collect in an `<unattributed>` bucket), `--by model` groups by model name. The grouped rollup is emitted as an additive `groups` array on the JSON output; `per_model` is always present, so a plain `rocky cost` is byte-for-byte unchanged. The tenant dimension is persisted on each `ModelExecution` as an additive, serde-defaulted field — no state-schema version bump, and pre-existing run records read back as unattributed.
+
 ### Changed
 
 - Added a live BigQuery MERGE-materialization regression test. The `Merge` strategy dispatches unconditionally to `BigQueryDialect::merge_into` (no per-dialect maintenance gate), so it is a BigQuery-reachable `rocky run` path; the new `#[ignore]`-gated test seeds a target, runs the emitted `MERGE … WHEN MATCHED THEN UPDATE … WHEN NOT MATCHED THEN INSERT ROW` against the sandbox, and asserts matched rows are updated and unmatched rows inserted. Mirrors the runner's `ColumnSelection::All` → explicit per-column resolution so it exercises the SQL replication actually emits.

--- a/engine/crates/rocky-cli/src/commands/catalog.rs
+++ b/engine/crates/rocky-cli/src/commands/catalog.rs
@@ -1229,6 +1229,7 @@ mod tests {
                 upstream_freshness: None,
                 bytes_scanned: None,
                 bytes_written: None,
+                tenant: None,
             }
         }
     }

--- a/engine/crates/rocky-cli/src/commands/cost.rs
+++ b/engine/crates/rocky-cli/src/commands/cost.rs
@@ -38,9 +38,47 @@ use rocky_core::config::load_rocky_config;
 use rocky_core::cost::{WarehouseType, compute_observed_cost_usd, warehouse_size_to_dbu_per_hour};
 use rocky_core::state::{ModelExecution, RunRecord, RunStatus, RunTrigger, StateStore};
 
-use crate::output::{CostOutput, PerModelCostHistorical};
+use crate::output::{CostGroup, CostOutput, PerModelCostHistorical};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Sentinel bucket key for executions with no recorded tenant under
+/// `--by tenant`. A literal angle-bracketed string so it can never
+/// collide with a real tenant name (schema-pattern components are
+/// validated identifiers).
+const UNATTRIBUTED: &str = "<unattributed>";
+
+/// Dimension to roll per-model cost up by, selected via `--by`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CostGroupBy {
+    /// One group per tenant (the discover-time `{tenant}` component);
+    /// models with no recorded tenant collect in an `"<unattributed>"`
+    /// bucket.
+    Tenant,
+    /// One group per model name.
+    Model,
+}
+
+impl CostGroupBy {
+    /// Parse the `--by` flag value. Accepts `tenant` / `model`
+    /// case-insensitively.
+    pub fn parse(s: &str) -> Result<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "tenant" => Ok(Self::Tenant),
+            "model" => Ok(Self::Model),
+            other => {
+                anyhow::bail!("unknown --by dimension '{other}' — expected 'tenant' or 'model'")
+            }
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Tenant => "tenant",
+            Self::Model => "model",
+        }
+    }
+}
 
 fn status_str(status: &RunStatus) -> &'static str {
     match status {
@@ -120,6 +158,7 @@ fn build_output(
     record: &RunRecord,
     adapter_info: Option<&(String, WarehouseType, f64, f64)>,
     model_filter: Option<&str>,
+    group_by: Option<CostGroupBy>,
 ) -> CostOutput {
     let executions: Vec<&ModelExecution> = record
         .models_executed
@@ -164,6 +203,7 @@ fn build_output(
         }
         per_model.push(PerModelCostHistorical {
             model_name: exec.model_name.clone(),
+            tenant: exec.tenant.clone(),
             status: exec.status.clone(),
             duration_ms: exec.duration_ms,
             rows_affected: exec.rows_affected,
@@ -172,6 +212,8 @@ fn build_output(
             cost_usd: cost,
         });
     }
+
+    let groups = group_by.map(|by| build_groups(&per_model, by));
 
     let adapter_type = adapter_info.map(|(name, _, _, _)| name.clone());
     let total_cost_usd = if any_cost { Some(total_cost) } else { None };
@@ -205,7 +247,75 @@ fn build_output(
         total_bytes_scanned: total_bytes_scanned_out,
         total_bytes_written: total_bytes_written_out,
         per_model,
+        groups,
     }
+}
+
+/// Roll the per-model rows up by the requested dimension into a stable,
+/// deterministically-ordered list of [`CostGroup`]s.
+///
+/// Determinism: groups are sorted by `key`, with the `"<unattributed>"`
+/// tenant bucket sorting naturally (its angle brackets sort before
+/// alphanumerics). This keeps `--by` output diff-stable across runs and
+/// across the (arbitrary) execution order in the stored record.
+fn build_groups(per_model: &[PerModelCostHistorical], by: CostGroupBy) -> Vec<CostGroup> {
+    use std::collections::BTreeMap;
+
+    // Accumulator per key. BTreeMap gives sorted, deterministic output.
+    struct Acc {
+        model_count: u64,
+        total_cost: f64,
+        any_cost: bool,
+        total_duration_ms: u64,
+        total_bytes_scanned: u64,
+        any_bytes_scanned: bool,
+        total_bytes_written: u64,
+        any_bytes_written: bool,
+    }
+
+    let mut acc: BTreeMap<String, Acc> = BTreeMap::new();
+    for m in per_model {
+        let key = match by {
+            CostGroupBy::Tenant => m.tenant.clone().unwrap_or_else(|| UNATTRIBUTED.to_string()),
+            CostGroupBy::Model => m.model_name.clone(),
+        };
+        let entry = acc.entry(key).or_insert(Acc {
+            model_count: 0,
+            total_cost: 0.0,
+            any_cost: false,
+            total_duration_ms: 0,
+            total_bytes_scanned: 0,
+            any_bytes_scanned: false,
+            total_bytes_written: 0,
+            any_bytes_written: false,
+        });
+        entry.model_count += 1;
+        if let Some(c) = m.cost_usd {
+            entry.total_cost += c;
+            entry.any_cost = true;
+        }
+        entry.total_duration_ms = entry.total_duration_ms.saturating_add(m.duration_ms);
+        if let Some(b) = m.bytes_scanned {
+            entry.total_bytes_scanned = entry.total_bytes_scanned.saturating_add(b);
+            entry.any_bytes_scanned = true;
+        }
+        if let Some(b) = m.bytes_written {
+            entry.total_bytes_written = entry.total_bytes_written.saturating_add(b);
+            entry.any_bytes_written = true;
+        }
+    }
+
+    acc.into_iter()
+        .map(|(key, a)| CostGroup {
+            dimension: by.as_str().to_string(),
+            key,
+            model_count: a.model_count,
+            total_cost_usd: a.any_cost.then_some(a.total_cost),
+            total_duration_ms: a.total_duration_ms,
+            total_bytes_scanned: a.any_bytes_scanned.then_some(a.total_bytes_scanned),
+            total_bytes_written: a.any_bytes_written.then_some(a.total_bytes_written),
+        })
+        .collect()
 }
 
 fn print_table(output: &CostOutput) {
@@ -262,6 +372,37 @@ fn print_table(output: &CostOutput) {
         Some(c) => println!("total_cost_usd: ${c:.6}"),
         None => println!("total_cost_usd: -"),
     }
+
+    if let Some(groups) = &output.groups {
+        println!();
+        let dimension = groups
+            .first()
+            .map(|g| g.dimension.as_str())
+            .unwrap_or("group");
+        println!("by {dimension} ({}):", groups.len());
+        println!(
+            "  {:<24}  {:>8}  {:>12}  {:>14}  {:>14}  {:>12}",
+            dimension, "models", "duration", "bytes_scan", "bytes_write", "cost_usd"
+        );
+        for g in groups {
+            let bs = g
+                .total_bytes_scanned
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "-".to_string());
+            let bw = g
+                .total_bytes_written
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "-".to_string());
+            let cost = g
+                .total_cost_usd
+                .map(|v| format!("${v:.6}"))
+                .unwrap_or_else(|| "-".to_string());
+            println!(
+                "  {:<24}  {:>8}  {:>12}  {:>14}  {:>14}  {:>12}",
+                g.key, g.model_count, g.total_duration_ms, bs, bw, cost
+            );
+        }
+    }
 }
 
 /// Execute `rocky cost <run_id|latest>`.
@@ -274,8 +415,10 @@ pub fn run_cost(
     config_path: &Path,
     target: &str,
     model_filter: Option<&str>,
+    by: Option<&str>,
     json: bool,
 ) -> Result<()> {
+    let group_by = by.map(CostGroupBy::parse).transpose()?;
     let store = StateStore::open_read_only(state_path)
         .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
 
@@ -301,7 +444,7 @@ pub fn run_cost(
             }
         };
 
-    let output = build_output(&record, adapter_info.as_ref(), model_filter);
+    let output = build_output(&record, adapter_info.as_ref(), model_filter, group_by);
 
     if model_filter.is_some() && output.per_model.is_empty() {
         anyhow::bail!(
@@ -333,6 +476,24 @@ mod tests {
         bytes_scanned: Option<u64>,
         bytes_written: Option<u64>,
     ) -> ModelExecution {
+        sample_exec_tenant(
+            name,
+            status,
+            duration_ms,
+            bytes_scanned,
+            bytes_written,
+            None,
+        )
+    }
+
+    fn sample_exec_tenant(
+        name: &str,
+        status: &str,
+        duration_ms: u64,
+        bytes_scanned: Option<u64>,
+        bytes_written: Option<u64>,
+        tenant: Option<&str>,
+    ) -> ModelExecution {
         let now = Utc.with_ymd_and_hms(2026, 4, 21, 12, 0, 0).unwrap();
         ModelExecution {
             model_name: name.to_string(),
@@ -346,6 +507,7 @@ mod tests {
             upstream_freshness: None,
             bytes_scanned,
             bytes_written,
+            tenant: tenant.map(str::to_string),
         }
     }
 
@@ -391,7 +553,7 @@ mod tests {
             cost_per_dbu,
         );
 
-        let out = build_output(&record, Some(&adapter), None);
+        let out = build_output(&record, Some(&adapter), None, None);
 
         assert_eq!(out.command, "cost");
         assert_eq!(out.run_id, "run-1");
@@ -428,7 +590,7 @@ mod tests {
             )],
         );
 
-        let out = build_output(&record, None, None);
+        let out = build_output(&record, None, None, None);
 
         assert_eq!(out.adapter_type, None);
         assert_eq!(out.total_duration_ms, 5_000);
@@ -459,7 +621,7 @@ mod tests {
         );
 
         let adapter = ("bigquery".to_string(), WarehouseType::BigQuery, 0.0, 0.0);
-        let out = build_output(&record, Some(&adapter), None);
+        let out = build_output(&record, Some(&adapter), None, None);
 
         let cost = out.per_model[0].cost_usd.expect("BQ cost should be Some");
         assert!((cost - 6.25).abs() < 1e-9);
@@ -475,10 +637,104 @@ mod tests {
             ],
         );
 
-        let out = build_output(&record, None, Some("orders"));
+        let out = build_output(&record, None, Some("orders"), None);
         assert_eq!(out.per_model.len(), 1);
         assert_eq!(out.per_model[0].model_name, "orders");
         assert_eq!(out.total_duration_ms, 1_000);
+    }
+
+    #[test]
+    fn no_grouping_leaves_groups_none() {
+        let record = sample_run(
+            "run-flat",
+            vec![sample_exec("orders", "success", 1_000, None, None)],
+        );
+        let out = build_output(&record, None, None, None);
+        assert!(out.groups.is_none(), "default cost output has no groups");
+        // per_model is always present regardless of grouping.
+        assert_eq!(out.per_model.len(), 1);
+    }
+
+    #[test]
+    fn group_by_tenant_buckets_and_sums() {
+        // Two tenants + one unattributed model. 60s on Medium @ $0.40/DBU.
+        let record = sample_run(
+            "run-tenant",
+            vec![
+                sample_exec_tenant("orders", "success", 30_000, Some(10), None, Some("acme")),
+                sample_exec_tenant("returns", "success", 10_000, Some(5), None, Some("acme")),
+                sample_exec_tenant("orders", "success", 20_000, Some(7), None, Some("globex")),
+                // No tenant → lands in the "<unattributed>" bucket.
+                sample_exec("internal_metrics", "success", 5_000, Some(3), None),
+            ],
+        );
+
+        let dbu_per_hour = warehouse_size_to_dbu_per_hour("Medium");
+        let adapter = (
+            "databricks".to_string(),
+            WarehouseType::Databricks,
+            dbu_per_hour,
+            0.40,
+        );
+
+        let out = build_output(&record, Some(&adapter), None, Some(CostGroupBy::Tenant));
+        let groups = out.groups.expect("groups present under --by tenant");
+
+        // Deterministic ordering: "<unattributed>" (angle bracket sorts
+        // first), then "acme", then "globex".
+        assert_eq!(
+            groups.iter().map(|g| g.key.as_str()).collect::<Vec<_>>(),
+            vec![UNATTRIBUTED, "acme", "globex"]
+        );
+
+        let acme = groups.iter().find(|g| g.key == "acme").unwrap();
+        assert_eq!(acme.dimension, "tenant");
+        assert_eq!(acme.model_count, 2);
+        assert_eq!(acme.total_duration_ms, 40_000);
+        assert_eq!(acme.total_bytes_scanned, Some(15));
+
+        // Group cost equals the sum of its members' per-model costs.
+        let acme_members_cost: f64 = out
+            .per_model
+            .iter()
+            .filter(|m| m.tenant.as_deref() == Some("acme"))
+            .map(|m| m.cost_usd.unwrap_or(0.0))
+            .sum();
+        assert!((acme.total_cost_usd.unwrap() - acme_members_cost).abs() < 1e-12);
+
+        let unattr = groups.iter().find(|g| g.key == UNATTRIBUTED).unwrap();
+        assert_eq!(unattr.model_count, 1);
+        assert_eq!(unattr.total_duration_ms, 5_000);
+    }
+
+    #[test]
+    fn group_by_model_collapses_repeated_model_names() {
+        // Same model name across two executions collapses into one group.
+        let record = sample_run(
+            "run-model",
+            vec![
+                sample_exec("orders", "success", 1_000, Some(10), None),
+                sample_exec("orders", "success", 2_000, Some(20), None),
+                sample_exec("customers", "success", 500, None, None),
+            ],
+        );
+
+        let out = build_output(&record, None, None, Some(CostGroupBy::Model));
+        let groups = out.groups.expect("groups present under --by model");
+
+        assert_eq!(groups.len(), 2);
+        let orders = groups.iter().find(|g| g.key == "orders").unwrap();
+        assert_eq!(orders.dimension, "model");
+        assert_eq!(orders.model_count, 2);
+        assert_eq!(orders.total_duration_ms, 3_000);
+        assert_eq!(orders.total_bytes_scanned, Some(30));
+    }
+
+    #[test]
+    fn group_by_parse_rejects_unknown_dimension() {
+        assert!(CostGroupBy::parse("tenant").is_ok());
+        assert!(CostGroupBy::parse("MODEL").is_ok());
+        assert!(CostGroupBy::parse("region").is_err());
     }
 
     #[test]

--- a/engine/crates/rocky-cli/src/commands/history.rs
+++ b/engine/crates/rocky-cli/src/commands/history.rs
@@ -462,6 +462,7 @@ mod tests {
                 upstream_freshness: None,
                 bytes_scanned: None,
                 bytes_written: None,
+                tenant: None,
             }],
             trigger: RunTrigger::Manual,
             config_hash: "cfg-hash".to_string(),
@@ -529,6 +530,7 @@ mod tests {
             upstream_freshness: None,
             bytes_scanned: None,
             bytes_written: None,
+            tenant: None,
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -432,4 +432,54 @@ mod tests {
         assert_eq!(regions[0], "us_west");
         assert_eq!(regions[1], "eu");
     }
+
+    /// End-to-end key agreement for the `rocky cost --by tenant` plumbing:
+    /// parse a real `src__{tenant}__{regions...}__{source}` schema with the
+    /// canonical pattern, run it through `parsed_to_json_map`, and apply the
+    /// *exact* extraction `run.rs` uses to populate `TableTask::tenant`.
+    /// This pins the contract that the run-side component map keys the tenant
+    /// under the literal `"tenant"` as a `Value::String` — if the schema
+    /// parser ever renamed that component, this fails instead of the feature
+    /// silently producing an all-`<unattributed>` cost rollup.
+    #[test]
+    fn parsed_to_json_map_keys_tenant_as_string_for_cost_attribution() {
+        use rocky_core::schema::SchemaPattern;
+
+        let pattern = SchemaPattern {
+            prefix: "src__".to_string(),
+            separator: "__".to_string(),
+            components: SchemaPattern::parse_components(&[
+                "tenant".to_string(),
+                "regions...".to_string(),
+                "source".to_string(),
+            ])
+            .unwrap(),
+        };
+        let parsed = pattern.parse("src__acme__us_west__shopify").unwrap();
+        let components = parsed_to_json_map(&parsed);
+
+        // The exact expression in run.rs's TableTask builder.
+        let tenant = components
+            .get("tenant")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        assert_eq!(tenant.as_deref(), Some("acme"));
+
+        // A pattern without a `{tenant}` component yields no tenant — the
+        // extraction returns None and the cost rollup buckets the model as
+        // unattributed.
+        let no_tenant_pattern = SchemaPattern {
+            prefix: "src__".to_string(),
+            separator: "__".to_string(),
+            components: SchemaPattern::parse_components(&["source".to_string()]).unwrap(),
+        };
+        let parsed_no_tenant = no_tenant_pattern.parse("src__shopify").unwrap();
+        let components_no_tenant = parsed_to_json_map(&parsed_no_tenant);
+        assert!(
+            components_no_tenant
+                .get("tenant")
+                .and_then(|v| v.as_str())
+                .is_none()
+        );
+    }
 }

--- a/engine/crates/rocky-cli/src/commands/preview.rs
+++ b/engine/crates/rocky-cli/src/commands/preview.rs
@@ -2265,6 +2265,7 @@ mod tests {
             upstream_freshness: None,
             bytes_scanned: bytes,
             bytes_written: None,
+            tenant: None,
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/replay.rs
+++ b/engine/crates/rocky-cli/src/commands/replay.rs
@@ -148,6 +148,7 @@ mod tests {
                 upstream_freshness: None,
                 bytes_scanned: Some(1024),
                 bytes_written: Some(2048),
+                tenant: None,
             })
             .collect();
         RunRecord {

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -155,6 +155,12 @@ struct TableTask {
     target_schema: String,
     table_name: String,
     asset_key_prefix: Vec<String>,
+    /// Tenant this table belongs to, lifted from the discover-time
+    /// schema-pattern `{tenant}` component. `None` when the pipeline's
+    /// schema pattern declares no `{tenant}` placeholder. Carried onto
+    /// the resulting `MaterializationOutput` so the persisted
+    /// `ModelExecution` records a tenant for `rocky cost --by tenant`.
+    tenant: Option<String>,
     check_column_match: bool,
     check_row_count: bool,
     check_freshness: bool,
@@ -1901,6 +1907,15 @@ pub async fn run(
                         }
                         prefix
                     },
+                    // Lift the tenant dimension off the discover-time
+                    // schema-pattern components. The map stores it as a
+                    // `Value::String`; `None` when the pattern has no
+                    // `{tenant}` placeholder. Flows to the materialization
+                    // and on to the persisted `ModelExecution`.
+                    tenant: components
+                        .get("tenant")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string),
                     check_column_match: pipeline.checks.column_match.enabled(),
                     check_row_count: pipeline.checks.row_count.enabled(),
                     check_freshness: pipeline.checks.freshness.is_some(),
@@ -4758,6 +4773,9 @@ pub(crate) async fn execute_models(
                             cost_usd: None,
                             bytes_scanned: None,
                             bytes_written: Some(summary.size_bytes),
+                            // Transformation models carry no tenant
+                            // dimension (no source-schema `{tenant}`).
+                            tenant: None,
                             job_ids: vec![],
                             // content_addressed is never skip-eligible.
                             skip_internal: None,
@@ -5420,6 +5438,9 @@ async fn execute_one_plain_model(
         cost_usd: None,
         bytes_scanned: bytes_scanned_acc,
         bytes_written: bytes_written_acc,
+        // Transformation models carry no tenant dimension (their asset
+        // key is `[catalog, schema, table]`, not a source-schema parse).
+        tenant: None,
         job_ids: job_ids_acc,
         // Stamped by the gate in `execute_models` after a successful build
         // when `--skip-unchanged` is enabled; `None` keeps default-off
@@ -5832,6 +5853,8 @@ async fn run_one_partition(
             cost_usd: None,
             bytes_scanned: bytes_scanned_acc,
             bytes_written: bytes_written_acc,
+            // time_interval models carry no tenant dimension.
+            tenant: None,
             job_ids: job_ids_acc,
             // time_interval is excluded from the v1 skip gate.
             skip_internal: None,
@@ -6661,6 +6684,10 @@ async fn process_table(
             cost_usd: None,
             bytes_scanned: exec_stats.bytes_scanned,
             bytes_written: exec_stats.bytes_written,
+            // Tenant lifted from the discover-time schema-pattern
+            // `{tenant}` component on the task. `None` for non-tenant
+            // patterns; carried onto the persisted ModelExecution.
+            tenant: task.tenant.clone(),
             job_ids: exec_stats.job_id.clone().into_iter().collect(),
             // Replication materializations are not gated by --skip-unchanged
             // in v1 (the gate covers transformation models).
@@ -9710,6 +9737,7 @@ merge_keys = ["id"]
                 upstream_freshness: None,
                 bytes_scanned: None,
                 bytes_written: None,
+                tenant: None,
             }],
             trigger: rocky_core::state::RunTrigger::Manual,
             config_hash: "cfg".to_string(),

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -794,6 +794,8 @@ pub async fn run_snapshot(
             // attribution + job-id capture is a follow-up wave.
             bytes_scanned: None,
             bytes_written: None,
+            // snapshot models carry no tenant dimension.
+            tenant: None,
             job_ids: Vec::new(),
             skip_internal: None,
         });

--- a/engine/crates/rocky-cli/src/commands/trace.rs
+++ b/engine/crates/rocky-cli/src/commands/trace.rs
@@ -245,6 +245,7 @@ mod tests {
             upstream_freshness: None,
             bytes_scanned: Some(1024),
             bytes_written: Some(2048),
+            tenant: None,
         }
     }
 

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -882,6 +882,17 @@ pub struct MaterializationOutput {
     /// can populate it without a schema break.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bytes_written: Option<u64>,
+    /// Tenant this materialization is attributed to, taken from the
+    /// discover-time schema-pattern `{tenant}` component. Present only
+    /// for replication pipelines whose schema pattern declares a
+    /// `{tenant}` placeholder; transformation / `time_interval` models
+    /// and non-tenant patterns leave it `None`. Carried onto the
+    /// persisted `rocky_core::state::ModelExecution` by
+    /// [`RunOutput::to_run_record`] so `rocky cost --by tenant` can roll
+    /// per-model cost up to a tenant dimension. Omitted from JSON when
+    /// `None` so non-tenant outputs stay byte-identical.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenant: Option<String>,
     /// Warehouse-side job identifiers for the SQL statements rocky
     /// issued to materialize this output. Populated for adapters whose
     /// REST API surfaces a job reference per statement (BigQuery
@@ -4088,6 +4099,7 @@ impl RunOutput {
                     .map(|s| s.upstream_freshness.clone()),
                 bytes_scanned: mat.bytes_scanned,
                 bytes_written: mat.bytes_written,
+                tenant: mat.tenant.clone(),
             });
         }
 
@@ -4110,6 +4122,9 @@ impl RunOutput {
                 upstream_freshness: None,
                 bytes_scanned: None,
                 bytes_written: None,
+                // Errors carry only the asset key, not the parsed schema
+                // components, so the tenant dimension is unavailable here.
+                tenant: None,
             });
         }
 
@@ -4424,6 +4439,7 @@ mod cost_finalize_tests {
             cost_usd: None,
             bytes_scanned: None,
             bytes_written: None,
+            tenant: None,
             job_ids: Vec::new(),
             skip_internal: None,
         }
@@ -4636,6 +4652,7 @@ mod run_record_tests {
             cost_usd: None,
             bytes_scanned: None,
             bytes_written: None,
+            tenant: None,
             job_ids: Vec::new(),
             skip_internal: None,
         }
@@ -4739,6 +4756,40 @@ mod run_record_tests {
         assert_eq!(failed.model_name, "broken");
         assert_eq!(failed.duration_ms, 0);
         assert!(matches!(record.status, RunStatus::PartialFailure));
+    }
+
+    #[test]
+    fn to_run_record_carries_tenant_onto_model_execution() {
+        let mut out = RunOutput::new(String::new(), 1_000, 1);
+        out.tables_copied = 1;
+        let run_started = fixed_start();
+        let mut m = mat(
+            &["shopify", "acme", "orders"],
+            1_000,
+            Some("h"),
+            run_started,
+        );
+        m.tenant = Some("acme".to_string());
+        out.materializations.push(m);
+
+        let started = fixed_start();
+        let finished = started + chrono::Duration::seconds(1);
+        let record = out.to_run_record(
+            "run-tenant",
+            started,
+            finished,
+            String::new(),
+            RunTrigger::Manual,
+            out.derive_run_status(),
+            RunRecordAudit::test_sentinels(),
+        );
+
+        assert_eq!(record.models_executed.len(), 1);
+        assert_eq!(
+            record.models_executed[0].tenant.as_deref(),
+            Some("acme"),
+            "tenant on the materialization must flow onto the persisted ModelExecution"
+        );
     }
 
     #[test]
@@ -5394,6 +5445,48 @@ pub struct CostOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total_bytes_written: Option<u64>,
     pub per_model: Vec<PerModelCostHistorical>,
+    /// Grouped cost rollup, present only when `--by <dimension>` is
+    /// passed. `--by model` produces one group per model; `--by tenant`
+    /// produces one group per tenant (models with no recorded tenant
+    /// land in an `"<unattributed>"` bucket). `None` (and omitted from
+    /// JSON) for a plain `rocky cost` invocation, so the default output
+    /// shape is unchanged. `per_model` is always present regardless of
+    /// grouping.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub groups: Option<Vec<CostGroup>>,
+}
+
+/// One grouped row in [`CostOutput::groups`], emitted when `rocky cost`
+/// is run with `--by <dimension>`.
+///
+/// Each group sums the per-model figures of the executions that share the
+/// grouping key (a tenant, or a model name). The cost roll-up uses the
+/// same `compute_observed_cost_usd` figures as [`PerModelCostHistorical`],
+/// so a `--by tenant` total equals the sum of its members' `cost_usd`.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CostGroup {
+    /// Dimension the grouping was performed on: `"tenant"` or `"model"`.
+    pub dimension: String,
+    /// The grouping key's value — the tenant name, the model name, or
+    /// the literal `"<unattributed>"` for the `--by tenant` bucket that
+    /// collects executions with no recorded tenant.
+    pub key: String,
+    /// Number of model executions rolled into this group.
+    pub model_count: u64,
+    /// Sum of every member's `cost_usd` that produced a number. `None`
+    /// when no member produced a cost.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_cost_usd: Option<f64>,
+    /// Wall-clock time summed across the group's member executions.
+    pub total_duration_ms: u64,
+    /// Sum of the group's member `bytes_scanned`. `None` when no member
+    /// reported bytes scanned.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_bytes_scanned: Option<u64>,
+    /// Sum of the group's member `bytes_written`. `None` when no member
+    /// reported bytes written.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_bytes_written: Option<u64>,
 }
 
 /// A single model's cost attribution inside [`CostOutput`].
@@ -5406,6 +5499,12 @@ pub struct CostOutput {
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct PerModelCostHistorical {
     pub model_name: String,
+    /// Tenant this execution was attributed to, read back from the
+    /// persisted `rocky_core::state::ModelExecution::tenant`. Present
+    /// only for replication executions whose source schema declared a
+    /// `{tenant}` component; `None` (and omitted from JSON) otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenant: Option<String>,
     pub status: String,
     pub duration_ms: u64,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -1045,6 +1045,19 @@ pub struct ModelExecution {
     /// wired it yet. Reserved for adapters that produce a natural
     /// bytes-written figure via their statistics surface.
     pub bytes_written: Option<u64>,
+    /// Tenant this execution is attributed to, sourced from the
+    /// discover-time schema-pattern `{tenant}` component (see
+    /// [`crate::schema`]). Populated only for replication pipelines
+    /// whose schema pattern declares a `{tenant}` placeholder;
+    /// transformation / `time_interval` models and non-tenant patterns
+    /// record `None`. Read back by `rocky cost --by tenant` to roll
+    /// per-model cost up to a tenant dimension.
+    ///
+    /// Serde-defaulted so records written before this field existed
+    /// forward-deserialize to `None` — no `CURRENT_SCHEMA_VERSION` bump.
+    /// Guarded by `test_pre_tenant_model_execution_forward_deserializes_to_none`.
+    #[serde(default)]
+    pub tenant: Option<String>,
 }
 
 /// A complete pipeline run record.
@@ -3796,6 +3809,7 @@ mod tests {
                 upstream_freshness: None,
                 bytes_scanned: None,
                 bytes_written: None,
+                tenant: None,
             }],
         );
         store.record_run(&run).unwrap();
@@ -3836,6 +3850,7 @@ mod tests {
                     upstream_freshness: None,
                     bytes_scanned: None,
                     bytes_written: None,
+                    tenant: None,
                 },
                 ModelExecution {
                     model_name: "customers".to_string(),
@@ -3849,6 +3864,7 @@ mod tests {
                     upstream_freshness: None,
                     bytes_scanned: None,
                     bytes_written: None,
+                    tenant: None,
                 },
             ],
         );
@@ -3877,6 +3893,7 @@ mod tests {
                     upstream_freshness: None,
                     bytes_scanned: None,
                     bytes_written: None,
+                    tenant: None,
                 }],
             );
             store.record_run(&run).unwrap();
@@ -3955,6 +3972,48 @@ mod tests {
         // bytes fields also default (these predate the skip fields too).
         assert_eq!(exec.bytes_scanned, None);
         assert_eq!(exec.bytes_written, None);
+        // The tenant attribution field also defaults to None on a blob
+        // that predates it.
+        assert_eq!(exec.tenant, None);
+    }
+
+    /// A `ModelExecution` blob written before the `tenant` attribution
+    /// field existed must forward-deserialize with `tenant = None`. This
+    /// is the load-bearing state-schema guard for `rocky cost --by
+    /// tenant`: the field is additive and serde-defaulted, so the redb
+    /// blob format is unchanged and `CURRENT_SCHEMA_VERSION` does not move.
+    /// A record lacking the field simply reports as unattributed.
+    #[test]
+    fn test_pre_tenant_model_execution_forward_deserializes_to_none() {
+        // Note: this blob carries the skip/bytes fields (a record from a
+        // binary after those landed) but omits `tenant` — the exact shape
+        // a pre-tenant binary would have persisted.
+        let pre_tenant_blob = br#"{
+            "model_name": "orders",
+            "started_at": "2024-01-01T12:00:00Z",
+            "finished_at": "2024-01-01T12:00:02Z",
+            "duration_ms": 2000,
+            "rows_affected": 5000,
+            "status": "success",
+            "sql_hash": "legacy-sql-hash",
+            "skip_hash": "logic-key",
+            "upstream_freshness": null,
+            "bytes_scanned": 4096,
+            "bytes_written": 2048
+        }"#;
+
+        let exec: ModelExecution = serde_json::from_slice(pre_tenant_blob)
+            .expect("pre-tenant ModelExecution must forward-deserialize");
+
+        // Original fields preserved.
+        assert_eq!(exec.model_name, "orders");
+        assert_eq!(exec.sql_hash, "legacy-sql-hash");
+        assert_eq!(exec.skip_hash.as_deref(), Some("logic-key"));
+        assert_eq!(exec.bytes_scanned, Some(4096));
+        assert_eq!(exec.bytes_written, Some(2048));
+        // The new attribution dimension defaults to None — a pre-tenant
+        // record is treated as unattributed, never crashes the read.
+        assert_eq!(exec.tenant, None);
     }
 
     /// End-to-end variant of the forward-compat guard: write a v5 blob

--- a/engine/crates/rocky-core/tests/e2e.rs
+++ b/engine/crates/rocky-core/tests/e2e.rs
@@ -469,6 +469,7 @@ fn test_run_history_flow() {
                 upstream_freshness: None,
                 bytes_scanned: None,
                 bytes_written: None,
+                tenant: None,
             },
             ModelExecution {
                 model_name: "customers".to_string(),
@@ -482,6 +483,7 @@ fn test_run_history_flow() {
                 upstream_freshness: None,
                 bytes_scanned: None,
                 bytes_written: None,
+                tenant: None,
             },
         ],
         trigger: RunTrigger::Manual,

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -564,6 +564,7 @@ fn seed_run_history(models_dir: &Path) {
             upstream_freshness: None,
             bytes_scanned: None,
             bytes_written: Some(1024),
+            tenant: None,
         }],
         trigger: RunTrigger::Manual,
         config_hash: "cfg".to_string(),

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -1472,6 +1472,13 @@ enum Command {
         /// Filter to a single model within the run
         #[arg(long)]
         model: Option<String>,
+        /// Roll the per-model cost up by a dimension: `tenant` (the
+        /// discover-time schema-pattern `{tenant}` component) or
+        /// `model`. Adds a `groups` array to the output; `per_model`
+        /// is always present regardless. Omit for the flat per-model
+        /// view.
+        #[arg(long, value_name = "DIMENSION")]
+        by: Option<String>,
     },
 
     /// PR preview workflow — pruned re-run on a per-PR branch with
@@ -3184,9 +3191,14 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
         Command::Trace { target, model } => {
             rocky_cli::commands::run_trace(&state_path, &target, model.as_deref(), json)
         }
-        Command::Cost { target, model } => {
-            rocky_cli::commands::run_cost(&state_path, &cli.config, &target, model.as_deref(), json)
-        }
+        Command::Cost { target, model, by } => rocky_cli::commands::run_cost(
+            &state_path,
+            &cli.config,
+            &target,
+            model.as_deref(),
+            by.as_deref(),
+            json,
+        ),
         Command::Preview { action } => match action {
             PreviewAction::Create { base, name, models } => {
                 rocky_cli::commands::run_preview_create(

--- a/schemas/cost.schema.json
+++ b/schemas/cost.schema.json
@@ -1,6 +1,64 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "CostGroup": {
+      "description": "One grouped row in [`CostOutput::groups`], emitted when `rocky cost` is run with `--by <dimension>`.\n\nEach group sums the per-model figures of the executions that share the grouping key (a tenant, or a model name). The cost roll-up uses the same `compute_observed_cost_usd` figures as [`PerModelCostHistorical`], so a `--by tenant` total equals the sum of its members' `cost_usd`.",
+      "properties": {
+        "dimension": {
+          "description": "Dimension the grouping was performed on: `\"tenant\"` or `\"model\"`.",
+          "type": "string"
+        },
+        "key": {
+          "description": "The grouping key's value — the tenant name, the model name, or the literal `\"<unattributed>\"` for the `--by tenant` bucket that collects executions with no recorded tenant.",
+          "type": "string"
+        },
+        "model_count": {
+          "description": "Number of model executions rolled into this group.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "total_bytes_scanned": {
+          "description": "Sum of the group's member `bytes_scanned`. `None` when no member reported bytes scanned.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "total_bytes_written": {
+          "description": "Sum of the group's member `bytes_written`. `None` when no member reported bytes written.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "total_cost_usd": {
+          "description": "Sum of every member's `cost_usd` that produced a number. `None` when no member produced a cost.",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "total_duration_ms": {
+          "description": "Wall-clock time summed across the group's member executions.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "dimension",
+        "key",
+        "model_count",
+        "total_duration_ms"
+      ],
+      "type": "object"
+    },
     "PerModelCostHistorical": {
       "description": "A single model's cost attribution inside [`CostOutput`].\n\nDistinct from [`ModelCostEntry`] (which lives on [`RunCostSummary`]) because the historical surface carries the richer fields the state store actually persists: model name (not asset-key vector), row/byte counts, and the recorded per-model status.",
       "properties": {
@@ -48,6 +106,13 @@
         },
         "status": {
           "type": "string"
+        },
+        "tenant": {
+          "description": "Tenant this execution was attributed to, read back from the persisted `rocky_core::state::ModelExecution::tenant`. Present only for replication executions whose source schema declared a `{tenant}` component; `None` (and omitted from JSON) otherwise.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -77,6 +142,16 @@
     },
     "finished_at": {
       "type": "string"
+    },
+    "groups": {
+      "description": "Grouped cost rollup, present only when `--by <dimension>` is passed. `--by model` produces one group per model; `--by tenant` produces one group per tenant (models with no recorded tenant land in an `\"<unattributed>\"` bucket). `None` (and omitted from JSON) for a plain `rocky cost` invocation, so the default output shape is unchanged. `per_model` is always present regardless of grouping.",
+      "items": {
+        "$ref": "#/definitions/CostGroup"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
     },
     "per_model": {
       "items": {

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -550,6 +550,13 @@
           "description": "Wall-clock timestamp captured at the moment the engine began executing this model. Used by `RunOutput::to_run_record` to build accurate per-model windows on the persisted `ModelExecution` — replaces the prior lossy reconstruction (`finished_at - duration`) that mis-ordered parallel runs. `finished_at` is derived as `started_at + duration_ms`; keeping one source of truth avoids drift between the two.",
           "format": "date-time",
           "type": "string"
+        },
+        "tenant": {
+          "description": "Tenant this materialization is attributed to, taken from the discover-time schema-pattern `{tenant}` component. Present only for replication pipelines whose schema pattern declares a `{tenant}` placeholder; transformation / `time_interval` models and non-tenant patterns leave it `None`. Carried onto the persisted `rocky_core::state::ModelExecution` by [`RunOutput::to_run_record`] so `rocky cost --by tenant` can roll per-model cost up to a tenant dimension. Omitted from JSON when `None` so non-tenant outputs stay byte-identical.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [

--- a/sdk/python/src/rocky_sdk/types_generated/cost_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/cost_schema.py
@@ -6,6 +6,43 @@ from __future__ import annotations
 from pydantic import BaseModel, conint
 
 
+class CostGroup(BaseModel):
+    """
+    One grouped row in [`CostOutput::groups`], emitted when `rocky cost` is run with `--by <dimension>`.
+
+    Each group sums the per-model figures of the executions that share the grouping key (a tenant, or a model name). The cost roll-up uses the same `compute_observed_cost_usd` figures as [`PerModelCostHistorical`], so a `--by tenant` total equals the sum of its members' `cost_usd`.
+    """
+
+    dimension: str
+    """
+    Dimension the grouping was performed on: `"tenant"` or `"model"`.
+    """
+    key: str
+    """
+    The grouping key's value — the tenant name, the model name, or the literal `"<unattributed>"` for the `--by tenant` bucket that collects executions with no recorded tenant.
+    """
+    model_count: conint(ge=0)
+    """
+    Number of model executions rolled into this group.
+    """
+    total_bytes_scanned: conint(ge=0) | None = None
+    """
+    Sum of the group's member `bytes_scanned`. `None` when no member reported bytes scanned.
+    """
+    total_bytes_written: conint(ge=0) | None = None
+    """
+    Sum of the group's member `bytes_written`. `None` when no member reported bytes written.
+    """
+    total_cost_usd: float | None = None
+    """
+    Sum of every member's `cost_usd` that produced a number. `None` when no member produced a cost.
+    """
+    total_duration_ms: conint(ge=0)
+    """
+    Wall-clock time summed across the group's member executions.
+    """
+
+
 class PerModelCostHistorical(BaseModel):
     """
     A single model's cost attribution inside [`CostOutput`].
@@ -31,6 +68,10 @@ class PerModelCostHistorical(BaseModel):
     model_name: str
     rows_affected: conint(ge=0) | None = None
     status: str
+    tenant: str | None = None
+    """
+    Tenant this execution was attributed to, read back from the persisted `rocky_core::state::ModelExecution::tenant`. Present only for replication executions whose source schema declared a `{tenant}` component; `None` (and omitted from JSON) otherwise.
+    """
 
 
 class CostOutput(BaseModel):
@@ -55,6 +96,10 @@ class CostOutput(BaseModel):
     command: str
     duration_ms: conint(ge=0)
     finished_at: str
+    groups: list[CostGroup] | None = None
+    """
+    Grouped cost rollup, present only when `--by <dimension>` is passed. `--by model` produces one group per model; `--by tenant` produces one group per tenant (models with no recorded tenant land in an `"<unattributed>"` bucket). `None` (and omitted from JSON) for a plain `rocky cost` invocation, so the default output shape is unchanged. `per_model` is always present regardless of grouping.
+    """
     per_model: list[PerModelCostHistorical]
     run_id: str
     started_at: str

--- a/sdk/python/src/rocky_sdk/types_generated/run_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/run_schema.py
@@ -618,6 +618,10 @@ class MaterializationOutput(BaseModel):
     """
     Wall-clock timestamp captured at the moment the engine began executing this model. Used by `RunOutput::to_run_record` to build accurate per-model windows on the persisted `ModelExecution` — replaces the prior lossy reconstruction (`finished_at - duration`) that mis-ordered parallel runs. `finished_at` is derived as `started_at + duration_ms`; keeping one source of truth avoids drift between the two.
     """
+    tenant: str | None = None
+    """
+    Tenant this materialization is attributed to, taken from the discover-time schema-pattern `{tenant}` component. Present only for replication pipelines whose schema pattern declares a `{tenant}` placeholder; transformation / `time_interval` models and non-tenant patterns leave it `None`. Carried onto the persisted `rocky_core::state::ModelExecution` by [`RunOutput::to_run_record`] so `rocky cost --by tenant` can roll per-model cost up to a tenant dimension. Omitted from JSON when `None` so non-tenant outputs stay byte-identical.
+    """
 
 
 class TableCheckOutput(BaseModel):


### PR DESCRIPTION
## What

Adds `rocky cost <run|latest> --by tenant` (and `--by model`) — a per-tenant / per-model cost rollup on top of the existing per-run, per-model cost attribution. This is speculative API surface (no current consumer); built conservatively and additively.

## How it works

- **Tenant dimension** is sourced from the already-parsed discover-time schema-pattern `{tenant}` component (the lower-risk path — see below). It is lifted onto `TableTask`, carried through `MaterializationOutput`, and copied onto the persisted `ModelExecution` in `RunOutput::to_run_record`. Replication models whose source schema declares `{tenant}` get a tenant; transformation / `time_interval` / snapshot models and non-tenant patterns report `None`.
- **Grouping** (`--by`) adds an additive `groups: Option<Vec<CostGroup>>` array to the `cost` JSON output. `per_model` is always present, so a plain `rocky cost` is byte-for-byte unchanged. `--by tenant` buckets models with no recorded tenant under `<unattributed>`; output is deterministically sorted by key.

## State-schema impact — NO version bump

**`CURRENT_SCHEMA_VERSION` is NOT bumped.** The new `ModelExecution.tenant` is an additive, serde-defaulted `Option<String>`, so the redb blob format is unchanged (zero-touch — no in-place migration, no blob walk). Pre-existing run records that lack the field forward-deserialize to `tenant = None` and are reported as unattributed.

This is pinned by a forward-deser guard: `test_pre_tenant_model_execution_forward_deserializes_to_none` deserializes a blob that omits `tenant` and asserts it defaults to `None` — mirroring the existing `test_pre_skip_gate_model_execution_forward_deserializes_to_none` precedent.

## Why path (a) — discover-time component over a `[cost.attribution]` config map

The task offered two sourcing paths. Chose (a) — reuse the already-parsed `components.get("tenant")` — because:

1. It reuses data the run already computed (`parsed_to_json_map(&parsed)`), no new config surface.
2. The alternative (a `[cost.attribution]` mapping on `CostSection`) sits under `deny_unknown_fields` and would regenerate the project config schema — a wider, higher-risk surface for speculative work.

The run-side reconstruction (`parsed_to_json_map`) keys the tenant under the literal `"tenant"` as a `Value::String`, agreeing with the discover-side `SourceOutput.components` shape. This key agreement is pinned by `parsed_to_json_map_keys_tenant_as_string_for_cost_attribution` so a future schema-parser rename fails loudly instead of silently producing an all-`<unattributed>` rollup.

**Honest limitation:** tenant attribution populates only for replication pipelines whose schema pattern declares `{tenant}`. A `[cost.attribution]` override for arbitrary pipelines is a documented follow-up.

## Codegen cascade

Ran `just codegen` (regenerated `schemas/cost.schema.json`, `schemas/run.schema.json`, the SDK Pydantic models, and the VS Code TypeScript types) and `just regen-fixtures` (zero fixture diff — the transformation playground POC has no tenant, so the `skip_serializing_if` field is omitted).

## Gates

- `cargo build --release` — clean
- `cargo test` (rocky-core 1367, rocky-cli 724, e2e 33, mcp roundtrip) — all green; new tests for grouping, tenant carry-through, forward-deser, and key agreement
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean
- `just codegen` — no further drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)
