### PR TITLE
fix(engine/rocky-lang): terminal-derive wildcard should not apply to derive+group

### DIFF
--- a/docs/src/content/docs/concepts/rocky-dsl.md
+++ b/docs/src/content/docs/concepts/rocky-dsl.md
@@ -22,11 +22,8 @@ A Rocky file is a sequence of pipeline steps. Data flows from the top step downw
 ```
 from orders
 where status == "completed"
-derive {
-    total: amount * quantity
-}
 group customer_id {
-    revenue: sum(total),
+    revenue: sum(amount * quantity),
     order_count: count()
 }
 sort revenue desc

--- a/engine/crates/rocky-lang/src/lower.rs
+++ b/engine/crates/rocky-lang/src/lower.rs
@@ -65,6 +65,12 @@ struct LowerContext {
     is_replicate: bool,
     // Tracks whether we've hit a GROUP BY (subsequent WHERE becomes HAVING)
     has_group: bool,
+    // Tracks whether a `derive` added computed columns, so `build_sql` can keep
+    // the base columns (`*, <derived>`) — but only when no explicit `select` or
+    // `group` established the projection.
+    has_derive: bool,
+    // Set by an explicit `select { ... }`, which replaces the projection.
+    explicit_select: bool,
 }
 
 impl LowerContext {
@@ -97,20 +103,18 @@ impl LowerContext {
             }
             PipelineStep::Derive(derivations) => {
                 // `derive` ADDS computed columns while PRESERVING existing ones
-                // (per the DSL spec). If no explicit column set has been
-                // established yet (no prior `select`/`group`), seed `*` so the
-                // base columns survive alongside the derived ones — otherwise
-                // `build_sql`, which emits `*` only when `select_columns` is
-                // empty, would drop every source column.
-                if self.select_columns.is_empty() {
-                    self.select_columns.push("*".to_string());
-                }
+                // (per the DSL spec). `build_sql` prepends `*` for a terminal
+                // derive (no following `select`/`group`) so the base columns
+                // survive; a following `select` replaces the projection and a
+                // following `group` establishes its own, so neither wants `*`.
+                self.has_derive = true;
                 for (name, expr) in derivations {
                     let sql_expr = lower_expr(expr);
                     self.select_columns.push(format!("{sql_expr} AS {name}"));
                 }
             }
             PipelineStep::Select(items) => {
+                self.explicit_select = true;
                 self.select_columns.clear();
                 for item in items {
                     match item {
@@ -200,6 +204,13 @@ impl LowerContext {
         if self.select_columns.is_empty() {
             sql.push('*');
         } else {
+            // A terminal `derive` (computed columns, no explicit `select` and no
+            // `group`) must keep the base columns, so prepend `*`. A `select`
+            // replaces the projection and a `group` establishes its own, so
+            // neither gets `*` (a `SELECT *` with GROUP BY is invalid SQL).
+            if self.has_derive && !self.explicit_select && !self.has_group {
+                sql.push_str("*, ");
+            }
             sql.push_str(&self.select_columns.join(", "));
         }
 
@@ -522,6 +533,51 @@ derive {
             sql.contains('*'),
             "derive must keep base columns (expected `SELECT *, ...`): {sql}"
         );
+    }
+
+    #[test]
+    fn test_lower_derive_then_group_has_no_wildcard() {
+        // A `derive` followed by a `group` must NOT emit `SELECT *` — a wildcard
+        // with GROUP BY is invalid SQL. The group establishes the projection, so
+        // the base-column-preserving `*` from a terminal derive must not apply.
+        let file = parse(
+            r#"from orders
+derive {
+    total: amount * quantity
+}
+group customer_id {
+    revenue: sum(total)
+}"#,
+        )
+        .unwrap();
+        let sql = lower_to_sql(&file).unwrap();
+        assert!(sql.contains("GROUP BY customer_id"), "{sql}");
+        assert!(
+            !sql.contains("SELECT *") && !sql.contains("*, "),
+            "derive+group must not emit a wildcard projection: {sql}"
+        );
+    }
+
+    #[test]
+    fn test_lower_derive_then_select_replaces() {
+        // An explicit `select` replaces the projection, so no base-column `*`.
+        let file = parse(
+            r#"from orders
+derive {
+    doubled: amount * 2
+}
+select {
+    id,
+    doubled
+}"#,
+        )
+        .unwrap();
+        let sql = lower_to_sql(&file).unwrap();
+        assert!(
+            !sql.contains('*'),
+            "explicit select replaces the projection (no wildcard): {sql}"
+        );
+        assert!(sql.contains("id, doubled"), "{sql}");
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #1007. The DSL `derive` base-column-preservation fix seeded `*` into the projection at the `derive` step, but `group` *appends* to that projection (unlike `select`, which replaces it) — so a `derive` followed by `group` emitted `SELECT *, ... GROUP BY ...`, invalid SQL.

The decision now lives in `build_sql`, keyed on `has_derive`/`explicit_select`: prepend `*` only for a **terminal** derive (no following `select` or `group`).

- **Terminal derive** — still preserves base columns (`SELECT *, <derived>`); verified the window-functions POC compiles and `rocky test` executes 2/2 on DuckDB.
- **derive+group** — restored to its prior projection (no wildcard).
- **derive+select** — unchanged (`select` replaces the projection).

Regression tests added for all three shapes.

Also corrects the DSL reference intro example, which used `derive`→`group` with an idealized lowering the compiler doesn't produce (it does not inline a derived alias into a group aggregation — a separate, pre-existing lowering gap). The example now inlines the expression so it lowers to exactly the documented SQL; the `derive` construct keeps its own accurate example.

No POC or example uses the derive→group pattern; it was already producing invalid SQL before #1007.