### PR TITLE
fix(engine/rocky-cli): keep rocky run -o json stdout pure (summary to stderr)

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`rocky run --output json` (including `--dag`) no longer prints a human summary line to stdout before the JSON payload.** Under the unified-DAG path each sub-run (replication load, transformation, seed) printed lines like "Copied N tables …", "transformation pipeline complete …", or "Seed complete …" to stdout ahead of the JSON document, forcing an orchestrator to slice from the first `{`. With `-o json`, stdout is now exactly the JSON document; that progress text goes to stderr. Human/table output is unchanged.
+
 ## [1.55.0] - 2026-06-27
 
 ### Added

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1049,6 +1049,15 @@ pub async fn run(
     // resolves and behavior is byte-identical.
     run_vars: &rocky_core::run_vars::RunVars,
 ) -> Result<()> {
+    // With `-o json` stdout is reserved for the JSON payload — route any
+    // human-readable summary/progress line (e.g. a `depends_on` upstream
+    // pipeline's "Copied …") to stderr so it can't precede the JSON document.
+    // Sub-runs under the unified DAG are invoked with `output_json = false`,
+    // so this is a no-op for them; the outer `run_with_dag` already reserved.
+    if output_json {
+        crate::output::reserve_stdout_for_json();
+    }
+
     let start = Instant::now();
     let started_at = Utc::now();
     // Unified run_id minted up front so the idempotency claim and every
@@ -3991,18 +4000,18 @@ pub async fn run(
         print_json(&output)?;
     } else {
         if let Some(ref resumed_from) = output.resumed_from {
-            println!(
+            crate::status_line!(
                 "Resumed from {resumed_from} (skipped {} tables)",
                 output.tables_skipped
             );
         }
-        println!(
+        crate::status_line!(
             "Copied {} tables in {:.1}s (run_id: {run_id})",
             output.tables_copied,
             output.duration_ms as f64 / 1000.0
         );
         if output.drift.tables_drifted > 0 {
-            println!(
+            crate::status_line!(
                 "Drift: {}/{} tables drifted",
                 output.drift.tables_drifted, output.drift.tables_checked
             );

--- a/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
+++ b/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
@@ -30,6 +30,15 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// the unified-DAG path shares the project's canonical state with every other
 /// `rocky run` invocation — it must never invent its own `.rocky_state` file.
 pub async fn run_with_dag(config_path: &Path, state_path: &Path, json: bool) -> Result<()> {
+    // Under `-o json` the orchestrator contract is that stdout is exactly one
+    // JSON document (the `DagRunOutput` below). Sub-runs are dispatched with
+    // `json = false` so they don't each emit their own JSON payload, which
+    // means they take their human-summary branch — route those lines to stderr
+    // so they can't precede the JSON on stdout. See `crate::status_line!`.
+    if json {
+        crate::output::reserve_stdout_for_json();
+    }
+
     let cfg = rocky_core::config::load_rocky_config(config_path).context(format!(
         "failed to load config from {}",
         config_path.display()

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -230,13 +230,13 @@ pub async fn run_transformation(
     if output_json {
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else {
-        println!(
+        crate::status_line!(
             "transformation pipeline complete: {} model(s) executed in {}ms",
             output.materializations.len(),
             output.duration_ms
         );
         for m in &output.materializations {
-            println!("  {} ({})", m.asset_key.join("."), m.metadata.strategy);
+            crate::status_line!("  {} ({})", m.asset_key.join("."), m.metadata.strategy);
         }
     }
 
@@ -471,7 +471,7 @@ pub async fn run_quality(
                 output.quarantine.len()
             )
         };
-        println!(
+        crate::status_line!(
             "quality pipeline complete: {total_checks} check(s) across {} table(s), {error_failures} error / {warning_failures} warning failed{quarantine_summary}, in {}ms",
             output.check_results.len(),
             output.duration_ms
@@ -865,7 +865,7 @@ pub async fn run_snapshot(
     if output_json {
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else {
-        println!(
+        crate::status_line!(
             "snapshot pipeline complete: {}.{}.{} -> {}.{}.{} in {}ms",
             pipeline.source.catalog,
             pipeline.source.schema,

--- a/engine/crates/rocky-cli/src/commands/seed.rs
+++ b/engine/crates/rocky-cli/src/commands/seed.rs
@@ -63,7 +63,7 @@ pub async fn run_seed(
             };
             print_json(&output)?;
         } else {
-            println!("No seed files found in {}", seeds_dir.display());
+            crate::status_line!("No seed files found in {}", seeds_dir.display());
         }
         return Ok(());
     }
@@ -171,18 +171,24 @@ pub async fn run_seed(
         };
         print_json(&output)?;
     } else {
-        println!(
+        crate::status_line!(
             "\nSeed complete: {} loaded, {} failed ({} ms)",
-            tables_loaded, tables_failed, duration_ms
+            tables_loaded,
+            tables_failed,
+            duration_ms
         );
         for t in &table_results {
             let status = if t.error.is_some() { "FAIL" } else { "OK" };
-            println!(
+            crate::status_line!(
                 "  [{status}] {} -> {} ({} rows, {} cols, {} ms)",
-                t.name, t.target, t.rows, t.columns, t.duration_ms
+                t.name,
+                t.target,
+                t.rows,
+                t.columns,
+                t.duration_ms
             );
             if let Some(ref err) = t.error {
-                println!("       {err}");
+                crate::status_line!("       {err}");
             }
         }
     }

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -4697,6 +4697,52 @@ pub fn print_json<T: Serialize>(output: &T) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Process-global flag: when set, stdout is reserved exclusively for the JSON
+/// document, so human-readable progress/summary lines must go to stderr.
+///
+/// The unified-DAG path (`rocky run --dag`, `rocky apply`) drives each node as
+/// a sub-run with `json = false`, so those sub-runs take their human-summary
+/// branch and would otherwise print "transformation pipeline complete: …",
+/// "Copied N tables …", "Seed complete: …" etc. to stdout *before* the outer
+/// `DagRunOutput` JSON payload. With `-o json` the orchestrator contract is
+/// that stdout is exactly one JSON document, so we flip this flag once at the
+/// top of a JSON-mode run and have the summary printers emit to stderr via
+/// [`status_line!`] instead. Human (table) mode never sets it.
+static STDOUT_RESERVED_FOR_JSON: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Reserve stdout for the JSON document — see [`STDOUT_RESERVED_FOR_JSON`].
+///
+/// Idempotent and set-only: called once when a run resolves to JSON output.
+pub fn reserve_stdout_for_json() {
+    STDOUT_RESERVED_FOR_JSON.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Whether human progress/summary lines must be routed to stderr instead of
+/// stdout — see [`STDOUT_RESERVED_FOR_JSON`]. Consulted by [`status_line!`].
+pub fn is_stdout_reserved_for_json() -> bool {
+    STDOUT_RESERVED_FOR_JSON.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Print a human-readable progress/summary line, honoring the
+/// stdout-reserved-for-JSON contract.
+///
+/// Identical to `println!` in human/table mode. When stdout is reserved for a
+/// JSON document (see [`reserve_stdout_for_json`]) the line is routed to stderr
+/// so it can't precede or corrupt the JSON payload an orchestrator parses from
+/// stdout. Use this for every run-path summary line that lives in a
+/// non-`output_json` branch.
+#[macro_export]
+macro_rules! status_line {
+    ($($arg:tt)*) => {{
+        if $crate::output::is_stdout_reserved_for_json() {
+            eprintln!($($arg)*);
+        } else {
+            println!($($arg)*);
+        }
+    }};
+}
+
 #[cfg(test)]
 mod cost_finalize_tests {
     use super::*;

--- a/engine/rocky/tests/run_dag_json_stdout.rs
+++ b/engine/rocky/tests/run_dag_json_stdout.rs
@@ -1,0 +1,136 @@
+//! Integration test for the `rocky run --dag --output json` stdout contract.
+//!
+//! Regression guard: under `-o json` the unified-DAG path must emit *exactly*
+//! one JSON document on stdout (the `DagRunOutput`). Historically each DAG
+//! sub-run (replication load, transformation, seed) was dispatched with
+//! `json = false` and printed its human summary line — "Copied N tables …",
+//! "transformation pipeline complete …" — to stdout *before* the JSON payload,
+//! so an orchestrator had to slice from the first `{`. Those lines now route to
+//! stderr; stdout stays pure JSON.
+//!
+//! Spawns the real `rocky` binary against a tiny DuckDB fixture with both a
+//! replication (`ingest`) and a transformation (`transform`) pipeline, so both
+//! summary printers are exercised on one run.
+
+use std::fs;
+use std::process::Command;
+
+/// A replication pipeline + a transformation pipeline over one DuckDB file.
+/// `ingest` copies `raw__orders.orders` into `staging__orders`; `transform`
+/// builds a model from the raw table. Both sub-runs print a human summary in
+/// table mode — under `-o json` those must land on stderr.
+const ROCKY_TOML: &str = r#"
+[adapter]
+type = "duckdb"
+path = "fixture.duckdb"
+
+[pipeline.ingest]
+strategy = "full_refresh"
+timestamp_column = "_updated_at"
+
+[pipeline.ingest.source.discovery]
+adapter = "default"
+
+[pipeline.ingest.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.ingest.target]
+catalog_template = "fixture"
+schema_template = "staging__{source}"
+
+[pipeline.ingest.target.governance]
+auto_create_schemas = true
+
+[pipeline.ingest.execution]
+concurrency = 1
+
+[pipeline.transform]
+type = "transformation"
+depends_on = ["ingest"]
+
+[pipeline.transform.target]
+adapter = "default"
+"#;
+
+const MODEL_SQL: &str = "SELECT order_id, customer_id, amount FROM raw__orders.orders\n";
+
+const MODEL_TOML: &str = r#"
+[target]
+catalog = "fixture"
+schema = "staging"
+"#;
+
+const SEED_SQL: &str = r#"
+CREATE SCHEMA IF NOT EXISTS raw__orders;
+CREATE SCHEMA IF NOT EXISTS staging;
+CREATE OR REPLACE TABLE raw__orders.orders AS
+SELECT
+    i AS order_id,
+    1 + (i % 5) AS customer_id,
+    CAST(i AS DOUBLE) AS amount,
+    TIMESTAMP '2026-01-01' + INTERVAL (i) SECOND AS _updated_at
+FROM generate_series(1, 10) AS t(i);
+"#;
+
+#[test]
+fn run_dag_json_stdout_is_a_single_json_document() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path();
+
+    // Seed the DuckDB fixture in-process (the binary links duckdb via
+    // rocky-duckdb; this dev-dep shares it).
+    {
+        let conn = duckdb::Connection::open(dir.join("fixture.duckdb")).expect("open duckdb");
+        conn.execute_batch(SEED_SQL).expect("seed sql");
+    }
+
+    fs::write(dir.join("rocky.toml"), ROCKY_TOML).expect("write rocky.toml");
+    let models_dir = dir.join("models");
+    fs::create_dir(&models_dir).expect("mkdir models");
+    fs::write(models_dir.join("stg_orders.sql"), MODEL_SQL).expect("write model sql");
+    fs::write(models_dir.join("stg_orders.toml"), MODEL_TOML).expect("write model toml");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_rocky"))
+        .arg("-c")
+        .arg(dir.join("rocky.toml"))
+        .arg("run")
+        .arg("--dag")
+        .arg("--output")
+        .arg("json")
+        .current_dir(dir)
+        .env("RUST_LOG", "error")
+        .output()
+        .expect("spawn rocky");
+
+    let stdout = String::from_utf8(out.stdout).expect("utf8 stdout");
+    let stderr = String::from_utf8(out.stderr).expect("utf8 stderr");
+
+    // stdout must parse as exactly one JSON value with no leading text — the
+    // core contract. `from_str` rejects both a human preamble and trailing
+    // junk after the document.
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!("stdout is not a single JSON document: {e}\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}");
+    });
+    assert_eq!(
+        parsed.get("command").and_then(|v| v.as_str()),
+        Some("run --dag"),
+        "expected a DagRunOutput on stdout, got: {stdout}"
+    );
+
+    // No human summary line may appear on stdout.
+    for needle in ["Copied", "pipeline complete", "Seed complete"] {
+        assert!(
+            !stdout.contains(needle),
+            "human summary '{needle}' leaked onto stdout:\n{stdout}"
+        );
+    }
+
+    // The summaries must still be emitted — just on stderr. The replication
+    // load's "Copied …" line is deterministic regardless of model success.
+    assert!(
+        stderr.contains("Copied"),
+        "expected the replication summary on stderr, got:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Problem

`rocky run -o json` is supposed to emit exactly one JSON document on stdout. The unified-DAG path (`rocky run --dag`, `rocky apply`) drives each node as a sub-run with `json = false`, so those sub-runs take their human-summary branch and print lines like `Copied N tables …`, `transformation pipeline complete …`, or `Seed complete …` to **stdout, ahead of** the outer `DagRunOutput` JSON. An orchestrator parsing stdout had to slice from the first `{`. Most visible with `--dag`, but any `-o json` run that hit a human-branch summary line was exposed.

## Fix

- New process-global flag `STDOUT_RESERVED_FOR_JSON`, set once via `reserve_stdout_for_json()` at the top of a JSON-mode run (`run`, `run_with_dag`).
- New `status_line!` macro: identical to `println!` in human/table mode, but routes to stderr when stdout is reserved for JSON.
- Converted the run-path summary printers (replication "Copied …", transformation/quality/snapshot "… pipeline complete", seed "Seed complete …" / per-table lines) from `println!` to `status_line!`.

Result: with `-o json`, stdout is exactly the JSON document and the progress text goes to stderr. Human/table mode is byte-for-byte unchanged.

## Verification

- New integration test `engine/rocky/tests/run_dag_json_stdout.rs` spawns the real binary against a DuckDB fixture wiring both a replication and a transformation pipeline, runs `run --dag --output json`, and asserts: stdout parses as a single JSON document (`command == "run --dag"`) with no `Copied` / `pipeline complete` / `Seed complete` leakage, and the summaries still appear on stderr.
- `cargo test`, `cargo clippy --all-targets`, and `cargo fmt --check` for `rocky-cli` / `rocky`.
