### PR TITLE
chore: release sdk 0.1.5 / dagster 1.52.0

### DIFF
--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,14 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.52.0] — 2026-06-23
+
 ### Added
 
 - **Engine check severity now maps to the Dagster asset-check severity.** A check the engine reports with `severity = "warning"` (configured in `rocky.toml`) is emitted as `AssetCheckSeverity.WARN`; `"error"` (the default) stays `ERROR`. Applies to every surfaced check on both the `RockyComponent` path and the `emit_check_results` / `load_rocky_assets` functional path. The advisory level is also surfaced in the check metadata so it's visible on a *passing* check, where Dagster doesn't render the severity. (Dagster Pipes mode is unaffected for now — the engine's Pipes path reports checks with a fixed `ERROR` severity; mapping the configured severity there is a separate engine follow-up.) (#959)
 
 ### Changed
 
-- **Will require `rocky-sdk>=0.1.5`** at release: the mapping reads `CheckResult.severity`, added to the SDK's wide model in 0.1.5. **Publish `rocky-sdk` 0.1.5 to PyPI and raise this floor before releasing `dagster-rocky`** — the published wheel resolves the floor from PyPI, not the monorepo path, so a stale `>=0.1.4` floor would silently map every check back to `ERROR`.
-- **Behavior change on upgrade:** a *failing* check configured `severity = "warning"` now emits `WARN` instead of `ERROR`, so it no longer degrades asset health. Alert policies keyed to `ASSET_HEALTH_DEGRADED` (and automation conditions gated on check health) will stop firing for advisory-severity check failures. This is the intended advisory semantics, but review any policy that relied on the prior always-`ERROR` behavior before upgrading.
+- **Raised the `rocky-sdk` floor to `>=0.1.5`** — the severity mapping reads `CheckResult.severity`, added to the SDK's wide model in 0.1.5. Released sdk-first so the published `dagster-rocky` wheel resolves the field from PyPI (not the monorepo path); a stale `>=0.1.4` floor would have silently mapped every check back to `ERROR`. (#959)
+- **Behavior change on upgrade:** a *failing* check configured `severity = "warning"` now emits `WARN` instead of `ERROR`, so it no longer degrades asset health. Alert policies keyed to `ASSET_HEALTH_DEGRADED` (and automation conditions gated on check health) will stop firing for advisory-severity check failures. This is the intended advisory semantics, but review any policy that relied on the prior always-`ERROR` behavior before upgrading. (#959)
 
 ## [1.51.0] — 2026-06-23
 

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.51.0"
+version = "1.52.0"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"
@@ -23,7 +23,7 @@ dependencies = [
     # package; RockyResource is a thin Dagster adapter over RockyClient. In-repo
     # dev/CI resolves this from the local path (see [tool.uv.sources]); the
     # published wheel floors on the released SDK.
-    "rocky-sdk>=0.1.4",
+    "rocky-sdk>=0.1.5",
     # Floor matches the version CI actually resolves and tests (uv.lock). The
     # RockyComponent path uses dagster.components.* APIs from preview namespaces,
     # so we advertise a tested floor rather than an older, never-exercised one.

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -220,7 +220,7 @@ wheels = [
 
 [[package]]
 name = "dagster-rocky"
-version = "1.51.0"
+version = "1.52.0"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },
@@ -910,7 +910,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "../../sdk/python" }
 dependencies = [
     { name = "pydantic" },

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5] — 2026-06-23
+
 ### Added
 
 - **`CheckResult.severity`** — the per-check failure severity (`"error"` | `"warning"`) the engine already emits on `rocky run` check results. The hand-written wide model omitted the field, so Pydantic's default `extra="ignore"` silently dropped the wire value and any consumer mapping it (e.g. `dagster-rocky`'s asset-check severity) only ever saw the default. Additive; defaults to `"error"` for older binaries that don't emit it, so existing parses are unaffected. (#959)

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rocky-sdk"
-version = "0.1.4"
+version = "0.1.5"
 description = "Typed Python client for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Release cut for the check-severity mapping shipped in #959. Engine and vscode have no unreleased work, so this is a 2-artifact cut.

## Versions
- **rocky-sdk** `0.1.4 → 0.1.5` (patch) — adds `CheckResult.severity` to the wide model.
- **dagster-rocky** `1.51.0 → 1.52.0` (minor) — maps engine check severity → `AssetCheckSeverity`; floor raised to `rocky-sdk>=0.1.5`.

## ⚠️ Tagging order (load-bearing)
After merge, tag + push **`sdk-v0.1.5` first**, let it publish to PyPI, **then** `dagster-v1.52.0` — the published dagster wheel resolves `rocky-sdk>=0.1.5` from PyPI, not the monorepo path.

## Pre-flight
- sdk: 36 passed, ruff clean, wheel builds (`rocky_sdk-0.1.5`).
- dagster: floor re-resolves `rocky-sdk 0.1.4→0.1.5`, 655 passed, ruff clean.
- `uv.lock` diffs are version-bumps only (no transitive churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)