### PR TITLE
fix(engine/rocky-cli): always emit run JSON on failure + apply governance tags on --model/--all paths

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1211,7 +1211,7 @@ pub async fn run(
             output.idempotency_key = Some(ctx.key.clone());
         }
 
-        execute_models(
+        let exec_result = execute_models(
             mdir,
             warehouse.as_ref(),
             state_store.as_ref(),
@@ -1232,7 +1232,47 @@ pub async fn run(
             rocky_cfg.reuse.enabled && !skip_opts.no_reuse,
             run_vars,
         )
-        .await?;
+        .await;
+
+        // A runtime model failure (warehouse rejected the SQL, an unresolved
+        // upstream, a divide-by-zero, ...) surfaces here as `Err` —
+        // `execute_models` stops at the first failing model and returns the
+        // error with the model named in the chain. Record it as a first-class
+        // run failure (bump `tables_failed`, push the error) so the JSON
+        // `RunOutput` below still emits with `status` / `errors[]` / any
+        // sibling materializations BEFORE the non-zero exit, mirroring the
+        // compile-error path which records into `output` and returns `Ok`.
+        // Without this the `?` short-circuited before `print_json`, leaving an
+        // orchestrator (Dagster) consuming `--output json` with empty stdout on
+        // a runtime failure. The terminal-status exit contract is honoured by
+        // `run_status_exit_result` below.
+        match exec_result {
+            Ok(()) => {
+                // Per-model `[governance.tags]` apply (scoped to the built
+                // model). The model-only path is one of the entry points the
+                // SDK / Dagster drive; without this its tags were silently
+                // dropped. Best-effort; no-op on DuckDB's Noop adapter.
+                let governance_adapter =
+                    adapter_registry.governance_adapter(&target_adapter_name);
+                apply_model_governance_tags(
+                    mdir,
+                    governance_adapter.as_ref(),
+                    &rocky_cfg,
+                    run_vars,
+                    Some(target_model),
+                )
+                .await;
+            }
+            Err(e) => {
+                output.tables_failed += 1;
+                output.errors.push(crate::output::TableErrorOutput {
+                    asset_key: vec![target_model.to_string()],
+                    error: format!("{e:#}"),
+                    failure_kind: crate::output::FailureKind::Unknown,
+                    cooldown_seconds: None,
+                });
+            }
+        }
 
         output.duration_ms = start.elapsed().as_millis() as u64;
 
@@ -3750,6 +3790,33 @@ pub async fn run(
                                 "apply retention policy failed"
                             );
                         }
+
+                    // --- Per-model governance tags ---
+                    //
+                    // Apply each model's `[governance.tags]` to its target
+                    // securable, reusing the governance compile already in
+                    // scope. The `--all`/`--models` path is one of the entry
+                    // points the SDK / Dagster drive; without this its tags
+                    // were silently dropped (only the full-DAG transformation
+                    // path applied them). Strategy-aware dispatch mirrors
+                    // [`apply_model_governance_tags`]; best-effort — a failure
+                    // warns but never aborts. No-op on DuckDB's Noop adapter.
+                    let tags = &model.config.governance.tags;
+                    if !tags.is_empty() {
+                        let tag_target = governance_tag_target(
+                            &model.config.strategy,
+                            &model.config.target.catalog,
+                            &model.config.target.schema,
+                            &model.config.target.table,
+                        );
+                        if let Err(e) = governance_adapter.set_tags(&tag_target, tags).await {
+                            warn!(
+                                model = %model.config.name,
+                                error = %e,
+                                "apply model governance tags failed"
+                            );
+                        }
+                    }
                 }
             }
 
@@ -5544,6 +5611,81 @@ fn transformation_strategy_name(strategy: &MaterializationStrategy) -> &'static 
 /// merge, materialized-view, dynamic-table, …) produces a table securable and
 /// maps to [`TagTarget::Table`]. Pure so the dispatch is unit-testable without
 /// a warehouse.
+/// Apply each model's `[governance.tags]` to its target securable after the
+/// models materialize.
+///
+/// Dispatch is strategy-aware via [`governance_tag_target`]: view-format
+/// models (`strategy = "view"`) tag via `ALTER VIEW ... SET TAGS`, everything
+/// else via `ALTER TABLE ... SET TAGS`. Models with no `[governance.tags]`
+/// are skipped — Unity Catalog rejects an empty `SET TAGS ()`. The
+/// `NoopGovernanceAdapter` (DuckDB and other non-governed targets) silently
+/// succeeds, so this is a reachable no-op there.
+///
+/// Best-effort: a tag failure warns but never aborts the run, mirroring the
+/// classification/retention governance posture on the replication path. The
+/// model set is re-compiled here (mirroring the classification/masking
+/// reconcile idiom) rather than threading resolved configs out of
+/// [`execute_models`], keeping that hot path's signature unchanged.
+///
+/// `only_model` scopes application to a single built model: `Some(name)` for
+/// the `rocky run --model <X>` path (which builds only `X`, so tagging
+/// unrelated, unbuilt models would target tables this run never created),
+/// `None` for the full-DAG transformation and replication `--all`/`--models`
+/// paths (which build every model).
+pub(crate) async fn apply_model_governance_tags(
+    models_dir: &Path,
+    governance_adapter: &dyn GovernanceAdapter,
+    rocky_cfg: &rocky_core::config::RockyConfig,
+    run_vars: &rocky_core::run_vars::RunVars,
+    only_model: Option<&str>,
+) {
+    let governance_compile =
+        rocky_compiler::compile::compile(&rocky_compiler::compile::CompilerConfig {
+            models_dir: models_dir.to_path_buf(),
+            contracts_dir: None,
+            source_schemas: std::collections::HashMap::new(),
+            source_column_info: std::collections::HashMap::new(),
+            mask: rocky_cfg.mask.clone(),
+            allow_unmasked: rocky_cfg.classifications.allow_unmasked.clone(),
+            project_freshness_default: rocky_cfg.freshness.has_default(),
+            // Resolve `@var()` on the governance reconcile compile too, so it
+            // doesn't re-read raw markers and spuriously report every variable
+            // as missing.
+            run_vars: run_vars.clone(),
+        });
+    match governance_compile {
+        Ok(gov_compile) => {
+            for model in &gov_compile.project.models {
+                if let Some(name) = only_model
+                    && model.config.name != name
+                {
+                    continue;
+                }
+                let tags = &model.config.governance.tags;
+                if tags.is_empty() {
+                    continue;
+                }
+                let target = governance_tag_target(
+                    &model.config.strategy,
+                    &model.config.target.catalog,
+                    &model.config.target.schema,
+                    &model.config.target.table,
+                );
+                if let Err(e) = governance_adapter.set_tags(&target, tags).await {
+                    warn!(
+                        model = %model.config.name,
+                        error = %e,
+                        "apply model governance tags failed"
+                    );
+                }
+            }
+        }
+        Err(e) => {
+            warn!(error = %e, "governance compile failed; skipping model tag application");
+        }
+    }
+}
+
 pub(crate) fn governance_tag_target(
     strategy: &rocky_core::models::StrategyConfig,
     catalog: &str,
@@ -9528,6 +9670,137 @@ merge_keys = ["id"]
             output.derive_run_status(),
             rocky_core::state::RunStatus::Failure
         ));
+    }
+
+    /// Write a plain model carrying a `[governance.tags]` block.
+    #[cfg(feature = "duckdb")]
+    fn write_tagged_model(dir: &std::path::Path, name: &str, sql: &str) {
+        std::fs::write(dir.join(format!("{name}.sql")), format!("{sql}\n"))
+            .expect("write model sql");
+        std::fs::write(
+            dir.join(format!("{name}.toml")),
+            "[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"\"\nschema = \"main\"\n\n[governance.tags]\ndomain = \"finance\"\n",
+        )
+        .expect("write model toml");
+    }
+
+    /// Counting [`GovernanceAdapter`] test double — records the table/view
+    /// name of every `set_tags` call so a test can assert exactly which
+    /// models were tagged. Every other trait method is an inert `Ok`.
+    #[cfg(feature = "duckdb")]
+    #[derive(Default)]
+    struct CountingGovernance {
+        tagged: std::sync::Mutex<Vec<String>>,
+    }
+
+    #[cfg(feature = "duckdb")]
+    #[async_trait::async_trait]
+    impl rocky_core::traits::GovernanceAdapter for CountingGovernance {
+        async fn set_tags(
+            &self,
+            target: &TagTarget,
+            _tags: &std::collections::BTreeMap<String, String>,
+        ) -> rocky_core::traits::AdapterResult<()> {
+            let name = match target {
+                TagTarget::Table { table, .. } => table.clone(),
+                TagTarget::View { view, .. } => view.clone(),
+                TagTarget::Catalog(catalog) => catalog.clone(),
+                TagTarget::Schema { schema, .. } => schema.clone(),
+            };
+            self.tagged.lock().unwrap().push(name);
+            Ok(())
+        }
+        async fn get_grants(
+            &self,
+            _target: &rocky_ir::ir::GrantTarget,
+        ) -> rocky_core::traits::AdapterResult<Vec<rocky_ir::ir::Grant>> {
+            Ok(vec![])
+        }
+        async fn apply_grants(
+            &self,
+            _grants: &[rocky_ir::ir::Grant],
+        ) -> rocky_core::traits::AdapterResult<()> {
+            Ok(())
+        }
+        async fn revoke_grants(
+            &self,
+            _grants: &[rocky_ir::ir::Grant],
+        ) -> rocky_core::traits::AdapterResult<()> {
+            Ok(())
+        }
+        async fn bind_workspace(
+            &self,
+            _catalog: &str,
+            _workspace_id: u64,
+            _binding_type: &str,
+        ) -> rocky_core::traits::AdapterResult<()> {
+            Ok(())
+        }
+        async fn set_isolation(
+            &self,
+            _catalog: &str,
+            _enabled: bool,
+        ) -> rocky_core::traits::AdapterResult<()> {
+            Ok(())
+        }
+    }
+
+    /// `apply_model_governance_tags` reaches the apply loop and applies each
+    /// tagged model's `[governance.tags]` — and the `only_model` filter scopes
+    /// application to the single built model, never the whole project. This is
+    /// the regression guard for the `rocky run --model <X>` and replication
+    /// `--all` paths, where per-model tags were previously dropped entirely.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn apply_model_governance_tags_respects_only_model_filter() {
+        let dir = tempfile::tempdir().unwrap();
+        let models = dir.path().join("models");
+        std::fs::create_dir_all(&models).unwrap();
+        // Two tagged models + one untagged.
+        write_tagged_model(&models, "alpha", "SELECT 1 AS id");
+        write_tagged_model(&models, "beta", "SELECT 2 AS id");
+        write_plain_model(&models, "gamma", "SELECT 3 AS id");
+
+        // Minimal config — the helper only reads `mask`, `classifications`,
+        // and `freshness`, which a bare DuckDB config leaves at defaults.
+        std::fs::write(
+            dir.path().join("rocky.toml"),
+            "[adapter]\ntype = \"duckdb\"\npath = \"t.duckdb\"\n",
+        )
+        .unwrap();
+        let cfg = rocky_core::config::parse_rocky_config(&dir.path().join("rocky.toml"))
+            .expect("parse minimal config");
+        let vars = rocky_core::run_vars::RunVars::new();
+
+        // `None` (full-DAG / replication `--all`): every tagged model is
+        // tagged; the untagged one is skipped.
+        let gov = CountingGovernance::default();
+        super::apply_model_governance_tags(&models, &gov, &cfg, &vars, None).await;
+        let mut tagged = gov.tagged.lock().unwrap().clone();
+        tagged.sort();
+        assert_eq!(
+            tagged,
+            vec!["alpha".to_string(), "beta".to_string()],
+            "None filter tags every model with [governance.tags], skips untagged"
+        );
+
+        // `Some(alpha)`: exactly one `set_tags`, for alpha only — beta must
+        // NOT be tagged even though it carries tags (it isn't built this run).
+        let gov = CountingGovernance::default();
+        super::apply_model_governance_tags(&models, &gov, &cfg, &vars, Some("alpha")).await;
+        assert_eq!(
+            *gov.tagged.lock().unwrap(),
+            vec!["alpha".to_string()],
+            "only_model scopes application to the built model"
+        );
+
+        // `Some(gamma)`: gamma has no tags, so zero `set_tags`.
+        let gov = CountingGovernance::default();
+        super::apply_model_governance_tags(&models, &gov, &cfg, &vars, Some("gamma")).await;
+        assert!(
+            gov.tagged.lock().unwrap().is_empty(),
+            "an untagged target issues no set_tags"
+        );
     }
 
     /// Materialize all models in `models_dir` against a fresh DuckDB file,

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -103,7 +103,7 @@ pub async fn run_transformation(
         let store = StateStore::open(state_path)
             .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
 
-        super::run::execute_models(
+        let exec_result = super::run::execute_models(
             &models_dir,
             warehouse_adapter.as_ref(),
             Some(&store),
@@ -121,64 +121,46 @@ pub async fn run_transformation(
             rocky_cfg.reuse.enabled,
             run_vars,
         )
-        .await?;
+        .await;
 
-        // --- Governance: per-model `[governance.tags]` ---
-        //
-        // After every model materializes, apply each model's
-        // `[governance.tags]` to its target securable through the
-        // `GovernanceAdapter`. Dispatch is strategy-aware: view-format models
-        // (`strategy = "view"`) tag via `ALTER VIEW ... SET TAGS`, everything
-        // else via `ALTER TABLE ... SET TAGS` (see [`super::run::governance_tag_target`]).
-        //
-        // Best-effort: a tag failure warns but never aborts the run, mirroring
-        // the classification/retention governance posture on the replication
-        // path. Models with no `[governance.tags]` are skipped — Unity Catalog
-        // rejects an empty `SET TAGS ()`. NoopGovernanceAdapter (DuckDB and
-        // other non-governed targets) silently succeeds.
-        //
-        // The model set is re-compiled here (mirroring `run.rs`'s governance
-        // reconcile idiom) rather than threading resolved configs out of
-        // `execute_models`, keeping that hot path's signature unchanged.
-        let governance_adapter = adapter_registry.governance_adapter(&pipeline.target.adapter);
-        let governance_compile =
-            rocky_compiler::compile::compile(&rocky_compiler::compile::CompilerConfig {
-                models_dir: models_dir.clone(),
-                contracts_dir: None,
-                source_schemas: std::collections::HashMap::new(),
-                source_column_info: std::collections::HashMap::new(),
-                mask: rocky_cfg.mask.clone(),
-                allow_unmasked: rocky_cfg.classifications.allow_unmasked.clone(),
-                project_freshness_default: rocky_cfg.freshness.has_default(),
-                // Resolve `@var()` on the governance reconcile compile too,
-                // so it doesn't re-read raw markers and spuriously report
-                // every variable as missing.
-                run_vars: run_vars.clone(),
-            });
-        match governance_compile {
-            Ok(gov_compile) => {
-                for model in &gov_compile.project.models {
-                    let tags = &model.config.governance.tags;
-                    if tags.is_empty() {
-                        continue;
-                    }
-                    let target = super::run::governance_tag_target(
-                        &model.config.strategy,
-                        &model.config.target.catalog,
-                        &model.config.target.schema,
-                        &model.config.target.table,
-                    );
-                    if let Err(e) = governance_adapter.set_tags(&target, tags).await {
-                        warn!(
-                            model = %model.config.name,
-                            error = %e,
-                            "apply model governance tags failed"
-                        );
-                    }
-                }
+        match exec_result {
+            Ok(()) => {
+                // --- Governance: per-model `[governance.tags]` ---
+                //
+                // After every model materializes, apply each model's
+                // `[governance.tags]` to its target securable. `None` filter:
+                // the full-DAG path builds every model, so every model is
+                // tagged. Best-effort; no-op on DuckDB's Noop adapter.
+                let governance_adapter =
+                    adapter_registry.governance_adapter(&pipeline.target.adapter);
+                super::run::apply_model_governance_tags(
+                    &models_dir,
+                    governance_adapter.as_ref(),
+                    rocky_cfg,
+                    run_vars,
+                    None,
+                )
+                .await;
             }
             Err(e) => {
-                warn!(error = %e, "governance compile failed; skipping model tag application");
+                // A runtime model failure (warehouse rejected the SQL, an
+                // unresolved upstream, ...) surfaces here as `Err`. Record it
+                // as a first-class run failure so the JSON `RunOutput` below
+                // still emits with `status` / `errors[]` / any sibling
+                // materializations BEFORE the non-zero exit, mirroring the
+                // compile-error path which records into `output` and returns
+                // `Ok`. Without this the `?` short-circuited before the JSON
+                // emit, leaving an orchestrator (Dagster) consuming
+                // `--output json` with empty stdout on a runtime failure. The
+                // terminal-status exit contract is honoured by
+                // `run_status_exit_result` below.
+                output.tables_failed += 1;
+                output.errors.push(crate::output::TableErrorOutput {
+                    asset_key: vec!["<runtime>".to_string()],
+                    error: format!("{e:#}"),
+                    failure_kind: crate::output::FailureKind::Unknown,
+                    cooldown_seconds: None,
+                });
             }
         }
 
@@ -1297,5 +1279,155 @@ auto_create_schemas = true
             .or_else(|| r.rows[0][0].as_str().and_then(|s| s.parse().ok()))
             .unwrap();
         assert_eq!(n, 3, "view over the 3-row source must return 3 rows");
+    }
+
+    /// Reached-ness guard for the `rocky run --model <X>` path's per-model
+    /// `[governance.tags]` application — the call site B4 fixed.
+    ///
+    /// Drives `run()` with `model_name_filter = Some("v_orders")` over a view
+    /// model carrying a `[governance.tags]` block. The model-only path must
+    /// reach the new `apply_model_governance_tags` step (no-op on DuckDB's Noop
+    /// adapter) without aborting, and the model must materialize. Before B4
+    /// this path never called the tag loop at all.
+    #[tokio::test]
+    async fn model_only_governance_tags_run_reaches_apply_path() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+        let models_dir = dir.join("models");
+        std::fs::create_dir(&models_dir).unwrap();
+        let db = dir.join("t.duckdb");
+        let state_path = dir.join(".rocky-state.redb");
+
+        seed_src(&db, 3).await;
+        std::fs::write(models_dir.join("v_orders.sql"), "SELECT id FROM main.src\n").unwrap();
+        std::fs::write(
+            models_dir.join("v_orders.toml"),
+            "[strategy]\ntype = \"view\"\n\n\
+             [target]\ncatalog = \"\"\nschema = \"main\"\ntable = \"v_orders\"\n\n\
+             [governance.tags]\ndomain = \"finance\"\ntier = \"gold\"\n",
+        )
+        .unwrap();
+        write_config(dir, &db, "");
+        let config_path = dir.join("rocky.toml");
+
+        let opts = PartitionRunOptions::default();
+        super::super::run::run(
+            &config_path,
+            None,
+            None,
+            &state_path,
+            None,
+            false,             // output_json
+            Some(&models_dir), // models_dir override — model-only path needs it
+            false,             // run_all
+            None,
+            false,
+            None,
+            &opts,
+            Some("v_orders"), // model_name_filter — the path under test
+            None,
+            None,
+            None,
+            &DeferOptions::default(),
+            &SkipRunOptions::default(),
+            &rocky_core::run_vars::RunVars::new(),
+        )
+        .await
+        .expect("model-only run must reach the governance.tags apply path and succeed");
+
+        // The view materialized — proving the model-only path ran end-to-end
+        // through the new apply step.
+        let a = DuckDbWarehouseAdapter::open(&db).expect("open db");
+        let r = a
+            .execute_query("SELECT COUNT(*) FROM main.v_orders")
+            .await
+            .expect("view must be queryable after model-only run");
+        let n = r.rows[0][0]
+            .as_i64()
+            .or_else(|| r.rows[0][0].as_str().and_then(|s| s.parse().ok()))
+            .unwrap();
+        assert_eq!(n, 3, "view over the 3-row source must return 3 rows");
+    }
+
+    /// A transformation model with valid SQL that fails at *execution* (it
+    /// reads a table the warehouse can't resolve) is a first-class run
+    /// failure, not a short-circuit that strands the orchestrator with empty
+    /// stdout.
+    ///
+    /// The run must (a) exit non-zero — `run()` returns `Err` — and (b) reach
+    /// the post-execute path: `persist_run_record` runs *before* the JSON emit
+    /// on the fall-through, so a persisted `RunRecord` with status `Failure`
+    /// proves the JSON `RunOutput` was emitted on the runtime-failure path.
+    /// Before the fix the `?` on `execute_models` short-circuited before both,
+    /// so no record was persisted and nothing was written to stdout.
+    #[tokio::test]
+    async fn runtime_failure_persists_failure_record_and_exits_nonzero() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+        let models_dir = dir.join("models");
+        std::fs::create_dir(&models_dir).unwrap();
+        let db = dir.join("t.duckdb");
+        let state_path = dir.join(".rocky-state.redb");
+
+        // Valid SQL, but `main.does_not_exist_xyz` is absent — DuckDB rejects
+        // it at execute time, a runtime failure (not a compile error).
+        std::fs::write(
+            models_dir.join("bad.sql"),
+            "SELECT * FROM main.does_not_exist_xyz\n",
+        )
+        .unwrap();
+        std::fs::write(
+            models_dir.join("bad.toml"),
+            "[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"\"\nschema = \"main\"\ntable = \"bad\"\n",
+        )
+        .unwrap();
+        write_config(dir, &db, "");
+        let config_path = dir.join("rocky.toml");
+
+        let opts = PartitionRunOptions::default();
+        let result = super::super::run::run(
+            &config_path,
+            None,
+            None,
+            &state_path,
+            None,
+            true, // output_json — the path an orchestrator drives
+            None,
+            false,
+            None,
+            false,
+            None,
+            &opts,
+            None,
+            None,
+            None,
+            None,
+            &DeferOptions::default(),
+            &SkipRunOptions::default(),
+            &rocky_core::run_vars::RunVars::new(),
+        )
+        .await;
+
+        // (a) Non-zero exit: the run surfaces as Err.
+        assert!(
+            result.is_err(),
+            "a runtime model failure must exit non-zero, not report success"
+        );
+
+        // (b) The post-execute path was reached (JSON emit + persist), so a
+        // RunRecord exists and its derived status is Failure.
+        let store = StateStore::open(&state_path).expect("open canonical state");
+        let runs = store.list_runs(10).expect("list runs");
+        assert_eq!(
+            runs.len(),
+            1,
+            "the runtime-failing run must still persist a RunRecord \
+             (proving it reached the post-execute JSON-emit path)"
+        );
+        assert!(
+            matches!(runs[0].status, rocky_core::state::RunStatus::Failure),
+            "the persisted run status must be Failure, got {:?}",
+            runs[0].status
+        );
     }
 }


### PR DESCRIPTION
Two related `rocky run` correctness fixes, both on entry points the SDK / Dagster drive.

## Bug 1 — `--output json` emitted empty stdout on a runtime model failure

When `execute_models` failed at runtime (warehouse rejected the SQL, an unresolved upstream, a divide-by-zero, ...), the `?` short-circuited *before* the JSON `RunOutput` was printed. An orchestrator consuming `--output json` got a non-zero exit with **empty stdout** — no `status`, no `errors[]`, no record of sibling materializations.

Fix: capture the `execute_models` result instead of `?`-ing it. On `Err`, record it as a first-class run failure (bump `tables_failed`, push a `TableErrorOutput`) so the JSON `RunOutput` still emits — with `status` / `errors[]` / any sibling materializations — *before* the non-zero exit. This mirrors the existing compile-error path, which records into `output` and falls through. The terminal-status exit contract is still honoured by `run_status_exit_result`.

Lands on both run paths that had the short-circuit:
- `commands/run.rs` — model-only (`--model <X>`)
- `commands/run_local.rs` — full-DAG transformation

## Bug 2 — per-model `[governance.tags]` silently dropped on the `--model` and `--all`/`--models` paths

Only the full-DAG transformation path applied each model's `[governance.tags]` to its target securable. The model-only (`--model <X>`) and replication (`--all`/`--models`) paths skipped tag application entirely, so those tags were silently dropped.

Fix: extract the tag loop into a shared `apply_model_governance_tags(...)` helper with an `only_model` filter:
- `--model <X>` calls it with `Some(X)` — scoped to the single built model, so it never targets tables this run didn't create.
- the `--all`/`--models` replication path now applies per-model tags inline.
- the full-DAG transformation path keeps the same behaviour, now via the shared helper (`None`).

Strategy-aware dispatch (`ALTER VIEW` vs `ALTER TABLE`) and the best-effort posture (a tag failure warns, never aborts) are unchanged. No-op on DuckDB's `NoopGovernanceAdapter`.

## Verified

Three regression tests, run green locally (`cargo test -p rocky-cli --features duckdb`) and covered by engine-ci:
- `runtime_failure_persists_failure_record_and_exits_nonzero` — a runtime-failing model exits non-zero **and** persists a `Failure` `RunRecord`, proving the post-execute JSON-emit path was reached (before the fix, neither happened).
- `apply_model_governance_tags_respects_only_model_filter` — a counting `GovernanceAdapter` double asserts `None` tags every tagged model, `Some(alpha)` tags only `alpha` (not sibling `beta`, which carries tags but isn't built), and an untagged target issues zero `set_tags`.
- `model_only_governance_tags_run_reaches_apply_path` — drives `run()` with `model_name_filter = Some("v_orders")` and confirms the view materializes through the new apply step.

No `*Output` struct changes, so no codegen or fixture regen needed.
