### PR TITLE
feat(engine/rocky-compiler): import-dbt fidelity — dbt_expectations tests, profiles anchors, dropped-contract warnings

### DIFF
--- a/editors/vscode/src/types/generated/import_dbt.ts
+++ b/editors/vscode/src/types/generated/import_dbt.ts
@@ -62,6 +62,14 @@ export type ImportDbtStructuredWarning =
       kind: "dropped_construct";
       name: string;
       [k: string]: unknown;
+    }
+  | {
+      constraints: number;
+      contract_path: string;
+      kind: "dropped_contract";
+      model: string;
+      typed_columns: number;
+      [k: string]: unknown;
     };
 /**
  * Lifecycle hook kind for [`ImportDbtStructuredWarning::DroppedHook`].
@@ -79,6 +87,10 @@ export interface ImportDbtOutput {
    * Number of dbt resources the importer does not translate that were detected and skipped (snapshots, metrics, semantic models, exposures).
    */
   constructs_dropped?: number;
+  /**
+   * Number of dbt models whose enforced `contract` (column `data_type`s / `constraints`) was dropped on import. Rocky enforces contracts via a `{model}.contract.toml` sidecar the importer does not auto-generate.
+   */
+  contracts_dropped?: number;
   dbt_version?: string | null;
   /**
    * Metadata about the emitted Rocky repo. Present when `--output-dir` triggered repo emission (the default for `rocky import-dbt`). Absent when emission was skipped or failed before disk writes.

--- a/engine/crates/rocky-cli/src/commands/import_dbt.rs
+++ b/engine/crates/rocky-cli/src/commands/import_dbt.rs
@@ -30,7 +30,10 @@ use anyhow::Result;
 
 use rocky_compiler::import::{
     dbt,
-    dbt::{HookKind, ImportDbtStructuredWarning as CompilerStructuredWarning, ImportResult},
+    dbt::{
+        HookKind, ImportDbtStructuredWarning as CompilerStructuredWarning, ImportResult,
+        ImportWarning, WarningCategory,
+    },
     dbt_manifest, dbt_profiles,
     dbt_profiles::{AdapterKind, ProfileResolution, StubReason},
     emit,
@@ -65,13 +68,28 @@ pub fn run_import_dbt(
     let default_target = default_target_from_profile(&profile);
 
     // Run the existing importer to produce the per-model translation result.
-    let import_result = run_importer(
+    let mut import_result = run_importer(
         dbt_project,
         &default_target,
         manifest_path,
         no_manifest,
         skip_unit_tests,
     )?;
+
+    // A `profiles.yml` that was present but couldn't be resolved fell back to
+    // a stub DuckDB adapter. Surface it loudly (a warning + in `--output json`)
+    // so the migration never silently defaults to duckdb.
+    if let Some(reason) = &profile.fallback_reason {
+        tracing::warn!(reason = %reason, "dbt profiles.yml fell back to a stub DuckDB adapter");
+        import_result.warnings.push(ImportWarning {
+            model: "<profiles.yml>".to_string(),
+            category: WarningCategory::ProfileFallback,
+            message: reason.clone(),
+            suggestion: Some(
+                "edit the [adapter] block in the emitted rocky.toml to point at your real warehouse".to_string(),
+            ),
+        });
+    }
 
     // Capture which models had their `view` materialization flattened to
     // FullRefresh by the importer — we re-rewrite those to Ephemeral at

--- a/engine/crates/rocky-cli/src/commands/import_dbt.rs
+++ b/engine/crates/rocky-cli/src/commands/import_dbt.rs
@@ -175,6 +175,7 @@ pub fn run_import_dbt(
             unit_tests_converted: import_result.unit_tests_converted,
             unit_tests_skipped: import_result.unit_tests_skipped,
             constructs_dropped: import_result.constructs_dropped,
+            contracts_dropped: import_result.contracts_dropped,
             macros_detected: import_result.macros_detected,
             imported_models: import_result
                 .imported
@@ -382,6 +383,17 @@ fn to_cli_structured_warning(w: &CompilerStructuredWarning) -> ImportDbtStructur
             construct: construct.clone(),
             name: name.clone(),
             detail: detail.clone(),
+        },
+        CompilerStructuredWarning::DroppedContract {
+            model,
+            typed_columns,
+            constraints,
+            contract_path,
+        } => ImportDbtStructuredWarning::DroppedContract {
+            model: model.clone(),
+            typed_columns: *typed_columns,
+            constraints: *constraints,
+            contract_path: contract_path.clone(),
         },
     }
 }

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -3326,6 +3326,11 @@ pub struct ImportDbtOutput {
     /// detected and skipped (snapshots, metrics, semantic models, exposures).
     #[serde(default)]
     pub constructs_dropped: usize,
+    /// Number of dbt models whose enforced `contract` (column `data_type`s /
+    /// `constraints`) was dropped on import. Rocky enforces contracts via a
+    /// `{model}.contract.toml` sidecar the importer does not auto-generate.
+    #[serde(default)]
+    pub contracts_dropped: usize,
     pub macros_detected: usize,
     pub imported_models: Vec<String>,
     pub warning_details: Vec<ImportDbtWarning>,
@@ -3450,6 +3455,16 @@ pub enum ImportDbtStructuredWarning {
         construct: String,
         name: String,
         detail: String,
+    },
+    /// A dbt model `contract` (`enforced: true`), column `data_type`s, and/or
+    /// `constraints` were dropped on import. Rocky enforces contracts via a
+    /// `{model}.contract.toml` sidecar the importer does not auto-generate;
+    /// the user must hand-author it. Visibility only — no stub generated.
+    DroppedContract {
+        model: String,
+        typed_columns: usize,
+        constraints: usize,
+        contract_path: String,
     },
 }
 

--- a/engine/crates/rocky-cli/tests/import_dbt_emit.rs
+++ b/engine/crates/rocky-cli/tests/import_dbt_emit.rs
@@ -215,10 +215,10 @@ fn emit_runnable_repo_from_rich_fixture() {
     assert!(notes.contains("Required env vars"));
     assert!(notes.contains("dbt generic tests"));
 
-    // Generic-test mapping: the four canonical built-ins land as
-    // `[[tests]]` blocks on each model sidecar. Non-canonical tests
-    // (e.g. `dbt_utils.accepted_range`) must NOT appear in the toml —
-    // they are surfaced as structured import warnings instead.
+    // Generic-test mapping: the canonical built-ins land as `[[tests]]`
+    // blocks on each model sidecar, and the dbt_utils/dbt_expectations
+    // long-tail tests with a native equivalent map too (here
+    // `dbt_utils.accepted_range` → `in_range`).
     let stg_orders_toml = std::fs::read_to_string(models_dir.join("stg_orders.toml")).unwrap();
     assert!(
         stg_orders_toml.contains("[[tests]]"),
@@ -234,14 +234,22 @@ fn emit_runnable_repo_from_rich_fixture() {
         stg_orders_toml.contains("to_table = \""),
         "relationships test must include a fully-qualified to_table"
     );
-    // Non-canonical test must NOT be stubbed in the emitted toml.
+    // dbt_utils.accepted_range now maps to a native `in_range` test, carrying
+    // the min/max bounds — it is NOT dropped. The dbt-side name must not leak
+    // into the emitted toml (the Rocky type is `in_range`).
+    assert!(
+        stg_orders_toml.contains("type = \"in_range\""),
+        "dbt_utils.accepted_range should map to an in_range test: {stg_orders_toml}"
+    );
+    assert!(stg_orders_toml.contains("min = \"0\""));
+    assert!(stg_orders_toml.contains("max = \"1000000\""));
     assert!(
         !stg_orders_toml.contains("dbt_utils"),
-        "non-canonical tests must not be stubbed as TODO entries; emitted toml should be clean"
+        "the dbt-side test name must not leak into the emitted toml"
     );
     assert!(
         !stg_orders_toml.to_lowercase().contains("accepted_range"),
-        "non-canonical tests must not be stubbed as TODO entries"
+        "the dbt-side test name must not leak into the emitted toml"
     );
 
     let stg_customers_toml_again =
@@ -261,24 +269,27 @@ fn emit_runnable_repo_from_rich_fixture() {
         "stg_orders should carry at least one TestDecl after loading"
     );
 
-    // The non-canonical test must surface as a structured warning whose
-    // category is `UnsupportedTest` (not silently dropped).
+    // dbt_utils.accepted_range now has a native equivalent, so it must NOT
+    // surface as an UnsupportedTest warning.
     assert!(
-        result.warnings.iter().any(
-            |w| matches!(w.category, dbt::WarningCategory::UnsupportedTest)
-                && w.message.contains("dbt_utils.accepted_range")
-        ),
-        "expected an UnsupportedTest warning for dbt_utils.accepted_range"
+        !result.warnings.iter().any(|w| matches!(
+            w.category,
+            dbt::WarningCategory::UnsupportedTest
+        ) && w.message.contains("dbt_utils.accepted_range")),
+        "dbt_utils.accepted_range now maps to in_range — it must not warn as unsupported"
     );
 
-    // Counter check: the four canonical mappings flow through `tests_converted`.
-    // Total tests in the fixture: order_id × {unique, not_null}, customer_id ×
-    // {not_null, relationships}, customer_id × {unique, not_null}, status ×
-    // accepted_values, amount × dbt_utils.accepted_range.
+    // Counter check. Total tests in the fixture: order_id × {unique, not_null},
+    // customer_id × {not_null, relationships}, customer_id × {unique, not_null},
+    // status × accepted_values, amount × dbt_utils.accepted_range. All eight
+    // now convert (accepted_range → in_range), so none are skipped.
     assert_eq!(result.tests_found, 8, "all schema.yml tests are counted");
-    assert_eq!(result.tests_skipped, 1, "one non-canonical test skipped");
     assert_eq!(
-        result.tests_converted, 7,
-        "seven canonical tests converted to TestDecls"
+        result.tests_skipped, 0,
+        "all tests now have a native mapping"
+    );
+    assert_eq!(
+        result.tests_converted, 8,
+        "all eight tests convert to TestDecls (accepted_range → in_range)"
     );
 }

--- a/engine/crates/rocky-compiler/src/import/dbt.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt.rs
@@ -79,6 +79,10 @@ pub enum WarningCategory {
     /// default), so the importer emitted a stub DuckDB adapter. Surfaced
     /// loudly so the migration never silently defaults to duckdb.
     ProfileFallback,
+    /// A dbt model `contract` (`enforced: true`), column `data_type`s, or
+    /// column `constraints` were dropped on import. Rocky enforces contracts
+    /// via a `{model}.contract.toml` sidecar the importer doesn't generate.
+    DroppedContract,
 }
 
 /// A warning produced during import.
@@ -163,6 +167,20 @@ pub enum ImportDbtStructuredWarning {
         name: String,
         detail: String,
     },
+    /// A dbt model `contract` (`contract: { enforced: true }`), column
+    /// `data_type`s, and/or column `constraints` were dropped on import.
+    /// Rocky enforces contracts via a `{model}.contract.toml` sidecar, but
+    /// the importer doesn't auto-generate one — the user must hand-author it.
+    /// Stub generation is out of scope; this is visibility only.
+    DroppedContract {
+        model: String,
+        /// Number of columns that declared a `data_type`.
+        typed_columns: usize,
+        /// Number of declared column constraints across all columns.
+        constraints: usize,
+        /// Path (relative to the emitted repo) the user should author.
+        contract_path: String,
+    },
 }
 
 /// A model that failed to import.
@@ -224,6 +242,10 @@ pub struct ImportResult {
     /// detected and skipped (snapshots, metrics, semantic models, exposures).
     /// Surfaced so a migration is never silently lossy.
     pub constructs_dropped: usize,
+    /// Number of dbt models whose enforced `contract` (column `data_type`s /
+    /// `constraints`) was dropped on import. Rocky enforces contracts via a
+    /// `{model}.contract.toml` sidecar the importer doesn't auto-generate.
+    pub contracts_dropped: usize,
 }
 
 /// A successfully imported model.
@@ -280,6 +302,7 @@ pub fn import_from_manifest(
         unit_tests_converted: 0,
         unit_tests_skipped: 0,
         constructs_dropped: 0,
+        contracts_dropped: 0,
     };
 
     // A manifest with no compiled SQL means every model falls back to the
@@ -757,6 +780,11 @@ fn import_manifest_node(
     // structured warnings so the downstream UI can route them.
     collect_dropped_config_warnings(&node.config, &node.name, result);
 
+    // Surface a dropped model contract (`contract: { enforced: true }` +
+    // column data_type/constraints). Rocky enforces contracts via a sidecar
+    // the importer doesn't generate — point the user at where to author it.
+    collect_dropped_contract_warnings(node, &table, result);
+
     // Detect unresolvable Jinja macros that survived `dbt compile`. dbt's
     // compile step inlines in-tree macros, so anything still present
     // points at an out-of-tree macro the user needs to hand-port.
@@ -1182,6 +1210,56 @@ fn collect_dropped_config_warnings(
     }
 }
 
+/// Detect a dropped dbt model contract and surface it. dbt's
+/// `contract: { enforced: true }` (plus per-column `data_type` / `constraints`)
+/// has no auto-translation in Rocky — contracts are enforced via a
+/// `{model}.contract.toml` sidecar the importer does not generate. We emit a
+/// structured + string warning naming the file the user should author, and
+/// bump `contracts_dropped`, so the loss is never silent. Stub generation is
+/// out of scope (visibility only).
+///
+/// Only fires when the contract is `enforced`; an un-enforced `contract` block
+/// (dbt's default) carries no semantics to lose.
+fn collect_dropped_contract_warnings(
+    node: &DbtManifestNode,
+    table: &str,
+    result: &mut ImportResult,
+) {
+    let enforced = node.config.contract.as_ref().is_some_and(|c| c.enforced);
+    if !enforced {
+        return;
+    }
+
+    let typed_columns = node
+        .columns
+        .values()
+        .filter(|c| c.data_type.is_some())
+        .count();
+    let constraints: usize = node.columns.values().map(|c| c.constraints.len()).sum();
+    let contract_path = format!("models/{table}.contract.toml");
+
+    result.contracts_dropped += 1;
+    result
+        .structured_warnings
+        .push(ImportDbtStructuredWarning::DroppedContract {
+            model: node.name.clone(),
+            typed_columns,
+            constraints,
+            contract_path: contract_path.clone(),
+        });
+    result.warnings.push(ImportWarning {
+        model: node.name.clone(),
+        category: WarningCategory::DroppedContract,
+        message: format!(
+            "enforced dbt contract dropped ({typed_columns} typed column(s), {constraints} constraint(s)) — \
+             Rocky enforces contracts via {contract_path}, which the importer does not auto-generate"
+        ),
+        suggestion: Some(format!(
+            "author {contract_path} declaring the required/protected columns to re-establish the contract"
+        )),
+    });
+}
+
 /// Translate dbt's `on_schema_change` values to a human-readable Rocky
 /// drift-policy hint. Used for the structured warning's
 /// `rocky_equivalent` field.
@@ -1368,6 +1446,7 @@ pub fn import_dbt_project(
         unit_tests_converted: 0,
         unit_tests_skipped: 0,
         constructs_dropped: 0,
+        contracts_dropped: 0,
     };
 
     // Verify at least one model directory exists
@@ -1834,6 +1913,10 @@ fn extract_dbt_config(content: &str) -> (StrategyConfig, Vec<String>) {
         alias: None,
         merge_update_columns: None,
         merge_exclude_columns: None,
+        // The regex path doesn't recover the contract block (it's nested config
+        // not present in the inline `config()` call); contract detection is
+        // manifest-only.
+        contract: None,
     };
 
     let mapping = map_manifest_strategy(&synthetic, "<regex-path>");
@@ -2268,6 +2351,7 @@ models:
             unit_tests_converted: 0,
             unit_tests_skipped: 0,
             constructs_dropped: 0,
+            contracts_dropped: 0,
         };
         apply_dbt_tests(dir.path(), &target, &mut result);
 
@@ -2625,6 +2709,84 @@ FROM {{ ref('stg_events') }}
         );
         assert!(result.structured_warnings.iter().any(|w| matches!(w,
             ImportDbtStructuredWarning::MicrobatchMapped { mapped_to, .. } if mapped_to == "merge")));
+    }
+
+    #[test]
+    fn test_manifest_enforced_contract_warns_and_counts() {
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": { "model.p.dim_customer": {
+                "unique_id": "model.p.dim_customer", "name": "dim_customer",
+                "resource_type": "model",
+                "compiled_code": "SELECT 1", "raw_code": "SELECT 1",
+                "depends_on": { "nodes": [], "macros": [] },
+                "config": { "materialized": "table", "contract": { "enforced": true } },
+                "columns": {
+                    "id": { "name": "id", "data_type": "bigint", "constraints": [{ "type": "not_null" }, { "type": "primary_key" }] },
+                    "email": { "name": "email", "data_type": "varchar" }
+                },
+                "tags": [], "schema": "s", "database": "d"
+            }},
+            "sources": {}
+        });
+        let result = import_from_manifest_json(&manifest);
+        assert_eq!(
+            result.contracts_dropped, 1,
+            "enforced contract must be counted"
+        );
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.category == WarningCategory::DroppedContract),
+            "must emit a DroppedContract string warning"
+        );
+        let structured = result
+            .structured_warnings
+            .iter()
+            .find_map(|w| match w {
+                ImportDbtStructuredWarning::DroppedContract {
+                    typed_columns,
+                    constraints,
+                    contract_path,
+                    ..
+                } => Some((*typed_columns, *constraints, contract_path.clone())),
+                _ => None,
+            })
+            .expect("must emit a DroppedContract structured warning");
+        assert_eq!(structured.0, 2, "two columns declared a data_type");
+        assert_eq!(structured.1, 2, "two constraints declared");
+        assert!(
+            structured.2.contains("dim_customer.contract.toml"),
+            "warning must point at the contract sidecar path: {}",
+            structured.2
+        );
+    }
+
+    #[test]
+    fn test_manifest_unenforced_contract_is_not_dropped() {
+        // dbt's default `contract: { enforced: false }` carries no semantics
+        // to lose; it must not trip the dropped-contract warning.
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": { "model.p.m": {
+                "unique_id": "model.p.m", "name": "m", "resource_type": "model",
+                "compiled_code": "SELECT 1", "raw_code": "SELECT 1",
+                "depends_on": { "nodes": [], "macros": [] },
+                "config": { "materialized": "table", "contract": { "enforced": false } },
+                "columns": { "id": { "name": "id", "data_type": "bigint" } },
+                "tags": [], "schema": "s", "database": "d"
+            }},
+            "sources": {}
+        });
+        let result = import_from_manifest_json(&manifest);
+        assert_eq!(result.contracts_dropped, 0);
+        assert!(
+            !result
+                .warnings
+                .iter()
+                .any(|w| w.category == WarningCategory::DroppedContract)
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-compiler/src/import/dbt.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt.rs
@@ -417,11 +417,22 @@ pub fn apply_dbt_tests(yaml_root: &Path, default_target: &TargetConfig, result: 
 
         result.tests_converted += decls.len();
         // "custom" = converted tests that aren't the canonical column-level
-        // built-ins — today the composite (`unique_combination_of_columns`)
-        // conversions. Previously always 0 because nothing custom converted.
+        // built-ins (not_null / unique / accepted_values / relationships):
+        // the composite (`unique_combination_of_columns`) conversion plus the
+        // dbt_expectations / dbt_utils long-tail mappings (in_range,
+        // regex_match, expression).
         result.tests_converted_custom += decls
             .iter()
-            .filter(|d| matches!(d.test_type, rocky_core::tests::TestType::Composite { .. }))
+            .filter(|d| {
+                use rocky_core::tests::TestType;
+                matches!(
+                    d.test_type,
+                    TestType::Composite { .. }
+                        | TestType::InRange { .. }
+                        | TestType::RegexMatch { .. }
+                        | TestType::Expression { .. }
+                )
+            })
             .count();
         result.tests_skipped += unsupported.len();
 
@@ -441,7 +452,7 @@ pub fn apply_dbt_tests(yaml_root: &Path, default_target: &TargetConfig, result: 
                 model: u.model.clone(),
                 category: WarningCategory::UnsupportedTest,
                 message: format!(
-                    "dbt test '{name}' on {where_} is outside the supported set (unique, not_null, accepted_values, relationships) — not translated",
+                    "dbt test '{name}' on {where_} has no native Rocky equivalent (supported: unique, not_null, accepted_values, relationships, unique_combination_of_columns, and the dbt_expectations/dbt_utils range/regex/in-set/expression tests) — not translated",
                     name = u.test_name,
                 ),
                 suggestion: Some(

--- a/engine/crates/rocky-compiler/src/import/dbt.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt.rs
@@ -74,6 +74,11 @@ pub enum WarningCategory {
     /// field value or a non-object row element (TOML has no null type).
     /// The test is dropped so it never aborts the rest of the import.
     UnserializableUnitTest,
+    /// A `profiles.yml` was present but could not be parsed/resolved (bad
+    /// YAML, unresolvable merge keys, or an `env_var()` `type` with no
+    /// default), so the importer emitted a stub DuckDB adapter. Surfaced
+    /// loudly so the migration never silently defaults to duckdb.
+    ProfileFallback,
 }
 
 /// A warning produced during import.

--- a/engine/crates/rocky-compiler/src/import/dbt_manifest.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt_manifest.rs
@@ -105,6 +105,19 @@ pub struct DbtNodeConfig {
     pub merge_update_columns: Option<Vec<String>>,
     /// `merge_exclude_columns` — columns excluded from the MERGE UPDATE (dbt).
     pub merge_exclude_columns: Option<Vec<String>>,
+    /// `contract` — dbt model contract enforcement (`{ enforced: true }`).
+    /// Rocky does not auto-generate `{model}.contract.toml` on import; the
+    /// importer surfaces this so the migration is never silently lossy.
+    pub contract: Option<DbtContractConfig>,
+}
+
+/// dbt model `contract` config — whether the model enforces a declared
+/// column-level contract (`config: { contract: { enforced: true } }`).
+#[derive(Debug, Clone, Default)]
+pub struct DbtContractConfig {
+    /// `enforced` — when true, dbt validates the model output against the
+    /// declared column types/constraints at build time.
+    pub enforced: bool,
 }
 
 /// unique_key can be a single string or a list.
@@ -119,6 +132,14 @@ pub enum UniqueKeyValue {
 pub struct DbtManifestColumn {
     pub name: String,
     pub description: Option<String>,
+    /// `data_type` — declared physical type (part of a dbt model contract).
+    /// Dropped on import (Rocky infers types from the model SQL); surfaced
+    /// alongside the contract warning so the loss is visible.
+    pub data_type: Option<String>,
+    /// `constraints` — declared column constraints (`not_null`, `primary_key`,
+    /// `check`, …) from a dbt model contract. Dropped on import; the count is
+    /// surfaced in the contract warning.
+    pub constraints: Vec<String>,
 }
 
 /// A unit-test definition extracted from `manifest.unit_tests`.
@@ -318,6 +339,15 @@ struct RawNodeConfig {
     /// `merge_exclude_columns` — columns excluded from the MERGE UPDATE.
     #[serde(default)]
     merge_exclude_columns: Option<Vec<String>>,
+    /// `contract` — dbt model contract enforcement block.
+    #[serde(default)]
+    contract: Option<RawContract>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawContract {
+    #[serde(default)]
+    enforced: bool,
 }
 
 #[derive(Deserialize)]
@@ -326,6 +356,20 @@ struct RawColumn {
     name: String,
     #[serde(default)]
     description: Option<String>,
+    /// `data_type` — declared physical type (model contract).
+    #[serde(default)]
+    data_type: Option<String>,
+    /// `constraints` — declared column constraints (model contract). dbt emits
+    /// these as objects (`{ type: "not_null", ... }`); we keep just the
+    /// constraint `type` for the dropped-contract warning.
+    #[serde(default)]
+    constraints: Vec<RawConstraint>,
+}
+
+#[derive(Deserialize)]
+struct RawConstraint {
+    #[serde(default, rename = "type")]
+    constraint_type: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -497,11 +541,18 @@ fn convert_node(raw: RawNode) -> DbtManifestNode {
         .columns
         .into_iter()
         .map(|(k, c)| {
+            let constraints = c
+                .constraints
+                .into_iter()
+                .filter_map(|x| x.constraint_type)
+                .collect();
             (
                 k,
                 DbtManifestColumn {
                     name: c.name,
                     description: c.description,
+                    data_type: c.data_type,
+                    constraints,
                 },
             )
         })
@@ -533,6 +584,9 @@ fn convert_node(raw: RawNode) -> DbtManifestNode {
             alias: config.alias,
             merge_update_columns: config.merge_update_columns,
             merge_exclude_columns: config.merge_exclude_columns,
+            contract: config.contract.map(|c| DbtContractConfig {
+                enforced: c.enforced,
+            }),
         },
         columns,
         description: raw.description.filter(|d| !d.is_empty()),

--- a/engine/crates/rocky-compiler/src/import/dbt_profiles.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt_profiles.rs
@@ -88,20 +88,45 @@ pub struct ProfileResolution {
     /// Schema / dataset name as declared in profiles.yml, when present —
     /// used as a default for `[target] schema`.
     pub schema: Option<String>,
+    /// A loud diagnostic when a `profiles.yml` was present but could not be
+    /// parsed/resolved, so the importer fell back to a stub DuckDB adapter.
+    /// `None` on a clean resolve. The CLI surfaces this as an import warning
+    /// (and in `--output json`) rather than silently defaulting to duckdb.
+    pub fallback_reason: Option<String>,
 }
 
 /// Resolve the adapter shape from a dbt project directory.
 ///
-/// Tries `<dbt_project>/profiles.yml`. If absent or unparseable, returns
-/// `None` and the caller stubs a DuckDB adapter with a TODO note. We
-/// deliberately do **not** read `~/.dbt/profiles.yml` — the importer
-/// is meant to operate on a self-contained project tree.
+/// Tries `<dbt_project>/profiles.yml`. Returns `None` only when no
+/// `profiles.yml` exists (the caller then stubs a DuckDB adapter for an
+/// absent profile). When a `profiles.yml` is present but can't be
+/// parsed/resolved, this returns a `Some(stub)` whose
+/// [`ProfileResolution::fallback_reason`] names the problem — so the caller
+/// warns loudly instead of silently defaulting to duckdb.
+///
+/// We deliberately do **not** read `~/.dbt/profiles.yml` — the importer is
+/// meant to operate on a self-contained project tree.
 pub fn resolve_from_project(dbt_project: &Path) -> Option<ProfileResolution> {
     let profiles_path = dbt_project.join("profiles.yml");
     if !profiles_path.exists() {
         return None;
     }
-    parse_profiles_file(&profiles_path).ok()
+    match parse_profiles_file(&profiles_path) {
+        Ok(resolved) => Some(resolved),
+        Err(reason) => {
+            tracing::warn!(
+                profiles = %profiles_path.display(),
+                reason = %reason,
+                "could not resolve dbt profiles.yml — falling back to a stub DuckDB adapter",
+            );
+            let mut stub = stub_resolution(StubReason::ProfilesUnparseable);
+            stub.fallback_reason = Some(format!(
+                "{}: {reason} — emitted a stub DuckDB adapter; edit the [adapter] block in rocky.toml manually",
+                profiles_path.display()
+            ));
+            Some(stub)
+        }
+    }
 }
 
 /// Stub adapter used when profiles.yml is missing or unparseable, or when
@@ -121,6 +146,7 @@ pub fn stub_resolution(reason: StubReason) -> ProfileResolution {
         env_vars: ProfileEnvVars::default(),
         database: None,
         schema: None,
+        fallback_reason: None,
     }
 }
 
@@ -145,6 +171,7 @@ pub fn resolution_for_kind(kind: AdapterKind, original_label: &str) -> ProfileRe
         env_vars,
         database: None,
         schema: None,
+        fallback_reason: None,
     }
 }
 
@@ -173,8 +200,27 @@ struct RawOutput {
 fn parse_profiles_file(path: &Path) -> Result<ProfileResolution, String> {
     let content = std::fs::read_to_string(path)
         .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
-    let parsed: ProfilesFile = serde_yaml::from_str(&content)
+
+    // Parse to an untyped `Value` first so we can resolve YAML merge keys
+    // (`<<: *anchor`). `serde_yaml` expands plain anchors/aliases on its own,
+    // but does NOT apply merge keys unless asked — without this a profile that
+    // factors common output config into a `&base` anchor loses its `type`
+    // field and silently falls back to duckdb.
+    let mut value: serde_yaml::Value = serde_yaml::from_str(&content)
         .map_err(|e| format!("failed to parse {}: {e}", path.display()))?;
+    value.apply_merge().map_err(|e| {
+        format!(
+            "failed to resolve YAML merge keys in {}: {e}",
+            path.display()
+        )
+    })?;
+
+    let parsed: ProfilesFile = serde_yaml::from_value(value).map_err(|e| {
+        format!(
+            "failed to read {} after merge-key resolution: {e}",
+            path.display()
+        )
+    })?;
 
     // Pick the first profile (dbt projects typically have exactly one).
     let (_profile_name, profile) = parsed
@@ -194,10 +240,26 @@ fn parse_profiles_file(path: &Path) -> Result<ProfileResolution, String> {
         .or_else(|| outputs.values().next())
         .ok_or_else(|| format!("{}: target '{target_name}' not found", path.display()))?;
 
-    let profile_type = output
+    let raw_type = output
         .profile_type
         .clone()
         .ok_or_else(|| format!("{}: missing 'type' on output", path.display()))?;
+
+    // The `type` field may be a `{{ env_var('ADAPTER','duckdb') }}` template
+    // rather than a literal. We never read the live secret — only the adapter
+    // discriminator matters, so use the env_var default when present. A
+    // template with no default is a genuine failure (we can't know the type).
+    let profile_type = match resolve_env_var_template(&raw_type) {
+        EnvVarType::Literal(s) => s,
+        EnvVarType::WithDefault(default) => default,
+        EnvVarType::NoDefault(var) => {
+            return Err(format!(
+                "{}: output 'type' is `{{{{ env_var('{var}') }}}}` with no default — \
+                 cannot determine the adapter type without resolving the env var",
+                path.display()
+            ));
+        }
+    };
 
     let kind = AdapterKind::from_dbt_type(&profile_type);
     let (adapter_toml, env_vars) = render_adapter_skeleton(&kind);
@@ -212,7 +274,68 @@ fn parse_profiles_file(path: &Path) -> Result<ProfileResolution, String> {
         env_vars,
         database,
         schema,
+        fallback_reason: None,
     })
+}
+
+/// Outcome of interpreting a profile `type` field that may be a dbt
+/// `{{ env_var(...) }}` template.
+#[derive(Debug, PartialEq, Eq)]
+enum EnvVarType {
+    /// A plain literal type (e.g. `duckdb`).
+    Literal(String),
+    /// `env_var('X', 'default')` — use the default as the discriminator.
+    WithDefault(String),
+    /// `env_var('X')` with no default — can't resolve without the secret.
+    NoDefault(String),
+}
+
+/// Interpret a profile `type` value that may be a dbt `{{ env_var('X','d') }}`
+/// template. Only the adapter discriminator matters, so the env-var **default**
+/// is used when present — the live value (a secret) is never read here.
+/// A non-template value is returned verbatim as a literal.
+fn resolve_env_var_template(raw: &str) -> EnvVarType {
+    let trimmed = raw.trim();
+    // Match `{{ env_var('NAME') }}` or `{{ env_var('NAME', 'default') }}`
+    // with single or double quotes. Anything that doesn't look like an
+    // env_var template is a literal.
+    let Some(inner) = trimmed
+        .strip_prefix("{{")
+        .and_then(|s| s.strip_suffix("}}"))
+        .map(str::trim)
+    else {
+        return EnvVarType::Literal(trimmed.to_string());
+    };
+    let Some(args) = inner
+        .strip_prefix("env_var(")
+        .and_then(|s| s.strip_suffix(')'))
+    else {
+        return EnvVarType::Literal(trimmed.to_string());
+    };
+
+    let parts: Vec<String> = split_quoted_args(args);
+    match parts.as_slice() {
+        [_name, default] => EnvVarType::WithDefault(default.clone()),
+        [name] => EnvVarType::NoDefault(name.clone()),
+        // Malformed env_var(...) — treat as a literal so the caller's
+        // adapter mapping flags it as Unmapped rather than crashing.
+        _ => EnvVarType::Literal(trimmed.to_string()),
+    }
+}
+
+/// Split a comma-separated list of single/double-quoted string args, trimming
+/// surrounding whitespace and the quote characters. Unquoted tokens are kept
+/// as-is (trimmed). Good enough for the `env_var('X','d')` shape; not a full
+/// expression parser.
+fn split_quoted_args(args: &str) -> Vec<String> {
+    args.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            s.trim_matches(|c| c == '\'' || c == '"' || c == ' ')
+                .to_string()
+        })
+        .collect()
 }
 
 fn render_adapter_skeleton(kind: &AdapterKind) -> (String, ProfileEnvVars) {
@@ -371,6 +494,90 @@ mod tests {
     fn missing_profiles_file_returns_none() {
         let dir = tempfile::TempDir::new().unwrap();
         assert!(resolve_from_project(dir.path()).is_none());
+    }
+
+    #[test]
+    fn resolves_yaml_merge_keys_anchor() {
+        // The output factors common config into a `&base` anchor and pulls it
+        // in with `<<: *base`. Without merge-key resolution the `type` field is
+        // missing and we'd silently fall back to duckdb.
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("profiles.yml"),
+            "shop:\n  target: prod\n  outputs:\n    base: &base\n      type: databricks\n      host: dbc-x.cloud.databricks.com\n      http_path: /sql/1.0/warehouses/abc\n    prod:\n      <<: *base\n      catalog: analytics\n      schema: marts\n",
+        )
+        .unwrap();
+        let resolved = resolve_from_project(dir.path()).unwrap();
+        assert_eq!(resolved.kind, AdapterKind::Databricks);
+        assert!(resolved.fallback_reason.is_none());
+        assert_eq!(resolved.database.as_deref(), Some("analytics"));
+        assert_eq!(resolved.schema.as_deref(), Some("marts"));
+    }
+
+    #[test]
+    fn resolves_env_var_type_with_default() {
+        // `type: "{{ env_var('ROCKY_ADAPTER', 'snowflake') }}"` — only the
+        // discriminator matters, so use the default. The live env var (a
+        // secret) is never read.
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("profiles.yml"),
+            "p:\n  target: dev\n  outputs:\n    dev:\n      type: \"{{ env_var('ROCKY_ADAPTER', 'snowflake') }}\"\n      schema: marts\n",
+        )
+        .unwrap();
+        let resolved = resolve_from_project(dir.path()).unwrap();
+        assert_eq!(resolved.kind, AdapterKind::Snowflake);
+        assert!(resolved.fallback_reason.is_none());
+    }
+
+    #[test]
+    fn env_var_type_without_default_falls_back_loudly() {
+        // `type: "{{ env_var('ROCKY_ADAPTER') }}"` with no default can't be
+        // resolved — must surface a loud fallback reason, not silently duckdb.
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("profiles.yml"),
+            "p:\n  target: dev\n  outputs:\n    dev:\n      type: \"{{ env_var('ROCKY_ADAPTER') }}\"\n      schema: marts\n",
+        )
+        .unwrap();
+        let resolved = resolve_from_project(dir.path()).unwrap();
+        assert_eq!(resolved.kind, AdapterKind::DuckDb);
+        let reason = resolved
+            .fallback_reason
+            .expect("must carry a loud fallback reason");
+        assert!(reason.contains("env_var"), "reason names env_var: {reason}");
+    }
+
+    #[test]
+    fn unparseable_profiles_surfaces_loud_fallback_reason() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("profiles.yml"), "this: : : not yaml\n").unwrap();
+        let resolved = resolve_from_project(dir.path()).unwrap();
+        assert_eq!(resolved.kind, AdapterKind::DuckDb);
+        assert!(
+            resolved.fallback_reason.is_some(),
+            "a present-but-unparseable profiles.yml must warn loudly, not silently default"
+        );
+    }
+
+    #[test]
+    fn resolve_env_var_template_variants() {
+        assert_eq!(
+            resolve_env_var_template("duckdb"),
+            EnvVarType::Literal("duckdb".to_string())
+        );
+        assert_eq!(
+            resolve_env_var_template("{{ env_var('X', 'snowflake') }}"),
+            EnvVarType::WithDefault("snowflake".to_string())
+        );
+        assert_eq!(
+            resolve_env_var_template("{{ env_var(\"X\", \"bigquery\") }}"),
+            EnvVarType::WithDefault("bigquery".to_string())
+        );
+        assert_eq!(
+            resolve_env_var_template("{{ env_var('X') }}"),
+            EnvVarType::NoDefault("X".to_string())
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-compiler/src/import/dbt_tests.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt_tests.rs
@@ -480,6 +480,51 @@ pub fn tests_to_test_decls(
                             test_name: "relationships".to_string(),
                         }),
                     },
+                    // dbt_expectations / dbt_utils long-tail tests with a
+                    // clear native Rocky equivalent. Anything whose payload
+                    // can't be translated (e.g. a regex the strict allowlist
+                    // rejects) keeps the UnsupportedTest warning.
+                    "dbt_expectations.expect_column_values_to_be_between"
+                    | "dbt_utils.accepted_range" => {
+                        push_or_unsupported(
+                            in_range_decl(&col.name, config),
+                            &mut decls,
+                            &mut unsupported,
+                            &model.name,
+                            &col.name,
+                            name,
+                        );
+                    }
+                    "dbt_expectations.expect_column_values_to_match_regex" => {
+                        push_or_unsupported(
+                            regex_match_decl(&col.name, config),
+                            &mut decls,
+                            &mut unsupported,
+                            &model.name,
+                            &col.name,
+                            name,
+                        );
+                    }
+                    "dbt_expectations.expect_column_values_to_be_in_set" => {
+                        push_or_unsupported(
+                            accepted_values_from_set_decl(&col.name, config),
+                            &mut decls,
+                            &mut unsupported,
+                            &model.name,
+                            &col.name,
+                            name,
+                        );
+                    }
+                    "dbt_utils.expression_is_true" | "dbt_expectations.expression_is_true" => {
+                        push_or_unsupported(
+                            expression_decl(Some(&col.name), config),
+                            &mut decls,
+                            &mut unsupported,
+                            &model.name,
+                            &col.name,
+                            name,
+                        );
+                    }
                     other => {
                         unsupported.push(UnsupportedTest {
                             model: model.name.clone(),
@@ -502,6 +547,22 @@ pub fn tests_to_test_decls(
                     || name == "dbt_utils.unique_combination_of_columns" =>
             {
                 match composite_unique_decl(config) {
+                    Some(decl) => decls.push(decl),
+                    None => unsupported.push(UnsupportedTest {
+                        model: model.name.clone(),
+                        column: None,
+                        test_name: name.clone(),
+                    }),
+                }
+            }
+            // `dbt_utils.expression_is_true` is most often declared at model
+            // level (it asserts a row-level SQL predicate, no column anchor).
+            // Map it to a Rocky `expression` test.
+            DbtTestDef::Configured { name, config }
+                if name == "dbt_utils.expression_is_true"
+                    || name == "dbt_expectations.expression_is_true" =>
+            {
+                match expression_decl(None, config) {
                     Some(decl) => decls.push(decl),
                     None => unsupported.push(UnsupportedTest {
                         model: model.name.clone(),
@@ -599,6 +660,126 @@ fn relationships_decl(
         severity: config_severity(config),
         filter: config_filter(config),
     })
+}
+
+/// Push a converted `[`TestDecl`]` or record an `[`UnsupportedTest`]` when
+/// the long-tail conversion couldn't produce a native equivalent (e.g. a
+/// regex the strict allowlist rejects, or a missing config key).
+fn push_or_unsupported(
+    decl: Option<TestDecl>,
+    decls: &mut Vec<TestDecl>,
+    unsupported: &mut Vec<UnsupportedTest>,
+    model: &str,
+    column: &str,
+    test_name: &str,
+) {
+    match decl {
+        Some(d) => decls.push(d),
+        None => unsupported.push(UnsupportedTest {
+            model: model.to_string(),
+            column: Some(column.to_string()),
+            test_name: test_name.to_string(),
+        }),
+    }
+}
+
+/// Convert a `min_value` / `max_value` range test
+/// (`dbt_expectations.expect_column_values_to_be_between`,
+/// `dbt_utils.accepted_range`) to a Rocky [`TestType::InRange`]. At least one
+/// bound must be present.
+fn in_range_decl(col_name: &str, config: &HashMap<String, serde_yaml::Value>) -> Option<TestDecl> {
+    let min = config.get("min_value").map(yaml_scalar_to_string);
+    let max = config.get("max_value").map(yaml_scalar_to_string);
+    if min.is_none() && max.is_none() {
+        return None;
+    }
+    Some(TestDecl {
+        test_type: TestType::InRange { min, max },
+        column: Some(col_name.to_string()),
+        severity: config_severity(config),
+        filter: config_filter(config),
+    })
+}
+
+/// Convert `dbt_expectations.expect_column_values_to_match_regex` to a Rocky
+/// [`TestType::RegexMatch`]. The pattern is validated by the compiler's
+/// strict allowlist later; here we only require it to be present and a
+/// string.
+fn regex_match_decl(
+    col_name: &str,
+    config: &HashMap<String, serde_yaml::Value>,
+) -> Option<TestDecl> {
+    let pattern = config.get("regex")?.as_str()?.to_string();
+    if pattern.is_empty() {
+        return None;
+    }
+    Some(TestDecl {
+        test_type: TestType::RegexMatch { pattern },
+        column: Some(col_name.to_string()),
+        severity: config_severity(config),
+        filter: config_filter(config),
+    })
+}
+
+/// Convert `dbt_expectations.expect_column_values_to_be_in_set` (config key
+/// `value_set`) to a Rocky [`TestType::AcceptedValues`].
+fn accepted_values_from_set_decl(
+    col_name: &str,
+    config: &HashMap<String, serde_yaml::Value>,
+) -> Option<TestDecl> {
+    let raw = config.get("value_set")?;
+    let values: Vec<String> = match raw {
+        serde_yaml::Value::Sequence(seq) => seq
+            .iter()
+            .filter_map(|v| match v {
+                serde_yaml::Value::String(s) => Some(s.clone()),
+                serde_yaml::Value::Number(n) => Some(n.to_string()),
+                serde_yaml::Value::Bool(b) => Some(b.to_string()),
+                _ => None,
+            })
+            .collect(),
+        _ => return None,
+    };
+    if values.is_empty() {
+        return None;
+    }
+    Some(TestDecl {
+        test_type: TestType::AcceptedValues { values },
+        column: Some(col_name.to_string()),
+        severity: config_severity(config),
+        filter: config_filter(config),
+    })
+}
+
+/// Convert `dbt_utils.expression_is_true` (config key `expression`) to a
+/// Rocky [`TestType::Expression`]. `column` is the optional anchor — `None`
+/// for model-level tests.
+fn expression_decl(
+    column: Option<&str>,
+    config: &HashMap<String, serde_yaml::Value>,
+) -> Option<TestDecl> {
+    let expression = config.get("expression")?.as_str()?.to_string();
+    if expression.trim().is_empty() {
+        return None;
+    }
+    Some(TestDecl {
+        test_type: TestType::Expression { expression },
+        column: column.map(str::to_string),
+        severity: config_severity(config),
+        filter: config_filter(config),
+    })
+}
+
+/// Render a YAML scalar (string / number / bool) as the string form Rocky's
+/// `in_range` bounds expect. Non-scalars render via the loose
+/// [`yaml_value_to_string`] fallback.
+fn yaml_scalar_to_string(v: &serde_yaml::Value) -> String {
+    match v {
+        serde_yaml::Value::String(s) => s.clone(),
+        serde_yaml::Value::Number(n) => n.to_string(),
+        serde_yaml::Value::Bool(b) => b.to_string(),
+        other => yaml_value_to_string(other),
+    }
 }
 
 /// dbt test `severity: warn` maps to a Rocky warning; anything else (incl.
@@ -983,6 +1164,202 @@ models:
             decls[0].column.is_none(),
             "composite uniqueness is model-level — no single column"
         );
+    }
+
+    #[test]
+    fn test_dbt_expectations_between_maps_to_in_range() {
+        let yaml = r#"
+models:
+  - name: orders
+    columns:
+      - name: amount
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
+              max_value: 1000
+"#;
+        let models = parse_model_yaml_content(yaml).unwrap();
+        let resolver = default_resolver();
+        let (decls, unsupported) = tests_to_test_decls(&models[0], &resolver);
+        assert!(unsupported.is_empty(), "must convert, not skip");
+        assert_eq!(decls.len(), 1);
+        match &decls[0].test_type {
+            TestType::InRange { min, max } => {
+                assert_eq!(min.as_deref(), Some("0"));
+                assert_eq!(max.as_deref(), Some("1000"));
+            }
+            other => panic!("expected InRange, got {other:?}"),
+        }
+        assert_eq!(decls[0].column.as_deref(), Some("amount"));
+    }
+
+    #[test]
+    fn test_dbt_utils_accepted_range_maps_to_in_range() {
+        let yaml = r#"
+models:
+  - name: orders
+    columns:
+      - name: qty
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 1
+"#;
+        let models = parse_model_yaml_content(yaml).unwrap();
+        let resolver = default_resolver();
+        let (decls, unsupported) = tests_to_test_decls(&models[0], &resolver);
+        assert!(unsupported.is_empty());
+        assert_eq!(decls.len(), 1);
+        match &decls[0].test_type {
+            TestType::InRange { min, max } => {
+                assert_eq!(min.as_deref(), Some("1"));
+                assert!(max.is_none());
+            }
+            other => panic!("expected InRange, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_dbt_expectations_match_regex_maps_to_regex_match() {
+        let yaml = r#"
+models:
+  - name: users
+    columns:
+      - name: email
+        tests:
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: "[a-z]+@[a-z]+"
+"#;
+        let models = parse_model_yaml_content(yaml).unwrap();
+        let resolver = default_resolver();
+        let (decls, unsupported) = tests_to_test_decls(&models[0], &resolver);
+        assert!(unsupported.is_empty());
+        assert_eq!(decls.len(), 1);
+        match &decls[0].test_type {
+            TestType::RegexMatch { pattern } => assert_eq!(pattern, "[a-z]+@[a-z]+"),
+            other => panic!("expected RegexMatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_dbt_expectations_be_in_set_maps_to_accepted_values() {
+        let yaml = r#"
+models:
+  - name: orders
+    columns:
+      - name: status
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_set:
+              value_set: ['pending', 'shipped', 'delivered']
+"#;
+        let models = parse_model_yaml_content(yaml).unwrap();
+        let resolver = default_resolver();
+        let (decls, unsupported) = tests_to_test_decls(&models[0], &resolver);
+        assert!(unsupported.is_empty());
+        assert_eq!(decls.len(), 1);
+        match &decls[0].test_type {
+            TestType::AcceptedValues { values } => {
+                assert_eq!(
+                    values,
+                    &vec![
+                        "pending".to_string(),
+                        "shipped".to_string(),
+                        "delivered".to_string()
+                    ]
+                );
+            }
+            other => panic!("expected AcceptedValues, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_dbt_utils_expression_is_true_model_level_maps_to_expression() {
+        let yaml = r#"
+models:
+  - name: orders
+    tests:
+      - dbt_utils.expression_is_true:
+          expression: "total = subtotal + tax"
+    columns:
+      - name: total
+"#;
+        let models = parse_model_yaml_content(yaml).unwrap();
+        let resolver = default_resolver();
+        let (decls, unsupported) = tests_to_test_decls(&models[0], &resolver);
+        assert!(
+            unsupported.is_empty(),
+            "model-level expression must convert"
+        );
+        assert_eq!(decls.len(), 1);
+        match &decls[0].test_type {
+            TestType::Expression { expression } => {
+                assert_eq!(expression, "total = subtotal + tax")
+            }
+            other => panic!("expected Expression, got {other:?}"),
+        }
+        assert!(decls[0].column.is_none());
+    }
+
+    #[test]
+    fn test_dbt_utils_expression_is_true_column_level_maps_to_expression() {
+        let yaml = r#"
+models:
+  - name: orders
+    columns:
+      - name: amount
+        tests:
+          - dbt_utils.expression_is_true:
+              expression: "amount >= 0"
+"#;
+        let models = parse_model_yaml_content(yaml).unwrap();
+        let resolver = default_resolver();
+        let (decls, unsupported) = tests_to_test_decls(&models[0], &resolver);
+        assert!(unsupported.is_empty());
+        assert_eq!(decls.len(), 1);
+        match &decls[0].test_type {
+            TestType::Expression { expression } => assert_eq!(expression, "amount >= 0"),
+            other => panic!("expected Expression, got {other:?}"),
+        }
+        assert_eq!(decls[0].column.as_deref(), Some("amount"));
+    }
+
+    #[test]
+    fn test_long_tail_test_without_native_equivalent_still_unsupported() {
+        let yaml = r#"
+models:
+  - name: orders
+    columns:
+      - name: amount
+        tests:
+          - dbt_expectations.expect_column_mean_to_be_between:
+              min_value: 1
+"#;
+        let models = parse_model_yaml_content(yaml).unwrap();
+        let resolver = default_resolver();
+        let (decls, unsupported) = tests_to_test_decls(&models[0], &resolver);
+        assert!(decls.is_empty(), "aggregate-mean has no native equivalent");
+        assert_eq!(unsupported.len(), 1);
+        assert_eq!(
+            unsupported[0].test_name,
+            "dbt_expectations.expect_column_mean_to_be_between"
+        );
+    }
+
+    #[test]
+    fn test_in_range_missing_both_bounds_is_unsupported() {
+        let yaml = r#"
+models:
+  - name: orders
+    columns:
+      - name: amount
+        tests:
+          - dbt_utils.accepted_range:
+              inclusive: true
+"#;
+        let models = parse_model_yaml_content(yaml).unwrap();
+        let resolver = default_resolver();
+        let (decls, unsupported) = tests_to_test_decls(&models[0], &resolver);
+        assert!(decls.is_empty());
+        assert_eq!(unsupported.len(), 1, "no bounds → cannot build in_range");
     }
 
     #[test]
@@ -1621,11 +1998,9 @@ models:
 
     #[test]
     fn test_decl_unsupported_simple_and_configured() {
-        let mut config = HashMap::new();
-        config.insert(
-            "min_value".to_string(),
-            serde_yaml::Value::Number(serde_yaml::Number::from(0)),
-        );
+        // Two tests with no native Rocky equivalent: a project-defined
+        // generic test (simple) and a dbt_utils test outside the long-tail
+        // mapping (configured). Both must surface as UnsupportedTest.
         let model = DbtModelYaml {
             name: "model".to_string(),
             description: None,
@@ -1635,8 +2010,8 @@ models:
                 tests: vec![
                     DbtTestDef::Simple("project_macro_test".to_string()),
                     DbtTestDef::Configured {
-                        name: "dbt_utils.accepted_range".to_string(),
-                        config,
+                        name: "dbt_utils.cardinality_equality".to_string(),
+                        config: HashMap::new(),
                     },
                 ],
             }],
@@ -1654,7 +2029,7 @@ models:
         assert!(
             unsupported
                 .iter()
-                .any(|u| u.test_name == "dbt_utils.accepted_range")
+                .any(|u| u.test_name == "dbt_utils.cardinality_equality")
         );
         for u in &unsupported {
             assert_eq!(u.model, "model");

--- a/engine/crates/rocky-compiler/src/import/emit.rs
+++ b/engine/crates/rocky-compiler/src/import/emit.rs
@@ -399,6 +399,11 @@ fn render_model_sidecar(config: &ModelConfig) -> String {
     out
 }
 
+/// Escape a string for a double-quoted TOML basic string (backslash + quote).
+fn toml_escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
 /// Serialise a [`TestDecl`] as a `[[tests]]` block matching the canonical
 /// Rocky model sidecar shape (`type = "..."`, `column = "..."`, plus
 /// type-specific fields). Mirrors the derived serde untagged shape used
@@ -439,12 +444,32 @@ fn render_test_decl(test: &TestDecl) -> String {
             let cols: Vec<String> = columns.iter().map(|c| format!("\"{c}\"")).collect();
             out.push_str(&format!("columns = [{}]\n", cols.join(", ")));
         }
-        // The dbt importer maps only the canonical built-ins + composite
-        // uniqueness to `TestDecl`. Anything else here would be programmer
-        // error — emit toml that won't load is worse than a panic, so refuse.
+        // dbt_expectations / dbt_utils long-tail mappings.
+        TestType::InRange { min, max } => {
+            out.push_str("type = \"in_range\"\n");
+            if let Some(min) = min {
+                out.push_str(&format!("min = \"{}\"\n", toml_escape(min)));
+            }
+            if let Some(max) = max {
+                out.push_str(&format!("max = \"{}\"\n", toml_escape(max)));
+            }
+        }
+        TestType::RegexMatch { pattern } => {
+            out.push_str("type = \"regex_match\"\n");
+            out.push_str(&format!("pattern = \"{}\"\n", toml_escape(pattern)));
+        }
+        TestType::Expression { expression } => {
+            out.push_str("type = \"expression\"\n");
+            out.push_str(&format!("expression = \"{}\"\n", toml_escape(expression)));
+        }
+        // The dbt importer maps only the canonical built-ins, composite
+        // uniqueness, and the dbt_expectations/dbt_utils long-tail
+        // (in_range / regex_match / expression) to `TestDecl`. Anything else
+        // here would be programmer error — emit toml that won't load is worse
+        // than a panic, so refuse.
         other => {
             unreachable!(
-                "rocky import-dbt only produces NotNull/Unique/AcceptedValues/Relationships TestDecls; got {:?}",
+                "rocky import-dbt does not produce this TestDecl variant; got {:?}",
                 std::mem::discriminant(other)
             );
         }

--- a/engine/crates/rocky-compiler/src/import/emit.rs
+++ b/engine/crates/rocky-compiler/src/import/emit.rs
@@ -602,7 +602,8 @@ fn write_structured_warnings(
             | W::DroppedOnSchemaChange { model, .. }
             | W::UnresolvableMacro { model, .. }
             | W::MicrobatchMissingEventTime { model }
-            | W::MicrobatchMapped { model, .. } => model.as_str(),
+            | W::MicrobatchMapped { model, .. }
+            | W::DroppedContract { model, .. } => model.as_str(),
             // Project-level drops have no owning model — group by their name.
             W::DroppedConstruct { name, .. } => name.as_str(),
         };
@@ -683,6 +684,16 @@ fn write_structured_warnings(
                     detail,
                 } => {
                     out.push_str(&format!("- **Dropped {construct}** `{name}` — {detail}\n"));
+                }
+                W::DroppedContract {
+                    typed_columns,
+                    constraints,
+                    contract_path,
+                    ..
+                } => {
+                    out.push_str(&format!(
+                        "- **Dropped enforced contract** ({typed_columns} typed column(s), {constraints} constraint(s)) — Rocky enforces contracts via `{contract_path}`, which the importer does not auto-generate. Author it to re-establish the contract.\n"
+                    ));
                 }
             }
         }
@@ -882,6 +893,7 @@ mod tests {
             unit_tests_converted: 0,
             unit_tests_skipped: 0,
             constructs_dropped: 0,
+            contracts_dropped: 0,
         }
     }
 

--- a/engine/crates/rocky-compiler/src/import/report.rs
+++ b/engine/crates/rocky-compiler/src/import/report.rs
@@ -506,6 +506,7 @@ mod tests {
             unit_tests_converted: 0,
             unit_tests_skipped: 0,
             constructs_dropped: 0,
+            contracts_dropped: 0,
         }
     }
 

--- a/schemas/import_dbt.schema.json
+++ b/schemas/import_dbt.schema.json
@@ -293,6 +293,41 @@
             "name"
           ],
           "type": "object"
+        },
+        {
+          "description": "A dbt model `contract` (`enforced: true`), column `data_type`s, and/or `constraints` were dropped on import. Rocky enforces contracts via a `{model}.contract.toml` sidecar the importer does not auto-generate; the user must hand-author it. Visibility only — no stub generated.",
+          "properties": {
+            "constraints": {
+              "format": "uint",
+              "minimum": 0.0,
+              "type": "integer"
+            },
+            "contract_path": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "dropped_contract"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "typed_columns": {
+              "format": "uint",
+              "minimum": 0.0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "constraints",
+            "contract_path",
+            "kind",
+            "model",
+            "typed_columns"
+          ],
+          "type": "object"
         }
       ]
     },
@@ -330,6 +365,13 @@
     "constructs_dropped": {
       "default": 0,
       "description": "Number of dbt resources the importer does not translate that were detected and skipped (snapshots, metrics, semantic models, exposures).",
+      "format": "uint",
+      "minimum": 0.0,
+      "type": "integer"
+    },
+    "contracts_dropped": {
+      "default": 0,
+      "description": "Number of dbt models whose enforced `contract` (column `data_type`s / `constraints`) was dropped on import. Rocky enforces contracts via a `{model}.contract.toml` sidecar the importer does not auto-generate.",
       "format": "uint",
       "minimum": 0.0,
       "type": "integer"

--- a/sdk/python/src/rocky_sdk/types_generated/import_dbt_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/import_dbt_schema.py
@@ -184,6 +184,22 @@ class ImportDbtStructuredWarning8(BaseModel):
     name: str
 
 
+class Kind40(StrEnum):
+    dropped_contract = "dropped_contract"
+
+
+class ImportDbtStructuredWarning9(BaseModel):
+    """
+    A dbt model `contract` (`enforced: true`), column `data_type`s, and/or `constraints` were dropped on import. Rocky enforces contracts via a `{model}.contract.toml` sidecar the importer does not auto-generate; the user must hand-author it. Visibility only — no stub generated.
+    """
+
+    constraints: conint(ge=0)
+    contract_path: str
+    kind: Kind40
+    model: str
+    typed_columns: conint(ge=0)
+
+
 class ImportDbtWarning(BaseModel):
     category: str
     message: str
@@ -202,6 +218,10 @@ class ImportDbtOutput(BaseModel):
     constructs_dropped: conint(ge=0) | None = 0
     """
     Number of dbt resources the importer does not translate that were detected and skipped (snapshots, metrics, semantic models, exposures).
+    """
+    contracts_dropped: conint(ge=0) | None = 0
+    """
+    Number of dbt models whose enforced `contract` (column `data_type`s / `constraints`) was dropped on import. Rocky enforces contracts via a `{model}.contract.toml` sidecar the importer does not auto-generate.
     """
     dbt_version: str | None = None
     emission: ImportDbtEmission | None = None
@@ -231,6 +251,7 @@ class ImportDbtOutput(BaseModel):
             | ImportDbtStructuredWarning6
             | ImportDbtStructuredWarning7
             | ImportDbtStructuredWarning8
+            | ImportDbtStructuredWarning9
         ]
         | None
     ) = Field([], validate_default=True)

--- a/sdk/python/src/rocky_sdk/types_generated/plan_promote_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/plan_promote_schema.py
@@ -83,7 +83,7 @@ class BreakingChange(BaseModel):
     model: str
 
 
-class Kind57(StrEnum):
+class Kind58(StrEnum):
     model_added = "model_added"
 
 
@@ -92,11 +92,11 @@ class BreakingChange53(BaseModel):
     A model present on the head side is absent on the base side.
     """
 
-    kind: Kind57
+    kind: Kind58
     model: str
 
 
-class Kind58(StrEnum):
+class Kind59(StrEnum):
     column_dropped = "column_dropped"
 
 
@@ -107,11 +107,11 @@ class BreakingChange54(BaseModel):
 
     column: str
     data_type: str
-    kind: Kind58
+    kind: Kind59
     model: str
 
 
-class Kind59(StrEnum):
+class Kind60(StrEnum):
     column_added = "column_added"
 
 
@@ -122,12 +122,12 @@ class BreakingChange55(BaseModel):
 
     column: str
     data_type: str
-    kind: Kind59
+    kind: Kind60
     model: str
     nullable: bool
 
 
-class Kind60(StrEnum):
+class Kind61(StrEnum):
     column_type_changed = "column_type_changed"
 
 
@@ -137,7 +137,7 @@ class BreakingChange56(BaseModel):
     """
 
     column: str
-    kind: Kind60
+    kind: Kind61
     model: str
     narrowing: bool
     """
@@ -147,7 +147,7 @@ class BreakingChange56(BaseModel):
     old_type: str
 
 
-class Kind61(StrEnum):
+class Kind62(StrEnum):
     column_nullability_changed = "column_nullability_changed"
 
 
@@ -157,13 +157,13 @@ class BreakingChange57(BaseModel):
     """
 
     column: str
-    kind: Kind61
+    kind: Kind62
     model: str
     new_nullable: bool
     old_nullable: bool
 
 
-class Kind62(StrEnum):
+class Kind63(StrEnum):
     column_reordered = "column_reordered"
 
 
@@ -173,13 +173,13 @@ class BreakingChange58(BaseModel):
     """
 
     column: str
-    kind: Kind62
+    kind: Kind63
     model: str
     new_index: conint(ge=0)
     old_index: conint(ge=0)
 
 
-class Kind63(StrEnum):
+class Kind64(StrEnum):
     materialization_strategy_changed = "materialization_strategy_changed"
 
 
@@ -188,13 +188,13 @@ class BreakingChange59(BaseModel):
     The materialization strategy switched between top-level variants (e.g. `FullRefresh` → `Incremental`).
     """
 
-    kind: Kind63
+    kind: Kind64
     model: str
     new_strategy: str
     old_strategy: str
 
 
-class Kind64(StrEnum):
+class Kind65(StrEnum):
     materialization_key_changed = "materialization_key_changed"
 
 
@@ -207,21 +207,6 @@ class BreakingChange60(BaseModel):
     """
     Which key changed: `unique_key`, `timestamp_column`, `partition_by`, `time_column`, `granularity`, `target_lag`, `update_columns`, `storage_prefix`, or `partition_columns`.
     """
-    kind: Kind64
-    model: str
-    new: list[str]
-    old: list[str]
-
-
-class Kind65(StrEnum):
-    replication_columns_changed = "replication_columns_changed"
-
-
-class BreakingChange61(BaseModel):
-    """
-    Replication column-selection mode flipped between `All` and `Explicit(...)` or the explicit list changed.
-    """
-
     kind: Kind65
     model: str
     new: list[str]
@@ -229,12 +214,12 @@ class BreakingChange61(BaseModel):
 
 
 class Kind66(StrEnum):
-    partition_by_changed = "partition_by_changed"
+    replication_columns_changed = "replication_columns_changed"
 
 
-class BreakingChange62(BaseModel):
+class BreakingChange61(BaseModel):
     """
-    `LakehouseOptions::partition_by` changed without the strategy changing. Distinct from `MaterializationKeyChanged` since this lives on `format_options` rather than the strategy enum.
+    Replication column-selection mode flipped between `All` and `Explicit(...)` or the explicit list changed.
     """
 
     kind: Kind66
@@ -244,6 +229,21 @@ class BreakingChange62(BaseModel):
 
 
 class Kind67(StrEnum):
+    partition_by_changed = "partition_by_changed"
+
+
+class BreakingChange62(BaseModel):
+    """
+    `LakehouseOptions::partition_by` changed without the strategy changing. Distinct from `MaterializationKeyChanged` since this lives on `format_options` rather than the strategy enum.
+    """
+
+    kind: Kind67
+    model: str
+    new: list[str]
+    old: list[str]
+
+
+class Kind68(StrEnum):
     target_renamed = "target_renamed"
 
 
@@ -252,13 +252,13 @@ class BreakingChange63(BaseModel):
     Target table reference renamed (catalog, schema, or table component).
     """
 
-    kind: Kind67
+    kind: Kind68
     model: str
     new: str
     old: str
 
 
-class Kind68(StrEnum):
+class Kind69(StrEnum):
     source_changed = "source_changed"
 
 
@@ -267,13 +267,13 @@ class BreakingChange64(BaseModel):
     Source reference rebound to a different table.
     """
 
-    kind: Kind68
+    kind: Kind69
     model: str
     new: list[str]
     old: list[str]
 
 
-class Kind69(StrEnum):
+class Kind70(StrEnum):
     column_mask_changed = "column_mask_changed"
 
 
@@ -283,13 +283,13 @@ class BreakingChange65(BaseModel):
     """
 
     column: str
-    kind: Kind69
+    kind: Kind70
     model: str
     new_strategy: str | None = None
     old_strategy: str | None = None
 
 
-class Kind70(StrEnum):
+class Kind71(StrEnum):
     lakehouse_format_changed = "lakehouse_format_changed"
 
 
@@ -298,13 +298,13 @@ class BreakingChange66(BaseModel):
     Lakehouse format switched (e.g. `DeltaTable` → `IcebergTable`).
     """
 
-    kind: Kind70
+    kind: Kind71
     model: str
     new: str
     old: str
 
 
-class Kind71(StrEnum):
+class Kind72(StrEnum):
     sql_body_changed = "sql_body_changed"
 
 
@@ -313,7 +313,7 @@ class BreakingChange67(BaseModel):
     SQL body changed without any other detectable structural change. Surfaced as `Info` because the typed-output shape is unchanged, but runtime row contents may differ.
     """
 
-    kind: Kind71
+    kind: Kind72
     model: str
 
 

--- a/sdk/python/src/rocky_sdk/types_generated/plan_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/plan_schema.py
@@ -21,7 +21,7 @@ class BreakingChange(BaseModel):
     model: str
 
 
-class Kind41(StrEnum):
+class Kind42(StrEnum):
     model_added = "model_added"
 
 
@@ -30,11 +30,11 @@ class BreakingChange36(BaseModel):
     A model present on the head side is absent on the base side.
     """
 
-    kind: Kind41
+    kind: Kind42
     model: str
 
 
-class Kind42(StrEnum):
+class Kind43(StrEnum):
     column_dropped = "column_dropped"
 
 
@@ -45,11 +45,11 @@ class BreakingChange37(BaseModel):
 
     column: str
     data_type: str
-    kind: Kind42
+    kind: Kind43
     model: str
 
 
-class Kind43(StrEnum):
+class Kind44(StrEnum):
     column_added = "column_added"
 
 
@@ -60,12 +60,12 @@ class BreakingChange38(BaseModel):
 
     column: str
     data_type: str
-    kind: Kind43
+    kind: Kind44
     model: str
     nullable: bool
 
 
-class Kind44(StrEnum):
+class Kind45(StrEnum):
     column_type_changed = "column_type_changed"
 
 
@@ -75,7 +75,7 @@ class BreakingChange39(BaseModel):
     """
 
     column: str
-    kind: Kind44
+    kind: Kind45
     model: str
     narrowing: bool
     """
@@ -85,7 +85,7 @@ class BreakingChange39(BaseModel):
     old_type: str
 
 
-class Kind45(StrEnum):
+class Kind46(StrEnum):
     column_nullability_changed = "column_nullability_changed"
 
 
@@ -95,13 +95,13 @@ class BreakingChange40(BaseModel):
     """
 
     column: str
-    kind: Kind45
+    kind: Kind46
     model: str
     new_nullable: bool
     old_nullable: bool
 
 
-class Kind46(StrEnum):
+class Kind47(StrEnum):
     column_reordered = "column_reordered"
 
 
@@ -111,13 +111,13 @@ class BreakingChange41(BaseModel):
     """
 
     column: str
-    kind: Kind46
+    kind: Kind47
     model: str
     new_index: conint(ge=0)
     old_index: conint(ge=0)
 
 
-class Kind47(StrEnum):
+class Kind48(StrEnum):
     materialization_strategy_changed = "materialization_strategy_changed"
 
 
@@ -126,13 +126,13 @@ class BreakingChange42(BaseModel):
     The materialization strategy switched between top-level variants (e.g. `FullRefresh` → `Incremental`).
     """
 
-    kind: Kind47
+    kind: Kind48
     model: str
     new_strategy: str
     old_strategy: str
 
 
-class Kind48(StrEnum):
+class Kind49(StrEnum):
     materialization_key_changed = "materialization_key_changed"
 
 
@@ -145,21 +145,6 @@ class BreakingChange43(BaseModel):
     """
     Which key changed: `unique_key`, `timestamp_column`, `partition_by`, `time_column`, `granularity`, `target_lag`, `update_columns`, `storage_prefix`, or `partition_columns`.
     """
-    kind: Kind48
-    model: str
-    new: list[str]
-    old: list[str]
-
-
-class Kind49(StrEnum):
-    replication_columns_changed = "replication_columns_changed"
-
-
-class BreakingChange44(BaseModel):
-    """
-    Replication column-selection mode flipped between `All` and `Explicit(...)` or the explicit list changed.
-    """
-
     kind: Kind49
     model: str
     new: list[str]
@@ -167,12 +152,12 @@ class BreakingChange44(BaseModel):
 
 
 class Kind50(StrEnum):
-    partition_by_changed = "partition_by_changed"
+    replication_columns_changed = "replication_columns_changed"
 
 
-class BreakingChange45(BaseModel):
+class BreakingChange44(BaseModel):
     """
-    `LakehouseOptions::partition_by` changed without the strategy changing. Distinct from `MaterializationKeyChanged` since this lives on `format_options` rather than the strategy enum.
+    Replication column-selection mode flipped between `All` and `Explicit(...)` or the explicit list changed.
     """
 
     kind: Kind50
@@ -182,6 +167,21 @@ class BreakingChange45(BaseModel):
 
 
 class Kind51(StrEnum):
+    partition_by_changed = "partition_by_changed"
+
+
+class BreakingChange45(BaseModel):
+    """
+    `LakehouseOptions::partition_by` changed without the strategy changing. Distinct from `MaterializationKeyChanged` since this lives on `format_options` rather than the strategy enum.
+    """
+
+    kind: Kind51
+    model: str
+    new: list[str]
+    old: list[str]
+
+
+class Kind52(StrEnum):
     target_renamed = "target_renamed"
 
 
@@ -190,13 +190,13 @@ class BreakingChange46(BaseModel):
     Target table reference renamed (catalog, schema, or table component).
     """
 
-    kind: Kind51
+    kind: Kind52
     model: str
     new: str
     old: str
 
 
-class Kind52(StrEnum):
+class Kind53(StrEnum):
     source_changed = "source_changed"
 
 
@@ -205,13 +205,13 @@ class BreakingChange47(BaseModel):
     Source reference rebound to a different table.
     """
 
-    kind: Kind52
+    kind: Kind53
     model: str
     new: list[str]
     old: list[str]
 
 
-class Kind53(StrEnum):
+class Kind54(StrEnum):
     column_mask_changed = "column_mask_changed"
 
 
@@ -221,13 +221,13 @@ class BreakingChange48(BaseModel):
     """
 
     column: str
-    kind: Kind53
+    kind: Kind54
     model: str
     new_strategy: str | None = None
     old_strategy: str | None = None
 
 
-class Kind54(StrEnum):
+class Kind55(StrEnum):
     lakehouse_format_changed = "lakehouse_format_changed"
 
 
@@ -236,13 +236,13 @@ class BreakingChange49(BaseModel):
     Lakehouse format switched (e.g. `DeltaTable` → `IcebergTable`).
     """
 
-    kind: Kind54
+    kind: Kind55
     model: str
     new: str
     old: str
 
 
-class Kind55(StrEnum):
+class Kind56(StrEnum):
     sql_body_changed = "sql_body_changed"
 
 
@@ -251,7 +251,7 @@ class BreakingChange50(BaseModel):
     SQL body changed without any other detectable structural change. Surfaced as `Info` because the typed-output shape is unchanged, but runtime row contents may differ.
     """
 
-    kind: Kind55
+    kind: Kind56
     model: str
 
 

--- a/sdk/python/src/rocky_sdk/types_generated/preview_diff_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/preview_diff_schema.py
@@ -73,7 +73,7 @@ class Kind(StrEnum):
     sampled = "sampled"
 
 
-class Kind73(StrEnum):
+class Kind74(StrEnum):
     bisection = "bisection"
 
 
@@ -173,7 +173,7 @@ class PreviewModelDiffAlgorithm2(BaseModel):
 
     bisection_stats: BisectionStatsOutput
     diff: PreviewBisectionRowDiff
-    kind: Kind73
+    kind: Kind74
 
 
 class PreviewModelDiff(BaseModel):

--- a/sdk/python/src/rocky_sdk/types_generated/review_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/review_schema.py
@@ -21,7 +21,7 @@ class BreakingChange(BaseModel):
     model: str
 
 
-class Kind75(StrEnum):
+class Kind76(StrEnum):
     model_added = "model_added"
 
 
@@ -30,11 +30,11 @@ class BreakingChange70(BaseModel):
     A model present on the head side is absent on the base side.
     """
 
-    kind: Kind75
+    kind: Kind76
     model: str
 
 
-class Kind76(StrEnum):
+class Kind77(StrEnum):
     column_dropped = "column_dropped"
 
 
@@ -45,11 +45,11 @@ class BreakingChange71(BaseModel):
 
     column: str
     data_type: str
-    kind: Kind76
+    kind: Kind77
     model: str
 
 
-class Kind77(StrEnum):
+class Kind78(StrEnum):
     column_added = "column_added"
 
 
@@ -60,12 +60,12 @@ class BreakingChange72(BaseModel):
 
     column: str
     data_type: str
-    kind: Kind77
+    kind: Kind78
     model: str
     nullable: bool
 
 
-class Kind78(StrEnum):
+class Kind79(StrEnum):
     column_type_changed = "column_type_changed"
 
 
@@ -75,7 +75,7 @@ class BreakingChange73(BaseModel):
     """
 
     column: str
-    kind: Kind78
+    kind: Kind79
     model: str
     narrowing: bool
     """
@@ -85,7 +85,7 @@ class BreakingChange73(BaseModel):
     old_type: str
 
 
-class Kind79(StrEnum):
+class Kind80(StrEnum):
     column_nullability_changed = "column_nullability_changed"
 
 
@@ -95,13 +95,13 @@ class BreakingChange74(BaseModel):
     """
 
     column: str
-    kind: Kind79
+    kind: Kind80
     model: str
     new_nullable: bool
     old_nullable: bool
 
 
-class Kind80(StrEnum):
+class Kind81(StrEnum):
     column_reordered = "column_reordered"
 
 
@@ -111,13 +111,13 @@ class BreakingChange75(BaseModel):
     """
 
     column: str
-    kind: Kind80
+    kind: Kind81
     model: str
     new_index: conint(ge=0)
     old_index: conint(ge=0)
 
 
-class Kind81(StrEnum):
+class Kind82(StrEnum):
     materialization_strategy_changed = "materialization_strategy_changed"
 
 
@@ -126,13 +126,13 @@ class BreakingChange76(BaseModel):
     The materialization strategy switched between top-level variants (e.g. `FullRefresh` → `Incremental`).
     """
 
-    kind: Kind81
+    kind: Kind82
     model: str
     new_strategy: str
     old_strategy: str
 
 
-class Kind82(StrEnum):
+class Kind83(StrEnum):
     materialization_key_changed = "materialization_key_changed"
 
 
@@ -145,21 +145,6 @@ class BreakingChange77(BaseModel):
     """
     Which key changed: `unique_key`, `timestamp_column`, `partition_by`, `time_column`, `granularity`, `target_lag`, `update_columns`, `storage_prefix`, or `partition_columns`.
     """
-    kind: Kind82
-    model: str
-    new: list[str]
-    old: list[str]
-
-
-class Kind83(StrEnum):
-    replication_columns_changed = "replication_columns_changed"
-
-
-class BreakingChange78(BaseModel):
-    """
-    Replication column-selection mode flipped between `All` and `Explicit(...)` or the explicit list changed.
-    """
-
     kind: Kind83
     model: str
     new: list[str]
@@ -167,12 +152,12 @@ class BreakingChange78(BaseModel):
 
 
 class Kind84(StrEnum):
-    partition_by_changed = "partition_by_changed"
+    replication_columns_changed = "replication_columns_changed"
 
 
-class BreakingChange79(BaseModel):
+class BreakingChange78(BaseModel):
     """
-    `LakehouseOptions::partition_by` changed without the strategy changing. Distinct from `MaterializationKeyChanged` since this lives on `format_options` rather than the strategy enum.
+    Replication column-selection mode flipped between `All` and `Explicit(...)` or the explicit list changed.
     """
 
     kind: Kind84
@@ -182,6 +167,21 @@ class BreakingChange79(BaseModel):
 
 
 class Kind85(StrEnum):
+    partition_by_changed = "partition_by_changed"
+
+
+class BreakingChange79(BaseModel):
+    """
+    `LakehouseOptions::partition_by` changed without the strategy changing. Distinct from `MaterializationKeyChanged` since this lives on `format_options` rather than the strategy enum.
+    """
+
+    kind: Kind85
+    model: str
+    new: list[str]
+    old: list[str]
+
+
+class Kind86(StrEnum):
     target_renamed = "target_renamed"
 
 
@@ -190,13 +190,13 @@ class BreakingChange80(BaseModel):
     Target table reference renamed (catalog, schema, or table component).
     """
 
-    kind: Kind85
+    kind: Kind86
     model: str
     new: str
     old: str
 
 
-class Kind86(StrEnum):
+class Kind87(StrEnum):
     source_changed = "source_changed"
 
 
@@ -205,13 +205,13 @@ class BreakingChange81(BaseModel):
     Source reference rebound to a different table.
     """
 
-    kind: Kind86
+    kind: Kind87
     model: str
     new: list[str]
     old: list[str]
 
 
-class Kind87(StrEnum):
+class Kind88(StrEnum):
     column_mask_changed = "column_mask_changed"
 
 
@@ -221,13 +221,13 @@ class BreakingChange82(BaseModel):
     """
 
     column: str
-    kind: Kind87
+    kind: Kind88
     model: str
     new_strategy: str | None = None
     old_strategy: str | None = None
 
 
-class Kind88(StrEnum):
+class Kind89(StrEnum):
     lakehouse_format_changed = "lakehouse_format_changed"
 
 
@@ -236,13 +236,13 @@ class BreakingChange83(BaseModel):
     Lakehouse format switched (e.g. `DeltaTable` → `IcebergTable`).
     """
 
-    kind: Kind88
+    kind: Kind89
     model: str
     new: str
     old: str
 
 
-class Kind89(StrEnum):
+class Kind90(StrEnum):
     sql_body_changed = "sql_body_changed"
 
 
@@ -251,7 +251,7 @@ class BreakingChange84(BaseModel):
     SQL body changed without any other detectable structural change. Surfaced as `Info` because the typed-output shape is unchanged, but runtime row contents may differ.
     """
 
-    kind: Kind89
+    kind: Kind90
     model: str
 
 


### PR DESCRIPTION
Three independent fidelity fixes for `rocky import-dbt`, each closing a case where a dbt migration could silently lose information. One commit per FR.

## FR-038 — dbt_expectations / dbt_utils tests → native assertions

The import-emit test mapper now translates the common long-tail generic tests that have a clear native Rocky equivalent, instead of dropping them as `UnsupportedTest`:

- `dbt_expectations.expect_column_values_to_be_between` → `in_range`
- `dbt_expectations.expect_column_values_to_match_regex` → `regex_match`
- `dbt_expectations.expect_column_values_to_be_in_set` → `accepted_values`
- `dbt_utils.expression_is_true` → `expression` (column- or model-level)
- `dbt_utils.accepted_range` → `in_range`

Each conversion carries the dbt severity (`warn` → `Warning`) and row filter (`where`). Anything without a native equivalent — or whose payload can't be translated (e.g. a regex the strict allowlist rejects, or a range with no bounds) — still keeps the `UnsupportedTest` warning. The `tests_converted` / `tests_skipped` / `tests_converted_custom` counters update accordingly.

## FR-040 — profiles.yml anchors + env_var() adapter detection

The minimal `profiles.yml` parser previously fell back to a stub DuckDB adapter whenever it couldn't read the output's `type`, including two common cases — so a migration could quietly land on the wrong warehouse.

- Resolve YAML merge keys / anchors (`<<: *base`) before reading the active output, so a profile that factors shared config into a `&base` anchor keeps its `type`.
- Treat `{{ env_var('X', 'default') }}` in the `type` field as the adapter discriminator using the default (the live secret is never read). An `env_var` with no default remains a genuine failure.
- On any present-but-unparseable `profiles.yml`, carry a loud `fallback_reason` that the CLI surfaces as a `ProfileFallback` import warning (also in `--output json`), instead of silently defaulting to duckdb.

## FR-042 — warn on dropped dbt model contracts

dbt model contracts (`contract: { enforced: true }`), column `data_type`s, and column `constraints` were dropped on import with no warning. A migration could silently lose contract enforcement.

Parse the contract / data_type / constraints out of the manifest node config and columns. When a contract is enforced, emit a structured per-model warning (new `DroppedContract` warning category) pointing at the `{model}.contract.toml` the user should author, plus a flat-string warning and a MIGRATION-NOTES entry. The drop is counted in a new `contracts_dropped` field on `ImportDbtOutput` (also surfaced in `--output json`). Stub generation is out of scope — this is visibility only.

Regenerates the `import_dbt` JSON schema and the Pydantic / TypeScript bindings via `just codegen` (the new structured-warning variant also shifts the global datamodel-codegen enum numbering in `plan` / `review` / `plan_promote` / `preview_diff`).

## Testing

Verified end-to-end via a real `rocky import-dbt` run, alongside the expanded unit coverage in `import_dbt_emit.rs` and the import test / profile modules.

## Note

FR-036 (microbatch → `time_interval`) is deferred separately — it surfaced a pre-existing compiler limitation.
