### PR TITLE
fix(engine): rocky plan honors merge + table_overrides on replication

### DIFF
--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -193,32 +193,46 @@ pub async fn plan(
                 })
                 .collect();
 
+            let target_label = if effective_target_catalog.is_empty() {
+                format!("{target_schema}.{}", table.name)
+            } else {
+                format!("{effective_target_catalog}.{target_schema}.{}", table.name)
+            };
+
             // Resolve the per-table override and the effective strategy the
             // SAME way `rocky run` does (`build_replication_strategy_with_override`),
             // so the preview reflects `merge` and per-table `[[table_overrides]]`
-            // instead of always rendering full_refresh. The two paths MUST agree
-            // — a plan that disagrees with run is the bug this closes.
+            // instead of always rendering full_refresh. plan and run MUST agree —
+            // divergence is the bug this closes.
             let effective_override = resolve_table_override(
                 &pipeline.table_overrides,
                 &conn.id,
                 &conn.schema,
                 &table.name,
             );
-            let strategy = super::run::build_replication_strategy_with_override(
+            let strategy = match super::run::build_replication_strategy_with_override(
                 pipeline,
                 &effective_override,
-            )
-            .unwrap_or_else(|e| {
-                // Only reachable for a `merge` strategy with no resolvable
-                // merge_keys — `rocky validate` (V001/V035) rejects that at
-                // config-load, so this is a defensive fallback, not a hot path.
-                tracing::warn!(
-                    table = %table.name,
-                    error = %e,
-                    "plan: could not resolve replication strategy; previewing as full_refresh"
-                );
-                MaterializationStrategy::FullRefresh
-            });
+            ) {
+                Ok(strategy) => strategy,
+                Err(e) => {
+                    // The builder rejects this strategy on a replication pipeline
+                    // (`dynamic_table`, or `merge` with no resolvable merge_keys).
+                    // `rocky run` fails this table via the same builder, so
+                    // reflect that rather than a spurious full_refresh CTAS.
+                    tracing::warn!(
+                        table = %table.name,
+                        error = %e,
+                        "plan: strategy unsupported on replication; run will fail this table"
+                    );
+                    output.statements.push(PlannedStatement {
+                        purpose: "unsupported".into(),
+                        target: target_label,
+                        sql: format!("-- {}: {e} (rocky run will fail this table)", table.name),
+                    });
+                    continue;
+                }
+            };
             let purpose = replication_copy_purpose(&strategy);
 
             // sql_gen consumes the typed IR directly.
@@ -228,7 +242,7 @@ pub async fn plan(
                     schema: target_schema.clone(),
                     table: table.name.clone(),
                 },
-                strategy.clone(),
+                strategy,
                 SourceRef {
                     catalog: effective_source_catalog.clone(),
                     schema: conn.schema.clone(),
@@ -243,18 +257,12 @@ pub async fn plan(
                 },
             );
 
-            // Render the forward-looking copy SQL for the resolved strategy —
-            // full_refresh → CTAS, incremental → INSERT with the 1970 sentinel
-            // watermark (the runner threads the real watermark at execute time),
-            // merge → MERGE INTO. See `replication_copy_sql` for the
-            // Snowflake-merge preview caveat.
+            // Forward-looking copy SQL matching what `rocky run` executes for
+            // the resolved strategy (full_refresh → CTAS, incremental → INSERT
+            // with the 1970 sentinel watermark the runner replaces at execute
+            // time, merge → MERGE INTO, view / materialized_view → their DDL).
             let sql = replication_copy_sql(&model_ir, dialect)?;
 
-            let target_label = if effective_target_catalog.is_empty() {
-                format!("{target_schema}.{}", table.name)
-            } else {
-                format!("{effective_target_catalog}.{target_schema}.{}", table.name)
-            };
             output.statements.push(PlannedStatement {
                 purpose: purpose.into(),
                 target: target_label,
@@ -547,13 +555,16 @@ fn strategy_purpose(strategy: &MaterializationStrategy) -> &'static str {
 /// Map a resolved replication-copy [`MaterializationStrategy`] to the `purpose`
 /// label used on a [`PlannedStatement`].
 ///
-/// `build_replication_strategy_with_override` only produces `FullRefresh`,
-/// `Incremental`, or `Merge` for a replication pipeline, so the catch-all is a
-/// defensive fallback rather than a reachable state.
+/// `build_replication_strategy_with_override` produces `FullRefresh`,
+/// `Incremental`, `Merge`, `View`, or `MaterializedView` for a replication
+/// pipeline (its only `Err` — `dynamic_table` — is handled at the call site, so
+/// it never reaches here). The catch-all is a defensive fallback.
 fn replication_copy_purpose(strategy: &MaterializationStrategy) -> &'static str {
     match strategy {
         MaterializationStrategy::Incremental { .. } => "incremental_copy",
         MaterializationStrategy::Merge { .. } => "merge_copy",
+        MaterializationStrategy::View => "view",
+        MaterializationStrategy::MaterializedView => "materialized_view",
         _ => "full_refresh_copy",
     }
 }
@@ -562,14 +573,17 @@ fn replication_copy_purpose(strategy: &MaterializationStrategy) -> &'static str 
 /// dialect and strategy `rocky run` will execute: `full_refresh` → `CREATE OR
 /// REPLACE TABLE AS`, `incremental` → `INSERT` with the 1970 sentinel watermark
 /// (the runner threads the real prior watermark at execute time), `merge` →
-/// `MERGE INTO`.
+/// `MERGE INTO`, `view` / `materialized_view` → their DDL (mirrors
+/// `run.rs::process_table`).
 ///
 /// `plan` is offline and has no live source schema, so a `Merge` is rendered
-/// with `ColumnSelection::All` (`UPDATE SET *`). Dialects that reject `*` in a
-/// `MERGE` (Snowflake) cannot be previewed exactly — the runner resolves the
-/// explicit column list from the live source at execute time — so those degrade
-/// to a shape-only preview naming the merge target, rather than erroring the
-/// whole plan. Databricks / DuckDB / BigQuery preview the exact `MERGE INTO`.
+/// with `ColumnSelection::All` (`UPDATE SET *`). A dialect whose MERGE requires
+/// an explicit column list (DuckDB, Snowflake, BigQuery — anything except
+/// Databricks today) cannot be previewed exactly, because the runner resolves
+/// that list from the live source at execute time; those degrade to a canonical
+/// shape preview via [`preview_merge_shape`] rather than erroring the whole
+/// plan. `materialized_view` DDL likewise degrades to a note on dialects that
+/// don't support it (DuckDB, Trino), where `rocky run` fails the table too.
 fn replication_copy_sql(model_ir: &ModelIr, dialect: &dyn SqlDialect) -> Result<String> {
     let sql = match &model_ir.materialization {
         MaterializationStrategy::FullRefresh => {
@@ -581,28 +595,42 @@ fn replication_copy_sql(model_ir: &ModelIr, dialect: &dyn SqlDialect) -> Result<
         MaterializationStrategy::Merge { .. } => {
             match sql_gen::generate_merge_sql(model_ir, dialect) {
                 Ok(sql) => sql,
-                // DuckDB / Snowflake reject `UPDATE SET *` and need an explicit
-                // column list the offline plan can't know; render the canonical
-                // shape instead of erroring the whole plan.
+                // The dialect rejected `UPDATE SET *` (needs explicit columns
+                // the offline plan can't know) or a merge key is invalid;
+                // `preview_merge_shape` renders the canonical shape or a note
+                // instead of erroring the whole plan.
                 Err(_) => preview_merge_shape(model_ir, dialect)?,
             }
         }
-        // Replication only builds full_refresh / incremental / merge.
-        _ => sql_gen::generate_insert_sql(model_ir, dialect, None)?,
+        MaterializationStrategy::View => {
+            let (target, body) = replication_target_and_body(model_ir, dialect)?;
+            dialect.view_ddl(&target, &body)?
+        }
+        MaterializationStrategy::MaterializedView => {
+            let (target, body) = replication_target_and_body(model_ir, dialect)?;
+            match dialect.materialized_view_ddl(&target, &body) {
+                Ok(sql) => sql,
+                Err(_) => format!(
+                    "-- MATERIALIZED VIEW {target}: not supported by {} \
+                     (rocky run will fail this table)",
+                    dialect.name()
+                ),
+            }
+        }
+        // `build_replication_strategy_with_override` never returns another
+        // variant for a replication pipeline; defensive fallback.
+        _ => sql_gen::generate_create_table_as_sql(model_ir, dialect)?,
     };
     Ok(sql)
 }
 
-/// Canonical `MERGE INTO … WHEN MATCHED THEN UPDATE SET *` preview for dialects
-/// whose `merge_into` requires an explicit column list (DuckDB, Snowflake) that
-/// an offline plan cannot resolve. Mirrors the shape `rocky run` emits once it
-/// has read the live source schema, with a trailing note that the explicit
-/// columns resolve at execute time — so the reviewer sees the table upserts,
-/// not full-refreshes.
-fn preview_merge_shape(model_ir: &ModelIr, dialect: &dyn SqlDialect) -> Result<String> {
-    let MaterializationStrategy::Merge { unique_key, .. } = &model_ir.materialization else {
-        return Ok(sql_gen::generate_create_table_as_sql(model_ir, dialect)?);
-    };
+/// The `(target_ref, "SELECT …\nFROM source_ref")` pair `rocky run` builds for a
+/// replication view / materialized-view / merge body. Kept in one place so the
+/// preview and the runner stay in lockstep.
+fn replication_target_and_body(
+    model_ir: &ModelIr,
+    dialect: &dyn SqlDialect,
+) -> Result<(String, String)> {
     let columns = model_ir
         .columns
         .as_ref()
@@ -618,13 +646,39 @@ fn preview_merge_shape(model_ir: &ModelIr, dialect: &dyn SqlDialect) -> Result<S
     )?;
     let source_ref = dialect.format_table_ref(&source.catalog, &source.schema, &source.table)?;
     let select = dialect.select_clause(columns, &model_ir.metadata_columns)?;
+    Ok((target, format!("{select}\nFROM {source_ref}")))
+}
+
+/// Canonical `MERGE INTO … WHEN MATCHED THEN UPDATE SET *` preview for dialects
+/// whose `merge_into` requires an explicit column list an offline plan cannot
+/// resolve. Mirrors the shape `rocky run` emits once it has read the live source
+/// schema, with a trailing note that the explicit columns resolve at execute
+/// time — so the reviewer sees the table upserts, not full-refreshes.
+///
+/// Merge keys are validated up front (as the real dialect `merge_into` does), so
+/// a bad `merge_key` surfaces as a note rather than a healthy-looking preview
+/// that `rocky run` would reject.
+fn preview_merge_shape(model_ir: &ModelIr, dialect: &dyn SqlDialect) -> Result<String> {
+    let MaterializationStrategy::Merge { unique_key, .. } = &model_ir.materialization else {
+        return Ok(sql_gen::generate_create_table_as_sql(model_ir, dialect)?);
+    };
+    if let Some(bad) = unique_key
+        .iter()
+        .find(|k| rocky_sql::validation::validate_identifier(k).is_err())
+    {
+        return Ok(format!(
+            "-- MERGE INTO {}.{}: invalid merge key {bad:?} (rocky run will fail this table)",
+            model_ir.target.schema, model_ir.target.table
+        ));
+    }
+    let (target, body) = replication_target_and_body(model_ir, dialect)?;
     let on = unique_key
         .iter()
         .map(|k| format!("t.{k} = s.{k}"))
         .collect::<Vec<_>>()
         .join(" AND ");
     Ok(format!(
-        "MERGE INTO {target} AS t\nUSING (\n{select}\nFROM {source_ref}\n) AS s\nON {on}\n\
+        "MERGE INTO {target} AS t\nUSING (\n{body}\n) AS s\nON {on}\n\
          WHEN MATCHED THEN UPDATE SET *\nWHEN NOT MATCHED THEN INSERT *\n\
          -- preview: {} resolves explicit UPDATE/INSERT columns from the live source at run time",
         dialect.name()
@@ -1753,17 +1807,14 @@ mod tests {
     // render full_refresh)
     // ------------------------------------------------------------------
 
-    fn merge_replication_ir() -> ModelIr {
+    fn replication_ir(strategy: MaterializationStrategy) -> ModelIr {
         ModelIr::replication(
             TargetRef {
                 catalog: "cat".into(),
                 schema: "staging".into(),
                 table: "orders".into(),
             },
-            MaterializationStrategy::Merge {
-                unique_key: vec![Arc::from("order_id")],
-                update_columns: ColumnSelection::All,
-            },
+            strategy,
             SourceRef {
                 catalog: "cat".into(),
                 schema: "raw".into(),
@@ -1779,8 +1830,17 @@ mod tests {
         )
     }
 
+    fn merge_ir() -> ModelIr {
+        replication_ir(MaterializationStrategy::Merge {
+            unique_key: vec![Arc::from("order_id")],
+            update_columns: ColumnSelection::All,
+        })
+    }
+
     #[test]
-    fn replication_copy_purpose_maps_the_three_replication_strategies() {
+    fn replication_copy_purpose_maps_every_builder_strategy() {
+        // Must cover every variant build_replication_strategy_with_override can
+        // return (its only Err — dynamic_table — is handled at the call site).
         assert_eq!(
             replication_copy_purpose(&MaterializationStrategy::FullRefresh),
             "full_refresh_copy"
@@ -1798,39 +1858,149 @@ mod tests {
             }),
             "merge_copy"
         );
+        assert_eq!(
+            replication_copy_purpose(&MaterializationStrategy::View),
+            "view"
+        );
+        assert_eq!(
+            replication_copy_purpose(&MaterializationStrategy::MaterializedView),
+            "materialized_view"
+        );
     }
 
     #[test]
-    fn replication_merge_preview_renders_merge_into_for_star_dialects() {
-        let ir = merge_replication_ir();
-        // Databricks / DuckDB accept `UPDATE SET *`, so the offline preview is
-        // exact — and must NOT be a full-refresh CTAS (the bug).
-        for adapter in ["duckdb", "databricks"] {
-            let dialect = dialect_for_adapter_type(adapter);
-            let sql = replication_copy_sql(&ir, dialect.as_ref()).expect("merge preview sql");
-            assert!(
-                sql.contains("MERGE INTO"),
-                "{adapter}: merge preview must render MERGE INTO, got:\n{sql}"
-            );
-            assert!(
-                !sql.to_uppercase().contains("CREATE OR REPLACE TABLE"),
-                "{adapter}: merge preview must not fall back to full_refresh CTAS, got:\n{sql}"
-            );
-        }
-    }
-
-    #[test]
-    fn replication_merge_preview_degrades_without_error_on_snowflake() {
-        // Snowflake's MERGE rejects `UPDATE SET *` and the explicit column list
-        // is only knowable from the live source, so the offline preview must
-        // degrade to a shape-only note — never error, never render full_refresh.
-        let ir = merge_replication_ir();
-        let dialect = dialect_for_adapter_type("snowflake");
-        let sql = replication_copy_sql(&ir, dialect.as_ref())
-            .expect("snowflake merge preview must not error the whole plan");
+    fn replication_full_refresh_and_incremental_preview_sql() {
+        let dialect = dialect_for_adapter_type("databricks");
+        let full = replication_copy_sql(
+            &replication_ir(MaterializationStrategy::FullRefresh),
+            dialect.as_ref(),
+        )
+        .expect("full_refresh sql");
         assert!(
-            sql.contains("MERGE INTO"),
-            "snowflake preview should still name the merge target, got:\n{sql}"
+            full.to_uppercase().contains("CREATE OR REPLACE TABLE"),
+            "full_refresh must render CTAS, got:\n{full}"
+        );
+
+        let incr = replication_copy_sql(
+            &replication_ir(MaterializationStrategy::Incremental {
+                timestamp_column: "_updated_at".into(),
+            }),
+            dialect.as_ref(),
+        )
+        .expect("incremental sql");
+        assert!(
+            incr.contains("INSERT INTO") && incr.contains("1970"),
+            "incremental must be an INSERT with the 1970 sentinel watermark, got:\n{incr}"
+        );
+    }
+
+    #[test]
+    fn replication_merge_preview_is_exact_on_databricks() {
+        // Databricks accepts `UPDATE SET *`, so the offline preview is the exact
+        // dialect SQL — no degrade note, byte-identical to generate_merge_sql.
+        let ir = merge_ir();
+        let dialect = dialect_for_adapter_type("databricks");
+        let preview = replication_copy_sql(&ir, dialect.as_ref()).expect("merge preview");
+        let exact =
+            sql_gen::generate_merge_sql(&ir, dialect.as_ref()).expect("databricks accepts `*`");
+        assert_eq!(
+            preview, exact,
+            "databricks merge preview must be the exact dialect MERGE, not a degrade"
+        );
+        assert!(preview.contains("MERGE INTO") && preview.contains("UPDATE SET *"));
+        assert!(
+            !preview.contains("-- preview:"),
+            "databricks is exact and must not carry the degrade note"
+        );
+    }
+
+    #[test]
+    fn replication_merge_preview_degrades_when_dialect_needs_explicit_columns() {
+        // Snowflake (like DuckDB / BigQuery) rejects `UPDATE SET *`; the explicit
+        // column list is only knowable from the live source, so the offline
+        // preview degrades to the canonical shape + note — never errors.
+        let ir = merge_ir();
+        let dialect = dialect_for_adapter_type("snowflake");
+        assert!(
+            sql_gen::generate_merge_sql(&ir, dialect.as_ref()).is_err(),
+            "precondition: snowflake generate_merge_sql rejects ColumnSelection::All"
+        );
+        let preview = replication_copy_sql(&ir, dialect.as_ref())
+            .expect("degrade path must not error the whole plan");
+        assert!(preview.contains("MERGE INTO"), "got:\n{preview}");
+        assert!(
+            preview.contains("-- preview:"),
+            "the degrade path must carry the run-time-resolution note, got:\n{preview}"
+        );
+    }
+
+    #[test]
+    fn replication_view_preview_renders_view_ddl_not_insert() {
+        let ir = replication_ir(MaterializationStrategy::View);
+        let dialect = dialect_for_adapter_type("databricks");
+        let sql = replication_copy_sql(&ir, dialect.as_ref()).expect("view preview");
+        let up = sql.to_uppercase();
+        assert!(
+            up.contains("CREATE") && up.contains("VIEW"),
+            "view strategy must preview as VIEW DDL, got:\n{sql}"
+        );
+        assert!(
+            !sql.contains("INSERT INTO"),
+            "view must not preview as an INSERT (the pre-fix regression), got:\n{sql}"
+        );
+    }
+
+    #[test]
+    fn table_override_merge_resolves_to_merge_strategy() {
+        // Guards the resolution wiring plan() and run() share: a per-table
+        // `[[table_overrides]]` merge on a full_refresh base must resolve to
+        // Merge for the matched table and stay FullRefresh for others. A revert
+        // of the plan-loop override call would leave this green but the CLI
+        // e2e (in the PR) red — this pins the resolution itself.
+        let toml = r#"
+[adapter.duck]
+type = "duckdb"
+path = "x.duckdb"
+
+[pipeline.p]
+type = "replication"
+strategy = "full_refresh"
+
+[[pipeline.p.table_overrides]]
+match.table = "orders"
+strategy = "merge"
+merge_keys = ["order_id"]
+
+[pipeline.p.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.p.target]
+catalog_template = "c"
+schema_template = "s__{source}"
+"#;
+        let cfg: rocky_core::config::RockyConfig = toml::from_str(toml).expect("parse config");
+        let (_name, pipeline) =
+            crate::registry::resolve_replication_pipeline(&cfg, None).expect("resolve pipeline");
+
+        let matched =
+            resolve_table_override(&pipeline.table_overrides, "conn", "raw__orders", "orders");
+        let s = crate::commands::run::build_replication_strategy_with_override(pipeline, &matched)
+            .expect("build strategy");
+        assert!(
+            matches!(s, MaterializationStrategy::Merge { .. }),
+            "matched table_override must resolve to Merge, got {s:?}"
+        );
+
+        let unmatched =
+            resolve_table_override(&pipeline.table_overrides, "conn", "raw__other", "widgets");
+        let s2 =
+            crate::commands::run::build_replication_strategy_with_override(pipeline, &unmatched)
+                .expect("build strategy");
+        assert!(
+            matches!(s2, MaterializationStrategy::FullRefresh),
+            "non-matching table must stay FullRefresh, got {s2:?}"
         );
     }
 

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -3,9 +3,10 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use chrono::Utc;
 
-use rocky_core::config::GovernanceOverride;
+use rocky_core::config::{GovernanceOverride, resolve_table_override};
 use rocky_core::source::DiscoveredConnector;
 use rocky_core::sql_gen;
+use rocky_core::traits::SqlDialect;
 use rocky_ir::*;
 
 use crate::output::*;
@@ -192,15 +193,33 @@ pub async fn plan(
                 })
                 .collect();
 
-            let (strategy, purpose) = match pipeline.strategy.as_str() {
-                "incremental" => (
-                    MaterializationStrategy::Incremental {
-                        timestamp_column: pipeline.timestamp_column.clone(),
-                    },
-                    "incremental_copy",
-                ),
-                _ => (MaterializationStrategy::FullRefresh, "full_refresh_copy"),
-            };
+            // Resolve the per-table override and the effective strategy the
+            // SAME way `rocky run` does (`build_replication_strategy_with_override`),
+            // so the preview reflects `merge` and per-table `[[table_overrides]]`
+            // instead of always rendering full_refresh. The two paths MUST agree
+            // — a plan that disagrees with run is the bug this closes.
+            let effective_override = resolve_table_override(
+                &pipeline.table_overrides,
+                &conn.id,
+                &conn.schema,
+                &table.name,
+            );
+            let strategy = super::run::build_replication_strategy_with_override(
+                pipeline,
+                &effective_override,
+            )
+            .unwrap_or_else(|e| {
+                // Only reachable for a `merge` strategy with no resolvable
+                // merge_keys — `rocky validate` (V001/V035) rejects that at
+                // config-load, so this is a defensive fallback, not a hot path.
+                tracing::warn!(
+                    table = %table.name,
+                    error = %e,
+                    "plan: could not resolve replication strategy; previewing as full_refresh"
+                );
+                MaterializationStrategy::FullRefresh
+            });
+            let purpose = replication_copy_purpose(&strategy);
 
             // sql_gen consumes the typed IR directly.
             let model_ir = ModelIr::replication(
@@ -224,24 +243,12 @@ pub async fn plan(
                 },
             );
 
-            // Pick the right SQL generator for the materialization strategy.
-            // Full refresh uses CREATE OR REPLACE TABLE AS so the target doesn't
-            // need to exist; incremental uses INSERT INTO which requires the
-            // target to already exist (created on the first full-refresh run).
-            //
-            // `plan` is forward-looking — it renders the SQL the runner would
-            // emit on a fresh run, so we pass `None` for the watermark to
-            // surface the 1970-01-01 sentinel literal. The runner reads the
-            // actual prior watermark from state at execute time.
-            let sql = match &strategy {
-                MaterializationStrategy::FullRefresh => {
-                    sql_gen::generate_create_table_as_sql(&model_ir, dialect)?
-                }
-                MaterializationStrategy::Incremental { .. } => {
-                    sql_gen::generate_insert_sql(&model_ir, dialect, None)?
-                }
-                _ => sql_gen::generate_insert_sql(&model_ir, dialect, None)?,
-            };
+            // Render the forward-looking copy SQL for the resolved strategy —
+            // full_refresh → CTAS, incremental → INSERT with the 1970 sentinel
+            // watermark (the runner threads the real watermark at execute time),
+            // merge → MERGE INTO. See `replication_copy_sql` for the
+            // Snowflake-merge preview caveat.
+            let sql = replication_copy_sql(&model_ir, dialect)?;
 
             let target_label = if effective_target_catalog.is_empty() {
                 format!("{target_schema}.{}", table.name)
@@ -535,6 +542,93 @@ fn strategy_purpose(strategy: &MaterializationStrategy) -> &'static str {
         MaterializationStrategy::Microbatch { .. } => "microbatch",
         MaterializationStrategy::ContentAddressed { .. } => "content_addressed",
     }
+}
+
+/// Map a resolved replication-copy [`MaterializationStrategy`] to the `purpose`
+/// label used on a [`PlannedStatement`].
+///
+/// `build_replication_strategy_with_override` only produces `FullRefresh`,
+/// `Incremental`, or `Merge` for a replication pipeline, so the catch-all is a
+/// defensive fallback rather than a reachable state.
+fn replication_copy_purpose(strategy: &MaterializationStrategy) -> &'static str {
+    match strategy {
+        MaterializationStrategy::Incremental { .. } => "incremental_copy",
+        MaterializationStrategy::Merge { .. } => "merge_copy",
+        _ => "full_refresh_copy",
+    }
+}
+
+/// Render the forward-looking copy SQL for one replication table, matching the
+/// dialect and strategy `rocky run` will execute: `full_refresh` → `CREATE OR
+/// REPLACE TABLE AS`, `incremental` → `INSERT` with the 1970 sentinel watermark
+/// (the runner threads the real prior watermark at execute time), `merge` →
+/// `MERGE INTO`.
+///
+/// `plan` is offline and has no live source schema, so a `Merge` is rendered
+/// with `ColumnSelection::All` (`UPDATE SET *`). Dialects that reject `*` in a
+/// `MERGE` (Snowflake) cannot be previewed exactly — the runner resolves the
+/// explicit column list from the live source at execute time — so those degrade
+/// to a shape-only preview naming the merge target, rather than erroring the
+/// whole plan. Databricks / DuckDB / BigQuery preview the exact `MERGE INTO`.
+fn replication_copy_sql(model_ir: &ModelIr, dialect: &dyn SqlDialect) -> Result<String> {
+    let sql = match &model_ir.materialization {
+        MaterializationStrategy::FullRefresh => {
+            sql_gen::generate_create_table_as_sql(model_ir, dialect)?
+        }
+        MaterializationStrategy::Incremental { .. } => {
+            sql_gen::generate_insert_sql(model_ir, dialect, None)?
+        }
+        MaterializationStrategy::Merge { .. } => {
+            match sql_gen::generate_merge_sql(model_ir, dialect) {
+                Ok(sql) => sql,
+                // DuckDB / Snowflake reject `UPDATE SET *` and need an explicit
+                // column list the offline plan can't know; render the canonical
+                // shape instead of erroring the whole plan.
+                Err(_) => preview_merge_shape(model_ir, dialect)?,
+            }
+        }
+        // Replication only builds full_refresh / incremental / merge.
+        _ => sql_gen::generate_insert_sql(model_ir, dialect, None)?,
+    };
+    Ok(sql)
+}
+
+/// Canonical `MERGE INTO … WHEN MATCHED THEN UPDATE SET *` preview for dialects
+/// whose `merge_into` requires an explicit column list (DuckDB, Snowflake) that
+/// an offline plan cannot resolve. Mirrors the shape `rocky run` emits once it
+/// has read the live source schema, with a trailing note that the explicit
+/// columns resolve at execute time — so the reviewer sees the table upserts,
+/// not full-refreshes.
+fn preview_merge_shape(model_ir: &ModelIr, dialect: &dyn SqlDialect) -> Result<String> {
+    let MaterializationStrategy::Merge { unique_key, .. } = &model_ir.materialization else {
+        return Ok(sql_gen::generate_create_table_as_sql(model_ir, dialect)?);
+    };
+    let columns = model_ir
+        .columns
+        .as_ref()
+        .expect("Replication variant guarantees `columns` is Some");
+    let source = model_ir
+        .source
+        .as_ref()
+        .expect("Replication variant guarantees `source` is Some");
+    let target = dialect.format_table_ref(
+        &model_ir.target.catalog,
+        &model_ir.target.schema,
+        &model_ir.target.table,
+    )?;
+    let source_ref = dialect.format_table_ref(&source.catalog, &source.schema, &source.table)?;
+    let select = dialect.select_clause(columns, &model_ir.metadata_columns)?;
+    let on = unique_key
+        .iter()
+        .map(|k| format!("t.{k} = s.{k}"))
+        .collect::<Vec<_>>()
+        .join(" AND ");
+    Ok(format!(
+        "MERGE INTO {target} AS t\nUSING (\n{select}\nFROM {source_ref}\n) AS s\nON {on}\n\
+         WHEN MATCHED THEN UPDATE SET *\nWHEN NOT MATCHED THEN INSERT *\n\
+         -- preview: {} resolves explicit UPDATE/INSERT columns from the live source at run time",
+        dialect.name()
+    ))
 }
 
 /// Side-effect-free SQL preview core: compile the project in-process and render
@@ -1648,8 +1742,97 @@ pub(crate) async fn build_promote_plan_inner(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use rocky_ir::MaskStrategy;
+
+    // ------------------------------------------------------------------
+    // replication copy preview — strategy / override fidelity (bug fix:
+    // `rocky plan` must reflect `merge` + `[[table_overrides]]`, not always
+    // render full_refresh)
+    // ------------------------------------------------------------------
+
+    fn merge_replication_ir() -> ModelIr {
+        ModelIr::replication(
+            TargetRef {
+                catalog: "cat".into(),
+                schema: "staging".into(),
+                table: "orders".into(),
+            },
+            MaterializationStrategy::Merge {
+                unique_key: vec![Arc::from("order_id")],
+                update_columns: ColumnSelection::All,
+            },
+            SourceRef {
+                catalog: "cat".into(),
+                schema: "raw".into(),
+                table: "orders".into(),
+            },
+            ColumnSelection::All,
+            vec![],
+            GovernanceConfig {
+                permissions_file: None,
+                auto_create_catalogs: false,
+                auto_create_schemas: false,
+            },
+        )
+    }
+
+    #[test]
+    fn replication_copy_purpose_maps_the_three_replication_strategies() {
+        assert_eq!(
+            replication_copy_purpose(&MaterializationStrategy::FullRefresh),
+            "full_refresh_copy"
+        );
+        assert_eq!(
+            replication_copy_purpose(&MaterializationStrategy::Incremental {
+                timestamp_column: "ts".into(),
+            }),
+            "incremental_copy"
+        );
+        assert_eq!(
+            replication_copy_purpose(&MaterializationStrategy::Merge {
+                unique_key: vec![Arc::from("id")],
+                update_columns: ColumnSelection::All,
+            }),
+            "merge_copy"
+        );
+    }
+
+    #[test]
+    fn replication_merge_preview_renders_merge_into_for_star_dialects() {
+        let ir = merge_replication_ir();
+        // Databricks / DuckDB accept `UPDATE SET *`, so the offline preview is
+        // exact — and must NOT be a full-refresh CTAS (the bug).
+        for adapter in ["duckdb", "databricks"] {
+            let dialect = dialect_for_adapter_type(adapter);
+            let sql = replication_copy_sql(&ir, dialect.as_ref()).expect("merge preview sql");
+            assert!(
+                sql.contains("MERGE INTO"),
+                "{adapter}: merge preview must render MERGE INTO, got:\n{sql}"
+            );
+            assert!(
+                !sql.to_uppercase().contains("CREATE OR REPLACE TABLE"),
+                "{adapter}: merge preview must not fall back to full_refresh CTAS, got:\n{sql}"
+            );
+        }
+    }
+
+    #[test]
+    fn replication_merge_preview_degrades_without_error_on_snowflake() {
+        // Snowflake's MERGE rejects `UPDATE SET *` and the explicit column list
+        // is only knowable from the live source, so the offline preview must
+        // degrade to a shape-only note — never error, never render full_refresh.
+        let ir = merge_replication_ir();
+        let dialect = dialect_for_adapter_type("snowflake");
+        let sql = replication_copy_sql(&ir, dialect.as_ref())
+            .expect("snowflake merge preview must not error the whole plan");
+        assert!(
+            sql.contains("MERGE INTO"),
+            "snowflake preview should still name the merge target, got:\n{sql}"
+        );
+    }
 
     // ------------------------------------------------------------------
     // render_retention_preview — warehouse dispatch

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -6483,7 +6483,7 @@ fn build_replication_strategy(
 /// T3 fail-fast lives here — an effective `strategy = "merge"` with
 /// no reachable merge_keys returns an error so the table fails (the
 /// pipeline keeps running and other tables continue).
-fn build_replication_strategy_with_override(
+pub(crate) fn build_replication_strategy_with_override(
     pipeline: &ReplicationPipelineConfig,
     override_: &ResolvedTableOverride,
 ) -> Result<MaterializationStrategy> {

--- a/engine/crates/rocky-databricks/tests/replication_merge_live.rs
+++ b/engine/crates/rocky-databricks/tests/replication_merge_live.rs
@@ -1,0 +1,274 @@
+//! Live Databricks replication-`merge` verification (audit, not a PR by default).
+//!
+//! Closes the "does `strategy = \"merge\"` actually emit + execute a `MERGE`
+//! on Databricks (not just DuckDB)?" gap. It reconstructs the exact dialect
+//! call-chain `rocky_core::sql_gen::generate_merge_sql` runs — `format_table_ref`
+//! ×2 → `select_clause` → `merge_into` — which is the same SQL
+//! `commands/run.rs` executes at materialization (run.rs: `Merge =>
+//! generate_merge_sql`). Then it runs that SQL against a real Databricks
+//! workspace and asserts upsert semantics + merge-key uniqueness.
+//!
+//! `#[ignore]`-gated; reads the same env vars as the other Databricks live
+//! tests:
+//!   DATABRICKS_HOST, DATABRICKS_HTTP_PATH,
+//!   DATABRICKS_TOKEN (or DATABRICKS_CLIENT_ID + DATABRICKS_CLIENT_SECRET),
+//!   DATABRICKS_TEST_CATALOG (or DATABRICKS_CATALOG_PREFIX)
+//! Every schema is `hc_`-prefixed and dropped CASCADE on exit.
+//!
+//! Run with:
+//!   cargo test -p rocky-databricks --test replication_merge_live -- --ignored --nocapture
+
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use rocky_core::traits::{SqlDialect, WarehouseAdapter};
+use rocky_databricks::adapter::DatabricksWarehouseAdapter;
+use rocky_databricks::auth::{Auth, AuthConfig};
+use rocky_databricks::connector::{ConnectorConfig, DatabricksConnector};
+use rocky_databricks::dialect::DatabricksSqlDialect;
+use rocky_ir::ColumnSelection;
+
+fn adapter_from_env() -> Option<DatabricksWarehouseAdapter> {
+    let host = std::env::var("DATABRICKS_HOST").ok()?;
+    let http_path = std::env::var("DATABRICKS_HTTP_PATH").ok()?;
+    let warehouse_id = ConnectorConfig::warehouse_id_from_http_path(&http_path)?;
+
+    let auth = Auth::from_config(AuthConfig {
+        host: host.clone(),
+        token: std::env::var("DATABRICKS_TOKEN").ok(),
+        client_id: std::env::var("DATABRICKS_CLIENT_ID").ok(),
+        client_secret: std::env::var("DATABRICKS_CLIENT_SECRET").ok(),
+    })
+    .ok()?;
+
+    let config = ConnectorConfig {
+        host,
+        warehouse_id,
+        timeout: Duration::from_secs(120),
+        retry: Default::default(),
+    };
+    Some(DatabricksWarehouseAdapter::new(DatabricksConnector::new(
+        config, auth,
+    )))
+}
+
+fn catalog_from_env() -> Option<String> {
+    std::env::var("DATABRICKS_TEST_CATALOG")
+        .or_else(|_| std::env::var("DATABRICKS_CATALOG_PREFIX"))
+        .ok()
+}
+
+fn suffix() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros()
+}
+
+fn as_i64(v: &serde_json::Value) -> Option<i64> {
+    v.as_i64()
+        .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+}
+
+async fn scalar_i64(adapter: &DatabricksWarehouseAdapter, sql: &str) -> i64 {
+    let r = adapter.execute_query(sql).await.expect("scalar query");
+    as_i64(&r.rows[0][0]).expect("scalar i64")
+}
+
+/// GREEN end-state: the `MERGE INTO … WHEN MATCHED THEN UPDATE SET * WHEN NOT
+/// MATCHED THEN INSERT *` that the replication runner emits for `strategy =
+/// "merge"` executes on Databricks, upserts correctly (matched rows updated,
+/// unmatched rows inserted), keeps the merge key unique (no row
+/// multiplication — the failure mode of a NULL/dup key), and is idempotent on
+/// re-run against an unchanged source.
+#[tokio::test]
+#[ignore]
+async fn live_databricks_replication_merge_upserts_and_is_idempotent() {
+    let Some(adapter) = adapter_from_env() else {
+        eprintln!("SKIP: Databricks env not set");
+        return;
+    };
+    let Some(catalog) = catalog_from_env() else {
+        eprintln!("SKIP: DATABRICKS_TEST_CATALOG / DATABRICKS_CATALOG_PREFIX not set");
+        return;
+    };
+
+    let s = suffix();
+    let src_schema = format!("hc_rmt_src_{s}");
+    let tgt_schema = format!("hc_rmt_tgt_{s}");
+    let table = "orders";
+
+    // Defensive: clear any prior leak from an aborted run.
+    let _ = adapter
+        .execute_statement(&format!(
+            "DROP SCHEMA IF EXISTS {catalog}.{src_schema} CASCADE"
+        ))
+        .await;
+    let _ = adapter
+        .execute_statement(&format!(
+            "DROP SCHEMA IF EXISTS {catalog}.{tgt_schema} CASCADE"
+        ))
+        .await;
+
+    // --- setup: source (3 rows) + empty target, identical schema ---
+    adapter
+        .execute_statement(&format!(
+            "CREATE SCHEMA IF NOT EXISTS {catalog}.{src_schema}"
+        ))
+        .await
+        .expect("create src schema");
+    adapter
+        .execute_statement(&format!(
+            "CREATE SCHEMA IF NOT EXISTS {catalog}.{tgt_schema}"
+        ))
+        .await
+        .expect("create tgt schema");
+    adapter
+        .execute_statement(&format!(
+            "CREATE OR REPLACE TABLE {catalog}.{src_schema}.{table} \
+             (order_id BIGINT, customer_id BIGINT, amount DECIMAL(10,2), status STRING)"
+        ))
+        .await
+        .expect("create source table");
+    adapter
+        .execute_statement(&format!(
+            "INSERT INTO {catalog}.{src_schema}.{table} VALUES \
+             (1,10,100.00,'completed'),(2,20,200.00,'completed'),(3,30,300.00,'pending')"
+        ))
+        .await
+        .expect("seed source");
+    adapter
+        .execute_statement(&format!(
+            "CREATE OR REPLACE TABLE {catalog}.{tgt_schema}.{table} \
+             (order_id BIGINT, customer_id BIGINT, amount DECIMAL(10,2), status STRING)"
+        ))
+        .await
+        .expect("create empty target");
+
+    // --- build the MERGE via the REAL dialect (mirrors generate_merge_sql) ---
+    let dialect = DatabricksSqlDialect;
+    let target_ref = dialect
+        .format_table_ref(&catalog, &tgt_schema, table)
+        .expect("target ref");
+    let source_ref = dialect
+        .format_table_ref(&catalog, &src_schema, table)
+        .expect("source ref");
+    let select_clause = dialect
+        .select_clause(&ColumnSelection::All, &[])
+        .expect("select clause");
+    let select = format!("{select_clause}\nFROM {source_ref}");
+    let keys = [Arc::<str>::from("order_id")];
+    let merge_sql = dialect
+        .merge_into(&target_ref, &select, &keys, &ColumnSelection::All)
+        .expect("merge sql");
+    println!(
+        "--- Rocky-emitted Databricks MERGE ---\n{merge_sql}\n--------------------------------------"
+    );
+
+    // MERGE #1: empty target -> all 3 source rows inserted (NOT MATCHED).
+    adapter
+        .execute_statement(&merge_sql)
+        .await
+        .expect("merge #1");
+    let count_1 = scalar_i64(
+        &adapter,
+        &format!("SELECT COUNT(*) FROM {catalog}.{tgt_schema}.{table}"),
+    )
+    .await;
+
+    // Mutate source: change order 1 (customer_id 10 -> 111), add order 4.
+    adapter
+        .execute_statement(&format!(
+            "UPDATE {catalog}.{src_schema}.{table} SET customer_id = 111 WHERE order_id = 1"
+        ))
+        .await
+        .expect("update source row");
+    adapter
+        .execute_statement(&format!(
+            "INSERT INTO {catalog}.{src_schema}.{table} VALUES (4,40,400.00,'completed')"
+        ))
+        .await
+        .expect("insert source row");
+
+    // MERGE #2: order 1 UPDATED (MATCHED), order 4 INSERTED (NOT MATCHED).
+    adapter
+        .execute_statement(&merge_sql)
+        .await
+        .expect("merge #2");
+    let count_2 = scalar_i64(
+        &adapter,
+        &format!("SELECT COUNT(*) FROM {catalog}.{tgt_schema}.{table}"),
+    )
+    .await;
+    let distinct_2 = scalar_i64(
+        &adapter,
+        &format!("SELECT COUNT(DISTINCT order_id) FROM {catalog}.{tgt_schema}.{table}"),
+    )
+    .await;
+    let cust_1 = scalar_i64(
+        &adapter,
+        &format!("SELECT customer_id FROM {catalog}.{tgt_schema}.{table} WHERE order_id = 1"),
+    )
+    .await;
+    let has_4 = scalar_i64(
+        &adapter,
+        &format!("SELECT COUNT(*) FROM {catalog}.{tgt_schema}.{table} WHERE order_id = 4"),
+    )
+    .await;
+
+    // MERGE #3: idempotent re-run against the unchanged source.
+    adapter
+        .execute_statement(&merge_sql)
+        .await
+        .expect("merge #3");
+    let count_3 = scalar_i64(
+        &adapter,
+        &format!("SELECT COUNT(*) FROM {catalog}.{tgt_schema}.{table}"),
+    )
+    .await;
+    let distinct_3 = scalar_i64(
+        &adapter,
+        &format!("SELECT COUNT(DISTINCT order_id) FROM {catalog}.{tgt_schema}.{table}"),
+    )
+    .await;
+
+    // --- teardown BEFORE asserts, so a failed assert still cleans up ---
+    let _ = adapter
+        .execute_statement(&format!(
+            "DROP SCHEMA IF EXISTS {catalog}.{src_schema} CASCADE"
+        ))
+        .await;
+    let _ = adapter
+        .execute_statement(&format!(
+            "DROP SCHEMA IF EXISTS {catalog}.{tgt_schema} CASCADE"
+        ))
+        .await;
+
+    println!(
+        "counts: run1={count_1} run2={count_2}(distinct={distinct_2}) run3={count_3}(distinct={distinct_3}); order1.customer_id={cust_1} has_order4={has_4}"
+    );
+
+    assert_eq!(
+        count_1, 3,
+        "MERGE #1 into empty target inserts all 3 source rows"
+    );
+    assert_eq!(
+        count_2, 4,
+        "MERGE #2 inserts order 4 + updates order 1 (no duplication)"
+    );
+    assert_eq!(distinct_2, 4, "merge key stays unique after upsert");
+    assert_eq!(
+        count_2, distinct_2,
+        "COUNT(*) must equal COUNT(DISTINCT order_id) — no row multiplication"
+    );
+    assert_eq!(
+        cust_1, 111,
+        "order 1 reflects the MATCHED UPDATE (10 -> 111)"
+    );
+    assert_eq!(has_4, 1, "order 4 present via the NOT MATCHED INSERT");
+    assert_eq!(
+        count_3, 4,
+        "MERGE #3 against an unchanged source is idempotent"
+    );
+    assert_eq!(distinct_3, 4, "idempotent re-run keeps keys unique");
+}


### PR DESCRIPTION
## Problem

On a replication pipeline, `rocky plan` previewed **every** table as `full_refresh_copy` (a `CREATE OR REPLACE TABLE … AS SELECT *`) whenever the strategy was anything other than `incremental` — including `strategy = "merge"` — and it never consulted `[[table_overrides]]` at all. Meanwhile `rocky run` and `rocky apply` correctly resolve the override and execute `MERGE INTO`.

So the dry-run contradicted execution: a user reviewing `rocky plan` for a merge pipeline saw zero `MERGE` statements and reasonably concluded merge-on-replication was inert, when in fact it runs correctly. `rocky plan` is the pre-run review surface, so a preview that disagrees with what `run`/`apply` do is a real trust defect (though not an execution-correctness bug — nothing ran the wrong SQL).

Root cause: the replication preview loop in `plan()` had its own simplified strategy match (`"incremental"` else `full_refresh`) and never called `resolve_table_override`, whereas the runner resolves both through `build_replication_strategy_with_override`.

## Fix

The preview now resolves each table's effective strategy through the **same** `resolve_table_override` + `build_replication_strategy_with_override` path the runner uses, so `plan` and `run` cannot drift. A `merge` pipeline (or a per-table merge override) now previews as `merge_copy` with a `MERGE INTO`, and per-table overrides are reflected.

`plan` is offline and has no live source schema, so a `Merge` is rendered with `ColumnSelection::All`. Databricks and BigQuery accept `UPDATE SET *`, so they preview the exact statement. DuckDB and Snowflake require an explicit column list the runner resolves from the live source at execute time; rather than error the whole plan, those render the canonical `MERGE INTO … WHEN MATCHED THEN UPDATE SET *` shape with a trailing note that the explicit columns resolve at run time. Incremental and full-refresh previews are unchanged.

## Verification

- New unit tests: the purpose mapping for all three replication strategies, the exact-`MERGE INTO` preview for `UPDATE SET *` dialects, and the no-error degrade path for a dialect that rejects `UPDATE SET *`.
- End-to-end via the CLI on the DuckDB replication example: pipeline-level `merge` and `[[table_overrides]]` both now show `merge_copy` + `MERGE INTO` (previously `full_refresh_copy`); incremental/full-refresh unchanged; `run` still emits `MERGE INTO` and is idempotent.
- Full `rocky-cli` unit suite green; `fmt` and `clippy --all-targets -D warnings` clean.

## Also included

A live (`#[ignore]`-gated) Databricks test that executes the replication `MERGE` against a real workspace and asserts upsert semantics, merge-key uniqueness (`COUNT(*) == COUNT(DISTINCT key)`), and idempotency — merge-on-replication previously had live coverage only on Snowflake.

The persisted `ReplicationPlan` carries no SQL (only the config + source-state snapshot), so this change does not affect `plan_id` determinism or `apply` replay.
