### PR TITLE
feat(engine/rocky-compiler): import dbt microbatch as time_interval (--microbatch-as)

### DIFF
--- a/engine/crates/rocky-cli/src/commands/import_dbt.rs
+++ b/engine/crates/rocky-cli/src/commands/import_dbt.rs
@@ -32,7 +32,7 @@ use rocky_compiler::import::{
     dbt,
     dbt::{
         HookKind, ImportDbtStructuredWarning as CompilerStructuredWarning, ImportResult,
-        ImportWarning, WarningCategory,
+        ImportWarning, MicrobatchMode, WarningCategory,
     },
     dbt_manifest, dbt_profiles,
     dbt_profiles::{AdapterKind, ProfileResolution, StubReason},
@@ -59,8 +59,11 @@ pub fn run_import_dbt(
     target_adapter: Option<&str>,
     overwrite: bool,
     skip_unit_tests: bool,
+    microbatch_as: &str,
     output_json: bool,
 ) -> Result<()> {
+    let microbatch_mode = MicrobatchMode::from_flag(microbatch_as);
+
     // Resolve adapter shape — profile detection unless --target-adapter overrides.
     let profile = resolve_profile(dbt_project, target_adapter);
     let adapter_override_label = target_adapter.map(std::string::ToString::to_string);
@@ -74,6 +77,7 @@ pub fn run_import_dbt(
         manifest_path,
         no_manifest,
         skip_unit_tests,
+        microbatch_mode,
     )?;
 
     // A `profiles.yml` that was present but couldn't be resolved fell back to
@@ -269,8 +273,12 @@ fn run_importer(
     manifest_path: Option<&Path>,
     no_manifest: bool,
     skip_unit_tests: bool,
+    microbatch_mode: MicrobatchMode,
 ) -> Result<ImportResult> {
     if no_manifest {
+        // The regex (`--no-manifest`) path keeps the default microbatch
+        // mapping; `--microbatch-as=time_interval` needs the compiled body
+        // only the manifest path carries.
         return dbt::import_dbt_project(dbt_project, default_target)
             .map_err(|e| anyhow::anyhow!("{e}"));
     }
@@ -295,7 +303,8 @@ fn run_importer(
 
     if let Some(ref mf) = manifest_file {
         let manifest = dbt_manifest::parse_manifest(mf).map_err(|e| anyhow::anyhow!("{e}"))?;
-        let mut result = dbt::import_from_manifest(&manifest, default_target, skip_unit_tests);
+        let mut result =
+            dbt::import_from_manifest(&manifest, default_target, skip_unit_tests, microbatch_mode);
         // The manifest path doesn't itself walk schema.yml files for tests.
         // Apply the dbt-tests pass against the project root so manifest
         // imports also pick up the four canonical generic tests.

--- a/engine/crates/rocky-cli/src/commands/validate_migration.rs
+++ b/engine/crates/rocky-cli/src/commands/validate_migration.rs
@@ -54,7 +54,12 @@ pub fn run_validate_migration(
     let import_result = if manifest_path.exists() {
         let manifest =
             dbt_manifest::parse_manifest(&manifest_path).map_err(|e| anyhow::anyhow!("{e}"))?;
-        dbt::import_from_manifest(&manifest, &default_target, false)
+        dbt::import_from_manifest(
+            &manifest,
+            &default_target,
+            false,
+            dbt::MicrobatchMode::Merge,
+        )
     } else {
         dbt::import_dbt_project(dbt_project, &default_target).map_err(|e| anyhow::anyhow!("{e}"))?
     };

--- a/engine/crates/rocky-compiler/src/import/dbt.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt.rs
@@ -36,6 +36,39 @@ use super::dbt_sources;
 // Public types
 // ---------------------------------------------------------------------------
 
+/// How a dbt microbatch model is translated on import.
+///
+/// dbt microbatch idempotently replaces each event-time partition. Rocky
+/// can express that faithfully as a [`StrategyConfig::TimeInterval`] model
+/// (bounded `@start_date`/`@end_date` window + lookback), but doing so
+/// requires rewriting the model body to reference those placeholders — not
+/// always safe. The default keeps the historical `merge` mapping for
+/// back-compat; `--microbatch-as=time_interval` opts into the
+/// bounded-window translation, falling back to `merge` (loudly) whenever the
+/// body can't be rewritten safely.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MicrobatchMode {
+    /// Map to an idempotent `merge` (or append-only when no `unique_key`).
+    /// The historical default — preserves existing import behavior.
+    #[default]
+    Merge,
+    /// Map to a `time_interval` model with a bounded per-partition window,
+    /// deriving granularity/lookback from the dbt config. Falls back to
+    /// `Merge` with a warning when the body can't be rewritten safely.
+    TimeInterval,
+}
+
+impl MicrobatchMode {
+    /// Parse the `--microbatch-as` CLI value. Unknown values map to the
+    /// default ([`MicrobatchMode::Merge`]); the caller validates the flag.
+    pub fn from_flag(value: &str) -> Self {
+        match value.to_ascii_lowercase().as_str() {
+            "time_interval" => Self::TimeInterval,
+            _ => Self::Merge,
+        }
+    }
+}
+
 /// How the import was performed.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ImportMethod {
@@ -275,6 +308,7 @@ pub fn import_from_manifest(
     manifest: &DbtManifest,
     default_target: &TargetConfig,
     skip_unit_tests: bool,
+    microbatch_mode: MicrobatchMode,
 ) -> ImportResult {
     let mut result = ImportResult {
         imported: Vec::new(),
@@ -316,7 +350,7 @@ pub fn import_from_manifest(
         .count();
 
     for node in manifest.nodes.values() {
-        import_manifest_node(node, default_target, &mut result);
+        import_manifest_node(node, default_target, microbatch_mode, &mut result);
     }
 
     if model_count > 0 && with_compiled == 0 {
@@ -726,6 +760,7 @@ fn attach_intent(result: &mut ImportResult, model_name: &str, description: Optio
 fn import_manifest_node(
     node: &DbtManifestNode,
     default_target: &TargetConfig,
+    microbatch_mode: MicrobatchMode,
     result: &mut ImportResult,
 ) {
     // Resolve the model's output coordinates up front so the raw-code fallback
@@ -750,7 +785,7 @@ fn import_manifest_node(
     let this_ref = format!("{catalog}.{schema}.{table}");
 
     // Use compiled_code (Jinja resolved) if available, else raw_code.
-    let sql = match &node.compiled_code {
+    let mut sql = match &node.compiled_code {
         Some(code) => code.clone(),
         None => {
             result.warnings.push(ImportWarning {
@@ -771,9 +806,17 @@ fn import_manifest_node(
         strategy,
         warnings: strategy_warnings,
         structured,
-    } = map_manifest_strategy(&node.config, &node.name);
+    } = map_manifest_strategy(&node.config, &node.name, microbatch_mode);
     result.warnings.extend(strategy_warnings);
     result.structured_warnings.extend(structured);
+
+    // A `time_interval` strategy can only originate from microbatch translation
+    // (`--microbatch-as=time_interval`). The model body must reference
+    // `@start_date`/`@end_date` so the runtime can bound each partition; wrap
+    // the original SELECT in a bounded subquery on the event-time column.
+    if let StrategyConfig::TimeInterval { time_column, .. } = &strategy {
+        sql = rewrite_body_for_time_interval(&sql, time_column);
+    }
 
     // Surface dbt-databricks specifics that Rocky doesn't auto-translate
     // (databricks_tags, pre/post hooks, on_schema_change). Emitted as
@@ -845,7 +888,11 @@ struct StrategyMappingOutput {
 /// (across all `incremental_strategy` values) / `ephemeral` /
 /// `microbatch`. Unknown materializations fall back to `FullRefresh` with
 /// a warning.
-fn map_manifest_strategy(config: &DbtNodeConfig, model_name: &str) -> StrategyMappingOutput {
+fn map_manifest_strategy(
+    config: &DbtNodeConfig,
+    model_name: &str,
+    microbatch_mode: MicrobatchMode,
+) -> StrategyMappingOutput {
     let mut warnings = Vec::new();
     let mut structured = Vec::new();
 
@@ -870,10 +917,20 @@ fn map_manifest_strategy(config: &DbtNodeConfig, model_name: &str) -> StrategyMa
             });
             StrategyConfig::FullRefresh
         }
-        "incremental" => {
-            map_incremental_strategy(config, model_name, &mut warnings, &mut structured)
-        }
-        "microbatch" => map_microbatch_strategy(config, model_name, &mut warnings, &mut structured),
+        "incremental" => map_incremental_strategy(
+            config,
+            model_name,
+            microbatch_mode,
+            &mut warnings,
+            &mut structured,
+        ),
+        "microbatch" => map_microbatch_strategy(
+            config,
+            model_name,
+            microbatch_mode,
+            &mut warnings,
+            &mut structured,
+        ),
         other => {
             warnings.push(ImportWarning {
                 model: model_name.to_string(),
@@ -906,6 +963,7 @@ fn map_manifest_strategy(config: &DbtNodeConfig, model_name: &str) -> StrategyMa
 fn map_incremental_strategy(
     config: &DbtNodeConfig,
     model_name: &str,
+    microbatch_mode: MicrobatchMode,
     warnings: &mut Vec<ImportWarning>,
     structured: &mut Vec<ImportDbtStructuredWarning>,
 ) -> StrategyConfig {
@@ -1027,7 +1085,7 @@ fn map_incremental_strategy(
             // microbatch form (`incremental_strategy='microbatch'`), so the
             // MicrobatchMapped structured warning must be threaded out to the
             // caller, not dropped into a local vec.
-            map_microbatch_strategy(config, model_name, warnings, structured)
+            map_microbatch_strategy(config, model_name, microbatch_mode, warnings, structured)
         }
         other => {
             warnings.push(ImportWarning {
@@ -1048,12 +1106,27 @@ fn map_incremental_strategy(
 }
 
 /// Map `materialized='microbatch'` (or `incremental_strategy='microbatch'`)
-/// to [`StrategyConfig::Microbatch`]. Emits a
+/// to a Rocky strategy. Emits a
 /// [`ImportDbtStructuredWarning::MicrobatchMissingEventTime`] + falls back
 /// to `FullRefresh` if `event_time` is absent.
+///
+/// When `microbatch_mode` is [`MicrobatchMode::TimeInterval`] and the
+/// `event_time` field is a valid SQL identifier, this produces a
+/// [`StrategyConfig::TimeInterval`] with bounded per-partition windows
+/// (granularity + lookback derived from the dbt `batch_size`/`lookback`
+/// config). The caller is responsible for rewriting the model body to
+/// reference `@start_date`/`@end_date` (see [`rewrite_body_for_time_interval`]).
+/// When the `event_time` field can't be rewritten safely, it falls back to
+/// the `merge` mapping and warns that bounded-window semantics were not
+/// preserved.
+///
+/// The default [`MicrobatchMode::Merge`] keeps the historical behavior: dbt
+/// microbatch idempotently replaces each batch partition, so it maps to an
+/// idempotent Rocky merge (key-upsert) — or append-only when no `unique_key`.
 fn map_microbatch_strategy(
     config: &DbtNodeConfig,
     model_name: &str,
+    microbatch_mode: MicrobatchMode,
     warnings: &mut Vec<ImportWarning>,
     structured: &mut Vec<ImportDbtStructuredWarning>,
 ) -> StrategyConfig {
@@ -1071,6 +1144,44 @@ fn map_microbatch_strategy(
         });
         return StrategyConfig::FullRefresh;
     };
+
+    // `--microbatch-as=time_interval`: try the faithful bounded-window
+    // mapping. The body rewrite injects `@start_date`/`@end_date` bounds on
+    // `event_time`, so the column must be a safe SQL identifier; if it isn't,
+    // fall through to the merge mapping and warn that the bounded-window
+    // semantics were not preserved.
+    if microbatch_mode == MicrobatchMode::TimeInterval {
+        if rocky_sql::validation::validate_identifier(&event_time).is_ok() {
+            let granularity = microbatch_granularity(config.batch_size.as_deref());
+            structured.push(ImportDbtStructuredWarning::MicrobatchMapped {
+                model: model_name.to_string(),
+                mapped_to: "time_interval".to_string(),
+            });
+            return StrategyConfig::TimeInterval {
+                time_column: event_time,
+                granularity,
+                lookback: config.lookback.unwrap_or(0),
+                // dbt has no equivalent of Rocky's batch_size (partition
+                // count per SQL statement); default to atomic per-partition.
+                batch_size: std::num::NonZeroU32::new(1).expect("1 is non-zero"),
+                first_partition: None,
+            };
+        }
+        warnings.push(ImportWarning {
+            model: model_name.to_string(),
+            category: WarningCategory::UnsupportedMaterialization,
+            message: format!(
+                "microbatch event_time '{event_time}' is not a safe SQL identifier — \
+                 could not rewrite the body to a bounded time_interval window; mapped to merge instead, \
+                 so dbt's bounded-window semantics were not preserved"
+            ),
+            suggestion: Some(
+                "set `event_time` to a plain column name in the dbt config, or hand-author a Rocky time_interval model with @start_date/@end_date".to_string(),
+            ),
+        });
+        // Fall through to the merge mapping below.
+    }
+
     // dbt microbatch idempotently REPLACES each batch partition. Rocky's
     // Microbatch strategy emits an append-only INSERT (sql_gen.rs), so importing
     // it as-is silently re-inserts the lookback window every run. dbt microbatch
@@ -1122,6 +1233,47 @@ fn map_microbatch_strategy(
             }
         }
     }
+}
+
+/// Map dbt's microbatch `batch_size` (`hour` / `day` / `month` / `year`) to a
+/// Rocky [`TimeGrain`]. dbt's `batch_size` is a *granularity*, not a count —
+/// it names the size of each partition window. Unrecognized or absent values
+/// default to `Day`, matching dbt's most common configuration.
+fn microbatch_granularity(batch_size: Option<&str>) -> rocky_ir::TimeGrain {
+    match batch_size.map(str::to_ascii_lowercase).as_deref() {
+        Some("hour") => rocky_ir::TimeGrain::Hour,
+        Some("month") => rocky_ir::TimeGrain::Month,
+        Some("year") => rocky_ir::TimeGrain::Year,
+        // "day" and anything unrecognized.
+        _ => rocky_ir::TimeGrain::Day,
+    }
+}
+
+/// Rewrite a model body so a `time_interval` strategy can bound each
+/// partition. dbt's `compiled_code` for a microbatch model carries no
+/// event-time filter (dbt injects the window at run time), so we wrap the
+/// original SELECT in a bounded subquery keyed on `event_time`:
+///
+/// ```sql
+/// SELECT * FROM (
+///   <original body>
+/// ) AS _rocky_microbatch
+/// WHERE event_time >= @start_date AND event_time < @end_date
+/// ```
+///
+/// Wrapping the whole query is safe against CTEs, `GROUP BY`, and set
+/// operations, and keeps `event_time` in the output so the compiler's
+/// `time_column` validation passes. The half-open `>= @start_date AND
+/// < @end_date` bound matches the runtime's partition filter in
+/// `sql_gen::generate_transformation_sql` (insert_overwrite_partition).
+///
+/// The caller has already validated `event_time` as a SQL identifier before
+/// choosing the `time_interval` strategy.
+fn rewrite_body_for_time_interval(sql: &str, event_time: &str) -> String {
+    let body = sql.trim().trim_end_matches(';');
+    format!(
+        "SELECT * FROM (\n{body}\n) AS _rocky_microbatch\nWHERE {event_time} >= @start_date AND {event_time} < @end_date"
+    )
 }
 
 /// Collect structured warnings for dbt config Rocky can't auto-translate
@@ -1919,7 +2071,12 @@ fn extract_dbt_config(content: &str) -> (StrategyConfig, Vec<String>) {
         contract: None,
     };
 
-    let mapping = map_manifest_strategy(&synthetic, "<regex-path>");
+    // The regex (`--no-manifest`) path always uses the default microbatch
+    // mapping. The `--microbatch-as=time_interval` translation needs the
+    // model's compiled body to rewrite (it injects `@start_date`/`@end_date`),
+    // which only the manifest path reliably provides; opting it in on the
+    // reduced-fidelity regex path would risk corrupting un-compiled Jinja.
+    let mapping = map_manifest_strategy(&synthetic, "<regex-path>", MicrobatchMode::Merge);
     for w in mapping.warnings {
         messages.push(w.message);
     }
@@ -2285,7 +2442,7 @@ FROM raw.orders
             schema: "staging".to_string(),
             table: String::new(),
         };
-        let result = import_from_manifest(&manifest, &target, false);
+        let result = import_from_manifest(&manifest, &target, false, MicrobatchMode::Merge);
 
         assert_eq!(result.import_method, ImportMethod::Manifest);
         assert_eq!(result.imported.len(), 1);
@@ -2399,7 +2556,7 @@ models:
             schema: "s".to_string(),
             table: String::new(),
         };
-        let result = import_from_manifest(&manifest, &target, false);
+        let result = import_from_manifest(&manifest, &target, false, MicrobatchMode::Merge);
 
         assert_eq!(result.imported.len(), 1);
         assert!(matches!(
@@ -2443,7 +2600,7 @@ models:
             schema: "s".to_string(),
             table: String::new(),
         };
-        let result = import_from_manifest(&manifest, &target, false);
+        let result = import_from_manifest(&manifest, &target, false, MicrobatchMode::Merge);
 
         assert_eq!(result.imported.len(), 1);
         assert!(matches!(
@@ -2622,7 +2779,155 @@ FROM {{ ref('stg_events') }}
             schema: "s".to_string(),
             table: String::new(),
         };
-        import_from_manifest(&manifest, &target, false)
+        import_from_manifest(&manifest, &target, false, MicrobatchMode::Merge)
+    }
+
+    fn import_from_manifest_json_with_mode(
+        manifest_json: &serde_json::Value,
+        mode: MicrobatchMode,
+    ) -> ImportResult {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("manifest.json");
+        std::fs::write(&path, manifest_json.to_string()).unwrap();
+        let manifest = dbt_manifest::parse_manifest(&path).unwrap();
+        let target = TargetConfig {
+            catalog: "w".to_string(),
+            schema: "s".to_string(),
+            table: String::new(),
+        };
+        import_from_manifest(&manifest, &target, false, mode)
+    }
+
+    #[test]
+    fn test_microbatch_as_time_interval_emits_time_interval_strategy() {
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": { "model.p.events_daily": {
+                "unique_id": "model.p.events_daily", "name": "events_daily",
+                "resource_type": "model",
+                "compiled_code": "SELECT event_ts, amount FROM raw.events",
+                "raw_code": "SELECT event_ts, amount FROM raw.events",
+                "depends_on": { "nodes": [], "macros": [] },
+                "config": {
+                    "materialized": "incremental",
+                    "incremental_strategy": "microbatch",
+                    "event_time": "event_ts",
+                    "batch_size": "day",
+                    "lookback": 3,
+                    "unique_key": "id"
+                },
+                "columns": {}, "tags": [], "schema": "s", "database": "d"
+            }},
+            "sources": {}
+        });
+        let result = import_from_manifest_json_with_mode(&manifest, MicrobatchMode::TimeInterval);
+        let model = &result.imported[0];
+        match &model.config.strategy {
+            StrategyConfig::TimeInterval {
+                time_column,
+                granularity,
+                lookback,
+                batch_size,
+                ..
+            } => {
+                assert_eq!(time_column, "event_ts");
+                assert_eq!(*granularity, rocky_ir::TimeGrain::Day);
+                assert_eq!(*lookback, 3);
+                assert_eq!(batch_size.get(), 1);
+            }
+            other => panic!("expected TimeInterval, got {other:?}"),
+        }
+        // Body must reference @start_date/@end_date so the runtime can bound it.
+        assert!(
+            model.sql.contains("@start_date") && model.sql.contains("@end_date"),
+            "rewritten body must inject the partition placeholders: {}",
+            model.sql
+        );
+        assert!(
+            model
+                .sql
+                .contains("event_ts >= @start_date AND event_ts < @end_date"),
+            "half-open bound must match the runtime partition filter: {}",
+            model.sql
+        );
+        assert!(
+            result.structured_warnings.iter().any(|w| matches!(w,
+                ImportDbtStructuredWarning::MicrobatchMapped { mapped_to, .. }
+                    if mapped_to == "time_interval")),
+            "must record the time_interval mapping"
+        );
+    }
+
+    #[test]
+    fn test_microbatch_default_mode_still_maps_to_merge() {
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": { "model.p.f": model_node("f",
+                serde_json::json!({ "materialized": "microbatch", "event_time": "ts", "batch_size": "day", "unique_key": "id" }),
+                serde_json::json!([])) },
+            "sources": {}
+        });
+        // Default mode is Merge — back-compat: no time_interval emitted.
+        let result = import_from_manifest_json(&manifest);
+        assert!(matches!(
+            result.imported[0].config.strategy,
+            StrategyConfig::Merge { .. }
+        ));
+        assert!(!result.imported[0].sql.contains("@start_date"));
+    }
+
+    #[test]
+    fn test_microbatch_as_time_interval_unsafe_event_time_falls_back_to_merge() {
+        // An event_time that isn't a plain identifier can't be safely
+        // interpolated; the importer must fall back to merge and warn that
+        // bounded-window semantics were not preserved.
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": { "model.p.f": model_node("f",
+                serde_json::json!({ "materialized": "microbatch", "event_time": "ts; DROP TABLE x", "batch_size": "day", "unique_key": "id" }),
+                serde_json::json!([])) },
+            "sources": {}
+        });
+        let result = import_from_manifest_json_with_mode(&manifest, MicrobatchMode::TimeInterval);
+        assert!(
+            matches!(
+                result.imported[0].config.strategy,
+                StrategyConfig::Merge { .. }
+            ),
+            "unsafe event_time must fall back to merge"
+        );
+        assert!(
+            result.warnings.iter().any(|w| w
+                .message
+                .contains("bounded-window semantics were not preserved")),
+            "must warn that the bounded-window mapping was skipped"
+        );
+    }
+
+    #[test]
+    fn test_microbatch_granularity_maps_batch_size() {
+        assert_eq!(
+            microbatch_granularity(Some("hour")),
+            rocky_ir::TimeGrain::Hour
+        );
+        assert_eq!(
+            microbatch_granularity(Some("day")),
+            rocky_ir::TimeGrain::Day
+        );
+        assert_eq!(
+            microbatch_granularity(Some("month")),
+            rocky_ir::TimeGrain::Month
+        );
+        assert_eq!(
+            microbatch_granularity(Some("year")),
+            rocky_ir::TimeGrain::Year
+        );
+        // Absent / unknown defaults to Day.
+        assert_eq!(microbatch_granularity(None), rocky_ir::TimeGrain::Day);
+        assert_eq!(
+            microbatch_granularity(Some("weird")),
+            rocky_ir::TimeGrain::Day
+        );
     }
 
     #[test]
@@ -3580,7 +3885,12 @@ FROM {{ ref('stg_events') }}
             table: String::new(),
         };
 
-        let result = import_from_manifest(&manifest, &target, /* skip_unit_tests */ true);
+        let result = import_from_manifest(
+            &manifest,
+            &target,
+            /* skip_unit_tests */ true,
+            MicrobatchMode::Merge,
+        );
 
         assert_eq!(result.unit_tests_found, 1);
         assert_eq!(result.unit_tests_converted, 0);

--- a/engine/crates/rocky-compiler/src/import/emit.rs
+++ b/engine/crates/rocky-compiler/src/import/emit.rs
@@ -350,10 +350,34 @@ fn render_model_sidecar(config: &ModelConfig) -> String {
             let keys: Vec<String> = partition_by.iter().map(|k| format!("\"{k}\"")).collect();
             out.push_str(&format!("partition_by = [{}]\n", keys.join(", ")));
         }
-        // TimeInterval + ContentAddressed don't arise from the dbt
-        // importer today; if we ever hit one, fall back to full_refresh
-        // (the user can hand-edit the sidecar).
-        _ => {
+        StrategyConfig::TimeInterval {
+            time_column,
+            granularity,
+            lookback,
+            batch_size,
+            first_partition,
+        } => {
+            out.push_str("type = \"time_interval\"\n");
+            out.push_str(&format!("time_column = \"{time_column}\"\n"));
+            let g = match granularity {
+                rocky_ir::TimeGrain::Hour => "hour",
+                rocky_ir::TimeGrain::Day => "day",
+                rocky_ir::TimeGrain::Month => "month",
+                rocky_ir::TimeGrain::Year => "year",
+            };
+            out.push_str(&format!("granularity = \"{g}\"\n"));
+            out.push_str(&format!("lookback = {lookback}\n"));
+            out.push_str(&format!("batch_size = {}\n", batch_size.get()));
+            if let Some(first) = first_partition {
+                out.push_str(&format!("first_partition = \"{first}\"\n"));
+            }
+        }
+        // ContentAddressed doesn't arise from the dbt importer today; if we
+        // ever hit one, fall back to full_refresh (the user can hand-edit the
+        // sidecar). Matched explicitly (not via `_`) so a newly added strategy
+        // forces a compile error here rather than silently degrading — the
+        // exact failure mode FR-036 fixed.
+        StrategyConfig::ContentAddressed { .. } => {
             out.push_str("type = \"full_refresh\"\n");
         }
     }
@@ -935,6 +959,74 @@ mod tests {
         assert!(toml_body.contains("[strategy]"));
         assert!(toml_body.contains("type = \"full_refresh\""));
         assert!(toml_body.contains("[target]"));
+    }
+
+    #[test]
+    fn time_interval_strategy_serializes_and_round_trips() {
+        use std::num::NonZeroU32;
+
+        let config = ModelConfig {
+            name: "fct_daily_orders".to_string(),
+            depends_on: vec![],
+            strategy: StrategyConfig::TimeInterval {
+                time_column: "order_date".to_string(),
+                granularity: rocky_ir::TimeGrain::Day,
+                lookback: 2,
+                batch_size: NonZeroU32::new(7).unwrap(),
+                first_partition: Some("2024-01-01".to_string()),
+            },
+            target: TargetConfig {
+                catalog: "warehouse".to_string(),
+                schema: "main".to_string(),
+                table: "fct_daily_orders".to_string(),
+            },
+            sources: vec![],
+            adapter: None,
+            intent: None,
+            freshness: None,
+            tests: vec![],
+            format: None,
+            format_options: None,
+            classification: Default::default(),
+            tags: Default::default(),
+            governance: Default::default(),
+            retention: None,
+            budget: None,
+            skip: None,
+            name_declared: String::new(),
+            target_table_declared: String::new(),
+        };
+
+        let sidecar = render_model_sidecar(&config);
+        // Emits the partition fields, not the stale `full_refresh` fallback.
+        assert!(sidecar.contains("type = \"time_interval\""));
+        assert!(sidecar.contains("time_column = \"order_date\""));
+        assert!(sidecar.contains("granularity = \"day\""));
+        assert!(sidecar.contains("lookback = 2"));
+        assert!(sidecar.contains("batch_size = 7"));
+        assert!(sidecar.contains("first_partition = \"2024-01-01\""));
+        assert!(!sidecar.contains("full_refresh"));
+
+        // Round-trips: the emitted sidecar parses back as a TimeInterval with
+        // the same fields, so `rocky run --partition <date>` substitutes
+        // @start_date / @end_date instead of failing on the dropped placeholders.
+        let parsed: ModelConfig = toml::from_str(&sidecar).unwrap();
+        match parsed.strategy {
+            StrategyConfig::TimeInterval {
+                ref time_column,
+                granularity,
+                lookback,
+                batch_size,
+                ref first_partition,
+            } => {
+                assert_eq!(time_column, "order_date");
+                assert_eq!(granularity, rocky_ir::TimeGrain::Day);
+                assert_eq!(lookback, 2);
+                assert_eq!(batch_size.get(), 7);
+                assert_eq!(first_partition.as_deref(), Some("2024-01-01"));
+            }
+            other => panic!("expected TimeInterval, got {other:?}"),
+        }
     }
 
     #[test]

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -1153,6 +1153,14 @@ enum Command {
         /// unit-test fixtures the Rocky sidecar can't represent.
         #[arg(long = "skip-unit-tests")]
         skip_unit_tests: bool,
+        /// How to translate dbt microbatch models. `merge` (default) keeps the
+        /// historical idempotent-merge mapping for back-compat. `time_interval`
+        /// emits a bounded per-partition `time_interval` model
+        /// (`@start_date`/`@end_date` window + lookback), falling back to merge
+        /// with a warning when the body can't be rewritten safely. Manifest
+        /// import only.
+        #[arg(long = "microbatch-as", default_value = "merge", value_parser = ["merge", "time_interval"])]
+        microbatch_as: String,
     },
 
     /// Interactive SQL shell against the configured warehouse
@@ -2904,6 +2912,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             target_adapter,
             overwrite,
             skip_unit_tests,
+            microbatch_as,
         } => rocky_cli::commands::run_import_dbt(
             &dbt_project,
             &output_dir,
@@ -2912,6 +2921,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             target_adapter.as_deref(),
             overwrite,
             skip_unit_tests,
+            &microbatch_as,
             json,
         ),
         Command::Shell { pipeline } => {


### PR DESCRIPTION
## Problem

`rocky import-dbt` mapped dbt `microbatch` models onto a `merge`/`incremental` strategy. That collapses microbatch's defining property — a bounded, per-partition window with configurable lookback — into a whole-table idempotent merge. The imported model loses the granularity, the per-batch `@start_date`/`@end_date` bounds, and the lookback that let the original run only ever touch a fixed slice of the table.

## Fix

Add an opt-in `--microbatch-as` flag to `rocky import-dbt`:

- `--microbatch-as=time_interval` maps dbt `microbatch` to Rocky's `time_interval` strategy, deriving granularity and lookback from the dbt `batch_size`/`lookback` config and rewriting the model body to bound each partition on the event-time column via injected `@start_date`/`@end_date` window predicates.
- `--microbatch-as=merge` (default) preserves the historical mapping for back-compat and emits a warning that the bounded-window semantics were not preserved.

When the body can't be rewritten safely, `time_interval` falls back to `merge` loudly (warning + structured warning) rather than emitting an unbounded model. Manifest-import only — the `--no-manifest` regex path keeps the default mapping since it lacks the compiled body needed to inject the window.

## Testing

Verified end-to-end through a real `rocky import-dbt` → `compile` → `run --partition` round-trip that materializes the bounded window. The round-trip relies on the SELECT-`*`-over-derived-table output-schema fix landed in #973, so the injected bounded subquery type-checks during compile.
