### PR TITLE
chore: release engine 1.55.2

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.55.2] - 2026-06-28
+
 ### Fixed
 
 - **`rocky compile` now rejects managed-Iceberg `format_options` that Databricks rejects at the warehouse — `partition_by` + `cluster_by` set together, and engine-managed TBLPROPERTIES (e.g. `write.format.default`) — with a clear diagnostic instead of a runtime warehouse rejection.** The check fires at compile time (diagnostic E035, naming the offending option) before any warehouse call, and the lakehouse DDL generator carries the same guard so the run path fails with a clear Rocky error if compile is bypassed. (FR-044)

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3862,7 +3862,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.55.1"
+version = "1.55.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3883,7 +3883,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.55.1"
+version = "1.55.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3896,7 +3896,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.55.1"
+version = "1.55.2"
 dependencies = [
  "indexmap",
  "reqwest 0.12.28",
@@ -3917,7 +3917,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.55.1"
+version = "1.55.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.55.1"
+version = "1.55.2"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3962,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.55.1"
+version = "1.55.2"
 dependencies = [
  "redis",
  "serde",
@@ -3974,7 +3974,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.55.1"
+version = "1.55.2"
 dependencies = [
  "async-trait",
  "serde",
@@ -3985,7 +3985,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.55.1"
+version = "1.55.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4038,7 +4038,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.55.1"
+version = "1.55.2"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -4065,7 +4065,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.55.1"
+version = "1.55.2"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4105,7 +4105,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.55.1"
+version = "1.55.2"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4131,7 +4131,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.55.1"
+version = "1.55.2"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4150,7 +4150,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.55.1"
+version = "1.55.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4168,7 +4168,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.55.1"
+version = "1.55.2"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4199,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.55.1"
+version = "1.55.2"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4224,7 +4224,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.55.1"
+version = "1.55.2"
 dependencies = [
  "blake3",
  "chrono",
@@ -4237,7 +4237,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.55.1"
+version = "1.55.2"
 dependencies = [
  "logos",
  "miette",
@@ -4249,7 +4249,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.55.1"
+version = "1.55.2"
 dependencies = [
  "rocky-server",
  "rustls",
@@ -4258,7 +4258,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.55.1"
+version = "1.55.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4283,7 +4283,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.55.1"
+version = "1.55.2"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4301,7 +4301,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.55.1"
+version = "1.55.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -4331,7 +4331,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.55.1"
+version = "1.55.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -4358,7 +4358,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.55.1"
+version = "1.55.2"
 dependencies = [
  "miette",
  "regex",
@@ -4371,7 +4371,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.55.1"
+version = "1.55.2"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4394,7 +4394,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.55.1"
+version = "1.55.2"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.55.1"
+version = "1.55.2"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.55.1"
+version = "1.55.2"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.55.1"
+version = "1.55.2"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.55.1"
+version = "1.55.2"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.55.1"
+version = "1.55.2"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.55.1"
+version = "1.55.2"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.55.1"
+version = "1.55.2"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.55.1"
+version = "1.55.2"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.55.1"
+version = "1.55.2"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.55.1"
+version = "1.55.2"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.55.1"
+version = "1.55.2"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.55.1"
+version = "1.55.2"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.55.1"
+version = "1.55.2"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.55.1"
+version = "1.55.2"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.55.1"
+version = "1.55.2"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.55.1"
+version = "1.55.2"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.55.1"
+version = "1.55.2"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.55.1"
+version = "1.55.2"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.55.1"
+version = "1.55.2"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.55.1"
+version = "1.55.2"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.55.1"
+version = "1.55.2"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.55.1"
+version = "1.55.2"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.55.1"
+version = "1.55.2"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.55.1"
+version = "1.55.2"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.55.1"
+version = "1.55.2"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Patch release on top of 1.55.1.

### Fixed
- **FR-044 (#996)** — `rocky compile` now rejects managed-Iceberg `format_options` Databricks rejects at the warehouse (`partition_by`+`cluster_by` together; engine-managed `write.format.*` TBLPROPERTIES) with a clear `E035` diagnostic instead of a runtime warehouse rejection.
- **FR-045 (#992)** — `rocky import-dbt` now ports dbt unit tests with null fixture cells instead of dropping them as `UnserializableUnitTest` (null cells omitted on emit; fixture builder unions the column set → SQL NULL).

Engine-only — no SDK cut (no `*Output` schema change; E035 is a string constant, codegen no-op). 25 crate versions → 1.55.2 + Cargo.lock. After merge: tag `engine-v1.55.2` → 5-platform build.