### PR TITLE
fix(engine/import-dbt): stop the silent failures (fidelity sprint)

### DIFF
--- a/docs/src/content/docs/guides/migrate-from-dbt.md
+++ b/docs/src/content/docs/guides/migrate-from-dbt.md
@@ -250,9 +250,13 @@ What the importer translates cleanly:
 - `{{ source('s', 't') }}` → fully qualified reference + sidecar `[[sources]]`
 - `{{ config(materialized='table' \| 'incremental' \| 'view') }}` → sidecar `[strategy]` block (`view` flattens to `ephemeral` after import; see caveat above)
 - `{{ config(unique_key=...) }}` → `merge` strategy with `unique_key` array
-- `{{ this }}` → resolved against the sidecar `[target]`
+- `{{ config(alias='name') }}` → the sidecar `[target].table` — the output relation — so the data lands in the aliased table rather than one named after the node (dropping this silently mis-routes data)
+- `{{ config(materialized='microbatch') }}` with a `unique_key` → an idempotent `merge` (dbt microbatch's partition-replace becomes key-upsert; flagged so you can review). Without a `unique_key` it stays append-only and is flagged as such.
+- `{{ config(merge_update_columns=[...]) }}` → the `merge` strategy's `update_columns`
+- dbt **tags** (node- and folder-level) → the sidecar `[tags]` block (`<tag> = "true"`)
+- `{{ this }}` → the model's own fully-qualified `catalog.schema.table`
 - `is_incremental()` branches → stripped (Rocky derives the watermark filter from `[strategy]`)
-- **dbt generic tests** (`unique`, `not_null`, `accepted_values`, `relationships`) are translated column-by-column to `[[tests]]` blocks in the model sidecar (see [Generic test mapping](#generic-test-mapping) below)
+- **dbt generic tests** (`unique`, `not_null`, `accepted_values`, `relationships`) are translated column-by-column to `[[tests]]` blocks — including the *configured* forms that carry `severity:` (a `warn` becomes a Rocky warning, not a hard error) and `where:` (a row filter) (see [Generic test mapping](#generic-test-mapping) below)
 - Top-level `dbt_project.yml`, used to detect project name and seeds path
 - `<dbt_project>/seeds/` → copied verbatim into `<out>/seeds/`
 - `profiles.yml` adapter type → mapped to a Rocky `[adapter]` block (DuckDB / Databricks / Snowflake / BigQuery), or a DuckDB stub when absent or unrecognised
@@ -262,12 +266,17 @@ By design, the importer does not translate the following. Rocky has no Jinja run
 - **dbt tests outside the canonical four.** `dbt_utils.*`, `dbt_expectations.*`, project-defined generic tests, and model-level (non-column) tests are surfaced as structured warnings (`UnsupportedTest`) per occurrence and not stubbed in the emitted TOML. Rewrite as a Rocky `expression` test or a quality-pipeline check.
 - **Singular tests** in `tests/` (custom SQL): copy and rewrite manually.
 - **dbt macros and `dbt_packages/`.** Rocky has no Jinja runtime, so macro bodies do not expand.
-- **`{% if %}`, `{% for %}`, `{{ var() }}`** outside of `is_incremental()`: emitted verbatim with a TODO marker.
+- **`{% for %}` / `{% set %}`** outside `is_incremental()` on the no-manifest path: **refused** — the model is listed as a failure rather than half-rendered into broken SQL (the loop/assignment body would survive exactly once). Re-run after `dbt compile` (the manifest path resolves them) or rewrite the model. A `{% if %}` is still emitted verbatim with a TODO marker — its body applies *unconditionally*, so review it. `{{ var() }}` is emitted with a TODO marker.
 - **Unmapped `materialized` values** (`materialized_view`, `dynamic_table`, `seed`): flattened to `full_refresh` and listed in `MIGRATION-NOTES.md`.
 - **Ephemeral CTE inlining into downstream model bodies**: see the run-prerequisite note above.
 - **Adapters Rocky does not natively support** (e.g. Postgres, Redshift): the generated repo stubs DuckDB so the project still loads. Replace the `[adapter]` block once a Rocky adapter for the warehouse exists, or pass `--target-adapter <kind>` to skip detection.
 - **Custom Jinja macros emitting SQL** (e.g. `{{ generate_schema_name() }}`, dynamic `UNION ALL` macros): surfaced as failed models with the macro name in the reason.
 - **Python dbt models** (`.py` files): not SQL; rewrite manually.
+- **Snapshots, MetricFlow metrics + semantic models, and exposures** are not translated, but are now **detected and counted** — `constructs_dropped` in the JSON output plus a `DroppedConstruct` warning each — so a migration is never silently lossy.
+
+:::caution[Run `dbt compile` first]
+The importer prefers `manifest.json` (Jinja already resolved). A manifest that was only *parsed*, not *compiled*, carries no compiled SQL — every model then falls back to the lower-fidelity regex render, which can mis-render Jinja. The importer now warns loudly when it detects a manifest with no compiled SQL, but regenerate it with `dbt compile` (including any required `--vars`) before importing.
+:::
 
 The remainder of this guide walks each phase in detail (mapping `profiles.yml` to `rocky.toml`, handling unsupported Jinja, converting tests to contracts, cutover strategy), reading top-to-bottom as a migration playbook.
 

--- a/editors/vscode/src/types/generated/import_dbt.ts
+++ b/editors/vscode/src/types/generated/import_dbt.ts
@@ -49,6 +49,19 @@ export type ImportDbtStructuredWarning =
       kind: "microbatch_missing_event_time";
       model: string;
       [k: string]: unknown;
+    }
+  | {
+      kind: "microbatch_mapped";
+      mapped_to: string;
+      model: string;
+      [k: string]: unknown;
+    }
+  | {
+      construct: string;
+      detail: string;
+      kind: "dropped_construct";
+      name: string;
+      [k: string]: unknown;
     };
 /**
  * Lifecycle hook kind for [`ImportDbtStructuredWarning::DroppedHook`].
@@ -62,6 +75,10 @@ export type ImportDbtHookKind = "pre" | "post";
  */
 export interface ImportDbtOutput {
   command: string;
+  /**
+   * Number of dbt resources the importer does not translate that were detected and skipped (snapshots, metrics, semantic models, exposures).
+   */
+  constructs_dropped?: number;
   dbt_version?: string | null;
   /**
    * Metadata about the emitted Rocky repo. Present when `--output-dir` triggered repo emission (the default for `rocky import-dbt`). Absent when emission was skipped or failed before disk writes.

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`rocky import-dbt` no longer silently mis-converts — it fixes or loudly flags each gap.** A migration tool that quietly emits wrong SQL is worse than one that errors, so this closes the silent failures: dbt **`alias`** now drives the sidecar `[target].table` (it was hardcoded to the node name, silently routing data to the wrong table); **`{{ this }}`** resolves to the model's real FQN (was a bogus `__this__`); **`{% for %}`/`{% set %}`** on the no-manifest path are **refused** rather than half-rendered into broken SQL (a `{% if %}` still emits with a TODO marker); dbt **`merge_update_columns`** carries into the `merge` strategy (was update-all); dbt **microbatch** maps to an idempotent `merge(unique_key)` instead of an append-only insert that re-inserts the lookback window every run; configured **`not_null`/`unique`** tests convert and carry `severity:`/`where:` (were dropped); dbt **tags** carry onto the model `[tags]` block; and the resources the importer skips (**snapshots, metrics, semantic models, exposures**) are now detected and counted (`constructs_dropped` + per-resource warnings) instead of vanishing. When a manifest carries no compiled SQL, the importer warns loudly to run `dbt compile` first rather than regex-rendering every model. (#944)
+
 ### Added
 
 - **`rocky cost --by tenant` (and `--by model`) — grouped cost rollups.** `rocky cost <run|latest>` can now roll its per-model cost attribution up by a dimension: `--by tenant` groups executions by the discover-time schema-pattern `{tenant}` component (replication models with no recorded tenant collect in an `<unattributed>` bucket), `--by model` groups by model name. The grouped rollup is emitted as an additive `groups` array on the JSON output; `per_model` is always present, so a plain `rocky cost` is byte-for-byte unchanged. The tenant dimension is persisted on each `ModelExecution` as an additive, serde-defaulted field — no state-schema version bump, and pre-existing run records read back as unattributed.

--- a/engine/crates/rocky-cli/src/commands/import_dbt.rs
+++ b/engine/crates/rocky-cli/src/commands/import_dbt.rs
@@ -340,5 +340,20 @@ fn to_cli_structured_warning(w: &CompilerStructuredWarning) -> ImportDbtStructur
                 model: model.clone(),
             }
         }
+        CompilerStructuredWarning::MicrobatchMapped { model, mapped_to } => {
+            ImportDbtStructuredWarning::MicrobatchMapped {
+                model: model.clone(),
+                mapped_to: mapped_to.clone(),
+            }
+        }
+        CompilerStructuredWarning::DroppedConstruct {
+            construct,
+            name,
+            detail,
+        } => ImportDbtStructuredWarning::DroppedConstruct {
+            construct: construct.clone(),
+            name: name.clone(),
+            detail: detail.clone(),
+        },
     }
 }

--- a/engine/crates/rocky-cli/src/commands/import_dbt.rs
+++ b/engine/crates/rocky-cli/src/commands/import_dbt.rs
@@ -148,6 +148,7 @@ pub fn run_import_dbt(
             unit_tests_found: import_result.unit_tests_found,
             unit_tests_converted: import_result.unit_tests_converted,
             unit_tests_skipped: import_result.unit_tests_skipped,
+            constructs_dropped: import_result.constructs_dropped,
             macros_detected: import_result.macros_detected,
             imported_models: import_result
                 .imported

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -3298,6 +3298,10 @@ pub struct ImportDbtOutput {
     /// fixture format, or otherwise unsupported shape.
     #[serde(default)]
     pub unit_tests_skipped: usize,
+    /// Number of dbt resources the importer does not translate that were
+    /// detected and skipped (snapshots, metrics, semantic models, exposures).
+    #[serde(default)]
+    pub constructs_dropped: usize,
     pub macros_detected: usize,
     pub imported_models: Vec<String>,
     pub warning_details: Vec<ImportDbtWarning>,

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -3411,6 +3411,18 @@ pub enum ImportDbtStructuredWarning {
     /// A microbatch model is missing the required `event_time` field —
     /// the importer fell back to `full_refresh`.
     MicrobatchMissingEventTime { model: String },
+    /// A dbt microbatch model was remapped: to an idempotent `merge`
+    /// (`mapped_to = "merge"`) when it has a `unique_key`, or kept append-only
+    /// (`mapped_to = "append"`) when it does not.
+    MicrobatchMapped { model: String, mapped_to: String },
+    /// A dbt construct the importer does not translate was detected and
+    /// skipped (snapshot, source freshness, grants, meta, metric, semantic
+    /// model, exposure), surfaced so a migration is never silently lossy.
+    DroppedConstruct {
+        construct: String,
+        name: String,
+        detail: String,
+    },
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/engine/crates/rocky-compiler/src/import/dbt.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt.rs
@@ -140,6 +140,20 @@ pub enum ImportDbtStructuredWarning {
     /// surfaces the gap so the user can either add `event_time` to the
     /// dbt source or pick a non-microbatch strategy.
     MicrobatchMissingEventTime { model: String },
+    /// A dbt microbatch model was remapped. With a `unique_key` it becomes an
+    /// idempotent Rocky `merge` (`mapped_to = "merge"`); without one it stays
+    /// append-only (`mapped_to = "append"`) and will re-insert the lookback
+    /// window every run, so it must be converted manually.
+    MicrobatchMapped { model: String, mapped_to: String },
+    /// A dbt construct the importer does not translate was detected and
+    /// skipped (snapshot, source freshness, grants, meta, metric, semantic
+    /// model, exposure). Surfaced with a count so a migration is never
+    /// silently lossy.
+    DroppedConstruct {
+        construct: String,
+        name: String,
+        detail: String,
+    },
 }
 
 /// A model that failed to import.
@@ -512,7 +526,28 @@ fn import_manifest_node(
     default_target: &TargetConfig,
     result: &mut ImportResult,
 ) {
-    // Use compiled_code (Jinja resolved) if available, else raw_code
+    // Resolve the model's output coordinates up front so the raw-code fallback
+    // (for {{ this }}) and the emitted target use the same values. dbt `alias`
+    // overrides the relation name; dropping it silently lands the data in a
+    // table named after the node.
+    let schema = node
+        .config
+        .schema
+        .clone()
+        .unwrap_or_else(|| default_target.schema.clone());
+    let catalog = if node.database.is_empty() {
+        default_target.catalog.clone()
+    } else {
+        node.database.clone()
+    };
+    let table = node
+        .config
+        .alias
+        .clone()
+        .unwrap_or_else(|| node.name.clone());
+    let this_ref = format!("{catalog}.{schema}.{table}");
+
+    // Use compiled_code (Jinja resolved) if available, else raw_code.
     let sql = match &node.compiled_code {
         Some(code) => code.clone(),
         None => {
@@ -523,7 +558,7 @@ fn import_manifest_node(
                     .to_string(),
                 suggestion: Some("run `dbt compile` to generate compiled SQL".to_string()),
             });
-            convert_jinja_to_sql(&node.raw_code)
+            convert_jinja_to_sql(&node.raw_code, &this_ref)
         }
     };
 
@@ -554,26 +589,14 @@ fn import_manifest_node(
     // Use description as intent
     let intent = node.description.clone();
 
-    let schema = node
-        .config
-        .schema
-        .as_deref()
-        .unwrap_or(&default_target.schema);
-
-    let catalog = if node.database.is_empty() {
-        default_target.catalog.clone()
-    } else {
-        node.database.clone()
-    };
-
     let config = ModelConfig {
         name: node.name.clone(),
         depends_on,
         strategy,
         target: TargetConfig {
             catalog,
-            schema: schema.to_string(),
-            table: node.name.clone(),
+            schema,
+            table,
         },
         sources: vec![],
         adapter: None,
@@ -583,7 +606,7 @@ fn import_manifest_node(
         format: None,
         format_options: None,
         classification: Default::default(),
-        tags: Default::default(),
+        tags: dbt_tags_to_map(&node.tags),
         retention: None,
         budget: None,
         skip: None,
@@ -697,10 +720,25 @@ fn map_incremental_strategy(
 
     match strategy_kind.as_str() {
         "merge" => match unique_keys {
-            Some(keys) if !keys.is_empty() => StrategyConfig::Merge {
-                unique_key: keys,
-                update_columns: None,
-            },
+            Some(keys) if !keys.is_empty() => {
+                // dbt `merge_exclude_columns` (update all-but-these) has no
+                // direct Rocky equivalent — without the full column list we
+                // can't invert it, so warn rather than silently update-all.
+                if config.merge_update_columns.is_none() && config.merge_exclude_columns.is_some() {
+                    warnings.push(ImportWarning {
+                        model: model_name.to_string(),
+                        category: WarningCategory::UnsupportedMaterialization,
+                        message: "merge_exclude_columns has no direct Rocky equivalent — the emitted merge updates all columns".to_string(),
+                        suggestion: Some(
+                            "list the columns to update via the emitted [strategy] `update_columns` instead".to_string(),
+                        ),
+                    });
+                }
+                StrategyConfig::Merge {
+                    unique_key: keys,
+                    update_columns: config.merge_update_columns.clone(),
+                }
+            }
             _ => {
                 warnings.push(ImportWarning {
                     model: model_name.to_string(),
@@ -824,9 +862,53 @@ fn map_microbatch_strategy(
         .map(|s| batch_size_to_grain(s, model_name, warnings))
         .unwrap_or(TimeGrain::Day);
 
-    StrategyConfig::Microbatch {
-        timestamp_column: event_time,
-        granularity,
+    // dbt microbatch idempotently REPLACES each batch partition. Rocky's
+    // Microbatch strategy emits an append-only INSERT (sql_gen.rs), so importing
+    // it as-is silently re-inserts the lookback window every run. dbt microbatch
+    // requires a `unique_key`, so map it to an idempotent Rocky merge instead;
+    // only fall back to append-only (loudly) if a key is somehow absent.
+    let unique_keys: Option<Vec<String>> = config.unique_key.as_ref().map(|uk| match uk {
+        UniqueKeyValue::Single(s) => vec![s.clone()],
+        UniqueKeyValue::Multiple(v) => v.clone(),
+    });
+
+    match unique_keys {
+        Some(keys) if !keys.is_empty() => {
+            warnings.push(ImportWarning {
+                model: model_name.to_string(),
+                category: WarningCategory::UnsupportedMaterialization,
+                message: "dbt microbatch mapped to an idempotent Rocky merge(unique_key); partition-replace becomes key-upsert, so rows removed from the source window are not deleted".to_string(),
+                suggestion: Some(
+                    "review the emitted [strategy] block; for true partition-replace use a time-interval model with @start_date/@end_date".to_string(),
+                ),
+            });
+            structured.push(ImportDbtStructuredWarning::MicrobatchMapped {
+                model: model_name.to_string(),
+                mapped_to: "merge".to_string(),
+            });
+            StrategyConfig::Merge {
+                unique_key: keys,
+                update_columns: config.merge_update_columns.clone(),
+            }
+        }
+        _ => {
+            warnings.push(ImportWarning {
+                model: model_name.to_string(),
+                category: WarningCategory::UnsupportedMaterialization,
+                message: "dbt microbatch without a unique_key imports as append-only and re-inserts the lookback window every run".to_string(),
+                suggestion: Some(
+                    "add a unique_key (microbatch requires one) so it maps to an idempotent merge, or convert to a time-interval strategy".to_string(),
+                ),
+            });
+            structured.push(ImportDbtStructuredWarning::MicrobatchMapped {
+                model: model_name.to_string(),
+                mapped_to: "append".to_string(),
+            });
+            StrategyConfig::Microbatch {
+                timestamp_column: event_time,
+                granularity,
+            }
+        }
     }
 }
 
@@ -1266,12 +1348,18 @@ fn import_single_model(
             block_re.is_match(&content_processed)
         };
         if has_non_incr_blocks {
-            warnings.push(ImportWarning {
-                model: name.to_string(),
-                category: WarningCategory::JinjaControlFlow,
-                message: "contains Jinja control flow ({% if %}, {% for %}) — replaced with TODO comments".to_string(),
-                suggestion: Some("consider using manifest.json import path for full Jinja resolution".to_string()),
-            });
+            // Refuse rather than half-render: `block_re` strips only the
+            // `{% %}` delimiters, so a `{% for %}`/`{% set %}`/non-incremental
+            // `{% if %}` body survives exactly once, yielding SQL that loads
+            // but is semantically wrong (a loop meant to emit N columns emits
+            // one broken fragment). A loud failure beats a silent mis-render.
+            return Err(
+                "contains unsupported Jinja control flow ({% for %}, {% set %}, or a \
+                 non-incremental {% if %}) that the no-manifest importer cannot faithfully \
+                 render — re-run after `dbt compile` (the manifest path resolves Jinja) or \
+                 rewrite the model without control flow"
+                    .to_string(),
+            );
         }
     }
     if content_processed.contains("{{ var(") {
@@ -1307,7 +1395,7 @@ fn import_single_model(
     }
 
     // Apply project config inheritance
-    let resolved_schema = if let Some(proj) = project_config {
+    let (resolved_schema, resolved_tags) = if let Some(proj) = project_config {
         let resolved = dbt_project::resolve_model_config(proj, rel_path);
         // Project-level materialization: only override if no model-level config
         if !content_processed.contains("config(") && matches!(strategy, StrategyConfig::FullRefresh)
@@ -1337,13 +1425,22 @@ fn import_single_model(
                 _ => {}
             }
         }
-        resolved.schema
+        (resolved.schema, resolved.tags)
     } else {
-        None
+        (None, Vec::new())
     };
 
-    // Convert Jinja refs to plain SQL
-    let sql = convert_jinja_to_sql(&content_processed);
+    // Resolve the model's output coordinates so {{ this }} substitutes the real
+    // FQN and the emitted target uses the same alias-aware table name.
+    let resolved_schema_str = resolved_schema.as_deref().unwrap_or(&default_target.schema);
+    let resolved_table = extract_dbt_alias(&content_processed).unwrap_or_else(|| name.to_string());
+    let this_ref = format!(
+        "{}.{}.{}",
+        default_target.catalog, resolved_schema_str, resolved_table
+    );
+
+    // Convert Jinja refs to plain SQL.
+    let sql = convert_jinja_to_sql(&content_processed, &this_ref);
 
     // Resolve source references
     let mut model_sources = Vec::new();
@@ -1366,16 +1463,14 @@ fn import_single_model(
         }
     }
 
-    let schema = resolved_schema.as_deref().unwrap_or(&default_target.schema);
-
     let config = ModelConfig {
         name: name.to_string(),
         depends_on: vec![], // Auto-resolved by compiler
         strategy,
         target: TargetConfig {
             catalog: default_target.catalog.clone(),
-            schema: schema.to_string(),
-            table: name.to_string(),
+            schema: resolved_schema_str.to_string(),
+            table: resolved_table,
         },
         sources: model_sources,
         adapter: None,
@@ -1385,7 +1480,7 @@ fn import_single_model(
         format: None,
         format_options: None,
         classification: Default::default(),
-        tags: Default::default(),
+        tags: dbt_tags_to_map(&resolved_tags),
         retention: None,
         budget: None,
         skip: None,
@@ -1497,6 +1592,26 @@ fn extract_timestamp_from_where(block: &str) -> Option<String> {
 /// discarded here on purpose — the regex path emits string warnings
 /// only (the manifest path is the canonical surface for
 /// structured-warning consumers).
+/// Map a dbt tag list onto Rocky's key/value `[tags]` shape. dbt tags are bare
+/// labels; each becomes `<tag> = "true"` so it stays a queryable key in
+/// `ModelConfig.tags` (a `BTreeMap<String, String>`).
+fn dbt_tags_to_map(tags: &[String]) -> std::collections::BTreeMap<String, String> {
+    tags.iter()
+        .filter(|t| !t.trim().is_empty())
+        .map(|t| (t.clone(), "true".to_string()))
+        .collect()
+}
+
+/// Best-effort parse of `alias='...'` from a model's `{{ config(...) }}` block
+/// on the regex (no-manifest) path. dbt `alias` overrides the output relation
+/// name; dropping it would silently route the model's data to a table named
+/// after the file.
+fn extract_dbt_alias(content: &str) -> Option<String> {
+    let config_re = Regex::new(r"\{\{\s*config\s*\(([^)]*)\)\s*\}\}").ok()?;
+    let caps = config_re.captures(content)?;
+    single_string_value(&caps[1], "alias")
+}
+
 fn extract_dbt_config(content: &str) -> (StrategyConfig, Vec<String>) {
     let mut messages = Vec::new();
 
@@ -1545,6 +1660,11 @@ fn extract_dbt_config(content: &str) -> (StrategyConfig, Vec<String>) {
         pre_hook: Vec::new(),
         post_hook: Vec::new(),
         on_schema_change: None,
+        // alias does not affect strategy selection; the regex path threads it
+        // to target.table separately via extract_dbt_alias.
+        alias: None,
+        merge_update_columns: None,
+        merge_exclude_columns: None,
     };
 
     let mapping = map_manifest_strategy(&synthetic, "<regex-path>");
@@ -1591,7 +1711,7 @@ fn single_string_value(config_str: &str, key: &str) -> Option<String> {
 // ---------------------------------------------------------------------------
 
 /// Convert dbt Jinja expressions to plain SQL.
-fn convert_jinja_to_sql(content: &str) -> String {
+fn convert_jinja_to_sql(content: &str, this_ref: &str) -> String {
     let mut sql = content.to_string();
 
     // Remove {{ config(...) }} blocks
@@ -1608,9 +1728,14 @@ fn convert_jinja_to_sql(content: &str) -> String {
             .unwrap();
     sql = source_re.replace_all(&sql, "$1.$2").to_string();
 
-    // {{ this }} -> __this__ (placeholder, resolved at execution)
+    // {{ this }} -> the model's own fully-qualified name. Substituting a real
+    // catalog.schema.table (NoExpand so dots/`$` are literal) avoids emitting a
+    // bogus `__this__` identifier that loads via the sidecar but fails at the
+    // warehouse.
     let this_re = Regex::new(r"\{\{\s*this\s*\}\}").unwrap();
-    sql = this_re.replace_all(&sql, "__this__").to_string();
+    sql = this_re
+        .replace_all(&sql, regex::NoExpand(this_ref))
+        .to_string();
 
     // Replace unsupported Jinja blocks with TODO comments
     let block_re = Regex::new(r"\{%[^%]*%\}").unwrap();
@@ -1661,31 +1786,41 @@ mod tests {
     #[test]
     fn test_convert_ref() {
         let input = "SELECT * FROM {{ ref('orders') }}";
-        assert_eq!(convert_jinja_to_sql(input), "SELECT * FROM orders");
+        assert_eq!(
+            convert_jinja_to_sql(input, "cat.sch.tbl"),
+            "SELECT * FROM orders"
+        );
     }
 
     #[test]
     fn test_convert_source() {
         let input = "SELECT * FROM {{ source('raw', 'customers') }}";
-        assert_eq!(convert_jinja_to_sql(input), "SELECT * FROM raw.customers");
+        assert_eq!(
+            convert_jinja_to_sql(input, "cat.sch.tbl"),
+            "SELECT * FROM raw.customers"
+        );
     }
 
     #[test]
     fn test_convert_config_removed() {
         let input = "{{ config(materialized='table') }}\nSELECT 1";
-        assert_eq!(convert_jinja_to_sql(input), "SELECT 1");
+        assert_eq!(convert_jinja_to_sql(input, "cat.sch.tbl"), "SELECT 1");
     }
 
     #[test]
     fn test_convert_this() {
         let input = "SELECT * FROM {{ this }}";
-        assert_eq!(convert_jinja_to_sql(input), "SELECT * FROM __this__");
+        // {{ this }} resolves to the model's own FQN, not a bogus __this__.
+        assert_eq!(
+            convert_jinja_to_sql(input, "cat.sch.tbl"),
+            "SELECT * FROM cat.sch.tbl"
+        );
     }
 
     #[test]
     fn test_convert_unsupported_jinja() {
         let input = "{% if some_condition %}WHERE id > 0{% endif %}";
-        let result = convert_jinja_to_sql(input);
+        let result = convert_jinja_to_sql(input, "cat.sch.tbl");
         assert!(result.contains("TODO: unsupported Jinja block"));
     }
 
@@ -1776,7 +1911,7 @@ mod tests {
     fn test_multiple_refs() {
         let input =
             "SELECT * FROM {{ ref('orders') }} o JOIN {{ ref('customers') }} c ON o.id = c.id";
-        let result = convert_jinja_to_sql(input);
+        let result = convert_jinja_to_sql(input, "cat.sch.tbl");
         assert_eq!(
             result,
             "SELECT * FROM orders o JOIN customers c ON o.id = c.id"

--- a/engine/crates/rocky-compiler/src/import/dbt.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt.rs
@@ -211,6 +211,10 @@ pub struct ImportResult {
     /// fixture format, or any other shape the importer can't faithfully
     /// translate.
     pub unit_tests_skipped: usize,
+    /// Number of dbt resources the importer does not translate that were
+    /// detected and skipped (snapshots, metrics, semantic models, exposures).
+    /// Surfaced so a migration is never silently lossy.
+    pub constructs_dropped: usize,
 }
 
 /// A successfully imported model.
@@ -258,15 +262,91 @@ pub fn import_from_manifest(manifest: &DbtManifest, default_target: &TargetConfi
         unit_tests_found: 0,
         unit_tests_converted: 0,
         unit_tests_skipped: 0,
+        constructs_dropped: 0,
     };
+
+    // A manifest with no compiled SQL means every model falls back to the
+    // reduced-fidelity raw-code path; detect it before importing so we can warn
+    // loudly rather than emit a plausible-but-wrong repo.
+    let model_count = manifest.nodes.len();
+    let with_compiled = manifest
+        .nodes
+        .values()
+        .filter(|n| n.compiled_code.is_some())
+        .count();
 
     for node in manifest.nodes.values() {
         import_manifest_node(node, default_target, &mut result);
     }
 
+    if model_count > 0 && with_compiled == 0 {
+        result.warnings.push(ImportWarning {
+            model: "<manifest>".to_string(),
+            category: WarningCategory::StaleManifest,
+            message: format!(
+                "none of the {model_count} manifest nodes carry compiled SQL — every model was \
+                 imported via the reduced-fidelity raw-code path, which can mis-render Jinja. The \
+                 import likely looks complete but is not faithful."
+            ),
+            suggestion: Some(
+                "regenerate the manifest with `dbt compile` (including any required --vars) and re-import".to_string(),
+            ),
+        });
+    }
+
+    // Surface the resource classes the importer does not translate so a
+    // migration is never silently lossy.
+    record_dropped_constructs(&manifest.dropped, &mut result);
+
     apply_dbt_unit_tests(manifest, &mut result);
 
     result
+}
+
+/// Emit a structured `DroppedConstruct` warning per non-zero dropped resource
+/// class (snapshots, metrics, semantic models, exposures) and bump
+/// `constructs_dropped`.
+fn record_dropped_constructs(dropped: &dbt_manifest::DbtDroppedCounts, result: &mut ImportResult) {
+    for (construct, count, detail) in [
+        (
+            "snapshot",
+            dropped.snapshots,
+            "Rocky has no snapshot pipeline yet — re-implement as a [snapshot] pipeline or keep it in dbt",
+        ),
+        (
+            "metric",
+            dropped.metrics,
+            "MetricFlow metrics are not imported — keep your semantic layer in dbt or a metrics tool",
+        ),
+        (
+            "semantic_model",
+            dropped.semantic_models,
+            "MetricFlow semantic models are not imported",
+        ),
+        (
+            "exposure",
+            dropped.exposures,
+            "dbt exposures (downstream-usage docs) are not imported",
+        ),
+    ] {
+        if count == 0 {
+            continue;
+        }
+        result.constructs_dropped += count;
+        result.warnings.push(ImportWarning {
+            model: "<project>".to_string(),
+            category: WarningCategory::UnsupportedMaterialization,
+            message: format!("{count} {construct}(s) skipped — {detail}"),
+            suggestion: None,
+        });
+        result
+            .structured_warnings
+            .push(ImportDbtStructuredWarning::DroppedConstruct {
+                construct: construct.to_string(),
+                name: format!("{count} total"),
+                detail: detail.to_string(),
+            });
+    }
 }
 
 /// Walk a dbt project's `models/` tree for `schema.yml` files, convert any
@@ -1209,6 +1289,7 @@ pub fn import_dbt_project(
         unit_tests_found: 0,
         unit_tests_converted: 0,
         unit_tests_skipped: 0,
+        constructs_dropped: 0,
     };
 
     // Verify at least one model directory exists
@@ -1343,23 +1424,32 @@ fn import_single_model(
 
     // Check for remaining unsupported Jinja patterns
     if content_processed.contains("{%") {
-        let has_non_incr_blocks = {
-            let block_re = Regex::new(r"\{%[^%]*%\}").unwrap();
-            block_re.is_match(&content_processed)
-        };
-        if has_non_incr_blocks {
-            // Refuse rather than half-render: `block_re` strips only the
-            // `{% %}` delimiters, so a `{% for %}`/`{% set %}`/non-incremental
-            // `{% if %}` body survives exactly once, yielding SQL that loads
-            // but is semantically wrong (a loop meant to emit N columns emits
-            // one broken fragment). A loud failure beats a silent mis-render.
+        // `{% for %}` / `{% set %}` REFUSE: the regex conversion strips only
+        // the `{% %}` delimiters, so a loop/assignment body survives exactly
+        // once — a loop meant to emit N columns emits one broken fragment that
+        // loads but is wrong. A loud failure beats a silent mis-render.
+        let for_set_re = Regex::new(r"\{%-?\s*(for|set)\b").unwrap();
+        if for_set_re.is_match(&content_processed) {
             return Err(
-                "contains unsupported Jinja control flow ({% for %}, {% set %}, or a \
-                 non-incremental {% if %}) that the no-manifest importer cannot faithfully \
-                 render — re-run after `dbt compile` (the manifest path resolves Jinja) or \
-                 rewrite the model without control flow"
+                "contains unsupported Jinja control flow ({% for %} or {% set %}) that the \
+                 no-manifest importer cannot faithfully render — re-run after `dbt compile` (the \
+                 manifest path resolves Jinja) or rewrite the model without loops/assignments"
                     .to_string(),
             );
+        }
+        // Other control flow ({% if %}) is still emitted with TODO markers and
+        // a warning — it degrades (the body is applied unconditionally) but
+        // stays inspectable for review, matching the long-standing behaviour.
+        let block_re = Regex::new(r"\{%[^%]*%\}").unwrap();
+        if block_re.is_match(&content_processed) {
+            warnings.push(ImportWarning {
+                model: name.to_string(),
+                category: WarningCategory::JinjaControlFlow,
+                message: "contains Jinja control flow ({% if %}) — emitted with TODO markers; the conditional body is applied unconditionally, so review the result".to_string(),
+                suggestion: Some(
+                    "use the manifest import path (`dbt compile`) for faithful Jinja resolution".to_string(),
+                ),
+            });
         }
     }
     if content_processed.contains("{{ var(") {
@@ -2335,6 +2425,120 @@ FROM {{ ref('stg_events') }}
             result.imported[0].config.strategy,
             StrategyConfig::View
         ));
+    }
+
+    fn model_node(
+        name: &str,
+        config: serde_json::Value,
+        tags: serde_json::Value,
+    ) -> serde_json::Value {
+        let mut node = serde_json::json!({
+            "unique_id": format!("model.p.{name}"),
+            "name": name,
+            "resource_type": "model",
+            "compiled_code": "SELECT 1",
+            "raw_code": "SELECT 1",
+            "depends_on": { "nodes": [], "macros": [] },
+            "columns": {}, "schema": "s", "database": "d"
+        });
+        node["config"] = config;
+        node["tags"] = tags;
+        node
+    }
+
+    #[test]
+    fn test_manifest_alias_overrides_target_table() {
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": { "model.p.m": model_node("m",
+                serde_json::json!({ "materialized": "table", "alias": "renamed" }),
+                serde_json::json!([])) },
+            "sources": {}
+        });
+        let result = import_from_manifest_json(&manifest);
+        // alias drives the physical table; the logical name is unchanged.
+        assert_eq!(result.imported[0].config.target.table, "renamed");
+        assert_eq!(result.imported[0].config.name, "m");
+    }
+
+    #[test]
+    fn test_manifest_microbatch_with_unique_key_maps_to_merge() {
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": { "model.p.f": model_node("f",
+                serde_json::json!({ "materialized": "microbatch", "event_time": "ts", "batch_size": "day", "unique_key": "id" }),
+                serde_json::json!([])) },
+            "sources": {}
+        });
+        let result = import_from_manifest_json(&manifest);
+        assert!(
+            matches!(
+                result.imported[0].config.strategy,
+                StrategyConfig::Merge { .. }
+            ),
+            "microbatch with a unique_key maps to an idempotent merge"
+        );
+        assert!(result.structured_warnings.iter().any(|w| matches!(w,
+            ImportDbtStructuredWarning::MicrobatchMapped { mapped_to, .. } if mapped_to == "merge")));
+    }
+
+    #[test]
+    fn test_manifest_tags_carry_onto_model() {
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": { "model.p.m": model_node("m",
+                serde_json::json!({ "materialized": "table" }),
+                serde_json::json!(["finance", "daily"])) },
+            "sources": {}
+        });
+        let result = import_from_manifest_json(&manifest);
+        let tags = &result.imported[0].config.tags;
+        assert_eq!(tags.get("finance").map(String::as_str), Some("true"));
+        assert_eq!(tags.get("daily").map(String::as_str), Some("true"));
+    }
+
+    #[test]
+    fn test_manifest_sweep_reports_dropped_constructs() {
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": {
+                "model.p.m": model_node("m", serde_json::json!({ "materialized": "table" }), serde_json::json!([])),
+                "snapshot.p.snap": {
+                    "unique_id": "snapshot.p.snap", "name": "snap",
+                    "resource_type": "snapshot", "raw_code": ""
+                }
+            },
+            "sources": {},
+            "metrics": { "metric.p.rev": {} }
+        });
+        let result = import_from_manifest_json(&manifest);
+        assert_eq!(result.imported.len(), 1, "only the model imports");
+        assert_eq!(result.constructs_dropped, 2, "1 snapshot + 1 metric");
+        assert!(result.structured_warnings.iter().any(|w| matches!(w,
+            ImportDbtStructuredWarning::DroppedConstruct { construct, .. } if construct == "snapshot")));
+    }
+
+    #[test]
+    fn test_manifest_without_compiled_code_warns_stale() {
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": { "model.p.m": {
+                "unique_id": "model.p.m", "name": "m", "resource_type": "model",
+                "raw_code": "SELECT 1",
+                "depends_on": { "nodes": [], "macros": [] },
+                "config": { "materialized": "table" },
+                "columns": {}, "tags": [], "schema": "s", "database": "d"
+            }},
+            "sources": {}
+        });
+        let result = import_from_manifest_json(&manifest);
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| matches!(w.category, WarningCategory::StaleManifest)),
+            "a manifest with no compiled SQL must warn loudly"
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-compiler/src/import/dbt.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt.rs
@@ -742,7 +742,9 @@ fn map_manifest_strategy(config: &DbtNodeConfig, model_name: &str) -> StrategyMa
             });
             StrategyConfig::FullRefresh
         }
-        "incremental" => map_incremental_strategy(config, model_name, &mut warnings),
+        "incremental" => {
+            map_incremental_strategy(config, model_name, &mut warnings, &mut structured)
+        }
         "microbatch" => map_microbatch_strategy(config, model_name, &mut warnings, &mut structured),
         other => {
             warnings.push(ImportWarning {
@@ -777,6 +779,7 @@ fn map_incremental_strategy(
     config: &DbtNodeConfig,
     model_name: &str,
     warnings: &mut Vec<ImportWarning>,
+    structured: &mut Vec<ImportDbtStructuredWarning>,
 ) -> StrategyConfig {
     let unique_keys: Option<Vec<String>> = config.unique_key.as_ref().map(|uk| match uk {
         UniqueKeyValue::Single(s) => vec![s.clone()],
@@ -889,10 +892,12 @@ fn map_incremental_strategy(
             }
         }
         "microbatch" => {
-            // Re-dispatch through the microbatch path so we get the
-            // same event_time validation + granularity translation.
-            let mut structured = Vec::new();
-            map_microbatch_strategy(config, model_name, warnings, &mut structured)
+            // Re-dispatch through the microbatch path for the same event_time
+            // validation + granularity translation. This is the REAL dbt
+            // microbatch form (`incremental_strategy='microbatch'`), so the
+            // MicrobatchMapped structured warning must be threaded out to the
+            // caller, not dropped into a local vec.
+            map_microbatch_strategy(config, model_name, warnings, structured)
         }
         other => {
             warnings.push(ImportWarning {
@@ -2465,8 +2470,13 @@ FROM {{ ref('stg_events') }}
     fn test_manifest_microbatch_with_unique_key_maps_to_merge() {
         let manifest = serde_json::json!({
             "metadata": { "project_name": "p" },
+            // The REAL dbt microbatch form: materialized='incremental' +
+            // incremental_strategy='microbatch' (there is no
+            // materialized='microbatch' in dbt). This routes through
+            // map_incremental_strategy, so it guards the structured-warning
+            // threading.
             "nodes": { "model.p.f": model_node("f",
-                serde_json::json!({ "materialized": "microbatch", "event_time": "ts", "batch_size": "day", "unique_key": "id" }),
+                serde_json::json!({ "materialized": "incremental", "incremental_strategy": "microbatch", "event_time": "ts", "batch_size": "day", "unique_key": "id" }),
                 serde_json::json!([])) },
             "sources": {}
         });

--- a/engine/crates/rocky-compiler/src/import/dbt_manifest.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt_manifest.rs
@@ -21,6 +21,19 @@ pub struct DbtManifest {
     /// Unit-test definitions keyed by `unit_test.<project>.<model>.<name>`.
     /// Empty when the manifest predates dbt's unit-test feature.
     pub unit_tests: HashMap<String, DbtManifestUnitTest>,
+    /// Counts of resource classes the importer does not translate, captured at
+    /// parse time so the sweep can report them.
+    pub dropped: DbtDroppedCounts,
+}
+
+/// Counts of dbt resource classes the importer skips. Surfaced (not silently
+/// ignored) via the import warning sweep.
+#[derive(Debug, Clone, Default)]
+pub struct DbtDroppedCounts {
+    pub snapshots: usize,
+    pub metrics: usize,
+    pub semantic_models: usize,
+    pub exposures: usize,
 }
 
 /// Manifest-level metadata.
@@ -169,6 +182,14 @@ struct RawManifest {
     sources: HashMap<String, RawManifestSource>,
     #[serde(default)]
     unit_tests: HashMap<String, RawUnitTest>,
+    // Count-only: resource classes the importer does not translate. Captured
+    // so the sweep can report them rather than silently ignoring them.
+    #[serde(default)]
+    metrics: HashMap<String, serde_json::Value>,
+    #[serde(default)]
+    semantic_models: HashMap<String, serde_json::Value>,
+    #[serde(default)]
+    exposures: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Deserialize, Default)]
@@ -340,6 +361,17 @@ pub fn parse_manifest(path: &Path) -> Result<DbtManifest, String> {
         project_name: raw.metadata.project_name.unwrap_or_default(),
     };
 
+    let dropped = DbtDroppedCounts {
+        snapshots: raw
+            .nodes
+            .values()
+            .filter(|n| n.resource_type == "snapshot")
+            .count(),
+        metrics: raw.metrics.len(),
+        semantic_models: raw.semantic_models.len(),
+        exposures: raw.exposures.len(),
+    };
+
     let nodes = raw
         .nodes
         .into_iter()
@@ -376,6 +408,7 @@ pub fn parse_manifest(path: &Path) -> Result<DbtManifest, String> {
         nodes,
         sources,
         unit_tests,
+        dropped,
     })
 }
 

--- a/engine/crates/rocky-compiler/src/import/dbt_manifest.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt_manifest.rs
@@ -85,6 +85,13 @@ pub struct DbtNodeConfig {
     /// `on_schema_change` — dbt-databricks drift policy. One of `ignore`,
     /// `fail`, `append_new_columns`, `sync_all_columns`.
     pub on_schema_change: Option<String>,
+    /// `alias` — overrides the output relation (table) name. When set, the
+    /// model materializes to this name instead of the node name.
+    pub alias: Option<String>,
+    /// `merge_update_columns` — explicit MERGE UPDATE column list (dbt).
+    pub merge_update_columns: Option<Vec<String>>,
+    /// `merge_exclude_columns` — columns excluded from the MERGE UPDATE (dbt).
+    pub merge_exclude_columns: Option<Vec<String>>,
 }
 
 /// unique_key can be a single string or a list.
@@ -278,6 +285,18 @@ struct RawNodeConfig {
     post_hook_dashed: Option<serde_json::Value>,
     #[serde(default)]
     on_schema_change: Option<String>,
+    /// `alias` — overrides the relation (table) name. dbt routes the model's
+    /// output to this name instead of the file/node name; dropping it silently
+    /// lands the data in the wrong table.
+    #[serde(default)]
+    alias: Option<String>,
+    /// `merge_update_columns` — the explicit columns to UPDATE on a MERGE
+    /// match. Dropping it silently turns a column-scoped merge into update-all.
+    #[serde(default)]
+    merge_update_columns: Option<Vec<String>>,
+    /// `merge_exclude_columns` — columns excluded from the MERGE UPDATE.
+    #[serde(default)]
+    merge_exclude_columns: Option<Vec<String>>,
 }
 
 #[derive(Deserialize)]
@@ -478,6 +497,9 @@ fn convert_node(raw: RawNode) -> DbtManifestNode {
             pre_hook,
             post_hook,
             on_schema_change: config.on_schema_change,
+            alias: config.alias,
+            merge_update_columns: config.merge_update_columns,
+            merge_exclude_columns: config.merge_exclude_columns,
         },
         columns,
         description: raw.description.filter(|d| !d.is_empty()),

--- a/engine/crates/rocky-compiler/src/import/dbt_tests.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt_tests.rs
@@ -438,6 +438,23 @@ pub fn tests_to_test_decls(
                     }
                 },
                 DbtTestDef::Configured { name, config } => match name.as_str() {
+                    // Configured not_null/unique (e.g. `{not_null: {where: …,
+                    // severity: warn}}`) previously fell to the catch-all and
+                    // were dropped — silently turning a scoped or warn-level
+                    // test into nothing, or a `severity: warn` into a hard
+                    // error. Convert them, carrying the row filter and severity.
+                    "not_null" => decls.push(TestDecl {
+                        test_type: TestType::NotNull,
+                        column: Some(col.name.clone()),
+                        severity: config_severity(config),
+                        filter: config_filter(config),
+                    }),
+                    "unique" => decls.push(TestDecl {
+                        test_type: TestType::Unique,
+                        column: Some(col.name.clone()),
+                        severity: config_severity(config),
+                        filter: config_filter(config),
+                    }),
                     "accepted_values" => match accepted_values_decl(&col.name, config) {
                         Some(decl) => decls.push(decl),
                         None => unsupported.push(UnsupportedTest {
@@ -494,8 +511,8 @@ fn accepted_values_decl(
     Some(TestDecl {
         test_type: TestType::AcceptedValues { values },
         column: Some(col_name.to_string()),
-        severity: TestSeverity::Error,
-        filter: None,
+        severity: config_severity(config),
+        filter: config_filter(config),
     })
 }
 
@@ -514,9 +531,27 @@ fn relationships_decl(
             to_column: field.to_string(),
         },
         column: Some(col_name.to_string()),
-        severity: TestSeverity::Error,
-        filter: None,
+        severity: config_severity(config),
+        filter: config_filter(config),
     })
+}
+
+/// dbt test `severity: warn` maps to a Rocky warning; anything else (incl.
+/// the default and `error`) is a hard error.
+fn config_severity(config: &HashMap<String, serde_yaml::Value>) -> TestSeverity {
+    match config.get("severity").and_then(serde_yaml::Value::as_str) {
+        Some(s) if s.eq_ignore_ascii_case("warn") => TestSeverity::Warning,
+        _ => TestSeverity::Error,
+    }
+}
+
+/// dbt test `where: <expr>` scopes the test to a row subset; map it to the
+/// Rocky test decl's row filter.
+fn config_filter(config: &HashMap<String, serde_yaml::Value>) -> Option<String> {
+    config
+        .get("where")
+        .and_then(serde_yaml::Value::as_str)
+        .map(str::to_string)
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/crates/rocky-compiler/src/import/dbt_tests.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt_tests.rs
@@ -851,6 +851,35 @@ models:
     }
 
     #[test]
+    fn test_configured_not_null_carries_severity_and_where() {
+        let yaml = r#"
+models:
+  - name: orders
+    columns:
+      - name: status
+        tests:
+          - not_null:
+              where: "created_at > '2026-01-01'"
+              severity: warn
+"#;
+        let models = parse_model_yaml_content(yaml).unwrap();
+        let resolver = default_resolver();
+        let (decls, unsupported) = tests_to_test_decls(&models[0], &resolver);
+        assert_eq!(
+            unsupported.len(),
+            0,
+            "configured not_null must convert, not drop"
+        );
+        assert_eq!(decls.len(), 1);
+        assert!(matches!(decls[0].test_type, TestType::NotNull));
+        assert_eq!(decls[0].severity, TestSeverity::Warning);
+        assert_eq!(
+            decls[0].filter.as_deref(),
+            Some("created_at > '2026-01-01'")
+        );
+    }
+
+    #[test]
     fn test_parse_model_without_tests() {
         let yaml = r#"
 models:

--- a/engine/crates/rocky-compiler/src/import/emit.rs
+++ b/engine/crates/rocky-compiler/src/import/emit.rs
@@ -346,6 +346,22 @@ fn render_model_sidecar(config: &ModelConfig) -> String {
     out.push_str(&format!("schema = \"{}\"\n", config.target.schema));
     out.push_str(&format!("table = \"{}\"\n", config.target.table));
 
+    if !config.tags.is_empty() {
+        out.push('\n');
+        out.push_str("[tags]\n");
+        for (k, v) in &config.tags {
+            let key = if !k.is_empty()
+                && k.chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+            {
+                k.clone()
+            } else {
+                format!("{k:?}")
+            };
+            out.push_str(&format!("{key} = \"{v}\"\n"));
+        }
+    }
+
     if !config.sources.is_empty() {
         out.push('\n');
         for src in &config.sources {
@@ -533,7 +549,10 @@ fn write_structured_warnings(
             | W::DroppedHook { model, .. }
             | W::DroppedOnSchemaChange { model, .. }
             | W::UnresolvableMacro { model, .. }
-            | W::MicrobatchMissingEventTime { model } => model.as_str(),
+            | W::MicrobatchMissingEventTime { model }
+            | W::MicrobatchMapped { model, .. } => model.as_str(),
+            // Project-level drops have no owning model — group by their name.
+            W::DroppedConstruct { name, .. } => name.as_str(),
         };
         by_model.entry(model).or_default().push(w);
     }
@@ -594,6 +613,24 @@ fn write_structured_warnings(
                     out.push_str(
                         "- **Microbatch missing `event_time`** — fell back to `full_refresh`. Add `event_time = '<timestamp_column>'` to the model's dbt config block\n",
                     );
+                }
+                W::MicrobatchMapped { mapped_to, .. } => {
+                    if mapped_to == "merge" {
+                        out.push_str(
+                            "- **dbt microbatch → idempotent `merge`** — partition-replace became key-upsert; rows removed from the source window are not deleted. Review the `[strategy]` block.\n",
+                        );
+                    } else {
+                        out.push_str(
+                            "- **dbt microbatch imported append-only** — re-inserts the lookback window every run. Add a `unique_key` (maps to an idempotent merge) or convert to a time-interval strategy.\n",
+                        );
+                    }
+                }
+                W::DroppedConstruct {
+                    construct,
+                    name,
+                    detail,
+                } => {
+                    out.push_str(&format!("- **Dropped {construct}** `{name}` — {detail}\n"));
                 }
             }
         }

--- a/engine/crates/rocky-compiler/src/import/emit.rs
+++ b/engine/crates/rocky-compiler/src/import/emit.rs
@@ -828,6 +828,7 @@ mod tests {
             unit_tests_found: 0,
             unit_tests_converted: 0,
             unit_tests_skipped: 0,
+            constructs_dropped: 0,
         }
     }
 

--- a/engine/crates/rocky-compiler/src/import/report.rs
+++ b/engine/crates/rocky-compiler/src/import/report.rs
@@ -502,6 +502,7 @@ mod tests {
             unit_tests_found: 0,
             unit_tests_converted: 0,
             unit_tests_skipped: 0,
+            constructs_dropped: 0,
         }
     }
 

--- a/examples/playground/pocs/06-developer-experience/14-import-dbt-failure-modes/README.md
+++ b/examples/playground/pocs/06-developer-experience/14-import-dbt-failure-modes/README.md
@@ -82,8 +82,8 @@ before pointing it at a real codebase.
     {
       "model": "stg_orders",
       "category": "JinjaControlFlow",
-      "message": "contains Jinja control flow ({% if %}, {% for %}) — replaced with TODO comments",
-      "suggestion": "consider using manifest.json import path for full Jinja resolution"
+      "message": "contains Jinja control flow ({% if %}) — emitted with TODO markers; the conditional body is applied unconditionally, so review the result",
+      "suggestion": "use the manifest import path (`dbt compile`) for faithful Jinja resolution"
     },
     {
       "model": "stg_variables",
@@ -106,7 +106,8 @@ before pointing it at a real codebase.
 - **dbt generic tests outside the canonical four** ...
 - **Singular tests** in `tests/` (custom SQL) — copy and rewrite manually.
 - **dbt macros / `dbt_packages/`** — Rocky has no Jinja runtime. ...
-- **`{% if %}` / `{% for %}` / `{{ var() }}`** ...
+- **`{% if %}` / `{{ var() }}`** — emitted with a TODO marker (the `{% if %}` body applies unconditionally — review it).
+- **`{% for %}` / `{% set %}`** — **refused** (listed under "Failed models") rather than half-rendered into broken SQL; `stg_loop` here demonstrates the refusal. Re-run after `dbt compile`.
 ## Warnings
 - `stg_orders` — JinjaControlFlow: ...
 - `stg_variables` — UnsupportedMacro: ...

--- a/examples/playground/pocs/06-developer-experience/14-import-dbt-failure-modes/dbt_project/models/stg_loop.sql
+++ b/examples/playground/pocs/06-developer-experience/14-import-dbt-failure-modes/dbt_project/models/stg_loop.sql
@@ -1,0 +1,11 @@
+{{ config(materialized='view') }}
+-- A {% for %} loop the no-manifest importer cannot faithfully render: the
+-- regex conversion strips only the {% %} delimiters, so the loop body would
+-- survive exactly once. The importer refuses this model rather than emit
+-- broken SQL.
+SELECT
+{% for col in ['order_id', 'customer_id', 'amount'] %}
+    {{ col }},
+{% endfor %}
+    1 AS sentinel
+FROM raw.orders

--- a/examples/playground/pocs/06-developer-experience/14-import-dbt-failure-modes/run.sh
+++ b/examples/playground/pocs/06-developer-experience/14-import-dbt-failure-modes/run.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # 14-import-dbt-failure-modes — exercise `rocky import-dbt`'s handling of the
 # deliberately out-of-scope dbt features:
-#   - models with `{% if target.name %}` branching (JinjaControlFlow warning)
+#   - models with `{% if target.name %}` branching (JinjaControlFlow warning,
+#     emitted with a TODO marker)
+#   - models with `{% for %}` loops (REFUSED — would half-render to broken SQL)
 #   - models with `{{ var() }}` references (UnsupportedMacro warning)
 #   - schema.yml tests outside the canonical four (UnsupportedTest warning)
 #   - `snapshots/`, `dbt_packages/`, and `tests/` trees (silently ignored)
@@ -83,6 +85,17 @@ for unwanted in orders_snapshot star assert_revenue_positive; do
         fail=1
     fi
 done
+
+# A {% for %} model is REFUSED (it would half-render into broken SQL) — it
+# must not be emitted, and the importer must report the refusal.
+if [ -f "imported/models/stg_loop.sql" ] || [ -f "imported/models/stg_loop.toml" ]; then
+    echo "FAIL: stg_loop ({% for %} model) should be refused, not emitted"
+    fail=1
+fi
+if ! grep -qi 'unsupported Jinja control flow' expected/import.log; then
+    echo "FAIL: import log should report the refused {% for %} model"
+    fail=1
+fi
 
 if [ "$fail" -eq 0 ]; then
     echo "ok  All assertions passed."

--- a/schemas/import_dbt.schema.json
+++ b/schemas/import_dbt.schema.json
@@ -243,6 +243,56 @@
             "model"
           ],
           "type": "object"
+        },
+        {
+          "description": "A dbt microbatch model was remapped: to an idempotent `merge` (`mapped_to = \"merge\"`) when it has a `unique_key`, or kept append-only (`mapped_to = \"append\"`) when it does not.",
+          "properties": {
+            "kind": {
+              "enum": [
+                "microbatch_mapped"
+              ],
+              "type": "string"
+            },
+            "mapped_to": {
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "mapped_to",
+            "model"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A dbt construct the importer does not translate was detected and skipped (snapshot, source freshness, grants, meta, metric, semantic model, exposure), surfaced so a migration is never silently lossy.",
+          "properties": {
+            "construct": {
+              "type": "string"
+            },
+            "detail": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "dropped_construct"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "construct",
+            "detail",
+            "kind",
+            "name"
+          ],
+          "type": "object"
         }
       ]
     },
@@ -276,6 +326,13 @@
   "properties": {
     "command": {
       "type": "string"
+    },
+    "constructs_dropped": {
+      "default": 0,
+      "description": "Number of dbt resources the importer does not translate that were detected and skipped (snapshots, metrics, semantic models, exposures).",
+      "format": "uint",
+      "minimum": 0.0,
+      "type": "integer"
     },
     "dbt_version": {
       "type": [

--- a/sdk/python/src/rocky_sdk/types_generated/import_dbt_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/import_dbt_schema.py
@@ -155,6 +155,35 @@ class ImportDbtStructuredWarning6(BaseModel):
     model: str
 
 
+class Kind38(StrEnum):
+    microbatch_mapped = "microbatch_mapped"
+
+
+class ImportDbtStructuredWarning7(BaseModel):
+    """
+    A dbt microbatch model was remapped: to an idempotent `merge` (`mapped_to = "merge"`) when it has a `unique_key`, or kept append-only (`mapped_to = "append"`) when it does not.
+    """
+
+    kind: Kind38
+    mapped_to: str
+    model: str
+
+
+class Kind39(StrEnum):
+    dropped_construct = "dropped_construct"
+
+
+class ImportDbtStructuredWarning8(BaseModel):
+    """
+    A dbt construct the importer does not translate was detected and skipped (snapshot, source freshness, grants, meta, metric, semantic model, exposure), surfaced so a migration is never silently lossy.
+    """
+
+    construct_: str = Field(..., alias="construct")
+    detail: str
+    kind: Kind39
+    name: str
+
+
 class ImportDbtWarning(BaseModel):
     category: str
     message: str
@@ -170,6 +199,10 @@ class ImportDbtOutput(BaseModel):
     """
 
     command: str
+    constructs_dropped: conint(ge=0) | None = 0
+    """
+    Number of dbt resources the importer does not translate that were detected and skipped (snapshots, metrics, semantic models, exposures).
+    """
     dbt_version: str | None = None
     emission: ImportDbtEmission | None = None
     """
@@ -196,6 +229,8 @@ class ImportDbtOutput(BaseModel):
             | ImportDbtStructuredWarning4
             | ImportDbtStructuredWarning5
             | ImportDbtStructuredWarning6
+            | ImportDbtStructuredWarning7
+            | ImportDbtStructuredWarning8
         ]
         | None
     ) = Field([], validate_default=True)

--- a/sdk/python/src/rocky_sdk/types_generated/plan_promote_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/plan_promote_schema.py
@@ -83,7 +83,7 @@ class BreakingChange(BaseModel):
     model: str
 
 
-class Kind55(StrEnum):
+class Kind57(StrEnum):
     model_added = "model_added"
 
 
@@ -92,11 +92,11 @@ class BreakingChange53(BaseModel):
     A model present on the head side is absent on the base side.
     """
 
-    kind: Kind55
+    kind: Kind57
     model: str
 
 
-class Kind56(StrEnum):
+class Kind58(StrEnum):
     column_dropped = "column_dropped"
 
 
@@ -107,11 +107,11 @@ class BreakingChange54(BaseModel):
 
     column: str
     data_type: str
-    kind: Kind56
+    kind: Kind58
     model: str
 
 
-class Kind57(StrEnum):
+class Kind59(StrEnum):
     column_added = "column_added"
 
 
@@ -122,12 +122,12 @@ class BreakingChange55(BaseModel):
 
     column: str
     data_type: str
-    kind: Kind57
+    kind: Kind59
     model: str
     nullable: bool
 
 
-class Kind58(StrEnum):
+class Kind60(StrEnum):
     column_type_changed = "column_type_changed"
 
 
@@ -137,7 +137,7 @@ class BreakingChange56(BaseModel):
     """
 
     column: str
-    kind: Kind58
+    kind: Kind60
     model: str
     narrowing: bool
     """
@@ -147,7 +147,7 @@ class BreakingChange56(BaseModel):
     old_type: str
 
 
-class Kind59(StrEnum):
+class Kind61(StrEnum):
     column_nullability_changed = "column_nullability_changed"
 
 
@@ -157,13 +157,13 @@ class BreakingChange57(BaseModel):
     """
 
     column: str
-    kind: Kind59
+    kind: Kind61
     model: str
     new_nullable: bool
     old_nullable: bool
 
 
-class Kind60(StrEnum):
+class Kind62(StrEnum):
     column_reordered = "column_reordered"
 
 
@@ -173,13 +173,13 @@ class BreakingChange58(BaseModel):
     """
 
     column: str
-    kind: Kind60
+    kind: Kind62
     model: str
     new_index: conint(ge=0)
     old_index: conint(ge=0)
 
 
-class Kind61(StrEnum):
+class Kind63(StrEnum):
     materialization_strategy_changed = "materialization_strategy_changed"
 
 
@@ -188,13 +188,13 @@ class BreakingChange59(BaseModel):
     The materialization strategy switched between top-level variants (e.g. `FullRefresh` → `Incremental`).
     """
 
-    kind: Kind61
+    kind: Kind63
     model: str
     new_strategy: str
     old_strategy: str
 
 
-class Kind62(StrEnum):
+class Kind64(StrEnum):
     materialization_key_changed = "materialization_key_changed"
 
 
@@ -207,13 +207,13 @@ class BreakingChange60(BaseModel):
     """
     Which key changed: `unique_key`, `timestamp_column`, `partition_by`, `time_column`, `granularity`, `target_lag`, `update_columns`, `storage_prefix`, or `partition_columns`.
     """
-    kind: Kind62
+    kind: Kind64
     model: str
     new: list[str]
     old: list[str]
 
 
-class Kind63(StrEnum):
+class Kind65(StrEnum):
     replication_columns_changed = "replication_columns_changed"
 
 
@@ -222,49 +222,19 @@ class BreakingChange61(BaseModel):
     Replication column-selection mode flipped between `All` and `Explicit(...)` or the explicit list changed.
     """
 
-    kind: Kind63
+    kind: Kind65
     model: str
     new: list[str]
     old: list[str]
 
 
-class Kind64(StrEnum):
+class Kind66(StrEnum):
     partition_by_changed = "partition_by_changed"
 
 
 class BreakingChange62(BaseModel):
     """
     `LakehouseOptions::partition_by` changed without the strategy changing. Distinct from `MaterializationKeyChanged` since this lives on `format_options` rather than the strategy enum.
-    """
-
-    kind: Kind64
-    model: str
-    new: list[str]
-    old: list[str]
-
-
-class Kind65(StrEnum):
-    target_renamed = "target_renamed"
-
-
-class BreakingChange63(BaseModel):
-    """
-    Target table reference renamed (catalog, schema, or table component).
-    """
-
-    kind: Kind65
-    model: str
-    new: str
-    old: str
-
-
-class Kind66(StrEnum):
-    source_changed = "source_changed"
-
-
-class BreakingChange64(BaseModel):
-    """
-    Source reference rebound to a different table.
     """
 
     kind: Kind66
@@ -274,6 +244,36 @@ class BreakingChange64(BaseModel):
 
 
 class Kind67(StrEnum):
+    target_renamed = "target_renamed"
+
+
+class BreakingChange63(BaseModel):
+    """
+    Target table reference renamed (catalog, schema, or table component).
+    """
+
+    kind: Kind67
+    model: str
+    new: str
+    old: str
+
+
+class Kind68(StrEnum):
+    source_changed = "source_changed"
+
+
+class BreakingChange64(BaseModel):
+    """
+    Source reference rebound to a different table.
+    """
+
+    kind: Kind68
+    model: str
+    new: list[str]
+    old: list[str]
+
+
+class Kind69(StrEnum):
     column_mask_changed = "column_mask_changed"
 
 
@@ -283,13 +283,13 @@ class BreakingChange65(BaseModel):
     """
 
     column: str
-    kind: Kind67
+    kind: Kind69
     model: str
     new_strategy: str | None = None
     old_strategy: str | None = None
 
 
-class Kind68(StrEnum):
+class Kind70(StrEnum):
     lakehouse_format_changed = "lakehouse_format_changed"
 
 
@@ -298,13 +298,13 @@ class BreakingChange66(BaseModel):
     Lakehouse format switched (e.g. `DeltaTable` → `IcebergTable`).
     """
 
-    kind: Kind68
+    kind: Kind70
     model: str
     new: str
     old: str
 
 
-class Kind69(StrEnum):
+class Kind71(StrEnum):
     sql_body_changed = "sql_body_changed"
 
 
@@ -313,7 +313,7 @@ class BreakingChange67(BaseModel):
     SQL body changed without any other detectable structural change. Surfaced as `Info` because the typed-output shape is unchanged, but runtime row contents may differ.
     """
 
-    kind: Kind69
+    kind: Kind71
     model: str
 
 

--- a/sdk/python/src/rocky_sdk/types_generated/plan_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/plan_schema.py
@@ -21,7 +21,7 @@ class BreakingChange(BaseModel):
     model: str
 
 
-class Kind39(StrEnum):
+class Kind41(StrEnum):
     model_added = "model_added"
 
 
@@ -30,11 +30,11 @@ class BreakingChange36(BaseModel):
     A model present on the head side is absent on the base side.
     """
 
-    kind: Kind39
+    kind: Kind41
     model: str
 
 
-class Kind40(StrEnum):
+class Kind42(StrEnum):
     column_dropped = "column_dropped"
 
 
@@ -45,11 +45,11 @@ class BreakingChange37(BaseModel):
 
     column: str
     data_type: str
-    kind: Kind40
+    kind: Kind42
     model: str
 
 
-class Kind41(StrEnum):
+class Kind43(StrEnum):
     column_added = "column_added"
 
 
@@ -60,12 +60,12 @@ class BreakingChange38(BaseModel):
 
     column: str
     data_type: str
-    kind: Kind41
+    kind: Kind43
     model: str
     nullable: bool
 
 
-class Kind42(StrEnum):
+class Kind44(StrEnum):
     column_type_changed = "column_type_changed"
 
 
@@ -75,7 +75,7 @@ class BreakingChange39(BaseModel):
     """
 
     column: str
-    kind: Kind42
+    kind: Kind44
     model: str
     narrowing: bool
     """
@@ -85,7 +85,7 @@ class BreakingChange39(BaseModel):
     old_type: str
 
 
-class Kind43(StrEnum):
+class Kind45(StrEnum):
     column_nullability_changed = "column_nullability_changed"
 
 
@@ -95,13 +95,13 @@ class BreakingChange40(BaseModel):
     """
 
     column: str
-    kind: Kind43
+    kind: Kind45
     model: str
     new_nullable: bool
     old_nullable: bool
 
 
-class Kind44(StrEnum):
+class Kind46(StrEnum):
     column_reordered = "column_reordered"
 
 
@@ -111,13 +111,13 @@ class BreakingChange41(BaseModel):
     """
 
     column: str
-    kind: Kind44
+    kind: Kind46
     model: str
     new_index: conint(ge=0)
     old_index: conint(ge=0)
 
 
-class Kind45(StrEnum):
+class Kind47(StrEnum):
     materialization_strategy_changed = "materialization_strategy_changed"
 
 
@@ -126,13 +126,13 @@ class BreakingChange42(BaseModel):
     The materialization strategy switched between top-level variants (e.g. `FullRefresh` → `Incremental`).
     """
 
-    kind: Kind45
+    kind: Kind47
     model: str
     new_strategy: str
     old_strategy: str
 
 
-class Kind46(StrEnum):
+class Kind48(StrEnum):
     materialization_key_changed = "materialization_key_changed"
 
 
@@ -145,13 +145,13 @@ class BreakingChange43(BaseModel):
     """
     Which key changed: `unique_key`, `timestamp_column`, `partition_by`, `time_column`, `granularity`, `target_lag`, `update_columns`, `storage_prefix`, or `partition_columns`.
     """
-    kind: Kind46
+    kind: Kind48
     model: str
     new: list[str]
     old: list[str]
 
 
-class Kind47(StrEnum):
+class Kind49(StrEnum):
     replication_columns_changed = "replication_columns_changed"
 
 
@@ -160,49 +160,19 @@ class BreakingChange44(BaseModel):
     Replication column-selection mode flipped between `All` and `Explicit(...)` or the explicit list changed.
     """
 
-    kind: Kind47
+    kind: Kind49
     model: str
     new: list[str]
     old: list[str]
 
 
-class Kind48(StrEnum):
+class Kind50(StrEnum):
     partition_by_changed = "partition_by_changed"
 
 
 class BreakingChange45(BaseModel):
     """
     `LakehouseOptions::partition_by` changed without the strategy changing. Distinct from `MaterializationKeyChanged` since this lives on `format_options` rather than the strategy enum.
-    """
-
-    kind: Kind48
-    model: str
-    new: list[str]
-    old: list[str]
-
-
-class Kind49(StrEnum):
-    target_renamed = "target_renamed"
-
-
-class BreakingChange46(BaseModel):
-    """
-    Target table reference renamed (catalog, schema, or table component).
-    """
-
-    kind: Kind49
-    model: str
-    new: str
-    old: str
-
-
-class Kind50(StrEnum):
-    source_changed = "source_changed"
-
-
-class BreakingChange47(BaseModel):
-    """
-    Source reference rebound to a different table.
     """
 
     kind: Kind50
@@ -212,6 +182,36 @@ class BreakingChange47(BaseModel):
 
 
 class Kind51(StrEnum):
+    target_renamed = "target_renamed"
+
+
+class BreakingChange46(BaseModel):
+    """
+    Target table reference renamed (catalog, schema, or table component).
+    """
+
+    kind: Kind51
+    model: str
+    new: str
+    old: str
+
+
+class Kind52(StrEnum):
+    source_changed = "source_changed"
+
+
+class BreakingChange47(BaseModel):
+    """
+    Source reference rebound to a different table.
+    """
+
+    kind: Kind52
+    model: str
+    new: list[str]
+    old: list[str]
+
+
+class Kind53(StrEnum):
     column_mask_changed = "column_mask_changed"
 
 
@@ -221,13 +221,13 @@ class BreakingChange48(BaseModel):
     """
 
     column: str
-    kind: Kind51
+    kind: Kind53
     model: str
     new_strategy: str | None = None
     old_strategy: str | None = None
 
 
-class Kind52(StrEnum):
+class Kind54(StrEnum):
     lakehouse_format_changed = "lakehouse_format_changed"
 
 
@@ -236,13 +236,13 @@ class BreakingChange49(BaseModel):
     Lakehouse format switched (e.g. `DeltaTable` → `IcebergTable`).
     """
 
-    kind: Kind52
+    kind: Kind54
     model: str
     new: str
     old: str
 
 
-class Kind53(StrEnum):
+class Kind55(StrEnum):
     sql_body_changed = "sql_body_changed"
 
 
@@ -251,7 +251,7 @@ class BreakingChange50(BaseModel):
     SQL body changed without any other detectable structural change. Surfaced as `Info` because the typed-output shape is unchanged, but runtime row contents may differ.
     """
 
-    kind: Kind53
+    kind: Kind55
     model: str
 
 

--- a/sdk/python/src/rocky_sdk/types_generated/preview_diff_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/preview_diff_schema.py
@@ -73,7 +73,7 @@ class Kind(StrEnum):
     sampled = "sampled"
 
 
-class Kind71(StrEnum):
+class Kind73(StrEnum):
     bisection = "bisection"
 
 
@@ -173,7 +173,7 @@ class PreviewModelDiffAlgorithm2(BaseModel):
 
     bisection_stats: BisectionStatsOutput
     diff: PreviewBisectionRowDiff
-    kind: Kind71
+    kind: Kind73
 
 
 class PreviewModelDiff(BaseModel):

--- a/sdk/python/src/rocky_sdk/types_generated/review_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/review_schema.py
@@ -21,7 +21,7 @@ class BreakingChange(BaseModel):
     model: str
 
 
-class Kind73(StrEnum):
+class Kind75(StrEnum):
     model_added = "model_added"
 
 
@@ -30,11 +30,11 @@ class BreakingChange70(BaseModel):
     A model present on the head side is absent on the base side.
     """
 
-    kind: Kind73
+    kind: Kind75
     model: str
 
 
-class Kind74(StrEnum):
+class Kind76(StrEnum):
     column_dropped = "column_dropped"
 
 
@@ -45,11 +45,11 @@ class BreakingChange71(BaseModel):
 
     column: str
     data_type: str
-    kind: Kind74
+    kind: Kind76
     model: str
 
 
-class Kind75(StrEnum):
+class Kind77(StrEnum):
     column_added = "column_added"
 
 
@@ -60,12 +60,12 @@ class BreakingChange72(BaseModel):
 
     column: str
     data_type: str
-    kind: Kind75
+    kind: Kind77
     model: str
     nullable: bool
 
 
-class Kind76(StrEnum):
+class Kind78(StrEnum):
     column_type_changed = "column_type_changed"
 
 
@@ -75,7 +75,7 @@ class BreakingChange73(BaseModel):
     """
 
     column: str
-    kind: Kind76
+    kind: Kind78
     model: str
     narrowing: bool
     """
@@ -85,7 +85,7 @@ class BreakingChange73(BaseModel):
     old_type: str
 
 
-class Kind77(StrEnum):
+class Kind79(StrEnum):
     column_nullability_changed = "column_nullability_changed"
 
 
@@ -95,13 +95,13 @@ class BreakingChange74(BaseModel):
     """
 
     column: str
-    kind: Kind77
+    kind: Kind79
     model: str
     new_nullable: bool
     old_nullable: bool
 
 
-class Kind78(StrEnum):
+class Kind80(StrEnum):
     column_reordered = "column_reordered"
 
 
@@ -111,13 +111,13 @@ class BreakingChange75(BaseModel):
     """
 
     column: str
-    kind: Kind78
+    kind: Kind80
     model: str
     new_index: conint(ge=0)
     old_index: conint(ge=0)
 
 
-class Kind79(StrEnum):
+class Kind81(StrEnum):
     materialization_strategy_changed = "materialization_strategy_changed"
 
 
@@ -126,13 +126,13 @@ class BreakingChange76(BaseModel):
     The materialization strategy switched between top-level variants (e.g. `FullRefresh` → `Incremental`).
     """
 
-    kind: Kind79
+    kind: Kind81
     model: str
     new_strategy: str
     old_strategy: str
 
 
-class Kind80(StrEnum):
+class Kind82(StrEnum):
     materialization_key_changed = "materialization_key_changed"
 
 
@@ -145,13 +145,13 @@ class BreakingChange77(BaseModel):
     """
     Which key changed: `unique_key`, `timestamp_column`, `partition_by`, `time_column`, `granularity`, `target_lag`, `update_columns`, `storage_prefix`, or `partition_columns`.
     """
-    kind: Kind80
+    kind: Kind82
     model: str
     new: list[str]
     old: list[str]
 
 
-class Kind81(StrEnum):
+class Kind83(StrEnum):
     replication_columns_changed = "replication_columns_changed"
 
 
@@ -160,49 +160,19 @@ class BreakingChange78(BaseModel):
     Replication column-selection mode flipped between `All` and `Explicit(...)` or the explicit list changed.
     """
 
-    kind: Kind81
+    kind: Kind83
     model: str
     new: list[str]
     old: list[str]
 
 
-class Kind82(StrEnum):
+class Kind84(StrEnum):
     partition_by_changed = "partition_by_changed"
 
 
 class BreakingChange79(BaseModel):
     """
     `LakehouseOptions::partition_by` changed without the strategy changing. Distinct from `MaterializationKeyChanged` since this lives on `format_options` rather than the strategy enum.
-    """
-
-    kind: Kind82
-    model: str
-    new: list[str]
-    old: list[str]
-
-
-class Kind83(StrEnum):
-    target_renamed = "target_renamed"
-
-
-class BreakingChange80(BaseModel):
-    """
-    Target table reference renamed (catalog, schema, or table component).
-    """
-
-    kind: Kind83
-    model: str
-    new: str
-    old: str
-
-
-class Kind84(StrEnum):
-    source_changed = "source_changed"
-
-
-class BreakingChange81(BaseModel):
-    """
-    Source reference rebound to a different table.
     """
 
     kind: Kind84
@@ -212,6 +182,36 @@ class BreakingChange81(BaseModel):
 
 
 class Kind85(StrEnum):
+    target_renamed = "target_renamed"
+
+
+class BreakingChange80(BaseModel):
+    """
+    Target table reference renamed (catalog, schema, or table component).
+    """
+
+    kind: Kind85
+    model: str
+    new: str
+    old: str
+
+
+class Kind86(StrEnum):
+    source_changed = "source_changed"
+
+
+class BreakingChange81(BaseModel):
+    """
+    Source reference rebound to a different table.
+    """
+
+    kind: Kind86
+    model: str
+    new: list[str]
+    old: list[str]
+
+
+class Kind87(StrEnum):
     column_mask_changed = "column_mask_changed"
 
 
@@ -221,13 +221,13 @@ class BreakingChange82(BaseModel):
     """
 
     column: str
-    kind: Kind85
+    kind: Kind87
     model: str
     new_strategy: str | None = None
     old_strategy: str | None = None
 
 
-class Kind86(StrEnum):
+class Kind88(StrEnum):
     lakehouse_format_changed = "lakehouse_format_changed"
 
 
@@ -236,13 +236,13 @@ class BreakingChange83(BaseModel):
     Lakehouse format switched (e.g. `DeltaTable` → `IcebergTable`).
     """
 
-    kind: Kind86
+    kind: Kind88
     model: str
     new: str
     old: str
 
 
-class Kind87(StrEnum):
+class Kind89(StrEnum):
     sql_body_changed = "sql_body_changed"
 
 
@@ -251,7 +251,7 @@ class BreakingChange84(BaseModel):
     SQL body changed without any other detectable structural change. Surfaced as `Info` because the typed-output shape is unchanged, but runtime row contents may differ.
     """
 
-    kind: Kind87
+    kind: Kind89
     model: str
 
 


### PR DESCRIPTION
## What

`rocky import-dbt` migrates the manifest happy-path well but, off that path, silently degrades or corrupts. **A migration tool that quietly emits wrong SQL or routes data to the wrong table is worse than one that errors.** This sprint converts each silent failure into either a correct conversion or a loud signal. Grounded in a real 1,131-model dbt project audit.

## Fixes (silent → correct, or silent → loud)

| Before (silent) | After |
|---|---|
| `alias` dropped → data lands in a node-named table | `alias` → `[target].table` |
| `{{ this }}` → bogus `__this__` identifier | resolves to the model's real `catalog.schema.table` |
| `{% for %}`/`{% set %}` half-rendered into broken SQL | **refused** (listed as a failure) on the no-manifest path; `{% if %}` still emits with a TODO marker |
| `merge_update_columns` dropped → update-all | carried into the `merge` strategy's `update_columns` |
| dbt **microbatch** → append-only insert that **double-inserts the lookback window every run** | idempotent **`merge(unique_key)`** (partition-replace → key-upsert, flagged); append-only kept + loudly flagged only when no `unique_key` |
| configured `not_null`/`unique` dropped; `severity:warn` → hard error; `where:` dropped | converted, carrying severity (`warn`→warning) + `where` filter |
| dbt tags discarded | carried onto the model `[tags]` block |
| snapshots / metrics / semantic models / exposures vanish | detected + counted (`constructs_dropped` + `DroppedConstruct` warnings) |
| a parse-only manifest (no compiled SQL) silently regex-renders every model | warns loudly to run `dbt compile` first |

The user-confirmed decision: **microbatch → `merge(unique_key)`** (dbt microbatch always carries a unique_key; `sql_gen` confirms `Merge` needs no `@start_date` placeholders, unlike `TimeInterval`). The one narrow gap — Merge won't delete rows dropped from the source window, irrelevant for append-only event facts — is documented in the warning.

## Tests / validation

- **6 new unit tests** (alias, microbatch→merge, tags, the dropped-construct sweep, stale-manifest banner, configured-test severity/where) — `rocky-compiler` import suite **151 passing**.
- The `import_dbt_emit` integration test passes; the narrowed for-loop refusal keeps `env_branched` (`{% if %}`) importing.
- **All 3 import-dbt POCs pass** against a freshly-built binary; **POC 14 extended** with a `{% for %}` model that the importer now refuses end-to-end.
- `clippy --all-targets --all-features -D warnings` + `fmt --check` clean; `just codegen` produces **no drift** (the `kind`-tagged enum renumber legitimately touches `plan`/`preview_diff`/`review` bindings).
- Docs: `migrate-from-dbt.md` documents every new behavior; CHANGELOG entry added.

## Deferred (in the analysis, not this PR)

Source-freshness *wiring* (no Rocky source-level freshness target — warned via the sweep instead), a true partition-replace `Microbatch` in Rocky core, `incremental_predicates`, model-level composite tests, and singular/custom-test translation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)