### PR TITLE
fix(dagster): mark RockyTimeoutError Failure non-retryable

### DIFF
--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A `rocky run` watchdog timeout now surfaces as a non-retryable `dg.Failure`.** `_rocky_error_to_failure` builds the `RockyTimeoutError` branch with `allow_retries=False`, so a blanket op `RetryPolicy` no longer retries a deterministic over-budget run. Re-running at the same budget re-fails by construction, so the old default turned one over-budget run into roughly 4x the budget in futile retries. The remedy for a genuinely borderline run is a larger per-call budget via `timeout_fn` (added in 1.54.0), not a same-budget re-run. The transient circuit-breaker path (`retry_after_seconds`) stays retryable, and consumers without a `RetryPolicy` are unaffected. (#1021)
+
 ## [1.54.0] — 2026-07-02
 
 ### Added

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -190,6 +190,15 @@ def _rocky_error_to_failure(exc: RockyError) -> dg.Failure:
     if isinstance(exc, RockyTimeoutError):
         return dg.Failure(
             description=f"Rocky command timed out after {exc.timeout_seconds}s (watchdog-killed)",
+            # A watchdog timeout is a deterministic "too slow", not a transient
+            # error: re-running the same over-budget command at the same budget
+            # re-fails by construction. Opt out of Dagster's retry machinery so a
+            # blanket op RetryPolicy doesn't turn one over-budget run into 4x the
+            # budget in futile retries. The remedy for a genuinely borderline run
+            # is a larger budget (per-call via `timeout_fn`), not a same-budget
+            # re-run. The retryable path (a transient circuit-breaker breach) is a
+            # distinct raise in `component._quota_breach_failure` and is unaffected.
+            allow_retries=False,
             metadata={
                 "stderr_tail": dg.MetadataValue.text(
                     _truncate_stderr_for_metadata(exc.stderr_tail)

--- a/integrations/dagster/tests/test_resource.py
+++ b/integrations/dagster/tests/test_resource.py
@@ -27,11 +27,17 @@ from rocky_sdk.client import (
     DEFAULT_HTTP_TIMEOUT_SECONDS,
     _parse_run_or_apply,
 )
-from rocky_sdk.exceptions import RockyOutputParseError, RockyServerError
+from rocky_sdk.exceptions import (
+    RockyCommandError,
+    RockyOutputParseError,
+    RockyServerError,
+    RockyTimeoutError,
+)
 
 from dagster_rocky.resource import (
     MIN_ROCKY_VERSION,
     RockyResource,
+    _rocky_error_to_failure,
     _truncate_stderr_for_metadata,
     _validate_governance_override,
 )
@@ -2514,3 +2520,42 @@ def test_run_rocky_failure_truncates_oversize_stderr_in_metadata():
     text = metadata["stderr_tail"].text
     assert len(text) <= 8300
     assert "truncated" in text
+
+
+# ---------------------------------------------------------------------------
+# Error translation: retryability
+# ---------------------------------------------------------------------------
+
+
+def test_timeout_failure_is_non_retryable():
+    """A watchdog timeout surfaces as a *non-retryable* ``dg.Failure``.
+
+    A timeout is a deterministic "too slow": re-running the same command at the
+    same budget re-fails by construction, so a blanket op ``RetryPolicy`` must
+    not retry it (otherwise one over-budget run becomes ~4x the budget in futile
+    retries). The fix adds ``allow_retries=False`` without dropping the
+    operator-debugging metadata the branch has always carried.
+    """
+    failure = _rocky_error_to_failure(
+        RockyTimeoutError(900, stderr_tail="copying orders…", duration_ms=901_234, pid=4242)
+    )
+
+    assert failure.allow_retries is False
+    assert "timed out after 900s" in failure.description
+    # Metadata preserved by the fix (regression guard against dropping the block).
+    assert failure.metadata["duration_ms"].value == 901_234
+    assert failure.metadata["pid"].value == 4242
+    assert "stderr_tail" in failure.metadata
+
+
+def test_non_timeout_failures_stay_retryable():
+    """The ``allow_retries`` opt-out is surgical to the timeout branch.
+
+    A plain command failure can be transient (a flaky warehouse statement), so
+    it keeps Dagster's default retry behavior (``allow_retries`` left at its
+    default, which allows retries). Pins that the timeout fix did not make every
+    ``RockyError`` non-retryable.
+    """
+    failure = _rocky_error_to_failure(RockyCommandError(1, stderr_tail="boom", duration_ms=12))
+
+    assert failure.allow_retries is not False


### PR DESCRIPTION
## What

A `rocky run` watchdog timeout now surfaces as a **non-retryable** `dg.Failure`.

`_rocky_error_to_failure` built the `RockyTimeoutError` branch as a plain `dg.Failure`, which defaults to retryable. A blanket op `RetryPolicy` therefore retried a watchdog timeout — re-running the same over-budget `rocky run` at the same budget, which re-fails by construction. One over-budget run became roughly 4x the budget in futile retries before failing.

## Fix

Construct the timeout branch with `allow_retries=False`. Surgical and one-directional:

- The transient circuit-breaker path (`_quota_breach_failure`, `retry_after_seconds`) is a distinct raise and stays retryable.
- Consumers without a `RetryPolicy` are unaffected (nothing to retry).
- The remedy for a genuinely borderline run is a larger per-call budget via `timeout_fn` (1.54.0), not a same-budget re-run.

## Tests

Adds first coverage for the timeout branch of `_rocky_error_to_failure`:

- `test_timeout_failure_is_non_retryable` — timeout → `allow_retries is False`, metadata preserved.
- `test_non_timeout_failures_stay_retryable` — a plain command failure keeps the default (retryable), proving the opt-out is surgical.

Full suite green (681 passed), `ruff check` + `ruff format --check` clean.

## Release

Lands under `[Unreleased]`; rides the next `dagster-v` cut (1.54.0 already shipped today).