### PR TITLE
fix(vscode): pin @types/vscode to engines floor so vsce package succeeds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,6 +59,11 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # @types/vscode must stay <= engines.vscode (^1.120.0), or `vsce package`
+      # fails at release time. Bump it by hand in lockstep with engines.vscode
+      # and the test-electron pin (src/test/runTest.ts), never via dependabot.
+      - dependency-name: "@types/vscode"
 
   # --- GitHub Actions (root workflows) ---
   - package-ecosystem: github-actions

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Maintenance: bumped the dependency group (`vscode-languageclient`, `@types/node`, `eslint`, `vscode-languageserver-protocol`) and refreshed the generated CLI type bindings for `import-dbt` (structured-warning variants) and `run` (the `compile-error` failure kind). No user-facing behavior change. (#1004, engine #972/#975)
 
+### Fixed
+
+- Pinned `@types/vscode` back to `1.120.0` to match `engines.vscode` (`^1.120.0`); a prior drift to `1.125.0` made `vsce package` fail the release build (`@types/vscode … greater than engines.vscode`). Added a dependabot `ignore` so `@types/vscode` stays in lockstep with the engine floor and the test-electron pin.
+
 ## [1.33.3] — 2026-06-23
 
 ### Changed

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -21,7 +21,7 @@
         "@types/node": "^26.0.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
-        "@types/vscode": "1.125.0",
+        "@types/vscode": "1.120.0",
         "@vscode/test-electron": "^3.0.0",
         "@vscode/vsce": "^3.9.1",
         "@xyflow/react": "^12.11.1",
@@ -2756,9 +2756,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.125.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
-      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
+      "version": "1.120.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
+      "integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
       "dev": true,
       "license": "MIT"
     },

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -998,7 +998,7 @@
     "@types/node": "^26.0.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
-    "@types/vscode": "1.125.0",
+    "@types/vscode": "1.120.0",
     "@vscode/test-electron": "^3.0.0",
     "@vscode/vsce": "^3.9.1",
     "@xyflow/react": "^12.11.1",


### PR DESCRIPTION
Unblocks the vscode-v1.33.4 release, whose `Build and publish` job failed at `vsce package`:

```
@types/vscode 1.125.0 greater than engines.vscode ^1.120.0.
Either upgrade engines.vscode or use an older @types/vscode version
```

`@types/vscode` had drifted to 1.125.0 (a prior bump) while `engines.vscode` stayed `^1.120.0` and the test-electron pin (`src/test/runTest.ts`) stayed `1.120.0`. `vsce` rejects `@types/vscode` above the engines floor, so the release build failed — but compile + unit CI pass, so it only surfaced at package/publish time.

## Fix
- Pin `@types/vscode` → `1.120.0` (matches the engines floor + test pin). The extension **compiles, packages, and passes 202 unit tests** against it, confirming it genuinely supports its declared floor — no need to raise the minimum VS Code version.
- Add a dependabot `ignore` for `@types/vscode` so it can only move by hand, in lockstep with `engines.vscode` + the test pin.

After merge, `vscode-v1.33.4` is re-tagged at the fixed commit to re-run the release (1.33.4 never reached the Marketplace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)