### PR TITLE
feat: map configured check severity to Dagster asset-check severity

### DIFF
--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Engine check severity now maps to the Dagster asset-check severity.** A check the engine reports with `severity = "warning"` (configured in `rocky.toml`) is emitted as `AssetCheckSeverity.WARN`; `"error"` (the default) stays `ERROR`. Applies to every surfaced check on both the `RockyComponent` path and the `emit_check_results` / `load_rocky_assets` functional path. The advisory level is also surfaced in the check metadata so it's visible on a *passing* check, where Dagster doesn't render the severity. (Dagster Pipes mode is unaffected for now — the engine's Pipes path reports checks with a fixed `ERROR` severity; mapping the configured severity there is a separate engine follow-up.)
+
+### Changed
+
+- **Will require `rocky-sdk>=0.1.5`** at release: the mapping reads `CheckResult.severity`, added to the SDK's wide model in 0.1.5. **Publish `rocky-sdk` 0.1.5 to PyPI and raise this floor before releasing `dagster-rocky`** — the published wheel resolves the floor from PyPI, not the monorepo path, so a stale `>=0.1.4` floor would silently map every check back to `ERROR`.
+- **Behavior change on upgrade:** a *failing* check configured `severity = "warning"` now emits `WARN` instead of `ERROR`, so it no longer degrades asset health. Alert policies keyed to `ASSET_HEALTH_DEGRADED` (and automation conditions gated on check health) will stop firing for advisory-severity check failures. This is the intended advisory semantics, but review any policy that relied on the prior always-`ERROR` behavior before upgrading.
+
 ## [1.51.0] — 2026-06-23
 
 ### Added

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Engine check severity now maps to the Dagster asset-check severity.** A check the engine reports with `severity = "warning"` (configured in `rocky.toml`) is emitted as `AssetCheckSeverity.WARN`; `"error"` (the default) stays `ERROR`. Applies to every surfaced check on both the `RockyComponent` path and the `emit_check_results` / `load_rocky_assets` functional path. The advisory level is also surfaced in the check metadata so it's visible on a *passing* check, where Dagster doesn't render the severity. (Dagster Pipes mode is unaffected for now — the engine's Pipes path reports checks with a fixed `ERROR` severity; mapping the configured severity there is a separate engine follow-up.)
+- **Engine check severity now maps to the Dagster asset-check severity.** A check the engine reports with `severity = "warning"` (configured in `rocky.toml`) is emitted as `AssetCheckSeverity.WARN`; `"error"` (the default) stays `ERROR`. Applies to every surfaced check on both the `RockyComponent` path and the `emit_check_results` / `load_rocky_assets` functional path. The advisory level is also surfaced in the check metadata so it's visible on a *passing* check, where Dagster doesn't render the severity. (Dagster Pipes mode is unaffected for now — the engine's Pipes path reports checks with a fixed `ERROR` severity; mapping the configured severity there is a separate engine follow-up.) (#959)
 
 ### Changed
 

--- a/integrations/dagster/src/dagster_rocky/__init__.py
+++ b/integrations/dagster/src/dagster_rocky/__init__.py
@@ -12,6 +12,7 @@ from .branch_deploy import (
 from .checks import (
     check_metadata,
     cost_metadata_from_optimize,
+    dagster_check_severity,
     emit_check_results,
     emit_materializations,
 )
@@ -176,6 +177,7 @@ __all__ = [
     "emit_check_results",
     "emit_materializations",
     "check_metadata",
+    "dagster_check_severity",
     "cost_metadata_from_optimize",
     "parse_rocky_output",
     # Freshness + automation (T1.1, T1.2, T5.2)

--- a/integrations/dagster/src/dagster_rocky/checks.py
+++ b/integrations/dagster/src/dagster_rocky/checks.py
@@ -15,6 +15,26 @@ from .contracts import sanitize_check_name
 from .types import CheckResult, MaterializationInfo, OptimizeResult, RunResult
 
 
+def dagster_check_severity(check: CheckResult) -> dg.AssetCheckSeverity:
+    """Map a Rocky check's configured severity to a Dagster ``AssetCheckSeverity``.
+
+    Rocky's :attr:`CheckResult.severity` carries the operator's configured
+    intent: ``"warning"`` is advisory, ``"error"`` (the default) is a hard
+    failure. A *failing* check surfaces at this severity — ``WARN`` does not
+    degrade asset health, ``ERROR`` does — so an advisory check can fail without
+    paging an ``ASSET_HEALTH_DEGRADED`` alert.
+
+    ``getattr`` (not ``check.severity``) is deliberate: a new ``dagster-rocky``
+    run against an older ``rocky-sdk`` whose wide ``CheckResult`` predates the
+    field degrades to ``ERROR`` rather than raising ``AttributeError``. Omitted
+    severity (older engine binaries) likewise preserves the prior fail-hard
+    behaviour.
+    """
+    if getattr(check, "severity", None) == "warning":
+        return dg.AssetCheckSeverity.WARN
+    return dg.AssetCheckSeverity.ERROR
+
+
 def emit_materializations(result: RunResult) -> list[dg.AssetMaterialization]:
     """Convert Rocky materializations into Dagster ``AssetMaterialization`` events."""
     return [
@@ -128,27 +148,12 @@ def check_metadata(check: CheckResult) -> dict[str, dg.MetadataValue]:
     if check.result_value is not None:
         metadata["result_value"] = dg.MetadataValue.int(check.result_value)
 
-    # Severity — surfaced only when advisory (``"warning"``). ``"error"`` is the
-    # implicit default, so showing it on every check would clutter the panel.
-    # This keeps the advisory level visible even on a *passing* check, where
+    # Severity — surfaced only when advisory (WARN). ``"error"`` is the implicit
+    # default, so showing it on every check would clutter the panel. Deriving
+    # from :func:`dagster_check_severity` keeps one source of truth for "is this
+    # advisory?" and makes the level visible even on a *passing* check, where
     # Dagster's ``AssetCheckSeverity`` is not rendered.
-    if getattr(check, "severity", None) == "warning":
+    if dagster_check_severity(check) is dg.AssetCheckSeverity.WARN:
         metadata["severity"] = dg.MetadataValue.text("warning")
 
     return metadata
-
-
-def dagster_check_severity(check: CheckResult) -> dg.AssetCheckSeverity:
-    """Map a Rocky check's configured severity to a Dagster ``AssetCheckSeverity``.
-
-    Rocky's :attr:`CheckResult.severity` carries the operator's configured
-    intent: ``"warning"`` is advisory, ``"error"`` (the default) is a hard
-    failure. A *failing* check surfaces at this severity — ``WARN`` does not
-    degrade asset health, ``ERROR`` does — so an advisory check can fail without
-    paging an ``ASSET_HEALTH_DEGRADED`` alert. Defaults to ``ERROR`` when the
-    engine omits severity (older binaries), preserving the prior fail-hard
-    behaviour.
-    """
-    if getattr(check, "severity", None) == "warning":
-        return dg.AssetCheckSeverity.WARN
-    return dg.AssetCheckSeverity.ERROR

--- a/integrations/dagster/src/dagster_rocky/checks.py
+++ b/integrations/dagster/src/dagster_rocky/checks.py
@@ -44,6 +44,7 @@ def emit_check_results(result: RunResult) -> list[dg.AssetCheckResult]:
                     asset_key=key,
                     check_name=sanitize_check_name(check.name),
                     passed=check.passed,
+                    severity=dagster_check_severity(check),
                     metadata=check_metadata(check),
                 )
             )
@@ -127,4 +128,27 @@ def check_metadata(check: CheckResult) -> dict[str, dg.MetadataValue]:
     if check.result_value is not None:
         metadata["result_value"] = dg.MetadataValue.int(check.result_value)
 
+    # Severity — surfaced only when advisory (``"warning"``). ``"error"`` is the
+    # implicit default, so showing it on every check would clutter the panel.
+    # This keeps the advisory level visible even on a *passing* check, where
+    # Dagster's ``AssetCheckSeverity`` is not rendered.
+    if getattr(check, "severity", None) == "warning":
+        metadata["severity"] = dg.MetadataValue.text("warning")
+
     return metadata
+
+
+def dagster_check_severity(check: CheckResult) -> dg.AssetCheckSeverity:
+    """Map a Rocky check's configured severity to a Dagster ``AssetCheckSeverity``.
+
+    Rocky's :attr:`CheckResult.severity` carries the operator's configured
+    intent: ``"warning"`` is advisory, ``"error"`` (the default) is a hard
+    failure. A *failing* check surfaces at this severity — ``WARN`` does not
+    degrade asset health, ``ERROR`` does — so an advisory check can fail without
+    paging an ``ASSET_HEALTH_DEGRADED`` alert. Defaults to ``ERROR`` when the
+    engine omits severity (older binaries), preserving the prior fail-hard
+    behaviour.
+    """
+    if getattr(check, "severity", None) == "warning":
+        return dg.AssetCheckSeverity.WARN
+    return dg.AssetCheckSeverity.ERROR

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -47,7 +47,7 @@ from dagster.components.utils.translation import TranslationFn, TranslationFnRes
 from dagster_shared.serdes.objects.models.defs_state_info import DefsStateManagementType
 from pydantic import ValidationError
 
-from .checks import check_metadata
+from .checks import check_metadata, dagster_check_severity
 from .column_lineage import build_column_lineage
 from .contracts import (
     ContractRules,
@@ -2966,6 +2966,7 @@ def _emit_results(
                 asset_key=asset_key,
                 check_name=check_name,
                 passed=check.passed,
+                severity=dagster_check_severity(check),
                 metadata=check_metadata(check),
             )
 

--- a/integrations/dagster/tests/test_checks.py
+++ b/integrations/dagster/tests/test_checks.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import dagster as dg
+
 from dagster_rocky.checks import (
     check_metadata,
     cost_metadata_from_optimize,
+    dagster_check_severity,
     emit_check_results,
     emit_materializations,
 )
@@ -43,6 +46,40 @@ def test_emit_check_results(run_json: str):
     assert events[4].check_name == "no_future_dates"
 
 
+def test_emit_check_results_maps_severity():
+    """The functional helper maps engine severity onto the emitted event, just
+    like ``RockyComponent``'s path — a failing advisory check is a Dagster WARN."""
+    result = RunResult.model_validate(
+        {
+            "version": "1.0.0",
+            "command": "run",
+            "filter": "tenant=acme",
+            "duration_ms": 1,
+            "tables_copied": 0,
+            "materializations": [],
+            "check_results": [
+                {
+                    "asset_key": ["fivetran", "acme", "shopify", "orders"],
+                    "checks": [
+                        {"name": "null_rate", "passed": False, "severity": "warning"},
+                        {"name": "row_count", "passed": False, "severity": "error"},
+                    ],
+                }
+            ],
+            "permissions": {
+                "grants_added": 0,
+                "grants_revoked": 0,
+                "catalogs_created": 0,
+                "schemas_created": 0,
+            },
+            "drift": {"tables_checked": 0, "tables_drifted": 0, "actions_taken": []},
+        }
+    )
+    by_name = {e.check_name: e for e in emit_check_results(result)}
+    assert by_name["null_rate"].severity == dg.AssetCheckSeverity.WARN
+    assert by_name["row_count"].severity == dg.AssetCheckSeverity.ERROR
+
+
 def test_check_metadata_only_includes_populated_fields():
     """``check_metadata`` should never emit ``None`` values."""
     minimal = CheckResult(name="row_count", passed=True, source_count=10, target_count=10)
@@ -58,6 +95,54 @@ def test_check_metadata_handles_empty_lists_as_none_text():
     metadata = check_metadata(check)
     assert metadata["missing_columns"].value == "(none)"
     assert metadata["extra_columns"].value == "(none)"
+
+
+def test_check_metadata_surfaces_advisory_severity():
+    """An advisory (``warning``) check surfaces its severity so it's visible in
+    the UI regardless of pass/fail — on a *passing* check Dagster doesn't render
+    the ``AssetCheckSeverity`` at all, and on a failing one the row corroborates
+    the WARN level."""
+    passing = CheckResult(
+        name="null_rate",
+        passed=True,
+        column="email",
+        null_rate=0.0,
+        threshold=0.05,
+        severity="warning",
+    )
+    failing = CheckResult(
+        name="null_rate",
+        passed=False,
+        column="email",
+        null_rate=0.9,
+        threshold=0.05,
+        severity="warning",
+    )
+    assert check_metadata(passing)["severity"].value == "warning"
+    assert check_metadata(failing)["severity"].value == "warning"
+
+
+def test_check_metadata_omits_default_error_severity():
+    """The implicit ``error`` default is not surfaced — it would clutter every
+    check's panel with no added signal."""
+    check = CheckResult(name="row_count", passed=True, source_count=10, target_count=10)
+    assert "severity" not in check_metadata(check)
+
+
+def test_dagster_check_severity_maps_engine_severity():
+    """``warning`` → WARN, ``error`` → ERROR, and an absent/defaulted severity
+    falls back to ERROR (back-compat with older binaries). The mapping reads the
+    configured *intent*, not the outcome, so it ignores ``passed`` — a passing
+    advisory check is still WARN."""
+    warn = CheckResult(name="null_rate", passed=False, severity="warning")
+    warn_passing = CheckResult(name="null_rate", passed=True, severity="warning")
+    err = CheckResult(name="row_count", passed=False, severity="error")
+    defaulted = CheckResult(name="row_count", passed=False)  # severity defaults to "error"
+
+    assert dagster_check_severity(warn) == dg.AssetCheckSeverity.WARN
+    assert dagster_check_severity(warn_passing) == dg.AssetCheckSeverity.WARN
+    assert dagster_check_severity(err) == dg.AssetCheckSeverity.ERROR
+    assert dagster_check_severity(defaulted) == dg.AssetCheckSeverity.ERROR
 
 
 def test_cost_metadata_from_optimize(optimize_json: str):

--- a/integrations/dagster/tests/test_emit_results_dedup.py
+++ b/integrations/dagster/tests/test_emit_results_dedup.py
@@ -348,3 +348,117 @@ def test_emit_results_materialization_yields_when_unique():
 
     mat_keys = {e.asset_key for e in events if isinstance(e, dg.MaterializeResult)}
     assert mat_keys == {orders, leads}
+
+
+# ---------------------------------------------------------------------------
+# Part D — _emit_results maps engine check severity → Dagster severity
+# ---------------------------------------------------------------------------
+
+
+def test_emit_results_maps_check_severity():
+    """A failing configured-``warning`` check surfaces as a Dagster WARN, not ERROR.
+
+    Without this, a failing advisory check degrades asset health and pages,
+    regardless of the operator's advisory intent — so consumers couldn't run a
+    "WARN-first, promote-to-error-later" rollout.
+    """
+    orders = dg.AssetKey(["fivetran", "acme", "us_west", "shopify", "orders"])
+    mapping = {("fivetran", "acme", "us_west", "shopify", "orders"): orders}
+    check_specs = [
+        dg.AssetCheckSpec(name="null_rate", asset=orders),
+        dg.AssetCheckSpec(name="row_count", asset=orders),
+    ]
+    table_check = TableCheckResult(
+        asset_key=["fivetran", "acme", "us_west", "shopify", "orders"],
+        checks=[
+            CheckResult(
+                name="null_rate",
+                passed=False,
+                column="email",
+                null_rate=0.9,
+                threshold=0.05,
+                severity="warning",
+            ),
+            CheckResult(
+                name="row_count", passed=False, source_count=10, target_count=9, severity="error"
+            ),
+        ],
+    )
+
+    events = list(
+        _emit_results(
+            results=[_run_result(check_results=[table_check])],
+            check_specs=check_specs,
+            selected_keys={orders},
+            rocky_key_to_dagster_key=mapping,
+        )
+    )
+
+    by_name = {e.check_name: e for e in events if isinstance(e, dg.AssetCheckResult)}
+    assert by_name["null_rate"].severity == dg.AssetCheckSeverity.WARN
+    assert by_name["row_count"].severity == dg.AssetCheckSeverity.ERROR
+
+
+def test_emit_results_defaults_omitted_severity_to_error():
+    """Back-compat: a check that OMITS severity on the wire stays ERROR, while a
+    sibling ``warning`` check in the same stream maps to WARN.
+
+    Parsing through ``RunResult.model_validate`` (not a positional constructor)
+    exercises the SDK's ``severity: str | None = "error"`` default for the
+    omitted field — the genuine older-binary path. Co-locating a WARN assertion
+    makes the ERROR provably a product of the mapping rather than Dagster's own
+    ``AssetCheckResult`` default: drop the ``severity=`` argument from the emit
+    path and the ``null_rate`` assertion below flips to ERROR and fails.
+    """
+    orders = dg.AssetKey(["fivetran", "acme", "us_west", "shopify", "orders"])
+    mapping = {("fivetran", "acme", "us_west", "shopify", "orders"): orders}
+    check_specs = [
+        dg.AssetCheckSpec(name="row_count", asset=orders),
+        dg.AssetCheckSpec(name="null_rate", asset=orders),
+    ]
+    run_result = RunResult.model_validate(
+        {
+            "version": "0.3.0",
+            "command": "run",
+            "filter": "tenant=acme",
+            "duration_ms": 1,
+            "tables_copied": 0,
+            "materializations": [],
+            "check_results": [
+                {
+                    "asset_key": ["fivetran", "acme", "us_west", "shopify", "orders"],
+                    "checks": [
+                        # severity OMITTED → SDK default "error" → ERROR
+                        {
+                            "name": "row_count",
+                            "passed": True,
+                            "source_count": 10,
+                            "target_count": 10,
+                        },
+                        # advisory failing check in the same stream → WARN
+                        {"name": "null_rate", "passed": False, "severity": "warning"},
+                    ],
+                }
+            ],
+            "permissions": {
+                "grants_added": 0,
+                "grants_revoked": 0,
+                "catalogs_created": 0,
+                "schemas_created": 0,
+            },
+            "drift": {"tables_checked": 0, "tables_drifted": 0, "actions_taken": []},
+        }
+    )
+
+    by_name = {
+        e.check_name: e
+        for e in _emit_results(
+            results=[run_result],
+            check_specs=check_specs,
+            selected_keys={orders},
+            rocky_key_to_dagster_key=mapping,
+        )
+        if isinstance(e, dg.AssetCheckResult)
+    }
+    assert by_name["row_count"].severity == dg.AssetCheckSeverity.ERROR
+    assert by_name["null_rate"].severity == dg.AssetCheckSeverity.WARN

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`CheckResult.severity`** — the per-check failure severity (`"error"` | `"warning"`) the engine already emits on `rocky run` check results. The hand-written wide model omitted the field, so Pydantic's default `extra="ignore"` silently dropped the wire value and any consumer mapping it (e.g. `dagster-rocky`'s asset-check severity) only ever saw the default. Additive; defaults to `"error"` for older binaries that don't emit it, so existing parses are unaffected.
+
 ## [0.1.4] — 2026-06-23
 
 ### Added

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`CheckResult.severity`** — the per-check failure severity (`"error"` | `"warning"`) the engine already emits on `rocky run` check results. The hand-written wide model omitted the field, so Pydantic's default `extra="ignore"` silently dropped the wire value and any consumer mapping it (e.g. `dagster-rocky`'s asset-check severity) only ever saw the default. Additive; defaults to `"error"` for older binaries that don't emit it, so existing parses are unaffected.
+- **`CheckResult.severity`** — the per-check failure severity (`"error"` | `"warning"`) the engine already emits on `rocky run` check results. The hand-written wide model omitted the field, so Pydantic's default `extra="ignore"` silently dropped the wire value and any consumer mapping it (e.g. `dagster-rocky`'s asset-check severity) only ever saw the default. Additive; defaults to `"error"` for older binaries that don't emit it, so existing parses are unaffected. (#959)
 
 ## [0.1.4] — 2026-06-23
 

--- a/sdk/python/src/rocky_sdk/types.py
+++ b/sdk/python/src/rocky_sdk/types.py
@@ -210,6 +210,13 @@ class MaterializationInfo(BaseModel):
 class CheckResult(BaseModel):
     name: str
     passed: bool
+    #: Configured failure severity emitted by the engine: ``"error"`` (a hard
+    #: failure) or ``"warning"`` (advisory — does not fail the run). Defaults to
+    #: ``"error"`` for older binaries that don't emit the field. Without this
+    #: field declared, Pydantic's default ``extra="ignore"`` would silently drop
+    #: the wire value, so any consumer mapping it (e.g. dagster-rocky's
+    #: ``AssetCheckSeverity``) would never see anything but the default.
+    severity: str | None = "error"
     # Row count fields
     source_count: int | None = None
     target_count: int | None = None

--- a/sdk/python/tests/test_types.py
+++ b/sdk/python/tests/test_types.py
@@ -9,6 +9,7 @@ import pytest
 from rocky_sdk import CiResult, CompileResult, DiscoverResult, TestResult, parse_rocky_output
 from rocky_sdk.client import _parse_rocky_json, _parse_run_or_apply
 from rocky_sdk.exceptions import RockyOutputParseError
+from rocky_sdk.types import CheckResult, RunResult
 
 DISCOVER_JSON = '{"version": "1.0.0", "command": "discover", "sources": []}'
 
@@ -84,6 +85,51 @@ def test_parse_ci_result_failures_are_objects():
     assert isinstance(result, CiResult)
     assert result.failures[0].name == "fct_orders"
     assert result.failures[0].error == "type mismatch"
+
+
+def test_check_result_preserves_severity():
+    # Shadow-drift regression: the runtime ``RunResult`` routes check results
+    # through this hand-written wide ``CheckResult`` (not the generated
+    # per-variant models). Without ``severity`` declared here, Pydantic's
+    # default ``extra="ignore"`` would silently drop the wire value, and any
+    # consumer mapping it (dagster-rocky's ``AssetCheckSeverity``) would only
+    # ever see the default. Captured shape from the live binary.
+    advisory = CheckResult.model_validate(
+        {"name": "null_rate", "passed": False, "severity": "warning"}
+    )
+    assert advisory.severity == "warning"
+
+    # Omitted severity (older binary) defaults to "error".
+    assert CheckResult.model_validate({"name": "row_count", "passed": True}).severity == "error"
+
+
+def test_run_result_threads_check_severity_through_table_checks():
+    # The whole path the orchestrator reads: run output → check_results →
+    # checks[].severity must survive into the wide model.
+    result = RunResult.model_validate(
+        {
+            "version": "1.0.0",
+            "command": "run",
+            "filter": "tenant=acme",
+            "duration_ms": 1,
+            "tables_copied": 0,
+            "materializations": [],
+            "check_results": [
+                {
+                    "asset_key": ["fivetran", "acme", "shopify", "orders"],
+                    "checks": [{"name": "null_rate", "passed": False, "severity": "warning"}],
+                }
+            ],
+            "permissions": {
+                "grants_added": 0,
+                "grants_revoked": 0,
+                "catalogs_created": 0,
+                "schemas_created": 0,
+            },
+            "drift": {"tables_checked": 0, "tables_drifted": 0, "actions_taken": []},
+        }
+    )
+    assert result.check_results[0].checks[0].severity == "warning"
 
 
 def test_parse_rocky_output_rejects_non_object():


### PR DESCRIPTION
## What

Map the engine's per-check `severity` onto the Dagster `AssetCheckResult.severity`. A check configured `severity = "warning"` in `rocky.toml` now surfaces as `AssetCheckSeverity.WARN` instead of the Dagster default `ERROR`; `"error"` stays `ERROR`.

A **failing** advisory check therefore no longer degrades asset health, so a "WARN-first, promote-to-error-later" rollout of a new check is finally possible — previously any failing check paged regardless of the operator's advisory intent.

## Why it needed two layers (the non-obvious part)

The engine already emits per-check `severity` on the wire for every check type that respects it (`freshness`, `null_rate`, `custom`, `cross_source_overlap`, `assertions`). But the runtime path parses check results into the **hand-written wide** `rocky_sdk.types.CheckResult`, which did **not** declare a `severity` field — so Pydantic's default `extra="ignore"` silently dropped the wire value. A dagster-only fix would have been inert (`getattr(check, "severity", None)` → always `None` → always `ERROR`).

So:

- **`rocky-sdk`** — add `CheckResult.severity` (`str | None = "error"`) so the wire value survives parsing. Additive; older binaries that omit it default to `"error"`.
- **`dagster-rocky`** — `dagster_check_severity()` maps the engine severity to `AssetCheckSeverity`, threaded into **both** emission paths: the `RockyComponent` `_emit_results` yield **and** the `emit_check_results` / `load_rocky_assets` functional helper. The advisory level is also surfaced in `check_metadata` so it's visible on a *passing* check (Dagster doesn't render the severity there).

Back-compat: defaults to `ERROR` whenever severity is absent.

## ⚠️ Release sequencing — REQUIRED

The published `dagster-rocky` wheel resolves `rocky-sdk` from PyPI (not the monorepo path). The current floor is `rocky-sdk>=0.1.4`, and **published 0.1.4 does not have the new `severity` field**. So at release:

1. **Publish `rocky-sdk` 0.1.5** (with `CheckResult.severity`) to PyPI **first**.
2. **Raise the `dagster-rocky` floor to `>=0.1.5`** and release it.

Skip this and a published install silently maps every check back to `ERROR`. In-repo CI passes regardless (path dependency), which is exactly what masks the gap — both CHANGELOGs' `[Unreleased]` sections record the requirement.

## Behavior change on upgrade

A failing check configured `severity = "warning"` flips from `ERROR` → `WARN`, so it no longer degrades asset health. Alert policies keyed to `ASSET_HEALTH_DEGRADED` (and automation conditions gated on check health) stop firing for advisory-severity failures. Intended advisory semantics, but review any policy relying on the prior always-`ERROR` behavior. Captured under `### Changed` in the dagster CHANGELOG.

## Known limitation (out of scope)

Dagster **Pipes** mode is unaffected: the engine's Pipes path reports checks with a fixed `ERROR` severity (`report_asset_check(..., PipesCheckSeverity::Error)`), bypassing `_emit_results`. Mapping the configured severity there is a small, separate engine follow-up.

## Tests

- `rocky-sdk`: shadow-drift regression — `severity` survives `CheckResult.model_validate` and threads through `RunResult` (`warning` preserved; omitted → `"error"`).
- `dagster-rocky`: the helper, both emission paths, the metadata surfacing (advisory only), and back-compat default → `ERROR`. The back-compat test parses through the wire (omitted severity) and co-locates a `WARN` assertion so it's **mutation-verified load-bearing** — removing the production `severity=` arg makes it fail (it didn't before).

`rocky-sdk` 36 passed · `dagster-rocky` 655 passed · `ruff check` + `ruff format --check` clean on both. No codegen / fixtures (hand-written model; engine wire output unchanged).

The diff was put through an adversarial multi-lens review (correctness / completeness / tests / regression+release); the `emit_check_results` second-path fix, the tautological-test rewrite, and the release-sequencing callout all came out of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
