### PR TITLE
fix(dagster): pruned-table handling for prune_unchanged runs

### DIFF
--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -162,6 +162,7 @@ def _engine_schema_mismatch_failure(command: str, exc: ValidationError) -> dg.Fa
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
+    from collections.abc import Set as AbstractSet
 
 #: Metadata key stamped on the zero-row ``MaterializeResult`` that the
 #: ``satisfy_empty_outputs`` mode emits for a *selected* output Rocky did
@@ -3098,6 +3099,18 @@ def _emit_results(
     # actually a hidden failure — so we skip the empty-emit for that whole
     # batch and let the downstream skip exactly as today. A visible skip
     # beats a zero-row success that masks a failure.
+    # Tables the engine pruned as unchanged since the last successful copy
+    # (`prune_unchanged`). They emit no materialization but are not failures:
+    # treat them as unchanged — a distinct zero-row continuity stamp, and their
+    # declared checks keep their prior result rather than flipping to a WARN
+    # placeholder (see `_emit_placeholder_checks`).
+    pruned_keys = {
+        remap(et.asset_key)
+        for r in results
+        for et in r.excluded_tables
+        if et.reason == "unchanged_since_last_copy"
+    } & selected_keys
+
     if satisfy_empty_outputs:
         unattributable = any(r.tables_failed > len(r.errors) for r in results)
         if unattributable:
@@ -3113,18 +3126,31 @@ def _emit_results(
         else:
             errored_keys = {remap(err.asset_key) for r in results for err in r.errors}
             empty_keys = selected_keys - materialized_keys - errored_keys
-            yield from _empty_output_results(empty_keys)
+            yield from _empty_output_results(empty_keys, pruned_keys)
+    elif pruned_keys:
+        # Pruning produced skipped tables but there is no empty-output pass to
+        # stamp them, so their assets aren't materialized this run and a same-run
+        # downstream will skip. Make the coupling visible.
+        _log.warning(
+            "prune_unchanged skipped %d table(s) this run, but satisfy_empty_outputs "
+            "is off — their assets are not materialized, so same-run downstreams will "
+            "skip. Enable satisfy_empty_outputs (streaming mode) to emit the zero-row "
+            "continuity signal for pruned tables.",
+            len(pruned_keys),
+        )
 
     yield from _emit_placeholder_checks(
         check_specs=check_specs,
         selected_keys=selected_keys,
         yielded_checks=yielded_checks,
         materialized_keys=materialized_keys,
+        pruned_keys=pruned_keys,
     )
 
 
 def _empty_output_results(
     empty_keys: Iterable[dg.AssetKey],
+    pruned_keys: AbstractSet[dg.AssetKey] = frozenset(),
 ) -> Iterator[dg.MaterializeResult]:
     """Yield a zero-row, dependency-satisfying result per absent key.
 
@@ -3134,15 +3160,25 @@ def _empty_output_results(
     yielded in a deterministic (sorted) order so the emitted event stream
     doesn't depend on set-iteration order. The caller is responsible for
     having already removed copied and errored keys from ``empty_keys``.
+
+    Keys in ``pruned_keys`` were skipped by ``prune_unchanged`` because the
+    source was unchanged since the last copy — a different situation from a
+    genuinely absent/empty table, so they carry a distinct reason and a
+    ``rocky/pruned_unchanged`` flag. The prior copy's data still stands.
     """
     for key in sorted(empty_keys, key=lambda k: k.to_user_string()):
+        pruned = key in pruned_keys
+        reason = (
+            "source unchanged since last copy — pruned by prune_unchanged; prior data stands"
+            if pruned
+            else "no rows copied for this partition (table absent or empty in the filtered run)"
+        )
         yield dg.MaterializeResult(
             asset_key=key,
             metadata={
                 EMPTY_FOR_PARTITION_METADATA_KEY: dg.MetadataValue.bool(True),
-                "rocky/reason": dg.MetadataValue.text(
-                    "no rows copied for this partition (table absent or empty in the filtered run)"
-                ),
+                "rocky/reason": dg.MetadataValue.text(reason),
+                "rocky/pruned_unchanged": dg.MetadataValue.bool(pruned),
                 "dagster/row_count": dg.MetadataValue.int(0),
             },
         )
@@ -3209,16 +3245,37 @@ def _emit_placeholder_checks(
     selected_keys: set[dg.AssetKey],
     yielded_checks: set[tuple[dg.AssetKey, str]],
     materialized_keys: set[dg.AssetKey],
+    pruned_keys: AbstractSet[dg.AssetKey] = frozenset(),
 ) -> Iterator[dg.AssetCheckResult]:
     """Emit placeholders for declared checks Rocky did not produce.
 
     Without these, Dagster logs "did not yield expected outputs" warnings
     for any pre-declared check that the actual run didn't cover.
+
+    A check on a ``prune_unchanged``-pruned table is neither run nor a failure:
+    the source is unchanged, so the last real evaluation still holds. Those emit
+    ``passed=True`` with a "not re-checked" status rather than the WARN /
+    ``passed=False`` placeholder an unmaterialized table would otherwise get —
+    so pruning doesn't overwrite a passing check with a spurious failure.
     """
     for cs in check_specs:
         if cs.asset_key not in selected_keys:
             continue
         if (cs.asset_key, cs.name) in yielded_checks:
+            continue
+
+        if cs.asset_key in pruned_keys:
+            yield dg.AssetCheckResult(
+                asset_key=cs.asset_key,
+                check_name=cs.name,
+                passed=True,
+                metadata={
+                    "status": dg.MetadataValue.text(
+                        "not re-checked: source unchanged since last copy "
+                        "(prune_unchanged) — prior result stands"
+                    )
+                },
+            )
             continue
 
         materialized = cs.asset_key in materialized_keys

--- a/integrations/dagster/tests/test_empty_outputs.py
+++ b/integrations/dagster/tests/test_empty_outputs.py
@@ -40,6 +40,7 @@ def _run_result(
     materializations: list[dict] | None = None,
     errors: list[dict] | None = None,
     tables_failed: int | None = None,
+    excluded_tables: list[dict] | None = None,
 ) -> RunResult:
     mats = materializations or []
     errs = errors or []
@@ -57,6 +58,7 @@ def _run_result(
             "materializations": mats,
             "check_results": [],
             "errors": errs,
+            "excluded_tables": excluded_tables or [],
             "permissions": {
                 "grants_added": 0,
                 "grants_revoked": 0,
@@ -469,3 +471,101 @@ def test_satisfy_empty_outputs_resolves_from_yaml():
     assert on.satisfy_empty_outputs is True
     off = RockyComponent.resolve_from_yaml("config_path: rocky.toml\n")
     assert off.satisfy_empty_outputs is False
+
+
+# --------------------------------------------------------------------------- #
+# prune_unchanged — a pruned (source-unchanged) table is distinct from absent,
+# and keeps its prior check result rather than flipping to a WARN placeholder.
+# --------------------------------------------------------------------------- #
+
+
+def _excluded(name: str, reason: str = "unchanged_since_last_copy") -> dict:
+    return {
+        "asset_key": [name],
+        "source_schema": "raw__sw",
+        "table_name": name,
+        "reason": reason,
+    }
+
+
+def test_pruned_table_gets_distinct_empty_stamp():
+    """A pruned (unchanged) table and a genuinely-absent table both get a
+    zero-row continuity stamp, but the pruned one carries the distinct reason +
+    ``rocky/pruned_unchanged=True`` so it isn't confused with absent/empty."""
+    a_raw, b_raw, c_raw = (dg.AssetKey([x]) for x in ("a_raw", "b_raw", "c_raw"))
+    mapping = {("a_raw",): a_raw, ("b_raw",): b_raw, ("c_raw",): c_raw}
+    # a_raw copied, b_raw pruned (unchanged), c_raw genuinely absent.
+    run_result = _run_result(
+        materializations=[_mat("a_raw")],
+        excluded_tables=[_excluded("b_raw")],
+    )
+
+    events = list(
+        _emit_results(
+            results=[run_result],
+            check_specs=[],
+            selected_keys={a_raw, b_raw, c_raw},
+            rocky_key_to_dagster_key=mapping,
+            satisfy_empty_outputs=True,
+        )
+    )
+    by_key = {
+        e.asset_key: e
+        for e in events
+        if isinstance(e, dg.MaterializeResult) and e.metadata.get(EMPTY_FOR_PARTITION_METADATA_KEY)
+    }
+    # Both b_raw (pruned) and c_raw (absent) get a continuity stamp...
+    assert set(by_key) == {b_raw, c_raw}
+    # ...but only b_raw is flagged pruned, with the distinct reason.
+    assert by_key[b_raw].metadata["rocky/pruned_unchanged"].value is True
+    assert "unchanged since last copy" in by_key[b_raw].metadata["rocky/reason"].value
+    assert by_key[c_raw].metadata["rocky/pruned_unchanged"].value is False
+    assert "absent or empty" in by_key[c_raw].metadata["rocky/reason"].value
+
+
+def test_pruned_table_check_passes_not_warns():
+    """A declared check on a pruned table emits passed=True (prior result
+    stands), NOT the passed=False/WARN placeholder an unmaterialized table would
+    otherwise get — pruning must not overwrite a passing check with a failure."""
+    b_raw = dg.AssetKey(["b_raw"])
+    mapping = {("b_raw",): b_raw}
+    run_result = _run_result(excluded_tables=[_excluded("b_raw")])
+
+    events = list(
+        _emit_results(
+            results=[run_result],
+            check_specs=[dg.AssetCheckSpec(name="row_count", asset=b_raw)],
+            selected_keys={b_raw},
+            rocky_key_to_dagster_key=mapping,
+            satisfy_empty_outputs=True,
+        )
+    )
+    checks = [e for e in events if isinstance(e, dg.AssetCheckResult)]
+    assert len(checks) == 1
+    assert checks[0].asset_key == b_raw
+    assert checks[0].check_name == "row_count"
+    assert checks[0].passed is True
+    assert "unchanged" in checks[0].metadata["status"].value
+
+
+def test_prune_without_satisfy_empty_outputs_warns(caplog):
+    """When pruning skips tables but satisfy_empty_outputs is off, the pruned
+    assets aren't materialized and same-run downstreams skip — surface the
+    coupling with a warning so it isn't a silent gap."""
+    import logging
+
+    b_raw = dg.AssetKey(["b_raw"])
+    mapping = {("b_raw",): b_raw}
+    run_result = _run_result(excluded_tables=[_excluded("b_raw")])
+
+    with caplog.at_level(logging.WARNING, logger="dagster_rocky.component"):
+        list(
+            _emit_results(
+                results=[run_result],
+                check_specs=[],
+                selected_keys={b_raw},
+                rocky_key_to_dagster_key=mapping,
+                satisfy_empty_outputs=False,
+            )
+        )
+    assert any("prune_unchanged skipped" in r.message for r in caplog.records)


### PR DESCRIPTION
Completes the Dagster side of engine skip-unchanged pruning (#1024). When `prune_unchanged` skips a table, the engine reports it under `excluded_tables` with reason `unchanged_since_last_copy` and emits no materialization. The component previously treated any unmaterialized selected key as absent/failed; it now distinguishes a *pruned-unchanged* table:

- **Checks don't flip to WARN.** A declared check on a pruned table emits `passed=True` with a "not re-checked: source unchanged" status, instead of the `passed=False`/WARN placeholder an unmaterialized table gets. Pruning no longer overwrites a passing check with a failure every run — the "prior results stand" promise.
- **Distinct continuity stamp.** The zero-row `MaterializeResult` for a pruned table carries a distinct reason + `rocky/pruned_unchanged=True`, so it isn't mislabeled as a genuinely absent/empty partition.
- **Visible coupling.** If pruning skips tables but `satisfy_empty_outputs` is off (nothing stamps the continuity signal), a warning surfaces it rather than letting same-run downstreams silently skip.

These were flagged by the adversarial review of #1024. Engine behavior is unchanged; this is component-side interpretation of `excluded_tables`. Tests cover the distinct stamp, the passing check, and the warning; full dagster suite green (684).