### PR TITLE
fix(engine/rocky-cli): reject --var with --dag/--watch instead of silently dropping it

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`rocky compile` now rejects managed-Iceberg `format_options` that Databricks rejects at the warehouse — `partition_by` + `cluster_by` set together, and engine-managed TBLPROPERTIES (e.g. `write.format.default`) — with a clear diagnostic instead of a runtime warehouse rejection.** The check fires at compile time (diagnostic E035, naming the offending option) before any warehouse call, and the lakehouse DDL generator carries the same guard so the run path fails with a clear Rocky error if compile is bypassed. (FR-044)
 - **`rocky import-dbt` now ports dbt unit tests with null fixture cells instead of dropping them as UnserializableUnitTest** — TOML has no null, so null cells are omitted on emit and the run-side fixture builder unions the column set across rows, materializing absent cells as SQL NULL. (FR-045)
+- **`rocky run --var` is now rejected with `--dag` / `--watch` instead of being silently dropped.** Those two dispatch paths compiled their sub-runs with an empty run-variable set, so a supplied `--var` was silently ignored — a model with inline `@var(name, default)` placeholders resolved to the default and the run still reported success (wrong data), and a required variable failed even though a value was supplied. The combination now errors clearly until `--var` is threaded through those paths.
 
 ## [1.55.1] - 2026-06-27
 

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -2516,6 +2516,18 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             // malformed pair (no `=`, empty/invalid name) is a clear CLI error.
             let run_vars = rocky_core::run_vars::RunVars::parse_pairs(&var)
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
+            // `--var` is only threaded through the standard run path. The `--dag`
+            // and `--watch` dispatch paths compile their sub-runs with an empty
+            // `RunVars`, so a supplied `--var` would be silently dropped —
+            // resolving to inline defaults (wrong data reported as success) or
+            // failing a required var that was in fact supplied. Reject the
+            // combination loudly until `--var` is threaded through those paths.
+            if !var.is_empty() && (dag || watch) {
+                anyhow::bail!(
+                    "--var is not yet supported with --dag or --watch (it would be \
+                     silently dropped); run without --dag/--watch, or remove --var"
+                );
+            }
             // --idempotency-key is mutually exclusive with --resume / --resume-latest:
             // a resume is an explicit override and should never be short-circuited.
             if idempotency_key.is_some() && (resume.is_some() || resume_latest) {

--- a/engine/rocky/tests/run_var_dag_guard.rs
+++ b/engine/rocky/tests/run_var_dag_guard.rs
@@ -1,0 +1,49 @@
+//! Regression: `rocky run --var` combined with `--dag` or `--watch` must error
+//! loudly rather than silently drop the variable. Those two dispatch paths
+//! compile their sub-runs with an empty `RunVars`, so a supplied `--var` would
+//! otherwise be ignored — resolving an inline `@var(name, default)` to the
+//! default and still reporting success (wrong data), or failing a required var
+//! that was in fact supplied. The guard fires right after `--var` is parsed,
+//! before any config/state load, so these need no project on disk.
+
+use std::process::Command;
+
+fn rocky() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_rocky"))
+}
+
+#[test]
+fn var_with_dag_is_rejected() {
+    let out = rocky()
+        .args(["run", "--dag", "--var", "x=y"])
+        .output()
+        .expect("spawn rocky");
+    assert!(
+        !out.status.success(),
+        "`run --dag --var` must exit non-zero, got {:?}",
+        out.status
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--var is not yet supported with --dag"),
+        "expected the --var/--dag guard message, got stderr: {stderr}"
+    );
+}
+
+#[test]
+fn var_with_watch_is_rejected() {
+    let out = rocky()
+        .args(["run", "--watch", "--var", "x=y"])
+        .output()
+        .expect("spawn rocky");
+    assert!(
+        !out.status.success(),
+        "`run --watch --var` must exit non-zero, got {:?}",
+        out.status
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--var is not yet supported"),
+        "expected the --var/--watch guard message, got stderr: {stderr}"
+    );
+}


### PR DESCRIPTION
## Problem
`rocky run --dag` (and `--watch`) **silently discard `--var`**. Both dispatch paths compile their sub-runs with an empty `RunVars`, so a supplied variable is ignored:
- **Silent wrong data:** a model with inline `@var(name, default)` resolves to the *default*, and the run still reports **success** with the wrong value.
- a *required* var fails (`E028 no value supplied`) even though a value **was** supplied.

Surfaced by a code review of 1.55.0–1.55.2 (pre-existing since the `--var` feature shipped in 1.55.0). The common paths (`--models`/`--all`/`--pipeline`) honor `--var` correctly.

## Fix
Guard the combination right after `--var` is parsed (before any config/state load) and error clearly, rather than silently mis-resolving. Threading `--var` through the unified-DAG dispatch is deferred (that path has a separate structural issue tracked as a follow-up), so the guard is the safe, correct interim.

## Testing
Real CLI: `run --dag --var` and `run --watch --var` both exit non-zero with the guard message; `run --dag` **without** `--var` is untouched (guard short-circuits on `var.is_empty()`). Subprocess regression test for both modes. build / fmt / clippy --all-targets clean.