### PR TITLE
chore: release engine 1.54.0 / sdk 0.1.4 / dagster 1.51.0 / vscode 1.33.3

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.33.3] — 2026-06-23
+
+### Changed
+
+- Regenerated the `discover` output type binding to include `configured_checks` (the engine's resolved check-name projection). No user-facing behavior change. (#955)
+
 ## [1.33.2] — 2026-06-22
 
 ### Changed

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocky",
-  "version": "1.33.2",
+  "version": "1.33.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocky",
-      "version": "1.33.2",
+      "version": "1.33.3",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^10.0.0"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.33.2",
+  "version": "1.33.3",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.54.0] - 2026-06-23
+
+### Added
+
+- **Replication pipelines now execute `[[checks.custom]]` and `null_rate` checks.** Custom checks previously ran only on quality pipelines and `null_rate` ran nowhere, so a replication pipeline can now enforce inline custom-SQL and per-column null-rate guards without standing up a separate quality pipeline. Null-rate results are named per column (`null_rate:<column>`). (#955)
+- **`rocky discover` projects the resolved check names a run will emit** under `checks.configured_checks`, so an orchestrator can pre-declare matching checks without re-reading `rocky.toml`. The projected names byte-match what the runner emits. (#955)
+
+### Changed
+
+- **`rocky validate` warns on data-quality config that won't run.** `V034` flags a configured check a pipeline type does not execute (for example `null_rate` on a quality pipeline); `V035` flags a replication `strategy` — at the pipeline level or in a `[[table_overrides]]` entry — that isn't recognized and would silently fall back to `full_refresh`. (#955, #956)
+
+### Fixed
+
+- **Null-rate checks no longer report a false pass on an unparseable count.** A sampled/null count that can't be parsed is skipped with a warning rather than treated as zero; the count parser also accepts integer aggregates returned as JSON floats. (#956)
+
 ## [1.53.0] - 2026-06-22
 
 ### Fixed

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3768,7 +3768,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3789,7 +3789,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3802,7 +3802,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "indexmap",
  "reqwest 0.12.28",
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3868,7 +3868,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "redis",
  "serde",
@@ -3880,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -3891,7 +3891,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4011,7 +4011,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4037,7 +4037,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4056,7 +4056,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4074,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4105,7 +4105,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4130,7 +4130,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "logos",
  "miette",
@@ -4155,7 +4155,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "rocky-server",
  "rustls",
@@ -4164,7 +4164,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4189,7 +4189,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4207,7 +4207,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4237,7 +4237,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -4264,7 +4264,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "miette",
  "regex",
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4300,7 +4300,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.53.0"
+version = "1.54.0"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.53.0"
+version = "1.54.0"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.53.0"
+version = "1.54.0"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.53.0"
+version = "1.54.0"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.53.0"
+version = "1.54.0"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.53.0"
+version = "1.54.0"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.53.0"
+version = "1.54.0"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.53.0"
+version = "1.54.0"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.53.0"
+version = "1.54.0"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.53.0"
+version = "1.54.0"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.53.0"
+version = "1.54.0"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.53.0"
+version = "1.54.0"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.53.0"
+version = "1.54.0"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.53.0"
+version = "1.54.0"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.53.0"
+version = "1.54.0"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.53.0"
+version = "1.54.0"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.53.0"
+version = "1.54.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.53.0"
+version = "1.54.0"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.53.0"
+version = "1.54.0"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.53.0"
+version = "1.54.0"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.53.0"
+version = "1.54.0"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.53.0"
+version = "1.54.0"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.53.0"
+version = "1.54.0"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.53.0"
+version = "1.54.0"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.53.0"
+version = "1.54.0"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.51.0] — 2026-06-23
+
+### Added
+
+- **`RockyComponent.surface_configured_checks`** (opt-in, default off) pre-declares one Dagster asset-check spec per engine-resolved configured check — per-asset `assertions`, `custom`, and `null_rate` — so they surface in the UI before any run, not just the four defaults. Names come verbatim from `rocky discover` and are sanitized to Dagster-valid form on both the declare and emit sides. (#955, #956)
+
 ### Changed
 
+- Raised the `rocky-sdk` floor to `>=0.1.4` — the component now reads the `configured_checks` projection.
 - Refreshed locked dependencies (`dagster` 1.13.10, `sqlalchemy` 2.0.51, `pytest` 9.1.1, `ruff` 0.15.18, plus transitives). The `dagster>=1.13.8` floor is unchanged — 1.13.10 is a bug-fix release with nothing on the integration's surface. Full suite (646 tests) green. (#939)
 
 ## [1.50.0] — 2026-06-19

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.50.0"
+version = "1.51.0"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"
@@ -23,7 +23,7 @@ dependencies = [
     # package; RockyResource is a thin Dagster adapter over RockyClient. In-repo
     # dev/CI resolves this from the local path (see [tool.uv.sources]); the
     # published wheel floors on the released SDK.
-    "rocky-sdk>=0.1.2",
+    "rocky-sdk>=0.1.4",
     # Floor matches the version CI actually resolves and tests (uv.lock). The
     # RockyComponent path uses dagster.components.* APIs from preview namespaces,
     # so we advertise a tested floor rather than an older, never-exercised one.

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -220,7 +220,7 @@ wheels = [
 
 [[package]]
 name = "dagster-rocky"
-version = "1.50.0"
+version = "1.51.0"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },
@@ -910,7 +910,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "../../sdk/python" }
 dependencies = [
     { name = "pydantic" },

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] — 2026-06-23
+
+### Added
+
+- `ChecksConfig.configured_checks` — the resolved per-model check names `rocky discover` now projects, typed as `ResolvedCheckName` (`name`, `kind`, `candidate`). Regenerated `types_generated/` for the engine 1.54.0 discover schema. Consumed by `dagster-rocky`'s `surface_configured_checks`. Additive — existing parses are unaffected. (#955)
+
 ## [0.1.3] — 2026-06-22
 
 ### Changed

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rocky-sdk"
-version = "0.1.3"
+version = "0.1.4"
 description = "Typed Python client for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Release: engine 1.54.0 / sdk 0.1.4 / dagster 1.51.0 / vscode 1.33.3

Quad-cut shipping the configured data-quality checks feature (#955 + review hardening #956).

| Artifact | Version | What ships |
|---|---|---|
| engine | 1.54.0 | custom / null_rate checks on replication; `V034`/`V035` validate warnings; discover `configured_checks` projection |
| rocky-sdk | 0.1.4 | `ChecksConfig.configured_checks` / `ResolvedCheckName` types |
| dagster-rocky | 1.51.0 | `surface_configured_checks`; floor raised to `rocky-sdk>=0.1.4` |
| vscode | 1.33.3 | regenerated discover type binding (no behavior change) |

Version bumps + CHANGELOGs + reconciled lockfiles only — no code changes. `just codegen` is clean (the version bump produces no binding drift).

**Tag order after merge:** `sdk-v0.1.4` → wait for PyPI → `dagster-v1.51.0`, then `engine-v1.54.0` and `vscode-v1.33.3`. The published `dagster-rocky` wheel resolves `rocky-sdk` from PyPI, so the SDK must publish first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
