### PR TITLE
test(playground): fix import-dbt POCs for the dbt-migration batch behavior

### DIFF
--- a/examples/playground/pocs/06-developer-experience/03-import-dbt-validate/dbt_project/models/schema.yml
+++ b/examples/playground/pocs/06-developer-experience/03-import-dbt-validate/dbt_project/models/schema.yml
@@ -1,8 +1,8 @@
 version: 2
 
 # Demonstrates `rocky import-dbt` mapping each of dbt's four canonical
-# generic tests onto Rocky `[[tests]]` blocks plus surfacing one
-# non-canonical test as a structured warning.
+# generic tests onto Rocky `[[tests]]` blocks, plus mapping a common
+# `dbt_utils` test (`accepted_range`) onto a native `in_range` block.
 models:
   - name: stg_orders
     description: Staged orders, one row per order, with a normalised status.
@@ -31,7 +31,7 @@ models:
               field: customer_id
       - name: total_revenue
         tests:
-          # Non-canonical: must surface as an `UnsupportedTest` warning,
-          # not stubbed in the emitted rocky.toml.
+          # Non-canonical but supported: maps to a native `[[tests]]`
+          # block of type `in_range` on the emitted model sidecar.
           - dbt_utils.accepted_range:
               min_value: 0

--- a/examples/playground/pocs/06-developer-experience/14-import-dbt-failure-modes/README.md
+++ b/examples/playground/pocs/06-developer-experience/14-import-dbt-failure-modes/README.md
@@ -9,26 +9,35 @@
 
 `rocky import-dbt` is opinionated about what it translates: canonical
 generic tests + `{{ ref }}` / `{{ source }}` / `{{ config }}` /
-`is_incremental()` translate cleanly; everything else is deliberately
-out of scope. This POC throws all the out-of-scope cases at the importer
-in one go and verifies the importer handles each one cleanly:
+`is_incremental()` translate cleanly, a growing set of common dbt
+constructs now **map** to native Rocky equivalents, and a small residue
+of genuinely runtime-only Jinja stays out of scope. This POC throws the
+edge cases at the importer in one go and verifies each is handled
+cleanly — distinguishing the constructs that map from the ones that warn
+or are refused:
 
-- A model with `{% if target.name == 'prod' %}` — surfaced as a
-  `JinjaControlFlow` warning, body emitted verbatim with a
+- A model with `{% if target.name == 'prod' %}` — still out of scope:
+  surfaced as a `JinjaControlFlow` warning, body emitted verbatim with a
   `-- TODO: dbt-jinja-not-translated` marker.
-- A model with `{{ var('cutoff') }}` — surfaced as an
-  `UnsupportedMacro` warning, the `{{ var() }}` expression rewritten
-  to a TODO placeholder.
-- `schema.yml` with `dbt_utils.accepted_range` — surfaced as an
-  `UnsupportedTest` warning, not stubbed in the emitted toml.
+- A model with `{{ var('cutoff') }}` — now **mapped** to Rocky's native
+  `@var(cutoff)` per-run variable marker, surfaced as an informational
+  `MappedConstruct` warning (supply the value with
+  `rocky run --var cutoff=...`, or an inline `@var(name, default)`).
+- `schema.yml` with `dbt_utils.accepted_range` — now **mapped** to a
+  native `[[tests]]` block of type `in_range` on the model sidecar; no
+  longer surfaced as an `UnsupportedTest` warning.
+- A model with `{% for %}` loops (`stg_loop`) — **refused** rather than
+  half-rendered into broken SQL; it lands under "Failed models".
 - `snapshots/`, `dbt_packages/`, and `tests/` (singular tests) trees —
   silently ignored. The importer walks `models/` only.
 
-The POC's `run.sh` asserts each of these end-to-end. The emitted SQL
-deliberately contains TODO-replaced fragments that won't `rocky compile`
-cleanly; the whole point is that out-of-scope dbt features need a
-manual follow-up pass. The happy-path counterpart that does compile
-end-to-end is [`03-import-dbt-validate`](../03-import-dbt-validate/).
+The POC's `run.sh` asserts each of these end-to-end. The `{% if %}`
+emission deliberately contains a TODO-replaced fragment that won't
+`rocky compile` cleanly; the point is that genuinely runtime-only Jinja
+needs a manual follow-up pass, while constructs like `var()` and
+`accepted_range` now arrive as native Rocky. The happy-path counterpart
+that does compile end-to-end is
+[`03-import-dbt-validate`](../03-import-dbt-validate/).
 
 ## Why it's distinctive vs `03-import-dbt-validate`
 
@@ -49,9 +58,10 @@ before pointing it at a real codebase.
 │   ├── dbt_project.yml
 │   ├── models/
 │   │   ├── sources.yml
-│   │   ├── schema.yml                      dbt_utils.accepted_range (unsupported test)
+│   │   ├── schema.yml                      dbt_utils.accepted_range (mapped to in_range)
 │   │   ├── stg_orders.sql                  {% if target.name == 'prod' %}
-│   │   └── stg_variables.sql               {{ var('cutoff') }}
+│   │   ├── stg_variables.sql               {{ var('cutoff') }} (mapped to @var)
+│   │   └── stg_loop.sql                    {% for %} loop (refused)
 │   ├── snapshots/orders_snapshot.sql       Out of scope — silently ignored
 │   ├── dbt_packages/dbt_utils/macros/star.sql   Out of scope — silently ignored
 │   └── tests/assert_revenue_positive.sql   Out of scope — singular test
@@ -67,17 +77,18 @@ before pointing it at a real codebase.
 ## Expected output
 
 ```
-=== rocky import-dbt (regex path, deliberately bad inputs) ===
+=== rocky import-dbt (regex path, edge-case inputs) ===
 {
   "version": "...",
   "command": "import-dbt",
   "import_method": "Regex",
   "imported": 2,
-  "warnings": 3,
-  "failed": 0,
+  "warnings": 2,
+  "failed": 1,
   "tests_found": 3,
-  "tests_converted": 2,
-  "tests_skipped": 1,
+  "tests_converted": 3,
+  "tests_converted_custom": 1,
+  "tests_skipped": 0,
   "warning_details": [
     {
       "model": "stg_orders",
@@ -87,15 +98,15 @@ before pointing it at a real codebase.
     },
     {
       "model": "stg_variables",
-      "category": "UnsupportedMacro",
-      "message": "contains {{ var() }} — not supported, replaced with TODO",
-      "suggestion": "replace with a literal value or use manifest.json import path"
-    },
+      "category": "MappedConstruct",
+      "message": "contains {{ var() }} — mapped to Rocky's `@var()` per-run variable marker",
+      "suggestion": "supply values at run time with `rocky run --var name=value`, or rely on an inline default `@var(name, default)`"
+    }
+  ],
+  "failed_details": [
     {
-      "model": "stg_orders",
-      "category": "UnsupportedTest",
-      "message": "dbt test 'dbt_utils.accepted_range' on column 'amount' is outside the supported set ...",
-      "suggestion": "rewrite as a Rocky `[[tests]]` of type `expression` or as a custom check in a quality pipeline"
+      "name": "stg_loop",
+      "reason": "contains unsupported Jinja control flow ({% for %} or {% set %}) ..."
     }
   ],
   ...
@@ -106,12 +117,13 @@ before pointing it at a real codebase.
 - **dbt generic tests outside the canonical four** ...
 - **Singular tests** in `tests/` (custom SQL) — copy and rewrite manually.
 - **dbt macros / `dbt_packages/`** — Rocky has no Jinja runtime. ...
-- **`{% if %}` / `{{ var() }}`** — emitted with a TODO marker (the `{% if %}` body applies unconditionally — review it).
+- **`{% if %}`** — emitted with a TODO marker (the body applies unconditionally — review it).
 - **`{% for %}` / `{% set %}`** — **refused** (listed under "Failed models") rather than half-rendered into broken SQL; `stg_loop` here demonstrates the refusal. Re-run after `dbt compile`.
 ## Warnings
 - `stg_orders` — JinjaControlFlow: ...
-- `stg_variables` — UnsupportedMacro: ...
-- `stg_orders` — UnsupportedTest: ...
+- `stg_variables` — MappedConstruct: {{ var() }} mapped to `@var()` ...
+## Failed models
+- `stg_loop` — contains unsupported Jinja control flow ({% for %} or {% set %}) ...
 
 === Emitted models/stg_orders.sql (target.name branch flagged) ===
 -- TODO: dbt-jinja-not-translated — see MIGRATION-NOTES.md

--- a/examples/playground/pocs/06-developer-experience/14-import-dbt-failure-modes/dbt_project/models/schema.yml
+++ b/examples/playground/pocs/06-developer-experience/14-import-dbt-failure-modes/dbt_project/models/schema.yml
@@ -1,8 +1,9 @@
 version: 2
 
-# Exercises the importer's failure-mode handling for non-canonical tests.
-# `unique` and `not_null` translate cleanly; `dbt_utils.accepted_range`
-# is surfaced as an `UnsupportedTest` warning — not stubbed in the toml.
+# Exercises the importer's test mapping. `unique` and `not_null` translate
+# cleanly; `dbt_utils.accepted_range` now maps to a native `[[tests]]` block
+# of type `in_range` on the emitted model sidecar (was an UnsupportedTest
+# warning in earlier versions).
 models:
   - name: stg_orders
     description: Staged orders with one branched-by-target predicate.

--- a/examples/playground/pocs/06-developer-experience/14-import-dbt-failure-modes/run.sh
+++ b/examples/playground/pocs/06-developer-experience/14-import-dbt-failure-modes/run.sh
@@ -1,24 +1,30 @@
 #!/usr/bin/env bash
 # 14-import-dbt-failure-modes — exercise `rocky import-dbt`'s handling of the
-# deliberately out-of-scope dbt features:
+# dbt features that sit at (or just outside) the edge of what it translates:
 #   - models with `{% if target.name %}` branching (JinjaControlFlow warning,
-#     emitted with a TODO marker)
+#     body emitted verbatim with a TODO marker)
 #   - models with `{% for %}` loops (REFUSED — would half-render to broken SQL)
-#   - models with `{{ var() }}` references (UnsupportedMacro warning)
-#   - schema.yml tests outside the canonical four (UnsupportedTest warning)
+#   - models with `{{ var() }}` references — now MAPPED to Rocky's native
+#     `@var(name)` per-run variable marker (MappedConstruct, informational)
+#   - schema.yml `dbt_utils.accepted_range` — now MAPPED to a native
+#     `[[tests]]` of type `in_range`, not surfaced as a warning
 #   - `snapshots/`, `dbt_packages/`, and `tests/` trees (silently ignored)
 #
 # Success criteria — all checked at the bottom of the script:
 #   - importer exits 0
-#   - 3 structured warnings: JinjaControlFlow + UnsupportedMacro + UnsupportedTest
-#   - 0 failed models (out-of-scope trees ignored, not failed)
+#   - 2 structured warnings: JinjaControlFlow + MappedConstruct
+#   - 1 failed model — the `{% for %}` model `stg_loop` is refused; the
+#     out-of-scope trees (snapshots/dbt_packages/tests) are ignored, not failed
 #   - MIGRATION-NOTES.md has the "Known limitations" heading and no "v0"
-#   - emitted SQL carries `-- TODO: dbt-jinja-not-translated` markers
+#   - the `{% if %}` model carries a `-- TODO: dbt-jinja-not-translated` marker
+#   - the `{{ var() }}` model carries a native `@var(` marker
 #
-# Note: the emission deliberately contains TODO-replaced SQL that won't
-# `rocky compile` cleanly — the whole point of the POC is that out-of-scope
-# features need a manual follow-up pass. The happy-path counterpart that
-# does compile end-to-end is `03-import-dbt-validate/`.
+# Note: the `{% if %}` emission deliberately contains a TODO-replaced fragment
+# that won't `rocky compile` cleanly — the point of the POC is that genuinely
+# out-of-scope Jinja control flow needs a manual follow-up pass, while several
+# constructs that used to warn (var(), accepted_range) now map to native Rocky
+# equivalents. The happy-path counterpart that compiles end-to-end is
+# `03-import-dbt-validate/`.
 set -uo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$HERE"
@@ -46,7 +52,7 @@ echo "=== Emitted models/stg_orders.sql (target.name branch flagged) ==="
 cat imported/models/stg_orders.sql
 
 echo
-echo "=== Emitted models/stg_variables.sql ({{ var() }} flagged) ==="
+echo "=== Emitted models/stg_variables.sql ({{ var() }} mapped to @var()) ==="
 cat imported/models/stg_variables.sql
 
 echo
@@ -63,16 +69,29 @@ if grep -q -i '\bv0\b' imported/MIGRATION-NOTES.md; then
     fail=1
 fi
 
-for marker_file in imported/models/stg_orders.sql imported/models/stg_variables.sql; do
-    if ! grep -q 'TODO: dbt-jinja-not-translated' "$marker_file"; then
-        echo "FAIL: $marker_file missing 'dbt-jinja-not-translated' marker"
-        fail=1
-    fi
-done
+# The `{% if %}` model (stg_orders) keeps its TODO marker — that Jinja
+# control flow is still out of scope and emitted verbatim for review.
+if ! grep -q 'TODO: dbt-jinja-not-translated' imported/models/stg_orders.sql; then
+    echo "FAIL: imported/models/stg_orders.sql missing 'dbt-jinja-not-translated' marker"
+    fail=1
+fi
 
-# Non-canonical schema.yml test must NOT be stubbed as a [[tests]] block.
-if grep -qi 'accepted_range\|dbt_utils' imported/models/stg_orders.toml; then
-    echo "FAIL: stg_orders.toml should not stub non-canonical tests as [[tests]] blocks"
+# The `{{ var() }}` model (stg_variables) is now MAPPED, not stubbed: the
+# `{{ var('cutoff') }}` reference becomes Rocky's native `@var(cutoff)` marker
+# (supply the value at run time with `rocky run --var cutoff=...`).
+if ! grep -q '@var(' imported/models/stg_variables.sql; then
+    echo "FAIL: imported/models/stg_variables.sql missing the mapped '@var(' marker"
+    fail=1
+fi
+if grep -q 'TODO: dbt-jinja-not-translated' imported/models/stg_variables.sql; then
+    echo "FAIL: stg_variables.sql should map {{ var() }} to @var(), not stub it with a TODO marker"
+    fail=1
+fi
+
+# `dbt_utils.accepted_range` is now MAPPED to a native [[tests]] type=in_range
+# block on the model sidecar — it is no longer surfaced as an UnsupportedTest.
+if ! grep -q 'in_range' imported/models/stg_orders.toml; then
+    echo "FAIL: stg_orders.toml should map dbt_utils.accepted_range to a native [[tests]] type=in_range block"
     fail=1
 fi
 


### PR DESCRIPTION
The recent `import-dbt` migration batch changed the importer output that the two import-dbt POCs assert against and narrate. One POC (`14-import-dbt-failure-modes`) went red; the other (`03-import-dbt-validate`) still passed but narrated outdated behavior.

## Shipped behavior these POCs now reflect
- `{{ var('x') }}` maps to Rocky's native `@var(x)` per-run variable marker (informational `MappedConstruct` warning), instead of a `TODO` stub + `UnsupportedMacro` warning.
- `dbt_utils.accepted_range` (and the `dbt_expectations` range tests) map to a native `[[tests]]` block of type `in_range`, instead of an `UnsupportedTest` warning.

## Changes
**`14-import-dbt-failure-modes` (was RED → green):**
- `run.sh`: marker assertion now checks `stg_orders.sql` keeps its `TODO` marker and `stg_variables.sql` carries the mapped `@var(` marker; `accepted_range` assertion flipped to positively require the native `in_range` block; success-criteria + header comments updated (2 warnings, 1 refused `{% for %}` model).
- `README.md`: expected-output block (`warnings` 3→2, `failed` 0→1, `tests_converted` 2→3, `tests_skipped` 1→0), warning_details (drop `UnsupportedMacro`/`UnsupportedTest`, add `MappedConstruct`), and the "what it shows"/layout narrative reframed around map-vs-warn.
- `dbt_project/models/schema.yml`: fixture comment corrected.

**`03-import-dbt-validate` (stayed green):**
- `dbt_project/models/schema.yml`: comments no longer claim `accepted_range` surfaces as an `UnsupportedTest` warning; they describe the native `in_range` mapping.

Both `run.sh` exit 0 against a freshly built `rocky 1.54.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)