### PR TITLE
feat(engine/rocky-cli): per-run variables (rocky run --var) into model SQL

### DIFF
--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -250,6 +250,9 @@ async fn execute_run_plan(
         // The skip gate is a runtime-only `rocky run` overlay, not persisted
         // on the plan; the two-step path builds every planned model.
         &crate::commands::run::SkipRunOptions::default(),
+        // Per-run `--var` values are not persisted on the plan; an
+        // `@var()` model would compile-error on a two-step apply.
+        &rocky_core::run_vars::RunVars::new(),
     )
     .await
     .with_context(|| format!("rocky apply run plan '{plan_id}' failed"))?;
@@ -465,6 +468,8 @@ async fn run_apply_replication_plan(
         &crate::commands::run::DeferOptions::default(),
         // The skip gate only applies to transformation models; inert here.
         &crate::commands::run::SkipRunOptions::default(),
+        // Replication apply runs no transformation models; vars are inert.
+        &rocky_core::run_vars::RunVars::new(),
     )
     .await
     .with_context(|| format!("rocky apply replication plan '{plan_id}' failed"))?;
@@ -834,6 +839,7 @@ pub async fn run_apply_inline_for_run(
     env: Option<&str>,
     defer_opts: &crate::commands::run::DeferOptions,
     skip_opts: &crate::commands::run::SkipRunOptions,
+    run_vars: &rocky_core::run_vars::RunVars,
 ) -> Result<()> {
     // Thin passthrough — routes to the existing run implementation.
     crate::commands::run::run(
@@ -855,6 +861,7 @@ pub async fn run_apply_inline_for_run(
         env,
         defer_opts,
         skip_opts,
+        run_vars,
     )
     .await
 }

--- a/engine/crates/rocky-cli/src/commands/compile.rs
+++ b/engine/crates/rocky-cli/src/commands/compile.rs
@@ -36,6 +36,7 @@ pub fn run_compile(
     target_dialect: Option<Dialect>,
     with_seed: bool,
     cache_ttl_override: Option<u64>,
+    run_vars: &rocky_core::run_vars::RunVars,
 ) -> Result<()> {
     let (output, text_data) = compile_inner(
         config_path,
@@ -47,6 +48,7 @@ pub fn run_compile(
         target_dialect,
         with_seed,
         cache_ttl_override,
+        run_vars,
     )?;
 
     if output_json {
@@ -81,6 +83,7 @@ fn compile_inner(
     target_dialect: Option<Dialect>,
     with_seed: bool,
     cache_ttl_override: Option<u64>,
+    run_vars: &rocky_core::run_vars::RunVars,
 ) -> Result<(CompileOutput, CompileTextData)> {
     // `source_schemas` precedence:
     //   1. `--with-seed` wins -> seed loader (explicit user intent,
@@ -137,6 +140,7 @@ fn compile_inner(
         mask,
         allow_unmasked,
         project_freshness_default,
+        run_vars: run_vars.clone(),
     };
 
     let mut result = compile::compile(&config)?;
@@ -394,6 +398,9 @@ pub fn compile_output(
         target_dialect,
         with_seed,
         cache_ttl_override,
+        // `compile_output` backs commands that don't expose `--var`
+        // (ci / dag); an `@var()` model would surface an E028 diagnostic.
+        &rocky_core::run_vars::RunVars::new(),
     )?;
     Ok(output)
 }
@@ -667,6 +674,7 @@ schema_template = "s"
             Some(Dialect::BigQuery),
             false,
             None,
+            &rocky_core::run_vars::RunVars::new(),
         )
         .unwrap_err();
         assert!(
@@ -694,6 +702,7 @@ schema_template = "s"
             None,
             false,
             None,
+            &rocky_core::run_vars::RunVars::new(),
         )
         .expect("compile should succeed without lint");
     }
@@ -717,6 +726,7 @@ schema_template = "s"
             Some(Dialect::Snowflake),
             false,
             None,
+            &rocky_core::run_vars::RunVars::new(),
         )
         .expect("snowflake target should accept NVL");
     }
@@ -742,6 +752,7 @@ schema_template = "s"
             None,
             false,
             None,
+            &rocky_core::run_vars::RunVars::new(),
         )
         .unwrap_err();
         assert!(
@@ -774,6 +785,7 @@ schema_template = "s"
             Some(Dialect::BigQuery),
             false,
             None,
+            &rocky_core::run_vars::RunVars::new(),
         )
         .unwrap_err();
         assert!(err.to_string().contains("compilation failed"));
@@ -802,6 +814,7 @@ schema_template = "s"
             None,
             false,
             None,
+            &rocky_core::run_vars::RunVars::new(),
         )
         .expect("allow-listed NVL should not trip the lint");
     }
@@ -830,6 +843,7 @@ schema_template = "s"
             None,
             false,
             None,
+            &rocky_core::run_vars::RunVars::new(),
         )
         .expect("pragma-exempted model should not trip the lint");
     }
@@ -859,6 +873,7 @@ schema_template = "s"
             None,
             false,
             None,
+            &rocky_core::run_vars::RunVars::new(),
         )
         .unwrap_err();
         assert!(
@@ -888,6 +903,7 @@ schema_template = "s"
             None,
             false,
             None,
+            &rocky_core::run_vars::RunVars::new(),
         )
         .expect("missing config should fall through, not error");
     }
@@ -937,6 +953,7 @@ schema_template = "s"
             None,
             true,
             None,
+            &rocky_core::run_vars::RunVars::new(),
         )
         .expect("with-seed compile should succeed");
     }
@@ -961,6 +978,7 @@ schema_template = "s"
             None,
             true,
             None,
+            &rocky_core::run_vars::RunVars::new(),
         )
         .unwrap_err();
         let msg = err.to_string();
@@ -988,6 +1006,7 @@ schema_template = "s"
             None,
             true,
             None,
+            &rocky_core::run_vars::RunVars::new(),
         )
         .unwrap_err();
         assert!(
@@ -1093,6 +1112,7 @@ schema_template = "s"
             None,
             false,
             None,
+            &rocky_core::run_vars::RunVars::new(),
         )
         .expect("compile with cache-backed source_schemas should succeed");
     }
@@ -1203,6 +1223,7 @@ schema_template = "s"
             None,
             false,
             None,
+            &rocky_core::run_vars::RunVars::new(),
         )
         .unwrap_err();
         assert!(
@@ -1231,6 +1252,7 @@ schema_template = "s"
             None,
             false,
             None,
+            &rocky_core::run_vars::RunVars::new(),
         )
         .expect("model without budget should compile cleanly");
     }
@@ -1262,6 +1284,7 @@ schema_template = "s"
             None,
             false,
             None,
+            &rocky_core::run_vars::RunVars::new(),
         )
         .unwrap_err();
         assert!(
@@ -1290,6 +1313,7 @@ schema_template = "s"
             None,
             false,
             None,
+            &rocky_core::run_vars::RunVars::new(),
         )
         .expect("generous budget should not trigger E027");
     }
@@ -1318,6 +1342,7 @@ schema_template = "s"
             None,
             false,
             None,
+            &rocky_core::run_vars::RunVars::new(),
         )
         .expect("compile without state file should succeed");
         assert!(

--- a/engine/crates/rocky-cli/src/commands/emit_sql.rs
+++ b/engine/crates/rocky-cli/src/commands/emit_sql.rs
@@ -98,6 +98,7 @@ fn emit_models(
     config_path: Option<&Path>,
     models_dir: &Path,
     model_filter: Option<&str>,
+    run_vars: &rocky_core::run_vars::RunVars,
 ) -> Result<EmitResult> {
     use rocky_compiler::compile::{self, CompilerConfig};
 
@@ -111,6 +112,7 @@ fn emit_models(
         mask: std::collections::BTreeMap::new(),
         allow_unmasked: vec![],
         project_freshness_default: false,
+        run_vars: run_vars.clone(),
     };
     let result = match compile::compile(&config) {
         Ok(r) => r,
@@ -242,11 +244,12 @@ pub fn run_emit_sql(
     models_dir: &Path,
     model_filter: Option<&str>,
     out_dir: Option<&Path>,
+    run_vars: &rocky_core::run_vars::RunVars,
 ) -> Result<()> {
     let EmitResult {
         models,
         mut skipped,
-    } = emit_models(config_path, models_dir, model_filter)?;
+    } = emit_models(config_path, models_dir, model_filter, run_vars)?;
 
     if models.is_empty() {
         println!("emit-sql: no transformation SQL to emit.");
@@ -343,7 +346,14 @@ mod tests {
         write_model(dir.path(), "m", "SELECT 1 AS id", "");
 
         // No config → DuckDB dialect.
-        let emitted = emit_models(None, dir.path(), None).unwrap().models;
+        let emitted = emit_models(
+            None,
+            dir.path(),
+            None,
+            &rocky_core::run_vars::RunVars::new(),
+        )
+        .unwrap()
+        .models;
         assert_eq!(emitted.len(), 1);
         assert_eq!(emitted[0].name, "m");
         assert!(!emitted[0].assumes_existing_target);
@@ -363,7 +373,14 @@ mod tests {
             "\n[[surrogate_key]]\nname = \"order_key\"\ncolumns = [\"order_id\"]\n",
         );
 
-        let emitted = emit_models(None, dir.path(), None).unwrap().models;
+        let emitted = emit_models(
+            None,
+            dir.path(),
+            None,
+            &rocky_core::run_vars::RunVars::new(),
+        )
+        .unwrap()
+        .models;
         assert_eq!(emitted.len(), 1);
         // The emitted SQL wraps the SELECT with the dbt-form hash column, exactly
         // as the materialization path does.
@@ -383,7 +400,14 @@ mod tests {
         write_model(dir.path(), "downstream", "SELECT id FROM upstream", "");
         write_model(dir.path(), "upstream", "SELECT 1 AS id", "");
 
-        let emitted = emit_models(None, dir.path(), None).unwrap().models;
+        let emitted = emit_models(
+            None,
+            dir.path(),
+            None,
+            &rocky_core::run_vars::RunVars::new(),
+        )
+        .unwrap()
+        .models;
         let names: Vec<&str> = emitted.iter().map(|m| m.name.as_str()).collect();
         let up = names.iter().position(|n| *n == "upstream").unwrap();
         let down = names.iter().position(|n| *n == "downstream").unwrap();
@@ -396,7 +420,14 @@ mod tests {
         write_model(dir.path(), "a", "SELECT 1 AS id", "");
         write_model(dir.path(), "b", "SELECT 2 AS id", "");
 
-        let emitted = emit_models(None, dir.path(), Some("b")).unwrap().models;
+        let emitted = emit_models(
+            None,
+            dir.path(),
+            Some("b"),
+            &rocky_core::run_vars::RunVars::new(),
+        )
+        .unwrap()
+        .models;
         assert_eq!(emitted.len(), 1);
         assert_eq!(emitted[0].name, "b");
     }
@@ -411,7 +442,14 @@ mod tests {
         )
         .unwrap();
 
-        let emitted = emit_models(None, dir.path(), None).unwrap().models;
+        let emitted = emit_models(
+            None,
+            dir.path(),
+            None,
+            &rocky_core::run_vars::RunVars::new(),
+        )
+        .unwrap()
+        .models;
         assert_eq!(emitted.len(), 1);
         // A merge emits a statement operating on an existing target, so it is
         // flagged and the written file carries the bootstrap/watermark caveat.
@@ -435,7 +473,14 @@ mod tests {
         write_model(&models, "m", "SELECT 'ok' AS status", "");
 
         let out = dir.path().join("sql");
-        run_emit_sql(None, &models, None, Some(&out)).unwrap();
+        run_emit_sql(
+            None,
+            &models,
+            None,
+            Some(&out),
+            &rocky_core::run_vars::RunVars::new(),
+        )
+        .unwrap();
         let emitted = std::fs::read_to_string(out.join("m.sql")).unwrap();
 
         // Execute the emitted SQL against a fresh DuckDB — no `rocky run`.

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -599,6 +599,7 @@ pub fn plan_preview_output(
         mask: std::collections::BTreeMap::new(),
         allow_unmasked: vec![],
         project_freshness_default: false,
+        run_vars: rocky_core::run_vars::RunVars::new(),
     };
     let result = match compile::compile(&config) {
         Ok(r) => r,
@@ -712,6 +713,7 @@ fn build_and_persist_run_plan(
         mask: std::collections::BTreeMap::new(),
         allow_unmasked: vec![],
         project_freshness_default: false,
+        run_vars: rocky_core::run_vars::RunVars::new(),
     };
 
     let result = compile::compile(&config).context("failed to compile models for run plan")?;
@@ -885,6 +887,7 @@ pub fn populate_governance_actions(
         mask: cfg.mask.clone(),
         allow_unmasked: cfg.classifications.allow_unmasked.clone(),
         project_freshness_default: cfg.freshness.has_default(),
+        run_vars: rocky_core::run_vars::RunVars::new(),
     })
     .context("failed to compile project for governance preview")?;
 
@@ -986,6 +989,7 @@ async fn check_plan_budget(
         mask: std::collections::BTreeMap::new(),
         allow_unmasked: vec![],
         project_freshness_default: false,
+        run_vars: rocky_core::run_vars::RunVars::new(),
     };
     let result = match rocky_compiler::compile::compile(&compile_cfg) {
         Ok(r) => r,

--- a/engine/crates/rocky-cli/src/commands/preview_rows.rs
+++ b/engine/crates/rocky-cli/src/commands/preview_rows.rs
@@ -130,6 +130,7 @@ pub async fn run_preview_rows(
         mask: rocky_cfg.mask.clone(),
         allow_unmasked: rocky_cfg.classifications.allow_unmasked.clone(),
         project_freshness_default: rocky_cfg.freshness.has_default(),
+        run_vars: rocky_core::run_vars::RunVars::new(),
     };
     let result = compile::compile(&compiler_cfg).map_err(|e| {
         err(

--- a/engine/crates/rocky-cli/src/commands/publish_ir.rs
+++ b/engine/crates/rocky-cli/src/commands/publish_ir.rs
@@ -85,6 +85,7 @@ pub fn run_publish_ir(
         mask: std::collections::BTreeMap::new(),
         allow_unmasked: Vec::new(),
         project_freshness_default: false,
+        run_vars: rocky_core::run_vars::RunVars::new(),
     };
 
     let result = compile::compile(&config)?;

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1034,6 +1034,10 @@ pub async fn run(
     // `--skip-unchanged` / `--force-rebuild` CLI overlay for the opt-in
     // model-skip gate. Default OFF (both `false`) ⇒ byte-identical behavior.
     skip_opts: &SkipRunOptions,
+    // `--var name=value` per-run variables. Substituted into `@var(name)`
+    // placeholders in model SQL at compile time. Empty ⇒ no `@var()` model
+    // resolves and behavior is byte-identical.
+    run_vars: &rocky_core::run_vars::RunVars,
 ) -> Result<()> {
     let start = Instant::now();
     let started_at = Utc::now();
@@ -1216,6 +1220,7 @@ pub async fn run(
             // suppresses the whole reuse path for this invocation — both the
             // point-to decision and the spine population it would feed.
             rocky_cfg.reuse.enabled && !skip_opts.no_reuse,
+            run_vars,
         )
         .await?;
 
@@ -1341,6 +1346,10 @@ pub async fn run(
                 // claimed key, matching the model-only / replication paths.
                 // The claim is finalized under this same value just below.
                 idempotency_key,
+                // `--var` per-run variables, so `@var()` markers in the
+                // transformation pipeline's models resolve to the supplied
+                // values (or inline defaults) at compile time.
+                run_vars,
             )
             .await?;
             finalize_idempotency_on_success(&mut idempotency_ctx, state_path, &run_id).await;
@@ -3611,6 +3620,7 @@ pub async fn run(
                     // Reuse is active iff `[reuse]` is enabled AND `--no-reuse`
                     // was not passed (clause 1 of the fail-closed decision).
                     rocky_cfg.reuse.enabled && !skip_opts.no_reuse,
+                    run_vars,
                 )
                 .await?;
                 Ok(())
@@ -3652,6 +3662,12 @@ pub async fn run(
                     mask: rocky_cfg.mask.clone(),
                     allow_unmasked: rocky_cfg.classifications.allow_unmasked.clone(),
                     project_freshness_default: rocky_cfg.freshness.has_default(),
+                    // Resolve `@var()` on the governance compile too, so this
+                    // second compile of the same models doesn't re-read raw
+                    // `@var()` tokens from disk and spuriously report every
+                    // variable as missing (or leave placeholders in the SQL
+                    // the masking/tag reconcile inspects).
+                    run_vars: run_vars.clone(),
                 },
             );
             if let Ok(gov_compile) = governance_compile {
@@ -4464,6 +4480,12 @@ pub(crate) async fn execute_models(
     // populated AND an eligible model whose inputs match a prior strong run
     // points-to that run's parquet instead of executing its SQL.
     reuse_enabled: bool,
+    // Per-run variables (`rocky run --var name=value`). Threaded into the
+    // compile config so `@var(name)` placeholders in model SQL resolve to the
+    // supplied value (or inline default) before typecheck and SQL generation.
+    // Empty for the call sites that don't expose `--var` (watch / dag / local
+    // / tests).
+    run_vars: &rocky_core::run_vars::RunVars,
 ) -> Result<()> {
     info!(models_dir = %models_dir.display(), "compiling and executing transformation models");
 
@@ -4495,6 +4517,7 @@ pub(crate) async fn execute_models(
         // this function (it already holds the loaded `RockyConfig`).
         // This pre-execution compile stays scoped to typecheck +
         // contract diagnostics to avoid broadening its signature.
+        run_vars: run_vars.clone(),
         ..Default::default()
     };
 
@@ -8065,6 +8088,7 @@ adapter = "default"
             None,
             &DeferOptions::default(),
             &SkipRunOptions::default(),
+            &rocky_core::run_vars::RunVars::new(),
         )
         .await
         .expect("transformation run should succeed");
@@ -8171,6 +8195,7 @@ schema = "mart"
             None,
             &DeferOptions::default(),
             &SkipRunOptions::default(),
+            &rocky_core::run_vars::RunVars::new(),
         )
         .await
         .expect(
@@ -9484,9 +9509,94 @@ merge_keys = ["id"]
             &DeferOptions::default(),
             super::SkipGateConfig::off(),
             false,
+            &rocky_core::run_vars::RunVars::new(),
         )
         .await;
         (output, result)
+    }
+
+    /// End-to-end run-path coverage for `--var`: a model whose SQL references
+    /// `@var(region)` materializes only the rows matching the supplied value
+    /// when a non-empty `RunVars` is threaded through `execute_models`.
+    ///
+    /// This guards the run-path threading specifically — the compiler-level
+    /// substitution is covered separately in `rocky-compiler`, but only an
+    /// execution test catches a regression where `execute_models` is handed an
+    /// empty `RunVars` (which would turn `@var()` into an E028 compile error
+    /// and silently skip the model).
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn run_var_substituted_and_materialized() {
+        use rocky_core::traits::WarehouseAdapter;
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        let db_path = tmp.path().join("var.duckdb");
+
+        // Seed a source table with mixed regions.
+        {
+            let seed = DuckDbWarehouseAdapter::open(&db_path).expect("open duckdb for seeding");
+            seed.execute_statement(
+                "CREATE TABLE main.base AS SELECT * FROM (VALUES \
+                 (1, 'us'), (2, 'eu'), (3, 'us'), (4, 'apac')) AS t(id, region)",
+            )
+            .await
+            .unwrap();
+        }
+
+        // Model filters on `@var(region)`.
+        std::fs::write(
+            models_dir.join("filtered.sql"),
+            "SELECT id, region FROM main.base WHERE region = '@var(region)'\n",
+        )
+        .unwrap();
+        std::fs::write(
+            models_dir.join("filtered.toml"),
+            "[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"\"\nschema = \"main\"\n",
+        )
+        .unwrap();
+
+        let adapter = DuckDbWarehouseAdapter::open(&db_path).expect("open duckdb");
+        let opts = PartitionRunOptions::default();
+        let mut output = RunOutput::new(String::new(), 0, 1);
+        let run_vars = rocky_core::run_vars::RunVars::parse_pairs(["region=us"]).unwrap();
+        super::execute_models(
+            &models_dir,
+            &adapter as &dyn rocky_core::traits::WarehouseAdapter,
+            None,
+            &opts,
+            "test-run",
+            None,
+            &mut output,
+            None,
+            None,
+            &rocky_core::config::SchemaCacheConfig::default(),
+            false,
+            &DeferOptions::default(),
+            super::SkipGateConfig::off(),
+            false,
+            &run_vars,
+        )
+        .await
+        .expect("run with --var should succeed");
+
+        // The target table holds only the `us` rows (ids 1 and 3).
+        let conn = rocky_duckdb::DuckDbConnector::open(&db_path).expect("open db");
+        let r = conn
+            .execute_sql("SELECT id FROM main.filtered ORDER BY id")
+            .expect("query filtered");
+        let ids: Vec<&str> = r
+            .rows
+            .iter()
+            .map(|row| row[0].as_str().unwrap_or_default())
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["1", "3"],
+            "only region='us' rows survive the @var filter"
+        );
     }
 
     /// `rocky run --model down --defer`: the selected model `down` reads its
@@ -9568,6 +9678,7 @@ merge_keys = ["id"]
             &defer_opts,
             super::SkipGateConfig::off(),
             false,
+            &rocky_core::run_vars::RunVars::new(),
         )
         .await
         .expect("deferred run must succeed");
@@ -9683,6 +9794,7 @@ merge_keys = ["id"]
             &DeferOptions::default(),
             super::SkipGateConfig::off(),
             false,
+            &rocky_core::run_vars::RunVars::new(),
         )
         .await;
 
@@ -9919,6 +10031,7 @@ merge_keys = ["id"]
             &DeferOptions::default(),
             gate,
             false,
+            &rocky_core::run_vars::RunVars::new(),
         )
         .await
         .expect("gate run must succeed");
@@ -10878,6 +10991,7 @@ merge_keys = ["id"]
                 &DeferOptions::default(),
                 active_gate(true, 0),
                 false,
+                &rocky_core::run_vars::RunVars::new(),
             )
             .await
             .unwrap();

--- a/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
+++ b/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
@@ -212,6 +212,10 @@ impl NodeDispatcher for CliDispatcher {
                     // (full-pipeline sub-runs); default OFF keeps sub-run
                     // behavior unchanged.
                     &super::run::SkipRunOptions::default(),
+                    // The unified-DAG driver does not surface `--var`; pass an
+                    // empty set so `@var()` models would compile-error rather
+                    // than silently resolve under a DAG run.
+                    &rocky_core::run_vars::RunVars::new(),
                 )
                 .await
                 .map_err(|e| e.to_string())

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -64,6 +64,10 @@ pub async fn run_transformation(
     // idempotency entry under `K`, so `rocky history --audit` shows
     // `idempotency_key=-` instead of `K`.
     idempotency_key: Option<&str>,
+    // `--var` per-run variables threaded from `run()`. Substituted into
+    // `@var()` markers in this pipeline's model SQL at compile time (both the
+    // execution compile and the governance reconcile compile below).
+    run_vars: &rocky_core::run_vars::RunVars,
 ) -> Result<()> {
     let start = Instant::now();
 
@@ -115,6 +119,7 @@ pub async fn run_transformation(
             &super::run::DeferOptions::default(),
             skip_gate,
             rocky_cfg.reuse.enabled,
+            run_vars,
         )
         .await?;
 
@@ -145,6 +150,10 @@ pub async fn run_transformation(
                 mask: rocky_cfg.mask.clone(),
                 allow_unmasked: rocky_cfg.classifications.allow_unmasked.clone(),
                 project_freshness_default: rocky_cfg.freshness.has_default(),
+                // Resolve `@var()` on the governance reconcile compile too,
+                // so it doesn't re-read raw markers and spuriously report
+                // every variable as missing.
+                run_vars: run_vars.clone(),
             });
         match governance_compile {
             Ok(gov_compile) => {
@@ -998,6 +1007,7 @@ mod tests {
             None, // env
             &DeferOptions::default(),
             &skip_opts,
+            &rocky_core::run_vars::RunVars::new(),
         )
         .await
         .expect("full-DAG transformation run should succeed");
@@ -1182,6 +1192,7 @@ auto_create_schemas = true
             None,      // env
             &DeferOptions::default(),
             &SkipRunOptions::default(),
+            &rocky_core::run_vars::RunVars::new(),
         )
         .await
         .expect("full-DAG transformation run with idempotency key should succeed");

--- a/engine/crates/rocky-cli/src/commands/run_watch.rs
+++ b/engine/crates/rocky-cli/src/commands/run_watch.rs
@@ -286,6 +286,8 @@ async fn iter_once(
         // selection to defer against.
         &super::run::DeferOptions::default(),
         skip_opts,
+        // `--watch` does not expose `--var` today; pass an empty set.
+        &rocky_core::run_vars::RunVars::new(),
     )
     .await;
     let elapsed_ms = started.elapsed().as_millis();

--- a/engine/crates/rocky-cli/src/commands/watch.rs
+++ b/engine/crates/rocky-cli/src/commands/watch.rs
@@ -141,6 +141,8 @@ fn print_compile_result(
         // freshness in a watch session should set `[cache.schemas]
         // ttl_seconds` in `rocky.toml` instead.
         None,
+        // `rocky compile --watch` does not expose `--var`.
+        &rocky_core::run_vars::RunVars::new(),
     ) {
         Ok(()) => {
             if !output_json {

--- a/engine/crates/rocky-compiler/src/compile.rs
+++ b/engine/crates/rocky-compiler/src/compile.rs
@@ -85,6 +85,14 @@ pub struct CompilerConfig {
     /// keep the default (`false`) and continue to see W005 per
     /// uncovered model.
     pub project_freshness_default: bool,
+    /// Per-run variables (`rocky run --var name=value`) substituted into each
+    /// model's SQL **before** the semantic graph and typecheck run, so the
+    /// resolved SQL flows uniformly into `rocky run`, `rocky compile`, and
+    /// `rocky emit-sql`. Empty by default; a model that references
+    /// `@var(name)` with no supplied value and no inline default yields an
+    /// E028 error diagnostic naming the variable. Distinct from `${ENV}`
+    /// config-time interpolation, which resolves while parsing `rocky.toml`.
+    pub run_vars: rocky_core::run_vars::RunVars,
 }
 
 /// Result of compilation.
@@ -186,10 +194,39 @@ pub fn compile_with_db(
 
 /// Compile a pre-loaded project (useful when models come from other sources).
 pub fn compile_project(
-    project: Project,
+    mut project: Project,
     config: &CompilerConfig,
 ) -> Result<CompileResult, CompileError> {
     let mut timings = PhaseTimings::default();
+
+    // 1b. Substitute per-run variables (`@var(name)` / `@var(name, default)`)
+    //     into each model's SQL before any SQL parsing happens, so the
+    //     resolved text flows uniformly through the semantic graph, typecheck,
+    //     and downstream SQL generation. A reference with no supplied value and
+    //     no inline default is recorded and turned into an E028 error
+    //     diagnostic naming the variable. This pass is a no-op (and allocates
+    //     nothing extra beyond the per-model scan) when no model uses `@var()`.
+    let mut run_var_diagnostics: Vec<Diagnostic> = Vec::new();
+    for model in &mut project.models {
+        let substitution = rocky_core::run_vars::substitute_run_vars(&model.sql, &config.run_vars);
+        for missing in substitution.missing {
+            run_var_diagnostics.push(
+                Diagnostic::error(
+                    super::diagnostic::E028,
+                    &model.config.name,
+                    format!(
+                        "model references run variable `@var({missing})` but no value was \
+                         supplied and it has no inline default"
+                    ),
+                )
+                .with_suggestion(format!(
+                    "pass `--var {missing}=<value>` or give the reference an inline default \
+                     `@var({missing}, <default>)`"
+                )),
+            );
+        }
+        model.sql = substitution.sql;
+    }
 
     // 2. Build semantic graph
     let sg_start = Instant::now();
@@ -284,6 +321,7 @@ pub fn compile_project(
     diagnostics.extend(blast_radius_diagnostics);
     diagnostics.extend(classification_diagnostics);
     diagnostics.extend(freshness_diagnostics);
+    diagnostics.extend(run_var_diagnostics);
 
     let has_errors = diagnostics
         .iter()

--- a/engine/crates/rocky-compiler/src/diagnostic.rs
+++ b/engine/crates/rocky-compiler/src/diagnostic.rs
@@ -55,6 +55,14 @@ pub const E026: &str = "E026";
 /// [`rocky_core::cost::propagate_costs`] using catalog-sourced table stats
 /// when available, falling back to conservative stub statistics.
 pub const E027: &str = "E027";
+/// Required run variable (`@var(name)`) referenced but not supplied.
+///
+/// Emitted by `rocky compile` / `rocky run` / `rocky emit-sql` when a model's
+/// SQL references `@var(name)` with no `--var name=value` supplied and no
+/// inline `@var(name, default)`. The fix is to pass `--var name=value` or to
+/// give the reference an inline default. Distinct from the config-time
+/// `${ENV}` interpolation, which resolves while parsing `rocky.toml`.
+pub const E028: &str = "E028";
 
 // Errors — imported producer contracts
 /// Consumer references a column that an imported producer snapshot dropped.

--- a/engine/crates/rocky-compiler/src/import/dbt.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt.rs
@@ -116,6 +116,10 @@ pub enum WarningCategory {
     /// column `constraints` were dropped on import. Rocky enforces contracts
     /// via a `{model}.contract.toml` sidecar the importer doesn't generate.
     DroppedContract,
+    /// A dbt construct was mapped to a native Rocky equivalent rather than
+    /// dropped — informational, not a degradation. Today this covers
+    /// `{{ var('x') }}` → `@var(x)` (Rocky's per-run variable marker).
+    MappedConstruct,
 }
 
 /// A warning produced during import.
@@ -1761,13 +1765,21 @@ fn import_single_model(
             });
         }
     }
+    // `{{ var('x') }}` is now mapped to Rocky's native per-run variable marker
+    // `@var(x)` (with `{{ var('x', 'd') }}` -> `@var(x, d)`) during
+    // `convert_jinja_to_sql`, so it is no longer an unsupported macro. Emit an
+    // informational note so the operator knows to supply the value at run time
+    // via `rocky run --var x=value` (or rely on the inline default).
     if content_processed.contains("{{ var(") {
         warnings.push(ImportWarning {
             model: name.to_string(),
-            category: WarningCategory::UnsupportedMacro,
-            message: "contains {{ var() }} — not supported, replaced with TODO".to_string(),
+            category: WarningCategory::MappedConstruct,
+            message: "contains {{ var() }} — mapped to Rocky's `@var()` per-run variable marker"
+                .to_string(),
             suggestion: Some(
-                "replace with a literal value or use manifest.json import path".to_string(),
+                "supply values at run time with `rocky run --var name=value`, or rely on an \
+                 inline default `@var(name, default)`"
+                    .to_string(),
             ),
         });
     }
@@ -2120,6 +2132,21 @@ fn single_string_value(config_str: &str, key: &str) -> Option<String> {
 // ---------------------------------------------------------------------------
 
 /// Convert dbt Jinja expressions to plain SQL.
+/// Strip a single pair of matching surrounding quotes (`'...'` or `"..."`)
+/// from `s`. Used to normalize a dbt `var('x', 'default')` literal default
+/// into the bare text Rocky's `@var(x, default)` expects.
+fn strip_surrounding_quotes(s: &str) -> &str {
+    let bytes = s.as_bytes();
+    if bytes.len() >= 2
+        && (bytes[0] == b'\'' || bytes[0] == b'"')
+        && bytes[bytes.len() - 1] == bytes[0]
+    {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    }
+}
+
 fn convert_jinja_to_sql(content: &str, this_ref: &str) -> String {
     let mut sql = content.to_string();
 
@@ -2136,6 +2163,27 @@ fn convert_jinja_to_sql(content: &str, this_ref: &str) -> String {
         Regex::new(r#"\{\{\s*source\s*\(\s*['"](\w+)['"]\s*,\s*['"](\w+)['"]\s*\)\s*\}\}"#)
             .unwrap();
     sql = source_re.replace_all(&sql, "$1.$2").to_string();
+
+    // {{ var('x') }} -> @var(x) and {{ var('x', 'd') }} -> @var(x, d).
+    // Rocky's per-run variables (`rocky run --var x=value`) are the native
+    // home for dbt vars: the marker stays parse-visible and is resolved at
+    // compile/render time. The default is emitted verbatim minus any
+    // surrounding quotes so a string default `'d'` and a bare default `42`
+    // both round-trip to `@var(x, d)` / `@var(x, 42)`.
+    let var_re =
+        Regex::new(r#"\{\{\s*var\s*\(\s*['"](\w+)['"]\s*(?:,\s*([^)]*?))?\s*\)\s*\}\}"#).unwrap();
+    sql = var_re
+        .replace_all(&sql, |caps: &regex::Captures<'_>| {
+            let name = &caps[1];
+            match caps.get(2) {
+                Some(default) => {
+                    let default = strip_surrounding_quotes(default.as_str().trim());
+                    format!("@var({name}, {default})")
+                }
+                None => format!("@var({name})"),
+            }
+        })
+        .to_string();
 
     // {{ this }} -> the model's own fully-qualified name. Substituting a real
     // catalog.schema.table (NoExpand so dots/`$` are literal) avoids emitting a
@@ -2198,6 +2246,37 @@ mod tests {
         assert_eq!(
             convert_jinja_to_sql(input, "cat.sch.tbl"),
             "SELECT * FROM orders"
+        );
+    }
+
+    #[test]
+    fn test_convert_var_no_default() {
+        // `{{ var('drop_date') }}` maps to Rocky's `@var(drop_date)` marker —
+        // NOT a TODO / unsupported-macro placeholder.
+        let input = "SELECT * FROM t WHERE d = '{{ var('drop_date') }}'";
+        let out = convert_jinja_to_sql(input, "cat.sch.tbl");
+        assert_eq!(out, "SELECT * FROM t WHERE d = '@var(drop_date)'");
+        assert!(!out.contains("TODO"));
+    }
+
+    #[test]
+    fn test_convert_var_with_string_default() {
+        // `{{ var('x', 'd') }}` maps to `@var(x, d)` — surrounding quotes on
+        // the literal default are stripped.
+        let input = "SELECT {{ var('region', 'us') }} AS r";
+        assert_eq!(
+            convert_jinja_to_sql(input, "cat.sch.tbl"),
+            "SELECT @var(region, us) AS r"
+        );
+    }
+
+    #[test]
+    fn test_convert_var_with_bare_default() {
+        // A non-string default (e.g. a number) round-trips verbatim.
+        let input = "SELECT {{ var('threshold', 100) }} AS t";
+        assert_eq!(
+            convert_jinja_to_sql(input, "cat.sch.tbl"),
+            "SELECT @var(threshold, 100) AS t"
         );
     }
 

--- a/engine/crates/rocky-compiler/tests/integration.rs
+++ b/engine/crates/rocky-compiler/tests/integration.rs
@@ -602,3 +602,89 @@ fn salsa_compile_with_db_invalidates_only_changed_file() {
          unrelated file is edited (per-file invalidation receipt)",
     );
 }
+
+// ---- Per-run variables (`@var()` substitution at compile time) ----
+
+/// Write a single `.sql` model (plus a minimal `.toml` sidecar) into a fresh
+/// temp models dir and return the dir handle so it stays alive for the test.
+fn temp_model_project(sql: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let models = dir.path().join("models");
+    std::fs::create_dir_all(&models).unwrap();
+    std::fs::write(models.join("m.sql"), sql).unwrap();
+    std::fs::write(
+        models.join("m.toml"),
+        "name = \"m\"\n\n[target]\ncatalog = \"cat\"\nschema = \"sch\"\ntable = \"m\"\n",
+    )
+    .unwrap();
+    dir
+}
+
+#[test]
+fn run_var_substituted_into_model_sql_at_compile_time() {
+    let dir = temp_model_project("SELECT * FROM raw.base WHERE region = '@var(region)'");
+    let config = CompilerConfig {
+        models_dir: dir.path().join("models"),
+        run_vars: rocky_core::run_vars::RunVars::parse_pairs(["region=us"]).unwrap(),
+        ..Default::default()
+    };
+
+    let result = compile(&config).unwrap();
+
+    let model = result.project.model("m").unwrap();
+    assert_eq!(
+        model.sql, "SELECT * FROM raw.base WHERE region = 'us'",
+        "the @var(region) marker must resolve to the supplied value"
+    );
+    assert!(
+        !result.diagnostics.iter().any(|d| &*d.code == "E028"),
+        "no missing-var diagnostic when the value is supplied"
+    );
+}
+
+#[test]
+fn missing_required_run_var_is_a_named_compile_error() {
+    let dir = temp_model_project("SELECT * FROM raw.base WHERE region = '@var(region)'");
+    let config = CompilerConfig {
+        models_dir: dir.path().join("models"),
+        // No `region` supplied and no inline default.
+        ..Default::default()
+    };
+
+    let result = compile(&config).unwrap();
+
+    assert!(
+        result.has_errors,
+        "a missing required var must fail compile"
+    );
+    let e028: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| &*d.code == "E028")
+        .collect();
+    assert_eq!(e028.len(), 1, "exactly one E028 for the one missing var");
+    assert!(
+        e028[0].message.contains("region"),
+        "the error must name the missing variable: {}",
+        e028[0].message
+    );
+}
+
+#[test]
+fn run_var_inline_default_used_when_unset() {
+    let dir = temp_model_project("SELECT * FROM raw.base WHERE d = '@var(drop_date, 2024-01-01)'");
+    let config = CompilerConfig {
+        models_dir: dir.path().join("models"),
+        // `drop_date` not supplied → falls back to the inline default.
+        ..Default::default()
+    };
+
+    let result = compile(&config).unwrap();
+
+    let model = result.project.model("m").unwrap();
+    assert_eq!(model.sql, "SELECT * FROM raw.base WHERE d = '2024-01-01'");
+    assert!(
+        !result.has_errors,
+        "an inline default satisfies the reference; no E028"
+    );
+}

--- a/engine/crates/rocky-core/src/lib.rs
+++ b/engine/crates/rocky-core/src/lib.rs
@@ -38,6 +38,7 @@ pub mod retry;
 pub mod retry_budget;
 pub mod reuse;
 pub mod role_graph;
+pub mod run_vars;
 pub mod schema;
 pub mod schema_cache;
 pub mod seeds;

--- a/engine/crates/rocky-core/src/run_vars.rs
+++ b/engine/crates/rocky-core/src/run_vars.rs
@@ -1,0 +1,324 @@
+//! Per-run variables (`rocky run --var name=value`) substituted into model SQL.
+//!
+//! A run variable is an explicit, parse-visible placeholder of the form
+//! `@var(name)` (or `@var(name, default)`) that the compiler resolves to a
+//! caller-supplied **string** at compile/render time. The substitution is
+//! textual — the operator owns any quoting or casting in their SQL:
+//!
+//! ```sql
+//! SELECT * FROM raw.base WHERE region = '@var(region)'
+//! ```
+//!
+//! invoked as `rocky run --var region=us` renders to
+//!
+//! ```sql
+//! SELECT * FROM raw.base WHERE region = 'us'
+//! ```
+//!
+//! This sits in the same `@`-family as the `@start_date` / `@end_date`
+//! `time_interval` placeholders: a run-time substitution that stays visible
+//! in the source. It is deliberately **distinct** from the config-time
+//! `${ENV}` interpolation that `rocky.toml` performs while parsing — `${ENV}`
+//! resolves connection/config values before the engine ever sees a model,
+//! whereas `@var()` resolves the run's logical inputs at compile time.
+//!
+//! A `@var(name)` reference with no supplied value and no inline default is a
+//! **missing** variable: [`substitute_run_vars`] reports its name so the
+//! compiler can raise a clear error naming it.
+
+use std::collections::BTreeMap;
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+/// Matches `@var(name)` and `@var(name, default)`.
+///
+/// - group 1 (`name`): a SQL-identifier-shaped variable name.
+/// - group 2 (`default`): everything after the first comma up to the closing
+///   paren, optional. Because it is `[^)]*`, an inline default may contain
+///   spaces, commas, quotes, and `=`, but **not** a literal `)`.
+static VAR_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"@var\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*(?:,\s*([^)]*?))?\s*\)")
+        .expect("hardcoded @var() regex compiles")
+});
+
+/// Sentinel substituted for a *missing* required variable.
+///
+/// Leaving the raw `@var(x)` token in place can make the downstream SQL
+/// parser emit a cryptic error that buries the clean "missing var" diagnostic
+/// the compiler raises. Substituting a parseable `NULL` keeps the SQL valid in
+/// both string (`'NULL'`) and bare (`= NULL`) positions; the compile is
+/// aborted by the error diagnostic anyway, so this SQL is never executed.
+const MISSING_SENTINEL: &str = "NULL";
+
+/// Error parsing a `--var name=value` pair from the CLI.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum RunVarParseError {
+    /// The argument had no `=` separator.
+    #[error("invalid --var '{0}': expected name=value (no '=' found)")]
+    MissingEquals(String),
+    /// The name portion (before `=`) was empty.
+    #[error("invalid --var '{0}': variable name is empty")]
+    EmptyName(String),
+    /// The name portion was not a valid SQL identifier.
+    #[error(
+        "invalid --var name '{0}': must match [A-Za-z_][A-Za-z0-9_]* \
+         (letters, digits, underscore; not starting with a digit)"
+    )]
+    InvalidName(String),
+}
+
+/// A resolved map of run variables, keyed by name.
+///
+/// Values are raw strings; the operator manages any SQL quoting/casting in
+/// their model SQL around the `@var()` placeholder.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RunVars {
+    vars: BTreeMap<String, String>,
+}
+
+impl RunVars {
+    /// An empty set of run variables.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether any variables are set.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.vars.is_empty()
+    }
+
+    /// Number of variables set.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.vars.len()
+    }
+
+    /// Look up a variable's value by name.
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&str> {
+        self.vars.get(name).map(String::as_str)
+    }
+
+    /// Insert a single already-validated `name`/`value` pair, overwriting any
+    /// previous value for `name`.
+    pub fn insert(&mut self, name: impl Into<String>, value: impl Into<String>) {
+        self.vars.insert(name.into(), value.into());
+    }
+
+    /// Parse a list of raw `name=value` CLI arguments into a [`RunVars`].
+    ///
+    /// The value may contain `=` (the split is on the **first** `=` only), so
+    /// `--var filter=a=b` sets `filter` to `a=b`. A later occurrence of a name
+    /// overwrites an earlier one.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RunVarParseError`] when an argument has no `=`, an empty
+    /// name, or a name that is not a valid SQL identifier.
+    pub fn parse_pairs<I, S>(pairs: I) -> Result<Self, RunVarParseError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut vars = BTreeMap::new();
+        for raw in pairs {
+            let raw = raw.as_ref();
+            let Some((name, value)) = raw.split_once('=') else {
+                return Err(RunVarParseError::MissingEquals(raw.to_string()));
+            };
+            if name.is_empty() {
+                return Err(RunVarParseError::EmptyName(raw.to_string()));
+            }
+            if !is_valid_var_name(name) {
+                return Err(RunVarParseError::InvalidName(name.to_string()));
+            }
+            vars.insert(name.to_string(), value.to_string());
+        }
+        Ok(Self { vars })
+    }
+}
+
+/// Whether `name` is a valid run-variable identifier: `[A-Za-z_][A-Za-z0-9_]*`.
+fn is_valid_var_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Result of a [`substitute_run_vars`] pass over one model's SQL.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Substitution {
+    /// SQL with every `@var()` occurrence resolved (supplied value, inline
+    /// default, or [`MISSING_SENTINEL`] for missing-required).
+    pub sql: String,
+    /// Names of variables referenced without a supplied value and without an
+    /// inline default — in first-seen order, de-duplicated.
+    pub missing: Vec<String>,
+}
+
+/// Substitute every `@var(name)` / `@var(name, default)` occurrence in `sql`.
+///
+/// Resolution order for each occurrence:
+/// 1. the supplied value from `vars`, when present;
+/// 2. otherwise the inline default, when the reference is `@var(name, default)`;
+/// 3. otherwise it is **missing**: the occurrence is replaced with a parseable
+///    sentinel and `name` is recorded in [`Substitution::missing`].
+///
+/// The replacement is always literal text — a value containing `$` is **not**
+/// interpreted as a regex capture reference.
+#[must_use]
+pub fn substitute_run_vars(sql: &str, vars: &RunVars) -> Substitution {
+    let mut missing: Vec<String> = Vec::new();
+    let resolved = VAR_RE.replace_all(sql, |caps: &regex::Captures<'_>| {
+        let name = &caps[1];
+        if let Some(value) = vars.get(name) {
+            return value.to_string();
+        }
+        if let Some(default) = caps.get(2) {
+            return default.as_str().trim().to_string();
+        }
+        if !missing.iter().any(|m| m == name) {
+            missing.push(name.to_string());
+        }
+        MISSING_SENTINEL.to_string()
+    });
+    Substitution {
+        sql: resolved.into_owned(),
+        missing,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_simple_pair() {
+        let vars = RunVars::parse_pairs(["region=us"]).unwrap();
+        assert_eq!(vars.get("region"), Some("us"));
+        assert_eq!(vars.len(), 1);
+    }
+
+    #[test]
+    fn parse_value_with_equals_splits_on_first() {
+        let vars = RunVars::parse_pairs(["clause=a=b=c"]).unwrap();
+        assert_eq!(vars.get("clause"), Some("a=b=c"));
+    }
+
+    #[test]
+    fn parse_empty_value_is_allowed() {
+        let vars = RunVars::parse_pairs(["region="]).unwrap();
+        assert_eq!(vars.get("region"), Some(""));
+    }
+
+    #[test]
+    fn parse_no_equals_errors() {
+        let err = RunVars::parse_pairs(["region"]).unwrap_err();
+        assert_eq!(err, RunVarParseError::MissingEquals("region".to_string()));
+    }
+
+    #[test]
+    fn parse_empty_name_errors() {
+        let err = RunVars::parse_pairs(["=us"]).unwrap_err();
+        assert_eq!(err, RunVarParseError::EmptyName("=us".to_string()));
+    }
+
+    #[test]
+    fn parse_invalid_name_errors() {
+        let err = RunVars::parse_pairs(["1region=us"]).unwrap_err();
+        assert_eq!(err, RunVarParseError::InvalidName("1region".to_string()));
+    }
+
+    #[test]
+    fn later_pair_overwrites_earlier() {
+        let vars = RunVars::parse_pairs(["region=us", "region=eu"]).unwrap();
+        assert_eq!(vars.get("region"), Some("eu"));
+    }
+
+    #[test]
+    fn substitute_supplied_value() {
+        let vars = RunVars::parse_pairs(["region=us"]).unwrap();
+        let out = substitute_run_vars("WHERE region = '@var(region)'", &vars);
+        assert_eq!(out.sql, "WHERE region = 'us'");
+        assert!(out.missing.is_empty());
+    }
+
+    #[test]
+    fn substitute_bare_position() {
+        let vars = RunVars::parse_pairs(["threshold=100"]).unwrap();
+        let out = substitute_run_vars("WHERE amount >= @var(threshold)", &vars);
+        assert_eq!(out.sql, "WHERE amount >= 100");
+        assert!(out.missing.is_empty());
+    }
+
+    #[test]
+    fn substitute_default_used_when_unset() {
+        let vars = RunVars::new();
+        let out = substitute_run_vars("WHERE d = '@var(drop_date, 2024-01-01)'", &vars);
+        assert_eq!(out.sql, "WHERE d = '2024-01-01'");
+        assert!(out.missing.is_empty());
+    }
+
+    #[test]
+    fn substitute_default_overridden_by_supplied() {
+        let vars = RunVars::parse_pairs(["drop_date=2025-12-31"]).unwrap();
+        let out = substitute_run_vars("WHERE d = '@var(drop_date, 2024-01-01)'", &vars);
+        assert_eq!(out.sql, "WHERE d = '2025-12-31'");
+    }
+
+    #[test]
+    fn substitute_missing_required_reports_name() {
+        let vars = RunVars::new();
+        let out = substitute_run_vars("WHERE region = '@var(region)'", &vars);
+        assert_eq!(out.missing, vec!["region".to_string()]);
+        // Sentinel keeps the SQL parseable.
+        assert_eq!(out.sql, "WHERE region = 'NULL'");
+    }
+
+    #[test]
+    fn substitute_missing_deduped_in_order() {
+        let vars = RunVars::new();
+        let out = substitute_run_vars("@var(b) @var(a) @var(b)", &vars);
+        assert_eq!(out.missing, vec!["b".to_string(), "a".to_string()]);
+    }
+
+    #[test]
+    fn substitute_value_with_dollar_is_literal() {
+        // A value containing `$1` must not be treated as a capture reference.
+        let vars = RunVars::parse_pairs(["money=$1,000"]).unwrap();
+        let out = substitute_run_vars("SELECT '@var(money)'", &vars);
+        assert_eq!(out.sql, "SELECT '$1,000'");
+    }
+
+    #[test]
+    fn substitute_repeated_occurrences() {
+        let vars = RunVars::parse_pairs(["x=Z"]).unwrap();
+        let out = substitute_run_vars("@var(x) @var(x)", &vars);
+        assert_eq!(out.sql, "Z Z");
+    }
+
+    #[test]
+    fn substitute_default_with_comma_and_quotes() {
+        let vars = RunVars::new();
+        let out = substitute_run_vars("IN (@var(list, 'a', 'b'))", &vars);
+        assert_eq!(out.sql, "IN ('a', 'b')");
+        assert!(out.missing.is_empty());
+    }
+
+    #[test]
+    fn substitute_no_var_is_identity() {
+        let vars = RunVars::new();
+        let sql = "SELECT * FROM t WHERE a = 1";
+        let out = substitute_run_vars(sql, &vars);
+        assert_eq!(out.sql, sql);
+        assert!(out.missing.is_empty());
+    }
+}

--- a/engine/crates/rocky-server/src/lsp.rs
+++ b/engine/crates/rocky-server/src/lsp.rs
@@ -447,6 +447,7 @@ impl RockyLsp {
             mask,
             allow_unmasked,
             project_freshness_default,
+            run_vars: rocky_core::run_vars::RunVars::new(),
         };
 
         match rocky_compiler::compile::compile(&config) {
@@ -5684,6 +5685,7 @@ mod tests {
             mask: cfg.mask,
             allow_unmasked: cfg.classifications.allow_unmasked,
             project_freshness_default,
+            run_vars: rocky_core::run_vars::RunVars::new(),
         };
         let result = rocky_compiler::compile::compile(&compile_config).unwrap();
 

--- a/engine/crates/rocky-server/src/state.rs
+++ b/engine/crates/rocky-server/src/state.rs
@@ -117,6 +117,7 @@ impl ServerState {
             mask,
             allow_unmasked,
             project_freshness_default,
+            run_vars: rocky_core::run_vars::RunVars::new(),
         };
 
         // The compile pass walks the model directory, parses every

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -732,6 +732,21 @@ enum Command {
         /// parallel to `--force-rebuild` for `--skip-unchanged`. Default OFF.
         #[arg(long)]
         no_reuse: bool,
+
+        /// Per-run variable substituted into model SQL. Repeatable:
+        /// `--var region=us --var since=2024-01-01`.
+        ///
+        /// Each occurrence of the marker `@var(name)` in a model's SQL is
+        /// replaced with the supplied value at compile time (the operator owns
+        /// any quoting, e.g. `where region = '@var(region)'`). A reference may
+        /// carry an inline default — `@var(name, default)` — used when the var
+        /// is not passed. A `@var(name)` with no value and no default is a
+        /// compile error naming the variable.
+        ///
+        /// The value may contain `=` (split is on the first `=` only). This is
+        /// distinct from `${ENV}` config-time interpolation in `rocky.toml`.
+        #[arg(long = "var", value_name = "NAME=VALUE")]
+        var: Vec<String>,
     },
 
     /// Compare shadow tables against production tables
@@ -839,6 +854,13 @@ enum Command {
         /// columns into concrete types.
         #[arg(long)]
         with_seed: bool,
+
+        /// Per-run variable substituted into model SQL (repeatable). Resolves
+        /// `@var(name)` markers to the supplied value so `rocky compile` type-
+        /// checks the same SQL `rocky run --var …` would execute. A required
+        /// `@var(name)` with no value and no inline default is a compile error.
+        #[arg(long = "var", value_name = "NAME=VALUE")]
+        var: Vec<String>,
     },
 
     /// Publish a snapshot of this project's compiled IR for consumers to
@@ -908,6 +930,12 @@ enum Command {
         /// When omitted, the concatenated SQL is printed to stdout.
         #[arg(long)]
         out_dir: Option<PathBuf>,
+
+        /// Per-run variable substituted into model SQL (repeatable). Resolves
+        /// `@var(name)` markers to the supplied value (or inline default) so
+        /// the emitted SQL shows the resolved text.
+        #[arg(long = "var", value_name = "NAME=VALUE")]
+        var: Vec<String>,
     },
 
     /// Emit a project-wide column-level lineage snapshot.
@@ -2467,7 +2495,12 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             skip_unchanged,
             force_rebuild,
             no_reuse,
+            var,
         } => {
+            // Parse `--var name=value` pairs into the run-variable map. A
+            // malformed pair (no `=`, empty/invalid name) is a clear CLI error.
+            let run_vars = rocky_core::run_vars::RunVars::parse_pairs(&var)
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
             // --idempotency-key is mutually exclusive with --resume / --resume-latest:
             // a resume is an explicit override and should never be short-circuited.
             if idempotency_key.is_some() && (resume.is_some() || resume_latest) {
@@ -2594,6 +2627,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                     env.as_deref(),
                     &defer_opts,
                     &skip_opts,
+                    &run_vars,
                 )
                 .await
             }
@@ -2683,18 +2717,24 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             expand_macros,
             target_dialect,
             with_seed,
-        } => rocky_cli::commands::run_compile(
-            Some(cli.config.as_path()),
-            &state_path,
-            &models,
-            contracts.as_deref(),
-            model.as_deref(),
-            json,
-            expand_macros,
-            target_dialect.map(Into::into),
-            with_seed,
-            cli.cache_ttl,
-        ),
+            var,
+        } => {
+            let run_vars = rocky_core::run_vars::RunVars::parse_pairs(&var)
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            rocky_cli::commands::run_compile(
+                Some(cli.config.as_path()),
+                &state_path,
+                &models,
+                contracts.as_deref(),
+                model.as_deref(),
+                json,
+                expand_macros,
+                target_dialect.map(Into::into),
+                with_seed,
+                cli.cache_ttl,
+                &run_vars,
+            )
+        }
         Command::PublishIr {
             models,
             contracts,
@@ -2725,12 +2765,18 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             models,
             model,
             out_dir,
-        } => rocky_cli::commands::run_emit_sql(
-            Some(cli.config.as_path()),
-            &models,
-            model.as_deref(),
-            out_dir.as_deref(),
-        ),
+            var,
+        } => {
+            let run_vars = rocky_core::run_vars::RunVars::parse_pairs(&var)
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            rocky_cli::commands::run_emit_sql(
+                Some(cli.config.as_path()),
+                &models,
+                model.as_deref(),
+                out_dir.as_deref(),
+                &run_vars,
+            )
+        }
         Command::Catalog {
             models,
             out,


### PR DESCRIPTION
## Problem

Rocky had no per-run variable channel. A model's SQL was fixed at author time, so there was no way to parameterize a single run's logical inputs (a region filter, a backfill date, a tenant id) without editing the source. The only existing interpolation, `${ENV}` in `rocky.toml`, resolves connection and config values at parse time, before the engine ever sees a model — it cannot reach into model SQL. As a consequence, `import-dbt` could not represent `{{ var() }}`: those references were emitted as a TODO, leaving imported models incomplete.

## Fix

Add an explicit, parse-visible per-run variable marker `@var(name)` (with an optional inline default, `@var(name, default)`) that the compiler resolves to a caller-supplied string at compile/render time.

- A repeatable `--var name=value` flag on `rocky run` (and `rocky compile` / `rocky emit-sql`) supplies the values.
- Substitution runs as a pass at the top of `compile_project`, before the semantic graph and typecheck, so the resolved SQL flows uniformly through run, compile, and emit-sql — including the transformation pipeline path and the governance reconcile compile, so the second compile never re-reads a raw marker.
- A `@var(name)` reference with no supplied value and no inline default is a missing required variable: the compiler raises an **E028** error naming the variable, which fails the run loudly rather than silently materializing a broken result.
- `import-dbt` now maps `{{ var('x') }}` to `@var(x)` and `{{ var('x', 'd') }}` to `@var(x, d)` instead of emitting a TODO.

`@var()` is a new public surface that sits in the same `@`-family as the existing `@start_date` / `@end_date` placeholders: a run-time substitution that stays visible in the source. It is deliberately distinct from `${ENV}` config-time interpolation — `${ENV}` resolves config before any model is seen, `@var()` resolves a run's logical inputs at compile time.

## Testing

- Rust unit tests for run-variable parsing (`name=value`, split on first `=`, identifier validation) and substitution (literal `$`-safe replacement, missing-required reporting).
- A real `rocky run --var` round-trip on a DuckDB project materializes the substituted value (the filter narrows the output rows).
- A missing required variable fails loudly with a non-zero exit and an **E028** diagnostic in JSON output; an inline default resolves with no flag supplied.
- The `import-dbt` mapping emits the `@var()` marker (both the bare and defaulted forms).
- `${ENV}` interpolation stays distinct and unaffected.
