### PR TITLE
fix: harden configured data-quality checks (review follow-up to #955)

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -3260,44 +3260,13 @@ pub async fn run(
                     continue;
                 }
             };
-            for custom in &pipeline.checks.custom {
-                let sql = custom.sql.replace("{table}", &full);
-                let severity = custom.severity;
-                let check = match shared_warehouse.execute_query(&sql).await {
-                    Ok(result) => {
-                        let result_value: u64 = result
-                            .rows
-                            .first()
-                            .and_then(|r| r.first())
-                            .and_then(|v| {
-                                v.as_u64().or_else(|| v.as_str().and_then(|s| s.parse().ok()))
-                            })
-                            .unwrap_or(0);
-                        checks::CheckResult {
-                            name: custom.name.clone(),
-                            passed: result_value >= custom.threshold,
-                            severity,
-                            details: checks::CheckDetails::Custom {
-                                query: sql,
-                                result_value,
-                                threshold: custom.threshold,
-                            },
-                        }
-                    }
-                    Err(e) => {
-                        warn!(error = %e, check = custom.name.as_str(), "custom check query failed");
-                        checks::CheckResult {
-                            name: custom.name.clone(),
-                            passed: false,
-                            severity,
-                            details: checks::CheckDetails::Custom {
-                                query: sql,
-                                result_value: 0,
-                                threshold: custom.threshold,
-                            },
-                        }
-                    }
-                };
+            let results = super::run_local::run_custom_checks(
+                shared_warehouse.as_ref(),
+                &full,
+                &pipeline.checks.custom,
+            )
+            .await;
+            if !results.is_empty() {
                 pending_checks
                     .entry(tref.full_name())
                     .or_insert_with(|| PendingCheck {
@@ -3305,7 +3274,7 @@ pub async fn run(
                         checks: Vec::new(),
                     })
                     .checks
-                    .push(check);
+                    .extend(results);
             }
         }
     }
@@ -3337,35 +3306,30 @@ pub async fn run(
             match shared_warehouse.execute_query(&sql).await {
                 Ok(result) => {
                     for row in &result.rows {
-                        let col = row
-                            .first()
-                            .and_then(|v| v.as_str())
-                            .unwrap_or_default()
-                            .to_string();
-                        let nulls = row
-                            .get(1)
-                            .and_then(|v| {
-                                v.as_u64().or_else(|| v.as_str().and_then(|s| s.parse().ok()))
-                            })
-                            .unwrap_or(0);
-                        let sampled = row
-                            .get(2)
-                            .and_then(|v| {
-                                v.as_u64().or_else(|| v.as_str().and_then(|s| s.parse().ok()))
-                            })
-                            .unwrap_or(0);
+                        let col = row.first().and_then(|v| v.as_str()).unwrap_or_default();
+                        // A parse failure on the counts is a malformed result,
+                        // not a real zero — skip the column rather than emit a
+                        // false PASS (rate 0.0). An empty (0-row) sample still
+                        // parses to a real 0 and correctly passes below.
+                        let (Some(nulls), Some(sampled)) =
+                            (checks::cell_as_u64(row.get(1)), checks::cell_as_u64(row.get(2)))
+                        else {
+                            warn!(table = %tref.full_name(), column = col, "null_rate counts unparseable — skipping column");
+                            continue;
+                        };
+                        if col.is_empty() {
+                            warn!(table = %tref.full_name(), "null_rate result missing column name — skipping");
+                            continue;
+                        }
                         let rate = if sampled == 0 {
                             0.0
                         } else {
                             nulls as f64 / sampled as f64
                         };
-                        let mut check =
-                            checks::check_null_rate(&col, rate, null_rate_cfg.threshold);
+                        // `check_null_rate` names the result `null_rate:{col}`,
+                        // byte-matching discover's projection.
+                        let mut check = checks::check_null_rate(col, rate, null_rate_cfg.threshold);
                         check.severity = null_rate_cfg.severity;
-                        // Per-column name so multiple columns don't collide as
-                        // identically-named "null_rate" results — shared with
-                        // discover's projection so the names byte-match.
-                        check.name = checks::null_rate_check_name(&col);
                         pending_checks
                             .entry(tref.full_name())
                             .or_insert_with(|| PendingCheck {

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -317,47 +317,16 @@ pub async fn run_quality(
                     }
                 }
 
-                // Custom checks
-                for custom in &pipeline.checks.custom {
-                    let sql = custom.sql.replace("{table}", &full_table);
-                    let severity = custom.severity;
-                    match warehouse_adapter.execute_query(&sql).await {
-                        Ok(result) => {
-                            let result_value: u64 = result
-                                .rows
-                                .first()
-                                .and_then(|r| r.first())
-                                .and_then(|v| {
-                                    v.as_u64()
-                                        .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
-                                })
-                                .unwrap_or(0);
-                            checks.push(CheckResult {
-                                name: custom.name.clone(),
-                                passed: result_value >= custom.threshold,
-                                severity,
-                                details: CheckDetails::Custom {
-                                    query: sql,
-                                    result_value,
-                                    threshold: custom.threshold,
-                                },
-                            });
-                        }
-                        Err(e) => {
-                            checks.push(CheckResult {
-                                name: custom.name.clone(),
-                                passed: false,
-                                severity,
-                                details: CheckDetails::Custom {
-                                    query: sql,
-                                    result_value: 0,
-                                    threshold: custom.threshold,
-                                },
-                            });
-                            warn!(error = %e, check = custom.name.as_str(), "custom check query failed");
-                        }
-                    }
-                }
+                // Custom checks — shared with the replication runner (run.rs)
+                // via `run_custom_checks`.
+                checks.extend(
+                    run_custom_checks(
+                        warehouse_adapter.as_ref(),
+                        &full_table,
+                        &pipeline.checks.custom,
+                    )
+                    .await,
+                );
 
                 // Row-level assertions — match by unqualified table name.
                 // Shared with the replication runner (run.rs) via
@@ -467,6 +436,56 @@ pub async fn run_quality(
 /// be dialect-formatted (quoted/qualified). Degradation is graceful: an
 /// SQL-generation error skips that assertion; a query error records a failed
 /// `CheckResult` — neither aborts the caller.
+/// Execute every custom check against `full_table`, returning one
+/// [`CheckResult`] per check. Shared by the quality runner (this module) and
+/// the replication runner (`run.rs`) so `[[checks.custom]]` fires identically
+/// on both surfaces. `full_table` must already be dialect-formatted
+/// (quoted/qualified). A query error records a failed `CheckResult` rather than
+/// aborting the caller.
+pub(crate) async fn run_custom_checks(
+    warehouse: &dyn rocky_core::traits::WarehouseAdapter,
+    full_table: &str,
+    customs: &[rocky_core::config::CustomCheckConfig],
+) -> Vec<rocky_core::checks::CheckResult> {
+    use rocky_core::checks::{CheckDetails, CheckResult, cell_as_u64};
+
+    let mut results = Vec::new();
+    for custom in customs {
+        let sql = custom.sql.replace("{table}", full_table);
+        let severity = custom.severity;
+        match warehouse.execute_query(&sql).await {
+            Ok(result) => {
+                let result_value =
+                    cell_as_u64(result.rows.first().and_then(|r| r.first())).unwrap_or(0);
+                results.push(CheckResult {
+                    name: custom.name.clone(),
+                    passed: result_value >= custom.threshold,
+                    severity,
+                    details: CheckDetails::Custom {
+                        query: sql,
+                        result_value,
+                        threshold: custom.threshold,
+                    },
+                });
+            }
+            Err(e) => {
+                warn!(error = %e, check = custom.name.as_str(), "custom check query failed");
+                results.push(CheckResult {
+                    name: custom.name.clone(),
+                    passed: false,
+                    severity,
+                    details: CheckDetails::Custom {
+                        query: sql,
+                        result_value: 0,
+                        threshold: custom.threshold,
+                    },
+                });
+            }
+        }
+    }
+    results
+}
+
 pub(crate) async fn run_table_assertions(
     warehouse: &dyn rocky_core::traits::WarehouseAdapter,
     dialect: &dyn rocky_core::traits::SqlDialect,

--- a/engine/crates/rocky-cli/src/commands/validate.rs
+++ b/engine/crates/rocky-cli/src/commands/validate.rs
@@ -498,21 +498,37 @@ fn inert_config_messages(
     }
 
     // A replication strategy typo parses cleanly and silently falls back to
-    // full_refresh at run time — surface it instead of letting it ship.
-    if let Some(repl) = pc.as_replication()
-        && !rocky_core::config::RECOGNIZED_REPLICATION_STRATEGIES.contains(&repl.strategy.as_str())
-    {
-        msgs.push(ValidateMessage {
+    // full_refresh at run time — surface it at both the pipeline level and in
+    // each `[[table_overrides]]` (the override flows through the same fallback).
+    if let Some(repl) = pc.as_replication() {
+        let recognized =
+            |s: &str| rocky_core::config::RECOGNIZED_REPLICATION_STRATEGIES.contains(&s);
+        let unrecognized = |strategy: &str, field: String| ValidateMessage {
             severity: "warn".into(),
             code: "V035".into(),
             message: format!(
-                "pipeline.{name}: strategy \"{}\" is not a recognized replication strategy and will silently fall back to full_refresh at run time. Recognized: {}.",
-                repl.strategy,
+                "pipeline.{name}: strategy \"{strategy}\" is not a recognized replication strategy and will silently fall back to full_refresh at run time. Recognized: {}.",
                 rocky_core::config::RECOGNIZED_REPLICATION_STRATEGIES.join(", ")
             ),
             file: None,
-            field: Some(format!("pipeline.{name}.strategy")),
-        });
+            field: Some(field),
+        };
+        if !recognized(&repl.strategy) {
+            msgs.push(unrecognized(
+                &repl.strategy,
+                format!("pipeline.{name}.strategy"),
+            ));
+        }
+        for (i, ov) in repl.table_overrides.iter().enumerate() {
+            if let Some(s) = ov.strategy.as_deref()
+                && !recognized(s)
+            {
+                msgs.push(unrecognized(
+                    s,
+                    format!("pipeline.{name}.table_overrides[{i}].strategy"),
+                ));
+            }
+        }
     }
 
     msgs

--- a/engine/crates/rocky-cli/src/pipes.rs
+++ b/engine/crates/rocky-cli/src/pipes.rs
@@ -212,6 +212,22 @@ impl PipesEmitter {
         severity: PipesCheckSeverity,
         metadata: &Value,
     ) {
+        // Dagster check names must match `^[A-Za-z0-9_]+$`, but engine check
+        // results carry structured names (`null_rate:<col>`,
+        // `cross_source_overlap:<src>.<table>`, `<kind>:<col>` assertions).
+        // Pipes IS the Dagster protocol, so map the invalid characters here so
+        // the emitted name matches the spec the dagster-rocky component
+        // pre-declares (which applies the same mapping, `sanitize_check_name`).
+        let check_name: String = check_name
+            .chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || c == '_' {
+                    c
+                } else {
+                    '_'
+                }
+            })
+            .collect();
         self.write_message(
             "report_asset_check",
             &json!({

--- a/engine/crates/rocky-core/src/checks.rs
+++ b/engine/crates/rocky-core/src/checks.rs
@@ -140,6 +140,24 @@ pub fn null_rate_check_name(column: &str) -> String {
     format!("null_rate:{column}")
 }
 
+/// Parse a query-result cell as a `u64`. Tolerates the three shapes adapters
+/// return integer aggregates in: a JSON integer, an integer encoded as a JSON
+/// string (Databricks/Snowflake REST), and an integral JSON float (e.g. `5.0`).
+/// Returns `None` when the cell is absent or not a non-negative integer — the
+/// caller decides whether that is a skip, an error, or a default, rather than a
+/// silent `0` masking a parse failure as a real count.
+pub fn cell_as_u64(cell: Option<&serde_json::Value>) -> Option<u64> {
+    cell.and_then(|v| {
+        v.as_u64()
+            .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+            .or_else(|| {
+                v.as_f64()
+                    .filter(|f| f.is_finite() && *f >= 0.0)
+                    .map(|f| f as u64)
+            })
+    })
+}
+
 /// Generates a batched null rate query using the given dialect's TABLESAMPLE syntax.
 /// Falls back to a full table scan if the dialect does not support TABLESAMPLE.
 pub fn generate_null_rate_sql(
@@ -320,7 +338,7 @@ pub fn check_column_match(
 /// Checks null rate for a column.
 pub fn check_null_rate(column: &str, null_rate: f64, threshold: f64) -> CheckResult {
     CheckResult {
-        name: "null_rate".to_string(),
+        name: null_rate_check_name(column),
         passed: null_rate <= threshold,
         severity: TestSeverity::Error,
         details: CheckDetails::NullRate {
@@ -418,6 +436,21 @@ mod tests {
             "cross_source_overlap:duckdb.orders"
         );
         assert_eq!(null_rate_check_name("amount"), "null_rate:amount");
+    }
+
+    #[test]
+    fn cell_as_u64_parses_int_string_and_float_but_not_garbage() {
+        use serde_json::json;
+        // The three shapes adapters return integer aggregates in.
+        assert_eq!(cell_as_u64(Some(&json!(5))), Some(5)); // JSON int
+        assert_eq!(cell_as_u64(Some(&json!("5"))), Some(5)); // int-as-string
+        assert_eq!(cell_as_u64(Some(&json!(5.0))), Some(5)); // integral float
+        assert_eq!(cell_as_u64(Some(&json!(0))), Some(0)); // a real zero is Some(0), not None
+        // A parse failure is None (so callers don't mistake it for a real 0).
+        assert_eq!(cell_as_u64(None), None);
+        assert_eq!(cell_as_u64(Some(&json!("abc"))), None);
+        assert_eq!(cell_as_u64(Some(&json!(-1.0))), None);
+        assert_eq!(cell_as_u64(Some(&serde_json::Value::Null)), None);
     }
 
     /// Test dialect that mirrors Databricks behavior for rocky-core tests.
@@ -631,7 +664,7 @@ mod tests {
     fn test_null_rate_pass() {
         let r = check_null_rate("email", 0.02, 0.05);
         assert!(r.passed);
-        assert_eq!(r.name, "null_rate");
+        assert_eq!(r.name, "null_rate:email");
     }
 
     #[test]

--- a/integrations/dagster/src/dagster_rocky/checks.py
+++ b/integrations/dagster/src/dagster_rocky/checks.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import dagster as dg
 
+from .contracts import sanitize_check_name
 from .types import CheckResult, MaterializationInfo, OptimizeResult, RunResult
 
 
@@ -26,7 +27,14 @@ def emit_materializations(result: RunResult) -> list[dg.AssetMaterialization]:
 
 
 def emit_check_results(result: RunResult) -> list[dg.AssetCheckResult]:
-    """Convert Rocky check results into Dagster ``AssetCheckResult`` events."""
+    """Convert Rocky check results into Dagster ``AssetCheckResult`` events.
+
+    Check names are passed through :func:`sanitize_check_name`: engine results
+    carry structured names (``null_rate:<col>``, ``cross_source_overlap:…``)
+    whose ``:``/``.`` separators are invalid Dagster check names and would raise
+    at event construction. The matching spec must be declared with the sanitized
+    name too (mirroring ``RockyComponent``'s emit path).
+    """
     events: list[dg.AssetCheckResult] = []
     for table_check in result.check_results:
         key = dg.AssetKey(table_check.asset_key)
@@ -34,7 +42,7 @@ def emit_check_results(result: RunResult) -> list[dg.AssetCheckResult]:
             events.append(
                 dg.AssetCheckResult(
                     asset_key=key,
-                    check_name=check.name,
+                    check_name=sanitize_check_name(check.name),
                     passed=check.passed,
                     metadata=check_metadata(check),
                 )

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -517,13 +517,16 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
     surface_compliance: bool = False
     #: When ``True``, pre-declares one :class:`dg.AssetCheckSpec` per
     #: engine-resolved *configured* (non-default) check name, per model, so the
-    #: Dagster UI surfaces assertions / cross_source_overlap / custom /
-    #: null_rate checks before any run — not just the four defaults. Names come
-    #: VERBATIM from ``discover.checks.configured_checks`` (the engine's
-    #: resolved-name projection); they are never re-derived in Python, so each
-    #: spec name byte-matches the ``CheckResult.name`` the engine emits and the
-    #: result lands against the spec instead of being dropped by
-    #: :func:`_emit_results`. Results flow through the existing emit path
+    #: Dagster UI surfaces per-asset assertions / custom / null_rate checks
+    #: before any run — not just the four defaults. Names come VERBATIM from
+    #: ``discover.checks.configured_checks`` (the engine's resolved-name
+    #: projection); they are never re-derived in Python, so each spec name
+    #: byte-matches the ``CheckResult.name`` the engine emits and the result
+    #: lands against the spec instead of being dropped by
+    #: :func:`_emit_results`. ``candidate`` (cross_source_overlap) names are
+    #: excluded — that group check is emitted once for the whole sibling set, so
+    #: per-asset specs would leave non-emitting siblings with a misleading
+    #: passing placeholder. Results flow through the existing emit path
     #: unchanged; a configured check not produced by a given run gets a passing
     #: placeholder via :func:`_emit_placeholder_checks`. Default ``False``
     #: preserves zero behaviour change.
@@ -1287,10 +1290,16 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
         # engine's discover projection. Names are used VERBATIM (never
         # re-derived in Python) so the pre-declared spec name byte-matches the
         # CheckResult.name the engine emits — see surface_configured_checks.
+        #
+        # `candidate` names (cross_source_overlap) are excluded: that is a GROUP
+        # check the engine emits once (on one sibling asset), so pre-declaring
+        # it on every same-named sibling would leave the others with a passing
+        # placeholder that doesn't reflect a real evaluation. Only exact,
+        # per-asset names (custom / null_rate / assertions) are surfaced.
         configured_checks_by_model: dict[str, list[str]] = {}
         if self.surface_configured_checks and discover.checks is not None:
             configured_checks_by_model = {
-                table: [c.name for c in names]
+                table: [c.name for c in names if not c.candidate]
                 for table, names in discover.checks.configured_checks.items()
             }
 

--- a/integrations/dagster/tests/test_execution.py
+++ b/integrations/dagster/tests/test_execution.py
@@ -450,14 +450,13 @@ def test_configured_checks_predeclared_when_opt_in(discover_json: str, tmp_path:
     }
     defs = _build_defs_with_flags(json.dumps(d), tmp_path, surface_configured_checks=True)
 
-    # Names are sanitized to Dagster-valid form (``:`` / ``.`` -> ``_``); the
-    # same sanitizer runs in _emit_results so the run-time result still lands.
+    # Exact per-asset names are sanitized to Dagster-valid form (``:`` -> ``_``);
+    # the same sanitizer runs in _emit_results so the run-time result lands.
     orders_specs = _check_specs_for_table(defs, "orders")
-    assert {
-        "orders_have_rows",
-        "null_rate_amount",
-        "cross_source_overlap_fivetran_orders",
-    } <= orders_specs
+    assert {"orders_have_rows", "null_rate_amount"} <= orders_specs
+    # The ``candidate`` cross_source_overlap name is a GROUP check — excluded so
+    # non-emitting siblings don't get a misleading passing placeholder.
+    assert "cross_source_overlap_fivetran_orders" not in orders_specs
     # The names attach to the matching asset only, not to other tables.
     assert "orders_have_rows" not in _check_specs_for_table(defs, "payments")
 


### PR DESCRIPTION
## What

Follow-up to #955 (already merged) addressing findings from a max-effort code review of that diff. No behaviour regression — these harden the configured-checks feature and fix edge cases the review surfaced.

### Correctness
- **null_rate fail-open** — if the sampled/null counts in a result row don't parse (an adapter returns them in an unexpected JSON shape), the column is now skipped with a warning instead of computing `rate = 0.0` and reporting a spurious PASS. A new `cell_as_u64` helper also handles integer aggregates returned as JSON floats (`5.0`). An empty (0-row) sample still parses to a real `0` and passes correctly.
- **Dagster group-check false-green** — `cross_source_overlap` is a group check the engine emits once (on one sibling asset). `surface_configured_checks` was pre-declaring it on every same-named sibling, leaving non-emitting siblings with a misleading passing placeholder. Those `candidate` names are now excluded (consuming the previously-unused `candidate` flag); only exact per-asset names (custom / null_rate / assertions) surface.
- **Raw check names crash Dagster** — `null_rate:<col>` / `cross_source_overlap:…` contain characters invalid in Dagster check names. Two emit paths weren't covered by the component's sanitizer: the public `emit_check_results()` helper (would raise) and the engine's Dagster Pipes emitter. Both now sanitize, matching the pre-declared spec names.
- **V035 coverage** — `rocky validate` now flags an unrecognized strategy in a per-table `[[table_overrides]]` entry too, not just the pipeline-level `strategy`.

### Cleanup
- Extracted `run_custom_checks` (shared by the replication and quality runners, mirroring `run_table_assertions`) and `cell_as_u64`, removing duplicated custom-check logic.
- Folded the per-column null_rate name into `check_null_rate` (dropping a post-build name override).

## Verification
- engine `cargo test` (745 + 1374), `clippy --all-targets`, `cargo fmt`
- Dagster `pytest` + `ruff`
- Re-verified custom + null_rate execution on DuckDB; discover↔run byte-match preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
