### PR TITLE
test(engine): de-flake run_watch SIGINT/re-run timeouts

### DIFF
--- a/engine/rocky/tests/run_watch.rs
+++ b/engine/rocky/tests/run_watch.rs
@@ -175,12 +175,12 @@ fn run_watch_reruns_on_file_change_and_exits_clean_on_sigint() {
     // Touch the watched config to provoke a re-run.
     touch(&cfg_path);
 
-    let second = wait_for(&stderr_rx, "run completed in", Duration::from_secs(8));
+    let second = wait_for(&stderr_rx, "run completed in", Duration::from_secs(20));
     if !second.matched {
         sigterm(pid);
         let _ = child.wait();
         panic!(
-            "second run never triggered within 8s after touch.\n\
+            "second run never triggered within 20s after touch.\n\
              stderr since first run:\n{}",
             second.buffered
         );
@@ -194,8 +194,13 @@ fn run_watch_reruns_on_file_change_and_exits_clean_on_sigint() {
     // Clean shutdown: SIGINT, then await exit.
     sigint(pid);
 
-    let exit = wait_with_timeout(&mut child, Duration::from_secs(8))
-        .expect("rocky did not exit within 8s of SIGINT");
+    // Generous budget: under a loaded CI runner the watch loop can take
+    // several seconds to wind down the in-flight run and drop the notify
+    // watcher after SIGINT. This is a max-wait deadline — `wait_with_timeout`
+    // returns as soon as the child exits, so a large budget doesn't slow the
+    // happy path, it only removes the flake window.
+    let exit = wait_with_timeout(&mut child, Duration::from_secs(30))
+        .expect("rocky did not exit within 30s of SIGINT");
 
     assert!(
         exit.success(),


### PR DESCRIPTION
## What

Widens the two tightest deadlines in the `run_watch_reruns_on_file_change_and_exits_clean_on_sigint` integration test:

- post-SIGINT exit budget: **8s → 30s**
- touch-triggered re-run budget: **8s → 20s** (matching the existing first-run budget)

## Why

This test failed on the `main` push of #963 (a `rustls`/`memmap2` patch bump — unrelated to file-watching or signals):

```
thread panicked at rocky/tests/run_watch.rs:198:
  rocky did not exit within 8s of SIGINT
```

It's a timing flake, not a regression: the object_store PR run built on the same `main` commit passed this same test, and the dependency bump touches neither `notify` nor signal handling. Under a loaded nextest run on the 4-core CI runner, the post-SIGINT wind-down (finishing the in-flight run, dropping the notify watcher) can exceed the 8s budget.

These are max-wait budgets — `wait_with_timeout`/`wait_for` return as soon as the process responds — so raising them removes the flake window without slowing the happy path.

## Verification

- `cargo test -p rocky --test run_watch` passes locally in ~6s.
- `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)