### PR TITLE
chore: release sdk 0.1.7 / dagster 1.54.0 / vscode 1.33.4

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.33.4] — 2026-07-02
+
+### Changed
+
+- Maintenance: bumped the dependency group (`vscode-languageclient`, `@types/node`, `eslint`, `vscode-languageserver-protocol`) and refreshed the generated CLI type bindings for `import-dbt` (structured-warning variants) and `run` (the `compile-error` failure kind). No user-facing behavior change. (#1004, engine #972/#975)
+
 ## [1.33.3] — 2026-06-23
 
 ### Changed

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocky",
-  "version": "1.33.3",
+  "version": "1.33.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocky",
-      "version": "1.33.3",
+      "version": "1.33.4",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^10.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.33.3",
+  "version": "1.33.4",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.54.0] — 2026-07-02
+
+### Added
+
+- **`RockyResource.timeout_fn` — a per-call watchdog-budget resolver.** Mirrors the existing per-call resolver pattern (`shadow_suffix_fn` / `governance_override_fn` / `idempotency_key_fn`), but the resolved value is threaded to the SDK watchdog as a per-call `timeout_seconds` override rather than a CLI argument (`timeout_seconds` is not a CLI flag). `run` / `run_streaming` / `run_pipes` also accept an explicit `timeout_seconds` (caller value wins; the resolver fires when omitted; `None` falls back to the static `timeout_seconds`). Lets a tenant-collapsed pipeline keep a tight hang-detection watchdog for the light tenants and grant only the heavy handful a larger copy budget, without a blanket relaxation. In Pipes mode the budget bounds only the watchdog-backed plan step, consistent with the documented apply-step contract. (#1012)
+
+### Changed
+
+- Floor `rocky-sdk>=0.1.7` — `timeout_fn` forwards the resolved budget to `RockyClient.run(timeout_seconds=…)`, the per-call override added in rocky-sdk 0.1.7.
+
 ## [1.53.0] — 2026-06-28
 
 ### Added

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.53.0"
+version = "1.54.0"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"
@@ -23,7 +23,7 @@ dependencies = [
     # package; RockyResource is a thin Dagster adapter over RockyClient. In-repo
     # dev/CI resolves this from the local path (see [tool.uv.sources]); the
     # published wheel floors on the released SDK.
-    "rocky-sdk>=0.1.5",
+    "rocky-sdk>=0.1.7",
     # Floor matches the version CI actually resolves and tests (uv.lock). The
     # RockyComponent path uses dagster.components.* APIs from preview namespaces,
     # so we advertise a tested floor rather than an older, never-exercised one.

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -220,7 +220,7 @@ wheels = [
 
 [[package]]
 name = "dagster-rocky"
-version = "1.53.0"
+version = "1.54.0"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },
@@ -910,7 +910,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "../../sdk/python" }
 dependencies = [
     { name = "pydantic" },

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7] — 2026-07-02
+
+### Added
+
+- **Per-call `timeout_seconds` override on `RockyClient.run()` / `run_cli()`.** The watchdog budget could previously only be set once at client construction, so a single wall-clock had to cover the whole `rocky run` (discover → copy every table → state upload). A tenant-collapsed run that copies a heavy tenant's tables in one invocation could not have both fast hang detection and a generous copy budget. `run()` / `run_cli()` now accept an optional `timeout_seconds` that overrides the construction-time budget for that one invocation — it is what the watchdog waits on and what `RockyTimeoutError` reports. Unset preserves the existing behavior exactly (forwarded only when supplied). Non-positive values raise `ValueError` before any subprocess spawns. (#1012)
+
 ## [0.1.6] — 2026-06-27
 
 ### Changed

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rocky-sdk"
-version = "0.1.6"
+version = "0.1.7"
 description = "Typed Python client for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.1.5"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Consolidated release cut.

## rocky-sdk 0.1.7
- **Per-call `timeout_seconds` override** on `RockyClient.run()` / `run_cli()` — overrides the construction-time watchdog budget for one invocation; unset preserves existing behavior; non-positive raises `ValueError` pre-spawn. (#1012)

## dagster-rocky 1.54.0
- **`RockyResource.timeout_fn`** — a per-call watchdog-budget resolver, alongside the existing `shadow_suffix_fn` / `governance_override_fn` / `idempotency_key_fn`. `run` / `run_streaming` / `run_pipes` also take an explicit `timeout_seconds` (caller wins → resolver → static). (#1012)
- Floor **`rocky-sdk>=0.1.7`** (the resolver forwards to `RockyClient.run(timeout_seconds=…)`).

## vscode 1.33.4
- Maintenance: dependency group bump + regenerated `import-dbt` / `run` CLI type bindings. No user-facing change. (#1004)

## Release order after merge
1. Tag `sdk-v0.1.7`, push → PyPI publish; **wait for it to land** (dagster floors on it).
2. Tag `dagster-v1.54.0`, push → PyPI publish.
3. Tag `vscode-v1.33.4`, push → Marketplace publish.

Pre-flight: sdk 42 + dagster 679 tests green, ruff clean, floor resolves via path dep, versions consistent. No codegen impact (#1012 touched no schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)