### PR TITLE
chore: release engine 1.55.0 / sdk 0.1.6

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.55.0] - 2026-06-27
+
 ### Added
 
 - **`rocky run --var name=value` — per-run variables in model SQL.** A model can reference an explicit `@var(name)` (or `@var(name, default)`) placeholder that the compiler resolves to a caller-supplied string at compile time, parallel to dbt's `{{ var() }}`. The substitution is textual — the operator owns SQL quoting — and a referenced variable with no value and no inline default fails the run with a diagnostic naming it. (#976)

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3768,7 +3768,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3789,7 +3789,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3802,7 +3802,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "indexmap",
  "reqwest 0.12.28",
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3868,7 +3868,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "redis",
  "serde",
@@ -3880,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -3891,7 +3891,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4011,7 +4011,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4037,7 +4037,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4056,7 +4056,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4074,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4105,7 +4105,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4130,7 +4130,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "logos",
  "miette",
@@ -4155,7 +4155,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "rocky-server",
  "rustls",
@@ -4164,7 +4164,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4189,7 +4189,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4207,7 +4207,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4237,7 +4237,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -4264,7 +4264,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "miette",
  "regex",
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4300,7 +4300,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.54.0"
+version = "1.55.0"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.54.0"
+version = "1.55.0"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.54.0"
+version = "1.55.0"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.54.0"
+version = "1.55.0"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.54.0"
+version = "1.55.0"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.54.0"
+version = "1.55.0"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.54.0"
+version = "1.55.0"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.54.0"
+version = "1.55.0"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.54.0"
+version = "1.55.0"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.54.0"
+version = "1.55.0"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.54.0"
+version = "1.55.0"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.54.0"
+version = "1.55.0"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.54.0"
+version = "1.55.0"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.54.0"
+version = "1.55.0"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.54.0"
+version = "1.55.0"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.54.0"
+version = "1.55.0"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.54.0"
+version = "1.55.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.54.0"
+version = "1.55.0"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.54.0"
+version = "1.55.0"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.54.0"
+version = "1.55.0"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.54.0"
+version = "1.55.0"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.54.0"
+version = "1.55.0"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.54.0"
+version = "1.55.0"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.54.0"
+version = "1.55.0"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.54.0"
+version = "1.55.0"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6] — 2026-06-27
+
+### Changed
+
+- **Regenerated `types_generated/` for engine 1.55.0.** `RunOutput.errors[].failure_kind` gains the `compile-error` variant — `rocky run` now reports a model that fails to compile as a first-class run failure (non-zero exit, `status` `failure`/`partial_failure`), surfacing the diagnostic in `errors[]` so a `RockyClient` consumer can parse and classify it. Additive; older binaries that don't emit it are unaffected. (engine #975)
+
 ## [0.1.5] — 2026-06-23
 
 ### Added

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rocky-sdk"
-version = "0.1.5"
+version = "0.1.6"
 description = "Typed Python client for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Release cut for the dbt→Rocky migration batch + its pre-release hardening.

## engine 1.55.0 (from 1.54.0)
The batch shipped under `[Unreleased]` — see `engine/CHANGELOG.md`:
- **Added:** `rocky run --var` / `@var()` per-run variables; `[governance.tags]` view-aware Unity Catalog tagging; lakehouse-format initial DDL for incremental strategies; seed pre/post-hooks; import-dbt fidelity (`dbt_expectations`/`dbt_utils` test mapping, `profiles.yml` anchors + `env_var()`, dropped-contract warnings); `import-dbt --microbatch-as=time_interval`; `import-dbt --skip-unit-tests`.
- **Changed (behavior):** `rocky run` now fails when a model does not compile (status `failure`/`partial_failure`, non-zero exit, diagnostic in `--output json` `errors[]` with `failure_kind: "compile-error"`); `rocky run --parallel` now defaults to 4 (overridable; DuckDB stays serial).
- **Fixed:** import-dbt no longer aborts on an unserializable unit test; `rocky compile` expands `SELECT *` over a derived table.

A pre-release adversarial bug-hunt found and fixed 10 further defects across the batch (bare `@var`, comment-`@var`, `SELECT*` microbatch import, dbt profile selection, governance-tag wiring on `--model`/`--all`, run-output JSON on runtime failure, seeds under `--dag`, seed row count, ci/test `--var`). Integration re-verify on merged main: `cargo test --workspace` 4383 passed / 0 failed, codegen + fixtures drift-clean, all scenarios re-smoked green.

## sdk 0.1.6 (from 0.1.5)
Regenerated `types_generated/` for engine 1.55.0 — `RunOutput.errors[].failure_kind` gains the `compile-error` variant so `RockyClient` consumers can parse and classify a compile-failure run. Additive.

## Mechanics
- 25 engine crate versions → 1.55.0 (+ `Cargo.lock`); `sdk/python/pyproject.toml` → 0.1.6.
- Both changelogs stamped 2026-06-27. Codegen no-op (`version` is runtime-emitted, not in the schema); fixtures sentinel the version field, so zero drift.
- After merge: tag `engine-v1.55.0` + `sdk-v0.1.6` → CI builds the 5 platform binaries + publishes the SDK wheel to PyPI. dagster + vscode not cut (no code changes; `dagster-rocky` resolves `rocky-sdk` 0.1.6 via its `>=0.1.5` floor).