### PR TITLE
fix(engine/rocky-compiler): make import-dbt resilient to unserializable dbt unit tests

### DIFF
--- a/engine/crates/rocky-cli/src/commands/import_dbt.rs
+++ b/engine/crates/rocky-cli/src/commands/import_dbt.rs
@@ -47,6 +47,7 @@ use crate::output::{
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Execute `rocky import-dbt`.
+#[allow(clippy::too_many_arguments)]
 pub fn run_import_dbt(
     dbt_project: &Path,
     output_dir: &Path,
@@ -54,6 +55,7 @@ pub fn run_import_dbt(
     no_manifest: bool,
     target_adapter: Option<&str>,
     overwrite: bool,
+    skip_unit_tests: bool,
     output_json: bool,
 ) -> Result<()> {
     // Resolve adapter shape — profile detection unless --target-adapter overrides.
@@ -63,7 +65,13 @@ pub fn run_import_dbt(
     let default_target = default_target_from_profile(&profile);
 
     // Run the existing importer to produce the per-model translation result.
-    let import_result = run_importer(dbt_project, &default_target, manifest_path, no_manifest)?;
+    let import_result = run_importer(
+        dbt_project,
+        &default_target,
+        manifest_path,
+        no_manifest,
+        skip_unit_tests,
+    )?;
 
     // Capture which models had their `view` materialization flattened to
     // FullRefresh by the importer — we re-rewrite those to Ephemeral at
@@ -241,6 +249,7 @@ fn run_importer(
     default_target: &TargetConfig,
     manifest_path: Option<&Path>,
     no_manifest: bool,
+    skip_unit_tests: bool,
 ) -> Result<ImportResult> {
     if no_manifest {
         return dbt::import_dbt_project(dbt_project, default_target)
@@ -267,7 +276,7 @@ fn run_importer(
 
     if let Some(ref mf) = manifest_file {
         let manifest = dbt_manifest::parse_manifest(mf).map_err(|e| anyhow::anyhow!("{e}"))?;
-        let mut result = dbt::import_from_manifest(&manifest, default_target);
+        let mut result = dbt::import_from_manifest(&manifest, default_target, skip_unit_tests);
         // The manifest path doesn't itself walk schema.yml files for tests.
         // Apply the dbt-tests pass against the project root so manifest
         // imports also pick up the four canonical generic tests.

--- a/engine/crates/rocky-cli/src/commands/validate_migration.rs
+++ b/engine/crates/rocky-cli/src/commands/validate_migration.rs
@@ -54,7 +54,7 @@ pub fn run_validate_migration(
     let import_result = if manifest_path.exists() {
         let manifest =
             dbt_manifest::parse_manifest(&manifest_path).map_err(|e| anyhow::anyhow!("{e}"))?;
-        dbt::import_from_manifest(&manifest, &default_target)
+        dbt::import_from_manifest(&manifest, &default_target, false)
     } else {
         dbt::import_dbt_project(dbt_project, &default_target).map_err(|e| anyhow::anyhow!("{e}"))?
     };

--- a/engine/crates/rocky-compiler/src/import/dbt.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt.rs
@@ -69,6 +69,11 @@ pub enum WarningCategory {
     /// `given.rows` or `expect.rows` (typically `csv` or `sql`). Inline
     /// `format = "dict"` is the only shape supported today.
     UnsupportedUnitTestFormat,
+    /// A `manifest.unit_tests` entry has fixture/expectation rows that
+    /// can't be represented in the Rocky sidecar TOML — typically a `null`
+    /// field value or a non-object row element (TOML has no null type).
+    /// The test is dropped so it never aborts the rest of the import.
+    UnserializableUnitTest,
 }
 
 /// A warning produced during import.
@@ -235,7 +240,15 @@ pub struct ImportedModel {
 ///
 /// Uses `compiled_code` (all Jinja resolved) for each model node, falling
 /// back to `raw_code` if compiled_code is absent.
-pub fn import_from_manifest(manifest: &DbtManifest, default_target: &TargetConfig) -> ImportResult {
+///
+/// When `skip_unit_tests` is set, `manifest.unit_tests` entries are counted
+/// but not converted (see [`apply_dbt_unit_tests`]) — backing the
+/// `rocky import-dbt --skip-unit-tests` flag.
+pub fn import_from_manifest(
+    manifest: &DbtManifest,
+    default_target: &TargetConfig,
+    skip_unit_tests: bool,
+) -> ImportResult {
     let mut result = ImportResult {
         imported: Vec::new(),
         warnings: Vec::new(),
@@ -297,7 +310,7 @@ pub fn import_from_manifest(manifest: &DbtManifest, default_target: &TargetConfi
     // migration is never silently lossy.
     record_dropped_constructs(&manifest.dropped, &mut result);
 
-    apply_dbt_unit_tests(manifest, &mut result);
+    apply_dbt_unit_tests(manifest, &mut result, skip_unit_tests);
 
     result
 }
@@ -453,9 +466,23 @@ pub fn apply_dbt_tests(yaml_root: &Path, default_target: &TargetConfig, result: 
 /// The `unit_tests_found`, `unit_tests_converted`, and
 /// `unit_tests_skipped` counters on [`ImportResult`] are updated in
 /// place.
-pub fn apply_dbt_unit_tests(manifest: &DbtManifest, result: &mut ImportResult) {
+///
+/// When `skip_unit_tests` is set, every entry is still counted in
+/// `unit_tests_found` but none are converted — each bumps
+/// `unit_tests_skipped` so the report stays honest. This backs the
+/// `rocky import-dbt --skip-unit-tests` escape hatch.
+pub fn apply_dbt_unit_tests(
+    manifest: &DbtManifest,
+    result: &mut ImportResult,
+    skip_unit_tests: bool,
+) {
     for ut in manifest.unit_tests.values() {
         result.unit_tests_found += 1;
+
+        if skip_unit_tests {
+            result.unit_tests_skipped += 1;
+            continue;
+        }
 
         if let Some(format) = ut.expect.format.as_deref()
             && !is_dict_format(format)
@@ -523,9 +550,54 @@ pub fn apply_dbt_unit_tests(manifest: &DbtManifest, result: &mut ImportResult) {
             given: ut.given.iter().map(convert_unit_test_given).collect(),
             expect: convert_unit_test_expect(&ut.expect),
         };
+
+        // Guard: the Rocky sidecar serializes `[[test]]` blocks to TOML,
+        // which has no `null` type. A fixture/expectation row carrying a
+        // `null` field value — or a non-object row element — can't be
+        // represented, and the `toml` crate fails the whole serialize with
+        // "unsupported unit type". Catch it here, per test, so one bad
+        // fixture never aborts the import of every other model/seed/test.
+        if let Err(reason) = check_unit_test_serializable(&test_def) {
+            tracing::warn!(
+                model = %ut.model,
+                unit_test = %ut.name,
+                reason = %reason,
+                "dropping dbt unit_test that can't be represented in Rocky sidecar TOML",
+            );
+            result.warnings.push(ImportWarning {
+                model: ut.model.clone(),
+                category: WarningCategory::UnserializableUnitTest,
+                message: format!(
+                    "dbt unit_test '{}' can't be represented in the Rocky sidecar TOML ({reason}) — skipped",
+                    ut.name
+                ),
+                suggestion: Some(
+                    "TOML has no null type; replace `null` fixture values with a sentinel \
+                     (or omit the column) in the dbt unit_test, then re-import".to_string(),
+                ),
+            });
+            result.unit_tests_skipped += 1;
+            continue;
+        }
+
         imported.unit_tests.push(test_def);
         result.unit_tests_converted += 1;
     }
+}
+
+/// Check that a converted unit test round-trips to the sidecar TOML the
+/// emitter writes. Returns `Err(reason)` when the `toml` crate rejects the
+/// shape — most commonly a `null` value inside a fixture/expectation row,
+/// which TOML cannot express. Mirrors the emitter's `[[test]]` wrapper so a
+/// pass here guarantees the emit-time serialize won't fail.
+fn check_unit_test_serializable(test: &UnitTestDef) -> Result<(), String> {
+    #[derive(serde::Serialize)]
+    struct Wrapper<'a> {
+        test: [&'a UnitTestDef; 1],
+    }
+    toml::to_string(&Wrapper { test: [test] })
+        .map(|_| ())
+        .map_err(|e| e.to_string())
 }
 
 /// `format` is treated as `dict` when absent or explicitly set to
@@ -2112,7 +2184,7 @@ FROM raw.orders
             schema: "staging".to_string(),
             table: String::new(),
         };
-        let result = import_from_manifest(&manifest, &target);
+        let result = import_from_manifest(&manifest, &target, false);
 
         assert_eq!(result.import_method, ImportMethod::Manifest);
         assert_eq!(result.imported.len(), 1);
@@ -2225,7 +2297,7 @@ models:
             schema: "s".to_string(),
             table: String::new(),
         };
-        let result = import_from_manifest(&manifest, &target);
+        let result = import_from_manifest(&manifest, &target, false);
 
         assert_eq!(result.imported.len(), 1);
         assert!(matches!(
@@ -2269,7 +2341,7 @@ models:
             schema: "s".to_string(),
             table: String::new(),
         };
-        let result = import_from_manifest(&manifest, &target);
+        let result = import_from_manifest(&manifest, &target, false);
 
         assert_eq!(result.imported.len(), 1);
         assert!(matches!(
@@ -2448,7 +2520,7 @@ FROM {{ ref('stg_events') }}
             schema: "s".to_string(),
             table: String::new(),
         };
-        import_from_manifest(&manifest, &target)
+        import_from_manifest(&manifest, &target, false)
     }
 
     #[test]
@@ -3206,6 +3278,135 @@ FROM {{ ref('stg_events') }}
         assert_eq!(result.unit_tests_skipped, 0);
         let imported = result.imported.iter().find(|m| m.name == "m").unwrap();
         assert_eq!(imported.unit_tests.len(), 1);
+    }
+
+    /// A `null` fixture value (TOML has no null type) must NOT abort the
+    /// import. The offending unit test is skipped + counted; every other
+    /// model/seed/test still imports — and a sibling null-free unit test in
+    /// the same manifest round-trips cleanly. Regression for the
+    /// `toml::to_string … unsupported unit type` import-abort bug.
+    #[test]
+    fn test_apply_dbt_unit_tests_null_fixture_value_skips_not_aborts() {
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": {
+                "model.p.m": {
+                    "unique_id": "model.p.m",
+                    "name": "m",
+                    "resource_type": "model",
+                    "compiled_code": "SELECT 1",
+                    "raw_code": "SELECT 1",
+                    "depends_on": { "nodes": [], "macros": [] },
+                    "config": { "materialized": "table" },
+                    "columns": {}, "tags": [], "schema": "s", "database": "d"
+                }
+            },
+            "sources": {},
+            "unit_tests": {
+                // Offending: a `null` field value inside an expectation row.
+                "unit_test.p.m.has_null": {
+                    "unique_id": "unit_test.p.m.has_null",
+                    "name": "has_null",
+                    "model": "m",
+                    "given": [{ "input": "ref('u')", "rows": [{ "id": 1, "note": "x" }] }],
+                    "expect": { "rows": [{ "id": 1, "note": null }], "format": "dict" },
+                    "tags": []
+                },
+                // Valid sibling: null-free, no description — must round-trip.
+                "unit_test.p.m.clean": {
+                    "unique_id": "unit_test.p.m.clean",
+                    "name": "clean",
+                    "model": "m",
+                    "given": [{ "input": "ref('u')", "rows": [{ "id": 2 }] }],
+                    "expect": { "rows": [{ "id": 2 }], "format": "dict" },
+                    "tags": []
+                }
+            }
+        });
+
+        let result = import_from_manifest_json(&manifest);
+
+        // Exit-0 behavior: the import completed, the model is present.
+        let imported = result
+            .imported
+            .iter()
+            .find(|m| m.name == "m")
+            .expect("model still imported despite the unserializable unit test");
+
+        // Counters: both seen, one converted, one skipped.
+        assert_eq!(result.unit_tests_found, 2);
+        assert_eq!(result.unit_tests_converted, 1);
+        assert_eq!(result.unit_tests_skipped, 1);
+
+        // Only the clean test is attached.
+        assert_eq!(imported.unit_tests.len(), 1);
+        assert_eq!(imported.unit_tests[0].name, "clean");
+
+        // A structured warning explains the skip.
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.category == WarningCategory::UnserializableUnitTest
+                    && w.message.contains("has_null")),
+            "expected an UnserializableUnitTest warning naming the dropped test"
+        );
+
+        // The retained test round-trips to the sidecar TOML the emitter writes.
+        let emitted = crate::import::emit::render_unit_tests("m", &imported.unit_tests);
+        assert!(
+            emitted.contains("[[test]]") && emitted.contains("clean"),
+            "clean test must serialize to a [[test]] block:\n{emitted}"
+        );
+    }
+
+    /// `--skip-unit-tests` counts every unit test as skipped, converts none,
+    /// and never aborts — even when a null-bearing fixture is present.
+    #[test]
+    fn test_skip_unit_tests_flag_skips_everything() {
+        let manifest_json = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": {
+                "model.p.m": {
+                    "unique_id": "model.p.m",
+                    "name": "m",
+                    "resource_type": "model",
+                    "compiled_code": "SELECT 1",
+                    "raw_code": "SELECT 1",
+                    "depends_on": { "nodes": [], "macros": [] },
+                    "config": { "materialized": "table" },
+                    "columns": {}, "tags": [], "schema": "s", "database": "d"
+                }
+            },
+            "sources": {},
+            "unit_tests": {
+                "unit_test.p.m.clean": {
+                    "unique_id": "unit_test.p.m.clean",
+                    "name": "clean",
+                    "model": "m",
+                    "given": [{ "input": "ref('u')", "rows": [{ "id": 2 }] }],
+                    "expect": { "rows": [{ "id": 2 }], "format": "dict" },
+                    "tags": []
+                }
+            }
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("manifest.json");
+        std::fs::write(&path, manifest_json.to_string()).unwrap();
+        let manifest = dbt_manifest::parse_manifest(&path).unwrap();
+        let target = TargetConfig {
+            catalog: "w".to_string(),
+            schema: "s".to_string(),
+            table: String::new(),
+        };
+
+        let result = import_from_manifest(&manifest, &target, /* skip_unit_tests */ true);
+
+        assert_eq!(result.unit_tests_found, 1);
+        assert_eq!(result.unit_tests_converted, 0);
+        assert_eq!(result.unit_tests_skipped, 1);
+        let imported = result.imported.iter().find(|m| m.name == "m").unwrap();
+        assert!(imported.unit_tests.is_empty());
     }
 
     // --- L1: model-path traversal rejection ---

--- a/engine/crates/rocky-compiler/src/import/emit.rs
+++ b/engine/crates/rocky-compiler/src/import/emit.rs
@@ -222,7 +222,7 @@ fn write_model_files(model: &ImportedModel, models_dir: &Path) -> Result<(), Str
 
     let mut toml_body = render_model_sidecar(&model.config);
     if !model.unit_tests.is_empty() {
-        toml_body.push_str(&render_unit_tests(&model.unit_tests)?);
+        toml_body.push_str(&render_unit_tests(&model.name, &model.unit_tests));
     }
     std::fs::write(&toml_path, toml_body)
         .map_err(|e| format!("failed to write {}: {e}", toml_path.display()))?;
@@ -232,17 +232,35 @@ fn write_model_files(model: &ImportedModel, models_dir: &Path) -> Result<(), Str
 /// Serialize a model's unit tests as `[[test]]` blocks. Uses the `toml`
 /// crate so the array-of-tables nesting (`[[test]]`, `[[test.given]]`,
 /// `[test.expect]`) matches what the [`UnitTestDef`] deserializer expects.
-fn render_unit_tests(tests: &[UnitTestDef]) -> Result<String, String> {
+///
+/// Each test is serialized individually so a single unrepresentable test
+/// (e.g. a `null` fixture value, which TOML can't express) is skipped with
+/// a warning rather than aborting the whole import. The upstream importer
+/// already drops such tests in `apply_dbt_unit_tests`; this is the
+/// defense-in-depth backstop so emission can never fail on a stray shape.
+pub(crate) fn render_unit_tests(model: &str, tests: &[UnitTestDef]) -> String {
     #[derive(Serialize)]
     struct Wrapper<'a> {
-        test: &'a [UnitTestDef],
+        test: [&'a UnitTestDef; 1],
     }
-    let body = toml::to_string(&Wrapper { test: tests })
-        .map_err(|e| format!("failed to serialize unit tests: {e}"))?;
-    let mut out = String::with_capacity(body.len() + 1);
-    out.push('\n');
-    out.push_str(&body);
-    Ok(out)
+    let mut out = String::new();
+    for test in tests {
+        match toml::to_string(&Wrapper { test: [test] }) {
+            Ok(body) => {
+                out.push('\n');
+                out.push_str(&body);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    model = %model,
+                    unit_test = %test.name,
+                    reason = %e,
+                    "skipping unit_test that can't be serialized to sidecar TOML",
+                );
+            }
+        }
+    }
+    out
 }
 
 /// Inject a comment line above any TODO/Jinja-leftover marker so reviewers

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -1147,6 +1147,12 @@ enum Command {
         /// Without this flag, the importer refuses to write into a non-empty directory.
         #[arg(long)]
         overwrite: bool,
+        /// Skip dbt unit-test (`manifest.unit_tests`) translation entirely.
+        /// Models, seeds, and generic tests still import; every unit test is
+        /// reported under `unit_tests_skipped`. Use when a manifest carries
+        /// unit-test fixtures the Rocky sidecar can't represent.
+        #[arg(long = "skip-unit-tests")]
+        skip_unit_tests: bool,
     },
 
     /// Interactive SQL shell against the configured warehouse
@@ -2897,6 +2903,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             no_manifest,
             target_adapter,
             overwrite,
+            skip_unit_tests,
         } => rocky_cli::commands::run_import_dbt(
             &dbt_project,
             &output_dir,
@@ -2904,6 +2911,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             no_manifest,
             target_adapter.as_deref(),
             overwrite,
+            skip_unit_tests,
             json,
         ),
         Command::Shell { pipeline } => {


### PR DESCRIPTION
## Problem

Certain dbt unit-test shapes (e.g. `null` or empty fixture values) made `toml::to_string` fail with `unsupported unit type` — TOML has no null type. Because the sidecar serialize happened up front, a single unrepresentable unit test aborted the **entire** manifest import: no models, seeds, or tests were emitted.

## Fix

- Resilient unit-test serialization: each `[[test]]` block is serialized individually, and any unit test that still can't be represented in the Rocky sidecar TOML degrades to a per-test warning plus a bump to the `unit_tests_skipped` counter, instead of aborting the import. Every other model, seed, and test still imports.
- New `--skip-unit-tests` flag on `rocky import-dbt` to bypass unit-test emission entirely (each unit test is counted under `unit_tests_skipped`).

## Testing

- Rust regression fixture: a manifest with a `null` fixture value is skipped + counted while a clean sibling unit test round-trips, and the model itself still imports.
- End-to-end `rocky import-dbt` integration check covering the `--skip-unit-tests` path.
- `--output json` surfaces `unit_tests_skipped` so callers can see what was dropped.
