### PR TITLE
docs: correct the type-mismatch diagnostic code in public copy (E013 → E011)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Compare two versions of your project and get a list of which downstream tables a
 ### More demos
 
 - [Schema drift recovery](examples/playground/pocs/02-performance/06-schema-drift-recover/): source column type changes upstream; Rocky detects it and rebuilds safely.
-- [Data contracts](examples/playground/pocs/01-quality/01-data-contracts-strict/): missing required columns, dropped protected columns, or unsafe type changes surface as errors (`E010` / `E013`) before a row is written.
+- [Data contracts](examples/playground/pocs/01-quality/01-data-contracts-strict/): missing required columns, dropped protected columns, or unsafe type changes surface as errors (`E010`, `E011`, `E013`) before a row is written.
 - [BigQuery cost to the byte](examples/playground/pocs/07-adapters/05-bigquery-native-queries/): `bytes_scanned` in the run receipt matches BigQuery's billing number exactly (requires credentials).
 - [Named branches + replay](examples/playground/pocs/00-foundations/06-branches-replay-lineage/): run against an isolated schema copy, inspect, then drop or promote.
 - [Column lineage](examples/playground/pocs/06-developer-experience/01-lineage-column-level/): trace a column in a downstream model back to its source.
@@ -98,7 +98,7 @@ Core features are production-ready on Databricks: the checker, named branches, r
 
 | Problem | dbt Core | Rocky |
 |---|---|---|
-| Source column type changes | Silent | `E013` at check time, blocks PR |
+| Source column type changes | Silent | Detected at run, rebuilt safely |
 | Required column disappears | Opt-in `contract: enforced` | `E010` at check time, blocks PR |
 | Column renamed, unknown blast radius | Table-level lineage, post-hoc | `rocky lineage-diff` at PR time, column-level |
 | `SELECT *` pulls an unexpected column | Silent | `P002` warning, downstream models named |

--- a/docs/src/content/docs/getting-started/introduction.md
+++ b/docs/src/content/docs/getting-started/introduction.md
@@ -18,7 +18,7 @@ The expensive failures in modern data platforms aren't slow queries. They're tru
 - Warehouse spend doubles in a month and nobody can attribute which model caused it.
 - An auditor asks who changed `fct_revenue.amount`, when, and why, and the honest answer is `git blame` and screenshots.
 
-**Rocky's answer is to make each of these failures a compile error or a CI gate**, caught before it ships. A column-type change is `E013` at compile; a rename's blast radius is a `rocky lineage-diff` comment on the PR; an unbudgeted cost spike is a `[budget]` block that fails the run; classified PII with no mask strategy fails `rocky compliance`. These are failures the warehouse can't see and the templating layer above it can't catch at compile time. For how Rocky stacks up against dbt Core, dbt Fusion, and SQLMesh, see the [comparison](/getting-started/comparison/).
+**Rocky's answer is to make each of these failures a compile error or a CI gate**, caught before it ships. A column-type change is `E011` at compile; a rename's blast radius is a `rocky lineage-diff` comment on the PR; an unbudgeted cost spike is a `[budget]` block that fails the run; classified PII with no mask strategy fails `rocky compliance`. These are failures the warehouse can't see and the templating layer above it can't catch at compile time. For how Rocky stacks up against dbt Core, dbt Fusion, and SQLMesh, see the [comparison](/getting-started/comparison/).
 
 ## Who Rocky is for
 
@@ -84,7 +84,7 @@ See the [Roadmap](/getting-started/roadmap/) for the full breakdown.
 | State | `manifest.json` + `target/` | Embedded `redb` database |
 | Branches | — | `rocky branch create`, `rocky run --branch <name>` |
 | Column-level lineage | Table-level (`dbt docs`); column-level needs Fusion or paid Catalog | Compile-time output, queryable per column |
-| Schema drift | Silent | `E013` at compile, blocks the PR |
+| Schema drift | Silent | Detected at run, rebuilt safely |
 | Cost attribution | — | Per-model, every run |
 | Replay | — | Content-addressed run record (re-execution on the roadmap) |
 

--- a/docs/src/content/docs/guides/migrate-from-dbt.md
+++ b/docs/src/content/docs/guides/migrate-from-dbt.md
@@ -10,7 +10,7 @@ Most teams adopting Rocky have a dbt project today, so the day-one question is "
 The wedge in five steps:
 
 1. **Run `rocky import-dbt`.** Jinja `{{ ref() }}` and `{{ source() }}` resolve to bare references; configs become TOML sidecars; the importer writes `MIGRATION-NOTES.md` listing anything that didn't translate.
-2. **Run `rocky compile`.** First time through, expect real diagnostics: `E013` on type mismatches, `P002` on `SELECT *` blast radius, `P001` on dialect-portability issues. Each one is something dbt Core couldn't catch.
+2. **Run `rocky compile`.** First time through, expect real diagnostics: `E011` on type mismatches, `P002` on `SELECT *` blast radius, `P001` on dialect-portability issues. Each one is something dbt Core couldn't catch.
 3. **Add contracts on the boundary models.** `[contract] required_columns = […]`, `protected_columns = […]`. From here, the column rename that quietly breaks 47 downstream models becomes an `E010` in CI before it ships.
 4. **Adopt `rocky lineage-diff` in PR review.** Per-changed-column downstream blast radius. Drops into a PR comment. This is the moment your team stops reviewing changes blind.
 5. **Turn on `rocky preview cost`.** Per-PR cost projection: catch expensive plans before they ship instead of explaining them after.

--- a/docs/src/content/docs/reference/glossary.md
+++ b/docs/src/content/docs/reference/glossary.md
@@ -29,7 +29,7 @@ A data-quality assertion that runs inline during a run (row counts, column match
 
 ### Compile-time contract
 
-A schema agreement Rocky enforces before any row is written. A missing required column or an unsafe type change becomes a compile error (`E010`, `E013`) that blocks the PR. See [Testing and contracts](/concepts/testing/).
+A schema agreement Rocky enforces before any row is written. A missing required column or an unsafe type change becomes a compile error (`E010`, `E011`) that blocks the PR. See [Testing and contracts](/concepts/testing/).
 
 ### Config group
 

--- a/engine/README.md
+++ b/engine/README.md
@@ -17,7 +17,7 @@ The expensive failures in modern data platforms aren't slow queries. They're tru
 - Warehouse spend doubles in a month and nobody can attribute which model caused it.
 - An auditor asks who changed `fct_revenue.amount`, when, and why, and the answer involves `git blame` and screenshots.
 
-Rocky turns each of these into a compile error or a blocked PR before it ships: a column-type change is `E013` at compile, a rename's blast radius is a `rocky lineage-diff` comment, an unbudgeted cost spike is a `[budget]` block that fails the run, and unmasked classified data fails `rocky compliance`. These failures are invisible to the warehouse and out of scope for the templating layer above it. Rocky is the typed graph in between: real type inference and diagnostic codes, not text macros or runtime checks. For how Rocky compares to dbt Core, dbt Fusion, and SQLMesh, see the [comparison page](https://rocky-data.dev/getting-started/comparison/).
+Rocky turns each of these into a compile error or a blocked PR before it ships: a column-type change is `E011` at compile, a rename's blast radius is a `rocky lineage-diff` comment, an unbudgeted cost spike is a `[budget]` block that fails the run, and unmasked classified data fails `rocky compliance`. These failures are invisible to the warehouse and out of scope for the templating layer above it. Rocky is the typed graph in between: real type inference and diagnostic codes, not text macros or runtime checks. For how Rocky compares to dbt Core, dbt Fusion, and SQLMesh, see the [comparison page](https://rocky-data.dev/getting-started/comparison/).
 
 ## Scope on the ELT spectrum
 


### PR DESCRIPTION
Found while reviewing the docs against the README. Front-door copy described a **column type change** as `E013`, but per the engine (`rocky-compiler/src/contracts.rs`) `E013` is *protected column removed* — a type mismatch is **`E011`** (the code whose fix "suggests a CAST"). The reference/concept pages and the engine already agree on this; only the marketing/intro surfaces drifted.

**Fixed (E013 → E011, contract type-mismatch framing):**
- `README.md` (data-contracts bullet → `E010, E011, E013`)
- `engine/README.md` ("a column-type change is `E011` at compile")
- `docs/getting-started/introduction.md`
- `docs/guides/migrate-from-dbt.md`
- `docs/reference/glossary.md`

**Reframed (schema-drift rows — wrong on code *and* mechanism):**
- `README.md` "Source column type changes" and `introduction.md` "Schema drift" claimed `E013` at compile / blocks the PR. Schema drift is detected **at run** and rebuilt safely (`concepts/schema-drift`), so both cells now say "Detected at run, rebuilt safely" — matching the README's own drift demo.

**Left unchanged (already correct):** the `E010`–`E013` ranges, `ROCKY_EXPLAINED.md`'s code mapping, `index.mdx`'s representative blocking-code example, and the historical CHANGELOG.

Docs build green (90 pages). Touches `engine/README.md`, so `engine-ci` runs (no Rust change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)