### PR TITLE
fix(engine/rocky-compiler): expand SELECT * over a derived table in output-schema inference

### DIFF
--- a/engine/crates/rocky-compiler/src/semantic.rs
+++ b/engine/crates/rocky-compiler/src/semantic.rs
@@ -340,6 +340,20 @@ pub fn build_semantic_graph(
                             });
                         }
                     }
+                } else if let Some(derived_cols) = &table_ref.derived_columns {
+                    // Derived table (subquery in FROM): expand to the inner
+                    // query's statically-resolved output columns. These carry
+                    // no cross-model edge (the subquery isn't a named model or
+                    // source), so their types stay Unknown — that's enough for
+                    // the column to exist in the output schema (e.g. the E020
+                    // time_column check) without weakening any type-shape check.
+                    for col_name in derived_cols {
+                        if output_names.insert(col_name.clone()) {
+                            output_columns.push(ColumnDef {
+                                name: col_name.clone(),
+                            });
+                        }
+                    }
                 } else if let Some(source_cols) = source_schemas.get(table_name.as_str()) {
                     // External source with known schema
                     for col in source_cols {
@@ -446,6 +460,44 @@ mod tests {
         assert!(!c_edges.is_empty());
         assert_eq!(&*c_edges[0].source.model, "b");
         assert_eq!(&*c_edges[0].source.column, "id");
+    }
+
+    #[test]
+    fn test_select_star_over_derived_table_expands_inner_columns() {
+        // `SELECT * FROM (<subquery>) AS alias` must expose the inner query's
+        // output columns in the model's schema, not an empty column set.
+        let models = vec![make_model(
+            "ti",
+            "SELECT * FROM (SELECT ts, id FROM raw.base) AS x \
+             WHERE ts >= @start_date AND ts < @end_date",
+        )];
+
+        let project = Project::from_models(models).unwrap();
+        let graph = build_semantic_graph(&project, &HashMap::new()).unwrap();
+
+        let schema = graph.models.get("ti").expect("model present");
+        assert!(schema.has_star);
+        let names: Vec<&str> = schema.columns.iter().map(|c| c.name.as_str()).collect();
+        assert!(names.contains(&"ts"), "expected ts in {names:?}");
+        assert!(names.contains(&"id"), "expected id in {names:?}");
+    }
+
+    #[test]
+    fn test_select_star_over_derived_table_missing_column() {
+        // The negative case: a column the inner query does NOT project must
+        // stay absent from the schema (so E020 still fires for it).
+        let models = vec![make_model(
+            "ti",
+            "SELECT * FROM (SELECT id FROM raw.base) AS x",
+        )];
+
+        let project = Project::from_models(models).unwrap();
+        let graph = build_semantic_graph(&project, &HashMap::new()).unwrap();
+
+        let schema = graph.models.get("ti").expect("model present");
+        let names: Vec<&str> = schema.columns.iter().map(|c| c.name.as_str()).collect();
+        assert!(names.contains(&"id"), "expected id in {names:?}");
+        assert!(!names.contains(&"ts"), "ts must be absent in {names:?}");
     }
 
     #[test]

--- a/engine/crates/rocky-compiler/src/typecheck.rs
+++ b/engine/crates/rocky-compiler/src/typecheck.rs
@@ -2073,6 +2073,68 @@ mod tests {
             .collect()
     }
 
+    fn make_time_interval_select_star_model(name: &str, time_column: &str, sql: &str) -> Model {
+        let mut model = make_model(name, sql);
+        model.config.strategy = StrategyConfig::TimeInterval {
+            time_column: time_column.to_string(),
+            granularity: rocky_ir::TimeGrain::Day,
+            lookback: 0,
+            batch_size: std::num::NonZeroU32::new(1).unwrap(),
+            first_partition: None,
+        };
+        model
+    }
+
+    #[test]
+    fn test_e020_not_fired_for_select_star_over_derived_table() {
+        // Regression: `SELECT * FROM (<subquery>) AS alias` used to compute an
+        // empty output schema, so E020 wrongly fired for a time_column the
+        // inner query clearly projects. The derived table now expands.
+        let models = vec![make_time_interval_select_star_model(
+            "ti",
+            "ts",
+            "SELECT * FROM (SELECT ts, id FROM raw.base) AS x \
+             WHERE ts >= @start_date AND ts < @end_date",
+        )];
+        let project = Project::from_models(models).unwrap();
+        let graph = build_semantic_graph(&project, &HashMap::new()).unwrap();
+        let result =
+            typecheck_project_with_models(&graph, &HashMap::new(), None, &project.models, None);
+
+        let ti_cols = result.typed_models.get("ti").unwrap();
+        assert!(
+            ti_cols.iter().any(|c| c.name == "ts"),
+            "expected ts in output schema, got: {ti_cols:?}"
+        );
+        assert!(
+            !result.diagnostics.iter().any(|d| &*d.code == "E020"),
+            "E020 must not fire when the inner query projects ts: {:?}",
+            result.diagnostics
+        );
+    }
+
+    #[test]
+    fn test_e020_still_fires_when_inner_query_omits_time_column() {
+        // The fix must not weaken E020: a genuinely-absent time_column still
+        // errors even with a SELECT * over a derived table.
+        let models = vec![make_time_interval_select_star_model(
+            "ti",
+            "ts",
+            "SELECT * FROM (SELECT id FROM raw.base) AS x \
+             WHERE id >= @start_date AND id < @end_date",
+        )];
+        let project = Project::from_models(models).unwrap();
+        let graph = build_semantic_graph(&project, &HashMap::new()).unwrap();
+        let result =
+            typecheck_project_with_models(&graph, &HashMap::new(), None, &project.models, None);
+
+        assert!(
+            result.diagnostics.iter().any(|d| &*d.code == "E020"),
+            "E020 must still fire for a missing time_column: {:?}",
+            result.diagnostics
+        );
+    }
+
     #[test]
     fn test_basic_type_propagation() {
         let models = vec![

--- a/engine/crates/rocky-sql/src/lineage.rs
+++ b/engine/crates/rocky-sql/src/lineage.rs
@@ -61,6 +61,16 @@ pub struct TableReference {
     pub name: String,
     /// Alias if any.
     pub alias: Option<String>,
+    /// Output column names of a derived table (subquery in the `FROM` clause),
+    /// when they can be determined statically — i.e. the subquery does not
+    /// itself project a `SELECT *`. `None` for plain table references and for
+    /// subqueries whose column set can't be enumerated (e.g. the inner query
+    /// is itself a `SELECT *`, or a nested derived table that doesn't expand).
+    ///
+    /// This lets `SELECT * FROM (<subquery>) AS alias` resolve to the inner
+    /// query's projected columns instead of an empty schema.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub derived_columns: Option<Vec<String>>,
 }
 
 /// Extracts the names of tables referenced in FROM/JOIN clauses.
@@ -139,12 +149,31 @@ fn extract_table_factor(factor: &TableFactor, tables: &mut Vec<TableReference>) 
             tables.push(TableReference {
                 name: name.to_string(),
                 alias: alias.as_ref().map(|a| a.name.value.clone()),
+                derived_columns: None,
             });
         }
-        TableFactor::Derived { alias: Some(a), .. } => {
+        TableFactor::Derived {
+            subquery,
+            alias: Some(a),
+            ..
+        } => {
+            // Resolve the subquery's output columns so that an outer
+            // `SELECT *` over this derived table can expand to them. We can
+            // only do this when the inner query enumerates its columns — an
+            // inner `SELECT *` (or a nested derived table that doesn't expand)
+            // leaves `has_star = true` with no individual columns, in which
+            // case we fall back to `None`.
+            let derived_columns = extract_query_lineage(subquery).ok().and_then(|inner| {
+                if inner.has_star || inner.columns.is_empty() {
+                    None
+                } else {
+                    Some(inner.columns.into_iter().map(|c| c.target_column).collect())
+                }
+            });
             tables.push(TableReference {
                 name: "(subquery)".to_string(),
                 alias: Some(a.name.value.clone()),
+                derived_columns,
             });
         }
         _ => {}
@@ -327,6 +356,77 @@ mod tests {
         let result = extract_lineage("SELECT * FROM catalog.schema.users").unwrap();
         assert!(result.has_star);
         assert!(result.columns.is_empty()); // star doesn't produce individual lineage
+    }
+
+    #[test]
+    fn test_derived_table_columns_resolved() {
+        // `SELECT * FROM (<subquery>) AS alias` records the inner query's
+        // output columns on the derived TableReference so the outer star can
+        // expand to them.
+        let result =
+            extract_lineage("SELECT * FROM (SELECT ts, id FROM raw.base) AS x WHERE ts >= '2026'")
+                .unwrap();
+        assert!(result.has_star);
+        assert_eq!(result.source_tables.len(), 1);
+        assert_eq!(result.source_tables[0].name, "(subquery)");
+        assert_eq!(result.source_tables[0].alias, Some("x".to_string()));
+        assert_eq!(
+            result.source_tables[0].derived_columns,
+            Some(vec!["ts".to_string(), "id".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_derived_table_columns_with_time_interval_placeholders() {
+        // The exact shape the import-dbt microbatch→time_interval rewrite emits.
+        let result = extract_lineage(
+            "SELECT * FROM (SELECT ts, id FROM raw.base) AS _rocky_microbatch \
+             WHERE ts >= @start_date AND ts < @end_date",
+        )
+        .unwrap();
+        assert!(result.has_star);
+        assert_eq!(
+            result.source_tables[0].derived_columns,
+            Some(vec!["ts".to_string(), "id".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_derived_table_uses_inner_output_names() {
+        // Inner aliases become the derived table's output column names.
+        let result =
+            extract_lineage("SELECT * FROM (SELECT ts AS event_time, id FROM raw.base) AS x")
+                .unwrap();
+        assert_eq!(
+            result.source_tables[0].derived_columns,
+            Some(vec!["event_time".to_string(), "id".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_qualified_wildcard_over_derived_table() {
+        // `SELECT x.*` (QualifiedWildcard) over a derived table still resolves.
+        let result = extract_lineage("SELECT x.* FROM (SELECT ts, id FROM raw.base) AS x").unwrap();
+        assert!(result.has_star);
+        assert_eq!(
+            result.source_tables[0].derived_columns,
+            Some(vec!["ts".to_string(), "id".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_derived_table_inner_star_not_resolved() {
+        // An inner `SELECT *` can't be enumerated statically — no derived
+        // columns, falling back to the pre-existing (empty) behavior.
+        let result = extract_lineage("SELECT * FROM (SELECT * FROM raw.base) AS x").unwrap();
+        assert!(result.has_star);
+        assert_eq!(result.source_tables[0].derived_columns, None);
+    }
+
+    #[test]
+    fn test_plain_table_has_no_derived_columns() {
+        let result = extract_lineage("SELECT * FROM catalog.schema.users").unwrap();
+        assert_eq!(result.source_tables[0].derived_columns, None);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`SELECT * FROM (<subquery>) AS alias` produced an empty output schema during schema inference. The outer `*` had nothing to expand against: a derived table (a subquery in the `FROM` clause) carried no resolved columns, unlike a named model or an external source. For `time_interval` models this wrongly tripped E020 — the configured `time_column` was clearly projected by the inner query, but the model's inferred schema came back empty, so the check reported the column as missing.

## Fix

- `rocky-sql` lineage now records a derived table's output column names on its `TableReference` (`derived_columns`). It resolves them by running lineage over the subquery and taking its projected columns, but only when the inner query enumerates them. An inner `SELECT *` (or a nested derived table that doesn't expand) leaves `has_star = true` with no individual columns; in that case `derived_columns` stays `None` and the prior behavior is preserved.
- `rocky-compiler` semantic-graph construction expands an outer `SELECT *` over a derived table to those inner column names. The columns carry no cross-model lineage edge (the subquery is neither a named model nor a source), so their types stay `Unknown`. That is enough for the column to exist in the output schema for the E020 `time_column` check without weakening any type-shape check.

## Testing

- `rocky-sql` and `rocky-compiler` unit tests covering derived-column resolution, qualified-wildcard (`x.*`) expansion, inner-alias output names, and the inner-`SELECT *` / plain-table fallbacks.
- Real `rocky compile` on a `time_interval` model shaped as `SELECT * FROM (<subquery>) AS alias`: compiles clean, no E020.
- `rocky run --partition` round-trip on the same model: partitions load over the resolved `time_column`.
- Negative case retained: E020 still fires when the inner query genuinely omits the configured `time_column`, verified both at the semantic/compiler layer and at typecheck.
