### PR TITLE
chore: release engine-v1.53.0 / sdk-v0.1.3 / vscode-v1.33.2

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.33.2] — 2026-06-22
+
 ### Changed
 
+- Regenerated `src/types/generated/` for the engine 1.53.0 output schemas: `cost` gains the grouped-rollup `groups` array, `import-dbt` the new structured-warning variants + `constructs_dropped`, plus refreshed `test` / `compile` / `catalog` / `run` interfaces. Additive, type-only changes.
 - Bumped `@types/node` to 26 and refreshed the lockfile to the latest in-range dependency versions (`@vscode/test-electron` 3.0.0, `vitest` 4.1.9, plus transitives). `@types/vscode` stays pinned at 1.120.0 to match the `engines.vscode` / test-electron triangle. 0 vulnerabilities; compile, lint, and unit tests green. (#939)
 
 ## [1.33.1] — 2026-06-14

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocky",
-  "version": "1.33.1",
+  "version": "1.33.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocky",
-      "version": "1.33.1",
+      "version": "1.33.2",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^10.0.0"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.33.1",
+  "version": "1.33.2",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.53.0] - 2026-06-22
+
 ### Fixed
 
 - **`rocky import-dbt` no longer silently mis-converts — it fixes or loudly flags each gap.** A migration tool that quietly emits wrong SQL is worse than one that errors, so this closes the silent failures: dbt **`alias`** now drives the sidecar `[target].table` (it was hardcoded to the node name, silently routing data to the wrong table); **`{{ this }}`** resolves to the model's real FQN (was a bogus `__this__`); **`{% for %}`/`{% set %}`** on the no-manifest path are **refused** rather than half-rendered into broken SQL (a `{% if %}` still emits with a TODO marker); dbt **`merge_update_columns`** carries into the `merge` strategy (was update-all); dbt **microbatch** maps to an idempotent `merge(unique_key)` instead of an append-only insert that re-inserts the lookback window every run; configured **`not_null`/`unique`** tests convert and carry `severity:`/`where:` (were dropped); dbt **tags** carry onto the model `[tags]` block; and the resources the importer skips (**snapshots, metrics, semantic models, exposures**) are now detected and counted (`constructs_dropped` + per-resource warnings) instead of vanishing. When a manifest carries no compiled SQL, the importer warns loudly to run `dbt compile` first rather than regex-rendering every model. (#944)

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3768,7 +3768,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3789,7 +3789,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3802,7 +3802,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "indexmap",
  "reqwest 0.12.28",
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3868,7 +3868,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "redis",
  "serde",
@@ -3880,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -3891,7 +3891,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4011,7 +4011,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4037,7 +4037,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4056,7 +4056,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4074,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4105,7 +4105,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4130,7 +4130,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "logos",
  "miette",
@@ -4155,7 +4155,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "rocky-server",
  "rustls",
@@ -4164,7 +4164,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4189,7 +4189,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4207,7 +4207,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4237,7 +4237,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -4264,7 +4264,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "miette",
  "regex",
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4300,7 +4300,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.52.0"
+version = "1.53.0"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.52.0"
+version = "1.53.0"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.52.0"
+version = "1.53.0"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.52.0"
+version = "1.53.0"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.52.0"
+version = "1.53.0"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.52.0"
+version = "1.53.0"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.52.0"
+version = "1.53.0"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.52.0"
+version = "1.53.0"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.52.0"
+version = "1.53.0"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.52.0"
+version = "1.53.0"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.52.0"
+version = "1.53.0"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.52.0"
+version = "1.53.0"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.52.0"
+version = "1.53.0"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.52.0"
+version = "1.53.0"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.52.0"
+version = "1.53.0"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.52.0"
+version = "1.53.0"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.52.0"
+version = "1.53.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.52.0"
+version = "1.53.0"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.52.0"
+version = "1.53.0"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.52.0"
+version = "1.53.0"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.52.0"
+version = "1.53.0"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.52.0"
+version = "1.53.0"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.52.0"
+version = "1.53.0"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.52.0"
+version = "1.53.0"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.52.0"
+version = "1.53.0"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] — 2026-06-22
+
 ### Changed
 
+- Regenerated `types_generated/` for the engine 1.53.0 output schemas: `import-dbt` gains the `microbatch_mapped` / `dropped_construct` structured-warning variants and a `constructs_dropped` count, `cost` gains the grouped-rollup `groups` array, and the cross-team-contract path exposes the new E031/E032/E034 diagnostics. Additive — existing parses are unaffected.
 - Refreshed locked dev-dependencies (`datamodel-code-generator` 0.64.1, `pytest` 9.1.1, `ruff` 0.15.18). Regenerated `types_generated/` with the new generator — byte-identical output, no drift. (#939)
 
 ## [0.1.2] — 2026-06-19

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rocky-sdk"
-version = "0.1.2"
+version = "0.1.3"
 description = "Typed Python client for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Consolidated triple-cut to drain the post-`engine-v1.52.0` backlog. Version bumps + CHANGELOGs only; no code changes.

## Scope

| Artifact | Version | Why |
|---|---|---|
| **engine** | 1.52.0 → **1.53.0** (minor) | the features below |
| **rocky-sdk** | 0.1.2 → **0.1.3** (patch) | regenerated bindings in lockstep |
| **vscode** | 1.33.1 → **1.33.2** (patch) | regenerated bindings + dep refresh |

**Dagster excluded** — no source change since `dagster-v1.50.0` (only a dep-lock refresh); its `rocky-sdk>=` floor is satisfied by 0.1.3.

## Engine 1.53.0 highlights

- **`rocky import-dbt` fidelity** (#944) + composite tests (#945) — stop the silent failures (alias→table, `{{this}}`→FQN, `{% for %}` refusal, microbatch→merge, configured tests, tags, dropped-resource sweep) + model-level `unique_combination_of_columns` → `composite`.
- **`rocky cost --by tenant` / `--by model`** (#941) — additive grouped rollups.
- **Cross-team contract checks** (#942/#943) — E031/E032/W030/W031 type+nullability diagnostics, `rocky imports update`, versioned snapshots (E034).
- **Windows install + `rocky-lsp`** (#931) — installers ship the standalone LSP binary; Windows rename-then-replace.
- Live BigQuery MERGE regression test (#940).

The SDK/VS Code bumps carry only the **regenerated `types_generated/` / `src/types/generated/`** for the new engine output schemas (import-dbt structured-warning variants + `constructs_dropped`, cost `groups`) — additive, so existing parses are unaffected.

## After merge

Tag + push `sdk-v0.1.3`, `vscode-v1.33.2`, then **`engine-v1.53.0` last** (so the engine release holds GitHub "Latest"). Each tag triggers its `*-release.yml` (engine → 5-platform binaries; sdk → PyPI via OIDC; vscode → Marketplace).

## Verification

- `just codegen` → **no drift** (engine builds at 1.53.0; bindings already in sync)
- All 33 changed files are version/changelog only; `grep '^version = "1.52.0"'` across engine Cargo.tomls returns 0