### PR TITLE
feat(sdk,dagster): per-call run-timeout resolver (decouple watchdog from copy phase)

### DIFF
--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -292,6 +292,7 @@ def _collect_supplied_run_kwargs(
     shadow_suffix: str | None,
     governance_override: dict | None,
     idempotency_key: str | None,
+    timeout_seconds: int | None = None,
 ) -> dict[str, Any]:
     """Build the ``kwargs`` dict handed to :meth:`RockyResource._apply_resolvers`.
 
@@ -308,6 +309,8 @@ def _collect_supplied_run_kwargs(
         kwargs["governance_override"] = governance_override
     if idempotency_key is not None:
         kwargs["idempotency_key"] = idempotency_key
+    if timeout_seconds is not None:
+        kwargs["timeout_seconds"] = timeout_seconds
     return kwargs
 
 
@@ -476,11 +479,17 @@ class RockyResource(dg.ConfigurableResource):
         contracts_dir: Optional directory containing contract files.
         server_url: Optional URL for a running ``rocky serve`` instance. When set,
             ``compile()``, ``lineage()`` and ``metrics()`` use the HTTP API.
-        timeout_seconds: Subprocess timeout for any one CLI invocation.
+        timeout_seconds: Default subprocess timeout for any one CLI invocation.
         shadow_suffix_fn: Optional resolver that produces ``shadow_suffix`` per
             call when the caller doesn't supply one. Returning ``None`` is a no-op.
         governance_override_fn: Optional resolver for ``governance_override``.
         idempotency_key_fn: Optional resolver for ``idempotency_key``.
+        timeout_fn: Optional resolver that produces a per-call ``timeout_seconds``
+            watchdog budget. Fires when the caller omits ``timeout_seconds``;
+            returning ``None`` falls back to the static :attr:`timeout_seconds`.
+            Lets a tenant-collapsed pipeline grant only its heavy tenants a larger
+            copy budget while keeping a tight hang-detection watchdog everywhere
+            else — e.g. ``lambda ctx: 5400 if ctx.filter in HEAVY else 900``.
     """
 
     binary_path: str = "rocky"
@@ -522,6 +531,12 @@ class RockyResource(dg.ConfigurableResource):
     shadow_suffix_fn: Annotated[Resolver | None, "resource_dependency"] = None
     governance_override_fn: Annotated[Resolver | None, "resource_dependency"] = None
     idempotency_key_fn: Annotated[Resolver | None, "resource_dependency"] = None
+    #: Optional resolver that produces a per-call ``timeout_seconds`` watchdog
+    #: budget. Unlike the three resolvers above (which inject CLI-argument
+    #: kwargs), the resolved value is threaded to the SDK watchdog as a per-call
+    #: override — ``timeout_seconds`` is not a CLI flag. Fires only when the
+    #: caller omits ``timeout_seconds``; ``None`` falls back to the static field.
+    timeout_fn: Annotated[Resolver | None, "resource_dependency"] = None
 
     # Lazily-built SDK client, cached per resource instance. Dagster rebuilds the
     # resource per asset; each rebuild gets a fresh client (re-resolves the
@@ -592,6 +607,10 @@ class RockyResource(dg.ConfigurableResource):
             ("shadow_suffix", self.shadow_suffix_fn),
             ("governance_override", self.governance_override_fn),
             ("idempotency_key", self.idempotency_key_fn),
+            # ``timeout_seconds`` is not a CLI flag: the run methods read the
+            # resolved value out of ``kwargs`` and thread it to the SDK watchdog
+            # as a per-call override, never to ``_build_run_args``.
+            ("timeout_seconds", self.timeout_fn),
         ):
             if fn is None or kw in kwargs:
                 continue
@@ -710,15 +729,24 @@ class RockyResource(dg.ConfigurableResource):
         """Build the argv for ``rocky plan`` (delegates to the client)."""
         return self._get_client()._build_plan_args(filter, **kwargs)
 
-    def _run_rocky(self, args: list[str], *, allow_partial: bool = False) -> str:
+    def _run_rocky(
+        self, args: list[str], *, allow_partial: bool = False, timeout_seconds: int | None = None
+    ) -> str:
         """Execute a Rocky CLI command and return stdout (errors → ``dg.Failure``).
 
         Streams the binary's stderr to the ``dagster_rocky`` module logger
         line-by-line. Used for read-only invocations without a Dagster context;
         for live ``context.log`` streaming see :meth:`_run_rocky_streaming`.
+
+        ``timeout_seconds`` overrides the client's static watchdog budget for this
+        one invocation; forwarded only when set so the default path is unchanged.
         """
         with _translating():
-            return self._get_client().run_cli(args, allow_partial=allow_partial)
+            if timeout_seconds is None:
+                return self._get_client().run_cli(args, allow_partial=allow_partial)
+            return self._get_client().run_cli(
+                args, allow_partial=allow_partial, timeout_seconds=timeout_seconds
+            )
 
     def _run_rocky_streaming(
         self,
@@ -800,6 +828,7 @@ class RockyResource(dg.ConfigurableResource):
         idempotency_key: str | None = None,
         defer: bool = False,
         defer_to: str | None = None,
+        timeout_seconds: int | None = None,
     ) -> RunResult:
         """Run ``rocky run --filter <key=value>`` and return the parsed result.
 
@@ -819,6 +848,10 @@ class RockyResource(dg.ConfigurableResource):
                 do NOT put secrets in idempotency keys.
             defer / defer_to: Resolve unbuilt ``ref()`` upstreams against an
                 existing schema instead of rebuilding.
+            timeout_seconds: Per-call watchdog budget (positive seconds) for this
+                one run. Overrides both :attr:`timeout_seconds` and any
+                :attr:`timeout_fn` resolver. When omitted, ``timeout_fn`` (if set)
+                resolves the budget, else the static :attr:`timeout_seconds`.
 
         Note on resolver interaction:
             Per-call resolvers registered on the resource fire for the matching
@@ -834,6 +867,7 @@ class RockyResource(dg.ConfigurableResource):
                 shadow_suffix=shadow_suffix,
                 governance_override=governance_override,
                 idempotency_key=idempotency_key,
+                timeout_seconds=timeout_seconds,
             ),
         )
         _validate_governance_override(resolved.get("governance_override"))
@@ -842,6 +876,7 @@ class RockyResource(dg.ConfigurableResource):
                 filter,
                 governance_override=resolved.get("governance_override"),
                 pipeline=pipeline,
+                timeout_seconds=resolved.get("timeout_seconds"),
                 run_models=run_models,
                 partition=partition,
                 partition_from=partition_from,
@@ -874,6 +909,7 @@ class RockyResource(dg.ConfigurableResource):
         idempotency_key: str | None = None,
         defer: bool = False,
         defer_to: str | None = None,
+        timeout_seconds: int | None = None,
     ) -> RunResult:
         """``rocky run`` with live stderr streaming to ``context.log``.
 
@@ -883,6 +919,9 @@ class RockyResource(dg.ConfigurableResource):
         Dagster ``@multi_asset`` / ``@op`` for runs longer than a few seconds. For
         full Dagster Pipes integration with structured events, use
         :meth:`run_pipes`.
+
+        ``timeout_seconds`` (and the :attr:`timeout_fn` resolver) apply here in
+        full: the whole ``rocky run`` — copy plus finalize — is watchdog-bound.
         """
         resolved = self._apply_resolvers(
             context=context,
@@ -892,6 +931,7 @@ class RockyResource(dg.ConfigurableResource):
                 shadow_suffix=shadow_suffix,
                 governance_override=governance_override,
                 idempotency_key=idempotency_key,
+                timeout_seconds=timeout_seconds,
             ),
         )
         _validate_governance_override(resolved.get("governance_override"))
@@ -916,6 +956,7 @@ class RockyResource(dg.ConfigurableResource):
                 idempotency_key=resolved.get("idempotency_key"),
                 defer=defer,
                 defer_to=defer_to,
+                timeout_seconds=resolved.get("timeout_seconds"),
                 log_callback=_sink,
             )
 
@@ -986,6 +1027,7 @@ class RockyResource(dg.ConfigurableResource):
         idempotency_key: str | None = None,
         defer: bool = False,
         defer_to: str | None = None,
+        timeout_seconds: int | None = None,
         pipes_client: dg.PipesSubprocessClient | None = None,
         asset_key_fn: Callable[[list[str]], dg.AssetKey | None] | None = None,
         include_keys: set[dg.AssetKey] | None = None,
@@ -1002,12 +1044,13 @@ class RockyResource(dg.ConfigurableResource):
             def my_warehouse_data(context: dg.AssetExecutionContext, rocky: RockyResource):
                 yield from rocky.run_pipes(context, filter="tenant=acme").get_results()
 
-        **Timeout contract.** ``timeout_seconds`` does **not** apply to the apply
-        step in Pipes mode — ``PipesSubprocessClient`` owns the subprocess and
-        exposes no kill hook. The plan step still routes through :meth:`_run_rocky`
+        **Timeout contract.** Neither ``timeout_seconds`` nor the
+        :attr:`timeout_fn` resolver bounds the apply step in Pipes mode —
+        ``PipesSubprocessClient`` owns the subprocess and exposes no kill hook.
+        Both bound only the plan step, which routes through :meth:`_run_rocky`
         and is watchdog-bound. Configure a Dagster-side run timeout for hard
-        bounding, or use :meth:`run_streaming` if you need the resource-level
-        watchdog.
+        bounding, or use :meth:`run_streaming` if you need a resource-level
+        watchdog around the copy.
 
         Args:
             context: Dagster execution context (required for Pipes injection).
@@ -1032,6 +1075,7 @@ class RockyResource(dg.ConfigurableResource):
                 shadow_suffix=shadow_suffix,
                 governance_override=governance_override,
                 idempotency_key=idempotency_key,
+                timeout_seconds=timeout_seconds,
             ),
         )
         _validate_governance_override(resolved.get("governance_override"))
@@ -1072,7 +1116,9 @@ class RockyResource(dg.ConfigurableResource):
             client = dg.PipesSubprocessClient()
         # Plan step is buffered and a separate subprocess (the engine's Pipes
         # emitter is a no-op on ``rocky plan`` — only ``rocky apply`` reports).
-        plan_stdout = self._run_rocky(plan_args)
+        # The per-call timeout bounds this watchdog-backed plan step (the apply
+        # step below is Pipes-owned and unbounded — see the timeout contract).
+        plan_stdout = self._run_rocky(plan_args, timeout_seconds=resolved.get("timeout_seconds"))
         plan_id = self._extract_plan_id(plan_stdout)
         if plan_id is None:
             raise dg.Failure(

--- a/integrations/dagster/tests/test_resolvers.py
+++ b/integrations/dagster/tests/test_resolvers.py
@@ -90,14 +90,19 @@ def _capture_run_args() -> tuple[list[list[str]], Any]:
 
     Resolver tests assert against ``captured[0]`` (the run argv). The fake
     stands in for :meth:`RockyClient.run_cli`, since ``rocky.run`` now delegates
-    resource -> client -> ``run_cli``.
+    resource -> client -> ``run_cli``. Each call's per-call ``timeout_seconds``
+    (forwarded by the SDK only when set) is recorded on ``fake_run.timeouts`` so
+    ``timeout_fn`` tests can assert what reached the watchdog boundary.
     """
     captured: list[list[str]] = []
+    timeouts: list[int | None] = []
 
-    def fake_run(self, args, *, allow_partial=False, log_callback=None):
+    def fake_run(self, args, *, allow_partial=False, log_callback=None, timeout_seconds=None):
         captured.append(args)
+        timeouts.append(timeout_seconds)
         return _empty_run_json()
 
+    fake_run.timeouts = timeouts  # type: ignore[attr-defined]
     return captured, fake_run
 
 
@@ -594,3 +599,165 @@ def test_resolvers_survive_dagster_materialize_lifecycle():
     assert "--shadow-suffix" in captured[0]
     idx = captured[0].index("--shadow-suffix")
     assert captured[0][idx + 1] == "_dagster_pr_xyz"
+
+
+# ---------------------------------------------------------------------------
+# timeout_fn — per-call watchdog budget (unlike the three above, the resolved
+# value is threaded to the SDK watchdog as a per-call override, not an argv flag)
+# ---------------------------------------------------------------------------
+
+
+def test_timeout_fn_resolves_per_call_budget():
+    calls: list[ResolverContext] = []
+
+    def fn(rc: ResolverContext) -> int:
+        calls.append(rc)
+        return 5400
+
+    rocky = RockyResource(timeout_fn=fn)
+    captured, fake_run = _capture_run_args()
+
+    with patch.object(RockyClient, "run_cli", autospec=True, side_effect=fake_run):
+        rocky.run(filter="client=cocacola")
+
+    assert len(calls) == 1
+    assert fake_run.timeouts == [5400]
+    # Not a CLI flag: nothing timeout-shaped is threaded into the run argv.
+    assert not any("timeout" in tok for tok in captured[0])
+
+
+def test_timeout_fn_skipped_when_caller_supplies_value():
+    """Caller-supplied ``timeout_seconds`` wins — resolver must not fire."""
+    calls: list[ResolverContext] = []
+
+    def fn(rc: ResolverContext) -> int:
+        calls.append(rc)
+        return 5400
+
+    rocky = RockyResource(timeout_fn=fn)
+    _, fake_run = _capture_run_args()
+
+    with patch.object(RockyClient, "run_cli", autospec=True, side_effect=fake_run):
+        rocky.run(filter="client=cocacola", timeout_seconds=99)
+
+    assert calls == []  # resolver never fired
+    assert fake_run.timeouts == [99]
+
+
+def test_timeout_fn_none_return_falls_back_to_static():
+    """A resolver returning ``None`` fires but leaves the static budget in force
+    (the SDK then omits the per-call override, so ``run_cli`` sees ``None``).
+    """
+    calls: list[str] = []
+
+    def fn(_rc: ResolverContext) -> int | None:
+        calls.append("fired")
+        return None
+
+    rocky = RockyResource(timeout_fn=fn)
+    _, fake_run = _capture_run_args()
+
+    with patch.object(RockyClient, "run_cli", autospec=True, side_effect=fake_run):
+        rocky.run(filter="waltdisney")
+
+    assert calls == ["fired"]
+    assert fake_run.timeouts == [None]
+
+
+def test_timeout_absent_leaves_static_budget():
+    """No resolver and no caller value → no per-call override reaches the SDK."""
+    rocky = RockyResource()
+    _, fake_run = _capture_run_args()
+
+    with patch.object(RockyClient, "run_cli", autospec=True, side_effect=fake_run):
+        rocky.run(filter="waltdisney")
+
+    assert fake_run.timeouts == [None]
+
+
+def test_timeout_fn_keys_on_filter_for_heavy_tenants():
+    """The FR's canonical shape: tight budget for light tenants, generous for
+    the handful of heavy ones, keyed off the run filter.
+    """
+    heavy = {"client=cocacola", "client=pfizer"}
+
+    def fn(rc: ResolverContext) -> int:
+        return 5400 if rc.filter in heavy else 900
+
+    rocky = RockyResource(timeout_fn=fn)
+    _, fake_run = _capture_run_args()
+
+    with patch.object(RockyClient, "run_cli", autospec=True, side_effect=fake_run):
+        rocky.run(filter="client=cocacola")
+        rocky.run(filter="client=waltdisney")
+
+    assert fake_run.timeouts == [5400, 900]
+
+
+def test_timeout_fn_fires_on_run_streaming():
+    rocky = RockyResource(timeout_fn=lambda _rc: 4242)
+    context = _captured_log_context()
+    _, fake_run = _capture_run_args()
+
+    with patch.object(RockyClient, "run_cli", autospec=True, side_effect=fake_run):
+        rocky.run_streaming(context, filter="client=cocacola")
+
+    assert fake_run.timeouts == [4242]
+
+
+def test_timeout_fn_bounds_run_pipes_plan_step():
+    """In Pipes mode the resolved budget bounds the watchdog-backed plan step
+    (the Pipes-owned apply step is unbounded — see the timeout contract).
+    """
+    rocky = RockyResource(timeout_fn=lambda _rc: 3333)
+    context = MagicMock()
+    pipes_client = MagicMock()
+    pipes_client.run = MagicMock(return_value=MagicMock())
+    seen: list[tuple[str, int | None]] = []
+
+    def fake_run(self, args, *, allow_partial=False, log_callback=None, timeout_seconds=None):
+        seen.append((args[0], timeout_seconds))
+        return _plan_json() if args[0] == "plan" else _empty_run_json()
+
+    with patch.object(RockyClient, "run_cli", autospec=True, side_effect=fake_run):
+        rocky.run_pipes(context, filter="client=cocacola", pipes_client=pipes_client)
+
+    # Only the plan step routes through run_cli; apply goes via pipes_client.run.
+    assert seen == [("plan", 3333)]
+
+
+def test_timeout_fn_nonpositive_value_surfaces_error():
+    """A resolver bug returning a non-positive budget fails loudly (the SDK
+    guard raises before any subprocess spawns); it is not a ``RockyError`` so it
+    is not translated to ``dg.Failure``.
+    """
+    rocky = RockyResource(timeout_fn=lambda _rc: 0)
+
+    with pytest.raises(ValueError, match="timeout_seconds must be a positive"):
+        rocky.run(filter="client=cocacola")
+
+
+def test_timeout_fn_survives_dagster_materialize_lifecycle():
+    """The ``Annotated`` resolver field survives Dagster's resource rebuild at
+    execution time (mirrors ``test_resolvers_survive_dagster_materialize_lifecycle``).
+    """
+
+    def my_timeout_resolver(_rc: ResolverContext) -> int:
+        return 5400
+
+    rocky = RockyResource(
+        binary_path="rocky",
+        config_path="rocky.toml",
+        timeout_fn=my_timeout_resolver,
+    )
+    _, fake_run = _capture_run_args()
+
+    @dg.asset
+    def my_asset(rocky: RockyResource) -> None:
+        rocky.run(filter="client=cocacola")
+
+    with patch.object(RockyClient, "run_cli", autospec=True, side_effect=fake_run):
+        result = dg.materialize([my_asset], resources={"rocky": rocky})
+
+    assert result.success
+    assert fake_run.timeouts == [5400]

--- a/integrations/dagster/tests/test_resource.py
+++ b/integrations/dagster/tests/test_resource.py
@@ -1409,7 +1409,7 @@ def test_run_pipes_threads_all_partition_flags():
 
     captured_plan_args: list[list[str]] = []
 
-    def fake_run_rocky(self, args, *, allow_partial=False):
+    def fake_run_rocky(self, args, *, allow_partial=False, timeout_seconds=None):
         captured_plan_args.append(args)
         return _plan_json()
 
@@ -1561,7 +1561,7 @@ def test_run_pipes_with_shadow_suffix():
 
     captured_plan_args: list[list[str]] = []
 
-    def fake_run_rocky(self, args, *, allow_partial=False):
+    def fake_run_rocky(self, args, *, allow_partial=False, timeout_seconds=None):
         captured_plan_args.append(args)
         return _plan_json()
 

--- a/sdk/python/src/rocky_sdk/client.py
+++ b/sdk/python/src/rocky_sdk/client.py
@@ -482,6 +482,7 @@ class RockyClient:
         *,
         allow_partial: bool = False,
         log_callback: Callable[[str], None] | None = None,
+        timeout_seconds: int | None = None,
     ) -> str:
         """Execute the Rocky CLI and return stdout.
 
@@ -499,14 +500,27 @@ class RockyClient:
                 with valid JSON (Rocky's partial-success semantics).
             log_callback: Per-stderr-line sink. Defaults to the client's logger
                 (``"rocky: <line>"`` at INFO).
+            timeout_seconds: Per-call wall-clock override for the watchdog. When
+                ``None`` (default), the client's construction-time
+                ``timeout_seconds`` governs. When set it must be positive, and
+                overrides that budget for this one invocation only.
 
         Raises:
             RockyBinaryNotFoundError: The binary is missing.
-            RockyTimeoutError: The subprocess exceeded ``timeout_seconds``.
+            RockyTimeoutError: The subprocess exceeded the effective timeout (the
+                per-call ``timeout_seconds`` when given, else the client default).
+            ValueError: ``timeout_seconds`` was supplied and non-positive.
             RockyPartialFailure: Non-zero exit with parseable JSON and
                 ``allow_partial=False``.
             RockyCommandError: Any other non-zero exit.
         """
+        if timeout_seconds is not None and timeout_seconds <= 0:
+            raise ValueError(
+                f"timeout_seconds must be a positive number of seconds, got {timeout_seconds!r}"
+            )
+        # A per-call override wins for this invocation only; otherwise the
+        # construction-time budget governs the watchdog and the timeout error.
+        effective_timeout = self.timeout_seconds if timeout_seconds is None else timeout_seconds
         self._verify_engine_version()
         cmd = self._build_cmd(args)
         sink = log_callback or (lambda line: self._logger.info("rocky: %s", line))
@@ -537,7 +551,7 @@ class RockyClient:
         self._logger.info(
             "rocky subprocess started: pid=%s timeout_s=%s cmd=%s",
             proc.pid,
-            self.timeout_seconds,
+            effective_timeout,
             " ".join(redact_argv(cmd)),
         )
 
@@ -566,7 +580,7 @@ class RockyClient:
         fired = threading.Event()
 
         def _watchdog() -> None:
-            if not fired.wait(self.timeout_seconds):
+            if not fired.wait(effective_timeout):
                 kill_process_group(proc)
                 fired.set()
 
@@ -613,7 +627,7 @@ class RockyClient:
 
         if killed_by_watchdog:
             raise RockyTimeoutError(
-                self.timeout_seconds,
+                effective_timeout,
                 stderr_tail=stderr_tail,
                 duration_ms=duration_ms,
                 pid=proc.pid,
@@ -737,6 +751,7 @@ class RockyClient:
         defer: bool = False,
         defer_to: str | None = None,
         log_callback: Callable[[str], None] | None = None,
+        timeout_seconds: int | None = None,
     ) -> RunResult:
         """Run ``rocky run --filter <key=value>`` and return the parsed result.
 
@@ -757,6 +772,11 @@ class RockyClient:
             defer / defer_to: Resolve unbuilt ``ref()`` upstreams against an
                 existing schema instead of rebuilding.
             log_callback: Per-stderr-line sink for live progress (e.g. ``print``).
+            timeout_seconds: Per-call watchdog override (positive seconds). When
+                ``None`` (default), the client's construction-time
+                ``timeout_seconds`` governs this run. A tenant-collapsed run that
+                copies a heavy client's tables in one invocation can pass a larger
+                budget here without relaxing it for every other run.
         """
         _validate_governance_override(governance_override)
         run_args = self._build_run_args(
@@ -776,7 +796,17 @@ class RockyClient:
             defer=defer,
             defer_to=defer_to,
         )
-        stdout = self.run_cli(run_args, allow_partial=True, log_callback=log_callback)
+        # Forward the per-call override only when supplied so the default path
+        # calls ``run_cli`` exactly as before (construction-time budget wins).
+        if timeout_seconds is None:
+            stdout = self.run_cli(run_args, allow_partial=True, log_callback=log_callback)
+        else:
+            stdout = self.run_cli(
+                run_args,
+                allow_partial=True,
+                log_callback=log_callback,
+                timeout_seconds=timeout_seconds,
+            )
         return _parse_run_or_apply(stdout, command="run")
 
     def run_model(

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -208,6 +208,59 @@ def test_run_cli_timeout_when_watchdog_kills():
     assert exc.value.timeout_seconds == client.timeout_seconds
 
 
+def test_run_cli_per_call_timeout_overrides_static():
+    """A per-call ``timeout_seconds`` supersedes the construction-time budget."""
+    client = _client(timeout_seconds=3600)
+    proc = _fake_popen(stdout="", stderr="slow\n", returncode=-signal.SIGKILL)
+    with (
+        patch("rocky_sdk.client.os.name", "posix"),
+        patch("rocky_sdk.client.subprocess.Popen", return_value=proc),
+        pytest.raises(RockyTimeoutError) as exc,
+    ):
+        client.run_cli(["run"], allow_partial=True, timeout_seconds=5)
+    # The error carries the effective (per-call) budget, not the static 3600.
+    assert exc.value.timeout_seconds == 5
+
+
+def test_run_cli_none_timeout_uses_static_budget():
+    """``timeout_seconds=None`` leaves the construction-time budget in force."""
+    client = _client(timeout_seconds=1234)
+    proc = _fake_popen(stdout="", stderr="", returncode=-signal.SIGKILL)
+    with (
+        patch("rocky_sdk.client.os.name", "posix"),
+        patch("rocky_sdk.client.subprocess.Popen", return_value=proc),
+        pytest.raises(RockyTimeoutError) as exc,
+    ):
+        client.run_cli(["run"], allow_partial=True, timeout_seconds=None)
+    assert exc.value.timeout_seconds == 1234
+
+
+@pytest.mark.parametrize("bad", [0, -1, -900])
+def test_run_cli_rejects_nonpositive_timeout(bad):
+    """A resolver bug returning a non-positive budget fails loudly, not silently."""
+    client = _client()
+    with (
+        patch("rocky_sdk.client.subprocess.Popen") as popen,
+        pytest.raises(ValueError, match="timeout_seconds must be a positive"),
+    ):
+        client.run_cli(["run"], timeout_seconds=bad)
+    # Rejected before any subprocess is spawned.
+    popen.assert_not_called()
+
+
+def test_run_forwards_per_call_timeout_to_watchdog():
+    """``run()`` threads its ``timeout_seconds`` down to the watchdog boundary."""
+    client = _client(timeout_seconds=3600)
+    proc = _fake_popen(stdout="", stderr="", returncode=-signal.SIGKILL)
+    with (
+        patch("rocky_sdk.client.os.name", "posix"),
+        patch("rocky_sdk.client.subprocess.Popen", return_value=proc),
+        pytest.raises(RockyTimeoutError) as exc,
+    ):
+        client.run("client=cocacola", timeout_seconds=42)
+    assert exc.value.timeout_seconds == 42
+
+
 def test_run_cli_binary_not_found():
     client = _client()
     with (


### PR DESCRIPTION
## Problem

`RockyClient.timeout_seconds` is a single construction-time wall-clock that the SDK watchdog enforces around the **entire** `rocky run` invocation (discover → copy every table → state upload → grants). On a tenant-collapsed replication pipeline, one run copies a whole tenant's tables in a single subprocess, so that one number is forced to be both:

- **small**, to catch a wedged state-upload / warehouse hang quickly (the reason the watchdog exists), and
- **large**, to avoid hard-killing a legitimately long copy for a heavy tenant.

Those requirements conflict. A blanket-large timeout makes every light tenant wait just as long for hang detection.

## Change

Add a **per-call timeout override**, threaded to the watchdog rather than the argv (it is not a CLI flag):

**`rocky-sdk`** — `run_cli()` and `run()` gain an optional `timeout_seconds`. When set it overrides the construction-time budget for that one invocation and is carried into the start log, the watchdog wait, and `RockyTimeoutError`; when `None` the static budget governs. Forwarded to `run_cli` only when set, so the default path is unchanged. Non-positive values raise `ValueError` before any subprocess spawns.

**`dagster-rocky`** — a `timeout_fn` resolver on `RockyResource`, mirroring the existing per-call resolver pattern (`shadow_suffix_fn` / `governance_override_fn` / `idempotency_key_fn`). `run` / `run_streaming` / `run_pipes` also accept an explicit `timeout_seconds` (caller value wins; the resolver fires when omitted; `None` falls back to the static field). In Pipes mode the budget bounds only the watchdog-backed plan step, consistent with the documented apply-step contract.

```python
RockyResource(
    ...,
    timeout_fn=lambda ctx: 5400 if ctx.filter in HEAVY else 900,
)
```

This keeps a tight hang-detection watchdog for the many light tenants and grants only the heavy handful a larger copy budget, without a blanket relaxation.

## Compatibility

Fully backward compatible: unset → current single-`timeout_seconds` behavior, byte-for-byte on the default path. `timeout_seconds` is not a wire type, so there is no codegen/schema impact.

## Tests

- SDK: per-call override supersedes the static budget, `None` uses the static budget, non-positive rejected before spawn, `run()` threads the value to the watchdog boundary.
- dagster: resolver fires / caller-wins / `None`-falls-back / absent; keys-on-filter; `run_streaming` and `run_pipes` plan-step paths; non-positive surfaces; and the `Annotated` field survives the `dg.materialize` resource-rebuild lifecycle.

Reviewed via a multi-dimension adversarial pass (concurrency, backward-compat, edge/validation, test coverage, correctness/docs) — no findings survived verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)