### PR TITLE
feat(engine/rocky-compiler): port dbt unit tests with null fixture cells (FR-045)

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`rocky import-dbt` now ports dbt unit tests with null fixture cells instead of dropping them as UnserializableUnitTest** — TOML has no null, so null cells are omitted on emit and the run-side fixture builder unions the column set across rows, materializing absent cells as SQL NULL. (FR-045)
+
 ## [1.55.1] - 2026-06-27
 
 ### Changed

--- a/engine/crates/rocky-compiler/src/import/dbt.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt.rs
@@ -683,15 +683,22 @@ pub fn apply_dbt_unit_tests(
 
 /// Check that a converted unit test round-trips to the sidecar TOML the
 /// emitter writes. Returns `Err(reason)` when the `toml` crate rejects the
-/// shape — most commonly a `null` value inside a fixture/expectation row,
-/// which TOML cannot express. Mirrors the emitter's `[[test]]` wrapper so a
-/// pass here guarantees the emit-time serialize won't fail.
+/// shape *after* null-stripping — e.g. a nested array/object TOML cannot
+/// express.
+///
+/// Null fixture/expectation cells are no longer fatal: TOML has no `null`
+/// type, so the emitter omits `null`-valued keys ([`emit::strip_null_fixture_cells`])
+/// and the run-side fixture builder materializes the absent cell back to SQL
+/// `NULL`. This check applies the same strip before serializing, so a test
+/// whose only obstacle was a null cell now passes here and ports as
+/// `CONVERTED`. (FR-045)
 fn check_unit_test_serializable(test: &UnitTestDef) -> Result<(), String> {
     #[derive(serde::Serialize)]
     struct Wrapper<'a> {
         test: [&'a UnitTestDef; 1],
     }
-    toml::to_string(&Wrapper { test: [test] })
+    let stripped = crate::import::emit::strip_null_fixture_cells(test);
+    toml::to_string(&Wrapper { test: [&stripped] })
         .map(|_| ())
         .map_err(|e| e.to_string())
 }
@@ -3863,13 +3870,13 @@ FROM {{ ref('stg_events') }}
         assert_eq!(imported.unit_tests.len(), 1);
     }
 
-    /// A `null` fixture value (TOML has no null type) must NOT abort the
-    /// import. The offending unit test is skipped + counted; every other
-    /// model/seed/test still imports — and a sibling null-free unit test in
-    /// the same manifest round-trips cleanly. Regression for the
-    /// `toml::to_string … unsupported unit type` import-abort bug.
+    /// FR-045: a `null` fixture/expectation cell (TOML has no null type) is no
+    /// longer dropped. The null key is omitted on emit and the run-side builder
+    /// materializes it back to SQL NULL, so the test ports as CONVERTED — not
+    /// UnserializableUnitTest. Covers the mixed/union case (a column null in
+    /// some rows, set in others) and asserts the emitted sidecar TOML is clean.
     #[test]
-    fn test_apply_dbt_unit_tests_null_fixture_value_skips_not_aborts() {
+    fn test_apply_dbt_unit_tests_null_fixture_value_converts() {
         let manifest = serde_json::json!({
             "metadata": { "project_name": "p" },
             "nodes": {
@@ -3886,16 +3893,95 @@ FROM {{ ref('stg_events') }}
             },
             "sources": {},
             "unit_tests": {
-                // Offending: a `null` field value inside an expectation row.
+                // Null cells in BOTH given and expect, plus the mixed/union
+                // case: `note` is set in row 1 but null in row 2.
                 "unit_test.p.m.has_null": {
                     "unique_id": "unit_test.p.m.has_null",
                     "name": "has_null",
                     "model": "m",
-                    "given": [{ "input": "ref('u')", "rows": [{ "id": 1, "note": "x" }] }],
+                    "given": [{ "input": "ref('u')", "rows": [
+                        { "id": 1, "note": "x" },
+                        { "id": 2, "note": null }
+                    ] }],
                     "expect": { "rows": [{ "id": 1, "note": null }], "format": "dict" },
                     "tags": []
+                }
+            }
+        });
+
+        let result = import_from_manifest_json(&manifest);
+
+        let imported = result
+            .imported
+            .iter()
+            .find(|m| m.name == "m")
+            .expect("model imported");
+
+        // Counters: seen and CONVERTED, none skipped.
+        assert_eq!(result.unit_tests_found, 1);
+        assert_eq!(result.unit_tests_converted, 1);
+        assert_eq!(result.unit_tests_skipped, 0);
+
+        // No UnserializableUnitTest warning — the null cell is no longer fatal.
+        assert!(
+            !result
+                .warnings
+                .iter()
+                .any(|w| w.category == WarningCategory::UnserializableUnitTest),
+            "null fixture cells must not trigger UnserializableUnitTest"
+        );
+
+        assert_eq!(imported.unit_tests.len(), 1);
+        assert_eq!(imported.unit_tests[0].name, "has_null");
+
+        // The emitted sidecar TOML serializes cleanly with the null key omitted.
+        let emitted = crate::import::emit::render_unit_tests("m", &imported.unit_tests);
+        assert!(
+            emitted.contains("[[test]]") && emitted.contains("has_null"),
+            "has_null test must serialize to a [[test]] block:\n{emitted}"
+        );
+        // The omitted null cell renders the row WITHOUT a `note = ` for that
+        // entry — re-parsing the sidecar must succeed (no stray null literal).
+        let parsed: toml::Value =
+            toml::from_str(&emitted).expect("emitted unit-test TOML must re-parse");
+        assert!(
+            parsed.get("test").is_some(),
+            "parsed sidecar carries [[test]]"
+        );
+    }
+
+    /// A test still genuinely unrepresentable after null-stripping (a `null`
+    /// nested inside an array, which a key-strip can't reach) is still dropped
+    /// with an UnserializableUnitTest warning, and never aborts the import.
+    #[test]
+    fn test_apply_dbt_unit_tests_nested_null_array_still_skips() {
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": {
+                "model.p.m": {
+                    "unique_id": "model.p.m",
+                    "name": "m",
+                    "resource_type": "model",
+                    "compiled_code": "SELECT 1",
+                    "raw_code": "SELECT 1",
+                    "depends_on": { "nodes": [], "macros": [] },
+                    "config": { "materialized": "table" },
+                    "columns": {}, "tags": [], "schema": "s", "database": "d"
+                }
+            },
+            "sources": {},
+            "unit_tests": {
+                // A null INSIDE an array — key-strip can't reach it, so TOML
+                // still can't express the row.
+                "unit_test.p.m.nested": {
+                    "unique_id": "unit_test.p.m.nested",
+                    "name": "nested",
+                    "model": "m",
+                    "given": [{ "input": "ref('u')", "rows": [{ "id": 1, "tags": [null] }] }],
+                    "expect": { "rows": [{ "id": 1 }], "format": "dict" },
+                    "tags": []
                 },
-                // Valid sibling: null-free, no description — must round-trip.
+                // Valid sibling: must still round-trip.
                 "unit_test.p.m.clean": {
                     "unique_id": "unit_test.p.m.clean",
                     "name": "clean",
@@ -3908,38 +3994,24 @@ FROM {{ ref('stg_events') }}
         });
 
         let result = import_from_manifest_json(&manifest);
-
-        // Exit-0 behavior: the import completed, the model is present.
         let imported = result
             .imported
             .iter()
             .find(|m| m.name == "m")
             .expect("model still imported despite the unserializable unit test");
 
-        // Counters: both seen, one converted, one skipped.
         assert_eq!(result.unit_tests_found, 2);
         assert_eq!(result.unit_tests_converted, 1);
         assert_eq!(result.unit_tests_skipped, 1);
-
-        // Only the clean test is attached.
         assert_eq!(imported.unit_tests.len(), 1);
         assert_eq!(imported.unit_tests[0].name, "clean");
-
-        // A structured warning explains the skip.
         assert!(
             result
                 .warnings
                 .iter()
                 .any(|w| w.category == WarningCategory::UnserializableUnitTest
-                    && w.message.contains("has_null")),
+                    && w.message.contains("nested")),
             "expected an UnserializableUnitTest warning naming the dropped test"
-        );
-
-        // The retained test round-trips to the sidecar TOML the emitter writes.
-        let emitted = crate::import::emit::render_unit_tests("m", &imported.unit_tests);
-        assert!(
-            emitted.contains("[[test]]") && emitted.contains("clean"),
-            "clean test must serialize to a [[test]] block:\n{emitted}"
         );
     }
 

--- a/engine/crates/rocky-compiler/src/import/emit.rs
+++ b/engine/crates/rocky-compiler/src/import/emit.rs
@@ -238,11 +238,18 @@ fn write_model_files(model: &ImportedModel, models_dir: &Path) -> Result<(), Str
 /// crate so the array-of-tables nesting (`[[test]]`, `[[test.given]]`,
 /// `[test.expect]`) matches what the [`UnitTestDef`] deserializer expects.
 ///
-/// Each test is serialized individually so a single unrepresentable test
-/// (e.g. a `null` fixture value, which TOML can't express) is skipped with
-/// a warning rather than aborting the whole import. The upstream importer
-/// already drops such tests in `apply_dbt_unit_tests`; this is the
-/// defense-in-depth backstop so emission can never fail on a stray shape.
+/// TOML has no `null` type, so before serializing each test we strip
+/// `null`-valued object keys from every fixture/expectation row (see
+/// [`strip_null_fixture_cells`]). A null cell ports cleanly as an omitted
+/// key; the run-side fixture builder unions the column set across rows and
+/// materializes the absent cell back to SQL `NULL`. (FR-045)
+///
+/// Each test is serialized individually so a single test that is *still*
+/// unrepresentable after null-stripping (e.g. a nested array/object TOML
+/// can't express) is skipped with a warning rather than aborting the whole
+/// import. The upstream importer already filters such tests in
+/// `apply_dbt_unit_tests`; this is the defense-in-depth backstop so emission
+/// can never fail on a stray shape.
 pub(crate) fn render_unit_tests(model: &str, tests: &[UnitTestDef]) -> String {
     #[derive(Serialize)]
     struct Wrapper<'a> {
@@ -250,7 +257,8 @@ pub(crate) fn render_unit_tests(model: &str, tests: &[UnitTestDef]) -> String {
     }
     let mut out = String::new();
     for test in tests {
-        match toml::to_string(&Wrapper { test: [test] }) {
+        let stripped = strip_null_fixture_cells(test);
+        match toml::to_string(&Wrapper { test: [&stripped] }) {
             Ok(body) => {
                 out.push('\n');
                 out.push_str(&body);
@@ -264,6 +272,37 @@ pub(crate) fn render_unit_tests(model: &str, tests: &[UnitTestDef]) -> String {
                 );
             }
         }
+    }
+    out
+}
+
+/// Return a copy of `test` with `null`-valued object keys removed from every
+/// fixture (`given`) and expectation (`expect`) row.
+///
+/// TOML has no `null` type, so a row carrying a JSON `null` cell can't
+/// serialize to the sidecar (`toml` fails the whole document with
+/// "unsupported unit type"). Omitting the key lets the row port as
+/// `CONVERTED`; the run-side fixture builder ([`fixture_to_sql`]) unions the
+/// column set across rows and emits SQL `NULL` for any absent cell, so a
+/// stripped cell round-trips to a NULL at test time. Non-null shapes (and any
+/// `null` nested inside an array, which a key-strip can't reach) are left
+/// untouched, preserving the genuine "still unserializable" signal. (FR-045)
+///
+/// [`fixture_to_sql`]: rocky_core::unit_test::fixture_to_sql
+pub(crate) fn strip_null_fixture_cells(test: &UnitTestDef) -> UnitTestDef {
+    fn strip_row_nulls(row: &mut serde_json::Value) {
+        if let Some(obj) = row.as_object_mut() {
+            obj.retain(|_, v| !v.is_null());
+        }
+    }
+    let mut out = test.clone();
+    for given in &mut out.given {
+        for row in &mut given.rows {
+            strip_row_nulls(row);
+        }
+    }
+    for row in &mut out.expect.rows {
+        strip_row_nulls(row);
     }
     out
 }
@@ -1333,6 +1372,83 @@ mod tests {
         assert_eq!(ut.given.len(), 1);
         assert_eq!(ut.given[0].model_ref, "int_orders");
         assert_eq!(ut.expect.rows.len(), 1);
+    }
+
+    /// FR-045: `null` fixture/expectation cells are stripped before serialize
+    /// (TOML has no null type), so the test serializes cleanly with the null
+    /// key omitted — and the rest of the row survives.
+    #[test]
+    fn render_unit_tests_strips_null_cells_and_serializes() {
+        use rocky_core::unit_test::{TestExpectation, TestFixture, UnitTestDef};
+
+        let test = UnitTestDef {
+            name: "null_handling".into(),
+            description: None,
+            given: vec![TestFixture {
+                model_ref: "u".into(),
+                // `note` set in row 1, null in row 2 (the union/mixed case).
+                rows: vec![
+                    serde_json::json!({ "id": 1, "note": "x" }),
+                    serde_json::json!({ "id": 2, "note": null }),
+                ],
+            }],
+            expect: TestExpectation {
+                rows: vec![serde_json::json!({ "id": 1, "note": null })],
+                ordered: false,
+            },
+        };
+
+        let emitted = render_unit_tests("m", std::slice::from_ref(&test));
+        assert!(
+            emitted.contains("[[test]]") && emitted.contains("null_handling"),
+            "null-bearing test must serialize:\n{emitted}"
+        );
+
+        // Re-parse: the null key is gone, the non-null cells remain.
+        #[derive(serde::Deserialize)]
+        struct UnitTestsOnly {
+            #[serde(default)]
+            test: Vec<UnitTestDef>,
+        }
+        let parsed: UnitTestsOnly = toml::from_str(&emitted).expect("emitted TOML re-parses");
+        assert_eq!(parsed.test.len(), 1);
+        let given_row2 = parsed.test[0].given[0].rows[1].as_object().unwrap();
+        assert!(
+            !given_row2.contains_key("note"),
+            "the null `note` key must be omitted: {given_row2:?}"
+        );
+        assert_eq!(
+            given_row2.get("id").and_then(serde_json::Value::as_i64),
+            Some(2)
+        );
+        let expect_row = parsed.test[0].expect.rows[0].as_object().unwrap();
+        assert!(!expect_row.contains_key("note"), "expect null cell omitted");
+    }
+
+    #[test]
+    fn strip_null_fixture_cells_leaves_non_null_untouched() {
+        use rocky_core::unit_test::{TestExpectation, TestFixture, UnitTestDef};
+
+        let test = UnitTestDef {
+            name: "t".into(),
+            description: None,
+            given: vec![TestFixture {
+                model_ref: "u".into(),
+                rows: vec![serde_json::json!({ "id": 1, "name": "a", "flag": false })],
+            }],
+            expect: TestExpectation {
+                rows: vec![serde_json::json!({ "id": 1 })],
+                ordered: false,
+            },
+        };
+        let stripped = strip_null_fixture_cells(&test);
+        let row = stripped.given[0].rows[0].as_object().unwrap();
+        assert_eq!(row.len(), 3, "no keys dropped when nothing is null");
+        // `false` is not null and must survive.
+        assert_eq!(
+            row.get("flag").and_then(serde_json::Value::as_bool),
+            Some(false)
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-core/src/unit_test.rs
+++ b/engine/crates/rocky-core/src/unit_test.rs
@@ -24,6 +24,8 @@
 //! ]
 //! ```
 
+use std::collections::BTreeSet;
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
@@ -120,32 +122,44 @@ pub fn json_to_sql_literal(value: &JsonValue) -> String {
 ///
 /// Returns a `CREATE TABLE <ref> AS SELECT ... UNION ALL ...` statement
 /// that the test runner can execute before running the model.
+///
+/// The column set is the **union** of object keys across all rows, sorted for
+/// deterministic SQL. Every per-row `SELECT` projects that same union, emitting
+/// [`json_to_sql_literal`] for a present cell and SQL `NULL` for an absent one.
+/// This keeps all `UNION ALL` branches column-consistent even when rows differ
+/// in shape — a cell that is `null` in some rows but set in others (or a key
+/// omitted by the dbt-import emitter because its value was JSON `null`)
+/// materializes as SQL `NULL` rather than dropping the column or skewing the
+/// `SELECT` width. (FR-045)
 pub fn fixture_to_sql(fixture: &TestFixture) -> Option<String> {
     if fixture.rows.is_empty() {
         return None;
     }
 
-    // Extract column names from the first row
-    let first_row = fixture.rows[0].as_object()?;
-    let columns: Vec<&str> = first_row.keys().map(std::string::String::as_str).collect();
+    // Union of column names across every row (sorted → deterministic SQL).
+    let mut col_set: BTreeSet<&str> = BTreeSet::new();
+    for row in &fixture.rows {
+        let obj = row.as_object()?;
+        for key in obj.keys() {
+            col_set.insert(key.as_str());
+        }
+    }
+    if col_set.is_empty() {
+        return None;
+    }
+    let columns: Vec<&str> = col_set.into_iter().collect();
 
     let mut selects = Vec::with_capacity(fixture.rows.len());
     for row in &fixture.rows {
         let table = row.as_object()?;
-        let values: Vec<String> = columns
-            .iter()
-            .map(|col| match table.get(*col) {
-                Some(JsonValue::String(s)) => format!("'{}'", s.replace('\'', "''")),
-                Some(JsonValue::Number(n)) => n.to_string(),
-                Some(JsonValue::Bool(b)) => b.to_string(),
-                _ => "NULL".to_string(),
-            })
-            .collect();
-
         let col_exprs: Vec<String> = columns
             .iter()
-            .zip(values.iter())
-            .map(|(col, val)| format!("{val} AS {col}"))
+            .map(|col| {
+                let lit = table
+                    .get(*col)
+                    .map_or_else(|| "NULL".to_string(), json_to_sql_literal);
+                format!("{lit} AS {col}")
+            })
             .collect();
         selects.push(format!("SELECT {}", col_exprs.join(", ")));
     }
@@ -221,5 +235,57 @@ mod tests {
         };
         let sql = fixture_to_sql(&fixture).unwrap();
         assert!(sql.contains("O''Brien")); // escaped single quote
+    }
+
+    #[test]
+    fn test_fixture_to_sql_union_of_keys_missing_key_is_null() {
+        // Row 1 omits `email` (a null cell omitted on emit, or genuinely
+        // absent); row 2 sets it. The union must carry `email`, and row 1
+        // must project it as SQL NULL so both SELECTs share one column set.
+        let fixture = TestFixture {
+            model_ref: "users".into(),
+            rows: vec![
+                serde_json::json!({ "id": 1 }),
+                serde_json::json!({ "id": 2, "email": "a@b.com" }),
+            ],
+        };
+        let sql = fixture_to_sql(&fixture).unwrap();
+
+        // Union column order is sorted: email before id.
+        let selects: Vec<&str> = sql.split("UNION ALL").collect();
+        assert_eq!(selects.len(), 2);
+        // Both branches project the same two columns in the same order.
+        assert!(selects[0].contains("NULL AS email"));
+        assert!(selects[0].contains("1 AS id"));
+        assert!(selects[1].contains("'a@b.com' AS email"));
+        assert!(selects[1].contains("2 AS id"));
+        // Every SELECT lists email then id (consistent shape across the union).
+        for sel in &selects {
+            let email_at = sel.find("AS email").expect("email column");
+            let id_at = sel.find("AS id").expect("id column");
+            assert!(email_at < id_at, "columns must be in stable union order");
+        }
+    }
+
+    #[test]
+    fn test_fixture_to_sql_explicit_null_cell_is_null() {
+        // An explicit JSON null cell renders as SQL NULL (json_to_sql_literal's
+        // catch-all arm), matching an omitted key.
+        let fixture = TestFixture {
+            model_ref: "users".into(),
+            rows: vec![serde_json::json!({ "id": 1, "email": serde_json::Value::Null })],
+        };
+        let sql = fixture_to_sql(&fixture).unwrap();
+        assert!(sql.contains("NULL AS email"));
+        assert!(sql.contains("1 AS id"));
+    }
+
+    #[test]
+    fn test_fixture_to_sql_all_empty_rows_is_none() {
+        let fixture = TestFixture {
+            model_ref: "empty".into(),
+            rows: vec![serde_json::json!({})],
+        };
+        assert!(fixture_to_sql(&fixture).is_none());
     }
 }

--- a/engine/crates/rocky-engine/src/test_runner.rs
+++ b/engine/crates/rocky-engine/src/test_runner.rs
@@ -682,4 +682,56 @@ mod tests {
         let run = run_unit_tests(&models, None).unwrap();
         assert_eq!(run.total(), 0);
     }
+
+    /// FR-045: the fixture sidecar omits a `note` key on row 1 (a null cell
+    /// dropped on emit) but sets it on row 2. The run-side builder must UNION
+    /// the column set across rows so `note` is present, materializing the
+    /// absent row-1 cell as SQL NULL. The model under test does null-handling
+    /// (`COALESCE(note, 'EMPTY')`); the test passes only if the built fixture
+    /// table actually carries a SQL NULL in row 1. The old `rows[0]`-only
+    /// column logic would have dropped the `note` column and failed model
+    /// execution outright.
+    #[test]
+    fn unit_test_union_of_keys_materializes_absent_cell_as_null() {
+        let dir = tempfile::tempdir().unwrap();
+        let models = dir.path().join("models");
+        std::fs::create_dir_all(&models).unwrap();
+
+        std::fs::write(models.join("orders.sql"), "SELECT 0 AS id, '' AS note").unwrap();
+        std::fs::write(
+            models.join("orders.toml"),
+            "[strategy]\ntype = \"full_refresh\"\n[target]\ncatalog=\"wh\"\nschema=\"main\"\n",
+        )
+        .unwrap();
+
+        // Model under test exercises NULL handling on the mocked column.
+        std::fs::write(
+            models.join("filled.sql"),
+            "SELECT id, COALESCE(note, 'EMPTY') AS note_filled FROM orders",
+        )
+        .unwrap();
+        // Row 1 OMITS `note` (the post-emit shape of a null cell); row 2 sets
+        // it. Only the union builder keeps the `note` column for both rows.
+        std::fs::write(
+            models.join("filled.toml"),
+            "[strategy]\ntype = \"full_refresh\"\n\
+             [target]\ncatalog = \"wh\"\nschema = \"main\"\n\n\
+             [[test]]\nname = \"null_coalesces\"\n\n\
+             [[test.given]]\nref = \"orders\"\n\
+             rows = [ { id = 1 }, { id = 2, note = \"hi\" } ]\n\n\
+             [test.expect]\n\
+             rows = [ { id = 1, note_filled = \"EMPTY\" }, { id = 2, note_filled = \"hi\" } ]\n",
+        )
+        .unwrap();
+
+        let run = run_unit_tests(&models, None).unwrap();
+        assert_eq!(run.total(), 1);
+        assert_eq!(
+            run.passed(),
+            1,
+            "union-of-keys NULL handling failed: {:?}",
+            run.results[0].error
+        );
+        assert!(run.results[0].passed);
+    }
 }


### PR DESCRIPTION
## Problem

A dbt unit test whose fixture (or expectation) carried a `null` cell could not be ported. TOML has no `null` type, so serializing the sidecar failed the whole document — and since #968 the importer dropped the entire unit test as `UnserializableUnitTest`. Any null in any row meant the test silently went missing.

## Fix

- **Emit:** strip `null`-valued keys from every fixture/expectation row before serializing. An omitted key is exactly how a SQL `NULL` is represented in the sidecar, so the test now ports as `CONVERTED` instead of being dropped.
- **Run:** the fixture builder unions the column set across all rows, so a cell absent from one row is materialized as SQL `NULL` for that row. The run side already mapped an explicit `null` value to `NULL`; the union closes the absent-key path.

A test that is *still* unrepresentable after null-stripping (e.g. a null nested inside an array, which a key-strip can't reach) keeps the existing skip-with-warning backstop, so the genuine "unserializable" signal is preserved.

## Testing

- Real `import-dbt` → `compile` → `test` round-trip over a fixture with null cells, including the mixed/union case (a column null in one row, present in another).
- Emit-side unit test: a null-bearing test serializes, re-parses, and the null key is gone while the rest of the row survives.
- Run-side unit test: absent/null cell resolves to `NULL` and the assertion passes.

Completes the FR-025 → FR-034 → FR-045 arc.
