### PR TITLE
chore(deps): upgrade object_store 0.11 → 0.14 (supersedes #964)

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -669,15 +669,6 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
@@ -1055,6 +1046,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crc-fast"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
+dependencies = [
+ "crc",
+ "digest 0.10.7",
+ "rustversion",
+ "spin 0.10.0",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1328,7 +1346,6 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
  "const-oid 0.9.6",
  "crypto-common 0.1.7",
 ]
@@ -1339,7 +1356,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.1",
+ "block-buffer",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
@@ -1987,7 +2004,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2256,10 +2272,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "jobserver"
@@ -2363,7 +2437,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -2562,16 +2636,6 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
@@ -2666,6 +2730,18 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -2827,34 +2903,45 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.11.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cfccb68961a56facde1163f9319e0d15743352344e7808a11795fb99698dcaf"
+checksum = "765784b4390c6bcf80316e5a22f4e3661b639c9d8c83246856643c27d8ce9dbe"
 dependencies = [
  "async-trait",
+ "aws-lc-rs",
  "base64",
  "bytes",
  "chrono",
- "futures",
+ "crc-fast",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body-util",
  "httparse",
  "humantime",
  "hyper",
- "itertools 0.13.0",
- "md-5 0.10.6",
+ "itertools 0.15.0",
+ "md-5",
+ "nix",
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand 0.8.6",
- "reqwest 0.12.28",
- "ring",
- "rustls-pemfile",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
+ "rustls-pki-types",
  "serde",
  "serde_json",
- "snafu",
+ "serde_urlencoded",
+ "thiserror",
  "tokio",
  "tracing",
  "url",
  "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3281,9 +3368,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
  "serde",
@@ -3315,6 +3402,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -3636,7 +3724,6 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3644,14 +3731,12 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tokio-util",
  "tower 0.5.3",
  "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -3667,23 +3752,32 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
+ "tokio-util",
  "tower 0.5.3",
  "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -4084,7 +4178,7 @@ dependencies = [
  "futures",
  "httpdate",
  "indexmap",
- "md-5 0.11.0",
+ "md-5",
  "object_store",
  "percent-encoding",
  "redis",
@@ -4421,15 +4515,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4438,6 +4523,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4793,6 +4905,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4823,27 +4945,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
-name = "snafu"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
-dependencies = [
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4864,6 +4965,12 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spki"
@@ -5796,9 +5903,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -5825,6 +5932,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -122,7 +122,7 @@ futures = "0.3"
 redis = "1.2"
 
 # Cloud object store (unified S3/GCS/Azure backend for state sync + loaders)
-object_store = { version = "0.11", features = ["aws", "gcp", "azure"] }
+object_store = { version = "0.14", features = ["aws", "gcp", "azure"] }
 bytes = "1"
 url = "2"
 

--- a/engine/crates/rocky-cli/src/commands/run_content_addressed.rs
+++ b/engine/crates/rocky-cli/src/commands/run_content_addressed.rs
@@ -1619,6 +1619,7 @@ mod tests {
     // OWN ledger row (its correct `file_path`/`commit_version`), not whichever
     // row the redb key order happens to surface first.
 
+    use object_store::ObjectStoreExt;
     use object_store::PutPayload;
     use object_store::memory::InMemory;
     use object_store::path::Path as ObjPath;

--- a/engine/crates/rocky-core/src/object_store.rs
+++ b/engine/crates/rocky-core/src/object_store.rs
@@ -21,7 +21,9 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use futures::StreamExt;
-use object_store::{ClientOptions, ObjectStore, PutMode, PutOptions, path::Path as ObjectPath};
+use object_store::{
+    ClientOptions, ObjectStore, ObjectStoreExt, PutMode, PutOptions, path::Path as ObjectPath,
+};
 use thiserror::Error;
 use tracing::debug;
 
@@ -142,7 +144,15 @@ impl ObjectStoreProvider {
             "s3" | "s3a" => {
                 let builder = object_store::aws::AmazonS3Builder::from_env()
                     .with_bucket_name(&bucket)
-                    .with_client_options(default_client_options());
+                    .with_client_options(default_client_options())
+                    // `put_if_not_exists` uses `PutMode::Create`, which needs S3
+                    // conditional put configured. `ETagMatch` emits `If-None-Match: *`
+                    // on `PutObject` (the create-if-absent primitive). We pin it
+                    // explicitly rather than rely on the `object_store` default —
+                    // that default flipped from `None` (→ `NotImplemented`) to
+                    // `ETagMatch` between 0.11 and 0.14, so an unpinned builder makes
+                    // the concurrent-writer guarantee silently version-dependent.
+                    .with_conditional_put(object_store::aws::S3ConditionalPut::ETagMatch);
                 Arc::new(builder.build()?)
             }
             "gs" | "gcs" => {

--- a/engine/crates/rocky-fivetran/src/state_cache/object_store_backend.rs
+++ b/engine/crates/rocky-fivetran/src/state_cache/object_store_backend.rs
@@ -39,7 +39,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use bytes::Bytes;
 use md5::{Digest, Md5};
-use object_store::{ObjectStore, path::Path as ObjectPath};
+use object_store::{ObjectStore, ObjectStoreExt, path::Path as ObjectPath};
 use tracing::debug;
 use url::Url;
 
@@ -118,9 +118,9 @@ impl ObjectStoreCache {
     fn object_path(&self, key: &str) -> ObjectPath {
         let mut p = self.prefix.clone();
         for segment in key.split('/') {
-            // `Path::child` re-encodes each segment, so we don't have
+            // `Path::join` re-encodes each segment, so we don't have
             // to escape `account_hash/destination_id` ourselves.
-            p = p.child(segment);
+            p = p.join(segment);
         }
         // We can't use `set_extension` on `object_store::Path`. Build a
         // new Path from the stringified form to add `.json`.

--- a/engine/crates/rocky-fivetran/tests/state_cache_object_store.rs
+++ b/engine/crates/rocky-fivetran/tests/state_cache_object_store.rs
@@ -82,7 +82,7 @@ async fn object_store_hash_dedupe_via_etag_compare() {
     // those ETags will match the MD5 of an unchanged object, so the
     // dedupe branch in `ObjectStoreCache::write` fires.
     //
-    // NOTE: object_store 0.11's LocalFileSystem ETag derivation isn't
+    // NOTE: object_store's LocalFileSystem ETag derivation isn't
     // a content-hash by default — it incorporates file size + mtime.
     // That means two writes of identical bytes a few milliseconds
     // apart produce DIFFERENT ETags from the LocalFS backend, even

--- a/engine/crates/rocky-iceberg/src/uniform_writer/discover.rs
+++ b/engine/crates/rocky-iceberg/src/uniform_writer/discover.rs
@@ -8,8 +8,8 @@
 
 use std::collections::HashMap;
 
-use object_store::ObjectStore;
 use object_store::path::Path;
+use object_store::{ObjectStore, ObjectStoreExt};
 use serde::Deserialize;
 
 use super::{Result, UniformTableState, UniformWriter, UniformWriterError};

--- a/engine/crates/rocky-iceberg/src/uniform_writer/mod.rs
+++ b/engine/crates/rocky-iceberg/src/uniform_writer/mod.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use arrow::array::RecordBatch;
 use bytes::Bytes;
 use object_store::path::Path;
-use object_store::{ObjectStore, PutMode, PutOptions, PutPayload};
+use object_store::{ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload};
 
 pub mod commit;
 pub mod discover;


### PR DESCRIPTION
## What
Upgrade `object_store` 0.11.2 → 0.14.0. **Supersedes #964** (dependabot's version-only bump, which doesn't compile).

## Why #964 couldn't merge
object_store 0.14 moved `get`/`put`/`delete`/`head` off the `ObjectStore` trait onto a new `ObjectStoreExt` extension trait. Dependabot bumps the version but can't adapt the code, so #964 fails to compile (Clippy/Test/build all red).

## Changes
- `ObjectStoreExt` import in the 5 files calling those convenience methods.
- `Path::child` → `Path::join` (child deprecated; **byte-identical** re-encoding — verified against both vendored versions, so fivetran state-cache keys are unchanged).
- **Pinned `.with_conditional_put(S3ConditionalPut::ETagMatch)`** on the wrapper's S3 builder. Surfaced by review: object_store's S3 conditional-put default flipped `None`(→`NotImplemented`) → `ETagMatch`(→`If-None-Match: *`) between 0.11 and 0.14, so the wrapper's `put_if_not_exists` was *latently broken on real S3* under 0.11 (it only worked through `run_content_addressed.rs`'s explicit ETagMatch). Pinning makes the concurrent-writer guarantee explicit + version-independent. The active ETagMatch create path is byte-identical across versions.

## Verified (compile-time + InMemory)
- `clippy --all-targets --all-features -D warnings` clean; affected-crate tests green (**2202 passed, 0 failed**); rustfmt clean.
- Conditional-put semantics source-proven behavior-preserving (active path identical; rocky matches `Error::AlreadyExists`).
- The dual-provider crypto-panic fix (`install_default(aws_lc_rs)` before any TLS) is intact in both binaries.

## ⚠️ DRAFT — needs a live S3 round-trip before merge
object_store 0.14 swaps its **network transport**: reqwest 0.12→0.13 (sole-consumed by object_store), direct `aws-lc-rs`, adds `rustls-platform-verifier`, bumps `quick-xml` 0.37→0.40 (ListObjects/multipart XML). These run **only against a real S3/GCS/Azure endpoint** — no unit test opens a socket (all InMemory), so compile + the 2202 green tests **cannot certify the new TLS/XML stack**. Same blind spot as the prior dual-provider TLS panic that green CI missed.

**Required before merge:** one live S3 `put` + `list` + `get` round-trip (env-var AWS creds + `ROCKY_TEST_S3_BUCKET`/`ROCKY_TEST_S3_PREFIX`). `list` is load-bearing — the only path exercising quick-xml 0.40; any op forces the new cert-verification handshake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)