### PR TITLE
feat(engine/rocky-mcp): structured error contract across MCP tools

### DIFF
--- a/.github/workflows/engine-evals.yml
+++ b/.github/workflows/engine-evals.yml
@@ -78,6 +78,16 @@ jobs:
         working-directory: engine/evals
         run: uv run python run_evals.py --selftest
 
+      # Creds-free (needs only the `rocky` binary built above): assert the
+      # structured MCP error envelope on bad input. Unlike the live authoring
+      # scenarios, this is deterministic — a failure here is a real contract
+      # regression, so it gates the job.
+      - name: Structured-error contract
+        working-directory: engine/evals
+        env:
+          ROCKY_BIN: ${{ github.workspace }}/engine/target/debug/rocky
+        run: uv run python run_evals.py --error-contract
+
       - name: Run the agent conformance suite
         working-directory: engine/evals
         env:

--- a/engine/crates/rocky-mcp/src/error.rs
+++ b/engine/crates/rocky-mcp/src/error.rs
@@ -1,0 +1,165 @@
+//! The structured error envelope every Rocky MCP tool returns on a failure
+//! path — the machine-UX analog of Rocky's diagnostic codes.
+//!
+//! A failing tool call comes back as a *tool-result* error (`is_error: true`)
+//! whose `structured_content` is a `{code, message, remediation_hint,
+//! policy_rule?}` object, so a connected agent can branch on a stable `code`
+//! and act on an actionable `remediation_hint` without scraping prose. This is
+//! deliberately **not** a JSON-RPC protocol error ([`rmcp::ErrorData`]):
+//! protocol errors carry a different wire shape and no result-level `is_error`
+//! flag, and would change the tools' failure semantics.
+//!
+//! ## Wire mechanics
+//!
+//! Every tool returns [`ToolResult<T>`] = `Result<Json<T>, Json<ToolError>>`.
+//! On the error arm rmcp serializes `Json<ToolError>` through its own
+//! `IntoCallToolResult for Json<T>` into `CallToolResult::structured(...)`, and
+//! its `Result` handling then flips `is_error` to `true`. The result is a
+//! `structured_content` object plus `is_error: true` — the same tested code
+//! path a successful `Json<T>` value takes, with no custom trait impls (a
+//! hand-written `impl IntoCallToolResult for ToolError` would collide with
+//! rmcp's blanket `impl<T: IntoContents>` under the orphan rule).
+
+use rmcp::Json;
+use schemars::JsonSchema;
+use serde::Serialize;
+
+/// The return type of every Rocky MCP tool: a lite `*Result` core on success,
+/// or the structured [`ToolError`] envelope on failure.
+pub type ToolResult<T> = Result<Json<T>, Json<ToolError>>;
+
+/// Stable, machine-matchable error class. Serialized snake_case so an agent can
+/// branch on the string without parsing the message. Extend deliberately — a
+/// new variant is a wire-contract addition, not a refactor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolErrorCode {
+    /// A tool argument was missing, malformed, or outside its accepted set
+    /// (e.g. an unknown `target_dialect`, an unknown `list` kind, an invalid
+    /// column or table reference).
+    InvalidArgument,
+    /// The project's `rocky.toml` could not be loaded or parsed.
+    ConfigInvalid,
+    /// The compile pipeline could not run to completion. Distinct from a clean
+    /// compile that reports error *diagnostics*: that is a successful result
+    /// with `has_errors: true`, not this error.
+    CompileFailed,
+    /// A named model was not found in the compiled project.
+    ModelNotFound,
+    /// The project has no compiled models for the requested action.
+    EmptyProject,
+    /// A warehouse operation failed — adapter resolution, `DESCRIBE`, or a
+    /// grounding query against the configured target.
+    WarehouseError,
+    /// An AI / LLM operation failed (client initialization or request).
+    AiError,
+    /// An unexpected internal failure. `message` carries the detail.
+    Internal,
+}
+
+/// The structured error envelope returned by a failing tool call.
+///
+/// `policy_rule` is reserved for the agent policy plane (a future deny /
+/// require-review decision names the rule that produced it); it is absent on
+/// every error today.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ToolError {
+    /// Stable error class the caller can branch on.
+    pub code: ToolErrorCode,
+    /// Human-readable description of what went wrong.
+    pub message: String,
+    /// A concrete next action that recovers from this error — the point of the
+    /// envelope. Never empty.
+    pub remediation_hint: String,
+    /// The policy rule behind a deny / require-review decision. Reserved for the
+    /// agent policy plane; always absent today.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policy_rule: Option<String>,
+}
+
+impl ToolError {
+    /// Build a wire-ready envelope. Returns `Json<ToolError>` so tool call sites
+    /// read `.map_err(|e| ToolError::compile_failed(...))?` and
+    /// `return Err(ToolError::empty_project(...))` with no extra wrapping.
+    fn wrap(
+        code: ToolErrorCode,
+        message: impl Into<String>,
+        remediation_hint: impl Into<String>,
+    ) -> Json<Self> {
+        Json(Self {
+            code,
+            message: message.into(),
+            remediation_hint: remediation_hint.into(),
+            policy_rule: None,
+        })
+    }
+
+    /// A tool argument was malformed or outside its accepted set. `hint` should
+    /// name the accepted values or the correct form.
+    pub fn invalid_argument(message: impl Into<String>, hint: impl Into<String>) -> Json<Self> {
+        Self::wrap(ToolErrorCode::InvalidArgument, message, hint)
+    }
+
+    /// `rocky.toml` could not be loaded or parsed.
+    pub fn config_invalid(message: impl Into<String>) -> Json<Self> {
+        Self::wrap(
+            ToolErrorCode::ConfigInvalid,
+            message,
+            "Fix rocky.toml: check the adapter/pipeline blocks parse and the file exists at the \
+             project root, then retry.",
+        )
+    }
+
+    /// The compile pipeline could not run to completion (a missing models
+    /// directory, an unreadable file, or a seed/cache failure) — not the same
+    /// as a clean compile that reports error diagnostics.
+    pub fn compile_failed(message: impl Into<String>) -> Json<Self> {
+        Self::wrap(
+            ToolErrorCode::CompileFailed,
+            message,
+            "Call the `compile` tool and fix the reported diagnostics (each carries a code, span, \
+             and suggestion); ensure rocky.toml and the models/ directory are present and readable.",
+        )
+    }
+
+    /// A named model was not found. `model` is the name the caller asked for.
+    pub fn model_not_found(model: impl std::fmt::Display) -> Json<Self> {
+        Self::wrap(
+            ToolErrorCode::ModelNotFound,
+            format!("model '{model}' not found in the project"),
+            "List the available models with the `list` tool (kind = \"models\") or `inspect_schema`, \
+             then retry with an exact model name.",
+        )
+    }
+
+    /// The project has no compiled models for the requested action.
+    pub fn empty_project(message: impl Into<String>) -> Json<Self> {
+        Self::wrap(
+            ToolErrorCode::EmptyProject,
+            message,
+            "Author at least one model (write a `.sql` file under models/ and `compile` it) before \
+             proposing or planning.",
+        )
+    }
+
+    /// A warehouse operation failed. `hint` should point at the specific
+    /// recovery (credentials, a missing table, connectivity).
+    pub fn warehouse_error(message: impl Into<String>, hint: impl Into<String>) -> Json<Self> {
+        Self::wrap(ToolErrorCode::WarehouseError, message, hint)
+    }
+
+    /// An AI / LLM operation failed (client init or request).
+    pub fn ai_error(message: impl Into<String>) -> Json<Self> {
+        Self::wrap(
+            ToolErrorCode::AiError,
+            message,
+            "Verify ANTHROPIC_API_KEY is set in the server environment and the model is reachable, \
+             then retry.",
+        )
+    }
+
+    /// An unexpected internal failure.
+    pub fn internal(message: impl Into<String>, hint: impl Into<String>) -> Json<Self> {
+        Self::wrap(ToolErrorCode::Internal, message, hint)
+    }
+}

--- a/engine/crates/rocky-mcp/src/lib.rs
+++ b/engine/crates/rocky-mcp/src/lib.rs
@@ -24,11 +24,13 @@
 //! lite structs) — Rocky's 0.8-deriving `*Output` types are projected into
 //! these lite shapes at the tool boundary.
 
+mod error;
 mod result_types;
 mod tools;
 
 use rmcp::{ServiceExt, transport::stdio};
 
+pub use error::{ToolError, ToolErrorCode, ToolResult};
 pub use tools::RockyMcpServer;
 
 /// Serve the Rocky MCP server over stdio until the client disconnects.

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -25,6 +25,7 @@ use rmcp::{
 use rocky_cli::commands;
 use rocky_compiler::compile::{self, CompileResult as CompilerResult, CompilerConfig};
 
+use crate::error::{ToolError, ToolResult};
 use crate::result_types::*;
 
 /// The server's `instructions` — the agent-authoring workflow. Sourced from
@@ -401,10 +402,7 @@ impl RockyMcpServer {
          `target_dialect` (databricks/snowflake/bigquery/duckdb) to additionally run the P001 \
          portability lint on demand: SQL that won't port to that dialect surfaces as P001."
     )]
-    async fn compile(
-        &self,
-        params: Parameters<CompileArgs>,
-    ) -> Result<Json<CompileResult>, String> {
+    async fn compile(&self, params: Parameters<CompileArgs>) -> ToolResult<CompileResult> {
         let args = params.0;
         let model = args.model.as_deref();
         // On-demand portability lint: parse the requested dialect (case-
@@ -430,7 +428,7 @@ impl RockyMcpServer {
             with_seed,
             None,
         )
-        .map_err(|e| format!("{e:#}"))?;
+        .map_err(|e| ToolError::compile_failed(format!("{e:#}")))?;
         Ok(Json(project_compile_result(&output)))
     }
 
@@ -442,11 +440,11 @@ impl RockyMcpServer {
     async fn plan_preview(
         &self,
         params: Parameters<PlanPreviewArgs>,
-    ) -> Result<Json<PlanPreviewResult>, String> {
+    ) -> ToolResult<PlanPreviewResult> {
         let model = params.0.model.as_deref();
         let output =
             commands::plan_preview_output(Some(&self.config_path), &self.models_dir, model, None)
-                .map_err(|e| format!("{e:#}"))?;
+                .map_err(|e| ToolError::compile_failed(format!("{e:#}")))?;
         let statements = output
             .statements
             .into_iter()
@@ -464,17 +462,16 @@ impl RockyMcpServer {
          model's columns plus upstream/downstream models and the model-level edge set. With \
          `column`, returns the column trace; set `downstream` to trace consumers instead of sources."
     )]
-    async fn lineage(
-        &self,
-        params: Parameters<LineageArgs>,
-    ) -> Result<Json<LineageResult>, String> {
+    async fn lineage(&self, params: Parameters<LineageArgs>) -> ToolResult<LineageResult> {
         let args = params.0;
-        let result = self.compile_full().map_err(|e| format!("{e:#}"))?;
+        let result = self
+            .compile_full()
+            .map_err(|e| ToolError::compile_failed(format!("{e:#}")))?;
 
         if let Some(column) = args.column.as_deref() {
             let out =
                 commands::column_lineage_output(&result, &args.model, column, args.downstream)
-                    .map_err(|e| format!("{e:#}"))?;
+                    .map_err(|_| ToolError::model_not_found(&args.model))?;
             let edges = out.trace.iter().map(edge_lite).collect();
             Ok(Json(LineageResult {
                 model: out.model,
@@ -486,8 +483,8 @@ impl RockyMcpServer {
                 edges,
             }))
         } else {
-            let out =
-                commands::lineage_output(&result, &args.model).map_err(|e| format!("{e:#}"))?;
+            let out = commands::lineage_output(&result, &args.model)
+                .map_err(|_| ToolError::model_not_found(&args.model))?;
             let edges = out.edges.iter().map(edge_lite).collect();
             let columns = out.columns.into_iter().map(|c| c.name).collect();
             Ok(Json(LineageResult {
@@ -506,9 +503,14 @@ impl RockyMcpServer {
         description = "Run the project's DuckDB-backed local tests (contracts + assertions) and \
          return pass/fail counts plus per-failure detail. Use after writing or changing a model."
     )]
-    async fn test(&self) -> Result<Json<TestResult>, String> {
-        let output =
-            commands::test_output(&self.models_dir, None, None).map_err(|e| format!("{e:#}"))?;
+    async fn test(&self) -> ToolResult<TestResult> {
+        let output = commands::test_output(&self.models_dir, None, None).map_err(|e| {
+            ToolError::internal(
+                format!("{e:#}"),
+                "The local test runner could not execute; confirm the project compiles (the \
+                 `compile` tool) and any `data/seed.sql` the tests need is present.",
+            )
+        })?;
         let failures = output
             .failures
             .into_iter()
@@ -527,12 +529,12 @@ impl RockyMcpServer {
     #[tool(
         description = "List project entities. `kind` is one of: models, pipelines, adapters, sources."
     )]
-    async fn list(&self, params: Parameters<ListArgs>) -> Result<Json<ListResult>, String> {
+    async fn list(&self, params: Parameters<ListArgs>) -> ToolResult<ListResult> {
         let kind = params.0.kind;
         let entries = match kind.as_str() {
             "models" => {
-                let out =
-                    commands::list_models_output(&self.models_dir).map_err(|e| format!("{e:#}"))?;
+                let out = commands::list_models_output(&self.models_dir)
+                    .map_err(|e| ToolError::compile_failed(format!("{e:#}")))?;
                 out.models
                     .into_iter()
                     .map(|m| ListEntry {
@@ -546,7 +548,7 @@ impl RockyMcpServer {
             }
             "pipelines" => {
                 let out = commands::list_pipelines_output(&self.config_path)
-                    .map_err(|e| format!("{e:#}"))?;
+                    .map_err(|e| ToolError::config_invalid(format!("{e:#}")))?;
                 out.pipelines
                     .into_iter()
                     .map(|p| ListEntry {
@@ -560,7 +562,7 @@ impl RockyMcpServer {
             }
             "adapters" => {
                 let out = commands::list_adapters_output(&self.config_path)
-                    .map_err(|e| format!("{e:#}"))?;
+                    .map_err(|e| ToolError::config_invalid(format!("{e:#}")))?;
                 out.adapters
                     .into_iter()
                     .map(|a| ListEntry {
@@ -573,7 +575,7 @@ impl RockyMcpServer {
             }
             "sources" => {
                 let out = commands::list_sources_output(&self.config_path)
-                    .map_err(|e| format!("{e:#}"))?;
+                    .map_err(|e| ToolError::config_invalid(format!("{e:#}")))?;
                 out.sources
                     .into_iter()
                     .map(|s| ListEntry {
@@ -585,8 +587,9 @@ impl RockyMcpServer {
                     .collect()
             }
             other => {
-                return Err(format!(
-                    "unknown kind '{other}' — expected models, pipelines, adapters, or sources"
+                return Err(ToolError::invalid_argument(
+                    format!("unknown kind '{other}'"),
+                    "Pass one of: models, pipelines, adapters, sources.",
                 ));
             }
         };
@@ -601,7 +604,7 @@ impl RockyMcpServer {
     async fn inspect_schema(
         &self,
         _params: Parameters<InspectSchemaArgs>,
-    ) -> Result<Json<InspectSchemaResult>, String> {
+    ) -> ToolResult<InspectSchemaResult> {
         let to_entries = |buckets: Vec<(String, Vec<rocky_compiler::types::TypedColumn>)>| {
             buckets
                 .into_iter()
@@ -639,7 +642,7 @@ impl RockyMcpServer {
             Err(e) if e.to_string().contains("no models found") => {
                 (Vec::new(), Vec::new(), std::collections::HashSet::new())
             }
-            Err(e) => return Err(format!("{e:#}")),
+            Err(e) => return Err(ToolError::compile_failed(format!("{e:#}"))),
         };
 
         // Surface the physical warehouse tables so an agent can ground a raw
@@ -672,7 +675,7 @@ impl RockyMcpServer {
     async fn breaking_change(
         &self,
         params: Parameters<BreakingChangeArgs>,
-    ) -> Result<Json<BreakingChangeResult>, String> {
+    ) -> ToolResult<BreakingChangeResult> {
         let base = params.0.base;
         Ok(Json(self.compute_breaking_change(&base)))
     }
@@ -682,19 +685,18 @@ impl RockyMcpServer {
          `lineage`). For each dependent, returns the focal model's columns it reads via \
          `via_columns`. Use to gauge the blast radius of changing a model before editing it."
     )]
-    async fn dependents(
-        &self,
-        params: Parameters<DependentsArgs>,
-    ) -> Result<Json<DependentsResult>, String> {
+    async fn dependents(&self, params: Parameters<DependentsArgs>) -> ToolResult<DependentsResult> {
         let model = params.0.model;
-        let result = self.compile_full().map_err(|e| format!("{e:#}"))?;
+        let result = self
+            .compile_full()
+            .map_err(|e| ToolError::compile_failed(format!("{e:#}")))?;
 
         // Assert the focal model exists in the semantic graph — same
         // not-found contract as `lineage_output`.
         let schema = result
             .semantic_graph
             .model_schema(&model)
-            .ok_or_else(|| format!("model '{model}' not found"))?;
+            .ok_or_else(|| ToolError::model_not_found(&model))?;
 
         // Downstream model names come straight from the model schema; the
         // per-dependent `via_columns` are the focal model's columns that feed
@@ -730,17 +732,14 @@ impl RockyMcpServer {
          project at once. For the column-level edge trace of a single model use `lineage`; for \
          typed columns alone use `inspect_schema`; for one model's consumers use `dependents`."
     )]
-    async fn catalog(
-        &self,
-        _params: Parameters<CatalogArgs>,
-    ) -> Result<Json<CatalogResult>, String> {
+    async fn catalog(&self, _params: Parameters<CatalogArgs>) -> ToolResult<CatalogResult> {
         let output = commands::compute_catalog_output(
             &self.config_path,
             &self.state_path(),
             &self.models_dir,
             None,
         )
-        .map_err(|e| format!("{e:#}"))?;
+        .map_err(|e| ToolError::compile_failed(format!("{e:#}")))?;
         Ok(Json(catalog_result(output)))
     }
 
@@ -751,15 +750,19 @@ impl RockyMcpServer {
          operational reality — is this model flaky, slow, recently changed? Empty when nothing has \
          been run yet."
     )]
-    async fn history(
-        &self,
-        params: Parameters<HistoryArgs>,
-    ) -> Result<Json<HistoryResult>, String> {
+    async fn history(&self, params: Parameters<HistoryArgs>) -> ToolResult<HistoryResult> {
         let state_path = self.state_path();
         match params.0.model {
             Some(model) => {
                 let out = commands::model_history_output(&state_path, &model, None, false, 20)
-                    .map_err(|e| format!("{e:#}"))?;
+                    .map_err(|e| {
+                        ToolError::internal(
+                            format!("{e:#}"),
+                            "Could not read the run history from the state store; ensure the \
+                             project has been run at least once (history is empty, not an error, \
+                             before the first run).",
+                        )
+                    })?;
                 let executions = out
                     .executions
                     .into_iter()
@@ -778,8 +781,14 @@ impl RockyMcpServer {
                 }))
             }
             None => {
-                let out = commands::history_runs_output(&state_path, None, false)
-                    .map_err(|e| format!("{e:#}"))?;
+                let out = commands::history_runs_output(&state_path, None, false).map_err(|e| {
+                    ToolError::internal(
+                        format!("{e:#}"),
+                        "Could not read the run history from the state store; ensure the \
+                             project has been run at least once (history is empty, not an error, \
+                             before the first run).",
+                    )
+                })?;
                 let runs = out
                     .runs
                     .into_iter()
@@ -807,10 +816,7 @@ impl RockyMcpServer {
          null-rate alerts. Pass `column` to also get that column's per-run trend. `message` is set \
          (and snapshots empty) when the model has no recorded metrics yet."
     )]
-    async fn metrics(
-        &self,
-        params: Parameters<MetricsArgs>,
-    ) -> Result<Json<MetricsResult>, String> {
+    async fn metrics(&self, params: Parameters<MetricsArgs>) -> ToolResult<MetricsResult> {
         let args = params.0;
         let out = commands::metrics_output(
             &self.state_path(),
@@ -819,7 +825,14 @@ impl RockyMcpServer {
             args.column.as_deref(),
             true,
         )
-        .map_err(|e| format!("{e:#}"))?;
+        .map_err(|e| {
+            ToolError::internal(
+                format!("{e:#}"),
+                "Could not read quality metrics from the state store; ensure the project has been \
+                 run at least once (a model with no recorded metrics returns an empty result with \
+                 a `message`, not an error).",
+            )
+        })?;
 
         let snapshots = out
             .snapshots
@@ -860,16 +873,20 @@ impl RockyMcpServer {
          the reasoning. Use to reason about materialization with Rocky's cost model rather than \
          guessing. `message` is set (and recommendations empty) when there's no run history yet."
     )]
-    async fn optimize(
-        &self,
-        params: Parameters<OptimizeArgs>,
-    ) -> Result<Json<OptimizeResult>, String> {
+    async fn optimize(&self, params: Parameters<OptimizeArgs>) -> ToolResult<OptimizeResult> {
         let out = commands::optimize_output(
             &self.state_path(),
             Some(&self.models_dir),
             params.0.model.as_deref(),
         )
-        .map_err(|e| format!("{e:#}"))?;
+        .map_err(|e| {
+            ToolError::internal(
+                format!("{e:#}"),
+                "Could not compute optimization recommendations; ensure the project compiles and \
+                 has run history (no history returns an empty result with a `message`, not an \
+                 error).",
+            )
+        })?;
         let recommendations = out
             .recommendations
             .into_iter()
@@ -898,7 +915,7 @@ impl RockyMcpServer {
     async fn suggest_freshness_block(
         &self,
         params: Parameters<SuggestFreshnessBlockArgs>,
-    ) -> Result<Json<SuggestFreshnessBlockResult>, String> {
+    ) -> ToolResult<SuggestFreshnessBlockResult> {
         let args = params.0;
 
         // Gate on the API key the same way the LSP's freshness arm does;
@@ -933,11 +950,11 @@ impl RockyMcpServer {
             max_tokens: rocky_ai::client::DEFAULT_MAX_TOKENS,
         };
         let client = rocky_ai::client::LlmClient::new(ai_config)
-            .map_err(|e| format!("AI client init failed: {e}"))?;
+            .map_err(|e| ToolError::ai_error(format!("AI client init failed: {e}")))?;
         let response = client
             .generate(&system_prompt, &user_prompt, None)
             .await
-            .map_err(|e| format!("AI request failed: {e}"))?;
+            .map_err(|e| ToolError::ai_error(format!("AI request failed: {e}")))?;
 
         let extracted = rocky_ai::generate::extract_code(&response.content);
         let snippet = extracted.trim();
@@ -975,7 +992,7 @@ impl RockyMcpServer {
     async fn draft_contract(
         &self,
         params: Parameters<DraftContractArgs>,
-    ) -> Result<Json<DraftContractResult>, String> {
+    ) -> ToolResult<DraftContractResult> {
         let model_name = params.0.model;
 
         let client = match self.make_ai_client() {
@@ -990,20 +1007,20 @@ impl RockyMcpServer {
                     ..Default::default()
                 }));
             }
-            Err(e) => return Err(format!("AI client init failed: {e}")),
+            Err(e) => return Err(ToolError::ai_error(format!("AI client init failed: {e}"))),
         };
 
         // The model's inferred output schema — the basis for compile-verifying
         // the drafted contract.
-        let compiled = self.compile_full().map_err(|e| format!("{e:#}"))?;
+        let compiled = self
+            .compile_full()
+            .map_err(|e| ToolError::compile_failed(format!("{e:#}")))?;
         let inferred_schema: Vec<rocky_compiler::types::TypedColumn> = compiled
             .type_check
             .typed_models
             .get(&model_name)
             .cloned()
-            .ok_or_else(|| {
-                format!("model '{model_name}' not found in compiled project (or has no schema)")
-            })?;
+            .ok_or_else(|| ToolError::model_not_found(&model_name))?;
 
         // Profile each column against the live target table.
         let profile = match self
@@ -1022,7 +1039,7 @@ impl RockyMcpServer {
 
         let drafted = rocky_ai::contract::draft_contract(&profile, &inferred_schema, &client, 3)
             .await
-            .map_err(|e| format!("contract draft failed: {e}"))?;
+            .map_err(|e| ToolError::ai_error(format!("contract draft failed: {e}")))?;
 
         Ok(Json(DraftContractResult {
             model: model_name,
@@ -1044,7 +1061,7 @@ impl RockyMcpServer {
     async fn generate_tests(
         &self,
         params: Parameters<GenerateTestsArgs>,
-    ) -> Result<Json<GenerateTestsResult>, String> {
+    ) -> ToolResult<GenerateTestsResult> {
         let model_name = params.0.model;
 
         let client = match self.make_ai_client() {
@@ -1059,13 +1076,13 @@ impl RockyMcpServer {
                     ..Default::default()
                 }));
             }
-            Err(e) => return Err(format!("AI client init failed: {e}")),
+            Err(e) => return Err(ToolError::ai_error(format!("AI client init failed: {e}"))),
         };
 
         let (compiled, model) = self.compile_and_find_model(&model_name)?;
         let assertions = rocky_ai::testgen::generate_tests(&model, &compiled, &client)
             .await
-            .map_err(|e| format!("test generation failed: {e}"))?;
+            .map_err(|e| ToolError::ai_error(format!("test generation failed: {e}")))?;
 
         let assertions = assertions
             .into_iter()
@@ -1094,7 +1111,7 @@ impl RockyMcpServer {
     async fn explain_model(
         &self,
         params: Parameters<ExplainModelArgs>,
-    ) -> Result<Json<ExplainModelResult>, String> {
+    ) -> ToolResult<ExplainModelResult> {
         let model_name = params.0.model;
 
         let client = match self.make_ai_client() {
@@ -1109,13 +1126,13 @@ impl RockyMcpServer {
                     ..Default::default()
                 }));
             }
-            Err(e) => return Err(format!("AI client init failed: {e}")),
+            Err(e) => return Err(ToolError::ai_error(format!("AI client init failed: {e}"))),
         };
 
         let (compiled, model) = self.compile_and_find_model(&model_name)?;
         let intent = rocky_ai::explain::explain_model(&model, &compiled, &client)
             .await
-            .map_err(|e| format!("explain failed: {e}"))?;
+            .map_err(|e| ToolError::ai_error(format!("explain failed: {e}")))?;
 
         Ok(Json(ExplainModelResult {
             model: model_name,
@@ -1157,15 +1174,17 @@ impl RockyMcpServer {
     fn compile_and_find_model(
         &self,
         model_name: &str,
-    ) -> Result<(CompilerResult, rocky_core::models::Model), String> {
-        let compiled = self.compile_full().map_err(|e| format!("{e:#}"))?;
+    ) -> Result<(CompilerResult, rocky_core::models::Model), Json<ToolError>> {
+        let compiled = self
+            .compile_full()
+            .map_err(|e| ToolError::compile_failed(format!("{e:#}")))?;
         let model = compiled
             .project
             .models
             .iter()
             .find(|m| m.config.name == model_name)
             .cloned()
-            .ok_or_else(|| format!("model '{model_name}' not found in project"))?;
+            .ok_or_else(|| ToolError::model_not_found(model_name))?;
         Ok((compiled, model))
     }
 
@@ -1261,11 +1280,11 @@ impl RockyMcpServer {
     async fn governance_preview(
         &self,
         params: Parameters<GovernancePreviewArgs>,
-    ) -> Result<Json<GovernancePreviewResult>, String> {
+    ) -> ToolResult<GovernancePreviewResult> {
         let env = params.0.env;
 
         let cfg = rocky_core::config::load_rocky_config(&self.config_path)
-            .map_err(|e| format!("could not load rocky.toml: {e:#}"))?;
+            .map_err(|e| ToolError::config_invalid(format!("could not load rocky.toml: {e:#}")))?;
         // Resolve the active pipeline's target adapter type — the same input
         // `rocky plan` feeds `populate_governance_actions` so retention's
         // `warehouse_preview` renders the warehouse-native form. This is the
@@ -1295,7 +1314,7 @@ impl RockyMcpServer {
             &adapter_type,
             &mut output,
         )
-        .map_err(|e| format!("governance preview failed: {e:#}"))?;
+        .map_err(|e| ToolError::compile_failed(format!("governance preview failed: {e:#}")))?;
 
         Ok(Json(GovernancePreviewResult {
             env,
@@ -1344,18 +1363,38 @@ impl RockyMcpServer {
     async fn drift_preview(
         &self,
         params: Parameters<DriftPreviewArgs>,
-    ) -> Result<Json<DriftPreviewResult>, String> {
+    ) -> ToolResult<DriftPreviewResult> {
         let args = params.0;
 
         let adapter = self
             .warehouse_adapter()
-            .map_err(|e| format!("could not resolve the warehouse adapter: {e:#}"))?
-            .ok_or_else(|| "could not resolve the target warehouse adapter".to_string())?;
+            .map_err(|e| {
+                ToolError::warehouse_error(
+                    format!("could not resolve the warehouse adapter: {e:#}"),
+                    "Check the [adapter] block in rocky.toml and that the target warehouse's \
+                     credentials are set in the server environment.",
+                )
+            })?
+            .ok_or_else(|| {
+                ToolError::warehouse_error(
+                    "could not resolve the target warehouse adapter",
+                    "Check the [adapter] block in rocky.toml and that the target warehouse's \
+                     credentials are set in the server environment.",
+                )
+            })?;
 
-        let source_ref = parse_table_ref(&args.source_table)
-            .ok_or_else(|| format!("invalid source_table reference '{}'", args.source_table))?;
-        let target_ref = parse_table_ref(&args.target_table)
-            .ok_or_else(|| format!("invalid target_table reference '{}'", args.target_table))?;
+        let source_ref = parse_table_ref(&args.source_table).ok_or_else(|| {
+            ToolError::invalid_argument(
+                format!("invalid source_table reference '{}'", args.source_table),
+                "Pass a qualified `schema.table` or `catalog.schema.table` reference.",
+            )
+        })?;
+        let target_ref = parse_table_ref(&args.target_table).ok_or_else(|| {
+            ToolError::invalid_argument(
+                format!("invalid target_table reference '{}'", args.target_table),
+                "Pass a qualified `schema.table` or `catalog.schema.table` reference.",
+            )
+        })?;
 
         // DESCRIBE both tables. A failed describe on the TARGET means it is not
         // materialized yet (the first run would create it) — that's a clean
@@ -1363,18 +1402,24 @@ impl RockyMcpServer {
         // the SOURCE is a genuine error (you asked to compare against a table
         // that isn't there).
         let source_cols = adapter.describe_table(&source_ref).await.map_err(|e| {
-            format!(
-                "could not describe source_table '{}': {e}",
-                args.source_table
+            ToolError::warehouse_error(
+                format!(
+                    "could not describe source_table '{}': {e}",
+                    args.source_table
+                ),
+                "Confirm the source table exists and the target adapter's credentials can read it.",
             )
         })?;
         // Most adapters `Err` on a missing table, but some report an empty
         // column set instead; treat an empty source as not-found rather than
         // letting it produce a vacuously "no drift" answer that would lie.
         if source_cols.is_empty() {
-            return Err(format!(
-                "source_table '{}' has no columns (table not found or empty schema)",
-                args.source_table
+            return Err(ToolError::warehouse_error(
+                format!(
+                    "source_table '{}' has no columns (table not found or empty schema)",
+                    args.source_table
+                ),
+                "Confirm the source table exists and is not empty.",
             ));
         }
         let target_cols = adapter
@@ -1444,13 +1489,16 @@ impl RockyMcpServer {
     async fn sample_rows(
         &self,
         params: Parameters<SampleRowsArgs>,
-    ) -> Result<Json<SampleRowsResult>, String> {
+    ) -> ToolResult<SampleRowsResult> {
         let args = params.0;
 
-        let prepared = self
-            .prepare_table_query(&args.model)
-            .await
-            .map_err(|e| format!("{e:#}"))?;
+        let prepared = self.prepare_table_query(&args.model).await.map_err(|e| {
+            ToolError::warehouse_error(
+                format!("{e:#}"),
+                "Confirm the model name or `schema.table` reference exists and the target \
+                     adapter in rocky.toml has live warehouse credentials.",
+            )
+        })?;
 
         // Build: SELECT * FROM <ref> [tablesample] LIMIT n. The ref is built
         // only from validated identifiers; never `format!`'d from raw input.
@@ -1469,7 +1517,13 @@ impl RockyMcpServer {
 
         let qr = query_grounding(prepared.adapter.as_ref(), &sql)
             .await
-            .map_err(|e| format!("sample query failed: {e}"))?;
+            .map_err(|e| {
+                ToolError::warehouse_error(
+                    format!("sample query failed: {e}"),
+                    "Confirm the table is materialized and the target adapter's credentials can \
+                     read it.",
+                )
+            })?;
 
         let columns = qr.columns.clone();
         let mut rows: Vec<Vec<String>> = Vec::new();
@@ -1504,16 +1558,24 @@ impl RockyMcpServer {
     async fn profile_column(
         &self,
         params: Parameters<ProfileColumnArgs>,
-    ) -> Result<Json<ProfileColumnResult>, String> {
+    ) -> ToolResult<ProfileColumnResult> {
         let args = params.0;
 
-        let prepared = self
-            .prepare_table_query(&args.model)
-            .await
-            .map_err(|e| format!("{e:#}"))?;
+        let prepared = self.prepare_table_query(&args.model).await.map_err(|e| {
+            ToolError::warehouse_error(
+                format!("{e:#}"),
+                "Confirm the model name or `schema.table` reference exists and the target \
+                     adapter in rocky.toml has live warehouse credentials.",
+            )
+        })?;
 
-        let col = rocky_sql::validation::validate_identifier(&args.column)
-            .map_err(|e| format!("invalid column identifier: {e}"))?;
+        let col = rocky_sql::validation::validate_identifier(&args.column).map_err(|e| {
+            ToolError::invalid_argument(
+                format!("invalid column identifier: {e}"),
+                "Pass a valid column name (letters, digits, and underscores); verify it with \
+                 `inspect_schema`.",
+            )
+        })?;
 
         // Cast to the dialect's string type — `VARCHAR` everywhere except
         // BigQuery, where it is `STRING` (BigQuery rejects `CAST(... AS VARCHAR)`).
@@ -1528,11 +1590,19 @@ impl RockyMcpServer {
 
         let qr = query_grounding(prepared.adapter.as_ref(), &sql)
             .await
-            .map_err(|e| format!("profile query failed: {e}"))?;
-        let row = qr
-            .rows
-            .first()
-            .ok_or_else(|| "profile query returned no rows".to_string())?;
+            .map_err(|e| {
+                ToolError::warehouse_error(
+                    format!("profile query failed: {e}"),
+                    "Confirm the table is materialized and the target adapter's credentials can \
+                     read it.",
+                )
+            })?;
+        let row = qr.rows.first().ok_or_else(|| {
+            ToolError::warehouse_error(
+                "profile query returned no rows",
+                "Confirm the target table is materialized and non-empty.",
+            )
+        })?;
 
         let as_u64 = |v: &serde_json::Value| -> u64 {
             match v {
@@ -1602,13 +1672,14 @@ impl RockyMcpServer {
          (`rocky review <plan_id> --approve`) before `rocky apply <plan_id>` will run it. Surface \
          the plan_id and the review/apply path to the user; never approve on their behalf."
     )]
-    async fn propose(
-        &self,
-        params: Parameters<ProposeArgs>,
-    ) -> Result<Json<ProposeResult>, String> {
-        let result = self.compile_full().map_err(|e| format!("{e:#}"))?;
+    async fn propose(&self, params: Parameters<ProposeArgs>) -> ToolResult<ProposeResult> {
+        let result = self
+            .compile_full()
+            .map_err(|e| ToolError::compile_failed(format!("{e:#}")))?;
         if result.project.models.is_empty() {
-            return Err("project has no compiled models to propose".to_string());
+            return Err(ToolError::empty_project(
+                "project has no compiled models to propose",
+            ));
         }
         let models: Vec<String> = result
             .project
@@ -1622,7 +1693,7 @@ impl RockyMcpServer {
         if let Some(model) = params.0.model.as_deref()
             && !models.iter().any(|m| m == model)
         {
-            return Err(format!("model '{model}' not found in project"));
+            return Err(ToolError::model_not_found(model));
         }
 
         let run_plan = build_ai_run_plan(params.0.model.clone(), &result);
@@ -1631,7 +1702,12 @@ impl RockyMcpServer {
             rocky_cli::plan_store::PlanKind::AiAuthored,
             &run_plan,
         )
-        .map_err(|e| format!("failed to write AI-authored plan: {e:#}"))?;
+        .map_err(|e| {
+            ToolError::internal(
+                format!("failed to write AI-authored plan: {e:#}"),
+                "Ensure the project directory is writable so the plan store can persist the plan.",
+            )
+        })?;
 
         Ok(Json(ProposeResult { plan_id, models }))
     }
@@ -2175,18 +2251,19 @@ fn json_as_u64(v: &serde_json::Value) -> u64 {
 ///
 /// Accepts the `Dialect` serde vocabulary case-insensitively
 /// (`databricks`/`snowflake`/`bigquery`/`duckdb`). An unrecognised value is a
-/// caller error returned as a `String` (the tool's `Err` arm), naming the
-/// accepted values rather than silently ignoring the request.
-fn parse_target_dialect(raw: &str) -> Result<rocky_sql::transpile::Dialect, String> {
+/// caller error returned as an [`InvalidArgument`](crate::error::ToolErrorCode)
+/// envelope naming the accepted values, rather than silently ignoring the
+/// request.
+fn parse_target_dialect(raw: &str) -> Result<rocky_sql::transpile::Dialect, rmcp::Json<ToolError>> {
     use rocky_sql::transpile::Dialect;
     match raw.trim().to_ascii_lowercase().as_str() {
         "databricks" => Ok(Dialect::Databricks),
         "snowflake" => Ok(Dialect::Snowflake),
         "bigquery" => Ok(Dialect::BigQuery),
         "duckdb" => Ok(Dialect::DuckDB),
-        other => Err(format!(
-            "unknown target_dialect '{other}': expected one of \
-             databricks, snowflake, bigquery, duckdb"
+        other => Err(ToolError::invalid_argument(
+            format!("unknown target_dialect '{other}'"),
+            "Pass one of: databricks, snowflake, bigquery, duckdb.",
         )),
     }
 }
@@ -2472,23 +2549,33 @@ mod tests {
     #[test]
     fn parse_target_dialect_accepts_known_values_case_insensitively() {
         use rocky_sql::transpile::Dialect;
-        assert_eq!(parse_target_dialect("bigquery"), Ok(Dialect::BigQuery));
-        assert_eq!(parse_target_dialect("BigQuery"), Ok(Dialect::BigQuery));
-        assert_eq!(parse_target_dialect(" snowflake "), Ok(Dialect::Snowflake));
-        assert_eq!(parse_target_dialect("DATABRICKS"), Ok(Dialect::Databricks));
-        assert_eq!(parse_target_dialect("duckdb"), Ok(Dialect::DuckDB));
+        // `Json<ToolError>` is not `Debug`, so match rather than `.expect()`.
+        let ok = |s: &str| match parse_target_dialect(s) {
+            Ok(d) => d,
+            Err(_) => panic!("'{s}' should parse to a known dialect"),
+        };
+        assert_eq!(ok("bigquery"), Dialect::BigQuery);
+        assert_eq!(ok("BigQuery"), Dialect::BigQuery);
+        assert_eq!(ok(" snowflake "), Dialect::Snowflake);
+        assert_eq!(ok("DATABRICKS"), Dialect::Databricks);
+        assert_eq!(ok("duckdb"), Dialect::DuckDB);
     }
 
     #[test]
     fn parse_target_dialect_rejects_unknown_value() {
         let err = parse_target_dialect("redshift").expect_err("unknown dialect must error");
+        // The failure is the structured envelope: an invalid_argument code, the
+        // offending value in the message, and the accepted set in the hint.
+        assert_eq!(err.0.code, crate::error::ToolErrorCode::InvalidArgument);
         assert!(
-            err.contains("redshift"),
-            "error should name the input: {err}"
+            err.0.message.contains("redshift"),
+            "message should name the input: {:?}",
+            err.0
         );
         assert!(
-            err.contains("bigquery"),
-            "error should list the accepted values: {err}"
+            err.0.remediation_hint.contains("bigquery"),
+            "hint should list the accepted values: {:?}",
+            err.0
         );
     }
 

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -1076,6 +1076,97 @@ async fn compile_rejects_unknown_target_dialect() {
         Some(true),
         "unknown target_dialect must be an error"
     );
+    // The failure carries the structured envelope: a machine-matchable code, a
+    // message, and an actionable remediation_hint that names the accepted set.
+    let err = result
+        .structured_content
+        .expect("a failing tool call carries the structured error envelope");
+    assert_eq!(err["code"], serde_json::json!("invalid_argument"));
+    assert!(
+        err["message"].as_str().unwrap().contains("redshift"),
+        "message names the offending value: {err:?}"
+    );
+    let hint = err["remediation_hint"].as_str().unwrap();
+    assert!(
+        hint.contains("duckdb") && hint.contains("snowflake"),
+        "remediation_hint names the accepted dialects: {hint:?}"
+    );
+
+    client.cancel().await.unwrap();
+}
+
+/// The structured-error contract, end-to-end over the wire: every failing tool
+/// call comes back as `is_error: true` with a `{code, message,
+/// remediation_hint}` envelope in `structured_content`. Drives one
+/// representative error class per code an offline call can reach, so the
+/// envelope shape is proven reachable through `rocky mcp` (not just unit-typed).
+#[tokio::test]
+async fn tool_failures_carry_structured_error_envelope() {
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+
+    // Assert a failing tool call carries the full envelope and return the
+    // parsed error object for further per-case assertions.
+    async fn expect_error(
+        client: &rmcp::service::RunningService<rmcp::RoleClient, ()>,
+        tool: &'static str,
+        args: serde_json::Value,
+    ) -> serde_json::Value {
+        let params = match args {
+            serde_json::Value::Null => CallToolRequestParams::new(tool),
+            other => {
+                CallToolRequestParams::new(tool).with_arguments(other.as_object().unwrap().clone())
+            }
+        };
+        let result = client
+            .call_tool(params)
+            .await
+            .unwrap_or_else(|e| panic!("{tool} call returns a result: {e}"));
+        assert_eq!(result.is_error, Some(true), "{tool} must be an error");
+        let err = result
+            .structured_content
+            .unwrap_or_else(|| panic!("{tool} error carries structured_content"));
+        for key in ["code", "message", "remediation_hint"] {
+            let v = err.get(key).and_then(|v| v.as_str());
+            assert!(
+                v.is_some_and(|s| !s.trim().is_empty()),
+                "{tool} envelope has a non-empty {key}: {err:?}"
+            );
+        }
+        // policy_rule is reserved for a future policy plane and absent today.
+        assert!(
+            err.get("policy_rule").is_none(),
+            "{tool} envelope omits policy_rule until the policy plane sets it: {err:?}"
+        );
+        err
+    }
+
+    // invalid_argument — unknown `list` kind (no compile, no warehouse).
+    let bad_kind = expect_error(&client, "list", serde_json::json!({ "kind": "frobnicate" })).await;
+    assert_eq!(bad_kind["code"], serde_json::json!("invalid_argument"));
+    assert!(
+        bad_kind["remediation_hint"]
+            .as_str()
+            .unwrap()
+            .contains("models"),
+        "list hint names the accepted kinds: {bad_kind:?}"
+    );
+
+    // model_not_found — the project compiles (one model) but the name is absent.
+    let ghost = expect_error(
+        &client,
+        "dependents",
+        serde_json::json!({ "model": "ghost" }),
+    )
+    .await;
+    assert_eq!(ghost["code"], serde_json::json!("model_not_found"));
+    let ghost_hint = ghost["remediation_hint"].as_str().unwrap();
+    assert!(
+        ghost_hint.contains("list") || ghost_hint.contains("inspect_schema"),
+        "model_not_found hint points at a discovery tool: {ghost_hint:?}"
+    );
 
     client.cancel().await.unwrap();
 }

--- a/engine/evals/README.md
+++ b/engine/evals/README.md
@@ -40,6 +40,11 @@ uv run python run_evals.py --scenario completed_revenue --model claude-opus-4-1 
 
 # Creds-free plumbing check (CI runs this on the no-secret path):
 uv run python run_evals.py --selftest
+
+# Structured-error contract check (needs only the `rocky` binary — no key, no
+# warehouse, no model): drives `rocky mcp` with bad input and asserts the
+# {code, message, remediation_hint} error envelope + hint quality.
+uv run python run_evals.py --error-contract
 ```
 
 `ROCKY_BIN` overrides binary discovery (otherwise: `engine/target/{release,debug}/rocky`,
@@ -73,6 +78,25 @@ from the agent's own claim of success:
 
 A scenario **passes** when all of its *required* checks pass; the reconcile bonus
 is recorded but never gates the pass.
+
+### The structured-error contract (`--error-contract`)
+
+A separate, **creds-free** check (needs only the `rocky` binary — no model key,
+no `claude`, no warehouse) asserts the MCP surface's *failure* paths, not just
+its success paths. It drives a real `rocky mcp` server over stdio with
+deliberately bad input and checks, with deterministic assertions, that every
+failing tool call returns a tool-result error (`isError: true`) carrying a
+`{code, message, remediation_hint, policy_rule?}` envelope in
+`structuredContent` — the machine-UX analog of Rocky's diagnostic codes — with a
+stable `code` and an *actionable* `remediation_hint` (e.g. an unknown dialect's
+hint must name the accepted set; a `model_not_found` hint must point at a
+discovery tool). It also pins the complementary shape: a genuine **compile
+error** is *not* an envelope — it is a successful call reporting
+`has_errors: true` with diagnostics that each carry a code and message.
+
+Unlike the live authoring scenarios (whose pass/fail is model-outcome variance),
+this contract is deterministic, so a failure is a real regression and **gates**
+the run. CI runs it on the no-secret path alongside `--selftest`.
 
 ### Why the agent gets no shell
 
@@ -126,6 +150,7 @@ engine/evals/
 │   ├── scoring.py               deterministic checks (pure fns)
 │   ├── scorecard.py             scorecard model + JSON/Markdown render
 │   ├── selftest.py              creds-free plumbing check
+│   ├── error_contract.py        creds-free structured-error contract check (rocky binary only)
 │   └── version.py               HARNESS_VERSION
 ├── fixtures/orders_trap/        the pinned DuckDB fixture (the reconcile trap)
 └── testdata/                    recorded transcript for --selftest

--- a/engine/evals/harness/error_contract.py
+++ b/engine/evals/harness/error_contract.py
@@ -1,0 +1,388 @@
+"""Structured-error contract check — creds-free, no model call.
+
+The MCP surface is the interface agents work through, so its *failure* paths get
+the same rigor as its success paths: every failing tool call must come back as a
+tool-result error (``isError: true``) whose ``structuredContent`` is a
+``{code, message, remediation_hint, policy_rule?}`` envelope — a stable machine
+code plus an *actionable* hint the agent can route on, the tool-layer analog of
+Rocky's diagnostic codes.
+
+This module asserts that contract end-to-end by driving a real ``rocky mcp``
+server over stdio with deliberately bad input and checking the envelope shape and
+hint quality with **deterministic assertions**. It needs only the ``rocky``
+binary — no ``$ANTHROPIC_API_KEY``, no ``claude`` CLI, no warehouse, no live
+model — so it is the half of the suite that actually *runs* on the no-secret CI
+path (the live authoring scenarios skip there).
+
+It also pins the complementary shape: a genuine **compile error** is *not* an
+envelope — it is a successful call reporting ``has_errors: true`` with
+diagnostics (each already carrying code/message/span/suggestion — the same house
+style). Forcing it into the error envelope would be wrong, so the two shapes are
+asserted separately.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+# The MCP protocol version the client advertises. Any version the server accepts
+# works; it negotiates down. Pinned so the handshake is reproducible.
+_PROTOCOL_VERSION = "2025-06-18"
+# Overall wall budget for one server round-trip (spawn + handshake + one call).
+# Generous: a cold binary on a loaded CI box, never interactive.
+_CALL_TIMEOUT_S = 60
+
+
+# --------------------------------------------------------------------------
+# minimal MCP stdio client (stdlib only)
+# --------------------------------------------------------------------------
+
+
+def _mcp_call_tool(
+    rocky_bin: Path,
+    project_dir: Path,
+    tool: str,
+    arguments: dict,
+    config: str = "rocky.toml",
+) -> dict:
+    """Drive one ``tools/call`` against a fresh ``rocky mcp`` server.
+
+    Batches the three JSON-RPC messages the MCP handshake needs (initialize →
+    initialized notification → the tool call) onto stdin, closes it, and reads
+    the server's line-delimited responses off stdout. Closing stdin gives the
+    stdio server EOF so it exits on its own — no interactive read loop to
+    deadlock. Returns the ``CallToolResult`` object for the tool call.
+    """
+    requests = [
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": _PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "rocky-error-contract-eval", "version": "0"},
+            },
+        },
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": tool, "arguments": arguments},
+        },
+    ]
+    payload = "".join(json.dumps(r) + "\n" for r in requests)
+
+    proc = subprocess.Popen(
+        [str(rocky_bin), "mcp", "--config", config],
+        cwd=str(project_dir),
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        out, err = proc.communicate(input=payload, timeout=_CALL_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        out, err = proc.communicate()
+        raise RuntimeError(
+            f"`rocky mcp` did not answer tools/call within {_CALL_TIMEOUT_S}s; "
+            f"stderr tail: {err[-500:]!r}"
+        ) from None
+
+    # The server logs to stderr; stdout is the JSON-RPC wire. Accept only the
+    # line that parses to the response for our tool call (id == 2) — a stray log
+    # line on stdout can never be mistaken for the result.
+    for line in out.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if msg.get("id") != 2:
+            continue
+        if "result" in msg:
+            return msg["result"]
+        if "error" in msg:
+            # A JSON-RPC *protocol* error is the wrong shape: the contract is a
+            # tool-*result* error, so surface this as a contract failure.
+            raise RuntimeError(
+                f"tool '{tool}' returned a JSON-RPC protocol error, not a tool-result "
+                f"error envelope: {msg['error']}"
+            )
+    raise RuntimeError(
+        f"no tools/call response from `rocky mcp` for '{tool}'. stdout={out[-500:]!r} "
+        f"stderr={err[-500:]!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# fixtures — minimal, self-contained projects per error case
+# --------------------------------------------------------------------------
+
+_MINIMAL_CONFIG = """\
+[adapter]
+type = "duckdb"
+path = "poc.duckdb"
+
+[pipeline.poc]
+strategy = "full_refresh"
+
+[pipeline.poc.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.poc.target]
+catalog_template = "poc"
+schema_template = "demo"
+"""
+
+
+def _model_sidecar(name: str) -> str:
+    return (
+        f'name = "{name}"\n\n'
+        '[strategy]\ntype = "full_refresh"\n\n'
+        f'[target]\ncatalog = "poc"\nschema = "demo"\ntable = "{name}"\n'
+    )
+
+
+def _write_valid_project(project: Path) -> None:
+    """A minimal, compilable DuckDB project (no warehouse connection needed).
+
+    Uses a per-model TOML sidecar (not just `_defaults.toml`): the `rocky`
+    model loader requires each `.sql` to carry frontmatter or a sidecar, so a
+    bare `.sql` would fail to load rather than compile.
+    """
+    (project / "models").mkdir(parents=True, exist_ok=True)
+    (project / "rocky.toml").write_text(_MINIMAL_CONFIG)
+    # A self-contained model with no source refs — compiles on a cold cache.
+    (project / "models" / "orders.sql").write_text("SELECT 1 AS id, 'COMPLETE' AS status\n")
+    (project / "models" / "orders.toml").write_text(_model_sidecar("orders"))
+
+
+def _write_broken_config_project(project: Path) -> None:
+    """A project whose `rocky.toml` is present but syntactically invalid."""
+    (project / "models").mkdir(parents=True, exist_ok=True)
+    # Unterminated table header — a hard TOML parse error, so config load fails.
+    (project / "rocky.toml").write_text('[adapter\ntype = "duckdb"\n')
+
+
+def _write_compile_error_project(project: Path) -> None:
+    """A project with one model that fails to compile (a real compile *error*).
+
+    The model references an unbound run variable (`@var(threshold)`) with no
+    supplied value and no inline default — an E028 error diagnostic. This fires
+    on a cold cache (no warm source schema needed) and, unlike a raw SQL parse
+    error (which is a *pipeline* failure surfaced as the error envelope), it is a
+    successful compile call reporting `has_errors: true` with diagnostics — the
+    exact shape this case is meant to pin.
+    """
+    (project / "models").mkdir(parents=True, exist_ok=True)
+    (project / "rocky.toml").write_text(_MINIMAL_CONFIG)
+    (project / "models" / "bad.sql").write_text("SELECT 1 AS id WHERE 1 = @var(threshold)\n")
+    (project / "models" / "bad.toml").write_text(_model_sidecar("bad"))
+
+
+def _write_parse_error_project(project: Path) -> None:
+    """A project whose model SQL does not parse — a compile *pipeline* failure
+    (distinct from an E-code diagnostic), which surfaces as the error envelope."""
+    (project / "models").mkdir(parents=True, exist_ok=True)
+    (project / "rocky.toml").write_text(_MINIMAL_CONFIG)
+    (project / "models" / "bad.sql").write_text("SELECT FROM\n")
+    (project / "models" / "bad.toml").write_text(_model_sidecar("bad"))
+
+
+# --------------------------------------------------------------------------
+# cases
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EnvelopeCase:
+    """A tool call that must fail with the structured error envelope."""
+
+    id: str
+    setup: Callable[[Path], None]
+    tool: str
+    arguments: dict
+    expected_code: str
+    #: Substrings the remediation_hint must contain (all of them) — the
+    #: deterministic hint-quality bar: the hint must point somewhere actionable.
+    hint_contains_all: tuple[str, ...] = ()
+    #: Substrings the remediation_hint must contain at least one of.
+    hint_contains_any: tuple[str, ...] = ()
+
+
+ENVELOPE_CASES: tuple[EnvelopeCase, ...] = (
+    EnvelopeCase(
+        id="invalid_argument__unknown_dialect",
+        setup=_write_valid_project,
+        tool="compile",
+        arguments={"target_dialect": "redshift"},
+        expected_code="invalid_argument",
+        # The hint must name the accepted dialects, not just say "bad value".
+        hint_contains_all=("duckdb", "snowflake"),
+    ),
+    EnvelopeCase(
+        id="invalid_argument__unknown_list_kind",
+        setup=_write_valid_project,
+        tool="list",
+        arguments={"kind": "frobnicate"},
+        expected_code="invalid_argument",
+        hint_contains_all=("models",),
+    ),
+    EnvelopeCase(
+        id="config_invalid__malformed_rocky_toml",
+        setup=_write_broken_config_project,
+        tool="governance_preview",
+        arguments={},
+        expected_code="config_invalid",
+        hint_contains_all=("rocky.toml",),
+    ),
+    EnvelopeCase(
+        id="model_not_found__unknown_model",
+        setup=_write_valid_project,
+        tool="dependents",
+        arguments={"model": "ghost"},
+        expected_code="model_not_found",
+        # The hint must route the agent to a discovery tool.
+        hint_contains_any=("list", "inspect_schema"),
+    ),
+    EnvelopeCase(
+        id="compile_failed__unparseable_sql",
+        setup=_write_parse_error_project,
+        tool="compile",
+        arguments={},
+        expected_code="compile_failed",
+        hint_contains_all=("compile",),
+    ),
+)
+
+
+@dataclass
+class CaseResult:
+    id: str
+    passed: bool
+    detail: str
+
+
+def _nonempty_str(obj: dict, key: str) -> str | None:
+    value = obj.get(key)
+    if isinstance(value, str) and value.strip():
+        return value
+    return None
+
+
+def _check_envelope_case(rocky_bin: Path, case: EnvelopeCase) -> CaseResult:
+    with TemporaryDirectory(prefix=f"rocky-errctr-{case.id}-") as tmp:
+        project = Path(tmp)
+        case.setup(project)
+        try:
+            result = _mcp_call_tool(rocky_bin, project, case.tool, case.arguments)
+        except RuntimeError as exc:
+            return CaseResult(case.id, False, str(exc))
+
+    if result.get("isError") is not True:
+        return CaseResult(case.id, False, f"expected isError=true, got {result.get('isError')!r}")
+
+    envelope = result.get("structuredContent")
+    if not isinstance(envelope, dict):
+        return CaseResult(case.id, False, f"no structuredContent envelope: {result!r}")
+
+    code = envelope.get("code")
+    if code != case.expected_code:
+        return CaseResult(case.id, False, f"code={code!r}, expected {case.expected_code!r}")
+
+    if _nonempty_str(envelope, "message") is None:
+        return CaseResult(case.id, False, "message is empty or missing")
+
+    hint = _nonempty_str(envelope, "remediation_hint")
+    if hint is None:
+        return CaseResult(case.id, False, "remediation_hint is empty or missing")
+
+    missing_all = [s for s in case.hint_contains_all if s not in hint]
+    if missing_all:
+        return CaseResult(case.id, False, f"hint missing required text {missing_all}: {hint!r}")
+    if case.hint_contains_any and not any(s in hint for s in case.hint_contains_any):
+        return CaseResult(
+            case.id, False, f"hint contains none of {case.hint_contains_any}: {hint!r}"
+        )
+
+    return CaseResult(case.id, True, f"code={code} hint={hint!r}")
+
+
+def _check_compile_error_shape(rocky_bin: Path) -> CaseResult:
+    """A genuine compile error is a *successful* call with diagnostics — NOT the
+    error envelope. Assert that complementary shape so the two never blur."""
+    case_id = "compile_error__diagnostics_not_envelope"
+    with TemporaryDirectory(prefix="rocky-errctr-compile-") as tmp:
+        project = Path(tmp)
+        _write_compile_error_project(project)
+        try:
+            result = _mcp_call_tool(rocky_bin, project, "compile", {})
+        except RuntimeError as exc:
+            return CaseResult(case_id, False, str(exc))
+
+    if result.get("isError") is True:
+        return CaseResult(case_id, False, "a compile error must NOT be a tool-result error")
+    body = result.get("structuredContent")
+    if not isinstance(body, dict):
+        return CaseResult(case_id, False, f"no structuredContent: {result!r}")
+    if body.get("has_errors") is not True:
+        return CaseResult(
+            case_id, False, f"expected has_errors=true, got {body.get('has_errors')!r}"
+        )
+    diagnostics = body.get("diagnostics")
+    if not isinstance(diagnostics, list) or not diagnostics:
+        return CaseResult(case_id, False, "expected non-empty diagnostics")
+    # Every diagnostic carries the actionable house style: a code and a message.
+    for diag in diagnostics:
+        if _nonempty_str(diag, "code") is None or _nonempty_str(diag, "message") is None:
+            return CaseResult(case_id, False, f"diagnostic missing code/message: {diag!r}")
+    return CaseResult(case_id, True, f"{len(diagnostics)} diagnostic(s), each with code+message")
+
+
+def run(rocky_bin: Path) -> tuple[int, list[CaseResult]]:
+    """Run every error-contract case. Returns (failure_count, results)."""
+    results = [_check_envelope_case(rocky_bin, case) for case in ENVELOPE_CASES]
+    results.append(_check_compile_error_shape(rocky_bin))
+    failures = sum(1 for r in results if not r.passed)
+    return failures, results
+
+
+def main() -> int:
+    """Creds-free entry point: needs only the `rocky` binary; skips clean without
+    it (exit 0), fails hard on a broken contract (exit 1)."""
+    # Imported lazily so this module stays importable without the rest of the
+    # harness on the path.
+    from harness.environ import resolve_rocky_bin
+
+    rocky_bin = resolve_rocky_bin()
+    if rocky_bin is None:
+        print(
+            "error-contract: SKIP — the `rocky` binary was not found "
+            "(set $ROCKY_BIN or build it with `cargo build` in engine/)",
+            file=sys.stderr,
+        )
+        return 0
+
+    failures, results = run(rocky_bin)
+    for r in results:
+        status = "ok   " if r.passed else "FAIL "
+        print(f"{status} {r.id}: {r.detail}", file=sys.stderr)
+    if failures:
+        print(f"\nerror-contract: {failures} failure(s)", file=sys.stderr)
+        return 1
+    print(f"\nerror-contract: all {len(results)} cases passed", file=sys.stderr)
+    return 0

--- a/engine/evals/harness/version.py
+++ b/engine/evals/harness/version.py
@@ -7,4 +7,4 @@ frontier-model change, or a real regression, and the version pin is what lets a
 reader tell them apart.
 """
 
-HARNESS_VERSION = "0.1.0"
+HARNESS_VERSION = "0.2.0"

--- a/engine/evals/run_evals.py
+++ b/engine/evals/run_evals.py
@@ -6,6 +6,7 @@ Usage:
     uv run python run_evals.py --scenario completed_revenue
     uv run python run_evals.py --model claude-opus-4-1 --max-attempts 2
     uv run python run_evals.py --selftest      # creds-free: score a recorded transcript
+    uv run python run_evals.py --error-contract # rocky-binary only: assert the MCP error envelope
 
 The live suite is NOT creds-free — it drives a scripted Claude Code session and
 needs $ANTHROPIC_API_KEY (plus the `claude`, `rocky`, and `duckdb` CLIs). When
@@ -29,6 +30,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from harness import error_contract as error_contract_mod
 from harness import selftest as selftest_mod
 from harness.driver import ClaudeCliDriver
 from harness.environ import resolve_environment
@@ -201,10 +203,19 @@ def main(argv: list[str]) -> int:
         action="store_true",
         help="creds-free plumbing check: score a recorded transcript, no model call",
     )
+    parser.add_argument(
+        "--error-contract",
+        action="store_true",
+        help="rocky-binary-only check: assert the structured MCP error envelope on bad input "
+        "(no model key, no warehouse)",
+    )
     args = parser.parse_args(argv)
 
     if args.selftest:
         return selftest_mod.run()
+
+    if args.error_contract:
+        return error_contract_mod.main()
 
     card = build_scorecard(args)
     json_path, md_path = write_outputs(card, args.output_dir)


### PR DESCRIPTION
## What

Every failing Rocky MCP tool call now returns **one machine-parseable error envelope** — `{code, message, remediation_hint, policy_rule?}` — as a tool-result error (`isError: true`) with the envelope in `structuredContent`. This is the tool-layer analog of Rocky's diagnostic codes: an agent branches on a stable `code` and acts on an actionable `remediation_hint` without scraping prose.

Mechanical change with **no behavior change to any tool's success path** — this only makes failures structured and actionable.

## How

- New `ToolError` / `ToolErrorCode` (8 stable snake_case codes) + a `ToolResult<T>` alias in `crates/rocky-mcp/src/error.rs`. Errors ride rmcp's own `Json<T>` serialization path (`Result<Json<T>, Json<ToolError>>`): on the error arm rmcp emits `structured_content` and flips `is_error` to `true` — so `is_error` semantics are preserved and **no custom trait impls** are needed (a hand-written `IntoCallToolResult for ToolError` would collide with rmcp's blanket impl under the orphan rule).
- Audited and routed **every error path across all 21 tools** (one of which is `propose`) plus the `compile_and_find_model` helper to the envelope, each with a per-site `code` and an actionable hint. Graceful-degradation arms are preserved exactly (no-API-key drafts, the cold-start "no models found" arm in `inspect_schema`, the absent-drift-target arm in `drift_preview`).
- `policy_rule` is reserved (absent on every error today) for a future policy plane.

### Error codes
`invalid_argument`, `config_invalid`, `compile_failed`, `model_not_found`, `empty_project`, `warehouse_error`, `ai_error`, `internal`. Seven are runtime-reachable; `empty_project` is retained as a defensive branch in `propose` but is not reachable via the CLI today (a 0-model project fails `compile` first, surfacing as `compile_failed`).

## Reachability + verification

- **Roundtrip test** (`tests/roundtrip.rs`) drives the in-process server end-to-end and asserts the `{code, message, remediation_hint}` envelope + `is_error: true` for the `invalid_argument` and `model_not_found` classes; the existing unknown-dialect test now asserts the full envelope. All 28 roundtrip + 13 lib tests pass.
- **New creds-free eval** (`engine/evals` — `run_evals.py --error-contract`) drives a real `rocky mcp` server over stdio (minimal stdlib JSON-RPC client, no key / no warehouse / no model) with deliberately bad input and asserts the envelope shape + **hint quality** on the common failure classes (`invalid_argument` ×2, `config_invalid` = the missing-config case, `model_not_found`, `compile_failed`), plus the complementary shape — a genuine **compile error** is a *successful* call reporting `has_errors: true` with diagnostics, **not** an envelope. Deterministic (verified repeatable across runs). Wired as a **gating** step in the label-gated evals CI job alongside `--selftest`.

## CI note

The new contract check is deterministic and creds-free, but it lives inside the `engine-evals` job, which is gated on the `evals` PR label (that job exists for the slower, billable live-agent loop). Reviewer's call whether the structured-error contract warrants an always-on lane; apply the `evals` label to this PR to exercise it in CI.

## Gates

`cargo fmt --check`, `cargo clippy --workspace --all-targets`, `cargo test --workspace` (0 failed), `ruff format --check` + `ruff check` on `engine/evals`, and the new eval (6/6, no flakes) all pass locally. No `*Output`/JsonSchema structs changed, so no `just codegen`.