### PR TITLE
fix(engine): @var run-variable follow-ups — comments, ci/test, dag/lineage

### DIFF
--- a/engine/crates/rocky-cli/src/commands/ci.rs
+++ b/engine/crates/rocky-cli/src/commands/ci.rs
@@ -7,8 +7,13 @@ use anyhow::Result;
 use crate::output::{CiOutput, TestFailure, print_json};
 
 /// Execute `rocky ci`.
-pub fn run_ci(models_dir: &Path, contracts_dir: Option<&Path>, output_json: bool) -> Result<()> {
-    let result = rocky_engine::ci::run_ci(models_dir, contracts_dir)?;
+pub fn run_ci(
+    models_dir: &Path,
+    contracts_dir: Option<&Path>,
+    output_json: bool,
+    run_vars: &rocky_core::run_vars::RunVars,
+) -> Result<()> {
+    let result = rocky_engine::ci::run_ci(models_dir, contracts_dir, run_vars)?;
 
     if output_json {
         let failures: Vec<TestFailure> = result

--- a/engine/crates/rocky-cli/src/commands/test.rs
+++ b/engine/crates/rocky-cli/src/commands/test.rs
@@ -60,7 +60,12 @@ pub fn test_output(
     contracts_dir: Option<&Path>,
     model_filter: Option<&str>,
 ) -> Result<TestOutput> {
-    let result = rocky_engine::test_runner::run_tests(models_dir, contracts_dir, model_filter)?;
+    let result = rocky_engine::test_runner::run_tests(
+        models_dir,
+        contracts_dir,
+        model_filter,
+        &rocky_core::run_vars::RunVars::new(),
+    )?;
     let failures: Vec<TestFailure> = result
         .failures
         .iter()
@@ -85,8 +90,10 @@ pub fn run_test(
     contracts_dir: Option<&Path>,
     model_filter: Option<&str>,
     output_json: bool,
+    run_vars: &rocky_core::run_vars::RunVars,
 ) -> Result<()> {
-    let result = rocky_engine::test_runner::run_tests(models_dir, contracts_dir, model_filter)?;
+    let result =
+        rocky_engine::test_runner::run_tests(models_dir, contracts_dir, model_filter, run_vars)?;
     let unit_run = rocky_engine::test_runner::run_unit_tests(models_dir, model_filter)?;
     let unit_failed = unit_run.total() - unit_run.passed();
 

--- a/engine/crates/rocky-core/src/run_vars.rs
+++ b/engine/crates/rocky-core/src/run_vars.rs
@@ -24,7 +24,9 @@
 //!
 //! A `@var(name)` reference with no supplied value and no inline default is a
 //! **missing** variable: [`substitute_run_vars`] reports its name so the
-//! compiler can raise a clear error naming it.
+//! compiler can raise a clear error naming it. References that appear only
+//! inside a SQL comment (`--` line or `/* … */` block) are ignored — they are
+//! neither substituted nor counted as missing.
 //!
 //! ## Trust boundary
 //!
@@ -185,10 +187,38 @@ pub struct Substitution {
 ///
 /// The replacement is always literal text — a value containing `$` is **not**
 /// interpreted as a regex capture reference.
+///
+/// References that fall inside a SQL comment — a `--` line comment or a
+/// `/* … */` block comment — are **ignored**: left in the text verbatim and
+/// never recorded as missing. Only executable SQL (including string literals,
+/// where the operator owns the quoting) drives substitution. A `@var(name)`
+/// mentioned only in a comment therefore does not turn into a missing-variable
+/// error. Comment detection is string-literal-aware, so a `--` or `/*` inside a
+/// `'…'` / `"…"` literal does **not** start a comment.
 #[must_use]
 pub fn substitute_run_vars(sql: &str, vars: &RunVars) -> Substitution {
+    // Fast path: nothing to do (and no comment scan) when the marker is absent.
+    if !sql.contains("@var(") {
+        return Substitution {
+            sql: sql.to_string(),
+            missing: Vec::new(),
+        };
+    }
+
+    let comments = comment_spans(sql);
+    let in_comment = |pos: usize| {
+        comments
+            .iter()
+            .any(|&(start, end)| pos >= start && pos < end)
+    };
+
     let mut missing: Vec<String> = Vec::new();
     let resolved = VAR_RE.replace_all(sql, |caps: &regex::Captures<'_>| {
+        let whole = caps.get(0).expect("group 0 always present");
+        // A reference inside a comment is left exactly as written.
+        if in_comment(whole.start()) {
+            return whole.as_str().to_string();
+        }
         let name = &caps[1];
         if let Some(value) = vars.get(name) {
             return value.to_string();
@@ -205,6 +235,96 @@ pub fn substitute_run_vars(sql: &str, vars: &RunVars) -> Substitution {
         sql: resolved.into_owned(),
         missing,
     }
+}
+
+/// State of the [`comment_spans`] scanner outside of any comment.
+///
+/// String-literal tracking lets the scanner tell a real comment opener from a
+/// `--` / `/*` that merely sits inside a quoted string.
+enum ScanMode {
+    /// Executable SQL (substitution applies here).
+    Code,
+    /// Inside a single-quoted `'…'` string literal.
+    SingleQuote,
+    /// Inside a double-quoted `"…"` identifier/string.
+    DoubleQuote,
+}
+
+/// Byte ranges (`start..end`, half-open) of every SQL comment in `sql`.
+///
+/// Recognises `--` line comments (up to but excluding the terminating newline)
+/// and `/* … */` block comments (an unterminated block runs to end of input).
+/// Comment openers inside a `'…'` or `"…"` literal are not treated as comments.
+/// Returned ranges are non-overlapping and in ascending order; all boundaries
+/// land on ASCII delimiters, so slicing `sql` at them is always char-safe.
+fn comment_spans(sql: &str) -> Vec<(usize, usize)> {
+    let bytes = sql.as_bytes();
+    let n = bytes.len();
+    let mut spans = Vec::new();
+    let mut mode = ScanMode::Code;
+    let mut i = 0;
+    while i < n {
+        match mode {
+            ScanMode::Code => match bytes[i] {
+                b'\'' => {
+                    mode = ScanMode::SingleQuote;
+                    i += 1;
+                }
+                b'"' => {
+                    mode = ScanMode::DoubleQuote;
+                    i += 1;
+                }
+                b'-' if i + 1 < n && bytes[i + 1] == b'-' => {
+                    let start = i;
+                    i += 2;
+                    while i < n && bytes[i] != b'\n' {
+                        i += 1;
+                    }
+                    spans.push((start, i));
+                }
+                b'/' if i + 1 < n && bytes[i + 1] == b'*' => {
+                    let start = i;
+                    i += 2;
+                    while i < n && !(bytes[i] == b'*' && i + 1 < n && bytes[i + 1] == b'/') {
+                        i += 1;
+                    }
+                    // Consume the closing `*/` when present; an unterminated
+                    // block comment ends at EOF.
+                    if i < n {
+                        i += 2;
+                    }
+                    spans.push((start, i));
+                }
+                _ => i += 1,
+            },
+            ScanMode::SingleQuote => {
+                if bytes[i] == b'\'' {
+                    // A doubled `''` is an escaped quote — stay in the string.
+                    if i + 1 < n && bytes[i + 1] == b'\'' {
+                        i += 2;
+                    } else {
+                        mode = ScanMode::Code;
+                        i += 1;
+                    }
+                } else {
+                    i += 1;
+                }
+            }
+            ScanMode::DoubleQuote => {
+                if bytes[i] == b'"' {
+                    if i + 1 < n && bytes[i + 1] == b'"' {
+                        i += 2;
+                    } else {
+                        mode = ScanMode::Code;
+                        i += 1;
+                    }
+                } else {
+                    i += 1;
+                }
+            }
+        }
+    }
+    spans
 }
 
 #[cfg(test)]
@@ -331,5 +451,66 @@ mod tests {
         let out = substitute_run_vars(sql, &vars);
         assert_eq!(out.sql, sql);
         assert!(out.missing.is_empty());
+    }
+
+    #[test]
+    fn var_in_line_comment_is_ignored() {
+        // The headline B3 case: a comment mentions @var but the executable
+        // SQL has none, so it must compile clean (no missing, no rewrite).
+        let vars = RunVars::new();
+        let sql = "-- filter by @var(threshold) later\nSELECT region FROM raw__sales.sales";
+        let out = substitute_run_vars(sql, &vars);
+        assert_eq!(out.sql, sql);
+        assert!(out.missing.is_empty());
+    }
+
+    #[test]
+    fn var_in_block_comment_is_ignored() {
+        let vars = RunVars::new();
+        let sql = "SELECT 1 /* todo: @var(threshold) */ FROM t";
+        let out = substitute_run_vars(sql, &vars);
+        assert_eq!(out.sql, sql);
+        assert!(out.missing.is_empty());
+    }
+
+    #[test]
+    fn var_in_trailing_line_comment_not_missing_but_code_var_is() {
+        // The executable @var is substituted/missing as usual; the commented
+        // one is left verbatim and never counted.
+        let vars = RunVars::new();
+        let sql = "SELECT region FROM t WHERE region = '@var(region)' -- TODO @var(other)";
+        let out = substitute_run_vars(sql, &vars);
+        assert_eq!(
+            out.sql,
+            "SELECT region FROM t WHERE region = 'NULL' -- TODO @var(other)"
+        );
+        assert_eq!(out.missing, vec!["region".to_string()]);
+    }
+
+    #[test]
+    fn var_inside_string_literal_still_substitutes_despite_dashes() {
+        // `--` inside a string literal must NOT start a comment, so the later
+        // @var in executable position is still substituted.
+        let vars = RunVars::parse_pairs(["y=Z"]).unwrap();
+        let out = substitute_run_vars("WHERE note = 'a -- b' AND x = @var(y)", &vars);
+        assert_eq!(out.sql, "WHERE note = 'a -- b' AND x = Z");
+        assert!(out.missing.is_empty());
+    }
+
+    #[test]
+    fn var_inside_string_with_block_marker_still_substitutes() {
+        let vars = RunVars::parse_pairs(["y=Z"]).unwrap();
+        let out = substitute_run_vars("WHERE note = 'a /* b' AND x = @var(y)", &vars);
+        assert_eq!(out.sql, "WHERE note = 'a /* b' AND x = Z");
+        assert!(out.missing.is_empty());
+    }
+
+    #[test]
+    fn comment_spans_skips_markers_inside_strings() {
+        // No comment: the `--` and `/*` live inside string literals.
+        assert!(comment_spans("SELECT '-- not a comment', '/* nor this */'").is_empty());
+        // A real line comment after a string is detected.
+        let spans = comment_spans("SELECT 'x' -- c");
+        assert_eq!(spans.len(), 1);
     }
 }

--- a/engine/crates/rocky-engine/src/ci.rs
+++ b/engine/crates/rocky-engine/src/ci.rs
@@ -58,12 +58,20 @@ impl CiResult {
 }
 
 /// Run the full CI pipeline.
-pub fn run_ci(models_dir: &Path, contracts_dir: Option<&Path>) -> anyhow::Result<CiResult> {
+///
+/// `run_vars` supplies per-run `@var(name)` substitutions so a required-var
+/// model passes `rocky ci --var name=value`; pass
+/// [`rocky_core::run_vars::RunVars::new`] when the caller has none.
+pub fn run_ci(
+    models_dir: &Path,
+    contracts_dir: Option<&Path>,
+    run_vars: &rocky_core::run_vars::RunVars,
+) -> anyhow::Result<CiResult> {
     info!("running CI pipeline");
 
     // Step 1: Compile
     info!("step 1: compile");
-    let test_result = crate::test_runner::run_tests(models_dir, contracts_dir, None)?;
+    let test_result = crate::test_runner::run_tests(models_dir, contracts_dir, None, run_vars)?;
 
     let compile_ok = !test_result
         .diagnostics

--- a/engine/crates/rocky-engine/src/test_runner.rs
+++ b/engine/crates/rocky-engine/src/test_runner.rs
@@ -58,16 +58,22 @@ pub struct TestResult {
 ///    when `model_filter` is set, so the filtered model's SQL can resolve)
 /// 3. Validate output against contracts (if present)
 /// 4. Report results (filtered to `model_filter` when set)
+///
+/// `run_vars` supplies per-run `@var(name)` substitutions so a required-var
+/// model compiles under `rocky test --var name=value`; pass
+/// [`rocky_core::run_vars::RunVars::new`] when the caller has none.
 pub fn run_tests(
     models_dir: &Path,
     contracts_dir: Option<&Path>,
     model_filter: Option<&str>,
+    run_vars: &rocky_core::run_vars::RunVars,
 ) -> anyhow::Result<TestResult> {
     let config = CompilerConfig {
         models_dir: models_dir.to_path_buf(),
         contracts_dir: contracts_dir.map(std::path::Path::to_path_buf),
         source_schemas: HashMap::new(),
         source_column_info: HashMap::new(),
+        run_vars: run_vars.clone(),
         ..Default::default()
     };
 
@@ -571,7 +577,7 @@ mod tests {
     #[test]
     fn full_run_itemizes_passes() {
         let (_tmp, models) = scaffold_two_model_project();
-        let result = run_tests(&models, None, None).unwrap();
+        let result = run_tests(&models, None, None, &rocky_core::run_vars::RunVars::new()).unwrap();
         assert_eq!(result.total, 2);
         assert_eq!(result.passed, 2);
         assert!(result.failures.is_empty());
@@ -591,7 +597,13 @@ mod tests {
     #[test]
     fn model_filter_scopes_results_to_one_model() {
         let (_tmp, models) = scaffold_two_model_project();
-        let result = run_tests(&models, None, Some("good_mart")).unwrap();
+        let result = run_tests(
+            &models,
+            None,
+            Some("good_mart"),
+            &rocky_core::run_vars::RunVars::new(),
+        )
+        .unwrap();
         assert_eq!(result.total, 1);
         assert_eq!(result.passed, 1);
         assert_eq!(result.model_results.len(), 1);

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -1258,6 +1258,13 @@ enum Command {
         /// Pipeline name (only used with --declarative; required if multiple pipelines defined)
         #[arg(long)]
         pipeline: Option<String>,
+        /// Per-run variable substituted into model SQL (repeatable). Resolves
+        /// `@var(name)` markers to the supplied value so a required-`@var`
+        /// model type-checks under `rocky test`, mirroring `rocky compile
+        /// --var` / `rocky run --var`. A required `@var(name)` with no value
+        /// and no inline default is a compile error.
+        #[arg(long = "var", value_name = "NAME=VALUE")]
+        var: Vec<String>,
     },
 
     /// Run CI pipeline: compile + test without warehouse credentials
@@ -1269,6 +1276,13 @@ enum Command {
         /// Contracts directory
         #[arg(long)]
         contracts: Option<PathBuf>,
+        /// Per-run variable substituted into model SQL (repeatable). Resolves
+        /// `@var(name)` markers to the supplied value so a required-`@var`
+        /// model passes the CI gate, mirroring `rocky compile --var` / `rocky
+        /// run --var`. A required `@var(name)` with no value and no inline
+        /// default is a compile error.
+        #[arg(long = "var", value_name = "NAME=VALUE")]
+        var: Vec<String>,
     },
 
     /// Detect changed models between git refs and generate a structural diff report
@@ -3008,6 +3022,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             model,
             declarative,
             pipeline,
+            var,
         } => {
             if declarative {
                 rocky_cli::commands::run_declarative_tests(
@@ -3019,12 +3034,26 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                 )
                 .await
             } else {
-                rocky_cli::commands::run_test(&models, contracts.as_deref(), model.as_deref(), json)
+                let run_vars = rocky_core::run_vars::RunVars::parse_pairs(&var)
+                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                rocky_cli::commands::run_test(
+                    &models,
+                    contracts.as_deref(),
+                    model.as_deref(),
+                    json,
+                    &run_vars,
+                )
             }
         }
         #[cfg(feature = "duckdb")]
-        Command::Ci { models, contracts } => {
-            rocky_cli::commands::run_ci(&models, contracts.as_deref(), json)
+        Command::Ci {
+            models,
+            contracts,
+            var,
+        } => {
+            let run_vars = rocky_core::run_vars::RunVars::parse_pairs(&var)
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            rocky_cli::commands::run_ci(&models, contracts.as_deref(), json, &run_vars)
         }
         Command::CiDiff {
             base_ref,


### PR DESCRIPTION
Follow-ups to the per-run `@var()` work (#976 `run --var`, #982 substitute-before-lineage). Two fixes, both narrowed to the load-time substitution that compile / run / ci / test and lineage extraction all share.

## Bugs fixed

**Comment-aware substitution (`substitute_run_vars`).** The substituter scanned the whole model body, so an `@var(x)` that appeared only inside a `--` line comment or a `/* … */` block comment was wrongly recorded as a missing required variable (spurious E028 failing compile/run/ci) and textually rewritten (comment corruption). Substitution now skips comment regions: only executable SQL drives substitution and missing-var detection. The comment scanner is string-literal-aware, so a `--` or `/*` inside a `'…'` / `"…"` literal does not start a comment, and an `@var` inside a string literal (where the operator owns the quoting) still substitutes. A model whose executable SQL has no `@var` but whose comment mentions one now compiles clean.

Because #982 routes this same load-time substitution ahead of dependency resolution / lineage extraction, the fix also covers the dag/lineage path: a commented `@var` no longer breaks lineage extraction or emits a spurious missing-var diagnostic there.

**`rocky ci` / `rocky test` accept `--var name=value`.** The repeatable flag now mirrors `rocky compile --var` / `rocky run --var`. Parsed `RunVars` thread through `run_ci` / `run_test` → `ci::run_ci` / `test_runner::run_tests` into `CompilerConfig`, so a required-`@var` model that is green under `compile --var region=us` also passes the test and CI gates.

## How verified

- `cargo test -p rocky-core run_vars` — 23 pass, including 6 new comment cases (line/block comment ignored; trailing-comment var not missing while the code var is; `--` / `/*` inside string literals still substitute).
- `cargo test -p rocky-engine --features duckdb test_runner` — green with the new `run_vars` parameter threaded through.
- End-to-end CLI smoke on a two-model DuckDB project (`@var(region)` in executable SQL + a comment-only `@var(threshold)`):
  - `rocky test` (no `--var`) → exit 1, only the executable `@var(region)` reported missing; the comment-only model compiles clean.
  - `rocky test --var region=us` → exit 0, both models pass.
  - `rocky ci --var region=us` → exit 0, `compile_ok` + `tests_ok`.
  - `--help` lists `--var` on both `test` and `ci`.
