### PR TITLE
docs: reconcile trust-framing nits (seven→trust dimensions, replay scope)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Core features are production-ready on Databricks: the checker, named branches, r
 
 - **Databricks is the 2026 focus.** Snowflake, BigQuery, and Trino work for the core loop but aren't as thorough yet. [Talk to us](https://github.com/rocky-data/rocky/discussions) if you need them in production now.
 - **AI features are early.** Generate → check → fix is shipped. Mass refactoring, auto-migration on type changes, and assertion generation are on the roadmap.
+- **Replay records and verifies; it doesn't re-execute yet.** Every run leaves a content-addressed record that `rocky replay` inspects and verifies against the ledger. Re-executing a past run from that record is on the roadmap.
 - **Iceberg.** Reading from a catalog is Beta. Writing straight to Iceberg is planned for 2026.
 - **No built-in metrics layer.** Use Cube, the dbt Semantic Layer, or whatever you have.
 - **Dagster is the one built-in scheduler integration** ([`dagster-rocky`](integrations/dagster/)). For anything else, use the [`rocky-sdk`](sdk/python/) Python client or `rocky serve`.

--- a/docs/src/content/docs/getting-started/introduction.md
+++ b/docs/src/content/docs/getting-started/introduction.md
@@ -47,7 +47,7 @@ Rocky owns the graph: dependencies, compile-time types, drift handling, incremen
 
 Quality is more than the inline runtime gate. Models can also declare fixture-driven unit tests (`rocky test`, run locally on DuckDB) and declarative data tests like not-null and uniqueness checks against warehouse rows (`rocky test --declarative`). See [Testing and Contracts](/concepts/testing/).
 
-## The seven trust dimensions
+## The trust dimensions
 
 1. **SQL as a typed, compiled language.** Column-level type inference across the full DAG. 35+ diagnostic codes (`E###` errors, `W###` warnings, `P###` portability lints) with actionable suggestions. Not text macros, but a real compiler with a real LSP.
 2. **Compile-time column-level lineage.** Every column traced through every transformation, before execution. `rocky lineage-diff main` lists per-column downstream blast radius for PR review. That CI gate is impossible without a compiled engine.

--- a/engine/README.md
+++ b/engine/README.md
@@ -30,7 +30,7 @@ Rocky turns each of these into a compile error or a blocked PR before it ships: 
 | Quality | ✅ | Inline assertions during `rocky run` |
 | Orchestration | Partial | First-class Dagster integration; `rocky serve` standalone |
 
-## The seven trust dimensions
+## The trust dimensions
 
 1. **SQL as a typed, compiled language.** Real type inference, diagnostic codes (`E###` errors, `W###` warnings, `P###` portability lints), and a real LSP, not text macros or runtime checks.
 2. **Compile-time column-level lineage.** Rocky knows every column's lineage before a row is written, so `rocky lineage-diff main` can block a PR when a downstream contract breaks.


### PR DESCRIPTION
The two low-priority nits from the README-vs-docs review.

- **"seven trust dimensions" → "the trust dimensions"** in the docs intro and `engine/README.md`. The hard "seven" contradicted the canonical "trust primitives (compiler, branches, replay, lineage, contracts, cost)" six-item shorthand used on every other page (and two paragraphs down in the same intro). Dropping the count removes the clash; the list content is unchanged.
- **Replay scope note in the README.** "Where Rocky is today" listed replay as production-ready with no caveat, while the docs are careful that replay is recording + ledger verification today and re-execution is roadmap. Added a matching bullet so the README doesn't imply re-execution.

Touches `engine/README.md`, so `engine-ci` runs (no Rust change). Docs build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)