### PR TITLE
feat(playground): demo POCs for rocky run --var and fail-loud-on-compile-error

### DIFF
--- a/examples/playground/README.md
+++ b/examples/playground/README.md
@@ -38,11 +38,11 @@ cd pocs/02-performance/01-incremental-watermark
 
 **Prerequisites:** Rocky CLI on PATH. Most POCs only need the [DuckDB CLI](https://duckdb.org) for seeding (`brew install duckdb`).
 
-**82 of 94 POCs run with no external credentials.** See each POC's README for prerequisites.
+**84 of 96 POCs run with no external credentials.** See each POC's README for prerequisites.
 
 ## The catalog
 
-### 00 — Foundations (16 POCs · DuckDB)
+### 00 — Foundations (17 POCs · DuckDB)
 
 DSL syntax, materialization basics, playground baseline, the trust-arc 1 storage primitives, file-format ingest and per-tenant routing, plus the plan/apply deployment workflow and project scaffolding.
 
@@ -64,8 +64,9 @@ DSL syntax, materialization basics, playground baseline, the trust-arc 1 storage
 | [12-init-scaffolding](pocs/00-foundations/12-init-scaffolding) | `rocky init --template duckdb` scaffolds a project that validates + compiles out of the box; `--template snowflake` shows the layout changes per warehouse |
 | [13-surrogate-keys](pocs/00-foundations/13-surrogate-keys) | A model sidecar `[[surrogate_key]]` block injects a deterministic, dbt_utils-identical MD5 hash column into the materialized table at `rocky run` |
 | [14-config-groups](pocs/00-foundations/14-config-groups) | One `models/groups/*.toml` fans `schema_template` + strategy + tags to N members via per-model `[args]`; `broken/` siblings show the `enforce` and pinned-schema-plus-args load guards |
+| [15-run-variables](pocs/00-foundations/15-run-variables) | Per-run `@var(name)` / `@var(name, default)` markers resolved by `rocky run --var` (and `compile` / `emit-sql`); a required var with no value fails compile with E028 — distinct from config-time `${ENV}` |
 
-### 01 — Quality (10 POCs · DuckDB)
+### 01 — Quality (11 POCs · DuckDB)
 
 Contracts, inline checks, anomaly detection, local testing, SCD-2 snapshots, standalone quality pipeline, freshness SLAs, cross-source overlap.
 
@@ -81,6 +82,7 @@ Contracts, inline checks, anomaly detection, local testing, SCD-2 snapshots, sta
 | [08-cross-source-overlap](pocs/01-quality/08-cross-source-overlap) | The same data arriving via two sibling sources — `cross_source_overlap` flags a business key shared across siblings (which per-table `unique` can't see) + `unique_expr` catches a derived-key duplicate, both at replication time |
 | [09-named-tests](pocs/01-quality/09-named-tests) | Define a check once in `test_definitions.toml`, apply it across models via `[[use_test]]` (column/severity overrides) alongside inline `[[tests]]` |
 | [10-unit-tests](pocs/01-quality/10-unit-tests) | Fixture-driven `[[test]]` blocks (`given` rows → `expect` rows) run by `rocky test` — multiset by default, positional with `ordered` |
+| [11-fail-loud-on-compile-error](pocs/01-quality/11-fail-loud-on-compile-error) | A model that fails to compile (E020) makes `rocky run` exit non-zero with status `partial_failure` and a `compile-error`; the broken table is never built while the clean model's data still lands |
 
 ### 02 — Performance (14 POCs · DuckDB)
 

--- a/examples/playground/pocs/00-foundations/15-run-variables/README.md
+++ b/examples/playground/pocs/00-foundations/15-run-variables/README.md
@@ -1,0 +1,73 @@
+# Per-run variables with `@var()`
+
+## Feature
+
+`@var(name)` markers in a model's SQL are resolved at run time from
+`rocky run --var name=value` (also accepted by `rocky compile` and
+`rocky emit-sql`). A marker may carry an inline default — `@var(name, default)`
+— and a required marker with no value and no default is a compile error.
+
+## Why it's distinctive
+
+`@var()` is the run-time half of Rocky's two-layer parameterisation, and it is
+deliberately distinct from the config-time `${ENV}` interpolation:
+
+- `${ENV}` is resolved while `rocky.toml` is parsed. It feeds connection and
+  config values into the engine before any model is seen.
+- `@var()` is resolved at compile/render time, per run, inside model SQL. It is
+  how one run differs from the next: which region to load, which cutoff date to
+  use.
+
+The marker stays visible in the source, so the SQL reads honestly and the
+operator owns any quoting (`where region = '@var(region)'`). A required
+variable that nobody supplied does not silently render to nothing. It fails the
+compile with **E028**, naming the variable and suggesting the fix.
+
+## Layout
+
+```
+rocky.toml                      Transformation pipeline over models/**
+models/
+  regional_sales.sql/.toml      Filters on @var(region) (required) and
+                                @var(channel, web) (optional, inline default)
+data/seed.sql                   raw__sales.sales across three regions x two channels
+run.sh                          Runs with --var, emits resolved SQL, and shows
+                                the missing-variable compile error
+```
+
+Each marker sits inside a string literal (`'@var(region)'`), which is how
+operator-owned quoting works and also keeps the pre-substitution SQL parseable.
+
+## Run
+
+```bash
+cd examples/playground/pocs/00-foundations/15-run-variables
+./run.sh
+```
+
+No credentials required — DuckDB only.
+
+## Expected output
+
+```
+==== 2. rocky run --var region=us — materialize ONLY us rows (channel defaults to web) ====
+OK: only us rows landed, channel defaulted to web (2 rows)
+
+==== 3. repeated --var: region=us AND channel=mobile selects a different slice ====
+OK: overriding the optional channel var changed the materialized slice
+
+==== 4. emit-sql --var region=us — markers resolve to literal values ====
+WHERE region  = 'us'
+  AND channel = 'web'
+OK: @var(region) resolved to 'us'; no @var() marker remains in the executable SQL
+
+==== 5. the optional @var(channel, web) resolved to its inline DEFAULT ====
+OK: @var(channel, web) resolved to 'web' with no --var supplied
+
+==== 6. a REQUIRED @var with no --var is a compile error (E028) ====
+  [E028] regional_sales: model references run variable `@var(region)` but no value was supplied and it has no inline default
+  suggestion: pass `--var region=<value>` or give the reference an inline default `@var(region, <default>)`
+OK: missing required @var(region) failed compile with E028 naming the variable
+
+PASS: @var() run variables resolve at run time ...
+```

--- a/examples/playground/pocs/00-foundations/15-run-variables/data/seed.sql
+++ b/examples/playground/pocs/00-foundations/15-run-variables/data/seed.sql
@@ -1,0 +1,26 @@
+-- Seed data for the run-variables POC.
+--
+-- run.sh loads this into the persistent poc.duckdb before running the
+-- pipeline:  duckdb poc.duckdb < data/seed.sql
+--
+-- Three regions across two channels so a `--var region=us` run can be shown to
+-- materialize ONLY the matching rows, and a `--var channel=mobile` override
+-- can be shown to change which rows land (the optional @var(channel, web)
+-- defaults to `web`).
+
+CREATE SCHEMA IF NOT EXISTS raw__sales;
+
+CREATE OR REPLACE TABLE raw__sales.sales (
+    region   VARCHAR,
+    channel  VARCHAR,
+    customer VARCHAR,
+    amount   INTEGER
+);
+
+INSERT INTO raw__sales.sales VALUES
+    ('us',   'web',    'alice',   100),
+    ('us',   'web',    'bob',     250),
+    ('us',   'mobile', 'carol',   180),
+    ('emea', 'web',    'dieter',  300),
+    ('emea', 'mobile', 'elena',   210),
+    ('apac', 'web',    'fumiko',  220);

--- a/examples/playground/pocs/00-foundations/15-run-variables/models/regional_sales.sql
+++ b/examples/playground/pocs/00-foundations/15-run-variables/models/regional_sales.sql
@@ -1,0 +1,19 @@
+-- A model parameterised by two per-run variables.
+--
+--   @var(region)          REQUIRED — no inline default. Must be supplied with
+--                         `--var region=<value>` or the compile fails (E028).
+--   @var(channel, web)    OPTIONAL — carries an inline default of `web`, used
+--                         when `--var channel=...` is not supplied.
+--
+-- The operator owns the quoting: each marker sits inside a string literal, so
+-- `--var region=us` renders `'us'`. `@var()` resolves at compile/render time,
+-- before any SQL is parsed — it is NOT rocky.toml's config-time `${ENV}`
+-- interpolation.
+SELECT
+    region,
+    channel,
+    customer,
+    amount
+FROM raw__sales.sales
+WHERE region  = '@var(region)'
+  AND channel = '@var(channel, web)'

--- a/examples/playground/pocs/00-foundations/15-run-variables/models/regional_sales.toml
+++ b/examples/playground/pocs/00-foundations/15-run-variables/models/regional_sales.toml
@@ -1,0 +1,13 @@
+depends_on = []
+
+[[sources]]
+catalog = ""
+schema = "raw__sales"
+table = "sales"
+
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "poc"
+schema = "main"

--- a/examples/playground/pocs/00-foundations/15-run-variables/rocky.toml
+++ b/examples/playground/pocs/00-foundations/15-run-variables/rocky.toml
@@ -1,0 +1,24 @@
+# 15-run-variables — per-run `@var()` variables substituted into model SQL.
+#
+# `regional_sales` filters on two run variables:
+#   - @var(region)          a REQUIRED variable (no inline default)
+#   - @var(min_amount, 0)   an OPTIONAL variable with an inline default of 0
+#
+# `rocky run --var region=us` renders `WHERE region = 'us' AND amount >= 0` and
+# materializes only the matching rows. Omitting `--var region` is a compile
+# error (E028) naming the variable, while the optional `min_amount` falls back
+# to its inline default.
+#
+# `@var()` is a RUN-TIME substitution and is deliberately distinct from the
+# config-time `${ENV}` interpolation rocky.toml performs while parsing.
+
+[adapter]
+type = "duckdb"
+path = "poc.duckdb"
+
+[pipeline.poc]
+type = "transformation"
+models = "models/**"
+
+[pipeline.poc.target.governance]
+auto_create_schemas = true

--- a/examples/playground/pocs/00-foundations/15-run-variables/run.sh
+++ b/examples/playground/pocs/00-foundations/15-run-variables/run.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# 15-run-variables — per-run `@var()` variables substituted into model SQL.
+#
+# The model `regional_sales` filters on two run variables:
+#   @var(region)        REQUIRED  — no inline default
+#   @var(channel, web)  OPTIONAL  — inline default of `web`
+#
+# This script proves:
+#   1. `rocky run --var region=us` materializes ONLY the matching rows
+#      (the optional channel defaults to `web`)
+#   2. a repeated `--var` (region + channel) changes which rows land
+#   3. `rocky emit-sql --var region=us` shows the RESOLVED values, not the
+#      literal `@var(...)` markers
+#   4. `@var(channel, web)` resolves to its inline DEFAULT when --var is omitted
+#   5. a REQUIRED `@var(region)` with no --var makes `rocky compile` fail with
+#      a clear E028 error naming the variable
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+mkdir -p expected
+rm -f .rocky-state.redb .rocky-state.redb.lock poc.duckdb
+rm -f models/.rocky-state.redb models/.rocky-state.redb.lock
+
+echo "==== 1. seed three regions across two channels ===="
+duckdb poc.duckdb < data/seed.sql
+echo "raw__sales.sales by region/channel:"
+duckdb poc.duckdb -c "SELECT region, channel, count(*) AS rows FROM raw__sales.sales GROUP BY region, channel ORDER BY region, channel"
+
+echo
+echo "==== 2. rocky run --var region=us — materialize ONLY us rows (channel defaults to web) ===="
+rocky -c rocky.toml -o json run --models models/ --var region=us \
+    > expected/run-us.json 2> expected/run-us.log
+echo "materialized poc.main.regional_sales:"
+duckdb poc.duckdb -c "SELECT region, channel, customer, amount FROM poc.main.regional_sales ORDER BY customer"
+
+REGIONS="$(duckdb -noheader -list poc.duckdb 'SELECT DISTINCT region FROM poc.main.regional_sales')"
+CHANNELS="$(duckdb -noheader -list poc.duckdb 'SELECT DISTINCT channel FROM poc.main.regional_sales')"
+US_WEB_ROWS="$(duckdb -noheader -list poc.duckdb 'SELECT count(*) FROM poc.main.regional_sales')"
+if [ "$REGIONS" != "us" ]; then
+    echo "FAIL: target holds regions other than 'us': [$REGIONS]" >&2
+    exit 1
+fi
+if [ "$CHANNELS" != "web" ]; then
+    echo "FAIL: channel did not default to 'web': [$CHANNELS]" >&2
+    exit 1
+fi
+if [ "$US_WEB_ROWS" -ne 2 ]; then
+    echo "FAIL: expected 2 us/web rows, got $US_WEB_ROWS" >&2
+    exit 1
+fi
+echo "OK: only us rows landed, channel defaulted to web ($US_WEB_ROWS rows)"
+
+echo
+echo "==== 3. repeated --var: region=us AND channel=mobile selects a different slice ===="
+rocky -c rocky.toml -o json run --models models/ --var region=us --var channel=mobile \
+    > expected/run-us-mobile.json 2> expected/run-us-mobile.log
+MOBILE_ROWS="$(duckdb -noheader -list poc.duckdb 'SELECT count(*) FROM poc.main.regional_sales')"
+MOBILE_CUST="$(duckdb -noheader -list poc.duckdb 'SELECT customer FROM poc.main.regional_sales')"
+echo "rows with region=us AND channel=mobile: $MOBILE_ROWS ($MOBILE_CUST)"
+if [ "$MOBILE_ROWS" -ne 1 ] || [ "$MOBILE_CUST" != "carol" ]; then
+    echo "FAIL: expected the single us/mobile row (carol), got $MOBILE_ROWS [$MOBILE_CUST]" >&2
+    exit 1
+fi
+echo "OK: overriding the optional channel var changed the materialized slice"
+
+echo
+echo "==== 4. emit-sql --var region=us — markers resolve to literal values ===="
+rocky emit-sql --models models/ --var region=us --out-dir build > /dev/null 2>&1
+# Strip the model's preserved `--` comment lines (which legitimately mention
+# the @var() markers) so the assertions look only at the executable SQL.
+EXEC_SQL="$(grep -v '^[[:space:]]*--' build/regional_sales.sql)"
+echo "emitted WHERE clause (comments stripped):"
+echo "$EXEC_SQL" | grep -i "where\|region\|channel"
+if ! echo "$EXEC_SQL" | grep -q "region  = 'us'"; then
+    echo "FAIL: emitted SQL did not resolve @var(region) to 'us'" >&2
+    exit 1
+fi
+if echo "$EXEC_SQL" | grep -q "@var("; then
+    echo "FAIL: emitted SQL still contains a literal @var() marker" >&2
+    exit 1
+fi
+echo "OK: @var(region) resolved to 'us'; no @var() marker remains in the executable SQL"
+
+echo
+echo "==== 5. the optional @var(channel, web) resolved to its inline DEFAULT ===="
+# channel was NOT passed to emit-sql above, so it falls back to web.
+if ! echo "$EXEC_SQL" | grep -q "channel = 'web'"; then
+    echo "FAIL: @var(channel, web) did not fall back to its inline default 'web'" >&2
+    exit 1
+fi
+echo "OK: @var(channel, web) resolved to 'web' with no --var supplied"
+
+echo
+echo "==== 6. a REQUIRED @var with no --var is a compile error (E028) ===="
+set +e
+rocky -o json compile --models models/ > expected/compile-missing.json 2> expected/compile-missing.log
+COMPILE_EXIT=$?
+set -e
+echo "rocky compile exit code (no --var region): $COMPILE_EXIT"
+if [ "$COMPILE_EXIT" -eq 0 ]; then
+    echo "FAIL: compile succeeded despite an unsupplied required @var(region)" >&2
+    exit 1
+fi
+echo "diagnostic:"
+jq -r '.diagnostics[]? | select(.code == "E028") | "  [\(.code)] \(.model): \(.message)\n  suggestion: \(.suggestion)"' \
+    expected/compile-missing.json
+if ! jq -e '.diagnostics[]? | select(.code == "E028") | .message | test("region")' \
+        expected/compile-missing.json > /dev/null; then
+    echo "FAIL: expected an E028 diagnostic naming the missing variable 'region'" >&2
+    exit 1
+fi
+echo "OK: missing required @var(region) failed compile with E028 naming the variable"
+
+echo
+echo "PASS: @var() run variables resolve at run time — a required var filters the"
+echo "      materialized rows and renders into emitted SQL, an optional var falls"
+echo "      back to its inline default, and an unsupplied required var fails E028."
+exit 0

--- a/examples/playground/pocs/01-quality/11-fail-loud-on-compile-error/README.md
+++ b/examples/playground/pocs/01-quality/11-fail-loud-on-compile-error/README.md
@@ -1,0 +1,81 @@
+# Fail loud on a compile error
+
+## Feature
+
+`rocky run` over a project that contains a model with a real compile error
+fails the run loudly: it exits non-zero, reports `partial_failure`, and records
+the broken model as a `compile-error` instead of quietly reporting a green run
+over a half-built warehouse.
+
+## Why it's distinctive
+
+A pipeline is only trustworthy if a broken model can't masquerade as a healthy
+one. Rocky type-checks every model before issuing SQL, so a model that can't
+compile is excluded from execution and surfaced as a failure rather than
+skipped in silence. The run's exit code and JSON status both reflect that one
+model didn't build, which is what lets an orchestrator (or a human) stop and
+look instead of shipping downstream on stale or missing data.
+
+Just as important: the failure is contained. The clean model in the same run
+still materializes. Rocky fails the broken model loudly without throwing away
+the good data that compiled fine, so a partial outage stays partial.
+
+The broken model here is a `time_interval` model whose declared
+`time_column = "order_date"` is absent from its `SELECT` output. Rocky catches
+that as **E020** at compile time, before any SQL reaches the warehouse.
+
+## Layout
+
+```
+rocky.toml                  Transformation pipeline over models/**
+models/
+  stg_orders.sql/.toml      Clean full_refresh model — always materializes
+  daily_revenue.sql/.toml   Broken time_interval model — E020 (time_column
+                            order_date missing from the SELECT output)
+daily_revenue.fixed.sql     The corrected SELECT (outputs order_date); run.sh
+                            applies it in the final step to show a green re-run
+data/seed.sql               One raw__sales.orders table feeding both models
+run.sh                      Runs the broken pipeline, asserts the loud failure
+                            + that good data landed, then fixes and re-runs
+```
+
+## Run
+
+```bash
+cd examples/playground/pocs/01-quality/11-fail-loud-on-compile-error
+./run.sh
+```
+
+No credentials required — DuckDB only.
+
+## Expected output
+
+The broken run exits non-zero and the script asserts every claim:
+
+```
+==== 3. assert: the run exited NON-ZERO ====
+OK: run exited 2 (non-zero) instead of silently succeeding
+
+==== 4. assert: status is partial_failure with a compile-error on daily_revenue ====
+status: PartialFailure
+errors recorded by the run:
+  - daily_revenue: failure_kind=compile-error :: [E020] time_column 'order_date' is not in the output schema of model 'daily_revenue'
+OK: daily_revenue failed loud with failure_kind=compile-error (E020)
+
+==== 5. assert: the broken model's table is ABSENT (never built) ====
+OK: poc.main.daily_revenue does not exist
+
+==== 6. assert: the clean model's data DID land ====
+poc.main.stg_orders rows: 30
+OK: the clean model materialized 30 rows despite the sibling failure
+
+==== 7. apply the one-line fix and re-run — the same pipeline goes green ====
+fixed run status: success (tables_failed: 0)
+OK: with the compile error fixed, the same pipeline runs green and builds daily_revenue
+
+PASS: rocky run failed loud on the compile error ...
+```
+
+The script exits 0 only because the run **correctly failed**: a green exit here
+proves Rocky reported the failure, kept the broken table out of the warehouse,
+and still landed the data that compiled.

--- a/examples/playground/pocs/01-quality/11-fail-loud-on-compile-error/daily_revenue.fixed.sql
+++ b/examples/playground/pocs/01-quality/11-fail-loud-on-compile-error/daily_revenue.fixed.sql
@@ -1,0 +1,15 @@
+-- The corrected SELECT for daily_revenue: it now outputs `order_date`, the
+-- column its sidecar declares as `time_column`. run.sh copies this over
+-- models/daily_revenue.sql in its final step to prove the same pipeline runs
+-- green once the compile error is fixed.
+--
+-- This file lives outside models/ on purpose so the pipeline's `models/**`
+-- glob never loads it as a second model.
+SELECT
+    CAST(order_at AS DATE) AS order_date,
+    region,
+    SUM(amount)            AS revenue
+FROM raw__sales.orders
+WHERE order_at >= @start_date
+  AND order_at <  @end_date
+GROUP BY 1, 2

--- a/examples/playground/pocs/01-quality/11-fail-loud-on-compile-error/data/seed.sql
+++ b/examples/playground/pocs/01-quality/11-fail-loud-on-compile-error/data/seed.sql
@@ -1,0 +1,18 @@
+-- Seed data for the fail-loud-on-compile-error POC.
+--
+-- run.sh loads this into the persistent poc.duckdb before running the
+-- pipeline:  duckdb poc.duckdb < data/seed.sql
+--
+-- A single raw source table feeds both the clean staging model and the
+-- broken time_interval model. All rows land on 2026-04-07 so the partition
+-- the run targets is non-empty.
+
+CREATE SCHEMA IF NOT EXISTS raw__sales;
+
+CREATE OR REPLACE TABLE raw__sales.orders AS
+SELECT
+    i AS order_id,
+    CASE WHEN i % 2 = 0 THEN 'us' ELSE 'emea' END AS region,
+    (i * 7 % 500) + 5 AS amount,
+    CAST(TIMESTAMP '2026-04-07 00:00:00' + ((i % 6) || ' hours')::INTERVAL AS TIMESTAMP) AS order_at
+FROM generate_series(1, 30) AS t(i);

--- a/examples/playground/pocs/01-quality/11-fail-loud-on-compile-error/models/daily_revenue.sql
+++ b/examples/playground/pocs/01-quality/11-fail-loud-on-compile-error/models/daily_revenue.sql
@@ -1,0 +1,17 @@
+-- A deliberately broken time_interval model.
+--
+-- The sidecar declares `time_column = "order_date"`, but this SELECT never
+-- outputs an `order_date` column — it only emits `region` and `revenue`.
+-- Rocky's compiler catches this as E020 (the time_column is absent from the
+-- model's output schema) before any SQL is issued to the warehouse.
+--
+-- The fix is to add the partition column to the SELECT, exactly as
+-- `daily_revenue.fixed.sql` does. run.sh applies that fix in its final step to
+-- show the same pipeline then runs green.
+SELECT
+    region,
+    SUM(amount) AS revenue
+FROM raw__sales.orders
+WHERE order_at >= @start_date
+  AND order_at <  @end_date
+GROUP BY region

--- a/examples/playground/pocs/01-quality/11-fail-loud-on-compile-error/models/daily_revenue.toml
+++ b/examples/playground/pocs/01-quality/11-fail-loud-on-compile-error/models/daily_revenue.toml
@@ -1,0 +1,19 @@
+depends_on = []
+
+[[sources]]
+catalog = ""
+schema = "raw__sales"
+table = "orders"
+
+[strategy]
+type = "time_interval"
+# Declared partition column. The SELECT in daily_revenue.sql does NOT output
+# this column, which is exactly the mistake Rocky catches as E020.
+time_column = "order_date"
+granularity = "day"
+first_partition = "2026-04-04"
+lookback = 0
+
+[target]
+catalog = "poc"
+schema = "main"

--- a/examples/playground/pocs/01-quality/11-fail-loud-on-compile-error/models/stg_orders.sql
+++ b/examples/playground/pocs/01-quality/11-fail-loud-on-compile-error/models/stg_orders.sql
@@ -1,0 +1,9 @@
+-- A clean staging model. Full refresh, no run-time placeholders, compiles
+-- and materializes on every run. This is the "good data" that must still
+-- land even when a sibling model in the same run fails to compile.
+SELECT
+    order_id,
+    region,
+    amount,
+    order_at
+FROM raw__sales.orders

--- a/examples/playground/pocs/01-quality/11-fail-loud-on-compile-error/models/stg_orders.toml
+++ b/examples/playground/pocs/01-quality/11-fail-loud-on-compile-error/models/stg_orders.toml
@@ -1,0 +1,13 @@
+depends_on = []
+
+[[sources]]
+catalog = ""
+schema = "raw__sales"
+table = "orders"
+
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "poc"
+schema = "main"

--- a/examples/playground/pocs/01-quality/11-fail-loud-on-compile-error/rocky.toml
+++ b/examples/playground/pocs/01-quality/11-fail-loud-on-compile-error/rocky.toml
@@ -1,0 +1,28 @@
+# 11-fail-loud-on-compile-error — Rocky's "fail loud, never silently drop data" guarantee.
+#
+# This POC runs a transformation pipeline with two independent models:
+#   - stg_orders     — a clean full_refresh model that materializes
+#   - daily_revenue  — a time_interval model with a real compile error (E020):
+#                      its declared time_column `order_date` is absent from the
+#                      model's SELECT output.
+#
+# When `rocky run` hits the broken model it does NOT pretend the run
+# succeeded. The broken model is excluded from execution and recorded as a
+# `compile-error` failure, the clean model still materializes, and the run
+# exits non-zero with status `partial_failure`. A pipeline that can't build
+# every model surfaces that fact instead of reporting a green run over a
+# half-built warehouse.
+
+[adapter]
+type = "duckdb"
+path = "poc.duckdb"
+
+[pipeline.poc]
+type = "transformation"
+models = "models/**"
+
+[pipeline.poc.target.governance]
+auto_create_schemas = true
+
+[pipeline.poc.execution]
+concurrency = 4

--- a/examples/playground/pocs/01-quality/11-fail-loud-on-compile-error/run.sh
+++ b/examples/playground/pocs/01-quality/11-fail-loud-on-compile-error/run.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# 11-fail-loud-on-compile-error — Rocky's "fail loud, never silently drop data".
+#
+# A transformation pipeline with two independent models:
+#   - stg_orders     — clean full_refresh, materializes
+#   - daily_revenue  — time_interval model with a real compile error (E020):
+#                      its declared `time_column = order_date` is absent from
+#                      the SELECT output.
+#
+# This script PROVES that `rocky run` over that project fails loudly instead of
+# reporting a green run:
+#   1. the run exits NON-ZERO
+#   2. `--output json` reports status `partial_failure`
+#   3. the broken model is recorded with failure_kind `compile-error` (E020)
+#   4. the broken model's target table is ABSENT (it never reached the warehouse)
+#   5. the clean model's table EXISTS and is fully populated — good data lands
+# Then it applies the one-line fix and shows the same pipeline runs green.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+mkdir -p expected
+rm -f .rocky-state.redb .rocky-state.redb.lock poc.duckdb
+rm -f models/.rocky-state.redb models/.rocky-state.redb.lock
+
+# The final step rewrites models/daily_revenue.sql with the fixed SELECT. Keep
+# a pristine copy and restore it on exit so the committed POC stays "broken"
+# (that is the demo subject) no matter how this script ends.
+BROKEN_BACKUP="$(mktemp)"
+cp models/daily_revenue.sql "$BROKEN_BACKUP"
+restore_broken() { cp "$BROKEN_BACKUP" models/daily_revenue.sql; rm -f "$BROKEN_BACKUP"; }
+trap restore_broken EXIT
+# On Ctrl-C / timeout, exit so the EXIT trap fires and restores the file rather
+# than leaving models/daily_revenue.sql in its temporarily-fixed state.
+trap 'exit 130' INT TERM
+
+echo "==== 1. seed a raw source table both models read ===="
+duckdb poc.duckdb < data/seed.sql
+echo "raw__sales.orders rows: $(duckdb -noheader -list poc.duckdb 'SELECT count(*) FROM raw__sales.orders')"
+
+echo
+echo "==== 2. rocky run — one clean model, one model that fails to compile ===="
+# The run is EXPECTED to fail. Capture the exit code without tripping `set -e`.
+set +e
+rocky -c rocky.toml -o json run --models models/ --partition 2026-04-07 \
+    > expected/run-broken.json 2> expected/run-broken.log
+RUN_EXIT=$?
+set -e
+echo "rocky run exit code: $RUN_EXIT"
+
+echo
+echo "==== 3. assert: the run exited NON-ZERO ===="
+if [ "$RUN_EXIT" -eq 0 ]; then
+    echo "FAIL: rocky run exited 0 over a project with a compile error" >&2
+    exit 1
+fi
+echo "OK: run exited $RUN_EXIT (non-zero) instead of silently succeeding"
+
+echo
+echo "==== 4. assert: status is PartialFailure with a compile-error on daily_revenue ===="
+STATUS="$(jq -r '.status' expected/run-broken.json)"
+echo "status: $STATUS"
+if [ "$STATUS" != "PartialFailure" ]; then
+    echo "FAIL: expected status PartialFailure, got '$STATUS'" >&2
+    exit 1
+fi
+
+echo "errors recorded by the run:"
+jq -r '.errors[] | "  - \(.asset_key | join(".")): failure_kind=\(.failure_kind) :: \(.error)"' \
+    expected/run-broken.json
+
+KIND="$(jq -r '.errors[] | select(.asset_key | index("daily_revenue")) | .failure_kind' expected/run-broken.json)"
+if [ "$KIND" != "compile-error" ]; then
+    echo "FAIL: expected failure_kind compile-error for daily_revenue, got '$KIND'" >&2
+    exit 1
+fi
+if ! jq -e '.errors[] | select(.asset_key | index("daily_revenue")) | .error | test("E020")' \
+        expected/run-broken.json > /dev/null; then
+    echo "FAIL: the daily_revenue error did not name the E020 compile diagnostic" >&2
+    exit 1
+fi
+echo "OK: daily_revenue failed loud with failure_kind=compile-error (E020)"
+
+echo
+echo "==== 5. assert: the broken model's table is ABSENT (never built) ===="
+if duckdb -noheader -list poc.duckdb "SELECT 1 FROM poc.main.daily_revenue LIMIT 1" 2>/dev/null; then
+    echo "FAIL: poc.main.daily_revenue exists — a broken model should not materialize" >&2
+    exit 1
+fi
+echo "OK: poc.main.daily_revenue does not exist"
+
+echo
+echo "==== 6. assert: the clean model's data DID land ===="
+GOOD_ROWS="$(duckdb -noheader -list poc.duckdb 'SELECT count(*) FROM poc.main.stg_orders')"
+echo "poc.main.stg_orders rows: $GOOD_ROWS"
+if [ "$GOOD_ROWS" -lt 1 ]; then
+    echo "FAIL: stg_orders is empty — the clean model should still materialize" >&2
+    exit 1
+fi
+echo "OK: the clean model materialized $GOOD_ROWS rows despite the sibling failure"
+
+echo
+echo "==== 7. apply the one-line fix and re-run — the same pipeline goes green ===="
+cp daily_revenue.fixed.sql models/daily_revenue.sql
+rm -f poc.duckdb
+duckdb poc.duckdb < data/seed.sql
+rocky -c rocky.toml -o json run --models models/ --partition 2026-04-07 \
+    > expected/run-fixed.json 2> expected/run-fixed.log
+FIXED_STATUS="$(jq -r '.status' expected/run-fixed.json)"
+FIXED_FAILED="$(jq -r '.tables_failed' expected/run-fixed.json)"
+echo "fixed run status: $FIXED_STATUS (tables_failed: $FIXED_FAILED)"
+if [ "$FIXED_STATUS" != "Success" ] || [ "$FIXED_FAILED" -ne 0 ]; then
+    echo "FAIL: expected a clean success after the fix, got status=$FIXED_STATUS failed=$FIXED_FAILED" >&2
+    exit 1
+fi
+FIXED_ROWS="$(duckdb -noheader -list poc.duckdb 'SELECT count(*) FROM poc.main.daily_revenue')"
+echo "poc.main.daily_revenue rows after fix: $FIXED_ROWS"
+if [ "$FIXED_ROWS" -lt 1 ]; then
+    echo "FAIL: daily_revenue did not materialize after the fix" >&2
+    exit 1
+fi
+echo "OK: with the compile error fixed, the same pipeline runs green and builds daily_revenue"
+
+echo
+echo "PASS: rocky run failed loud on the compile error (non-zero exit, partial_failure,"
+echo "      compile-error on daily_revenue), the broken table was never built, the clean"
+echo "      model's data still landed, and the fixed pipeline then ran green."
+exit 0


### PR DESCRIPTION
Two new playground POCs that showcase recently shipped features. Both are DuckDB-only and run end-to-end with no credentials via a single `./run.sh`.

## `00-foundations/15-run-variables` — `rocky run --var` (#976)

Demonstrates per-run `@var(name)` / `@var(name, default)` markers resolved at compile/render time from `rocky run --var name=value` (also accepted by `compile` and `emit-sql`). The model filters on a required `@var(region)` and an optional `@var(channel, web)`. `run.sh` materializes a single slice, overrides the optional var to land a different slice, emits the resolved SQL to show no marker survives, and proves a required var with no value fails compile with **E028**. Frames run-time `@var()` as the deliberate counterpart to config-time `${ENV}` interpolation.

## `01-quality/11-fail-loud-on-compile-error` — fail loud on compile error (#975)

Demonstrates that `rocky run` over a project containing a model with a real compile error fails the run loudly rather than reporting a green run over a half-built warehouse. The broken `time_interval` model (declared `time_column` missing from its `SELECT`, caught as **E020** before any SQL reaches the warehouse) makes the run exit non-zero with status `partial_failure` and a `compile-error`, while the clean sibling model still materializes. `run.sh` asserts the non-zero exit, the recorded failure, the absent broken table, and the landed good data, then applies a one-line fix and re-runs green.

## POC count

The catalog count rose by 2 (94 → 96; 82 → 84 run with no credentials). The count cascade is committed in `examples/playground/README.md`.
