### PR TITLE
feat: execute, validate, and surface configured data-quality checks

### DIFF
--- a/editors/vscode/src/types/generated/discover.ts
+++ b/editors/vscode/src/types/generated/discover.ts
@@ -46,7 +46,25 @@ export interface DiscoverOutput {
  * This is intentionally a thin projection of `rocky_core::config::ChecksConfig` — only the fields downstream orchestrators currently consume are exposed. Add fields as new integrations need them.
  */
 export interface ChecksConfigOutput {
+  /**
+   * Resolved per-model check names the pipeline will emit as `CheckResult.name` at run time, keyed by unqualified table/model name. Only the NON-default checks are listed — the four defaults (row_count/column_match/freshness/anomaly) are well-known and pre-declared by consumers. A consumer (e.g. Dagster) declares an asset-check spec per name so the spec name byte-matches the emitted result. Empty (and omitted) when no non-default checks are configured.
+   */
+  configured_checks?: {
+    [k: string]: ResolvedCheckNameOutput[];
+  };
   freshness?: FreshnessConfigOutput | null;
+  [k: string]: unknown;
+}
+/**
+ * A resolved check name `rocky discover` projects so a consumer can pre-declare a matching check spec. `name` byte-matches the `CheckResult.name` the runner emits at run time. `candidate` is `true` for names whose existence depends on runtime-discovered siblings (`cross_source_overlap`) and so may not be emitted on every run.
+ */
+export interface ResolvedCheckNameOutput {
+  candidate?: boolean;
+  /**
+   * The check-kind tag: `custom` | `assertion` | `null_rate` | `cross_source_overlap`.
+   */
+  kind: string;
+  name: string;
   [k: string]: unknown;
 }
 /**

--- a/engine/crates/rocky-cli/src/commands/discover.rs
+++ b/engine/crates/rocky-cli/src/commands/discover.rs
@@ -288,7 +288,14 @@ pub async fn discover(
         emit_fivetran_state(&rocky_cfg, emit_path, no_cache).await?;
     }
 
-    let checks_output = ChecksConfigOutput::from_engine(&pipeline.checks);
+    // `rocky discover` is replication-only, so the projection gates on the
+    // replication runner's executed-check-kinds and reads the discovered
+    // (source_type, table) pairs from `output_sources` (borrowed before move).
+    let checks_output = ChecksConfigOutput::from_engine(
+        &pipeline.checks,
+        rocky_core::config::ReplicationPipelineConfig::EXECUTED_CHECK_KINDS,
+        &output_sources,
+    );
     let output = DiscoverOutput::new(output_sources)
         .with_checks(checks_output)
         .with_excluded_tables(excluded_tables)

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -3241,6 +3241,148 @@ pub async fn run(
         }
     }
 
+    // Custom SQL checks on each replication target. Ported from the quality
+    // runner so `[[checks.custom]]` fires at replication time too. Driven by
+    // `assertion_targets` (every materialized table); surfaced advisorily like
+    // the other replication checks — the run reports pass/fail in the JSON
+    // CheckResult + severity rather than bailing (the data has already landed).
+    if !pipeline.checks.custom.is_empty() {
+        let dialect = shared_warehouse.dialect();
+        for (tref, asset_key) in &assertion_targets {
+            let full = match dialect.format_table_ref(&tref.catalog, &tref.schema, &tref.table) {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!(
+                        table = %tref.full_name(),
+                        error = %e,
+                        "custom check table ref formatting failed — skipping"
+                    );
+                    continue;
+                }
+            };
+            for custom in &pipeline.checks.custom {
+                let sql = custom.sql.replace("{table}", &full);
+                let severity = custom.severity;
+                let check = match shared_warehouse.execute_query(&sql).await {
+                    Ok(result) => {
+                        let result_value: u64 = result
+                            .rows
+                            .first()
+                            .and_then(|r| r.first())
+                            .and_then(|v| {
+                                v.as_u64().or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+                            })
+                            .unwrap_or(0);
+                        checks::CheckResult {
+                            name: custom.name.clone(),
+                            passed: result_value >= custom.threshold,
+                            severity,
+                            details: checks::CheckDetails::Custom {
+                                query: sql,
+                                result_value,
+                                threshold: custom.threshold,
+                            },
+                        }
+                    }
+                    Err(e) => {
+                        warn!(error = %e, check = custom.name.as_str(), "custom check query failed");
+                        checks::CheckResult {
+                            name: custom.name.clone(),
+                            passed: false,
+                            severity,
+                            details: checks::CheckDetails::Custom {
+                                query: sql,
+                                result_value: 0,
+                                threshold: custom.threshold,
+                            },
+                        }
+                    }
+                };
+                pending_checks
+                    .entry(tref.full_name())
+                    .or_insert_with(|| PendingCheck {
+                        asset_key: asset_key.clone(),
+                        checks: Vec::new(),
+                    })
+                    .checks
+                    .push(check);
+            }
+        }
+    }
+
+    // Null-rate checks: sample each configured column and flag when the null
+    // fraction exceeds the threshold. `generate_null_rate_sql` returns one row
+    // per column `(col, nulls, sampled)`; the rate is computed per row. Like the
+    // other replication checks this is advisory — the configured severity rides
+    // into the JSON CheckResult and the orchestrator decides.
+    if let Some(ref null_rate_cfg) = pipeline.checks.null_rate {
+        let dialect = shared_warehouse.dialect();
+        for (tref, asset_key) in &assertion_targets {
+            let sql = match checks::generate_null_rate_sql(
+                tref,
+                &null_rate_cfg.columns,
+                null_rate_cfg.sample_percent,
+                dialect,
+            ) {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!(
+                        table = %tref.full_name(),
+                        error = %e,
+                        "null_rate SQL generation failed — skipping"
+                    );
+                    continue;
+                }
+            };
+            match shared_warehouse.execute_query(&sql).await {
+                Ok(result) => {
+                    for row in &result.rows {
+                        let col = row
+                            .first()
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_default()
+                            .to_string();
+                        let nulls = row
+                            .get(1)
+                            .and_then(|v| {
+                                v.as_u64().or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+                            })
+                            .unwrap_or(0);
+                        let sampled = row
+                            .get(2)
+                            .and_then(|v| {
+                                v.as_u64().or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+                            })
+                            .unwrap_or(0);
+                        let rate = if sampled == 0 {
+                            0.0
+                        } else {
+                            nulls as f64 / sampled as f64
+                        };
+                        let mut check =
+                            checks::check_null_rate(&col, rate, null_rate_cfg.threshold);
+                        check.severity = null_rate_cfg.severity;
+                        // Per-column name so multiple columns don't collide as
+                        // identically-named "null_rate" results — shared with
+                        // discover's projection so the names byte-match.
+                        check.name = checks::null_rate_check_name(&col);
+                        pending_checks
+                            .entry(tref.full_name())
+                            .or_insert_with(|| PendingCheck {
+                                asset_key: asset_key.clone(),
+                                checks: Vec::new(),
+                            })
+                            .checks
+                            .push(check);
+                    }
+                }
+                Err(e) => {
+                    warn!(table = %tref.full_name(), error = %e, "null_rate query failed — skipping");
+                }
+            }
+        }
+    }
+
     // Cross-source overlap — flag a business key shared across SIBLING targets:
     // tables with the same source type + table name that landed in more than
     // one target schema (the hierarchy/tenant fan-out that gets unioned
@@ -3254,25 +3396,27 @@ pub async fn run(
         match overlap_cfg.resolved_key_exprs() {
             Ok(key_exprs) => {
                 // (source_type, table) -> sibling members (target ref, asset key).
+                // The ≥2 grouping and the result name come from shared helpers
+                // in rocky-core so `rocky discover` can declare the exact same
+                // overlap names this runner emits (byte-match guarantee).
                 type SiblingGroups = HashMap<(String, String), Vec<(TableRef, Vec<String>)>>;
                 let mut groups: SiblingGroups = HashMap::new();
+                let mut pairs: Vec<(String, String)> = Vec::new();
                 for (tref, asset_key) in &assertion_targets {
                     let source_type = asset_key.first().cloned().unwrap_or_default();
+                    let key = (source_type, tref.table.clone());
+                    pairs.push(key.clone());
                     groups
-                        .entry((source_type, tref.table.clone()))
+                        .entry(key)
                         .or_default()
                         .push((tref.clone(), asset_key.clone()));
                 }
-                // Deterministic order for stable output.
-                let mut group_keys: Vec<&(String, String)> = groups.keys().collect();
-                group_keys.sort();
+                // Qualifying (source_type, table) keys (≥2 siblings), sorted.
+                let qualifying = checks::cross_source_overlap_groups(pairs);
 
                 let dialect = shared_warehouse.dialect();
-                for gk in group_keys {
+                for gk in &qualifying {
                     let members = &groups[gk];
-                    if members.len() < 2 {
-                        continue; // a single target cannot overlap with itself
-                    }
                     let (source_type, table) = gk;
                     let siblings: Vec<TableRef> =
                         members.iter().map(|(t, _)| t.clone()).collect();
@@ -3285,7 +3429,7 @@ pub async fn run(
                             continue;
                         }
                     };
-                    let name = format!("cross_source_overlap:{source_type}.{table}");
+                    let name = checks::cross_source_overlap_name(source_type, table);
                     match shared_warehouse.execute_query(&sql).await {
                         Ok(result) => {
                             let overlap_count = result.rows.len() as u64;
@@ -5940,6 +6084,11 @@ fn build_replication_strategy_with_override(
         .as_deref()
         .unwrap_or(pipeline.timestamp_column.as_str());
 
+    // The recognized arms below must stay in lockstep with
+    // `rocky_core::config::RECOGNIZED_REPLICATION_STRATEGIES`, which the
+    // `rocky validate` V035 lint uses to flag a strategy that silently falls
+    // through the `_` arm to full_refresh. The
+    // `recognized_replication_strategies_match_builder` test pins the relationship.
     match effective_strategy {
         "incremental" => Ok(MaterializationStrategy::Incremental {
             timestamp_column: effective_timestamp.to_string(),
@@ -8211,6 +8360,54 @@ merge_keys_fallback = ["fallback_only"]
         let pipeline = parse_pipeline(r#"strategy = "totally_made_up""#);
         let strategy = build_replication_strategy(&pipeline).expect("strategy build");
         assert!(matches!(strategy, MaterializationStrategy::FullRefresh));
+    }
+
+    #[test]
+    fn recognized_replication_strategies_match_builder() {
+        use rocky_core::config::RECOGNIZED_REPLICATION_STRATEGIES as RECOGNIZED;
+
+        // The validate lint (V035) trusts this const to decide whether a
+        // strategy string silently falls back to full_refresh. Pin it to the
+        // builder so the two can never drift.
+        assert_eq!(
+            RECOGNIZED,
+            &[
+                "incremental",
+                "merge",
+                "view",
+                "materialized_view",
+                "dynamic_table",
+                "full_refresh"
+            ],
+            "RECOGNIZED_REPLICATION_STRATEGIES changed — update \
+             build_replication_strategy_with_override and this guard together"
+        );
+
+        for s in RECOGNIZED {
+            let toml = if *s == "merge" {
+                format!("strategy = \"{s}\"\nmerge_keys = [\"id\"]\n")
+            } else {
+                format!("strategy = \"{s}\"\n")
+            };
+            let pipeline = parse_pipeline(&toml);
+            match (*s, build_replication_strategy(&pipeline)) {
+                ("full_refresh", Ok(MaterializationStrategy::FullRefresh)) => {}
+                ("dynamic_table", Err(_)) => {}
+                (_, Ok(MaterializationStrategy::FullRefresh)) => {
+                    panic!("recognized strategy {s} silently fell back to full_refresh")
+                }
+                (_, Ok(_)) => {}
+                (other, res) => panic!("unexpected result for {other}: {res:?}"),
+            }
+        }
+
+        // A value the lint must flag: not recognized, silently full_refresh.
+        let bogus = parse_pipeline(r#"strategy = "time_interval""#);
+        assert!(matches!(
+            build_replication_strategy(&bogus),
+            Ok(MaterializationStrategy::FullRefresh)
+        ));
+        assert!(!RECOGNIZED.contains(&"time_interval"));
     }
 
     // ----- PR-B3: per-table override application -----

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -494,11 +494,8 @@ pub(crate) async fn run_table_assertions(
                 continue;
             }
         };
-        let kind = test_type_kind(&test.test_type);
-        let name = assertion
-            .name
-            .clone()
-            .unwrap_or_else(|| format!("{kind}:{}", test.column.as_deref().unwrap_or("-")));
+        let kind = rocky_core::tests::test_type_kind(&test.test_type);
+        let name = assertion.resolved_name();
 
         match warehouse.execute_query(&sql).await {
             Ok(result) => {
@@ -530,27 +527,6 @@ pub(crate) async fn run_table_assertions(
         }
     }
     results
-}
-
-/// Short snake_case tag for each `TestType` variant — embedded in check
-/// result details so downstream consumers can distinguish assertion kinds.
-fn test_type_kind(t: &rocky_core::tests::TestType) -> &'static str {
-    use rocky_core::tests::TestType;
-    match t {
-        TestType::NotNull => "not_null",
-        TestType::Unique => "unique",
-        TestType::UniqueExpr { .. } => "unique_expr",
-        TestType::AcceptedValues { .. } => "accepted_values",
-        TestType::Relationships { .. } => "relationships",
-        TestType::Expression { .. } => "expression",
-        TestType::RowCountRange { .. } => "row_count_range",
-        TestType::InRange { .. } => "in_range",
-        TestType::RegexMatch { .. } => "regex_match",
-        TestType::Aggregate { .. } => "aggregate",
-        TestType::Composite { .. } => "composite",
-        TestType::NotInFuture => "not_in_future",
-        TestType::OlderThanNDays { .. } => "older_than_n_days",
-    }
 }
 
 /// Classify an assertion query's result into `(passed, failing_rows)`.

--- a/engine/crates/rocky-cli/src/commands/validate.rs
+++ b/engine/crates/rocky-cli/src/commands/validate.rs
@@ -141,6 +141,13 @@ fn validate_inner(config_path: &Path) -> Result<ValidateOutput> {
             for msg in msgs {
                 out.push(msg);
             }
+
+            // Warn on check/strategy config a pipeline type won't act on, so
+            // silently-dead config is caught at validate time rather than after
+            // a clean run that never executed the guard.
+            for msg in inert_config_messages(name, pc) {
+                out.push(msg);
+            }
         }
 
         // Validate pipeline dependency graph (depends_on)
@@ -461,6 +468,70 @@ fn validate_adapter(
     }
 
     (ok, msgs)
+}
+
+/// Warnings for check/strategy config a pipeline's runner will not act on.
+/// Driven by [`PipelineConfig::executed_check_kinds`] (the shared source of
+/// truth) so the lint can never claim a check runs that the runner skips.
+fn inert_config_messages(
+    name: &str,
+    pc: &rocky_core::config::PipelineConfig,
+) -> Vec<ValidateMessage> {
+    let mut msgs = Vec::new();
+
+    // Configured checks the runner for this pipeline type never executes.
+    let executed = pc.executed_check_kinds();
+    for kind in pc.checks().configured_explicit_kinds() {
+        if !executed.contains(&kind) {
+            let field = check_kind_field(kind);
+            msgs.push(ValidateMessage {
+                severity: "warn".into(),
+                code: "V034".into(),
+                message: format!(
+                    "pipeline.{name}: checks.{field} is configured but a {} pipeline does not execute it — the check never runs (no-op). Move it to a pipeline type that runs it, or remove it.",
+                    pc.pipeline_type_str()
+                ),
+                file: None,
+                field: Some(format!("pipeline.{name}.checks.{field}")),
+            });
+        }
+    }
+
+    // A replication strategy typo parses cleanly and silently falls back to
+    // full_refresh at run time — surface it instead of letting it ship.
+    if let Some(repl) = pc.as_replication()
+        && !rocky_core::config::RECOGNIZED_REPLICATION_STRATEGIES.contains(&repl.strategy.as_str())
+    {
+        msgs.push(ValidateMessage {
+            severity: "warn".into(),
+            code: "V035".into(),
+            message: format!(
+                "pipeline.{name}: strategy \"{}\" is not a recognized replication strategy and will silently fall back to full_refresh at run time. Recognized: {}.",
+                repl.strategy,
+                rocky_core::config::RECOGNIZED_REPLICATION_STRATEGIES.join(", ")
+            ),
+            file: None,
+            field: Some(format!("pipeline.{name}.strategy")),
+        });
+    }
+
+    msgs
+}
+
+/// The `[checks]` sub-field name for a [`CheckKind`], used to point the
+/// inert-config warning at the offending key.
+fn check_kind_field(kind: rocky_core::checks::CheckKind) -> &'static str {
+    use rocky_core::checks::CheckKind;
+    match kind {
+        CheckKind::RowCount => "row_count",
+        CheckKind::ColumnMatch => "column_match",
+        CheckKind::Freshness => "freshness",
+        CheckKind::NullRate => "null_rate",
+        CheckKind::Custom => "custom",
+        CheckKind::CrossSourceOverlap => "cross_source_overlap",
+        CheckKind::Assertions => "assertions",
+        CheckKind::Anomaly => "anomaly_threshold_pct",
+    }
 }
 
 fn validate_replication_pipeline(
@@ -1202,6 +1273,127 @@ backend = "local"
         assert!(out.adapters[0].ok);
         assert_eq!(out.pipelines.len(), 1);
         assert!(out.pipelines[0].ok);
+    }
+
+    #[test]
+    fn inert_check_on_quality_pipeline_emits_v034() {
+        // A quality pipeline runs only row_count / custom / assertions, so a
+        // configured `freshness` check never executes — V034 must surface it.
+        let out = validate_toml(
+            r#"
+[adapter.local]
+type = "duckdb"
+
+[pipeline.q]
+type = "quality"
+
+[pipeline.q.target]
+adapter = "local"
+
+[[pipeline.q.tables]]
+catalog = "poc"
+schema  = "s"
+table   = "t"
+
+[pipeline.q.checks]
+enabled = true
+freshness = { threshold_seconds = 3600 }
+"#,
+        );
+        assert!(out.valid, "inert config is a warning, not an error");
+        let v034: Vec<_> = out
+            .messages
+            .iter()
+            .filter(|m| m.code == "V034" && m.severity == "warn")
+            .collect();
+        assert_eq!(v034.len(), 1, "expected one V034: {:?}", out.messages);
+        assert_eq!(
+            v034[0].field.as_deref(),
+            Some("pipeline.q.checks.freshness")
+        );
+    }
+
+    #[test]
+    fn configured_checks_on_replication_do_not_warn() {
+        // Replication executes custom + null_rate (and the rest), so none of
+        // these is inert — guards the runner/lint coupling: if a future change
+        // stops the replication runner executing one of these, this test and
+        // `executed_check_kinds` must move together.
+        let out = validate_toml(
+            r#"
+[adapter.local]
+type = "duckdb"
+
+[pipeline.poc]
+type = "replication"
+strategy = "full_refresh"
+
+[pipeline.poc.source]
+adapter = "local"
+
+[pipeline.poc.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.poc.target]
+adapter = "local"
+catalog_template = "poc"
+schema_template = "demo"
+
+[pipeline.poc.checks]
+enabled = true
+null_rate = { columns = ["a"], threshold = 0.1 }
+
+[[pipeline.poc.checks.custom]]
+name = "has_rows"
+sql = "SELECT COUNT(*) FROM {table}"
+threshold = 1
+"#,
+        );
+        let inert: Vec<_> = out.messages.iter().filter(|m| m.code == "V034").collect();
+        assert!(
+            inert.is_empty(),
+            "replication runs custom + null_rate — expected no V034: {inert:?}"
+        );
+    }
+
+    #[test]
+    fn unrecognized_replication_strategy_emits_v035() {
+        // `time_interval` is not a replication strategy — it parses clean and
+        // silently becomes full_refresh at run time. The lint must catch it.
+        let out = validate_toml(
+            r#"
+[adapter.local]
+type = "duckdb"
+
+[pipeline.poc]
+type = "replication"
+strategy = "time_interval"
+
+[pipeline.poc.source]
+adapter = "local"
+
+[pipeline.poc.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.poc.target]
+adapter = "local"
+catalog_template = "poc"
+schema_template = "demo"
+"#,
+        );
+        assert!(out.valid, "a strategy typo is a warning, not an error");
+        let v035: Vec<_> = out
+            .messages
+            .iter()
+            .filter(|m| m.code == "V035" && m.severity == "warn")
+            .collect();
+        assert_eq!(v035.len(), 1, "expected one V035: {:?}", out.messages);
+        assert_eq!(v035[0].field.as_deref(), Some("pipeline.poc.strategy"));
+        assert!(v035[0].message.contains("full_refresh"));
     }
 
     #[test]

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -138,6 +138,30 @@ pub struct CollisionCandidateOutput {
 pub struct ChecksConfigOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub freshness: Option<FreshnessConfigOutput>,
+    /// Resolved per-model check names the pipeline will emit as
+    /// `CheckResult.name` at run time, keyed by unqualified table/model name.
+    /// Only the NON-default checks are listed — the four defaults
+    /// (row_count/column_match/freshness/anomaly) are well-known and
+    /// pre-declared by consumers. A consumer (e.g. Dagster) declares an
+    /// asset-check spec per name so the spec name byte-matches the emitted
+    /// result. Empty (and omitted) when no non-default checks are configured.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub configured_checks: BTreeMap<String, Vec<ResolvedCheckNameOutput>>,
+}
+
+/// A resolved check name `rocky discover` projects so a consumer can
+/// pre-declare a matching check spec. `name` byte-matches the
+/// `CheckResult.name` the runner emits at run time. `candidate` is `true` for
+/// names whose existence depends on runtime-discovered siblings
+/// (`cross_source_overlap`) and so may not be emitted on every run.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ResolvedCheckNameOutput {
+    pub name: String,
+    /// The check-kind tag: `custom` | `assertion` | `null_rate` |
+    /// `cross_source_overlap`.
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub candidate: bool,
 }
 
 /// Freshness check configuration projected into the discover output.
@@ -3784,14 +3808,214 @@ impl DiscoverOutput {
 
 impl ChecksConfigOutput {
     /// Project the engine `ChecksConfig` into its CLI output shape.
-    /// Returns `None` when nothing freshness-related is configured (the only
-    /// field currently surfaced); add more conditions here as fields are added.
-    pub fn from_engine(cfg: &rocky_core::config::ChecksConfig) -> Option<Self> {
+    ///
+    /// `executed_kinds` is the set of check kinds the pipeline type actually
+    /// runs (see `PipelineConfig::executed_check_kinds`) — names are projected
+    /// only for kinds the runner will execute, so discover never advertises a
+    /// check that won't produce a result. `sources` supplies the
+    /// `(source_type, table)` pairs the projection (and the cross-source
+    /// overlap grouping) needs. Returns `None` when nothing is surfaced.
+    pub fn from_engine(
+        cfg: &rocky_core::config::ChecksConfig,
+        executed_kinds: &[rocky_core::checks::CheckKind],
+        sources: &[SourceOutput],
+    ) -> Option<Self> {
+        use rocky_core::checks::CheckKind;
+
         let freshness = cfg.freshness.as_ref().map(|f| FreshnessConfigOutput {
             threshold_seconds: f.threshold_seconds,
         });
-        freshness.as_ref()?;
-        Some(ChecksConfigOutput { freshness })
+
+        let runs = |k: CheckKind| executed_kinds.contains(&k);
+        let mut configured_checks: BTreeMap<String, Vec<ResolvedCheckNameOutput>> = BTreeMap::new();
+
+        // (source_type, table) pairs across discovered sources.
+        let pairs: Vec<(String, String)> = sources
+            .iter()
+            .flat_map(|s| {
+                s.tables
+                    .iter()
+                    .map(move |t| (s.source_type.clone(), t.name.clone()))
+            })
+            .collect();
+        let unique_tables: std::collections::BTreeSet<&str> =
+            pairs.iter().map(|(_, t)| t.as_str()).collect();
+
+        // Custom checks run against every materialized table.
+        if runs(CheckKind::Custom) {
+            for &table in &unique_tables {
+                for custom in &cfg.custom {
+                    configured_checks
+                        .entry(table.to_string())
+                        .or_default()
+                        .push(ResolvedCheckNameOutput {
+                            name: custom.name.clone(),
+                            kind: "custom".into(),
+                            candidate: false,
+                        });
+                }
+            }
+        }
+
+        // Null-rate: one result per configured column, per table.
+        if runs(CheckKind::NullRate)
+            && let Some(nr) = cfg.null_rate.as_ref()
+        {
+            for &table in &unique_tables {
+                for col in &nr.columns {
+                    configured_checks
+                        .entry(table.to_string())
+                        .or_default()
+                        .push(ResolvedCheckNameOutput {
+                            name: rocky_core::checks::null_rate_check_name(col),
+                            kind: "null_rate".into(),
+                            candidate: false,
+                        });
+                }
+            }
+        }
+
+        // Assertions attach to their specific target table.
+        if runs(CheckKind::Assertions) {
+            for assertion in &cfg.assertions {
+                configured_checks
+                    .entry(assertion.table.clone())
+                    .or_default()
+                    .push(ResolvedCheckNameOutput {
+                        name: assertion.resolved_name(),
+                        kind: "assertion".into(),
+                        candidate: false,
+                    });
+            }
+        }
+
+        // Cross-source overlap: candidate names for ≥2 (source_type, table)
+        // groups — marked `candidate` because the actual set depends on
+        // runtime-discovered siblings, which may differ from what discover sees.
+        if runs(CheckKind::CrossSourceOverlap) && cfg.cross_source_overlap.is_some() {
+            for (source_type, table) in
+                rocky_core::checks::cross_source_overlap_groups(pairs.iter().cloned())
+            {
+                configured_checks
+                    .entry(table.clone())
+                    .or_default()
+                    .push(ResolvedCheckNameOutput {
+                        name: rocky_core::checks::cross_source_overlap_name(&source_type, &table),
+                        kind: "cross_source_overlap".into(),
+                        candidate: true,
+                    });
+            }
+        }
+
+        // Dedup identical names per table (e.g. a custom check on a table name
+        // that appears under multiple sources), preserving declaration order.
+        for names in configured_checks.values_mut() {
+            let mut seen = std::collections::HashSet::new();
+            names.retain(|n| seen.insert(n.name.clone()));
+        }
+
+        if freshness.is_none() && configured_checks.is_empty() {
+            return None;
+        }
+        Some(ChecksConfigOutput {
+            freshness,
+            configured_checks,
+        })
+    }
+}
+
+#[cfg(test)]
+mod checks_config_projection_tests {
+    use super::*;
+    use rocky_core::checks::CheckKind;
+
+    fn source(source_type: &str, table: &str) -> SourceOutput {
+        SourceOutput {
+            id: format!("{source_type}.{table}"),
+            components: IndexMap::new(),
+            source_type: source_type.to_string(),
+            last_sync_at: None,
+            tables: vec![TableOutput {
+                name: table.to_string(),
+                row_count: None,
+            }],
+            metadata: IndexMap::new(),
+        }
+    }
+
+    fn checks_cfg() -> rocky_core::config::ChecksConfig {
+        toml::from_str(
+            r#"
+null_rate = { columns = ["amount"], threshold = 0.1 }
+cross_source_overlap = { keys = ["id"] }
+
+[[custom]]
+name = "has_rows"
+sql = "SELECT COUNT(*) FROM {table}"
+threshold = 1
+
+[[assertions]]
+name = "id_not_null"
+table = "orders"
+type = "not_null"
+column = "id"
+"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn replication_projects_all_kinds_with_overlap_marked_candidate() {
+        // Two sources sharing (source_type, table) form an overlap sibling group.
+        let sources = vec![source("duckdb", "orders"), source("duckdb", "orders")];
+        let out = ChecksConfigOutput::from_engine(
+            &checks_cfg(),
+            rocky_core::config::ReplicationPipelineConfig::EXECUTED_CHECK_KINDS,
+            &sources,
+        )
+        .expect("projection present");
+
+        let names = &out.configured_checks["orders"];
+        let by_name: std::collections::HashMap<&str, &ResolvedCheckNameOutput> =
+            names.iter().map(|n| (n.name.as_str(), n)).collect();
+        assert!(by_name.contains_key("has_rows"));
+        assert!(by_name.contains_key("null_rate:amount"));
+        assert!(by_name.contains_key("id_not_null"));
+        let overlap = by_name
+            .get("cross_source_overlap:duckdb.orders")
+            .expect("overlap name projected");
+        assert!(overlap.candidate, "overlap names must be marked candidate");
+        // The exact-name checks are not candidates.
+        assert!(!by_name["has_rows"].candidate);
+    }
+
+    #[test]
+    fn gates_out_kinds_the_pipeline_type_does_not_run() {
+        // A quality-style executed set runs custom + assertions but NOT
+        // null_rate / cross_source_overlap — those must not be projected.
+        let sources = vec![source("duckdb", "orders")];
+        let executed = &[
+            CheckKind::RowCount,
+            CheckKind::Custom,
+            CheckKind::Assertions,
+        ];
+        let out = ChecksConfigOutput::from_engine(&checks_cfg(), executed, &sources)
+            .expect("custom + assertion still project");
+
+        let names: Vec<&str> = out.configured_checks["orders"]
+            .iter()
+            .map(|n| n.name.as_str())
+            .collect();
+        assert!(names.contains(&"has_rows"));
+        assert!(names.contains(&"id_not_null"));
+        assert!(
+            !names.iter().any(|n| n.starts_with("null_rate")),
+            "null_rate must be gated out: {names:?}"
+        );
+        assert!(
+            !names.iter().any(|n| n.starts_with("cross_source_overlap")),
+            "cross_source_overlap must be gated out: {names:?}"
+        );
     }
 }
 

--- a/engine/crates/rocky-core/src/checks.rs
+++ b/engine/crates/rocky-core/src/checks.rs
@@ -86,6 +86,60 @@ pub enum CheckDetails {
     },
 }
 
+/// The kinds of data-quality check Rocky can emit a [`CheckResult`] for.
+///
+/// Used to reason about which checks a given pipeline type actually executes —
+/// see [`crate::config::PipelineConfig::executed_check_kinds`], the single
+/// source of truth shared by the `rocky validate` inert-config lint and the
+/// `rocky discover` check-name projection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckKind {
+    RowCount,
+    ColumnMatch,
+    Freshness,
+    NullRate,
+    Custom,
+    CrossSourceOverlap,
+    Assertions,
+    Anomaly,
+}
+
+/// The `CheckResult.name` for a cross-source-overlap check on a
+/// `(source_type, table)` sibling group. Shared by the replication runner
+/// (emit time, `run.rs`) and `rocky discover` (declare time) so the declared
+/// name byte-matches the emitted name.
+pub fn cross_source_overlap_name(source_type: &str, table: &str) -> String {
+    format!("cross_source_overlap:{source_type}.{table}")
+}
+
+/// The `(source_type, table)` keys with ≥2 sibling targets — the groups a
+/// cross-source-overlap check actually runs against, sorted for determinism
+/// (a single target cannot overlap with itself). Shared by the runner and
+/// discover so the declared overlap-name SET is computed by one rule.
+pub fn cross_source_overlap_groups<I>(pairs: I) -> Vec<(String, String)>
+where
+    I: IntoIterator<Item = (String, String)>,
+{
+    let mut counts: std::collections::BTreeMap<(String, String), usize> =
+        std::collections::BTreeMap::new();
+    for pair in pairs {
+        *counts.entry(pair).or_default() += 1;
+    }
+    counts
+        .into_iter()
+        .filter(|(_, n)| *n >= 2)
+        .map(|(key, _)| key)
+        .collect()
+}
+
+/// The `CheckResult.name` for a null-rate check on `column` — per-column so
+/// multiple configured columns produce distinct, individually-addressable
+/// results (a single static name would collide across columns). Shared by the
+/// replication runner and `rocky discover`.
+pub fn null_rate_check_name(column: &str) -> String {
+    format!("null_rate:{column}")
+}
+
 /// Generates a batched null rate query using the given dialect's TABLESAMPLE syntax.
 /// Falls back to a full table scan if the dialect does not support TABLESAMPLE.
 pub fn generate_null_rate_sql(
@@ -337,6 +391,34 @@ mod tests {
     use crate::traits::{AdapterError, AdapterResult, SqlDialect};
     use rocky_ir::ColumnSelection;
     use rocky_ir::MetadataColumn;
+
+    #[test]
+    fn cross_source_overlap_groups_keeps_only_siblings_sorted() {
+        let pairs = vec![
+            ("duckdb".to_string(), "orders".to_string()),
+            ("duckdb".to_string(), "orders".to_string()),
+            ("duckdb".to_string(), "lonely".to_string()),
+            ("shopify".to_string(), "orders".to_string()),
+            ("shopify".to_string(), "orders".to_string()),
+        ];
+        // Only (source_type, table) with ≥2 members survive, sorted.
+        assert_eq!(
+            cross_source_overlap_groups(pairs),
+            vec![
+                ("duckdb".to_string(), "orders".to_string()),
+                ("shopify".to_string(), "orders".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn shared_check_name_formats() {
+        assert_eq!(
+            cross_source_overlap_name("duckdb", "orders"),
+            "cross_source_overlap:duckdb.orders"
+        );
+        assert_eq!(null_rate_check_name("amount"), "null_rate:amount");
+    }
 
     /// Test dialect that mirrors Databricks behavior for rocky-core tests.
     struct TestDialect;

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -944,6 +944,48 @@ fn default_fail_on_error() -> bool {
     true
 }
 
+/// Replication `strategy` values the runner recognizes. Anything else parses
+/// cleanly but silently falls back to `full_refresh` at run time, so the
+/// `rocky validate` lint warns on unrecognized values (V035).
+///
+/// Keep this in lockstep with `build_replication_strategy_with_override` in
+/// `rocky-cli` (`commands/run.rs`) — a drift test there pins the relationship.
+pub const RECOGNIZED_REPLICATION_STRATEGIES: &[&str] = &[
+    "incremental",
+    "merge",
+    "view",
+    "materialized_view",
+    "dynamic_table",
+    "full_refresh",
+];
+
+impl ChecksConfig {
+    /// The check kinds a user has *explicitly opted into* — an `Option` is
+    /// `Some` or a `Vec` is non-empty. Toggle-style checks (`row_count`,
+    /// `column_match`) and the always-defaulted `anomaly_threshold_pct` are
+    /// deliberately excluded so the inert-config lint never fires on a default.
+    pub fn configured_explicit_kinds(&self) -> Vec<crate::checks::CheckKind> {
+        use crate::checks::CheckKind;
+        let mut kinds = Vec::new();
+        if self.freshness.is_some() {
+            kinds.push(CheckKind::Freshness);
+        }
+        if self.null_rate.is_some() {
+            kinds.push(CheckKind::NullRate);
+        }
+        if !self.custom.is_empty() {
+            kinds.push(CheckKind::Custom);
+        }
+        if self.cross_source_overlap.is_some() {
+            kinds.push(CheckKind::CrossSourceOverlap);
+        }
+        if !self.assertions.is_empty() {
+            kinds.push(CheckKind::Assertions);
+        }
+        kinds
+    }
+}
+
 /// Per-check-kind toggle that accepts either a plain boolean (legacy form)
 /// or a struct with `enabled` + `severity`.
 ///
@@ -1024,6 +1066,22 @@ pub struct QualityAssertion {
     /// type-specific fields like `values` / `to_table`).
     #[serde(flatten)]
     pub test: crate::tests::TestDecl,
+}
+
+impl QualityAssertion {
+    /// The `CheckResult.name` this assertion emits — the explicit `name` if
+    /// set, else a synthesized `"{kind}:{column}"`. Shared by the runners (via
+    /// `run_table_assertions`) and the `rocky discover` check-name projection
+    /// so the declared name byte-matches the emitted one.
+    pub fn resolved_name(&self) -> String {
+        self.name.clone().unwrap_or_else(|| {
+            format!(
+                "{}:{}",
+                crate::tests::test_type_kind(&self.test.test_type),
+                self.test.column.as_deref().unwrap_or("-")
+            )
+        })
+    }
 }
 
 /// How to handle rows that fail error-severity row-level assertions.
@@ -3431,6 +3489,23 @@ impl PipelineConfig {
         }
     }
 
+    /// The check kinds the `rocky run` runner for this pipeline type actually
+    /// executes — the single source of truth shared by the `rocky validate`
+    /// inert-config lint and the `rocky discover` check-name projection.
+    ///
+    /// Keep this in lockstep with the runners in `rocky-cli`: `commands/run.rs`
+    /// (replication) and `commands/run_local.rs` (`run_quality`).
+    /// Transformation, snapshot, and load pipelines run no pipeline-level
+    /// checks today, so they report an empty set.
+    pub fn executed_check_kinds(&self) -> &'static [crate::checks::CheckKind] {
+        use crate::checks::CheckKind::{Assertions, Custom, RowCount};
+        match self {
+            Self::Replication(_) => ReplicationPipelineConfig::EXECUTED_CHECK_KINDS,
+            Self::Quality(_) => &[RowCount, Custom, Assertions],
+            Self::Transformation(_) | Self::Snapshot(_) | Self::Load(_) => &[],
+        }
+    }
+
     /// Returns the target adapter name regardless of variant.
     pub fn target_adapter(&self) -> &str {
         match self {
@@ -4938,6 +5013,22 @@ fn is_bare_pipeline(val: &toml::Value) -> bool {
 }
 
 impl ReplicationPipelineConfig {
+    /// Check kinds the replication runner (`rocky-cli` `run.rs`) executes — the
+    /// single source of truth shared by [`PipelineConfig::executed_check_kinds`],
+    /// the `rocky validate` inert-config lint, and the `rocky discover`
+    /// check-name projection (`rocky discover` is replication-only). Keep in
+    /// lockstep with the check-execution blocks in `run.rs`.
+    pub const EXECUTED_CHECK_KINDS: &'static [crate::checks::CheckKind] = &[
+        crate::checks::CheckKind::RowCount,
+        crate::checks::CheckKind::ColumnMatch,
+        crate::checks::CheckKind::Freshness,
+        crate::checks::CheckKind::NullRate,
+        crate::checks::CheckKind::Custom,
+        crate::checks::CheckKind::CrossSourceOverlap,
+        crate::checks::CheckKind::Assertions,
+        crate::checks::CheckKind::Anomaly,
+    ];
+
     /// Builds a SchemaPattern from the source configuration.
     pub fn schema_pattern(&self) -> Result<SchemaPattern, crate::schema::SchemaError> {
         self.source.schema_pattern.to_schema_pattern()
@@ -7829,6 +7920,39 @@ concurrency = "turbo"
         let fixed = ConcurrencyMode::Fixed(16);
         let json = serde_json::to_string(&fixed).unwrap();
         assert_eq!(json, "16");
+    }
+
+    #[test]
+    fn configured_explicit_kinds_reports_only_opt_in_checks() {
+        use crate::checks::CheckKind;
+
+        // An empty/default checks block opts into nothing — row_count and
+        // column_match toggles and the always-defaulted anomaly threshold are
+        // not "explicitly configured", so the inert lint never fires on them.
+        assert!(
+            ChecksConfig::default()
+                .configured_explicit_kinds()
+                .is_empty()
+        );
+
+        let cfg: ChecksConfig = toml::from_str(
+            r#"
+null_rate = { columns = ["a"], threshold = 0.1 }
+freshness = { threshold_seconds = 3600 }
+
+[[custom]]
+name = "c"
+sql = "SELECT 1"
+threshold = 1
+"#,
+        )
+        .unwrap();
+        let kinds = cfg.configured_explicit_kinds();
+        assert!(kinds.contains(&CheckKind::NullRate));
+        assert!(kinds.contains(&CheckKind::Freshness));
+        assert!(kinds.contains(&CheckKind::Custom));
+        assert!(!kinds.contains(&CheckKind::RowCount));
+        assert!(!kinds.contains(&CheckKind::Anomaly));
     }
 
     // -- Budget ------------------------------------------------------------

--- a/engine/crates/rocky-core/src/tests.rs
+++ b/engine/crates/rocky-core/src/tests.rs
@@ -352,6 +352,28 @@ pub struct TestDecl {
     pub filter: Option<String>,
 }
 
+/// Short snake_case tag for each [`TestType`] variant — embedded in assertion
+/// `CheckResult` details and used to synthesize an assertion's name when none
+/// is set. Shared by the runners (`rocky-cli`) and the `rocky discover`
+/// check-name projection so a synthesized name resolves identically on both.
+pub fn test_type_kind(t: &TestType) -> &'static str {
+    match t {
+        TestType::NotNull => "not_null",
+        TestType::Unique => "unique",
+        TestType::UniqueExpr { .. } => "unique_expr",
+        TestType::AcceptedValues { .. } => "accepted_values",
+        TestType::Relationships { .. } => "relationships",
+        TestType::Expression { .. } => "expression",
+        TestType::RowCountRange { .. } => "row_count_range",
+        TestType::InRange { .. } => "in_range",
+        TestType::RegexMatch { .. } => "regex_match",
+        TestType::Aggregate { .. } => "aggregate",
+        TestType::Composite { .. } => "composite",
+        TestType::NotInFuture => "not_in_future",
+        TestType::OlderThanNDays { .. } => "older_than_n_days",
+    }
+}
+
 // ---------------------------------------------------------------------------
 // SQL generation
 // ---------------------------------------------------------------------------

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -51,9 +51,11 @@ from .checks import check_metadata
 from .column_lineage import build_column_lineage
 from .contracts import (
     ContractRules,
+    configured_check_specs_for_model,
     contract_check_results_from_diagnostics,
     contract_check_specs_for_model,
     discover_contract_rules,
+    sanitize_check_name,
 )
 from .derived_models import (
     ModelGroup,
@@ -513,6 +515,19 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
     #: :func:`_emit_placeholder_checks`. Default ``False`` preserves zero
     #: behaviour change.
     surface_compliance: bool = False
+    #: When ``True``, pre-declares one :class:`dg.AssetCheckSpec` per
+    #: engine-resolved *configured* (non-default) check name, per model, so the
+    #: Dagster UI surfaces assertions / cross_source_overlap / custom /
+    #: null_rate checks before any run — not just the four defaults. Names come
+    #: VERBATIM from ``discover.checks.configured_checks`` (the engine's
+    #: resolved-name projection); they are never re-derived in Python, so each
+    #: spec name byte-matches the ``CheckResult.name`` the engine emits and the
+    #: result lands against the spec instead of being dropped by
+    #: :func:`_emit_results`. Results flow through the existing emit path
+    #: unchanged; a configured check not produced by a given run gets a passing
+    #: placeholder via :func:`_emit_placeholder_checks`. Default ``False``
+    #: preserves zero behaviour change.
+    surface_configured_checks: bool = False
     #: When ``True``, the multi-asset invokes
     #: :meth:`RockyResource.retention_status` once per materialization batch
     #: and emits one :class:`dg.AssetObservation` per
@@ -1268,10 +1283,22 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
             else {}
         )
 
+        # Configured non-default check names per model, sourced from the
+        # engine's discover projection. Names are used VERBATIM (never
+        # re-derived in Python) so the pre-declared spec name byte-matches the
+        # CheckResult.name the engine emits — see surface_configured_checks.
+        configured_checks_by_model: dict[str, list[str]] = {}
+        if self.surface_configured_checks and discover.checks is not None:
+            configured_checks_by_model = {
+                table: [c.name for c in names]
+                for table, names in discover.checks.configured_checks.items()
+            }
+
         check_specs = _build_check_specs(
             groups,
             contract_rules_by_model,
             surface_compliance=self.surface_compliance,
+            configured_checks_by_model=configured_checks_by_model,
             partitions_def=tenant_partitions_def,
         )
 
@@ -1991,6 +2018,7 @@ def _build_check_specs(
     contract_rules_by_model: dict[str, ContractRules] | None = None,
     *,
     surface_compliance: bool = False,
+    configured_checks_by_model: dict[str, list[str]] | None = None,
     partitions_def: dg.PartitionsDefinition | None = None,
 ) -> list[dg.AssetCheckSpec]:
     """Pre-declare check specs for every asset in every group.
@@ -2081,6 +2109,16 @@ def _build_check_specs(
                     spec.key, rules, partitions_def=partitions_def
                 ):
                     _add(contract_spec)
+
+            # Configured non-default checks (opt-in via surface_configured_checks).
+            # Names come VERBATIM from the engine's discover projection so the
+            # spec name byte-matches the CheckResult.name the engine emits.
+            configured_names = (configured_checks_by_model or {}).get(table_name)
+            if configured_names:
+                for configured_spec in configured_check_specs_for_model(
+                    spec.key, configured_names, partitions_def=partitions_def
+                ):
+                    _add(configured_spec)
 
     return specs
 
@@ -2898,21 +2936,26 @@ def _emit_results(
         if asset_key not in selected_keys:
             continue
         for check in table_check.checks:
-            spec_key = (asset_key, check.name)
+            # Sanitize the engine name (it may carry ``:`` / ``.`` separators,
+            # e.g. ``null_rate:amount``) to the Dagster-valid form used when the
+            # spec was declared, so configured checks match instead of being
+            # dropped. Identity for the default/contract/compliance names.
+            check_name = sanitize_check_name(check.name)
+            spec_key = (asset_key, check_name)
             if spec_key not in declared_checks:
                 continue
             if spec_key in yielded_checks:
                 _log.debug(
                     "Skipping duplicate AssetCheckResult emission: %s for %s "
                     "(already yielded earlier in this op)",
-                    check.name,
+                    check_name,
                     asset_key,
                 )
                 continue
             yielded_checks.add(spec_key)
             yield dg.AssetCheckResult(
                 asset_key=asset_key,
-                check_name=check.name,
+                check_name=check_name,
                 passed=check.passed,
                 metadata=check_metadata(check),
             )

--- a/integrations/dagster/src/dagster_rocky/contracts.py
+++ b/integrations/dagster/src/dagster_rocky/contracts.py
@@ -35,6 +35,7 @@ auto-wires them when ``contracts_dir`` is configured.
 from __future__ import annotations
 
 import logging
+import re
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
@@ -221,6 +222,75 @@ def contract_check_specs_for_model(
             description=(
                 "Column types and nullability constraints from .contract.toml are satisfied"
             ),
+            partitions_def=partitions_def,
+        )
+
+
+_INVALID_CHECK_NAME_CHARS = re.compile(r"[^A-Za-z0-9_]")
+
+
+def sanitize_check_name(name: str) -> str:
+    """Map an engine ``CheckResult.name`` to a Dagster-valid check name.
+
+    Dagster check (op output) names must match ``^[A-Za-z0-9_]+$``, but the
+    engine emits structured names with ``:`` / ``.`` separators
+    (``null_rate:amount``, ``cross_source_overlap:src.table``, synthesized
+    ``{kind}:{column}`` assertions). Each invalid character is replaced with
+    ``_`` so the name can be declared as a spec.
+
+    The function is applied identically when **declaring** a configured-check
+    spec and when **matching/emitting** the run-time result (in
+    ``_emit_results``), so the sanitized spec name and the sanitized run-time
+    name still agree — the engine's discover/run byte-match is preserved
+    through one extra deterministic transform on both sides. For the default,
+    contract, and compliance check names (already valid) it is the identity.
+
+    The mapping is not injective: two *distinct* engine check names that differ
+    only in their separators (e.g. ``a:b`` and ``a.b``, or a custom check named
+    literally ``null_rate_amount`` alongside a ``null_rate`` on column
+    ``amount``) collapse to the same Dagster name and are surfaced as a single
+    check. Configured check names that sanitize-collide on one asset are not
+    supported — give them distinct ``[A-Za-z0-9_]`` names to surface both.
+    """
+    return _INVALID_CHECK_NAME_CHARS.sub("_", name)
+
+
+def configured_check_specs_for_model(
+    asset_key: dg.AssetKey,
+    check_names: list[str],
+    *,
+    partitions_def: dg.PartitionsDefinition | None = None,
+) -> Iterator[dg.AssetCheckSpec]:
+    """Yield one ``AssetCheckSpec`` per engine-resolved configured check name.
+
+    ``check_names`` come VERBATIM from ``rocky discover``'s check-name
+    projection (``discover.checks.configured_checks``) — they are **never**
+    re-derived in Python — then passed through :func:`sanitize_check_name` so
+    they satisfy Dagster's name constraints. This matters for the dynamic
+    ``cross_source_overlap`` name (``cross_source_overlap:{source_type}.{table}``):
+    only the engine knows the exact string it will emit, so the spec name is
+    derived from discover (not re-built in Python) and the same sanitizer runs
+    in ``_emit_results`` so the run-time ``AssetCheckResult`` lands against the
+    spec rather than being silently dropped.
+
+    Args:
+        asset_key: The Dagster asset key the checks belong to.
+        check_names: Resolved check names from the engine, used verbatim.
+        partitions_def: Optional ``PartitionsDefinition`` to attach to each
+            spec. Must equal the target asset's ``partitions_def`` (Dagster
+            enforces this). Note (Dagster 1.13.x): a **preview** API whose UI
+            summary/badge status is last-writer-wins across partitions — only
+            the raw history is per-partition. ``None`` (unpartitioned) is
+            byte-identical to prior behaviour. Mirrors
+            :func:`contract_check_specs_for_model`.
+
+    Yields:
+        ``dg.AssetCheckSpec`` instances — one per name, in order.
+    """
+    for name in check_names:
+        yield dg.AssetCheckSpec(
+            name=sanitize_check_name(name),
+            asset=asset_key,
             partitions_def=partitions_def,
         )
 

--- a/integrations/dagster/tests/test_execution.py
+++ b/integrations/dagster/tests/test_execution.py
@@ -339,6 +339,7 @@ def _build_defs_with_flags(
     *,
     surface_compliance: bool = False,
     surface_retention_status: bool = False,
+    surface_configured_checks: bool = False,
 ) -> dg.Definitions:
     """Same as ``_build_defs`` but with governance opt-ins on the component."""
     state_file = tmp_path / "state.json"
@@ -347,6 +348,7 @@ def _build_defs_with_flags(
         config_path="rocky.toml",
         surface_compliance=surface_compliance,
         surface_retention_status=surface_retention_status,
+        surface_configured_checks=surface_configured_checks,
     )
     return component.build_defs_from_state(context=None, state_path=state_file)
 
@@ -416,6 +418,98 @@ def test_compliance_check_spec_absent_by_default(discover_json: str, tmp_path: P
         if isinstance(asset_def, dg.AssetsDefinition):
             names = {cs.name for cs in asset_def.check_specs}
             assert "compliance_exception" not in names
+
+
+def _check_specs_for_table(defs: dg.Definitions, table: str) -> set[str]:
+    return {
+        cs.name
+        for asset_def in defs.assets or []
+        if isinstance(asset_def, dg.AssetsDefinition)
+        for cs in asset_def.check_specs
+        if cs.asset_key.path[-1] == table
+    }
+
+
+def test_configured_checks_predeclared_when_opt_in(discover_json: str, tmp_path: Path):
+    """``surface_configured_checks=True`` pre-declares one ``AssetCheckSpec``
+    per engine-resolved non-default check name from
+    ``discover.checks.configured_checks``, using the names VERBATIM (so they
+    byte-match the ``CheckResult.name`` the engine emits) on the matching
+    asset only."""
+    d = json.loads(discover_json)
+    d.setdefault("checks", {})["configured_checks"] = {
+        "orders": [
+            {"name": "orders_have_rows", "kind": "custom"},
+            {"name": "null_rate:amount", "kind": "null_rate"},
+            {
+                "name": "cross_source_overlap:fivetran.orders",
+                "kind": "cross_source_overlap",
+                "candidate": True,
+            },
+        ]
+    }
+    defs = _build_defs_with_flags(json.dumps(d), tmp_path, surface_configured_checks=True)
+
+    # Names are sanitized to Dagster-valid form (``:`` / ``.`` -> ``_``); the
+    # same sanitizer runs in _emit_results so the run-time result still lands.
+    orders_specs = _check_specs_for_table(defs, "orders")
+    assert {
+        "orders_have_rows",
+        "null_rate_amount",
+        "cross_source_overlap_fivetran_orders",
+    } <= orders_specs
+    # The names attach to the matching asset only, not to other tables.
+    assert "orders_have_rows" not in _check_specs_for_table(defs, "payments")
+
+
+def test_configured_checks_absent_by_default(discover_json: str, tmp_path: Path):
+    """Default ``surface_configured_checks=False`` declares no configured-check
+    specs even when discover carries them — zero behaviour change."""
+    d = json.loads(discover_json)
+    d.setdefault("checks", {})["configured_checks"] = {
+        "orders": [{"name": "orders_have_rows", "kind": "custom"}]
+    }
+    defs = _build_defs_with_flags(json.dumps(d), tmp_path)  # flag off
+    assert "orders_have_rows" not in _check_specs_for_table(defs, "orders")
+
+
+def test_configured_check_result_surfaces_after_sanitize(
+    discover_json: str, run_json: str, tmp_path: Path
+):
+    """End-to-end: a configured check whose engine name contains ``:``
+    (``null_rate:amount``) is pre-declared (sanitized to ``null_rate_amount``)
+    AND its run-time result lands as an ``AssetCheckResult`` — the same
+    sanitizer on both sides keeps spec and result matched instead of dropped by
+    ``_emit_results``."""
+    d = json.loads(discover_json)
+    d.setdefault("checks", {})["configured_checks"] = {
+        "orders": [{"name": "null_rate:amount", "kind": "null_rate"}]
+    }
+    defs = _build_defs_with_flags(json.dumps(d), tmp_path, surface_configured_checks=True)
+
+    orders_key = dg.AssetKey(["fivetran", "acme", "us_west", "shopify", "orders"])
+    run = json.loads(run_json)
+    for table_check in run.get("check_results", []):
+        if table_check["asset_key"] == list(orders_key.path):
+            table_check["checks"].append(
+                {
+                    "name": "null_rate:amount",
+                    "passed": True,
+                    "column": "amount",
+                    "null_rate": 0.0,
+                    "threshold": 0.1,
+                }
+            )
+    run_result = RunResult.model_validate(run)
+
+    exec_result = _materialize_with_governance(defs, run_result, [orders_key])
+    assert exec_result.success
+    check_names = {
+        e.event_specific_data.check_name
+        for e in exec_result.all_events
+        if e.event_type_value == "ASSET_CHECK_EVALUATION"
+    }
+    assert "null_rate_amount" in check_names, check_names
 
 
 def test_governance_events_emitted_when_both_flags_true(

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -910,7 +910,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "../../sdk/python" }
 dependencies = [
     { name = "pydantic" },

--- a/schemas/discover.schema.json
+++ b/schemas/discover.schema.json
@@ -4,6 +4,16 @@
     "ChecksConfigOutput": {
       "description": "Pipeline-level checks configuration projected into the discover output.\n\nThis is intentionally a thin projection of `rocky_core::config::ChecksConfig` — only the fields downstream orchestrators currently consume are exposed. Add fields as new integrations need them.",
       "properties": {
+        "configured_checks": {
+          "additionalProperties": {
+            "items": {
+              "$ref": "#/definitions/ResolvedCheckNameOutput"
+            },
+            "type": "array"
+          },
+          "description": "Resolved per-model check names the pipeline will emit as `CheckResult.name` at run time, keyed by unqualified table/model name. Only the NON-default checks are listed — the four defaults (row_count/column_match/freshness/anomaly) are well-known and pre-declared by consumers. A consumer (e.g. Dagster) declares an asset-check spec per name so the spec name byte-matches the emitted result. Empty (and omitted) when no non-default checks are configured.",
+          "type": "object"
+        },
         "freshness": {
           "anyOf": [
             {
@@ -122,6 +132,26 @@
       },
       "required": [
         "threshold_seconds"
+      ],
+      "type": "object"
+    },
+    "ResolvedCheckNameOutput": {
+      "description": "A resolved check name `rocky discover` projects so a consumer can pre-declare a matching check spec. `name` byte-matches the `CheckResult.name` the runner emits at run time. `candidate` is `true` for names whose existence depends on runtime-discovered siblings (`cross_source_overlap`) and so may not be emitted on every run.",
+      "properties": {
+        "candidate": {
+          "type": "boolean"
+        },
+        "kind": {
+          "description": "The check-kind tag: `custom` | `assertion` | `null_rate` | `cross_source_overlap`.",
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "name"
       ],
       "type": "object"
     },

--- a/sdk/python/src/rocky_sdk/types.py
+++ b/sdk/python/src/rocky_sdk/types.py
@@ -54,6 +54,24 @@ class FreshnessConfig(BaseModel):
     threshold_seconds: int
 
 
+class ResolvedCheckName(BaseModel):
+    """A resolved check name ``rocky discover`` projects so a consumer can
+    pre-declare a matching check spec.
+
+    ``name`` byte-matches the ``CheckResult.name`` the engine emits at run
+    time, so a consumer can declare a spec with this exact name and have the
+    run-time result land against it. ``candidate`` is ``True`` for names whose
+    existence depends on runtime-discovered siblings (``cross_source_overlap``)
+    and so may not be emitted on every run.
+    """
+
+    name: str
+    #: Check-kind tag: ``custom`` | ``assertion`` | ``null_rate`` |
+    #: ``cross_source_overlap``.
+    kind: str
+    candidate: bool = False
+
+
 class ChecksConfig(BaseModel):
     """Pipeline-level checks configuration projected into the discover output.
 
@@ -62,6 +80,13 @@ class ChecksConfig(BaseModel):
     """
 
     freshness: FreshnessConfig | None = None
+    #: Resolved per-model check names the pipeline emits as ``CheckResult.name``
+    #: at run time, keyed by unqualified table/model name. Only the non-default
+    #: checks (custom / assertion / null_rate / cross_source_overlap) are
+    #: listed. Consumed by ``dagster-rocky``'s ``surface_configured_checks`` to
+    #: pre-declare matching asset-check specs. Empty when no non-default checks
+    #: are configured.
+    configured_checks: dict[str, list[ResolvedCheckName]] = Field(default_factory=dict)
 
 
 class DiscoverResult(BaseModel):

--- a/sdk/python/src/rocky_sdk/types_generated/discover_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/discover_schema.py
@@ -89,6 +89,19 @@ class FreshnessConfigOutput(BaseModel):
     threshold_seconds: conint(ge=0)
 
 
+class ResolvedCheckNameOutput(BaseModel):
+    """
+    A resolved check name `rocky discover` projects so a consumer can pre-declare a matching check spec. `name` byte-matches the `CheckResult.name` the runner emits at run time. `candidate` is `true` for names whose existence depends on runtime-discovered siblings (`cross_source_overlap`) and so may not be emitted on every run.
+    """
+
+    candidate: bool | None = None
+    kind: str
+    """
+    The check-kind tag: `custom` | `assertion` | `null_rate` | `cross_source_overlap`.
+    """
+    name: str
+
+
 class TableOutput(BaseModel):
     name: str
     row_count: conint(ge=0) | None = None
@@ -101,6 +114,10 @@ class ChecksConfigOutput(BaseModel):
     This is intentionally a thin projection of `rocky_core::config::ChecksConfig` — only the fields downstream orchestrators currently consume are exposed. Add fields as new integrations need them.
     """
 
+    configured_checks: dict[str, list[ResolvedCheckNameOutput]] | None = None
+    """
+    Resolved per-model check names the pipeline will emit as `CheckResult.name` at run time, keyed by unqualified table/model name. Only the NON-default checks are listed — the four defaults (row_count/column_match/freshness/anomaly) are well-known and pre-declared by consumers. A consumer (e.g. Dagster) declares an asset-check spec per name so the spec name byte-matches the emitted result. Empty (and omitted) when no non-default checks are configured.
+    """
     freshness: FreshnessConfigOutput | None = None
 
 


### PR DESCRIPTION
## What

Pipeline-level data-quality check config could be accepted but never executed, with no signal that the guard was inert. This lands three connected fixes.

### Execute `custom` + `null_rate` on replication
The replication runner now runs `[[checks.custom]]` and `null_rate`, which were previously quality-pipeline-only / unwired. Null-rate results are named per column (`null_rate:<column>`) so multiple columns surface as distinct, individually-addressable results.

### Warn on inert check / strategy config
`rocky validate` now warns when a pipeline declares config its runner won't act on:
- **V034** — a configured check kind the pipeline type doesn't execute (the check silently never runs).
- **V035** — an unrecognized replication `strategy` that parses clean and silently falls back to `full_refresh` at run time.

Both read one source of truth, `PipelineConfig::executed_check_kinds()`, kept in lockstep with the runners by a drift test (and a matching const for the recognized strategies).

### Surface configured checks in Dagster
`rocky discover` projects the resolved per-model check names a pipeline will emit (`ChecksConfigOutput.configured_checks`), reusing the runner's own name/grouping helpers so the declared names byte-match the emitted `CheckResult.name`. New opt-in `RockyComponent.surface_configured_checks` pre-declares one asset-check spec per name so non-default checks (assertions, cross-source overlap, custom, null_rate) reach the UI — not just the four defaults. Engine names that carry `:`/`.` separators are sanitized to Dagster-valid names symmetrically on the declare and emit sides, so results still land against their specs.

## Verification

- **Live-verified against DuckDB:** custom + null_rate execute on a replication pipeline, and the discover-declared names byte-match the run-emitted names (the core byte-match invariant), including the Dagster sanitization end-to-end.
- engine `cargo test` / `clippy --all-targets` / `cargo fmt`
- SDK + Dagster `pytest` + `ruff`
- `just codegen` — discover schema, SDK Pydantic, and VS Code TypeScript regenerated in lockstep
- `just regen-fixtures` — no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)
