### PR TITLE
fix(engine/rocky-compiler): substitute run variables before lineage extraction (bare @var)

### DIFF
--- a/engine/crates/rocky-compiler/src/compile.rs
+++ b/engine/crates/rocky-compiler/src/compile.rs
@@ -168,12 +168,22 @@ pub fn compile_with_db(
 ) -> Result<CompileResult, CompileError> {
     let total_start = Instant::now();
 
-    // 1. Load and resolve project (salsa-driven for .rocky files).
+    // 1. Load project, substitute per-run variables, then resolve.
+    //
+    //    Substitution happens **before** `Project::from_models` runs
+    //    dependency resolution / lineage extraction, so a bare `@var(...)`
+    //    marker outside a string literal (e.g. `WHERE amount >= @var(min)`)
+    //    is resolved to its value (or the parseable missing sentinel) before
+    //    it ever reaches the SQL parser. Resolving after load is too late:
+    //    lineage extraction on the raw `@var(` text fails and load returns an
+    //    error before `compile_project` can substitute.
     let load_start = Instant::now();
-    let project = Project::load_with_db(&config.models_dir, db)?;
+    let mut models = Project::load_models_with_db(&config.models_dir, db)?;
+    let run_var_diagnostics = substitute_run_vars_into_models(&mut models, &config.run_vars);
+    let project = Project::from_models(models)?;
     let project_load_ms = load_start.elapsed().as_millis() as u64;
 
-    let mut result = compile_project(project, config)?;
+    let mut result = compile_project(project, config, run_var_diagnostics)?;
     result.timings.project_load_ms = project_load_ms;
     result.timings.total_ms = total_start.elapsed().as_millis() as u64;
 
@@ -192,23 +202,24 @@ pub fn compile_with_db(
     Ok(result)
 }
 
-/// Compile a pre-loaded project (useful when models come from other sources).
-pub fn compile_project(
-    mut project: Project,
-    config: &CompilerConfig,
-) -> Result<CompileResult, CompileError> {
-    let mut timings = PhaseTimings::default();
-
-    // 1b. Substitute per-run variables (`@var(name)` / `@var(name, default)`)
-    //     into each model's SQL before any SQL parsing happens, so the
-    //     resolved text flows uniformly through the semantic graph, typecheck,
-    //     and downstream SQL generation. A reference with no supplied value and
-    //     no inline default is recorded and turned into an E028 error
-    //     diagnostic naming the variable. This pass is a no-op (and allocates
-    //     nothing extra beyond the per-model scan) when no model uses `@var()`.
+/// Substitute per-run variables into each model's SQL **before** dependency
+/// resolution / lineage extraction.
+///
+/// Each `@var(name)` / `@var(name, default)` occurrence is replaced with its
+/// supplied value, its inline default, or — when neither exists — a parseable
+/// sentinel (`NULL`). Because the marker is gone before the SQL parser sees
+/// it, a bare reference outside a string literal (`WHERE amount >= @var(min)`)
+/// no longer breaks lineage extraction. Returns one E028 error diagnostic per
+/// required variable that had no supplied value and no inline default, naming
+/// the variable. A no-op (beyond the per-model regex scan) when no model uses
+/// `@var()`.
+fn substitute_run_vars_into_models(
+    models: &mut [rocky_core::models::Model],
+    run_vars: &rocky_core::run_vars::RunVars,
+) -> Vec<Diagnostic> {
     let mut run_var_diagnostics: Vec<Diagnostic> = Vec::new();
-    for model in &mut project.models {
-        let substitution = rocky_core::run_vars::substitute_run_vars(&model.sql, &config.run_vars);
+    for model in models {
+        let substitution = rocky_core::run_vars::substitute_run_vars(&model.sql, run_vars);
         for missing in substitution.missing {
             run_var_diagnostics.push(
                 Diagnostic::error(
@@ -227,6 +238,21 @@ pub fn compile_project(
         }
         model.sql = substitution.sql;
     }
+    run_var_diagnostics
+}
+
+/// Compile a pre-loaded project (useful when models come from other sources).
+///
+/// `run_var_diagnostics` carries the E028 diagnostics produced by
+/// [`substitute_run_vars_into_models`] at load time (before resolution), which
+/// are merged into the final diagnostic set. Callers that don't use per-run
+/// variables pass an empty `Vec`.
+pub fn compile_project(
+    project: Project,
+    config: &CompilerConfig,
+    run_var_diagnostics: Vec<Diagnostic>,
+) -> Result<CompileResult, CompileError> {
+    let mut timings = PhaseTimings::default();
 
     // 2. Build semantic graph
     let sg_start = Instant::now();
@@ -376,8 +402,13 @@ pub fn compile_incremental(
 
     // 1. Load the new project + rebuild the semantic graph. Both are cheap
     //    relative to typecheck — the whole point of the optimization.
+    //    Substitute per-run variables before resolution for the same reason
+    //    as the full-compile path: a bare `@var(...)` must never reach the
+    //    SQL parser during lineage extraction (see `compile_with_db`).
     let load_start = Instant::now();
-    let project = Project::load(&config.models_dir)?;
+    let mut models = Project::load_models(&config.models_dir)?;
+    let run_var_diagnostics = substitute_run_vars_into_models(&mut models, &config.run_vars);
+    let project = Project::from_models(models)?;
     let project_load_ms = load_start.elapsed().as_millis() as u64;
 
     let sg_start = Instant::now();
@@ -516,6 +547,7 @@ pub fn compile_incremental(
     diagnostics.extend(blast_radius_diagnostics);
     diagnostics.extend(classification_diagnostics);
     diagnostics.extend(freshness_diagnostics);
+    diagnostics.extend(run_var_diagnostics);
 
     let has_errors = diagnostics
         .iter()

--- a/engine/crates/rocky-compiler/src/project.rs
+++ b/engine/crates/rocky-compiler/src/project.rs
@@ -103,6 +103,21 @@ impl Project {
         models_dir: &Path,
         db: &mut crate::salsa_compile::RockyDatabase,
     ) -> Result<Self, ProjectError> {
+        Self::from_models(Self::load_models_with_db(models_dir, db)?)
+    }
+
+    /// Load every model from a directory **without** resolving dependencies.
+    ///
+    /// Returns the raw `Model` set (`.sql` sidecars + `.rocky` files) before
+    /// `resolve_dependencies` / lineage extraction has run. Callers that need
+    /// to mutate model SQL ahead of resolution — e.g. substituting per-run
+    /// `@var()` variables so a bare marker never reaches the SQL parser — load
+    /// here, transform, then call [`Project::from_models`]. Most callers want
+    /// [`Project::load_with_db`], which chains the two.
+    pub fn load_models_with_db(
+        models_dir: &Path,
+        db: &mut crate::salsa_compile::RockyDatabase,
+    ) -> Result<Vec<Model>, ProjectError> {
         let mut models = models::load_models_from_dir(models_dir)?;
 
         // Also load .rocky files via the salsa pipeline
@@ -118,7 +133,17 @@ impl Project {
             });
         }
 
-        Self::from_models(models)
+        Ok(models)
+    }
+
+    /// Load every model from a directory **without** resolving dependencies,
+    /// using a transient salsa database for the `.rocky` parse pipeline.
+    ///
+    /// The non-`db` counterpart to [`Project::load_models_with_db`] — mirrors
+    /// [`Project::load`]'s relationship to [`Project::load_with_db`].
+    pub fn load_models(models_dir: &Path) -> Result<Vec<Model>, ProjectError> {
+        let mut db = crate::salsa_compile::RockyDatabase::default();
+        Self::load_models_with_db(models_dir, &mut db)
     }
 
     /// Build a project from pre-loaded models.

--- a/engine/crates/rocky-compiler/tests/integration.rs
+++ b/engine/crates/rocky-compiler/tests/integration.rs
@@ -688,3 +688,116 @@ fn run_var_inline_default_used_when_unset() {
         "an inline default satisfies the reference; no E028"
     );
 }
+
+/// Write a two-model project: a clean root `up` and a downstream `down` whose
+/// SQL the caller supplies (it should reference `up`). Neither sidecar sets
+/// `depends_on`, so the `up → down` edge can only come from lineage extraction
+/// over `down`'s SQL — which is exactly what we want to prove survives `@var`
+/// substitution.
+fn temp_linear_two_model_project(down_sql: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let models = dir.path().join("models");
+    std::fs::create_dir_all(&models).unwrap();
+    std::fs::write(models.join("up.sql"), "SELECT 1 AS id, 100 AS amount").unwrap();
+    std::fs::write(
+        models.join("up.toml"),
+        "name = \"up\"\n\n[target]\ncatalog = \"cat\"\nschema = \"sch\"\ntable = \"up\"\n",
+    )
+    .unwrap();
+    std::fs::write(models.join("down.sql"), down_sql).unwrap();
+    std::fs::write(
+        models.join("down.toml"),
+        "name = \"down\"\n\n[target]\ncatalog = \"cat\"\nschema = \"sch\"\ntable = \"down\"\n",
+    )
+    .unwrap();
+    dir
+}
+
+/// Regression: a BARE `@var(...)` marker outside any string literal
+/// (`WHERE amount >= @var(threshold)`) must compile clean. Before run-var
+/// substitution was moved ahead of lineage extraction, this crashed compile
+/// with a sqlparser `Expected: end of statement, found: (` error during
+/// dependency resolution — the raw `@var(` text reached the parser. The
+/// existing `run_vars` unit test never caught it because it exercised
+/// `substitute_run_vars` in isolation, not the lineage → compile path.
+#[test]
+fn bare_run_var_outside_string_literal_compiles_and_keeps_dependency() {
+    let dir =
+        temp_linear_two_model_project("SELECT id, amount FROM up WHERE amount >= @var(threshold)");
+    let config = CompilerConfig {
+        models_dir: dir.path().join("models"),
+        run_vars: rocky_core::run_vars::RunVars::parse_pairs(["threshold=100"]).unwrap(),
+        ..Default::default()
+    };
+
+    // The crux: this used to return `Err(CompileError::Project(..))`.
+    let result = compile(&config).unwrap();
+
+    assert!(
+        !result.has_errors,
+        "a bare @var must compile clean: {:?}",
+        result.diagnostics
+    );
+
+    let down = result.project.model("down").unwrap();
+    assert_eq!(
+        down.sql, "SELECT id, amount FROM up WHERE amount >= 100",
+        "the bare @var(threshold) marker must resolve to the supplied value"
+    );
+    assert!(
+        !down.sql.contains("@var("),
+        "no @var() marker may remain in the executable SQL"
+    );
+
+    // The `up → down` dependency must still be auto-resolved from the
+    // substituted SQL: a bare @var sitting next to a real table ref doesn't
+    // drop the edge.
+    let up_pos = result
+        .project
+        .execution_order
+        .iter()
+        .position(|n| n == "up")
+        .expect("up must be in the execution order");
+    let down_pos = result
+        .project
+        .execution_order
+        .iter()
+        .position(|n| n == "down")
+        .expect("down must be in the execution order");
+    assert!(
+        up_pos < down_pos,
+        "up must resolve as a dependency of down and execute first"
+    );
+}
+
+/// A missing required BARE `@var` renders to the parseable `NULL` sentinel, so
+/// compile returns `Ok` with an E028 diagnostic naming the variable rather
+/// than crashing in lineage extraction.
+#[test]
+fn missing_bare_run_var_yields_e028_not_a_parser_crash() {
+    let dir =
+        temp_linear_two_model_project("SELECT id, amount FROM up WHERE amount >= @var(threshold)");
+    let config = CompilerConfig {
+        models_dir: dir.path().join("models"),
+        // No `threshold` supplied and no inline default.
+        ..Default::default()
+    };
+
+    let result = compile(&config).unwrap();
+
+    assert!(
+        result.has_errors,
+        "a missing required bare var must fail compile"
+    );
+    let e028: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| &*d.code == "E028")
+        .collect();
+    assert_eq!(e028.len(), 1, "exactly one E028 for the one missing var");
+    assert!(
+        e028[0].message.contains("threshold"),
+        "the error must name the missing variable: {}",
+        e028[0].message
+    );
+}

--- a/examples/playground/pocs/00-foundations/15-run-variables/README.md
+++ b/examples/playground/pocs/00-foundations/15-run-variables/README.md
@@ -23,20 +23,24 @@ operator owns any quoting (`where region = '@var(region)'`). A required
 variable that nobody supplied does not silently render to nothing. It fails the
 compile with **E028**, naming the variable and suggesting the fix.
 
+A marker works in either position. Inside a string literal the operator owns
+the quoting (`region = '@var(region)'`); bare in numeric or expression position
+it renders without quotes (`amount >= @var(min_amount, 0)`). Substitution runs
+before the SQL is parsed for lineage and type checking, so a bare marker never
+trips the parser.
+
 ## Layout
 
 ```
 rocky.toml                      Transformation pipeline over models/**
 models/
-  regional_sales.sql/.toml      Filters on @var(region) (required) and
-                                @var(channel, web) (optional, inline default)
+  regional_sales.sql/.toml      Filters on @var(region) (required, quoted),
+                                @var(channel, web) (optional, quoted) and
+                                @var(min_amount, 0) (optional, BARE numeric)
 data/seed.sql                   raw__sales.sales across three regions x two channels
 run.sh                          Runs with --var, emits resolved SQL, and shows
                                 the missing-variable compile error
 ```
-
-Each marker sits inside a string literal (`'@var(region)'`), which is how
-operator-owned quoting works and also keeps the pre-substitution SQL parseable.
 
 ## Run
 
@@ -56,15 +60,20 @@ OK: only us rows landed, channel defaulted to web (2 rows)
 ==== 3. repeated --var: region=us AND channel=mobile selects a different slice ====
 OK: overriding the optional channel var changed the materialized slice
 
-==== 4. emit-sql --var region=us — markers resolve to literal values ====
+==== 4. a BARE @var(min_amount, 0) in numeric position works on the run path ====
+rows with region=us AND amount >= 200: 1 (bob)
+OK: a bare numeric @var filtered the run — no string-literal wrapper needed
+
+==== 5. emit-sql --var region=us — markers resolve to literal values ====
 WHERE region  = 'us'
   AND channel = 'web'
-OK: @var(region) resolved to 'us'; no @var() marker remains in the executable SQL
+  AND amount >= 0
+OK: quoted @var(region) -> 'us' and bare @var(min_amount, 0) -> amount >= 0; no marker remains
 
-==== 5. the optional @var(channel, web) resolved to its inline DEFAULT ====
+==== 6. the optional @var(channel, web) resolved to its inline DEFAULT ====
 OK: @var(channel, web) resolved to 'web' with no --var supplied
 
-==== 6. a REQUIRED @var with no --var is a compile error (E028) ====
+==== 7. a REQUIRED @var with no --var is a compile error (E028) ====
   [E028] regional_sales: model references run variable `@var(region)` but no value was supplied and it has no inline default
   suggestion: pass `--var region=<value>` or give the reference an inline default `@var(region, <default>)`
 OK: missing required @var(region) failed compile with E028 naming the variable

--- a/examples/playground/pocs/00-foundations/15-run-variables/models/regional_sales.sql
+++ b/examples/playground/pocs/00-foundations/15-run-variables/models/regional_sales.sql
@@ -1,14 +1,18 @@
--- A model parameterised by two per-run variables.
+-- A model parameterised by three per-run variables.
 --
 --   @var(region)          REQUIRED — no inline default. Must be supplied with
 --                         `--var region=<value>` or the compile fails (E028).
 --   @var(channel, web)    OPTIONAL — carries an inline default of `web`, used
 --                         when `--var channel=...` is not supplied.
+--   @var(min_amount, 0)   OPTIONAL — a BARE marker (no surrounding quotes) in
+--                         numeric position. `--var min_amount=200` renders
+--                         `amount >= 200`; omitted, it falls back to `0`.
 --
--- The operator owns the quoting: each marker sits inside a string literal, so
--- `--var region=us` renders `'us'`. `@var()` resolves at compile/render time,
--- before any SQL is parsed — it is NOT rocky.toml's config-time `${ENV}`
--- interpolation.
+-- `@var()` resolves at compile/render time, before any SQL is parsed, so a
+-- marker works whether it sits inside a string literal (the quoted region /
+-- channel filters, where the operator owns the quoting) or bare in numeric
+-- position (`amount >= @var(min_amount, 0)`). It is NOT rocky.toml's
+-- config-time `${ENV}` interpolation.
 SELECT
     region,
     channel,
@@ -17,3 +21,4 @@ SELECT
 FROM raw__sales.sales
 WHERE region  = '@var(region)'
   AND channel = '@var(channel, web)'
+  AND amount >= @var(min_amount, 0)

--- a/examples/playground/pocs/00-foundations/15-run-variables/rocky.toml
+++ b/examples/playground/pocs/00-foundations/15-run-variables/rocky.toml
@@ -1,13 +1,15 @@
 # 15-run-variables — per-run `@var()` variables substituted into model SQL.
 #
-# `regional_sales` filters on two run variables:
-#   - @var(region)          a REQUIRED variable (no inline default)
-#   - @var(min_amount, 0)   an OPTIONAL variable with an inline default of 0
+# `regional_sales` filters on three run variables:
+#   - @var(region)          a REQUIRED variable (no inline default), quoted
+#   - @var(channel, web)    an OPTIONAL variable, quoted, default `web`
+#   - @var(min_amount, 0)   an OPTIONAL variable, BARE in numeric position,
+#                           default `0`
 #
-# `rocky run --var region=us` renders `WHERE region = 'us' AND amount >= 0` and
-# materializes only the matching rows. Omitting `--var region` is a compile
-# error (E028) naming the variable, while the optional `min_amount` falls back
-# to its inline default.
+# `rocky run --var region=us` renders `WHERE region = 'us' AND channel = 'web'
+# AND amount >= 0` and materializes only the matching rows. Omitting `--var
+# region` is a compile error (E028) naming the variable, while the optional
+# `channel` / `min_amount` fall back to their inline defaults.
 #
 # `@var()` is a RUN-TIME substitution and is deliberately distinct from the
 # config-time `${ENV}` interpolation rocky.toml performs while parsing.

--- a/examples/playground/pocs/00-foundations/15-run-variables/run.sh
+++ b/examples/playground/pocs/00-foundations/15-run-variables/run.sh
@@ -1,18 +1,22 @@
 #!/usr/bin/env bash
 # 15-run-variables — per-run `@var()` variables substituted into model SQL.
 #
-# The model `regional_sales` filters on two run variables:
-#   @var(region)        REQUIRED  — no inline default
-#   @var(channel, web)  OPTIONAL  — inline default of `web`
+# The model `regional_sales` filters on three run variables:
+#   @var(region)         REQUIRED  — no inline default, inside a string literal
+#   @var(channel, web)   OPTIONAL  — inline default of `web`, inside a literal
+#   @var(min_amount, 0)  OPTIONAL  — inline default of `0`, BARE (numeric, no
+#                                    surrounding quotes)
 #
 # This script proves:
 #   1. `rocky run --var region=us` materializes ONLY the matching rows
-#      (the optional channel defaults to `web`)
+#      (the optional channel defaults to `web`, min_amount to `0`)
 #   2. a repeated `--var` (region + channel) changes which rows land
-#   3. `rocky emit-sql --var region=us` shows the RESOLVED values, not the
-#      literal `@var(...)` markers
-#   4. `@var(channel, web)` resolves to its inline DEFAULT when --var is omitted
-#   5. a REQUIRED `@var(region)` with no --var makes `rocky compile` fail with
+#   3. a BARE `@var(min_amount, 0)` in numeric position works on the run path:
+#      `--var min_amount=200` filters to amounts >= 200
+#   4. `rocky emit-sql --var region=us` shows the RESOLVED values, not the
+#      literal `@var(...)` markers — both quoted and bare
+#   5. `@var(channel, web)` resolves to its inline DEFAULT when --var is omitted
+#   6. a REQUIRED `@var(region)` with no --var makes `rocky compile` fail with
 #      a clear E028 error naming the variable
 set -euo pipefail
 
@@ -66,25 +70,45 @@ fi
 echo "OK: overriding the optional channel var changed the materialized slice"
 
 echo
-echo "==== 4. emit-sql --var region=us — markers resolve to literal values ===="
+echo "==== 4. a BARE @var(min_amount, 0) in numeric position works on the run path ===="
+# min_amount is bare (no surrounding quotes): `amount >= @var(min_amount, 0)`.
+# Supplying --var min_amount=200 keeps only us/web rows with amount >= 200.
+rocky -c rocky.toml -o json run --models models/ --var region=us --var min_amount=200 \
+    > expected/run-us-min200.json 2> expected/run-us-min200.log
+MIN_ROWS="$(duckdb -noheader -list poc.duckdb 'SELECT count(*) FROM poc.main.regional_sales')"
+MIN_CUST="$(duckdb -noheader -list poc.duckdb 'SELECT customer FROM poc.main.regional_sales')"
+echo "rows with region=us AND amount >= 200: $MIN_ROWS ($MIN_CUST)"
+if [ "$MIN_ROWS" -ne 1 ] || [ "$MIN_CUST" != "bob" ]; then
+    echo "FAIL: expected the single us/web row with amount >= 200 (bob), got $MIN_ROWS [$MIN_CUST]" >&2
+    exit 1
+fi
+echo "OK: a bare numeric @var filtered the run — no string-literal wrapper needed"
+
+echo
+echo "==== 5. emit-sql --var region=us — markers resolve to literal values ===="
 rocky emit-sql --models models/ --var region=us --out-dir build > /dev/null 2>&1
 # Strip the model's preserved `--` comment lines (which legitimately mention
 # the @var() markers) so the assertions look only at the executable SQL.
 EXEC_SQL="$(grep -v '^[[:space:]]*--' build/regional_sales.sql)"
 echo "emitted WHERE clause (comments stripped):"
-echo "$EXEC_SQL" | grep -i "where\|region\|channel"
+echo "$EXEC_SQL" | grep -i "where\|region\|channel\|amount"
 if ! echo "$EXEC_SQL" | grep -q "region  = 'us'"; then
     echo "FAIL: emitted SQL did not resolve @var(region) to 'us'" >&2
+    exit 1
+fi
+# The bare @var(min_amount, 0) renders into numeric position — no quotes.
+if ! echo "$EXEC_SQL" | grep -q "amount >= 0"; then
+    echo "FAIL: bare @var(min_amount, 0) did not resolve to numeric 'amount >= 0'" >&2
     exit 1
 fi
 if echo "$EXEC_SQL" | grep -q "@var("; then
     echo "FAIL: emitted SQL still contains a literal @var() marker" >&2
     exit 1
 fi
-echo "OK: @var(region) resolved to 'us'; no @var() marker remains in the executable SQL"
+echo "OK: quoted @var(region) -> 'us' and bare @var(min_amount, 0) -> amount >= 0; no marker remains"
 
 echo
-echo "==== 5. the optional @var(channel, web) resolved to its inline DEFAULT ===="
+echo "==== 6. the optional @var(channel, web) resolved to its inline DEFAULT ===="
 # channel was NOT passed to emit-sql above, so it falls back to web.
 if ! echo "$EXEC_SQL" | grep -q "channel = 'web'"; then
     echo "FAIL: @var(channel, web) did not fall back to its inline default 'web'" >&2
@@ -93,7 +117,7 @@ fi
 echo "OK: @var(channel, web) resolved to 'web' with no --var supplied"
 
 echo
-echo "==== 6. a REQUIRED @var with no --var is a compile error (E028) ===="
+echo "==== 7. a REQUIRED @var with no --var is a compile error (E028) ===="
 set +e
 rocky -o json compile --models models/ > expected/compile-missing.json 2> expected/compile-missing.log
 COMPILE_EXIT=$?


### PR DESCRIPTION
## Problem

A bare `@var()` marker used outside a string literal — e.g. `WHERE amount >= @var(min_amount)` in numeric position — crashed `rocky compile` / `emit-sql` / `run`. Dependency resolution parsed each model's raw SQL for lineage extraction *before* run-variable substitution ran, so the literal `@var(` text reached the SQL parser and failed with `Expected: end of statement, found: (`. Only the quoted, string-literal form (`'@var(region)'`) worked, because there the marker was hidden inside a string token the parser tolerated.

## Fix

Substitute per-run variables **before** lineage extraction so `@var(...)` resolves end-to-end in every path (compile, emit-sql, run, and the incremental-compile path).

- Loading is split into "load models" and "resolve dependencies": models are loaded, run-vars are substituted into their SQL, then dependency resolution / lineage extraction runs over the already-substituted SQL. The marker is gone before the parser ever sees it, regardless of whether it sat inside a string literal or bare in expression position.
- A missing required variable (no supplied value, no inline default) still raises **E028** naming the variable — it now renders to a parseable sentinel first, so compile returns a clean diagnostic instead of crashing in the parser.
- Added the end-to-end test the original unit test lacked: the prior `run_vars` unit test exercised `substitute_run_vars` in isolation and never covered the lineage to compile path where the crash actually lived.

## Testing

- Real `rocky compile` / `emit-sql` / `run` over a project with a bare `@var()` in numeric position now compiles clean and materializes the substituted value, and the auto-resolved upstream dependency edge survives substitution.
- A missing required bare variable fails loudly with an **E028** diagnostic naming the variable instead of a parser crash.
- The quoted, string-literal `@var()` form is unaffected.
- The run-variables demo POC is updated to exercise a bare `@var(min_amount, 0)` marker alongside the existing quoted markers.

Completes the unreleased #976 `@var` feature.
