### PR TITLE
chore(ci): speed up engine-ci test job; cancel superseded PR runs

### DIFF
--- a/.github/workflows/codegen-drift.yml
+++ b/.github/workflows/codegen-drift.yml
@@ -32,6 +32,13 @@ on:
       - 'justfile'
       - '.github/workflows/codegen-drift.yml'
 
+# Cancel superseded in-progress runs on the same PR — a new push supersedes the
+# previous run instead of letting both finish. Scoped to pull_request so a
+# fast-follow merge to main never cancels a main-branch validation run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_BUILD_JOBS: 4

--- a/.github/workflows/dagster-ci.yml
+++ b/.github/workflows/dagster-ci.yml
@@ -16,6 +16,13 @@ on:
       - 'schemas/**'
       - '.github/workflows/dagster-ci.yml'
 
+# Cancel superseded in-progress runs on the same PR — a new push supersedes the
+# previous run instead of letting both finish. Scoped to pull_request so a
+# fast-follow merge to main never cancels a main-branch validation run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 defaults:
   run:
     working-directory: integrations/dagster

--- a/.github/workflows/engine-ci.yml
+++ b/.github/workflows/engine-ci.yml
@@ -14,6 +14,13 @@ on:
       - 'schemas/**'
       - '.github/workflows/engine-ci.yml'
 
+# Cancel superseded in-progress runs on the same PR — a new push supersedes the
+# previous run instead of letting both finish. Scoped to pull_request so a
+# fast-follow merge to main never cancels a main-branch validation run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
@@ -35,6 +42,16 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    # CI-only: emit `line-tables-only` debuginfo on the dev+test profiles
+    # instead of full debuginfo. Linking the workspace's test binaries with
+    # full debuginfo dominated the build half of this job; line tables keep
+    # file:line in panic backtraces while cutting codegen + link time. Both
+    # profiles are needed — `cargo test` builds deps under `dev` but the
+    # crates-under-test + harnesses (the part that rebuilds every run) under
+    # `test`. Does not affect the `--release` jobs.
+    env:
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
+      CARGO_PROFILE_TEST_DEBUG: line-tables-only
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -46,7 +63,18 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
           sudo fallocate -l 4G /mnt/swapfile && sudo chmod 600 /mnt/swapfile && sudo mkswap /mnt/swapfile && sudo swapon /mnt/swapfile || true
       - run: sudo apt-get update && sudo apt-get install -y cmake
-      - run: cargo test --all-targets --all-features
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
+        with:
+          tool: nextest
+      # nextest runs all test binaries in one global scheduler instead of
+      # serially per-binary like `cargo test`, which is the win on a suite
+      # this wide. It builds lib + bin + integration tests (no benches /
+      # examples — those carry no `#[test]` and are still type-checked by the
+      # clippy job's `--all-targets`). Like the prior `cargo test --all-targets`
+      # it does not run doctests; the workspace has none.
+      - name: Run tests (nextest)
+        run: cargo nextest run --all-features
 
   clippy:
     name: Clippy

--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -14,6 +14,13 @@ on:
       - 'schemas/**'
       - '.github/workflows/sdk-ci.yml'
 
+# Cancel superseded in-progress runs on the same PR — a new push supersedes the
+# previous run instead of letting both finish. Scoped to pull_request so a
+# fast-follow merge to main never cancels a main-branch validation run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # CI only reads the repo; restrict the token to the minimum (CodeQL ql-for-actions).
 permissions:
   contents: read

--- a/.github/workflows/vscode-ci.yml
+++ b/.github/workflows/vscode-ci.yml
@@ -14,6 +14,13 @@ on:
       - 'schemas/**'
       - '.github/workflows/vscode-ci.yml'
 
+# Cancel superseded in-progress runs on the same PR — a new push supersedes the
+# previous run instead of letting both finish. Scoped to pull_request so a
+# fast-follow merge to main never cancels a main-branch validation run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 defaults:
   run:
     working-directory: editors/vscode


### PR DESCRIPTION
## Why

PRs that touch `engine/**` take ~28 min of CI wall-clock. Measured across recent runs, **`engine-ci` is the sole long pole** — every other workflow runs in parallel and finishes well under it (`codegen-drift` ~9 min is the next-longest). Inside `engine-ci`, one job dominates:

| engine-ci job | duration |
|---|---|
| **Test** (`cargo test --all-targets --all-features`) | **~26-28 min** |
| Release-build smoke | ~5 min |
| Clippy (same `--all-targets --all-features`) | **~2 min** |
| Format / Adapter boundary | <1 min |

Clippy running the identical flags in ~2 min proves the Swatinem cache already works (DuckDB is not recompiling). The Test job's time splits ~50/50: **~13 min building + linking the workspace test binaries**, then **~12 min running them serially**, one binary at a time, across thousands of tests.

## What

- **Run tests with `cargo-nextest`.** One global scheduler across all test binaries instead of `cargo test`'s serial per-binary execution — the win on a suite this wide. Dropping `--all-targets` also stops this job from building the criterion benches/examples (they carry no `#[test]`; clippy's `--all-targets` still type-checks them). No doctests exist, so test selection matches the prior command.
- **`line-tables-only` debuginfo on the dev+test profiles, CI-only, scoped to the Test job.** Full debuginfo dominated the link of the test binaries; line tables keep `file:line` in panic backtraces. `--release` jobs are unaffected.
- **`concurrency` group on the per-PR CI workflows** so a new push cancels the superseded in-progress run. Scoped to `pull_request` so a fast-follow merge never cancels a main-branch validation run.

## Verifying

This PR edits all five CI workflow files, so each one runs here. Note the **first** `engine-ci` run on this branch pays a one-time cold rebuild — the debuginfo env re-keys the Test job's rust-cache (`CARGO_*` is part of the key). The **steady-state** number shows on a re-run once the new cache is warm; I'll capture per-step timings from that.

After this lands, `codegen-drift` (~9 min, also on `engine/**`) becomes the practical floor — a sensible follow-up if more headroom is wanted. Going below the 4-core compile ceiling would need a paid larger runner, deliberately out of scope.
