### PR TITLE
docs(engine): code-review follow-ups — failure-count semantics, run-var trust note, CHANGELOG

### DIFF
--- a/editors/vscode/src/types/generated/run.ts
+++ b/editors/vscode/src/types/generated/run.ts
@@ -175,6 +175,9 @@ export interface RunOutput {
    */
   status: RunStatus;
   tables_copied: number;
+  /**
+   * Total number of failed tables/models for the run, **including** pre-execution compile failures: a model that fails to type-check is counted here even though it never reached the execution phase. This is the authoritative failure count — consumers should key overall pass/fail on the top-level `tables_failed` / `status` / `errors`, not on `execution.tables_failed`, which counts only execution-phase (copy / runtime) failures and excludes models excluded before execution.
+   */
   tables_failed: number;
   tables_skipped: number;
   version: string;
@@ -320,6 +323,9 @@ export interface ExecutionSummary {
    * Number of rate-limit signals (HTTP 429 / UC_REQUEST_LIMIT_EXCEEDED) that triggered concurrency reduction. Only present when adaptive concurrency is enabled.
    */
   rate_limits_detected?: number | null;
+  /**
+   * Tables that failed during the **execution phase** — copy or runtime failures while materializing. This does **not** include models excluded before execution started (for example, a model that failed to compile); those are counted only in the top-level `RunOutput.tables_failed`. For overall run pass/fail, read the top-level `tables_failed` / `status`, not this `execution.tables_failed`.
+   */
   tables_failed: number;
   tables_processed: number;
   [k: string]: unknown;

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`rocky run --var name=value` — per-run variables in model SQL.** A model can reference an explicit `@var(name)` (or `@var(name, default)`) placeholder that the compiler resolves to a caller-supplied string at compile time, parallel to dbt's `{{ var() }}`. The substitution is textual — the operator owns SQL quoting — and a referenced variable with no value and no inline default fails the run with a diagnostic naming it. (#976)
+- **`[governance.tags]` propagation on transformation runs, with view-aware Unity Catalog tag DDL.** Model and pipeline governance tags are applied to transformation targets, emitting the correct tag DDL for a view versus a table. (#971)
+- **Lakehouse-format initial DDL for incremental strategies.** The first materialization of an incremental model emits the configured lakehouse-format table DDL instead of an untyped create. (#970)
+- **Seed pre/post-hooks.** `rocky seed` fires the same `pre_hook` / `post_hook` lifecycle as model materialization. (#969)
+- **`rocky import-dbt` fidelity: `dbt_expectations` / `dbt_utils` test mapping, `profiles.yml` anchors + `env_var(...)`, and dropped-contract warnings.** Common `dbt_expectations` / `dbt_utils` generic tests map to native Rocky tests where there is a clear equivalent (carrying severity and row filter); `profiles.yml` YAML anchors / merge keys and `{{ env_var(...) }}` adapter types resolve instead of silently falling back to DuckDB; and a dbt model `contract: { enforced: true }` (with its column `data_type`s and `constraints`) no longer drops silently on import — the importer emits a per-model warning and a `contracts_dropped` count flagging the lost enforcement. (#972)
+- **`rocky import-dbt --microbatch-as=time_interval`** translates a dbt microbatch model to a Rocky `time_interval` strategy (granularity and lookback derived from the dbt config); the default `merge` keeps the idempotent-merge mapping. (#974)
+- **`rocky import-dbt --skip-unit-tests`** skips translating dbt `unit_tests`, counting them as dropped constructs. (#968)
+
+### Changed
+
+- **`rocky run` now fails when a model does not compile.** A model that fails to type-check was previously logged as a WARN, skipped, and the run still reported `status: "success"` / exit 0 with the model un-materialized. A compile error is now a first-class run failure: the run reports `status` `failure` or `partial_failure`, exits non-zero (1 or 2), counts the model in `tables_failed`, and surfaces the diagnostic in `--output json` `errors` with `failure_kind: "compile-error"`. This also reclassifies a transformation run where some models materialized and one failed at runtime from `failure` / exit 1 to `partial_failure` / exit 2. (#975)
+- **`rocky run --parallel` now defaults to 4** (was serial / `1`). It stays overridable: `--parallel 1` forces serial, and adapters that do not support concurrent execution (e.g. DuckDB) stay serial regardless. Concurrent-capable warehouses (Databricks, Snowflake) now run up to 4 models or partitions per layer concurrently by default, relying on the adapters' adaptive throttling. (#977)
+
+### Fixed
+
+- **`rocky import-dbt` no longer aborts on an unserializable dbt unit test.** A unit test whose payload can't be serialized is counted as a dropped construct and reported, rather than failing the whole import. (#968)
+- **`rocky compile` expands `SELECT *` over a derived table** during output-schema inference, so a model selecting `*` from a subquery or CTE infers the correct columns. (#973)
+
 ## [1.54.0] - 2026-06-23
 
 ### Added

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -171,17 +171,27 @@ pub(crate) fn run_status_exit_result(output: &RunOutput, run_id: &str) -> Result
 /// to `status = Success` / exit 0.
 ///
 /// This merges instead: it keeps the already-recorded compile-error entries,
-/// folds their count (held in `output.tables_failed` at call time, since
-/// nothing but the compile section mutates it before the merge) into the total
-/// alongside the copy failures, appends the parallel-copy errors, and
-/// re-derives `output.status` so a `--output json` consumer reads the right
-/// terminal status (not the `RunOutput::new` default of `success`). A clean
-/// run still derives `Success`; a copy-only failure behaves exactly as before.
+/// folds their count (the number of distinct compile-failed models, counted
+/// directly from the retained entries rather than inferred from
+/// `output.tables_failed`) into the total alongside the copy failures, appends
+/// the parallel-copy errors, and re-derives `output.status` so a
+/// `--output json` consumer reads the right terminal status (not the
+/// `RunOutput::new` default of `success`). A clean run still derives
+/// `Success`; a copy-only failure behaves exactly as before.
 fn merge_replication_compile_and_copy_errors(output: &mut RunOutput, table_errors: &[TableError]) {
-    let compile_failed_count = output.tables_failed;
     output
         .errors
         .retain(|e| e.failure_kind == crate::output::FailureKind::CompileError);
+    // Count distinct compile-failed models from the retained entries rather
+    // than inferring from `tables_failed`: the compile path records one
+    // `errors` entry per diagnostic but bumps `tables_failed` once per model,
+    // so count distinct asset_keys, not raw entries.
+    let compile_failed_count = output
+        .errors
+        .iter()
+        .map(|e| e.asset_key.as_slice())
+        .collect::<std::collections::BTreeSet<_>>()
+        .len();
     output.tables_failed = compile_failed_count + table_errors.len();
     output
         .errors
@@ -9306,6 +9316,40 @@ merge_keys = ["id"]
             crate::output::FailureKind::CompileError
         );
         // No progress + a failure → total Failure, never Success.
+        assert!(matches!(out.status, rocky_core::state::RunStatus::Failure));
+    }
+
+    /// A single model that emits **two** compile-error diagnostics produces two
+    /// `errors` entries sharing one asset_key but only one `tables_failed`
+    /// bump (the per-model compile path dedups the count via a model set). The
+    /// merge counts distinct models, not raw entries, so `tables_failed` stays
+    /// `1`. Guards against re-inflating the count to `errors.len()` — the
+    /// single-entry tests above pass either way.
+    #[test]
+    fn merge_counts_distinct_models_not_diagnostics() {
+        let mut out = RunOutput::new(String::new(), 0, 1);
+        // One model ("broken") with two distinct error diagnostics → two
+        // entries, one model. Mirrors `execute_models`' per-diagnostic push
+        // against its per-model `tables_failed` bump.
+        out.tables_failed = 1;
+        for code in ["E020", "E021"] {
+            out.errors.push(crate::output::TableErrorOutput {
+                asset_key: vec!["broken".to_string()],
+                error: format!("[{code}] compile error on broken"),
+                failure_kind: crate::output::FailureKind::CompileError,
+                cooldown_seconds: None,
+            });
+        }
+        let no_copy_errors: Vec<TableError> = Vec::new();
+
+        super::merge_replication_compile_and_copy_errors(&mut out, &no_copy_errors);
+
+        // Distinct failing models == 1, even though two diagnostics survive.
+        assert_eq!(
+            out.tables_failed, 1,
+            "one model with two diagnostics counts once, not twice"
+        );
+        assert_eq!(out.errors.len(), 2, "both diagnostics are preserved");
         assert!(matches!(out.status, rocky_core::state::RunStatus::Failure));
     }
 

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -238,6 +238,13 @@ pub struct RunOutput {
     pub filter: String,
     pub duration_ms: u64,
     pub tables_copied: usize,
+    /// Total number of failed tables/models for the run, **including**
+    /// pre-execution compile failures: a model that fails to type-check is
+    /// counted here even though it never reached the execution phase. This is
+    /// the authoritative failure count — consumers should key overall pass/fail
+    /// on the top-level `tables_failed` / `status` / `errors`, not on
+    /// `execution.tables_failed`, which counts only execution-phase (copy /
+    /// runtime) failures and excludes models excluded before execution.
     pub tables_failed: usize,
     #[serde(skip_serializing_if = "is_zero")]
     pub tables_skipped: usize,
@@ -434,6 +441,12 @@ fn is_zero(v: &usize) -> bool {
 pub struct ExecutionSummary {
     pub concurrency: usize,
     pub tables_processed: usize,
+    /// Tables that failed during the **execution phase** — copy or runtime
+    /// failures while materializing. This does **not** include models excluded
+    /// before execution started (for example, a model that failed to compile);
+    /// those are counted only in the top-level `RunOutput.tables_failed`. For
+    /// overall run pass/fail, read the top-level `tables_failed` / `status`,
+    /// not this `execution.tables_failed`.
     pub tables_failed: usize,
     /// Whether adaptive concurrency (AIMD throttle) was enabled for this run.
     #[serde(skip_serializing_if = "std::ops::Not::not")]

--- a/engine/crates/rocky-core/src/run_vars.rs
+++ b/engine/crates/rocky-core/src/run_vars.rs
@@ -25,6 +25,17 @@
 //! A `@var(name)` reference with no supplied value and no inline default is a
 //! **missing** variable: [`substitute_run_vars`] reports its name so the
 //! compiler can raise a clear error naming it.
+//!
+//! ## Trust boundary
+//!
+//! The substitution is **textual, with no escaping of the substituted value** —
+//! by design, for parity with dbt's `{{ var() }}`. The operator owns SQL
+//! quoting and casting; only the variable *name* is validated (as a SQL
+//! identifier). This is safe for the operator-supplied CLI `--var` values that
+//! are the only source today. If a future caller ever feeds `--var` values
+//! from a less-trusted source — for example a Dagster `run_vars` passthrough
+//! driven by partition keys or external config — those values must be escaped
+//! or bound before substitution rather than spliced in raw.
 
 use std::collections::BTreeMap;
 use std::sync::LazyLock;

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -356,6 +356,7 @@
           ]
         },
         "tables_failed": {
+          "description": "Tables that failed during the **execution phase** — copy or runtime failures while materializing. This does **not** include models excluded before execution started (for example, a model that failed to compile); those are counted only in the top-level `RunOutput.tables_failed`. For overall run pass/fail, read the top-level `tables_failed` / `status`, not this `execution.tables_failed`.",
           "format": "uint",
           "minimum": 0.0,
           "type": "integer"
@@ -1247,6 +1248,7 @@
       "type": "integer"
     },
     "tables_failed": {
+      "description": "Total number of failed tables/models for the run, **including** pre-execution compile failures: a model that fails to type-check is counted here even though it never reached the execution phase. This is the authoritative failure count — consumers should key overall pass/fail on the top-level `tables_failed` / `status` / `errors`, not on `execution.tables_failed`, which counts only execution-phase (copy / runtime) failures and excludes models excluded before execution.",
       "format": "uint",
       "minimum": 0.0,
       "type": "integer"

--- a/sdk/python/src/rocky_sdk/types_generated/run_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/run_schema.py
@@ -89,6 +89,9 @@ class ExecutionSummary(BaseModel):
     Number of rate-limit signals (HTTP 429 / UC_REQUEST_LIMIT_EXCEEDED) that triggered concurrency reduction. Only present when adaptive concurrency is enabled.
     """
     tables_failed: conint(ge=0)
+    """
+    Tables that failed during the **execution phase** — copy or runtime failures while materializing. This does **not** include models excluded before execution started (for example, a model that failed to compile); those are counted only in the top-level `RunOutput.tables_failed`. For overall run pass/fail, read the top-level `tables_failed` / `status`, not this `execution.tables_failed`.
+    """
     tables_processed: conint(ge=0)
 
 
@@ -717,5 +720,8 @@ class RunOutput(BaseModel):
     """
     tables_copied: conint(ge=0)
     tables_failed: conint(ge=0)
+    """
+    Total number of failed tables/models for the run, **including** pre-execution compile failures: a model that fails to type-check is counted here even though it never reached the execution phase. This is the authoritative failure count — consumers should key overall pass/fail on the top-level `tables_failed` / `status` / `errors`, not on `execution.tables_failed`, which counts only execution-phase (copy / runtime) failures and excludes models excluded before execution.
+    """
     tables_skipped: conint(ge=0)
     version: str


### PR DESCRIPTION
Post-merge polish from a code review of the dbt-migration batch (PRs #968–#977, unreleased on top of engine-v1.54.0). No behavior change beyond doc/CHANGELOG clarity and a behavior-preserving merge-helper refactor.

## Changes

- **Clarify the two `tables_failed` fields** (`output.rs` doc comments). `RunOutput.tables_failed` is the authoritative total *including* pre-execution compile failures; `ExecutionSummary.tables_failed` (the `execution` field) counts only execution-phase copy/runtime failures. Consumers should key overall pass/fail on the top-level `tables_failed` / `status` / `errors`, not on `execution.tables_failed`. These derive `JsonSchema`, so `schemas/run.schema.json` and the Pydantic/TS bindings are regenerated via `just codegen`.
- **Merge-helper robustness** (`run.rs`). `merge_replication_compile_and_copy_errors` no longer proxies the compile-failure count through `output.tables_failed`; it counts the retained `CompileError` entries directly. Counted *distinct* models (asset_keys), not raw entries, because the per-model compile path pushes one `errors` entry per diagnostic but bumps `tables_failed` once per model — so `output.errors.len()` would over-count a model with several diagnostics. Behavior-preserving.
- **Run-var trust-boundary note** (`run_vars.rs` module doc). `@var()` substitution is textual with no value escaping (dbt `var()` parity; the operator owns SQL quoting, variable names are identifier-validated). Safe for operator-supplied CLI `--var`; a future less-trusted feed (e.g. a Dagster `run_vars` passthrough driven by partition keys / external config) must escape or bind values first.
- **CHANGELOG** — recorded the dbt-migration batch under `[Unreleased]`, with the two behavior changes explicit under `### Changed`: `rocky run` now fails when a model does not compile (#975), and `rocky run --parallel` now defaults to 4 (#977).
- **Test** — discriminating unit test for the merge-helper count (two diagnostics, one model → `tables_failed == 1`); the prior single-entry tests passed either implementation.

## Verification

`cargo build`, `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test -p rocky-cli -p rocky-core` all green; `just codegen` reproduces zero drift (schema + Pydantic + TS committed); `just regen-fixtures` produces no diff.
