### PR TITLE
feat(engine/rocky-core): validate managed-Iceberg format_options at compile time (FR-044)

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`rocky compile` now rejects managed-Iceberg `format_options` that Databricks rejects at the warehouse — `partition_by` + `cluster_by` set together, and engine-managed TBLPROPERTIES (e.g. `write.format.default`) — with a clear diagnostic instead of a runtime warehouse rejection.** The check fires at compile time (diagnostic E035, naming the offending option) before any warehouse call, and the lakehouse DDL generator carries the same guard so the run path fails with a clear Rocky error if compile is bypassed. (FR-044)
 - **`rocky import-dbt` now ports dbt unit tests with null fixture cells instead of dropping them as UnserializableUnitTest** — TOML has no null, so null cells are omitted on emit and the run-side fixture builder unions the column set across rows, materializing absent cells as SQL NULL. (FR-045)
 
 ## [1.55.1] - 2026-06-27

--- a/engine/crates/rocky-compiler/src/compile.rs
+++ b/engine/crates/rocky-compiler/src/compile.rs
@@ -341,12 +341,20 @@ pub fn compile_project(
         config.project_freshness_default,
     );
 
-    // 9. Merge all diagnostics.
+    // 9. Managed-Iceberg format_options (E035). Reject `format_options` the
+    //    Databricks warehouse rejects at execution (partition_by + cluster_by
+    //    together; engine-managed `write.format.*` properties) so the error
+    //    surfaces at compile time, naming the offending option, instead of as
+    //    a first-run warehouse rejection. (FR-044)
+    let lakehouse_diagnostics = typecheck::check_lakehouse_format_options(&project.models);
+
+    // 10. Merge all diagnostics.
     let mut diagnostics = type_check.diagnostics.clone();
     diagnostics.extend(contract_diagnostics.iter().cloned());
     diagnostics.extend(blast_radius_diagnostics);
     diagnostics.extend(classification_diagnostics);
     diagnostics.extend(freshness_diagnostics);
+    diagnostics.extend(lakehouse_diagnostics);
     diagnostics.extend(run_var_diagnostics);
 
     let has_errors = diagnostics
@@ -542,11 +550,16 @@ pub fn compile_incremental(
         config.project_freshness_default,
     );
 
+    // E035: managed-Iceberg format_options, mirroring the full-compile path so
+    // the LSP (incremental) surface matches `rocky compile`. (FR-044)
+    let lakehouse_diagnostics = typecheck::check_lakehouse_format_options(&project.models);
+
     let mut diagnostics = type_check.diagnostics.clone();
     diagnostics.extend(contract_diagnostics.iter().cloned());
     diagnostics.extend(blast_radius_diagnostics);
     diagnostics.extend(classification_diagnostics);
     diagnostics.extend(freshness_diagnostics);
+    diagnostics.extend(lakehouse_diagnostics);
     diagnostics.extend(run_var_diagnostics);
 
     let has_errors = diagnostics

--- a/engine/crates/rocky-compiler/src/diagnostic.rs
+++ b/engine/crates/rocky-compiler/src/diagnostic.rs
@@ -117,6 +117,20 @@ pub const E033: &str = "E033";
 /// — upgrade rocky to read the producer's newer snapshot format.
 pub const E034: &str = "E034";
 
+/// Managed-Iceberg `format_options` declares a combination the warehouse
+/// rejects at execution.
+///
+/// Emitted by `rocky compile` when a model sets `format = "iceberg_table"`
+/// with `format_options` that Databricks managed Iceberg refuses: `partition_by`
+/// and `cluster_by` set together (mutually exclusive), or an engine-managed
+/// `write.format.*` table property. Surfacing this at compile time turns a
+/// first-run warehouse error into a clear diagnostic that names the offending
+/// option, before any warehouse call. The constraint logic is shared with the
+/// DDL generator's run-path guard via
+/// [`rocky_ir::lakehouse::validate_managed_iceberg_options`], so the two checks
+/// can never drift. (FR-044)
+pub const E035: &str = "E035";
+
 // Warnings
 /// Unused model (no downstream consumers).
 pub const W001: &str = "W001";

--- a/engine/crates/rocky-compiler/src/typecheck.rs
+++ b/engine/crates/rocky-compiler/src/typecheck.rs
@@ -18,8 +18,8 @@ use sqlparser::parser::Parser;
 
 use crate::compile::default_type_mapper;
 use crate::diagnostic::{
-    Diagnostic, E001, E020, E021, E022, E023, E024, E025, E026, I001, I002, SourceSpan, W001, W002,
-    W003, W004, W005,
+    Diagnostic, E001, E020, E021, E022, E023, E024, E025, E026, E035, I001, I002, SourceSpan, W001,
+    W002, W003, W004, W005,
 };
 use crate::semantic::{ModelSchema, SemanticGraph};
 use crate::types::{RockyType, TypedColumn};
@@ -941,6 +941,35 @@ pub fn check_freshness_coverage(
         diagnostics.push(
             Diagnostic::warning(W005, &model.config.name, message).with_suggestion(suggestion),
         );
+    }
+    diagnostics
+}
+
+/// E035 — reject managed-Iceberg `format_options` that the Databricks
+/// warehouse rejects at execution, so `rocky compile` surfaces a clear
+/// diagnostic before any warehouse call.
+///
+/// Delegates the constraint logic to
+/// [`rocky_ir::lakehouse::validate_managed_iceberg_options`] — the same
+/// function the DDL generator guards with — so the compile-time and run-time
+/// checks can never drift. Emits one error diagnostic per violation; each
+/// message names the offending option(s). Models without a lakehouse `format`
+/// (or without `format_options`) are skipped.
+pub fn check_lakehouse_format_options(models: &[rocky_core::models::Model]) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+    for model in models {
+        let Some(format) = &model.config.format else {
+            continue;
+        };
+        let Some(options) = &model.config.format_options else {
+            continue;
+        };
+        for violation in rocky_ir::lakehouse::validate_managed_iceberg_options(format, options) {
+            diagnostics.push(
+                Diagnostic::error(E035, &model.config.name, violation.message)
+                    .with_suggestion(violation.suggestion),
+            );
+        }
     }
     diagnostics
 }
@@ -3299,5 +3328,98 @@ mod tests {
             diags.is_empty(),
             "a project-level [freshness] default should suppress all W005s, got: {diags:?}"
         );
+    }
+
+    // ----- E035: managed-Iceberg format_options -----
+
+    fn make_iceberg_model(name: &str, options: rocky_ir::LakehouseOptions) -> Model {
+        let mut m = make_model(name, "SELECT 1 AS id");
+        m.config.format = Some(rocky_ir::LakehouseFormat::IcebergTable);
+        m.config.format_options = Some(options);
+        m
+    }
+
+    #[test]
+    fn e035_partition_and_cluster_together_emits_error_naming_options() {
+        let models = vec![make_iceberg_model(
+            "fct_events",
+            rocky_ir::LakehouseOptions {
+                partition_by: vec!["event_date".into()],
+                cluster_by: vec!["user_id".into()],
+                ..Default::default()
+            },
+        )];
+        let diags = check_lakehouse_format_options(&models);
+        assert_eq!(diags.len(), 1, "expected one E035, got: {diags:?}");
+        let d = &diags[0];
+        assert_eq!(&*d.code, "E035");
+        assert!(d.is_error());
+        assert_eq!(d.model, "fct_events");
+        let msg = d.message.as_ref();
+        assert!(msg.contains("partition_by"), "names partition_by: {msg}");
+        assert!(msg.contains("cluster_by"), "names cluster_by: {msg}");
+        assert!(d.suggestion.is_some());
+    }
+
+    #[test]
+    fn e035_write_format_property_emits_error_naming_key() {
+        let models = vec![make_iceberg_model(
+            "fct_events",
+            rocky_ir::LakehouseOptions {
+                table_properties: vec![("write.format.default".into(), "parquet".into())],
+                ..Default::default()
+            },
+        )];
+        let diags = check_lakehouse_format_options(&models);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(&*diags[0].code, "E035");
+        assert!(
+            diags[0].message.contains("write.format.default"),
+            "names the offending key: {}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn e035_valid_iceberg_options_emit_nothing() {
+        let models = vec![
+            make_iceberg_model(
+                "partitioned",
+                rocky_ir::LakehouseOptions {
+                    partition_by: vec!["event_date".into()],
+                    table_properties: vec![("delta.enableChangeDataFeed".into(), "true".into())],
+                    ..Default::default()
+                },
+            ),
+            make_iceberg_model(
+                "clustered",
+                rocky_ir::LakehouseOptions {
+                    cluster_by: vec!["user_id".into()],
+                    ..Default::default()
+                },
+            ),
+        ];
+        let diags = check_lakehouse_format_options(&models);
+        assert!(
+            diags.is_empty(),
+            "valid combos emit nothing, got: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn e035_non_iceberg_and_formatless_models_skipped() {
+        // Delta with partition+cluster+write.format is fine; a model with no
+        // lakehouse format is skipped entirely.
+        let mut delta = make_model("delta_m", "SELECT 1 AS id");
+        delta.config.format = Some(rocky_ir::LakehouseFormat::DeltaTable);
+        delta.config.format_options = Some(rocky_ir::LakehouseOptions {
+            partition_by: vec!["region".into()],
+            cluster_by: vec!["id".into()],
+            table_properties: vec![("write.format.default".into(), "parquet".into())],
+            ..Default::default()
+        });
+        let plain = make_model("plain_m", "SELECT 1 AS id");
+        let diags = check_lakehouse_format_options(&[delta, plain]);
+        assert!(diags.is_empty(), "got: {diags:?}");
     }
 }

--- a/engine/crates/rocky-core/src/lakehouse.rs
+++ b/engine/crates/rocky-core/src/lakehouse.rs
@@ -65,6 +65,19 @@ pub fn generate_lakehouse_ddl(
     // Validate option identifiers up front.
     validate_options(options)?;
 
+    // Reject managed-Iceberg `format_options` that the Databricks warehouse
+    // rejects at execution (partition_by + cluster_by together; engine-managed
+    // `write.format.*` properties). This is the run-path guard: the same
+    // constraints are surfaced earlier as `rocky compile` diagnostics (E035),
+    // but if compile is bypassed we still fail with a clear Rocky error here
+    // instead of a raw warehouse rejection on the first run.
+    if let Some(violation) = rocky_ir::lakehouse::validate_managed_iceberg_options(format, options)
+        .into_iter()
+        .next()
+    {
+        return Err(LakehouseError::ManagedIcebergUnsupported(violation.message));
+    }
+
     match format {
         LakehouseFormat::DeltaTable => generate_delta_ddl(target, select_sql, options),
         LakehouseFormat::IcebergTable => generate_iceberg_ddl(target, select_sql, options),
@@ -579,10 +592,9 @@ mod tests {
     }
 
     #[test]
-    fn test_iceberg_table_with_partitioning_and_clustering() {
+    fn test_iceberg_table_partition_only() {
         let opts = LakehouseOptions {
             partition_by: vec!["event_date".into()],
-            cluster_by: vec!["user_id".into()],
             ..default_opts()
         };
         let stmts = generate_lakehouse_ddl(
@@ -597,7 +609,127 @@ mod tests {
         let sql = &stmts[0];
         assert!(sql.contains("USING ICEBERG"));
         assert!(sql.contains("PARTITIONED BY (event_date)"));
+        assert!(!sql.contains("CLUSTER BY"));
+    }
+
+    #[test]
+    fn test_iceberg_table_cluster_only() {
+        let opts = LakehouseOptions {
+            cluster_by: vec!["user_id".into()],
+            ..default_opts()
+        };
+        let stmts = generate_lakehouse_ddl(
+            &LakehouseFormat::IcebergTable,
+            "cat.sch.events",
+            "SELECT * FROM cat.raw.events",
+            &opts,
+            &dialect(),
+        )
+        .unwrap();
+
+        let sql = &stmts[0];
+        assert!(sql.contains("USING ICEBERG"));
         assert!(sql.contains("CLUSTER BY (user_id)"));
+        assert!(!sql.contains("PARTITIONED BY"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Managed-Iceberg format_options guard (FR-044)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_iceberg_partition_and_cluster_together_is_rejected() {
+        // Databricks managed Iceberg rejects PARTITIONED BY + CLUSTER BY
+        // together at the warehouse; `generate_lakehouse_ddl` must fail fast
+        // with a clear error that names both options instead of emitting DDL.
+        let opts = LakehouseOptions {
+            partition_by: vec!["event_date".into()],
+            cluster_by: vec!["user_id".into()],
+            ..default_opts()
+        };
+        let err = generate_lakehouse_ddl(
+            &LakehouseFormat::IcebergTable,
+            "cat.sch.events",
+            "SELECT * FROM cat.raw.events",
+            &opts,
+            &dialect(),
+        )
+        .expect_err("partition + cluster on Iceberg must be rejected");
+
+        match err {
+            LakehouseError::ManagedIcebergUnsupported(msg) => {
+                assert!(msg.contains("partition_by"), "names partition_by: {msg}");
+                assert!(msg.contains("cluster_by"), "names cluster_by: {msg}");
+            }
+            other => panic!("expected ManagedIcebergUnsupported, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_iceberg_write_format_property_is_rejected() {
+        let opts = LakehouseOptions {
+            table_properties: vec![("write.format.default".into(), "parquet".into())],
+            ..default_opts()
+        };
+        let err = generate_lakehouse_ddl(
+            &LakehouseFormat::IcebergTable,
+            "cat.sch.events",
+            "SELECT * FROM cat.raw.events",
+            &opts,
+            &dialect(),
+        )
+        .expect_err("engine-managed write.format.* property must be rejected");
+
+        match err {
+            LakehouseError::ManagedIcebergUnsupported(msg) => {
+                assert!(
+                    msg.contains("write.format.default"),
+                    "names the offending key: {msg}"
+                );
+            }
+            other => panic!("expected ManagedIcebergUnsupported, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_iceberg_benign_property_is_accepted() {
+        // A non-`write.format.*` property (and partition-only) must still emit.
+        let opts = LakehouseOptions {
+            partition_by: vec!["event_date".into()],
+            table_properties: vec![("delta.enableChangeDataFeed".into(), "true".into())],
+            ..default_opts()
+        };
+        let stmts = generate_lakehouse_ddl(
+            &LakehouseFormat::IcebergTable,
+            "cat.sch.events",
+            "SELECT * FROM cat.raw.events",
+            &opts,
+            &dialect(),
+        )
+        .expect("benign Iceberg options must compile");
+        assert!(stmts[0].contains("USING ICEBERG"));
+    }
+
+    #[test]
+    fn test_delta_partition_and_cluster_together_is_allowed() {
+        // The managed-Iceberg rules must not touch Delta — partition + cluster
+        // together is a supported Delta combo.
+        let opts = LakehouseOptions {
+            partition_by: vec!["region".into()],
+            cluster_by: vec!["id".into()],
+            ..default_opts()
+        };
+        let stmts = generate_lakehouse_ddl(
+            &LakehouseFormat::DeltaTable,
+            "cat.sch.orders",
+            "SELECT * FROM cat.raw.orders",
+            &opts,
+            &dialect(),
+        )
+        .expect("Delta partition + cluster must still compile");
+        let sql = &stmts[0];
+        assert!(sql.contains("PARTITIONED BY (region)"));
+        assert!(sql.contains("CLUSTER BY (id)"));
     }
 
     // -----------------------------------------------------------------------

--- a/engine/crates/rocky-core/src/sql_gen.rs
+++ b/engine/crates/rocky-core/src/sql_gen.rs
@@ -2270,7 +2270,9 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             LakehouseFormat::IcebergTable,
             LakehouseOptions {
                 partition_by: vec!["event_date".into()],
-                table_properties: vec![("write.format.default".into(), "parquet".into())],
+                // Benign (non-`write.format.*`) property — managed Iceberg
+                // rejects engine-managed `write.format.*` keys (FR-044).
+                table_properties: vec![("team".into(), "growth".into())],
                 ..LakehouseOptions::default()
             },
             MaterializationStrategy::Microbatch {
@@ -2300,14 +2302,16 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
         // Core guarantee: an Incremental model declaring iceberg_table
         // format yields USING ICEBERG plus its format_options on first-run
         // initial DDL — the same code path the runtime invokes when the
-        // target is missing.
+        // target is missing. Managed Iceberg forbids PARTITIONED BY +
+        // CLUSTER BY together and engine-managed `write.format.*` properties
+        // (FR-044), so this fixture uses partitioning + a benign property.
         let plan = lakehouse_ir(
             LakehouseFormat::IcebergTable,
             LakehouseOptions {
                 partition_by: vec!["region".into()],
-                cluster_by: vec!["id".into()],
-                table_properties: vec![("write.format.default".into(), "parquet".into())],
+                table_properties: vec![("team".into(), "growth".into())],
                 comment: Some("Incremental orders mart".into()),
+                ..LakehouseOptions::default()
             },
             MaterializationStrategy::Incremental {
                 timestamp_column: "updated_at".into(),
@@ -2325,11 +2329,11 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             "should include partitioning: {sql}"
         );
         assert!(
-            sql.contains("CLUSTER BY (id)"),
-            "should include clustering: {sql}"
+            sql.contains("COMMENT 'Incremental orders mart'"),
+            "should include comment: {sql}"
         );
         assert!(
-            sql.contains("write.format.default"),
+            sql.contains("TBLPROPERTIES"),
             "should include format_options table properties: {sql}"
         );
     }

--- a/engine/crates/rocky-databricks/tests/managed_iceberg_format_validation_live.rs
+++ b/engine/crates/rocky-databricks/tests/managed_iceberg_format_validation_live.rs
@@ -1,0 +1,142 @@
+//! Live Databricks confirmation that managed Iceberg rejects the
+//! `format_options` combos Rocky now blocks at compile time (FR-044).
+//!
+//! Rocky validates managed-Iceberg `format_options` so a bad combo surfaces as
+//! a clear `rocky compile` diagnostic (E035) — and as a `LakehouseError` in the
+//! DDL generator — *before* any warehouse call. This live test pins the
+//! ground truth that motivates that validation: the raw `USING ICEBERG` DDL
+//! Rocky would otherwise have emitted is, in fact, rejected by the warehouse:
+//!
+//! 1. `PARTITIONED BY (...) CLUSTER BY (...)` together →
+//!    `SPECIFY_CLUSTER_BY_WITH_PARTITIONED_BY_IS_NOT_ALLOWED`.
+//! 2. `TBLPROPERTIES ('write.format.default' = ...)` →
+//!    `MANAGED_ICEBERG_OPERATION_NOT_SUPPORTED`.
+//!
+//! `#[ignore]`-gated because it requires a real Databricks workspace. Reads the
+//! sandbox config from `ROCKY_TEST_DATABRICKS_*` env vars (mirrors
+//! `lakehouse_initial_ddl_live.rs`); no workspace identifiers are hardcoded.
+//! Any schema it creates uses the `hcv2_` prefix and is dropped on completion.
+//!
+//! ```bash
+//! ROCKY_TEST_DATABRICKS_HOST=<your-host> \
+//! ROCKY_TEST_DATABRICKS_HTTP_PATH=<your-http-path> \
+//! ROCKY_TEST_DATABRICKS_TOKEN=<your-token> \
+//! ROCKY_TEST_DATABRICKS_CATALOG=hcv2_<your-catalog> \
+//! cargo test -p rocky-databricks --test managed_iceberg_format_validation_live -- --ignored --nocapture
+//! ```
+
+use std::time::Duration;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use rocky_core::traits::WarehouseAdapter;
+use rocky_databricks::adapter::DatabricksWarehouseAdapter;
+use rocky_databricks::auth::{Auth, AuthConfig};
+use rocky_databricks::connector::{ConnectorConfig, DatabricksConnector};
+
+/// Build an adapter + target catalog from the `ROCKY_TEST_DATABRICKS_*` sandbox
+/// env vars. Returns `None` (test skips) when the host/http-path aren't set.
+fn adapter_from_env() -> Option<(DatabricksWarehouseAdapter, String)> {
+    let host = std::env::var("ROCKY_TEST_DATABRICKS_HOST").ok()?;
+    let http_path = std::env::var("ROCKY_TEST_DATABRICKS_HTTP_PATH").ok()?;
+    let warehouse_id = ConnectorConfig::warehouse_id_from_http_path(&http_path)?;
+    let catalog = std::env::var("ROCKY_TEST_DATABRICKS_CATALOG").ok()?;
+
+    let auth = Auth::from_config(AuthConfig {
+        host: host.clone(),
+        token: std::env::var("ROCKY_TEST_DATABRICKS_TOKEN").ok(),
+        client_id: std::env::var("ROCKY_TEST_DATABRICKS_CLIENT_ID").ok(),
+        client_secret: std::env::var("ROCKY_TEST_DATABRICKS_CLIENT_SECRET").ok(),
+    })
+    .ok()?;
+
+    let config = ConnectorConfig {
+        host,
+        warehouse_id,
+        timeout: Duration::from_secs(180),
+        retry: Default::default(),
+    };
+    let connector = DatabricksConnector::new(config, auth);
+    Some((DatabricksWarehouseAdapter::new(connector), catalog))
+}
+
+fn schema_suffix() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros()
+}
+
+async fn create_schema(adapter: &DatabricksWarehouseAdapter, catalog: &str, schema: &str) {
+    adapter
+        .execute_statement(&format!(
+            "CREATE SCHEMA IF NOT EXISTS `{catalog}`.`{schema}`"
+        ))
+        .await
+        .expect("create schema");
+}
+
+async fn drop_schema(adapter: &DatabricksWarehouseAdapter, catalog: &str, schema: &str) {
+    let _ = adapter
+        .execute_statement(&format!(
+            "DROP SCHEMA IF EXISTS `{catalog}`.`{schema}` CASCADE"
+        ))
+        .await;
+}
+
+/// The warehouse must reject managed-Iceberg DDL with partition+cluster
+/// together and with an engine-managed `write.format.default` property — the
+/// exact two combos Rocky's E035 / `ManagedIcebergUnsupported` guard blocks at
+/// compile/plan time.
+#[tokio::test]
+#[ignore = "requires ROCKY_TEST_DATABRICKS_* env vars; run with --ignored"]
+async fn live_managed_iceberg_rejects_blocked_format_options() {
+    let Some((adapter, catalog)) = adapter_from_env() else {
+        eprintln!("skipping: ROCKY_TEST_DATABRICKS_* not set");
+        return;
+    };
+    let suffix = schema_suffix();
+    let schema = format!("hcv2_mi_fmt_{suffix}");
+    create_schema(&adapter, &catalog, &schema).await;
+
+    // (1) PARTITIONED BY + CLUSTER BY together on managed Iceberg.
+    let partition_plus_cluster = format!(
+        "CREATE OR REPLACE TABLE `{catalog}`.`{schema}`.`bad_part_cluster`\n\
+         USING ICEBERG\n\
+         PARTITIONED BY (region)\n\
+         CLUSTER BY (id)\n\
+         AS\nSELECT CAST(id % 3 AS STRING) AS region, id FROM range(0, 10)"
+    );
+    let err1 = adapter
+        .execute_statement(&partition_plus_cluster)
+        .await
+        .expect_err("warehouse must reject partition + cluster on Iceberg");
+    let msg1 = err1.to_string();
+    assert!(
+        msg1.contains("SPECIFY_CLUSTER_BY_WITH_PARTITIONED_BY_IS_NOT_ALLOWED")
+            || msg1.to_lowercase().contains("cluster")
+            || msg1.to_lowercase().contains("partition"),
+        "expected a partition/cluster mutual-exclusion rejection, got: {msg1}"
+    );
+
+    // (2) Engine-managed write.format.default property on managed Iceberg.
+    let write_format_property = format!(
+        "CREATE OR REPLACE TABLE `{catalog}`.`{schema}`.`bad_write_format`\n\
+         USING ICEBERG\n\
+         PARTITIONED BY (region)\n\
+         TBLPROPERTIES ('write.format.default' = 'parquet')\n\
+         AS\nSELECT CAST(id % 3 AS STRING) AS region, id FROM range(0, 10)"
+    );
+    let err2 = adapter
+        .execute_statement(&write_format_property)
+        .await
+        .expect_err("warehouse must reject engine-managed write.format.default on Iceberg");
+    let msg2 = err2.to_string();
+    assert!(
+        msg2.contains("MANAGED_ICEBERG_OPERATION_NOT_SUPPORTED")
+            || msg2.to_lowercase().contains("not supported")
+            || msg2.to_lowercase().contains("write.format"),
+        "expected a managed-Iceberg property rejection, got: {msg2}"
+    );
+
+    drop_schema(&adapter, &catalog, &schema).await;
+}

--- a/engine/crates/rocky-ir/src/lakehouse.rs
+++ b/engine/crates/rocky-ir/src/lakehouse.rs
@@ -35,6 +35,111 @@ pub enum LakehouseError {
 
     #[error("invalid option: {0}")]
     InvalidOption(String),
+
+    /// Managed-Iceberg `format_options` declared a combination the Databricks
+    /// warehouse rejects at execution.
+    ///
+    /// Raised by `generate_lakehouse_ddl` (and surfaced earlier as a
+    /// `rocky compile` diagnostic, before any warehouse call) when an Iceberg
+    /// model sets mutually-exclusive `partition_by` + `cluster_by`, or an
+    /// engine-managed `write.format.*` table property. Without this guard
+    /// Databricks rejects the generated DDL at the warehouse on the first run
+    /// (`SPECIFY_CLUSTER_BY_WITH_PARTITIONED_BY_IS_NOT_ALLOWED` /
+    /// `MANAGED_ICEBERG_OPERATION_NOT_SUPPORTED`). The message names the
+    /// offending option.
+    #[error("invalid managed-Iceberg format_options: {0}")]
+    ManagedIcebergUnsupported(String),
+}
+
+// ---------------------------------------------------------------------------
+// Managed-Iceberg format_options validation
+// ---------------------------------------------------------------------------
+
+/// A managed-Iceberg `format_options` constraint that Databricks rejects at
+/// the warehouse.
+///
+/// Each carries a ready-to-render `message` (which names the offending
+/// option) and an actionable `suggestion`. The compiler maps these onto
+/// `E035` diagnostics; the DDL generator turns the first one into a
+/// [`LakehouseError::ManagedIcebergUnsupported`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedIcebergViolation {
+    /// Human-readable description that names the offending option(s).
+    pub message: String,
+    /// Actionable fix.
+    pub suggestion: String,
+}
+
+/// Does `key` name an engine-managed Iceberg table property?
+///
+/// Databricks **managed Iceberg** owns the on-disk write format, so it rejects
+/// any `write.format.*` table property (e.g. `write.format.default`) with
+/// `MANAGED_ICEBERG_OPERATION_NOT_SUPPORTED`. The reserved set is deliberately
+/// narrow — only the `write.format.` family that the warehouse controls — so
+/// benign properties (`delta.*`, user-defined keys, `comment`) keep passing.
+fn is_engine_managed_iceberg_property(key: &str) -> bool {
+    key.starts_with("write.format.")
+}
+
+/// Validate managed-Iceberg `format_options` against the constraints
+/// Databricks enforces at the warehouse, returning one
+/// [`ManagedIcebergViolation`] per problem (an empty vec means valid).
+///
+/// Only [`LakehouseFormat::IcebergTable`] is checked; every other format
+/// returns no violations. The two rules:
+///
+/// 1. `partition_by` and `cluster_by` are **mutually exclusive** on Iceberg —
+///    Databricks rejects them together with
+///    `SPECIFY_CLUSTER_BY_WITH_PARTITIONED_BY_IS_NOT_ALLOWED`.
+/// 2. Engine-managed `write.format.*` table properties are rejected with
+///    `MANAGED_ICEBERG_OPERATION_NOT_SUPPORTED` (see
+///    [`is_engine_managed_iceberg_property`]).
+///
+/// This is the single source of truth shared by the `rocky compile`
+/// diagnostic path and the `generate_lakehouse_ddl` run-path guard, so the
+/// two checks can never drift.
+#[must_use]
+pub fn validate_managed_iceberg_options(
+    format: &LakehouseFormat,
+    options: &LakehouseOptions,
+) -> Vec<ManagedIcebergViolation> {
+    if !matches!(format, LakehouseFormat::IcebergTable) {
+        return Vec::new();
+    }
+
+    let mut violations = Vec::new();
+
+    if !options.partition_by.is_empty() && !options.cluster_by.is_empty() {
+        violations.push(ManagedIcebergViolation {
+            message: format!(
+                "managed-Iceberg format sets both partition_by ({}) and cluster_by ({}); \
+                 Databricks Iceberg rejects PARTITIONED BY together with CLUSTER BY \
+                 (they are mutually exclusive)",
+                options.partition_by.join(", "),
+                options.cluster_by.join(", "),
+            ),
+            suggestion:
+                "keep either partition_by or cluster_by on an iceberg_table model, not both"
+                    .to_string(),
+        });
+    }
+
+    for (key, _value) in &options.table_properties {
+        if is_engine_managed_iceberg_property(key) {
+            violations.push(ManagedIcebergViolation {
+                message: format!(
+                    "managed-Iceberg format sets the engine-managed table property '{key}'; \
+                     Databricks manages the Iceberg write format itself and rejects it"
+                ),
+                suggestion: format!(
+                    "remove the '{key}' table property — Databricks managed Iceberg controls \
+                     the write.format.* family"
+                ),
+            });
+        }
+    }
+
+    violations
 }
 
 // ---------------------------------------------------------------------------
@@ -101,4 +206,116 @@ pub struct LakehouseOptions {
     /// Optional comment on the table/view.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub comment: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iceberg_partition_and_cluster_together_is_rejected() {
+        let opts = LakehouseOptions {
+            partition_by: vec!["event_date".into()],
+            cluster_by: vec!["user_id".into()],
+            ..LakehouseOptions::default()
+        };
+        let violations = validate_managed_iceberg_options(&LakehouseFormat::IcebergTable, &opts);
+        assert_eq!(violations.len(), 1, "exactly one violation expected");
+        // The message must name both offending options.
+        let msg = &violations[0].message;
+        assert!(msg.contains("partition_by"), "names partition_by: {msg}");
+        assert!(msg.contains("cluster_by"), "names cluster_by: {msg}");
+        assert!(msg.contains("event_date"), "names the column: {msg}");
+        assert!(msg.contains("user_id"), "names the column: {msg}");
+    }
+
+    #[test]
+    fn iceberg_write_format_default_property_is_rejected() {
+        let opts = LakehouseOptions {
+            table_properties: vec![("write.format.default".into(), "parquet".into())],
+            ..LakehouseOptions::default()
+        };
+        let violations = validate_managed_iceberg_options(&LakehouseFormat::IcebergTable, &opts);
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0].message.contains("write.format.default"),
+            "names the offending key: {}",
+            violations[0].message
+        );
+    }
+
+    #[test]
+    fn iceberg_partition_only_is_accepted() {
+        let opts = LakehouseOptions {
+            partition_by: vec!["event_date".into()],
+            ..LakehouseOptions::default()
+        };
+        assert!(validate_managed_iceberg_options(&LakehouseFormat::IcebergTable, &opts).is_empty());
+    }
+
+    #[test]
+    fn iceberg_cluster_only_is_accepted() {
+        let opts = LakehouseOptions {
+            cluster_by: vec!["user_id".into()],
+            ..LakehouseOptions::default()
+        };
+        assert!(validate_managed_iceberg_options(&LakehouseFormat::IcebergTable, &opts).is_empty());
+    }
+
+    #[test]
+    fn iceberg_benign_properties_are_accepted() {
+        let opts = LakehouseOptions {
+            partition_by: vec!["event_date".into()],
+            table_properties: vec![
+                ("delta.enableChangeDataFeed".into(), "true".into()),
+                ("team".into(), "growth".into()),
+            ],
+            comment: Some("benign".into()),
+            ..LakehouseOptions::default()
+        };
+        assert!(
+            validate_managed_iceberg_options(&LakehouseFormat::IcebergTable, &opts).is_empty(),
+            "benign delta.*/user properties must not be flagged"
+        );
+    }
+
+    #[test]
+    fn non_iceberg_formats_are_never_flagged() {
+        // The same partition+cluster+write.format combo on Delta is fine —
+        // the managed-Iceberg constraints apply only to Iceberg.
+        let opts = LakehouseOptions {
+            partition_by: vec!["region".into()],
+            cluster_by: vec!["id".into()],
+            table_properties: vec![("write.format.default".into(), "parquet".into())],
+            ..LakehouseOptions::default()
+        };
+        for format in [
+            LakehouseFormat::DeltaTable,
+            LakehouseFormat::Table,
+            LakehouseFormat::StreamingTable,
+            LakehouseFormat::MaterializedView,
+            LakehouseFormat::View,
+        ] {
+            assert!(
+                validate_managed_iceberg_options(&format, &opts).is_empty(),
+                "format {format} must not be subject to managed-Iceberg rules"
+            );
+        }
+    }
+
+    #[test]
+    fn iceberg_both_violations_reported() {
+        let opts = LakehouseOptions {
+            partition_by: vec!["region".into()],
+            cluster_by: vec!["id".into()],
+            table_properties: vec![("write.format.version".into(), "2".into())],
+            ..LakehouseOptions::default()
+        };
+        let violations = validate_managed_iceberg_options(&LakehouseFormat::IcebergTable, &opts);
+        assert_eq!(violations.len(), 2, "both rules fire independently");
+    }
 }

--- a/engine/rocky/tests/compile_managed_iceberg.rs
+++ b/engine/rocky/tests/compile_managed_iceberg.rs
@@ -1,0 +1,138 @@
+//! Integration test for the `rocky compile` managed-Iceberg `format_options`
+//! diagnostic (E035, FR-044).
+//!
+//! Proves the validation is reachable end-to-end from the real CLI — not just
+//! a unit-tested helper. A model declaring `format = "iceberg_table"` with
+//! both `partition_by` and `cluster_by` (a combo Databricks managed Iceberg
+//! rejects at the warehouse) must surface a clear `rocky compile` diagnostic
+//! that names both options, with `has_errors = true`, *before* any warehouse
+//! call. A model declaring only one of the two compiles clean.
+//!
+//! Spawns the real `rocky` binary against a models-only fixture (no
+//! `rocky.toml` needed — `rocky compile` tolerates its absence).
+
+use std::fs;
+use std::process::Command;
+
+const BAD_SQL: &str = "SELECT 1 AS id\n";
+
+/// Iceberg model with both partition_by and cluster_by — rejected (E035).
+const BAD_TOML: &str = r#"
+name = "fct_bad"
+format = "iceberg_table"
+
+[target]
+catalog = "warehouse"
+schema = "silver"
+
+[format_options]
+partition_by = ["event_date"]
+cluster_by = ["user_id"]
+"#;
+
+const GOOD_SQL: &str = "SELECT 1 AS id\n";
+
+/// Iceberg model with partitioning only — valid.
+const GOOD_TOML: &str = r#"
+name = "fct_good"
+format = "iceberg_table"
+
+[target]
+catalog = "warehouse"
+schema = "silver"
+
+[format_options]
+partition_by = ["event_date"]
+"#;
+
+fn compile_json(models_dir: &std::path::Path) -> serde_json::Value {
+    let out = Command::new(env!("CARGO_BIN_EXE_rocky"))
+        .arg("compile")
+        .arg("--models")
+        .arg(models_dir)
+        .arg("--output")
+        .arg("json")
+        .env("RUST_LOG", "error")
+        .output()
+        .expect("spawn rocky compile");
+
+    let stdout = String::from_utf8(out.stdout).expect("utf8 stdout");
+    let stderr = String::from_utf8(out.stderr).expect("utf8 stderr");
+    serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!("stdout is not a single JSON document: {e}\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}");
+    })
+}
+
+#[test]
+fn compile_rejects_iceberg_partition_plus_cluster_with_e035() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let models = tmp.path().join("models");
+    fs::create_dir(&models).expect("mkdir models");
+    fs::write(models.join("fct_bad.sql"), BAD_SQL).expect("write bad sql");
+    fs::write(models.join("fct_bad.toml"), BAD_TOML).expect("write bad toml");
+
+    let parsed = compile_json(&models);
+
+    assert_eq!(
+        parsed.get("command").and_then(|v| v.as_str()),
+        Some("compile"),
+        "expected a CompileOutput on stdout, got: {parsed}"
+    );
+    assert_eq!(
+        parsed
+            .get("has_errors")
+            .and_then(serde_json::Value::as_bool),
+        Some(true),
+        "managed-Iceberg partition + cluster must set has_errors: {parsed}"
+    );
+
+    let diagnostics = parsed
+        .get("diagnostics")
+        .and_then(|v| v.as_array())
+        .expect("diagnostics array");
+    let e035 = diagnostics
+        .iter()
+        .find(|d| d.get("code").and_then(|c| c.as_str()) == Some("E035"))
+        .unwrap_or_else(|| panic!("expected an E035 diagnostic, got: {diagnostics:?}"));
+
+    let message = e035
+        .get("message")
+        .and_then(|m| m.as_str())
+        .expect("diagnostic message");
+    // The diagnostic must NAME both offending options so the fix is obvious.
+    assert!(
+        message.contains("partition_by"),
+        "E035 message must name partition_by: {message}"
+    );
+    assert!(
+        message.contains("cluster_by"),
+        "E035 message must name cluster_by: {message}"
+    );
+    assert_eq!(
+        e035.get("severity").and_then(|s| s.as_str()),
+        Some("Error"),
+        "E035 must be an Error: {e035:?}"
+    );
+}
+
+#[test]
+fn compile_accepts_iceberg_partition_only() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let models = tmp.path().join("models");
+    fs::create_dir(&models).expect("mkdir models");
+    fs::write(models.join("fct_good.sql"), GOOD_SQL).expect("write good sql");
+    fs::write(models.join("fct_good.toml"), GOOD_TOML).expect("write good toml");
+
+    let parsed = compile_json(&models);
+
+    let diagnostics = parsed
+        .get("diagnostics")
+        .and_then(|v| v.as_array())
+        .expect("diagnostics array");
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.get("code").and_then(|c| c.as_str()) == Some("E035")),
+        "a partition-only iceberg_table model must not emit E035, got: {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
## Problem

Rocky emitted managed-Iceberg DDL that Databricks rejects at the warehouse on the first run: `partition_by` + `cluster_by` set together (mutually exclusive on managed Iceberg), and engine-managed `write.format.*` TBLPROPERTIES like `write.format.default`. The failure only surfaced at execution, as a raw warehouse error.

## Fix

Validate managed-Iceberg `format_options` at compile time. `rocky compile` now surfaces a clear `E035` diagnostic that names the offending option, before any warehouse call. The same constraint logic also guards the run path in `generate_lakehouse_ddl`, so a bypassed compile still fails with a clear Rocky error instead of a raw warehouse rejection. Both checks delegate to a single shared `rocky_ir::lakehouse::validate_managed_iceberg_options`, so compile-time and run-time can't drift.

**reachable_from:** wired into `compile_project` (so it fires on `rocky compile`) and `compile_incremental` (so the LSP surface matches); the run-path guard is reached from `generate_lakehouse_ddl`.

## Testing

- A real `rocky compile` integration test asserts the `E035` diagnostic fires and names both `partition_by` and `cluster_by`.
- Valid combinations (partition-only, cluster-only, benign properties, and Delta with partition + cluster) compile clean — no false positives.
- `#[ignore]` live Databricks regression test confirms the warehouse rejects the same blocked `format_options` (reads sandbox config from `ROCKY_TEST_DATABRICKS_*`).
