### PR TITLE
feat(dagster): scope BacklogCap count to the sensor own runs (FR-028)

### DIFF
--- a/docs/src/content/docs/dagster/sensors.md
+++ b/docs/src/content/docs/dagster/sensors.md
@@ -149,6 +149,8 @@ sensor = rocky_source_sensor(
 
 Before each emit, the sensor counts in-flight runs matching `tag_key=<value>` in the non-terminal statuses (`QUEUED`, `NOT_STARTED`, `STARTING`, `STARTED` by default; override via `BacklogCap.statuses`). If the count is at or above `max_in_flight`, the `RunRequest` is suppressed.
 
+The count is scoped to **this sensor's own runs**: every `RunRequest` the sensor emits carries a stable `rocky/sensor=<name>` tag, and the in-flight count filters on it, so a co-tagged run from an unrelated job never trips the cap. Pass `BacklogCap(scope_tags={...})` to narrow the count further with extra exact-match tag filters.
+
 **The cursor still advances on suppression**: the in-flight run picks up the latest data via Rocky's per-source state. Freezing the cursor would compound the failure: the next tick would re-detect the same sync, retry the same suppressed emit, and never recover until the queue drains below cap.
 
 `BacklogCap` is opt-in. Default behavior (no cap) is unchanged.

--- a/integrations/dagster/src/dagster_rocky/sensor.py
+++ b/integrations/dagster/src/dagster_rocky/sensor.py
@@ -31,7 +31,7 @@ from .resource import RockyResource
 from .translator import RockyDagsterTranslator, strip_tenant_component
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator, Sequence
+    from collections.abc import Callable, Iterator, Mapping, Sequence
 
     from dagster._core.definitions.asset_selection import CoercibleToAssetSelection
 
@@ -39,6 +39,11 @@ if TYPE_CHECKING:
 
 
 Granularity = Literal["per_source", "per_group"]
+
+# Stable marker tag stamped on every RunRequest the sensor emits, set to the
+# sensor's own ``name``. The backlog cap ANDs this into its in-flight count so
+# the cap only ever counts runs THIS sensor launched (FR-028).
+SENSOR_MARKER_TAG = "rocky/sensor"
 
 
 # ---------------------------------------------------------------------------
@@ -59,6 +64,20 @@ class BacklogCap(NamedTuple):
     will pick up the latest data via Rocky's per-source state. Suppressing
     the emit *and* freezing the cursor would create a stuck-tick where
     nothing progresses until the in-flight queue drains below cap.
+
+    The count is always scoped to **this sensor's own emitted runs**: every
+    RunRequest the sensor returns carries a stable ``rocky/sensor=<name>``
+    tag, and the in-flight count filters on that marker in addition to
+    ``tag_key``. So a foreign job that happens to tag its runs with the same
+    ``tag_key`` value never inflates the count — without this, a co-tagged
+    run from an unrelated job (the normal multi-job tenant topology) would
+    trigger false back-pressure. This self-scoping is the primary,
+    zero-config behavior; ``scope_tags`` is an optional further narrowing.
+
+    ``scope_tags`` adds extra exact-match tag filters that are AND-ed into
+    the in-flight count (count-site only — they are not stamped onto emitted
+    RunRequests). ``None`` is normalized to an empty mapping at use, so it
+    never becomes a shared mutable default.
     """
 
     tag_key: str
@@ -69,6 +88,7 @@ class BacklogCap(NamedTuple):
         dg.DagsterRunStatus.STARTING,
         dg.DagsterRunStatus.STARTED,
     )
+    scope_tags: Mapping[str, str] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -159,9 +179,13 @@ def rocky_source_sensor(
             Defaults to ``STOPPED`` so users opt in explicitly.
         backlog_cap: Opt-in :class:`BacklogCap` config to suppress emits
             when too many in-flight runs already share a tag value.
-            Defaults to ``None`` (no suppression). The cursor still
-            advances when an emit is suppressed so the in-flight run
-            picks up the latest data via Rocky's per-source state.
+            Defaults to ``None`` (no suppression). The in-flight count is
+            scoped to this sensor's own emitted runs (via the stable
+            ``rocky/sensor=<name>`` tag every RunRequest carries), so a
+            co-tagged run from an unrelated job never trips the cap. The
+            cursor still advances when an emit is suppressed so the
+            in-flight run picks up the latest data via Rocky's per-source
+            state.
         on_run_request_emitted: Optional best-effort callback fired once
             per RunRequest the sensor will return (after suppression
             decisions). Exceptions are caught and logged at WARN — a
@@ -289,6 +313,7 @@ def rocky_source_sensor(
                 tenant_partitions_name=tenant_partitions_name,
                 sync_partitions=sync_partitions_from_discover,
                 context=context,
+                sensor_name=name,
             )
             # Roll back the cursor for sources we did NOT emit (skipped because
             # their partition doesn't exist yet under sync-off, or a non-scalar
@@ -301,10 +326,10 @@ def rocky_source_sensor(
                     new_cursor.pop(sid, None)
         elif granularity == "per_source":
             request_pairs: list[tuple[dg.RunRequest, tuple[SourceInfo, ...]]] = [
-                (_per_source_request(source, translator), (source,)) for source in triggered
+                (_per_source_request(source, translator, name), (source,)) for source in triggered
             ]
         else:
-            request_pairs = list(_per_group_request_pairs(triggered, translator))
+            request_pairs = list(_per_group_request_pairs(triggered, translator, name))
 
         # FR-015: opt-in per-tag-key in-flight backlog cap. Suppresses the
         # emit but advances the cursor — the in-flight run will pick up
@@ -320,7 +345,15 @@ def rocky_source_sensor(
                 in_flight = len(
                     context.instance.get_runs(
                         filters=dg.RunsFilter(
-                            tags={backlog_cap.tag_key: tag_value},
+                            # Self-scope the count to runs THIS sensor launched
+                            # (rocky/sensor=name), so a foreign job co-tagging
+                            # runs with the same tag_key value can't inflate the
+                            # count and trigger false back-pressure (FR-028).
+                            tags={
+                                SENSOR_MARKER_TAG: name,
+                                backlog_cap.tag_key: tag_value,
+                                **(backlog_cap.scope_tags or {}),
+                            },
                             statuses=list(backlog_cap.statuses),
                         ),
                         limit=backlog_cap.max_in_flight + 1,
@@ -391,6 +424,7 @@ def _iso_before(earlier_iso: str, later_iso: str) -> bool:
 def _per_source_request(
     source: SourceInfo,
     translator: RockyDagsterTranslator,
+    sensor_name: str,
 ) -> dg.RunRequest:
     """Build one ``RunRequest`` for a single triggered source."""
     asset_keys = [translator.get_asset_key(source, table) for table in source.tables]
@@ -399,6 +433,7 @@ def _per_source_request(
         run_key=f"{source.id}-{sync_iso}",
         asset_selection=asset_keys,
         tags={
+            SENSOR_MARKER_TAG: sensor_name,
             "rocky/source_id": source.id,
             "rocky/sync_at": sync_iso,
         },
@@ -408,6 +443,7 @@ def _per_source_request(
 def _per_group_request_pairs(
     triggered: Sequence[SourceInfo],
     translator: RockyDagsterTranslator,
+    sensor_name: str,
 ) -> Iterator[tuple[dg.RunRequest, tuple[SourceInfo, ...]]]:
     """Group triggered sources by translator group; yield ``(RunRequest, sources)`` pairs."""
     by_group: dict[str, list[SourceInfo]] = defaultdict(list)
@@ -428,6 +464,7 @@ def _per_group_request_pairs(
             run_key=f"{group_name}-{sync_iso}",
             asset_selection=asset_keys,
             tags={
+                SENSOR_MARKER_TAG: sensor_name,
                 "rocky/group": group_name,
                 "rocky/sync_at": sync_iso,
             },
@@ -445,6 +482,7 @@ def _tenant_partition_request(
     translator: RockyDagsterTranslator,
     tenant_component: str,
     partition_key: str,
+    sensor_name: str,
 ) -> dg.RunRequest:
     """Build one ``RunRequest`` materialising a tenant partition of the
     collapsed asset.
@@ -467,6 +505,7 @@ def _tenant_partition_request(
         asset_selection=asset_keys,
         partition_key=partition_key,
         tags={
+            SENSOR_MARKER_TAG: sensor_name,
             f"rocky/{tenant_component}": str(raw_value),
             "rocky/source_id": source.id,
             "rocky/sync_at": sync_iso,
@@ -482,6 +521,7 @@ def _tenant_request_pairs(
     tenant_partitions_name: str,
     sync_partitions: bool,
     context: dg.SensorEvaluationContext,
+    sensor_name: str,
 ) -> tuple[
     list[tuple[dg.RunRequest, tuple[SourceInfo, ...]]],
     list[dg.AddDynamicPartitionsRequest],
@@ -533,7 +573,9 @@ def _tenant_request_pairs(
             queued_new.add(partition_key)
         pairs.append(
             (
-                _tenant_partition_request(source, translator, tenant_component, partition_key),
+                _tenant_partition_request(
+                    source, translator, tenant_component, partition_key, sensor_name
+                ),
                 (source,),
             )
         )

--- a/integrations/dagster/tests/test_sensor.py
+++ b/integrations/dagster/tests/test_sensor.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import dagster as dg
+from dagster._core.test_utils import create_run_for_test
 
 from dagster_rocky import (
     BacklogCap,
@@ -408,10 +409,15 @@ def test_backlog_cap_suppresses_when_in_flight_at_or_above_max():
     assert result.run_requests == []
     # …but cursor still advances so we don't re-detect on the next tick
     assert json.loads(result.cursor)["s1"] == "2026-04-08T10:00:00+00:00"
-    # And the cap was actually consulted with the correct filter shape
+    # And the cap was actually consulted with the correct filter shape —
+    # self-scoped to this sensor's own runs via the rocky/sensor marker
+    # (default sensor name) AND the configured tag_key (FR-028).
     instance.get_runs.assert_called_once()
     call = instance.get_runs.call_args
-    assert call.kwargs["filters"].tags == {"rocky/source_id": "s1"}
+    assert call.kwargs["filters"].tags == {
+        "rocky/sensor": "rocky_source_sensor",
+        "rocky/source_id": "s1",
+    }
     assert call.kwargs["limit"] == 3  # max_in_flight + 1
 
 
@@ -535,6 +541,188 @@ def test_backlog_cap_per_group_cursors_advance_independently():
     cursor = json.loads(result.cursor)
     assert cursor["s1"] == "2026-04-08T10:00:00+00:00"
     assert cursor["s2"] == "2026-04-08T11:00:00+00:00"
+
+
+# ---------------------------------------------------------------------------
+# FR-028 — backlog cap is scoped to the sensor's OWN emitted runs
+#
+# These exercise the REAL count path against a live ``DagsterInstance`` with
+# planted runs (no ``get_runs`` mock), so they prove the self-scoping holds
+# end-to-end: ``RunsFilter`` AND-semantics + the ``rocky/sensor`` marker the
+# sensor stamps on every emit.
+# ---------------------------------------------------------------------------
+
+
+def _plant_run(
+    instance: dg.DagsterInstance,
+    *,
+    tags: dict[str, str],
+    status: dg.DagsterRunStatus = dg.DagsterRunStatus.STARTED,
+) -> None:
+    """Plant one Dagster run carrying ``tags`` in ``status`` on the instance."""
+    create_run_for_test(instance, job_name="planted_job", status=status, tags=tags)
+
+
+def test_backlog_cap_ignores_foreign_run_without_sensor_marker():
+    """A foreign run tagged ``{tag_key: value}`` but WITHOUT ``rocky/sensor``
+    is not counted toward the cap — so it cannot trigger false back-pressure
+    on this sensor's legitimate emit (FR-028)."""
+    rocky = RockyResource()
+    discover = _discover(_source("s1", "acme", ["orders"], _ts(2026, 4, 8, 10)))
+    instance = dg.DagsterInstance.ephemeral()
+    # Co-tagged by an unrelated job — same tag_key value, no rocky/sensor.
+    _plant_run(instance, tags={"rocky/source_id": "s1"})
+
+    with patch.object(RockyResource, "discover", return_value=discover):
+        sensor = rocky_source_sensor(
+            rocky_resource=rocky,
+            target=dg.AssetSelection.assets(dg.AssetKey(["fivetran", "acme"])),
+            minimum_interval_seconds=60,
+            backlog_cap=BacklogCap(tag_key="rocky/source_id", max_in_flight=1),
+        )
+        result = sensor(dg.build_sensor_context(cursor=None, instance=instance))
+
+    # The foreign run is invisible to the self-scoped count → emit goes through.
+    assert len(result.run_requests) == 1
+    assert result.run_requests[0].tags["rocky/source_id"] == "s1"
+
+
+def test_backlog_cap_counts_own_in_flight_runs_and_suppresses():
+    """The sensor's OWN in-flight runs (carrying ``rocky/sensor=<name>``) ARE
+    counted and DO suppress the emit at ``max_in_flight`` (FR-028)."""
+    rocky = RockyResource()
+    discover = _discover(_source("s1", "acme", ["orders"], _ts(2026, 4, 8, 11)))
+    instance = dg.DagsterInstance.ephemeral()
+    # A run this very sensor launched earlier, still in flight.
+    _plant_run(instance, tags={"rocky/sensor": "my_sensor", "rocky/source_id": "s1"})
+
+    with patch.object(RockyResource, "discover", return_value=discover):
+        sensor = rocky_source_sensor(
+            rocky_resource=rocky,
+            name="my_sensor",
+            target=dg.AssetSelection.assets(dg.AssetKey(["fivetran", "acme"])),
+            minimum_interval_seconds=60,
+            backlog_cap=BacklogCap(tag_key="rocky/source_id", max_in_flight=1),
+        )
+        result = sensor(dg.build_sensor_context(cursor=None, instance=instance))
+
+    # One own run in flight, cap=1 → suppressed, but cursor still advances.
+    assert result.run_requests == []
+    assert json.loads(result.cursor)["s1"] == "2026-04-08T11:00:00+00:00"
+
+
+def test_backlog_cap_does_not_cross_count_between_distinct_sensors():
+    """Two sensors with DISTINCT names do not cross-count: sensor B's
+    in-flight run does not suppress sensor A's emit (FR-028)."""
+    rocky = RockyResource()
+    discover = _discover(_source("s1", "acme", ["orders"], _ts(2026, 4, 8, 10)))
+    instance = dg.DagsterInstance.ephemeral()
+    # An in-flight run owned by a DIFFERENT sensor (sensor_b), same tag_key value.
+    _plant_run(instance, tags={"rocky/sensor": "sensor_b", "rocky/source_id": "s1"})
+
+    with patch.object(RockyResource, "discover", return_value=discover):
+        sensor_a = rocky_source_sensor(
+            rocky_resource=rocky,
+            name="sensor_a",
+            target=dg.AssetSelection.assets(dg.AssetKey(["fivetran", "acme"])),
+            minimum_interval_seconds=60,
+            backlog_cap=BacklogCap(tag_key="rocky/source_id", max_in_flight=1),
+        )
+        result = sensor_a(dg.build_sensor_context(cursor=None, instance=instance))
+
+    # sensor_b's run is out of sensor_a's scope → sensor_a still emits.
+    assert len(result.run_requests) == 1
+    assert result.run_requests[0].tags["rocky/source_id"] == "s1"
+    assert result.run_requests[0].tags["rocky/sensor"] == "sensor_a"
+
+
+def test_backlog_cap_scope_tags_narrows_the_count():
+    """``scope_tags`` AND-s extra exact-match filters into the count. A run
+    that carries the sensor marker + tag_key but NOT the scope tag falls out
+    of the count; one that carries all three is counted (FR-028)."""
+    rocky = RockyResource()
+    discover = _discover(_source("s1", "acme", ["orders"], _ts(2026, 4, 8, 10)))
+
+    # Case 1: in-flight own run lacks the scope tag → not counted → emit.
+    inst_unscoped = dg.DagsterInstance.ephemeral()
+    _plant_run(inst_unscoped, tags={"rocky/sensor": "my_sensor", "rocky/source_id": "s1"})
+
+    # Case 2: in-flight own run also carries team=alpha → counted → suppress.
+    inst_scoped = dg.DagsterInstance.ephemeral()
+    _plant_run(
+        inst_scoped,
+        tags={"rocky/sensor": "my_sensor", "rocky/source_id": "s1", "team": "alpha"},
+    )
+
+    def _build() -> dg.SensorDefinition:
+        return rocky_source_sensor(
+            rocky_resource=rocky,
+            name="my_sensor",
+            target=dg.AssetSelection.assets(dg.AssetKey(["fivetran", "acme"])),
+            minimum_interval_seconds=60,
+            backlog_cap=BacklogCap(
+                tag_key="rocky/source_id",
+                max_in_flight=1,
+                scope_tags={"team": "alpha"},
+            ),
+        )
+
+    with patch.object(RockyResource, "discover", return_value=discover):
+        sensor = _build()
+        unscoped = sensor(dg.build_sensor_context(cursor=None, instance=inst_unscoped))
+        scoped = sensor(dg.build_sensor_context(cursor=None, instance=inst_scoped))
+
+    # Scope tag narrows the count: the un-scoped run is invisible, the
+    # team=alpha run is counted and trips the cap.
+    assert len(unscoped.run_requests) == 1
+    assert scoped.run_requests == []
+
+
+def test_emitted_run_requests_carry_sensor_marker_in_all_modes():
+    """Every emitted RunRequest carries ``rocky/sensor=<name>`` — in
+    per_source, per_group, AND tenant-as-partition mode (FR-028 stamping)."""
+    rocky = RockyResource()
+    discover = _discover(
+        _source("s1", "acme", ["orders"], _ts(2026, 4, 8, 10)),
+        _source("s2", "globex", ["invoices"], _ts(2026, 4, 8, 11)),
+    )
+
+    # per_source
+    with patch.object(RockyResource, "discover", return_value=discover):
+        per_source = rocky_source_sensor(
+            rocky_resource=rocky,
+            name="marker_sensor",
+            target=dg.AssetSelection.assets(dg.AssetKey(["fivetran", "acme"])),
+            granularity="per_source",
+            minimum_interval_seconds=60,
+        )(dg.build_sensor_context(cursor=None))
+    assert per_source.run_requests
+    assert all(req.tags["rocky/sensor"] == "marker_sensor" for req in per_source.run_requests)
+
+    # per_group
+    with patch.object(RockyResource, "discover", return_value=discover):
+        per_group = rocky_source_sensor(
+            rocky_resource=rocky,
+            name="marker_sensor",
+            target=dg.AssetSelection.assets(dg.AssetKey(["fivetran", "acme"])),
+            granularity="per_group",
+            minimum_interval_seconds=60,
+        )(dg.build_sensor_context(cursor=None))
+    assert per_group.run_requests
+    assert all(req.tags["rocky/sensor"] == "marker_sensor" for req in per_group.run_requests)
+
+    # tenant-as-partition mode
+    with patch.object(RockyResource, "discover", return_value=discover):
+        tenant = rocky_source_sensor(
+            rocky_resource=rocky,
+            name="marker_sensor",
+            target=dg.AssetSelection.assets(dg.AssetKey(["fivetran", "acme"])),
+            minimum_interval_seconds=60,
+            tenant_component="tenant",
+            tenant_partitions_name="tenants",
+        )(dg.build_sensor_context(cursor=None, instance=dg.DagsterInstance.ephemeral()))
+    assert tenant.run_requests
+    assert all(req.tags["rocky/sensor"] == "marker_sensor" for req in tenant.run_requests)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`BacklogCap` counted in-flight runs with a deployment-global `instance.get_runs(filters=RunsFilter(tags={tag_key: value}))`. That count is not scoped to the sensor — in the common multi-job tenant topology, an unrelated job that co-tags its runs with the same `tag_key=value` inflates the count and trips the cap, producing false back-pressure that suppresses emits this sensor should have made.

## Fix

- Stamp a stable `rocky/sensor=<name>` marker on every `RunRequest` the sensor emits (all paths: per-source, per-group, tenant-partition).
- AND that marker into the in-flight count filter, so the cap only ever counts runs this sensor launched.
- Add optional `BacklogCap.scope_tags` to narrow the count further with extra exact-match tag filters (count-site only; not stamped onto emitted runs). `None` normalizes to an empty mapping, so it never becomes a shared mutable default.

Self-scoping is the primary, zero-config behavior; `scope_tags` is an opt-in further narrowing. Default (no cap) is unchanged.

## Testing

- A foreign co-tagged run (missing the sensor marker) is no longer counted.
- The cap still fires on a real backlog of the sensor's own in-flight runs.
- Cross-sensor isolation: two distinct sensors do not count each other's runs.
- All emit paths (per-source, per-group, tenant-partition) stamp the marker tag.
