### PR TITLE
feat(dagster): scope tenant-collapse runs to the host's asset-selection (FR-048)

### DIFF
--- a/docs/src/content/docs/dagster/component.md
+++ b/docs/src/content/docs/dagster/component.md
@@ -66,6 +66,8 @@ class MyRockyComponent(RockyComponent):
 
 Hook exceptions are logged and swallowed so a failing side-effect (typically the S3/Valkey push) cannot block code-server boot.
 
+When you use the tenant-as-partition collapse (`tenant:` / `TenantConfig`), set `tenant.scope_runs_to_selection: true` (default off) to scope a tenant partition run to the connectors the host actually selected, emitting one `rocky run --filter id=<source>` per selected connector instead of re-copying the whole tenant. It only narrows on a strict subset of the tenant's connectors (a full or empty selection still runs the whole tenant), and each `id=` targets that partition's own source, so per-tenant isolation is preserved.
+
 ## State storage
 
 By default, the component stores its state on the local filesystem. The `defs_state` mechanism in Dagster makes this configurable for alternative storage backends.

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`TenantConfig.scope_runs_to_selection`** (opt-in, default off) scopes a tenant-collapse run to the connectors the host actually selected, emitting one `rocky run --filter id=<source>` per selected connector instead of re-copying the whole tenant on every partition run. The narrowing only kicks in when the host selected a *strict subset* of the tenant's connectors; a full or empty selection still runs the whole tenant via `{component}={value}`. Each `id=` filter targets the active partition's own source, so per-tenant physical isolation is preserved. Default off keeps the existing full-tenant behavior. (FR-048)
+
 ## [1.52.0] — 2026-06-23
 
 ### Added

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -280,6 +280,19 @@ class _GroupBuild:
     #: table name → collapsed asset key, the run-time fallback for engine
     #: materialization keys whose tenant is not yet in the load-time map.
     collapsed_key_by_table: dict[str, dg.AssetKey] = field(default_factory=dict)
+    #: Per-partition selection map for the opt-in connector scoping:
+    #: ``partition key (tenant) → {collapsed asset key → that tenant's
+    #: source id}``. Lets a tenant-collapse run narrow to the host-selected
+    #: connectors via ``id=`` filters that stay tenant-correct — each id is
+    #: the *active partition's* own source — even though the collapsed key is
+    #: itself tenant-agnostic. Populated only on the collapse path; the
+    #: default path (and the no-tenant path) leave it empty.
+    partition_key_to_selection_source_ids: dict[str, dict[dg.AssetKey, str]] = field(
+        default_factory=dict
+    )
+    #: Mirrors ``TenantConfig.scope_runs_to_selection`` onto the group so
+    #: :func:`_tenant_partition_filters` can read the opt-in at run time.
+    scope_runs_to_selection: bool = False
 
 
 @dataclass
@@ -357,11 +370,21 @@ class TenantConfig(dg.Model, dg.Resolvable):
             component's sensor adds newly-discovered tenant values to the
             partition set on each tick (via ``dynamic_partitions_requests``).
             Set ``False`` to manage the partition set out-of-band.
+        scope_runs_to_selection: When ``True``, a tenant partition run scopes
+            to the connectors the host actually selected — emitting one
+            ``rocky run --filter id=<source>`` per selected connector (each
+            source id is that tenant's own catalog, so physical isolation
+            holds) — instead of re-copying the whole tenant. The narrowing
+            only kicks in when the host selected a *strict subset* of the
+            tenant's connectors; a full or empty selection still runs the
+            whole tenant via ``{component}={value}``. Default ``False``
+            preserves the original full-tenant behavior.
     """
 
     component: str
     partitions_name: str
     sync_partitions_from_discover: bool = True
+    scope_runs_to_selection: bool = False
 
 
 class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
@@ -1772,6 +1795,7 @@ def _build_collapsed_group_contexts(
         group.partitions_def = partitions_def
         group.tenant_component = tenant.component
         group.source_ids = {m.id for m in members}
+        group.scope_runs_to_selection = tenant.scope_runs_to_selection
 
         # Single chokepoint for the tenant key: translator.get_partition_key
         # (default None → raw component value). Map each key back to the raw
@@ -1841,12 +1865,28 @@ def _build_collapsed_group_contexts(
         # table) → the shared collapsed spec key; at run time only the
         # active partition's keys are emitted.
         for member in members:
+            # Re-derive this member's partition key exactly as the
+            # partition_key_to_filter_value loop above does (translator
+            # override, else the raw component value) so the selection map is
+            # keyed by the SAME partition key the run later sees in
+            # ``context.partition_key``.
+            raw_value = member.components[tenant.component]
+            assert isinstance(raw_value, str)  # guarded above
+            override = translator.get_partition_key(member)
+            member_partition_key = raw_value if override is None else override
             for member_table in member.tables:
                 spec_key = spec_key_by_table.get(member_table.name)
                 if spec_key is not None:
                     group.rocky_key_to_dagster_key[_native_rocky_key(member, member_table.name)] = (
                         spec_key
                     )
+                    # {collapsed key → this tenant's source id} so a
+                    # host-selected connector subset can scope the run via a
+                    # tenant-correct ``id=`` filter (the collapsed key alone
+                    # is tenant-agnostic and would lose the active tenant).
+                    group.partition_key_to_selection_source_ids.setdefault(
+                        member_partition_key, {}
+                    )[spec_key] = member.id
         groups.append(group)
 
     return groups
@@ -1907,6 +1947,7 @@ def _coalesce_collapsed_groups(
     merged = _GroupBuild(name=name)
     merged.partitions_def = groups[0].partitions_def
     merged.tenant_component = groups[0].tenant_component
+    merged.scope_runs_to_selection = groups[0].scope_runs_to_selection
 
     spec_keys: set[dg.AssetKey] = set()
     # table name → its single collapsed key, or None once a second distinct key
@@ -1915,6 +1956,16 @@ def _coalesce_collapsed_groups(
 
     for group in groups:
         merged.source_ids |= group.source_ids
+
+        # Union the per-partition selection map. Each group is a distinct
+        # connector (keyed by its non-tenant components), so within a given
+        # partition the groups' collapsed keys are disjoint — there is no real
+        # (partition_key, key) collision. ``setdefault`` keeps the first
+        # defensively, matching the spec / native-key merges below.
+        for pkey, key_source_ids in group.partition_key_to_selection_source_ids.items():
+            dest = merged.partition_key_to_selection_source_ids.setdefault(pkey, {})
+            for spec_key, source_id in key_source_ids.items():
+                dest.setdefault(spec_key, source_id)
 
         for spec in group.specs:
             if spec.key in spec_keys:
@@ -2341,7 +2392,7 @@ def _make_rocky_asset(
         # partition key (→ that tenant's own catalog); the default path
         # uses the group / per-source filter.
         if group.partitions_def is not None and group.tenant_component is not None:
-            filters = _tenant_partition_filters(group, context)
+            filters = _tenant_partition_filters(group, context, selected_keys)
         else:
             filters = _select_filters(group, selected_keys, context)
 
@@ -2644,6 +2695,7 @@ def _select_filters(
 def _tenant_partition_filters(
     group: _GroupBuild,
     context: dg.AssetExecutionContext,
+    selected_keys: set[dg.AssetKey],
 ) -> list[str]:
     """Build the per-tenant ``--filter`` for a collapsed, partitioned run.
 
@@ -2657,6 +2709,19 @@ def _tenant_partition_filters(
     multi-run backfill), so exactly one partition key is present.
     ``BackfillPolicy.single_run()`` (a partition *range* in one run) is
     rejected: a single ``--filter`` value cannot span tenant catalogs.
+
+    Connector scoping (opt-in, off by default): when
+    :attr:`_GroupBuild.scope_runs_to_selection` is set AND the host
+    selected a *strict subset* of this tenant's connectors, return one
+    ``id=<source>`` filter per selected connector instead of the whole
+    tenant. Each id is looked up in
+    :attr:`_GroupBuild.partition_key_to_selection_source_ids` for the
+    *active partition*, so the source it targets is that tenant's own
+    catalog — ``id`` is globally unique, so isolation holds even though the
+    collapsed asset key is tenant-agnostic. A full selection (every
+    connector) or an empty / unmapped selection (e.g. a brand-new tenant
+    not yet in the map) falls back to the whole-tenant filter — fewer runs,
+    and the safe default when the subset can't be resolved.
     """
     if not context.has_partition_key:
         raise dg.Failure(
@@ -2671,10 +2736,33 @@ def _tenant_partition_filters(
     partition_key = context.partition_key
     filter_value = group.partition_key_to_filter_value.get(partition_key, partition_key)
     assert group.tenant_component is not None  # set whenever partitions_def is
-    context.log.info(
-        f"Tenant partition '{partition_key}' → --filter {group.tenant_component}={filter_value}"
-    )
-    return [f"{group.tenant_component}={filter_value}"]
+    tenant_filter = f"{group.tenant_component}={filter_value}"
+
+    if group.scope_runs_to_selection:
+        # Source ids for THIS partition's connectors only — the strict-subset
+        # comparison must be against the active tenant's source set, never the
+        # group-wide ``source_ids`` (which spans every tenant).
+        partition_source_ids = group.partition_key_to_selection_source_ids.get(partition_key, {})
+        needed_source_ids = {
+            partition_source_ids[k] for k in selected_keys if k in partition_source_ids
+        }
+        partition_source_set = set(partition_source_ids.values())
+        if needed_source_ids and needed_source_ids != partition_source_set:
+            scoped = [f"id={sid}" for sid in sorted(needed_source_ids)]
+            context.log.info(
+                f"Tenant partition '{partition_key}': scoping to "
+                f"{len(needed_source_ids)}/{len(partition_source_set)} selected "
+                f"connectors → {scoped}"
+            )
+            return scoped
+        context.log.info(
+            f"Tenant partition '{partition_key}': selection covers the whole tenant "
+            f"(or is unresolved) → --filter {tenant_filter}"
+        )
+        return [tenant_filter]
+
+    context.log.info(f"Tenant partition '{partition_key}' → --filter {tenant_filter}")
+    return [tenant_filter]
 
 
 def _run_filters(

--- a/integrations/dagster/tests/test_tenant_partition.py
+++ b/integrations/dagster/tests/test_tenant_partition.py
@@ -31,6 +31,7 @@ from dagster_rocky.component import (
     _coalesce_collapsed_groups,
     _CompileState,
     _make_rocky_asset,
+    _run_filters,
     _tenant_partition_filters,
 )
 from dagster_rocky.translator import RockyDagsterTranslator
@@ -247,7 +248,7 @@ class _FakeCtx:
 
 def test_tenant_partition_filters_maps_key_to_filter():
     groups, _ = _collapse(_discover(_source("coca_cola", ["orders"]), _source("pepsi", ["orders"])))
-    filters = _tenant_partition_filters(groups[0], _FakeCtx("pepsi"))
+    filters = _tenant_partition_filters(groups[0], _FakeCtx("pepsi"), set())
     assert filters == ["client=pepsi"]
 
 
@@ -255,14 +256,266 @@ def test_tenant_partition_filters_uses_raw_value_for_unknown_key():
     # A brand-new tenant partition (added by the sensor before the next state
     # refresh) isn't in the map yet → fall back to the key itself.
     groups, _ = _collapse(_discover(_source("coca_cola", ["orders"])))
-    filters = _tenant_partition_filters(groups[0], _FakeCtx("newtenant"))
+    filters = _tenant_partition_filters(groups[0], _FakeCtx("newtenant"), set())
     assert filters == ["client=newtenant"]
 
 
 def test_tenant_partition_filters_rejects_single_run_backfill():
     groups, _ = _collapse(_discover(_source("coca_cola", ["orders"])))
     with pytest.raises(dg.Failure, match="single_run"):
-        _tenant_partition_filters(groups[0], _FakeCtx(None))
+        _tenant_partition_filters(groups[0], _FakeCtx(None), set())
+
+
+# --------------------------------------------------------------------------- #
+# Connector scoping: tenant run honours the host's asset-selection (opt-in)
+# --------------------------------------------------------------------------- #
+
+
+def _scoped_source(client: str, connector: str, tables: list[str]) -> SourceInfo:
+    # Each ``connector`` is a distinct non-tenant ``source`` component, so the
+    # collapsed (tenant-stripped) keys differ per connector. Source id encodes
+    # both axes so the per-partition map is easy to assert on.
+    return SourceInfo(
+        id=f"{client}__{connector}",
+        components={"client": client, "region": "usa", "source": connector},
+        source_type="fivetran",
+        last_sync_at=None,
+        tables=[TableInfo(name=t, row_count=1) for t in tables],
+    )
+
+
+def _tenant_scoped() -> TenantConfig:
+    return TenantConfig(
+        component="client",
+        partitions_name="rocky_clients",
+        scope_runs_to_selection=True,
+    )
+
+
+def _scoped_key(connector: str) -> dg.AssetKey:
+    return dg.AssetKey(["fivetran", "usa", connector, "orders"])
+
+
+def _scoped_merged_group(tenant: TenantConfig):
+    """Two tenants × three connectors, built through the REAL collapse +
+    coalesce path (not a synthetic ``_GroupBuild``) so the tests prove the
+    selection map is actually wired — it was empty on the collapse path
+    before, which would make the opt-in inert in production."""
+    discover = _discover(
+        *[
+            _scoped_source(client, connector, ["orders"])
+            for client in ("acme", "widgets")
+            for connector in ("connector_a", "connector_b", "connector_c")
+        ]
+    )
+    pdef = dg.DynamicPartitionsDefinition(name="rocky_clients")
+    groups = _build_collapsed_group_contexts(discover, RockyDagsterTranslator(), tenant, pdef)
+    merged = _coalesce_collapsed_groups(groups, name="tenant_rocky_clients")
+    assert len(merged) == 1
+    return merged[0]
+
+
+def _empty_run_result(filter_str: str) -> RunResult:
+    return RunResult.model_validate(
+        {
+            "version": "0.3.0",
+            "command": "run",
+            "filter": filter_str,
+            "duration_ms": 1,
+            "tables_copied": 0,
+            "tables_failed": 0,
+            "materializations": [],
+            "check_results": [],
+            "permissions": {
+                "grants_added": 0,
+                "grants_revoked": 0,
+                "catalogs_created": 0,
+                "schemas_created": 0,
+            },
+            "drift": {"tables_checked": 0, "tables_drifted": 0, "actions_taken": []},
+        }
+    )
+
+
+def test_selection_source_id_map_populated_through_real_builders():
+    # Wiring proof: the per-partition selection map is populated by the real
+    # collapse + coalesce path (and the opt-in is mirrored onto the group).
+    merged = _scoped_merged_group(_tenant_scoped())
+    assert merged.scope_runs_to_selection is True
+    assert set(merged.partition_key_to_selection_source_ids) == {"acme", "widgets"}
+    assert merged.partition_key_to_selection_source_ids["widgets"] == {
+        _scoped_key("connector_a"): "widgets__connector_a",
+        _scoped_key("connector_b"): "widgets__connector_b",
+        _scoped_key("connector_c"): "widgets__connector_c",
+    }
+
+
+def test_tenant_scope_off_ignores_selection():
+    # Back-compat: with the opt-in OFF, a connector subset still runs the whole
+    # tenant — unchanged from before.
+    merged = _scoped_merged_group(_tenant())  # scope_runs_to_selection defaults False
+    assert merged.scope_runs_to_selection is False
+    filters = _tenant_partition_filters(merged, _FakeCtx("widgets"), {_scoped_key("connector_a")})
+    assert filters == ["client=widgets"]
+
+
+def test_tenant_scope_on_strict_subset_returns_partition_scoped_id():
+    merged = _scoped_merged_group(_tenant_scoped())
+    filters = _tenant_partition_filters(merged, _FakeCtx("widgets"), {_scoped_key("connector_a")})
+    # The selected connector's source id for THIS partition (widgets) only —
+    # not acme's, not the other connectors, not the whole-tenant filter.
+    assert filters == ["id=widgets__connector_a"]
+
+
+def test_tenant_scope_on_two_of_three_subset_is_sorted():
+    merged = _scoped_merged_group(_tenant_scoped())
+    filters = _tenant_partition_filters(
+        merged,
+        _FakeCtx("widgets"),
+        {_scoped_key("connector_c"), _scoped_key("connector_a")},
+    )
+    assert filters == ["id=widgets__connector_a", "id=widgets__connector_c"]
+
+
+def test_tenant_scope_on_full_selection_runs_whole_tenant():
+    merged = _scoped_merged_group(_tenant_scoped())
+    all_keys = {_scoped_key(c) for c in ("connector_a", "connector_b", "connector_c")}
+    filters = _tenant_partition_filters(merged, _FakeCtx("widgets"), all_keys)
+    assert filters == ["client=widgets"]
+
+
+def test_tenant_scope_on_empty_selection_runs_whole_tenant():
+    merged = _scoped_merged_group(_tenant_scoped())
+    filters = _tenant_partition_filters(merged, _FakeCtx("widgets"), set())
+    assert filters == ["client=widgets"]
+
+
+def test_tenant_scope_on_is_partition_specific():
+    # Same selected connector, different partition → that partition's own
+    # source id. Proves the id= filter follows the active tenant (so isolation
+    # holds), rather than a fixed first-seen tenant.
+    merged = _scoped_merged_group(_tenant_scoped())
+    acme = _tenant_partition_filters(merged, _FakeCtx("acme"), {_scoped_key("connector_b")})
+    widgets = _tenant_partition_filters(merged, _FakeCtx("widgets"), {_scoped_key("connector_b")})
+    assert acme == ["id=acme__connector_b"]
+    assert widgets == ["id=widgets__connector_b"]
+
+
+def test_tenant_scope_on_guard_still_rejects_missing_partition_key():
+    merged = _scoped_merged_group(_tenant_scoped())
+    with pytest.raises(dg.Failure, match="single_run"):
+        _tenant_partition_filters(merged, _FakeCtx(None), {_scoped_key("connector_a")})
+
+
+def test_run_filters_issues_one_rocky_run_per_id_filter():
+    # A 2-element id= list (the scoped tenant subset) runs as two separate,
+    # scoped `rocky run` invocations.
+    rocky = MagicMock()
+    rocky.run.side_effect = lambda *, filter: _empty_run_result(filter)
+    filters = ["id=widgets__connector_a", "id=widgets__connector_b"]
+    results, cooldown = _run_filters(_FakeCtx("widgets"), rocky, filters, streaming=False)
+    assert [call.kwargs["filter"] for call in rocky.run.call_args_list] == filters
+    assert rocky.run.call_count == 2
+    assert cooldown is None
+    assert [r.filter for r in results] == filters
+
+
+def _scoped_two_connector_state(tmp_path):
+    discover = {
+        "version": "0.3.0",
+        "command": "discover",
+        "sources": [
+            {
+                "id": "acme__connector_a",
+                "source_type": "fivetran",
+                "components": {"client": "acme", "region": "usa", "source": "connector_a"},
+                "tables": [{"name": "orders"}],
+            },
+            {
+                "id": "acme__connector_b",
+                "source_type": "fivetran",
+                "components": {"client": "acme", "region": "usa", "source": "connector_b"},
+                "tables": [{"name": "leads"}],
+            },
+        ],
+    }
+    state_file = tmp_path / "state.json"
+    state_file.write_text(json.dumps({"discover": discover}))
+    return state_file
+
+
+def test_scope_on_subset_materialization_runs_scoped_id_filter(tmp_path):
+    # End-to-end through the real op: opt-in ON + a one-connector subset
+    # selection on a tenant partition issues a single `rocky run --filter
+    # id=<that connector's source>` instead of the whole-tenant filter. This
+    # is the composition the unit tests don't cover (selection → call site →
+    # _tenant_partition_filters → scoped run), and the seam that was inert
+    # before the per-partition map.
+    state_file = _scoped_two_connector_state(tmp_path)
+    component = RockyComponent(
+        config_path="rocky.toml",
+        tenant=TenantConfig(
+            component="client",
+            partitions_name="rocky_clients",
+            scope_runs_to_selection=True,
+        ),
+    )
+    defs = component.build_defs_from_state(context=None, state_path=state_file)
+    asset_defs = [a for a in (defs.assets or []) if isinstance(a, dg.AssetsDefinition)]
+    assert len(asset_defs) == 1
+    a = dg.AssetKey(["fivetran", "usa", "connector_a", "orders"])
+    b = dg.AssetKey(["fivetran", "usa", "connector_b", "leads"])
+    assert {a, b} <= {k for ad in asset_defs for k in ad.keys}
+
+    run_result = RunResult.model_validate(
+        {
+            "version": "0.3.0",
+            "command": "run",
+            "filter": "id=acme__connector_a",
+            "duration_ms": 10,
+            "tables_copied": 1,
+            "tables_failed": 0,
+            "materializations": [
+                {
+                    "asset_key": ["fivetran", "acme", "usa", "connector_a", "orders"],
+                    "rows_copied": 10,
+                    "duration_ms": 5,
+                    "metadata": {"strategy": "full_refresh"},
+                }
+            ],
+            "check_results": [],
+            "permissions": {
+                "grants_added": 0,
+                "grants_revoked": 0,
+                "catalogs_created": 0,
+                "schemas_created": 0,
+            },
+            "drift": {"tables_checked": 1, "tables_drifted": 0, "actions_taken": []},
+        }
+    )
+
+    instance = dg.DagsterInstance.ephemeral()
+    instance.add_dynamic_partitions("rocky_clients", ["acme"])
+
+    mock_run = MagicMock(return_value=run_result)
+    with (
+        patch.object(RockyResource, "run_streaming", mock_run),
+        patch.object(RockyResource, "run", return_value=run_result),
+    ):
+        result = dg.materialize(
+            asset_defs,
+            resources={"rocky": RockyResource(config_path="rocky.toml")},
+            selection=[a],  # subset: one of the tenant's two connectors
+            partition_key="acme",
+            instance=instance,
+            raise_on_error=False,
+        )
+
+    assert result.success
+    # Exactly one run, scoped to the selected connector's OWN source id.
+    assert mock_run.call_count == 1
+    assert mock_run.call_args.kwargs["filter"] == "id=acme__connector_a"
+    assert {e.asset_key for e in result.get_asset_materialization_events()} == {a}
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Problem
Under `RockyComponent.tenant`, a host run is launched per partition with an `asset_selection` (the host knows which connectors changed). The collapsed execution path derived the engine command from the partition value only (`rocky run --filter <tenant_component>=<tenant>`, whole tenant) and **discarded the selection** — so a run that selected one connector still re-copied the entire tenant. For a sparse, event-driven pipeline that's the common case.

## Fix (opt-in, dagster-only)
`TenantConfig.scope_runs_to_selection: bool = False`. When ON and a tenant run's `asset_selection` is a **strict subset** of the tenant's connectors, the run is scoped to the selected connectors via `id=<source_id>` filters (one scoped `rocky run` per selected connector); default OFF keeps today's whole-tenant behavior. A new partition-keyed `{tenant -> {key -> that tenant's source id}}` map is populated in the real collapse builders so the scope is **tenant-correct** (the same connector name under different tenants resolves to the right source).

Chose the contained dagster-only path over growing comma/OR semantics on the engine `--filter` (shared by plan/compare/branch/run + external resolvers); it handles the motivating single-connector case identically and doesn't foreclose an engine multi-value filter later.

## Testing
Independently + adversarially verified through the **real builders** + `dg.materialize`: a one-connector subset on a 2-tenant×3-connector setup issues exactly `id=<that tenant's connector>` (not the whole tenant, not the other tenant's same-named connector); back-compat (off / full / empty selection → whole-tenant); strict-subset boundary exact; partition guard intact. 674 tests green; mutation tests confirm the assertions discriminate (the original spec's `key_to_source_id` reuse would have been inert).