### PR TITLE
fix(engine): security/perf/bug hardening sweep

### DIFF
--- a/engine/crates/rocky-bigquery/src/dialect.rs
+++ b/engine/crates/rocky-bigquery/src/dialect.rs
@@ -55,7 +55,19 @@ impl SqlDialect for BigQueryDialect {
             .join(" AND ");
 
         let update_set = match update_cols {
-            ColumnSelection::All => "target = source".to_string(),
+            // BigQuery MERGE has no `UPDATE SET *` / whole-row form (unlike
+            // Databricks). The runner resolves `ColumnSelection::All` against
+            // the model's columns before SQL-gen; reaching here with `All`
+            // means none were resolvable, so fail fast with a clear message
+            // instead of emitting the invalid `UPDATE SET target = source`.
+            // Mirrors the Snowflake and DuckDB dialects.
+            ColumnSelection::All => {
+                return Err(AdapterError::msg(
+                    "BigQuery MERGE does not support UPDATE SET * — no update \
+                     columns could be resolved. Specify update_columns explicitly \
+                     on the model's [strategy].",
+                ));
+            }
             ColumnSelection::Explicit(cols) => cols
                 .iter()
                 .map(|c| format!("target.{c} = source.{c}"))
@@ -383,17 +395,40 @@ mod tests {
     }
 
     #[test]
-    fn test_merge_into() {
+    fn test_merge_rejects_update_set_star() {
+        // Regression: BigQuery has no `UPDATE SET *` / whole-row form, so an
+        // unresolved `ColumnSelection::All` must fail fast (like Snowflake and
+        // DuckDB) instead of emitting the invalid `UPDATE SET target = source`.
         let d = BigQueryDialect;
-        let sql = d
+        let err = d
             .merge_into(
                 "`p`.`d`.`t`",
                 "SELECT * FROM src",
                 &["id".into()],
                 &ColumnSelection::All,
             )
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("UPDATE SET *"),
+            "expected a clear fail-fast error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_merge_into_explicit_columns() {
+        let d = BigQueryDialect;
+        let sql = d
+            .merge_into(
+                "`p`.`d`.`t`",
+                "SELECT * FROM src",
+                &["id".into()],
+                &ColumnSelection::Explicit(vec!["status".into(), "amount".into()]),
+            )
             .unwrap();
         assert!(sql.contains("MERGE INTO"));
+        assert!(sql.contains(
+            "WHEN MATCHED THEN UPDATE SET target.status = source.status, target.amount = source.amount"
+        ));
         assert!(sql.contains("WHEN NOT MATCHED THEN INSERT ROW"));
     }
 

--- a/engine/crates/rocky-cli/src/commands/emit_sql.rs
+++ b/engine/crates/rocky-cli/src/commands/emit_sql.rs
@@ -136,6 +136,24 @@ fn emit_models(
         }
     };
 
+    // A successful compile can still carry error diagnostics — e.g. E028 for a
+    // required `@var(...)` with no supplied value, which substitutes the
+    // MISSING_SENTINEL ("NULL") into the SQL. `rocky compile`/`run` refuse to
+    // proceed in that case; emit-sql must too, rather than emitting (and, with
+    // `--out-dir`, persisting) provably-wrong SQL. Mirrors the compile command.
+    if result.has_errors {
+        let errors: Vec<String> = result
+            .diagnostics
+            .iter()
+            .filter(|d| d.is_error())
+            .map(|d| format!("{}: {} ({})", d.code, d.message, d.model))
+            .collect();
+        anyhow::bail!(
+            "emit-sql: compilation failed with errors:\n  {}",
+            errors.join("\n  ")
+        );
+    }
+
     // Iterate in the project's topological execution order so the emitted files
     // are runnable in sequence (a model never precedes one it reads). Models not
     // listed in `execution_order` (defensive) fall to the end in IR order.
@@ -170,12 +188,14 @@ fn emit_models(
 
     let mut emitted = Vec::new();
     let mut skipped = Vec::new();
+    let mut filter_matched = false;
     for model_ir in ordered {
         let model_name = model_ir.name.as_ref();
-        if let Some(f) = model_filter
-            && model_name != f
-        {
-            continue;
+        if let Some(f) = model_filter {
+            if model_name != f {
+                continue;
+            }
+            filter_matched = true;
         }
 
         let mut model_ir = model_ir.clone();
@@ -217,6 +237,16 @@ fn emit_models(
             }
         }
     }
+    // An explicit `--model <name>` that matched nothing is a user error (a
+    // typo, or a model that doesn't exist), not an empty success — otherwise
+    // `emit-sql --model X --out-dir out/` writes nothing and exits 0 while a
+    // deploy script believes it emitted. Mirrors `rocky cost --model`.
+    if let Some(f) = model_filter
+        && !filter_matched
+    {
+        anyhow::bail!("emit-sql: model '{f}' not found (no transformation model with that name)");
+    }
+
     Ok(EmitResult {
         models: emitted,
         skipped,
@@ -430,6 +460,40 @@ mod tests {
         .models;
         assert_eq!(emitted.len(), 1);
         assert_eq!(emitted[0].name, "b");
+    }
+
+    #[test]
+    fn unknown_model_filter_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        write_model(dir.path(), "a", "SELECT 1 AS id", "");
+        // Regression: a `--model` that matches nothing must error, not silently
+        // succeed with an empty result (which a deploy script reads as success).
+        let err = emit_models(
+            None,
+            dir.path(),
+            Some("nope"),
+            &rocky_core::run_vars::RunVars::new(),
+        )
+        .err()
+        .expect("unknown --model must error");
+        assert!(err.to_string().contains("not found"), "{err}");
+    }
+
+    #[test]
+    fn missing_required_var_errors_instead_of_emitting_sentinel() {
+        let dir = tempfile::tempdir().unwrap();
+        write_model(dir.path(), "m", "SELECT '@var(region)' AS r", "");
+        // Regression: emit-sql must honor compile errors (E028) rather than
+        // emit the MISSING_SENTINEL ("NULL") for a required @var with no value.
+        let err = emit_models(
+            None,
+            dir.path(),
+            None,
+            &rocky_core::run_vars::RunVars::new(),
+        )
+        .err()
+        .expect("missing required @var must error");
+        assert!(err.to_string().contains("compilation failed"), "{err}");
     }
 
     #[test]

--- a/engine/crates/rocky-cli/src/commands/imports_check.rs
+++ b/engine/crates/rocky-cli/src/commands/imports_check.rs
@@ -273,13 +273,22 @@ pub fn imports_diagnostics(
             }
 
             let reference = match rocky_sql::lineage::extract_lineage(&model.sql) {
-                Ok(lineage) if !lineage.has_star => Reference::Columns(
-                    lineage
-                        .columns
-                        .iter()
-                        .map(|c| c.source_column.to_lowercase())
-                        .collect(),
-                ),
+                Ok(lineage) if !lineage.has_star => {
+                    // Build the read-set from a COMPLETE column walk (WHERE /
+                    // JOIN ON / GROUP BY / HAVING / ORDER BY / every expression
+                    // operand), not `lineage.columns` — which captures only the
+                    // top-level projection's first-traceable refs and would let
+                    // a breaking change to a column read elsewhere (a WHERE
+                    // filter, a 2nd function arg, a CASE/arithmetic operand)
+                    // slip the gate silently. An empty result (no columns
+                    // resolved) falls back to the conservative Unfiltered.
+                    let cols = rocky_sql::lineage::referenced_columns(&model.sql);
+                    if cols.is_empty() {
+                        Reference::Unfiltered
+                    } else {
+                        Reference::Columns(cols)
+                    }
+                }
                 // `SELECT *` or unparsable SQL: be conservative.
                 _ => Reference::Unfiltered,
             };

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -3686,15 +3686,25 @@ pub async fn run(
             }
             .await;
             if let Err(e) = exec_result {
-                let _ = hook_registry
-                    .fire(&HookContext::pipeline_error(
-                        &run_id,
-                        pipeline_name,
-                        &format!("{e:#}"),
-                    ))
-                    .await;
-                let _ = hook_registry.wait_async_webhooks().await;
-                return Err(e);
+                // Record the runtime model failure as a table error and fall
+                // through to the terminal emit instead of returning raw `Err`.
+                // `execute_models` stops at the first failing model, having
+                // already recorded the earlier successes in `output`; returning
+                // `Err` here skipped `print_json` + `persist_run_record`, so
+                // `--output json` stdout was empty and the process exited 1
+                // instead of the PartialFailure sentinel (exit 2). Routing
+                // through `table_errors` lets the existing merge + terminal
+                // machinery report it like any other partial failure (the
+                // copy-failure block below fires `pipeline_error` + drains
+                // webhooks once for the accumulated failures), mirroring the
+                // model-only path.
+                table_errors.push(TableError {
+                    asset_key: vec![pipeline_name.to_string()],
+                    error: format!("{e:#}"),
+                    task_index: None,
+                    failure_kind: crate::output::FailureKind::Unknown,
+                    cooldown_seconds: None,
+                });
             }
 
             // Governance: column classification + masking reconcile (§1.1 + §1.2).
@@ -5782,6 +5792,15 @@ async fn execute_one_plain_model(
     exec_ctx: ExecutionContext<'_>,
 ) -> Result<MaterializationOutput> {
     let mut model_ir = model.to_model_ir();
+    // Enrich typed columns from the typechecker (bare `to_model_ir()` leaves
+    // them empty) so a `merge` strategy with an implicit all-columns update set
+    // resolves to an explicit per-column list at SQL-gen. Mirrors
+    // `typed_model_ir` / `project_ir_from_compile`. Without it, BigQuery emits
+    // an invalid `UPDATE SET target = source` and Snowflake/DuckDB reject
+    // `UPDATE SET *` for a transformation merge with no explicit columns.
+    if let Some(cols) = exec_ctx.typed_models.get(model_name) {
+        model_ir.typed_columns = cols.clone();
+    }
     // Inject declared surrogate-key columns by wrapping the model's SELECT.
     // Transformation models materialize their raw SQL directly (never the
     // replication-only metadata-column path), so the wrap is what surfaces the

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -185,6 +185,16 @@ pub async fn run_transformation(
         .unwrap_or_default();
     output.populate_cost_summary(&adapter_type, &rocky_cfg.cost);
 
+    // Enforce the global run-level `[budget]`. The replication (run.rs) and
+    // model-only paths both run this after cost population; without it the
+    // guardrail is a silent no-op on the transformation path — the highest-
+    // compute pipeline type, exactly where a scan/cost/duration cap matters
+    // most. `check_and_record_budget` records any breach into
+    // `output.budget_breaches` (surfaced in the JSON) and returns `Err` when
+    // `on_breach = "error"`; the error is propagated after the JSON is emitted
+    // (below) so a consumer still sees the final payload.
+    let budget_result = output.check_and_record_budget(&rocky_cfg.budget, Some(run_id));
+
     // Persist the RunRecord (after cost population, so the recorded
     // `ModelExecution` entries carry cost + `skip_hash` + upstream
     // freshness signatures). Mirrors the replication / model-only call
@@ -239,6 +249,11 @@ pub async fn run_transformation(
             crate::status_line!("  {} ({})", m.asset_key.join("."), m.metadata.strategy);
         }
     }
+
+    // Propagate a hard `[budget]` breach (`on_breach = "error"`) now that the
+    // JSON payload has been emitted, matching the replication / model-only
+    // ordering.
+    budget_result?;
 
     // Honour the run-status exit-code contract. A model that failed to
     // compile (recorded in `output.errors` / `tables_failed` by
@@ -515,16 +530,21 @@ pub(crate) async fn run_custom_checks(
             Ok(result) => {
                 let result_value =
                     cell_as_u64(result.rows.first().and_then(|r| r.first())).unwrap_or(0);
-                results.push(CheckResult {
-                    name: custom.name.clone(),
-                    passed: result_value >= custom.threshold,
-                    severity,
-                    details: CheckDetails::Custom {
-                        query: sql,
-                        result_value,
-                        threshold: custom.threshold,
-                    },
-                });
+                // Delegate to the single canonical custom-check evaluator so the
+                // wired path and `checks::check_custom` can't drift on the pass
+                // condition again. `threshold` is the MAX allowed failing-row
+                // count, so the check passes iff `result_value <= threshold`
+                // (with the default `threshold = 0`, a violation-counting check
+                // passes only when it finds zero rows). `check_custom` defaults
+                // severity to Error; restore the check's configured severity.
+                let mut check = rocky_core::checks::check_custom(
+                    &custom.name,
+                    &sql,
+                    result_value,
+                    custom.threshold,
+                );
+                check.severity = severity;
+                results.push(check);
             }
             Err(e) => {
                 warn!(error = %e, check = custom.name.as_str(), "custom check query failed");

--- a/engine/crates/rocky-compiler/src/import/dbt.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt.rs
@@ -2155,8 +2155,13 @@ pub fn detect_is_incremental(sql: &str) -> (String, Option<IncrementalDetection>
             None => String::new(),
         };
 
+        // `NoExpand` so a `$` in the operator's else-block SQL (dollar-quoted
+        // literals, Snowflake positional `$1`, a literal `$100`) is copied
+        // verbatim instead of being interpreted as a capture-group reference.
+        // Matches the guard already applied to the ref-rewrite at the bottom of
+        // `convert_jinja_to_sql`.
         processed = incr_re
-            .replace(&processed, replacement.as_str())
+            .replace(&processed, regex::NoExpand(replacement.as_str()))
             .to_string();
     }
 
@@ -2442,6 +2447,36 @@ pub fn write_imported_models(models: &[ImportedModel], output_dir: &Path) -> Res
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn detect_is_incremental_does_not_expand_dollar_in_else_block() {
+        // Regression: the else-block SQL was passed as a `&str` replacement to
+        // `Regex::replace`, so a `$` sequence was interpreted as a capture-group
+        // reference and silently corrupted the imported SQL. `NoExpand` copies
+        // it verbatim.
+        let sql = "{% if is_incremental() %} WHERE synced > 1 \
+                   {% else %} WHERE note = 'costs $100' {% endif %}";
+        let (processed, _) = detect_is_incremental(sql);
+        assert!(
+            processed.contains("costs $100"),
+            "`$100` must survive verbatim, got: {processed}"
+        );
+    }
+
+    #[test]
+    fn detect_is_incremental_preserves_dollar_quoted_and_positional() {
+        let (processed, _) = detect_is_incremental(
+            "{% if is_incremental() %}x{% else %} WHERE a = $1 AND tag = $$active$$ {% endif %}",
+        );
+        assert!(
+            processed.contains("$1"),
+            "positional `$1` preserved: {processed}"
+        );
+        assert!(
+            processed.contains("$$active$$"),
+            "dollar-quoted preserved: {processed}"
+        );
+    }
 
     // --- Jinja conversion tests ---
 

--- a/engine/crates/rocky-compiler/src/import/emit.rs
+++ b/engine/crates/rocky-compiler/src/import/emit.rs
@@ -217,6 +217,19 @@ fn prepare_out_dir(out_dir: &Path, policy: OverwritePolicy) -> Result<(), String
 }
 
 fn write_model_files(model: &ImportedModel, models_dir: &Path) -> Result<(), String> {
+    // A dbt manifest is a third-party build artifact; its node `name` flows
+    // straight into these filesystem paths. Reject a name that is not a plain
+    // filename component so a hostile or garbled manifest can't traverse
+    // outside `models_dir` (`../../x`, `/etc/x`, `a/b`) with attacker-controlled
+    // content — the write-side mirror of the read-side `safe_join_under` guard.
+    if !is_safe_model_file_stem(&model.name) {
+        return Err(format!(
+            "model name {:?} is not a safe file name — model names may not \
+             contain path separators, parent-dir (`..`), or absolute-path \
+             components",
+            model.name
+        ));
+    }
     let sql_path = models_dir.join(format!("{}.sql", model.name));
     let toml_path = models_dir.join(format!("{}.toml", model.name));
 
@@ -322,22 +335,20 @@ fn annotate_unsupported_jinja(sql: &str) -> String {
 fn render_model_sidecar(config: &ModelConfig) -> String {
     // Lean serializer — matches the pattern used by `rocky ai` for sidecars
     // (see CHANGELOG #414): we deliberately do NOT serialize empty default
-    // collections (`depends_on = []`, etc.) so the file stays compact.
+    // collections (`depends_on = []`, etc.) so the file stays compact. Every
+    // manifest-derived string value goes through `toml_escape`.
     let mut out = String::new();
-    out.push_str(&format!("name = \"{}\"\n", config.name));
+    out.push_str(&format!("name = \"{}\"\n", toml_escape(&config.name)));
     if !config.depends_on.is_empty() {
         let quoted: Vec<String> = config
             .depends_on
             .iter()
-            .map(|s| format!("\"{s}\""))
+            .map(|s| format!("\"{}\"", toml_escape(s)))
             .collect();
         out.push_str(&format!("depends_on = [{}]\n", quoted.join(", ")));
     }
     if let Some(intent) = &config.intent {
-        out.push_str(&format!(
-            "intent = \"{}\"\n",
-            intent.replace('\\', "\\\\").replace('"', "\\\"")
-        ));
+        out.push_str(&format!("intent = \"{}\"\n", toml_escape(intent)));
     }
     out.push('\n');
 
@@ -348,17 +359,26 @@ fn render_model_sidecar(config: &ModelConfig) -> String {
         }
         StrategyConfig::Incremental { timestamp_column } => {
             out.push_str("type = \"incremental\"\n");
-            out.push_str(&format!("timestamp_column = \"{timestamp_column}\"\n"));
+            out.push_str(&format!(
+                "timestamp_column = \"{}\"\n",
+                toml_escape(timestamp_column)
+            ));
         }
         StrategyConfig::Merge {
             unique_key,
             update_columns,
         } => {
             out.push_str("type = \"merge\"\n");
-            let keys: Vec<String> = unique_key.iter().map(|k| format!("\"{k}\"")).collect();
+            let keys: Vec<String> = unique_key
+                .iter()
+                .map(|k| format!("\"{}\"", toml_escape(k)))
+                .collect();
             out.push_str(&format!("unique_key = [{}]\n", keys.join(", ")));
             if let Some(cols) = update_columns {
-                let cs: Vec<String> = cols.iter().map(|c| format!("\"{c}\"")).collect();
+                let cs: Vec<String> = cols
+                    .iter()
+                    .map(|c| format!("\"{}\"", toml_escape(c)))
+                    .collect();
                 out.push_str(&format!("update_columns = [{}]\n", cs.join(", ")));
             }
         }
@@ -373,14 +393,17 @@ fn render_model_sidecar(config: &ModelConfig) -> String {
         }
         StrategyConfig::DynamicTable { target_lag } => {
             out.push_str("type = \"dynamic_table\"\n");
-            out.push_str(&format!("target_lag = \"{target_lag}\"\n"));
+            out.push_str(&format!("target_lag = \"{}\"\n", toml_escape(target_lag)));
         }
         StrategyConfig::Microbatch {
             timestamp_column,
             granularity,
         } => {
             out.push_str("type = \"microbatch\"\n");
-            out.push_str(&format!("timestamp_column = \"{timestamp_column}\"\n"));
+            out.push_str(&format!(
+                "timestamp_column = \"{}\"\n",
+                toml_escape(timestamp_column)
+            ));
             let g = match granularity {
                 rocky_ir::TimeGrain::Hour => "hour",
                 rocky_ir::TimeGrain::Day => "day",
@@ -391,7 +414,10 @@ fn render_model_sidecar(config: &ModelConfig) -> String {
         }
         StrategyConfig::DeleteInsert { partition_by } => {
             out.push_str("type = \"delete_insert\"\n");
-            let keys: Vec<String> = partition_by.iter().map(|k| format!("\"{k}\"")).collect();
+            let keys: Vec<String> = partition_by
+                .iter()
+                .map(|k| format!("\"{}\"", toml_escape(k)))
+                .collect();
             out.push_str(&format!("partition_by = [{}]\n", keys.join(", ")));
         }
         StrategyConfig::TimeInterval {
@@ -402,7 +428,7 @@ fn render_model_sidecar(config: &ModelConfig) -> String {
             first_partition,
         } => {
             out.push_str("type = \"time_interval\"\n");
-            out.push_str(&format!("time_column = \"{time_column}\"\n"));
+            out.push_str(&format!("time_column = \"{}\"\n", toml_escape(time_column)));
             let g = match granularity {
                 rocky_ir::TimeGrain::Hour => "hour",
                 rocky_ir::TimeGrain::Day => "day",
@@ -413,7 +439,7 @@ fn render_model_sidecar(config: &ModelConfig) -> String {
             out.push_str(&format!("lookback = {lookback}\n"));
             out.push_str(&format!("batch_size = {}\n", batch_size.get()));
             if let Some(first) = first_partition {
-                out.push_str(&format!("first_partition = \"{first}\"\n"));
+                out.push_str(&format!("first_partition = \"{}\"\n", toml_escape(first)));
             }
         }
         // ContentAddressed doesn't arise from the dbt importer today; if we
@@ -428,9 +454,18 @@ fn render_model_sidecar(config: &ModelConfig) -> String {
     out.push('\n');
 
     out.push_str("[target]\n");
-    out.push_str(&format!("catalog = \"{}\"\n", config.target.catalog));
-    out.push_str(&format!("schema = \"{}\"\n", config.target.schema));
-    out.push_str(&format!("table = \"{}\"\n", config.target.table));
+    out.push_str(&format!(
+        "catalog = \"{}\"\n",
+        toml_escape(&config.target.catalog)
+    ));
+    out.push_str(&format!(
+        "schema = \"{}\"\n",
+        toml_escape(&config.target.schema)
+    ));
+    out.push_str(&format!(
+        "table = \"{}\"\n",
+        toml_escape(&config.target.table)
+    ));
 
     if !config.tags.is_empty() {
         out.push('\n');
@@ -444,7 +479,7 @@ fn render_model_sidecar(config: &ModelConfig) -> String {
             } else {
                 format!("{k:?}")
             };
-            out.push_str(&format!("{key} = \"{v}\"\n"));
+            out.push_str(&format!("{key} = \"{}\"\n", toml_escape(v)));
         }
     }
 
@@ -452,9 +487,9 @@ fn render_model_sidecar(config: &ModelConfig) -> String {
         out.push('\n');
         for src in &config.sources {
             out.push_str("[[sources]]\n");
-            out.push_str(&format!("catalog = \"{}\"\n", src.catalog));
-            out.push_str(&format!("schema = \"{}\"\n", src.schema));
-            out.push_str(&format!("table = \"{}\"\n", src.table));
+            out.push_str(&format!("catalog = \"{}\"\n", toml_escape(&src.catalog)));
+            out.push_str(&format!("schema = \"{}\"\n", toml_escape(&src.schema)));
+            out.push_str(&format!("table = \"{}\"\n", toml_escape(&src.table)));
         }
     }
 
@@ -467,9 +502,39 @@ fn render_model_sidecar(config: &ModelConfig) -> String {
     out
 }
 
-/// Escape a string for a double-quoted TOML basic string (backslash + quote).
+/// True when `name` is safe to use as a single `<name>.sql` / `<name>.toml`
+/// filename component: non-empty, no path separators, no parent-/absolute-path
+/// escape. A dbt manifest node name is third-party input, so a name failing
+/// this (`../x`, `/etc/x`, `a/b`) must not reach a `models_dir.join(...)`.
+fn is_safe_model_file_stem(name: &str) -> bool {
+    !name.is_empty()
+        && !name.contains('/')
+        && !name.contains('\\')
+        && !Path::new(name).is_absolute()
+        && Path::new(name).components().count() == 1
+        && Path::new(name).file_name().and_then(|n| n.to_str()) == Some(name)
+}
+
+/// Escape a string for a double-quoted TOML basic string. dbt-manifest-derived
+/// values (model/target/column names, refs, tag values) are not guaranteed to
+/// be quote-, backslash-, or newline-free, so every interpolated value must go
+/// through this — otherwise such a value could break, or inject extra keys
+/// into, the generated sidecar TOML. Control characters (incl. a raw newline,
+/// which is invalid inside a TOML basic string) are escaped too.
 fn toml_escape(s: &str) -> String {
-    s.replace('\\', "\\\\").replace('"', "\\\"")
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c.is_control() => out.push_str(&format!("\\u{:04X}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out
 }
 
 /// Serialise a [`TestDecl`] as a `[[tests]]` block matching the canonical
@@ -491,7 +556,7 @@ fn render_test_decl(test: &TestDecl) -> String {
             out.push_str("type = \"accepted_values\"\n");
             let escaped: Vec<String> = values
                 .iter()
-                .map(|v| format!("\"{}\"", v.replace('\\', "\\\\").replace('"', "\\\"")))
+                .map(|v| format!("\"{}\"", toml_escape(v)))
                 .collect();
             out.push_str(&format!("values = [{}]\n", escaped.join(", ")));
         }
@@ -500,8 +565,8 @@ fn render_test_decl(test: &TestDecl) -> String {
             to_column,
         } => {
             out.push_str("type = \"relationships\"\n");
-            out.push_str(&format!("to_table = \"{to_table}\"\n"));
-            out.push_str(&format!("to_column = \"{to_column}\"\n"));
+            out.push_str(&format!("to_table = \"{}\"\n", toml_escape(to_table)));
+            out.push_str(&format!("to_column = \"{}\"\n", toml_escape(to_column)));
         }
         TestType::Composite { kind, columns } => {
             out.push_str("type = \"composite\"\n");
@@ -509,7 +574,10 @@ fn render_test_decl(test: &TestDecl) -> String {
                 CompositeKind::Unique => "unique",
             };
             out.push_str(&format!("kind = \"{kind_str}\"\n"));
-            let cols: Vec<String> = columns.iter().map(|c| format!("\"{c}\"")).collect();
+            let cols: Vec<String> = columns
+                .iter()
+                .map(|c| format!("\"{}\"", toml_escape(c)))
+                .collect();
             out.push_str(&format!("columns = [{}]\n", cols.join(", ")));
         }
         // dbt_expectations / dbt_utils long-tail mappings.
@@ -543,16 +611,13 @@ fn render_test_decl(test: &TestDecl) -> String {
         }
     }
     if let Some(col) = &test.column {
-        out.push_str(&format!("column = \"{col}\"\n"));
+        out.push_str(&format!("column = \"{}\"\n", toml_escape(col)));
     }
     if test.severity != TestSeverity::Error {
         out.push_str("severity = \"warning\"\n");
     }
     if let Some(filter) = &test.filter {
-        out.push_str(&format!(
-            "filter = \"{}\"\n",
-            filter.replace('\\', "\\\\").replace('"', "\\\"")
-        ));
+        out.push_str(&format!("filter = \"{}\"\n", toml_escape(filter)));
     }
     out
 }
@@ -953,6 +1018,33 @@ fn write_migration_notes(path: &Path, ctx: &MigrationContext<'_>) -> Result<(), 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn is_safe_model_file_stem_rejects_traversal() {
+        assert!(is_safe_model_file_stem("stg_orders"));
+        assert!(is_safe_model_file_stem("dim_customer_v2"));
+        // Regression: a manifest node name must not traverse out of models_dir.
+        assert!(!is_safe_model_file_stem("../../escaped"));
+        assert!(!is_safe_model_file_stem("/etc/passwd"));
+        assert!(!is_safe_model_file_stem("a/b"));
+        assert!(!is_safe_model_file_stem("a\\b"));
+        assert!(!is_safe_model_file_stem(".."));
+        assert!(!is_safe_model_file_stem(""));
+    }
+
+    #[test]
+    fn toml_escape_escapes_quotes_backslash_and_newline() {
+        // Regression: an unescaped manifest value with a quote/newline could
+        // break — or inject keys into — the generated sidecar TOML.
+        assert_eq!(toml_escape(r#"a"b"#), r#"a\"b"#);
+        assert_eq!(toml_escape(r"a\b"), r"a\\b");
+        assert_eq!(toml_escape("a\nb"), r"a\nb");
+        // The escaped value round-trips through a TOML parse as one string.
+        let escaped = toml_escape("evil\"\nname = \"injected");
+        let doc = format!("name = \"{escaped}\"\n");
+        let parsed: toml::Value = toml::from_str(&doc).unwrap();
+        assert!(parsed.get("injected").is_none(), "must not inject a key");
+    }
     use crate::import::dbt::ImportMethod;
     use crate::import::dbt_profiles::{AdapterKind, resolution_for_kind};
     use rocky_core::models::{ModelConfig, StrategyConfig, TargetConfig};

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -2109,7 +2109,13 @@ fn format_env_var_hint(substitutions: &[EnvVarSubstitution]) -> String {
         .filter(|sub| seen.insert(&sub.name))
         .map(|sub| {
             let truncated = if sub.value.len() > MAX_VALUE_LEN {
-                format!("{}…", &sub.value[..MAX_VALUE_LEN])
+                // Truncate on a UTF-8 char boundary — a fixed byte slice panics
+                // when byte MAX_VALUE_LEN lands inside a multibyte character.
+                let end = (0..=MAX_VALUE_LEN)
+                    .rev()
+                    .find(|&i| sub.value.is_char_boundary(i))
+                    .unwrap_or(0);
+                format!("{}…", &sub.value[..end])
             } else {
                 sub.value.clone()
             };
@@ -5046,6 +5052,21 @@ impl ReplicationPipelineConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn format_env_var_hint_truncates_on_char_boundary() {
+        // Regression: a fixed `&value[..40]` slice panicked when byte 40 landed
+        // inside a multibyte character. A long value with multibyte chars
+        // spanning the boundary must truncate cleanly (no panic).
+        let value = "é".repeat(30); // 60 bytes; byte 40 is mid-character
+        let subs = vec![EnvVarSubstitution {
+            name: "SECRET".to_string(),
+            value,
+        }];
+        let hint = format_env_var_hint(&subs); // must not panic
+        assert!(hint.contains("SECRET"));
+        assert!(hint.contains('…'));
+    }
 
     #[test]
     fn test_imports_block_parses() {

--- a/engine/crates/rocky-core/src/hooks/template.rs
+++ b/engine/crates/rocky-core/src/hooks/template.rs
@@ -55,6 +55,46 @@ pub fn render_or_serialize(
     }
 }
 
+/// Like [`render_template`] but JSON-escapes every substituted value. Use this
+/// when the template is a JSON document (a webhook body / built-in preset): the
+/// template's own structure stays literal while interpolated data-derived
+/// values (error text, table/model names, anomaly descriptions) become safe
+/// JSON string content. Without it a value containing a `"`, `\`, or newline —
+/// common in a stringified warehouse error — breaks or injects into the payload.
+pub fn render_template_json(
+    template: &str,
+    context: &HookContext,
+) -> Result<String, TemplateError> {
+    let lookup = build_lookup(context)?;
+    let after_conditionals = resolve_conditionals(template, &lookup)?;
+    Ok(substitute_fields_inner(&after_conditionals, &lookup, true))
+}
+
+/// JSON-body variant of [`render_or_serialize`]: renders the provided template
+/// with JSON-escaped values, or serializes the full context when none is given.
+pub fn render_or_serialize_json(
+    template: Option<&str>,
+    context: &HookContext,
+) -> Result<String, TemplateError> {
+    match template {
+        Some(t) => render_template_json(t, context),
+        None => Ok(serde_json::to_string(context)?),
+    }
+}
+
+/// Escape a string as JSON string content (without the surrounding quotes) so a
+/// data-derived value substituted into a JSON body can't break out of its
+/// string. Delegates to `serde_json` so quotes, backslashes, control characters
+/// and newlines are all handled.
+fn json_escape(s: &str) -> String {
+    let quoted = serde_json::Value::String(s.to_string()).to_string();
+    // `Value::String` always serializes as `"…"`; strip the outer quotes.
+    quoted
+        .get(1..quoted.len().saturating_sub(1))
+        .unwrap_or("")
+        .to_string()
+}
+
 // ---------------------------------------------------------------------------
 // Internal: build flat lookup map
 // ---------------------------------------------------------------------------
@@ -153,6 +193,14 @@ fn resolve_conditionals(
 // ---------------------------------------------------------------------------
 
 fn substitute_fields(input: &str, lookup: &HashMap<String, String>) -> String {
+    substitute_fields_inner(input, lookup, false)
+}
+
+fn substitute_fields_inner(
+    input: &str,
+    lookup: &HashMap<String, String>,
+    json_escape_values: bool,
+) -> String {
     const OPEN: &str = "{{";
     const CLOSE: &str = "}}";
 
@@ -175,7 +223,11 @@ fn substitute_fields(input: &str, lookup: &HashMap<String, String>) -> String {
 
         let field = field_raw.trim();
         if let Some(value) = lookup.get(field) {
-            result.push_str(value);
+            if json_escape_values {
+                result.push_str(&json_escape(value));
+            } else {
+                result.push_str(value);
+            }
         }
         // else: empty string (intentionally no output for unknown fields).
 
@@ -318,5 +370,33 @@ mod tests {
         let template = r#"{"text": "{{model}} failed: {{error}}"}"#;
         let result = render_template(template, &ctx).unwrap();
         assert_eq!(result, r#"{"text": "my_model failed: timeout after 30s"}"#);
+    }
+
+    #[test]
+    fn test_json_body_escapes_quotes_and_newlines() {
+        // Regression: a data-derived error with a `"` / newline used to break
+        // or inject into the JSON webhook payload. `render_template_json` must
+        // escape substituted values so the body stays valid JSON.
+        let mut ctx = HookContext::materialize_error(
+            "run-1",
+            "pipe",
+            "cat.sch.t",
+            "boom \"quote\" and\nnewline",
+        );
+        ctx.model = Some("my_model".to_string());
+        let template = r#"{"text": "{{model}}: {{error}}"}"#;
+        let result = render_template_json(template, &ctx).unwrap();
+        // The rendered body must parse as JSON and preserve the raw value.
+        let parsed: serde_json::Value =
+            serde_json::from_str(&result).expect("rendered webhook body must be valid JSON");
+        assert_eq!(parsed["text"], "my_model: boom \"quote\" and\nnewline");
+    }
+
+    #[test]
+    fn test_plain_render_still_unescaped() {
+        // Non-JSON rendering path is unchanged (values inserted raw).
+        let ctx = test_context();
+        let result = render_template("Model: {{model}}", &ctx).unwrap();
+        assert_eq!(result, "Model: my_model");
     }
 }

--- a/engine/crates/rocky-core/src/hooks/webhook.rs
+++ b/engine/crates/rocky-core/src/hooks/webhook.rs
@@ -188,8 +188,11 @@ pub async fn fire_webhook(
     ctx: &HookContext,
     http: &reqwest::Client,
 ) -> Result<(HookResult, Option<AsyncWebhookHandle>), WebhookError> {
-    // Render the body
-    let body = template::render_or_serialize(config.body_template.as_deref(), ctx)?;
+    // Render the body. The webhook is always sent as `application/json`, so
+    // JSON-escape substituted values — a data-derived value (a stringified
+    // warehouse error, a table/model name) containing a `"` or newline would
+    // otherwise break, or inject into, the payload.
+    let body = template::render_or_serialize_json(config.body_template.as_deref(), ctx)?;
 
     if config.async_mode {
         let url = config.url.clone();

--- a/engine/crates/rocky-core/src/run_vars.rs
+++ b/engine/crates/rocky-core/src/run_vars.rs
@@ -298,7 +298,14 @@ fn comment_spans(sql: &str) -> Vec<(usize, usize)> {
                 _ => i += 1,
             },
             ScanMode::SingleQuote => {
-                if bytes[i] == b'\'' {
+                // A backslash escapes the next byte on warehouses that honor
+                // C-style string escapes (Databricks/Spark, Snowflake,
+                // BigQuery), so `\'` does not close the string — skip both
+                // bytes. (DuckDB treats `\` literally; that is a pre-existing
+                // Rocky-parser-vs-dialect gap, independent of @var.)
+                if bytes[i] == b'\\' && i + 1 < n {
+                    i += 2;
+                } else if bytes[i] == b'\'' {
                     // A doubled `''` is an escaped quote — stay in the string.
                     if i + 1 < n && bytes[i + 1] == b'\'' {
                         i += 2;
@@ -311,7 +318,9 @@ fn comment_spans(sql: &str) -> Vec<(usize, usize)> {
                 }
             }
             ScanMode::DoubleQuote => {
-                if bytes[i] == b'"' {
+                if bytes[i] == b'\\' && i + 1 < n {
+                    i += 2;
+                } else if bytes[i] == b'"' {
                     if i + 1 < n && bytes[i + 1] == b'"' {
                         i += 2;
                     } else {
@@ -412,6 +421,23 @@ mod tests {
         assert_eq!(out.missing, vec!["region".to_string()]);
         // Sentinel keeps the SQL parseable.
         assert_eq!(out.sql, "WHERE region = 'NULL'");
+    }
+
+    #[test]
+    fn substitute_var_inside_backslash_escaped_string() {
+        // Regression: the comment scanner treated `\'` as a closing quote, so a
+        // `@var` after a `--` that is actually inside a backslash-escaped string
+        // literal was misclassified as comment content and silently skipped. On
+        // warehouses that honor `\'` (Databricks/Snowflake/BigQuery) the whole
+        // literal is one string, so the var must still substitute.
+        let vars = RunVars::parse_pairs(["z=42"]).unwrap();
+        let out = substitute_run_vars(r"SELECT 'x\'y -- @var(z)' AS c FROM t", &vars);
+        assert!(
+            out.sql.contains("42"),
+            "var inside a backslash-escaped string must substitute: {}",
+            out.sql
+        );
+        assert!(out.missing.is_empty());
     }
 
     #[test]

--- a/engine/crates/rocky-core/src/sql_gen.rs
+++ b/engine/crates/rocky-core/src/sql_gen.rs
@@ -4,7 +4,8 @@ use thiserror::Error;
 use crate::lakehouse::{self, LakehouseError};
 use crate::traits::{AdapterError, SqlDialect};
 use rocky_ir::{
-    ArchivePlanIr, CompactPlanIr, MaterializationStrategy, ModelIr, ModelIrVariant, PartitionWindow,
+    ArchivePlanIr, ColumnSelection, CompactPlanIr, MaterializationStrategy, ModelIr,
+    ModelIrVariant, PartitionWindow,
 };
 
 /// Build the canonical `expected X ModelIr for \`name\`, found <actual>` error
@@ -181,6 +182,26 @@ pub fn generate_create_table_as_sql(
 ///
 /// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
 /// a replication-variant [`ModelIr`] (see [`rocky_ir::ModelIrVariant`]).
+/// Expand an implicit `ColumnSelection::All` for a `merge` to an explicit list
+/// built from the model's typed output columns. Returns the selection unchanged
+/// when it is already explicit or when `typed_columns` is empty (a partial
+/// typecheck), so the dialect's own behavior — including Snowflake/DuckDB's and
+/// BigQuery's clear "UPDATE SET * unsupported" error — still stands in that case.
+fn resolve_merge_columns(
+    update_columns: &ColumnSelection,
+    typed_columns: &[rocky_ir::types::TypedColumn],
+) -> ColumnSelection {
+    match update_columns {
+        ColumnSelection::All if !typed_columns.is_empty() => ColumnSelection::Explicit(
+            typed_columns
+                .iter()
+                .map(|c| std::sync::Arc::from(c.name.as_str()))
+                .collect(),
+        ),
+        _ => update_columns.clone(),
+    }
+}
+
 pub fn generate_merge_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
@@ -332,7 +353,15 @@ pub fn generate_transformation_sql_with_warehouse(
             unique_key,
             update_columns,
         } => {
-            let stmt = dialect.merge_into(&target, &model_ir.sql, unique_key, update_columns)?;
+            // Resolve an implicit `ColumnSelection::All` against the model's
+            // typed output columns so every dialect receives an explicit column
+            // list. BigQuery has no `UPDATE SET *` form and Snowflake/DuckDB
+            // reject it; the replication path resolves `All` against the
+            // discovered source schema, the transformation path against
+            // `typed_columns`. Without this a transformation `merge` with no
+            // explicit `update_columns` is broken on every adapter but Databricks.
+            let resolved = resolve_merge_columns(update_columns, &model_ir.typed_columns);
+            let stmt = dialect.merge_into(&target, &model_ir.sql, unique_key, &resolved)?;
             Ok(vec![stmt])
         }
         MaterializationStrategy::View => Ok(vec![generate_view_sql(model_ir, dialect)?]),
@@ -1450,6 +1479,56 @@ mod tests {
         };
         let sql = generate_select_sql(&ir, &dialect(), None).unwrap();
         assert!(!sql.contains("WHERE")); // merge SELECT is a full scan
+    }
+
+    #[test]
+    fn resolve_merge_columns_expands_all_from_typed_columns() {
+        use rocky_ir::types::{RockyType, TypedColumn};
+        let typed = vec![
+            TypedColumn {
+                name: "id".into(),
+                data_type: RockyType::Int64,
+                nullable: false,
+            },
+            TypedColumn {
+                name: "amount".into(),
+                data_type: RockyType::Int64,
+                nullable: true,
+            },
+        ];
+        match resolve_merge_columns(&ColumnSelection::All, &typed) {
+            ColumnSelection::Explicit(cols) => {
+                assert_eq!(cols.len(), 2);
+                assert_eq!(&*cols[0], "id");
+                assert_eq!(&*cols[1], "amount");
+            }
+            ColumnSelection::All => panic!("All should have resolved to Explicit"),
+        }
+    }
+
+    #[test]
+    fn resolve_merge_columns_keeps_all_when_typed_empty() {
+        // A partial typecheck (no columns) leaves `All`, so the dialect's own
+        // clear error (Snowflake/DuckDB/BigQuery) still fires rather than a
+        // silently-wrong empty column list.
+        assert!(matches!(
+            resolve_merge_columns(&ColumnSelection::All, &[]),
+            ColumnSelection::All
+        ));
+    }
+
+    #[test]
+    fn resolve_merge_columns_leaves_explicit_untouched() {
+        use rocky_ir::types::{RockyType, TypedColumn};
+        let typed = vec![TypedColumn {
+            name: "id".into(),
+            data_type: RockyType::Int64,
+            nullable: false,
+        }];
+        match resolve_merge_columns(&ColumnSelection::Explicit(vec!["x".into()]), &typed) {
+            ColumnSelection::Explicit(cols) => assert_eq!(cols.len(), 1),
+            ColumnSelection::All => panic!("Explicit must stay Explicit"),
+        }
     }
 
     #[test]

--- a/engine/crates/rocky-iceberg/src/uniform_writer/mod.rs
+++ b/engine/crates/rocky-iceberg/src/uniform_writer/mod.rs
@@ -260,6 +260,22 @@ impl UniformWriter {
                     .to_string(),
             ));
         }
+        // Scope guard: this writer allocates each partition group's baseRowId
+        // range from the per-call `state.row_tracking_next_id`, so it cannot
+        // sequence globally-disjoint ranges across >=2 groups — colliding
+        // ranges plus an under-counted rowIdHighWaterMark silently corrupt
+        // Delta row-tracking metadata. Refuse rowTracking here, mirroring
+        // `commit_pointer_with_state`; the caller must fall back to a normal
+        // build.
+        if state.row_tracking_enabled {
+            return Err(UniformWriterError::DeltaLog(
+                "partitioned content-addressed write does not support rowTracking \
+                 tables (per-group baseRowId allocation cannot be globally \
+                 sequenced across partition groups); falling back to a normal \
+                 build is the caller's responsibility"
+                    .to_string(),
+            ));
+        }
         // Validate keys match the table's partition columns.
         let table_partitions: HashSet<&str> =
             state.partition_columns.iter().map(String::as_str).collect();
@@ -862,6 +878,42 @@ mod tests {
             }
             other => panic!("expected PartitionedUnsupported, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn write_partitioned_batch_rejects_row_tracking() {
+        // Regression: a partitioned + rowTracking table allocates each
+        // group's baseRowId range from the per-call next-id and cannot
+        // globally sequence them, so it must be refused (like the point-to
+        // writer) rather than silently corrupt Delta row-tracking metadata.
+        let store: Arc<InMemory> = Arc::new(InMemory::new());
+        let writer = UniformWriter::new(
+            UniformWriterConfig {
+                catalog: "c".into(),
+                schema: "s".into(),
+                table: "t".into(),
+                prefix: "tbl".into(),
+                engine_info: "rocky-iceberg/test".into(),
+            },
+            store.clone() as Arc<dyn ObjectStore>,
+            Arc::new(PanicSqlClient),
+        );
+        let state = UniformTableState {
+            physical: HashMap::new(),
+            field_id: HashMap::new(),
+            partition_columns: vec!["region".to_string()],
+            row_tracking_enabled: true,
+            deletion_vectors_enabled: false,
+            next_commit_version: 1,
+            row_tracking_next_id: 0,
+        };
+        let mut pv = HashMap::new();
+        pv.insert("region".to_string(), "eu".to_string());
+        let err = writer
+            .write_partitioned_batch_with_state(make_partitioned_batch("eu", 1), pv, state)
+            .await
+            .expect_err("rowTracking partitioned write must be refused");
+        assert!(err.to_string().contains("rowTracking"), "{err}");
     }
 
     #[tokio::test]

--- a/engine/crates/rocky-lang/src/lower.rs
+++ b/engine/crates/rocky-lang/src/lower.rs
@@ -96,6 +96,15 @@ impl LowerContext {
                 }
             }
             PipelineStep::Derive(derivations) => {
+                // `derive` ADDS computed columns while PRESERVING existing ones
+                // (per the DSL spec). If no explicit column set has been
+                // established yet (no prior `select`/`group`), seed `*` so the
+                // base columns survive alongside the derived ones — otherwise
+                // `build_sql`, which emits `*` only when `select_columns` is
+                // empty, would drop every source column.
+                if self.select_columns.is_empty() {
+                    self.select_columns.push("*".to_string());
+                }
                 for (name, expr) in derivations {
                     let sql_expr = lower_expr(expr);
                     self.select_columns.push(format!("{sql_expr} AS {name}"));
@@ -505,6 +514,14 @@ derive {
         .unwrap();
         let sql = lower_to_sql(&file).unwrap();
         assert!(sql.contains("amount * quantity AS total"));
+        // Regression: `derive` must PRESERVE existing columns (per the DSL
+        // spec), so with no prior `select`/`group` the base columns survive via
+        // a leading `*`. Previously the derived column REPLACED the projection,
+        // silently dropping every source column.
+        assert!(
+            sql.contains('*'),
+            "derive must keep base columns (expected `SELECT *, ...`): {sql}"
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-sql/src/lineage.rs
+++ b/engine/crates/rocky-sql/src/lineage.rs
@@ -366,9 +366,98 @@ fn extract_expr_lineage(
     }
 }
 
+/// Every source column a single-source consumer model references, lowercased —
+/// collected from the WHOLE statement (projection, `WHERE`, `JOIN ... ON`,
+/// `GROUP BY`, `HAVING`, `ORDER BY`, and every operand of a function call,
+/// binary op, or `CASE`), not just the top-level projection that
+/// [`extract_lineage`] walks.
+///
+/// This exists for the cross-team-contract gate (`rocky compile` / `rocky ci`),
+/// which must know *every* producer column a consumer touches so a breaking
+/// change to a column read only in — say — a `WHERE` filter or a `COALESCE`'s
+/// second argument is still flagged. [`extract_lineage`] deliberately captures
+/// only projection output columns (for the Inspector / lineage surfaces), so it
+/// under-reports for this purpose.
+///
+/// Returns an empty set on a parse failure; the caller treats an empty result
+/// conservatively (all producer columns considered read).
+pub fn referenced_columns(sql: &str) -> std::collections::BTreeSet<String> {
+    use std::ops::ControlFlow;
+
+    use sqlparser::ast::{Ident, Visit, Visitor};
+
+    struct ColumnRefVisitor {
+        columns: std::collections::BTreeSet<String>,
+    }
+
+    impl Visitor for ColumnRefVisitor {
+        type Break = ();
+
+        fn pre_visit_expr(&mut self, expr: &Expr) -> ControlFlow<()> {
+            match expr {
+                Expr::Identifier(Ident { value, .. }) => {
+                    self.columns.insert(value.to_lowercase());
+                }
+                // `t.col` / `cat.sch.t.col` — the trailing part is the column.
+                Expr::CompoundIdentifier(parts) => {
+                    if let Some(last) = parts.last() {
+                        self.columns.insert(last.value.to_lowercase());
+                    }
+                }
+                _ => {}
+            }
+            ControlFlow::Continue(())
+        }
+    }
+
+    let mut visitor = ColumnRefVisitor {
+        columns: std::collections::BTreeSet::new(),
+    };
+    if let Ok(statement) = crate::parser::parse_single_statement(sql) {
+        let _: ControlFlow<()> = statement.visit(&mut visitor);
+    }
+    visitor.columns
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn referenced_columns_captures_where_and_all_function_args() {
+        // Regression: `extract_lineage` walked only the projection and only a
+        // function's FIRST arg, so `region` (WHERE) and `amount` (COALESCE 2nd
+        // arg) were dropped from the cross-team-contract read-set.
+        let cols = referenced_columns(
+            "SELECT id, COALESCE(id, amount) AS a FROM shop.core.orders WHERE region = 'US'",
+        );
+        assert!(cols.contains("id"));
+        assert!(cols.contains("amount"), "2nd COALESCE arg must be captured");
+        assert!(cols.contains("region"), "WHERE column must be captured");
+    }
+
+    #[test]
+    fn referenced_columns_captures_binary_and_case_operands() {
+        let cols = referenced_columns(
+            "SELECT price * quantity AS total, CASE WHEN status = 'x' THEN 1 ELSE 0 END AS f \
+             FROM shop.core.orders",
+        );
+        for c in ["price", "quantity", "status"] {
+            assert!(cols.contains(c), "operand `{c}` must be captured");
+        }
+    }
+
+    #[test]
+    fn referenced_columns_captures_compound_identifier_column() {
+        let cols = referenced_columns("SELECT o.id FROM shop.core.orders o WHERE o.region = 'US'");
+        assert!(cols.contains("id"));
+        assert!(cols.contains("region"));
+    }
+
+    #[test]
+    fn referenced_columns_empty_on_unparsable() {
+        assert!(referenced_columns("SELCT FROM").is_empty());
+    }
 
     #[test]
     fn test_simple_select() {


### PR DESCRIPTION
A hardening sweep across the engine: 13 confirmed findings from a two-pass review, each adversarially verified against the actual call path (operator-run-CLI threat model — operator-authored input is not treated as an attack surface). Every fix carries a regression test that fails without it; the two high-severity items are additionally verified end-to-end on DuckDB.

## Security

- **import-dbt path traversal + sidecar injection** — a dbt manifest is a third-party build artifact, but its node `name` flowed unvalidated into `models_dir.join(...)` + `std::fs::write` (arbitrary-path, arbitrary-content write), and `render_model_sidecar` interpolated manifest values into TOML with only `intent` escaped. `write_model_files` now rejects unsafe filename components (mirroring the read-side `safe_join_under`), and every sidecar value goes through a hardened `toml_escape`.
- **cross-team-contract gate under-enforced** — `extract_lineage` captures only the top-level projection (and only a function's first argument), so the E030/E031/E032 gate missed producer columns a consumer reads via `WHERE`, a 2nd+ function arg, arithmetic, or `CASE` — letting genuine breaking changes pass silently. `imports_check` now builds the read-set from a complete column walk over the whole statement.
- **webhook JSON injection** — webhook bodies (always `application/json`, incl. the built-in slack/pagerduty/datadog/teams presets) substituted data-derived values (error text, table/model names) raw; a value with a quote or newline broke or injected into the payload. Bodies now render with JSON-escaped values.
- **env-var hint panic** — `format_env_var_hint` sliced a substituted value at a fixed byte offset, panicking on a multibyte character at the boundary; now truncates on a char boundary.

## Bugs

- **transformation `merge` unresolved columns** — a transformation `merge` model with no `update_columns` passed `ColumnSelection::All` straight to the dialect: BigQuery emitted the invalid `UPDATE SET target = source`, Snowflake/DuckDB errored on `UPDATE SET *`; only Databricks worked. The transformation path now resolves `All` against the model's typed output columns (the run path enriches `typed_columns` from the typechecker), and BigQuery fails fast on `All` like its siblings. *Verified on DuckDB: a transformation merge now bootstraps and upserts correctly.*
- **replication partial-failure reporting** — a runtime model failure on the replication `--all`/`--models` path returned a raw error, skipping the JSON emit and exiting 1 with empty stdout instead of the PartialFailure sentinel (exit 2). It now records the failure and flows through the terminal emit. *Verified on DuckDB: `rocky run --all --output json` with a failing model now exits 2 with a populated `errors[]`.*
- **`[[checks.custom]]` inverted comparison** — the wired custom-check evaluator used `result_value >= threshold`, so a violation-counting check was reported PASS (and with the default `threshold = 0` could never fail). It now delegates to the canonical `checks::check_custom` (`<= threshold`), removing the duplicate that had drifted.
- **budget not enforced on transformation runs** — the transformation path never ran the `[budget]` check, making the guardrail a silent no-op on the highest-compute pipeline type. It now runs and propagates a hard breach, matching the replication and model-only paths.
- **iceberg partitioned rowTracking corruption** — the partitioned content-addressed writer allocated colliding `baseRowId` ranges across partition groups (silently corrupting Delta row-tracking metadata); it now refuses that combination, mirroring the point-to writer's guard.
- **DSL `derive` dropped base columns** — `derive` replaced the projection instead of adding to it, silently dropping every source column against the documented "preserves existing" contract; it now seeds `*` when no explicit column set exists yet.
- **emit-sql inconsistencies** — `rocky emit-sql` now honors compile errors (bails instead of emitting/persisting the missing-`@var` sentinel `NULL`) and errors on a `--model` that matches nothing (instead of silently succeeding).
- **`@var` in backslash-escaped strings** — the comment scanner treated `\'` as a closing quote, so a `@var` inside a backslash-escaped string literal (honored on Databricks/Snowflake/BigQuery) was misclassified as a comment and silently skipped; the scanner now handles backslash escapes.
- **import-dbt regex `$`-expansion** — the no-manifest import path passed else-block SQL as a `&str` replacement to `Regex::replace`, so a `$` in the operator's SQL was interpreted as a capture-group reference and silently corrupted the output; now wrapped in `regex::NoExpand`.

## Verification

`cargo test` (all affected crates), `clippy --all-targets`, and `fmt --check` are green; schema export is byte-identical (no codegen drift). The two high-severity fixes were driven end-to-end on a local DuckDB pipeline.