### PR TITLE
feat(engine/rocky-core): record producer-side output column hashes

### DIFF
--- a/engine/crates/rocky-cli/src/commands/catalog.rs
+++ b/engine/crates/rocky-cli/src/commands/catalog.rs
@@ -1235,6 +1235,7 @@ mod tests {
                 input_proof_class: None,
                 env_hash: None,
                 hash_scheme: None,
+                output_column_hashes: None,
             }
         }
     }

--- a/engine/crates/rocky-cli/src/commands/cost.rs
+++ b/engine/crates/rocky-cli/src/commands/cost.rs
@@ -513,6 +513,7 @@ mod tests {
             input_proof_class: None,
             env_hash: None,
             hash_scheme: None,
+            output_column_hashes: None,
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/history.rs
+++ b/engine/crates/rocky-cli/src/commands/history.rs
@@ -468,6 +468,7 @@ mod tests {
                 input_proof_class: None,
                 env_hash: None,
                 hash_scheme: None,
+                output_column_hashes: None,
             }],
             trigger: RunTrigger::Manual,
             config_hash: "cfg-hash".to_string(),
@@ -541,6 +542,7 @@ mod tests {
             input_proof_class: None,
             env_hash: None,
             hash_scheme: None,
+            output_column_hashes: None,
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/preview.rs
+++ b/engine/crates/rocky-cli/src/commands/preview.rs
@@ -2271,6 +2271,7 @@ mod tests {
             input_proof_class: None,
             env_hash: None,
             hash_scheme: None,
+            output_column_hashes: None,
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/replay.rs
+++ b/engine/crates/rocky-cli/src/commands/replay.rs
@@ -366,6 +366,7 @@ mod tests {
                 input_proof_class: None,
                 env_hash: None,
                 hash_scheme: None,
+                output_column_hashes: None,
             })
             .collect();
         RunRecord {

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -5218,6 +5218,13 @@ pub(crate) async fn execute_models(
                                 &model_ir,
                                 warehouse.dialect().name(),
                             )),
+                            // Producer-side per-output-column content hashes for
+                            // this content-addressed build. Empty (⇒ `None`) on a
+                            // point-to reuse or a partitioned table — both degrade
+                            // to a safe rebuild in the later skip gate. Captured
+                            // only; nothing consults it yet.
+                            output_column_hashes: (!summary.output_column_hashes.is_empty())
+                                .then(|| summary.output_column_hashes.clone()),
                         });
                         // Per-model decision (reporting-only). A
                         // content_addressed model is never skip-eligible, so it
@@ -6065,6 +6072,8 @@ async fn execute_one_plain_model(
             &model_ir,
             warehouse.dialect().name(),
         )),
+        // Not the content-addressed write path — no in-process column bytes.
+        output_column_hashes: None,
     })
 }
 
@@ -6496,6 +6505,8 @@ async fn run_one_partition(
                 &model.to_model_ir(),
                 warehouse.dialect().name(),
             )),
+            // Not the content-addressed write path — no in-process column bytes.
+            output_column_hashes: None,
         }),
     }
 }
@@ -7403,6 +7414,8 @@ async fn process_table(
                 &model_ir,
                 dialect.name(),
             )),
+            // Not the content-addressed write path — no in-process column bytes.
+            output_column_hashes: None,
         },
         drift_checked: true,
         drift_detected: drift_action,
@@ -11226,6 +11239,7 @@ merge_keys = ["id"]
                 input_proof_class: None,
                 env_hash: None,
                 hash_scheme: None,
+                output_column_hashes: None,
             }],
             trigger: rocky_core::state::RunTrigger::Manual,
             config_hash: "cfg".to_string(),

--- a/engine/crates/rocky-cli/src/commands/run_content_addressed.rs
+++ b/engine/crates/rocky-cli/src/commands/run_content_addressed.rs
@@ -748,7 +748,14 @@ pub async fn execute_content_addressed_model(
     let total_rows = batch.num_rows();
 
     // 6. Write — split path on partitioned vs unpartitioned.
-    let (last_blake3, last_commit_version, last_file_path, total_size_bytes) =
+    //
+    // `output_column_hashes` is captured only on the unpartitioned path: a
+    // partitioned model writes one file per partition group, and folding the
+    // per-file column hashes into a single per-column table hash is a deferred
+    // correctness surface. Partitioned models therefore record no per-column
+    // hashes (empty ⇒ a safe rebuild in the later skip gate), scoping this
+    // capture to unpartitioned tables first.
+    let (last_blake3, last_commit_version, last_file_path, total_size_bytes, output_column_hashes) =
         if partition_columns.is_empty() {
             let write_result = writer
                 .write_batch_with_state(batch, state)
@@ -759,6 +766,7 @@ pub async fn execute_content_addressed_model(
                 write_result.commit_version,
                 write_result.file_path,
                 write_result.size_bytes,
+                write_result.column_hashes,
             )
         } else {
             // Partitioned: group rows by partition tuple and emit one
@@ -794,6 +802,8 @@ pub async fn execute_content_addressed_model(
                 last_commit_version,
                 last_file_path,
                 total_size_bytes,
+                // Partitioned outputs: no per-column table hash (deferred fold).
+                Vec::new(),
             )
         };
 
@@ -808,6 +818,7 @@ pub async fn execute_content_addressed_model(
         commit_version: last_commit_version,
         file_path: last_file_path,
         size_bytes: total_size_bytes,
+        output_column_hashes,
         // A normal BUILD wrote fresh bytes — no point-to provenance.
         reused_from: None,
     })
@@ -984,6 +995,9 @@ async fn attempt_point_to_reuse(
         commit_version: write_result.commit_version,
         file_path: write_result.file_path,
         size_bytes: write_result.size_bytes,
+        // Point-to reuse references R's already-written bytes; no Arrow batch
+        // is hashed here (R's own build recorded its column hashes).
+        output_column_hashes: write_result.column_hashes,
         reused_from: Some(ReuseProvenance {
             reused_run_id: candidate.run_id.clone(),
             blake3_hash: candidate.blake3_hash.clone(),
@@ -1174,6 +1188,13 @@ pub struct ContentAddressedRunSummary {
     pub commit_version: u64,
     pub file_path: String,
     pub size_bytes: u64,
+    /// Per-output-column content hashes over the written Arrow columns, in
+    /// table column order (see [`rocky_core::state::ColumnHash`]). Populated on
+    /// a genuine **unpartitioned** build; **empty** on a point-to reuse (no
+    /// fresh bytes) and on a partitioned build (per-file fold deferred). The
+    /// runner stamps a non-empty value onto the model's `ModelExecution`;
+    /// nothing consults it yet.
+    pub output_column_hashes: Vec<rocky_core::state::ColumnHash>,
     /// `Some` when this run **reused** a prior run `R`'s bytes via a zero-copy
     /// point-to commit instead of executing the model SQL. `None` for a normal
     /// BUILD (including every reuse-decision fall-back to BUILD). The

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -875,6 +875,8 @@ pub async fn run_snapshot(
                 &model_ir,
                 dialect.name(),
             )),
+            // Not the content-addressed write path — no in-process column bytes.
+            output_column_hashes: None,
         });
     } else {
         output.tables_failed = 1;

--- a/engine/crates/rocky-cli/src/commands/trace.rs
+++ b/engine/crates/rocky-cli/src/commands/trace.rs
@@ -251,6 +251,7 @@ mod tests {
             input_proof_class: None,
             env_hash: None,
             hash_scheme: None,
+            output_column_hashes: None,
         }
     }
 

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -973,6 +973,17 @@ pub struct MaterializationOutput {
     #[serde(skip)]
     #[schemars(skip)]
     pub recipe_identity: Option<RecipeIdentityInternal>,
+    /// State-internal per-output-column content hashes, co-located with the
+    /// model so [`RunOutput::to_run_record`] can stamp them onto the persisted
+    /// `ModelExecution.output_column_hashes`. Populated only by the
+    /// content-addressed runner on a genuine unpartitioned build; `None`
+    /// everywhere else (every non-content-addressed path, reuse, partitioned).
+    ///
+    /// Never serialized and never part of the JSON schema (via `#[serde(skip)]`
+    /// and `#[schemars(skip)]`) — same pattern as [`Self::recipe_identity`].
+    #[serde(skip)]
+    #[schemars(skip)]
+    pub output_column_hashes: Option<Vec<rocky_core::state::ColumnHash>>,
 }
 
 /// State-internal skip-gate result for one materialized model, carried on
@@ -4501,6 +4512,10 @@ impl RunOutput {
                 hash_scheme: mat.recipe_identity.as_ref().map(|r| r.hash_scheme.clone()),
                 input_hash: input_hash.clone(),
                 input_proof_class,
+                // Per-output-column content hashes, populated by the
+                // content-addressed runner on a genuine unpartitioned build;
+                // `None` on every other path (carried straight through).
+                output_column_hashes: mat.output_column_hashes.clone(),
             });
         }
 
@@ -4533,6 +4548,8 @@ impl RunOutput {
                 input_proof_class: None,
                 env_hash: None,
                 hash_scheme: None,
+                // A failed execution recorded no output columns.
+                output_column_hashes: None,
             });
         }
 
@@ -4904,6 +4921,7 @@ mod cost_finalize_tests {
             job_ids: Vec::new(),
             skip_internal: None,
             recipe_identity: None,
+            output_column_hashes: None,
         }
     }
 
@@ -5118,6 +5136,7 @@ mod run_record_tests {
             job_ids: Vec::new(),
             skip_internal: None,
             recipe_identity: None,
+            output_column_hashes: None,
         }
     }
 
@@ -5253,6 +5272,51 @@ mod run_record_tests {
             Some("acme"),
             "tenant on the materialization must flow onto the persisted ModelExecution"
         );
+    }
+
+    #[test]
+    fn to_run_record_carries_output_column_hashes_onto_model_execution() {
+        let mut out = RunOutput::new(String::new(), 1_000, 1);
+        out.tables_copied = 1;
+        let run_started = fixed_start();
+        let mut m = mat(&["orders"], 1_000, Some("h"), run_started);
+        // A content-addressed build stamps its producer-side per-column hashes
+        // onto the carrier; `to_run_record` must copy them onto the persisted
+        // `ModelExecution.output_column_hashes`.
+        m.output_column_hashes = Some(vec![
+            rocky_core::state::ColumnHash {
+                column: "id".to_string(),
+                hash: "hash-id".to_string(),
+            },
+            rocky_core::state::ColumnHash {
+                column: "amount".to_string(),
+                hash: "hash-amount".to_string(),
+            },
+        ]);
+        out.materializations.push(m);
+
+        let started = fixed_start();
+        let finished = started + chrono::Duration::seconds(1);
+        let record = out.to_run_record(
+            "run-colhash",
+            started,
+            finished,
+            String::new(),
+            RunTrigger::Manual,
+            out.derive_run_status(),
+            RunRecordAudit::test_sentinels(),
+        );
+
+        assert_eq!(record.models_executed.len(), 1);
+        let hashes = record.models_executed[0]
+            .output_column_hashes
+            .as_ref()
+            .expect("output_column_hashes must flow onto the persisted ModelExecution");
+        assert_eq!(hashes.len(), 2);
+        assert_eq!(hashes[0].column, "id");
+        assert_eq!(hashes[0].hash, "hash-id");
+        assert_eq!(hashes[1].column, "amount");
+        assert_eq!(hashes[1].hash, "hash-amount");
     }
 
     #[test]

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -226,7 +226,14 @@ pub const LOCAL_ONLY_TABLE_NAMES: &[&str] = &["schema_cache"];
 ///   storage-layout requirement; a leaner precedent (`ModelExecution::tenant`)
 ///   added a blob field without a bump. Guarded by
 ///   `test_v10_model_execution_forward_deserializes_recipe_identity_none`.
-const CURRENT_SCHEMA_VERSION: u32 = 11;
+/// - **v12** — adds `output_column_hashes` (per-output-column content hashes;
+///   see [`ColumnHash`]) to the [`ModelExecution`] blob. Pure additive
+///   blob-field change, same shape as the v11 recipe-identity fields: the new
+///   field is `#[serde(default)]`, so a v11 `RunRecord` forward-deserializes
+///   with it `None` and a v12 blob back-reads cleanly on a v11 binary (serde
+///   ignores the extra key). No new tables, no in-place migration. Guarded by
+///   `test_v11_model_execution_forward_deserializes_output_column_hashes_none`.
+const CURRENT_SCHEMA_VERSION: u32 = 12;
 
 /// Errors from the embedded redb state store.
 #[derive(Debug, Error)]
@@ -1044,6 +1051,29 @@ pub struct UpstreamSig {
     pub row_count: Option<u64>,
 }
 
+/// A single output column's content hash, captured on a successful
+/// content-addressed build.
+///
+/// `hash` is `hex(blake3(...))` over the written Arrow column's serialized
+/// content (values + type, in table column order) — content, not schema. Two
+/// columns with byte-identical stored content share a hash; a schema-stable
+/// value change (a WHERE/JOIN/CASE rewrite that keeps the type but moves the
+/// data) flips it. The hash is intentionally over-sensitive: row-order or
+/// encoding differences make it differ even when the logical content is the
+/// same, so a mismatch can only ever cause a (safe) rebuild, never a wrong
+/// skip.
+///
+/// State-internal — never part of any `*Output` JSON schema, so it carries no
+/// codegen (matches the `skip_hash` / `upstream_freshness` / recipe-identity
+/// precedent).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ColumnHash {
+    /// The output column's name, in the table's column order.
+    pub column: String,
+    /// `hex(blake3(...))` of the column's serialized content.
+    pub hash: String,
+}
+
 /// Execution record for a single model within a run.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ModelExecution {
@@ -1151,6 +1181,22 @@ pub struct ModelExecution {
     /// failed executions and pre-v11 records.
     #[serde(default)]
     pub hash_scheme: Option<String>,
+
+    // --- Output column hashes (schema v12) -------------------------------
+    /// Per-output-column content hashes captured on a successful
+    /// content-addressed build, in the table's column order. The producer
+    /// side of the per-column skip substrate: "what did each of my columns
+    /// hash to when I built?" (see [`ColumnHash`]).
+    ///
+    /// `None` for pre-v12 executions, failed executions, non-content-addressed
+    /// builds, and content-addressed builds that reused a prior run's bytes or
+    /// wrote a partitioned table (both deferred — see the runner). Captured
+    /// only; nothing consults it yet (the consumer-side baseline and skip gate
+    /// are later phases). State-internal — carries no codegen. Serde-defaulted
+    /// so a pre-v12 blob forward-deserializes with it `None`; guarded by
+    /// `test_v11_model_execution_forward_deserializes_output_column_hashes_none`.
+    #[serde(default)]
+    pub output_column_hashes: Option<Vec<ColumnHash>>,
 }
 
 /// A complete pipeline run record.
@@ -3938,6 +3984,7 @@ mod tests {
                 input_proof_class: None,
                 env_hash: None,
                 hash_scheme: None,
+                output_column_hashes: None,
             }],
         );
         store.record_run(&run).unwrap();
@@ -3984,6 +4031,7 @@ mod tests {
                     input_proof_class: None,
                     env_hash: None,
                     hash_scheme: None,
+                    output_column_hashes: None,
                 },
                 ModelExecution {
                     model_name: "customers".to_string(),
@@ -4003,6 +4051,7 @@ mod tests {
                     input_proof_class: None,
                     env_hash: None,
                     hash_scheme: None,
+                    output_column_hashes: None,
                 },
             ],
         );
@@ -4037,6 +4086,7 @@ mod tests {
                     input_proof_class: None,
                     env_hash: None,
                     hash_scheme: None,
+                    output_column_hashes: None,
                 }],
             );
             store.record_run(&run).unwrap();
@@ -4195,6 +4245,44 @@ mod tests {
         assert_eq!(exec.hash_scheme, None);
     }
 
+    /// v11 → v12 forward-compat: a `ModelExecution` blob written before
+    /// `output_column_hashes` existed (a full v11 record carrying the
+    /// recipe-identity triple but no `output_column_hashes` key) must
+    /// forward-deserialize with the field defaulting to `None`.
+    #[test]
+    fn test_v11_model_execution_forward_deserializes_output_column_hashes_none() {
+        let v11_blob = br#"{
+            "model_name": "orders",
+            "started_at": "2024-01-01T12:00:00Z",
+            "finished_at": "2024-01-01T12:00:02Z",
+            "duration_ms": 2000,
+            "rows_affected": 5000,
+            "status": "success",
+            "sql_hash": "legacy-sql-hash",
+            "skip_hash": "logic-key",
+            "upstream_freshness": null,
+            "bytes_scanned": 4096,
+            "bytes_written": 2048,
+            "tenant": "acme",
+            "recipe_hash": "rh",
+            "input_hash": "ih",
+            "input_proof_class": "heuristic",
+            "env_hash": "eh",
+            "hash_scheme": "v1"
+        }"#;
+
+        let exec: ModelExecution = serde_json::from_slice(v11_blob)
+            .expect("pre-v12 ModelExecution must forward-deserialize");
+
+        // Prior fields (incl. the v11 triple) preserved.
+        assert_eq!(exec.model_name, "orders");
+        assert_eq!(exec.recipe_hash.as_deref(), Some("rh"));
+        assert_eq!(exec.hash_scheme.as_deref(), Some("v1"));
+        // The new field defaults to None — a pre-v12 record is treated as
+        // "no output column hashes recorded", never crashes the read.
+        assert_eq!(exec.output_column_hashes, None);
+    }
+
     /// A v11 `ModelExecution` blob (carrying the triple) must back-read on a
     /// binary that predates it: serde ignores the unknown keys, so a v10 reader
     /// never breaks on a v11 row. Emulated by deserializing the full v11 shape
@@ -4219,6 +4307,10 @@ mod tests {
             input_proof_class: Some("heuristic".to_string()),
             env_hash: Some("eh".to_string()),
             hash_scheme: Some("v1".to_string()),
+            output_column_hashes: Some(vec![ColumnHash {
+                column: "id".to_string(),
+                hash: "col-hash".to_string(),
+            }]),
         };
         let json = serde_json::to_string(&exec).unwrap();
         let back: ModelExecution = serde_json::from_str(&json).unwrap();
@@ -4227,6 +4319,13 @@ mod tests {
         assert_eq!(back.input_proof_class.as_deref(), Some("heuristic"));
         assert_eq!(back.env_hash.as_deref(), Some("eh"));
         assert_eq!(back.hash_scheme.as_deref(), Some("v1"));
+        assert_eq!(
+            back.output_column_hashes,
+            Some(vec![ColumnHash {
+                column: "id".to_string(),
+                hash: "col-hash".to_string(),
+            }])
+        );
     }
 
     /// 🔴 Ledger-readability tripwire. The durable ledger's records
@@ -4262,6 +4361,7 @@ mod tests {
             input_proof_class: Some("heuristic".to_string()),
             env_hash: Some("env-ghi".to_string()),
             hash_scheme: Some("v1".to_string()),
+            output_column_hashes: None,
         };
         let exec_json = serde_json::to_string(&exec).unwrap();
 
@@ -4289,7 +4389,7 @@ mod tests {
             return;
         }
 
-        const EXEC_GOLDEN: &str = r#"{"model_name":"fct_orders","started_at":"2024-01-01T12:00:00Z","finished_at":"2024-01-01T12:00:00Z","duration_ms":2000,"rows_affected":10,"status":"success","sql_hash":"sql","skip_hash":"logic-key","upstream_freshness":null,"bytes_scanned":null,"bytes_written":null,"tenant":null,"recipe_hash":"recipe-abc","input_hash":"input-def","input_proof_class":"heuristic","env_hash":"env-ghi","hash_scheme":"v1"}"#;
+        const EXEC_GOLDEN: &str = r#"{"model_name":"fct_orders","started_at":"2024-01-01T12:00:00Z","finished_at":"2024-01-01T12:00:00Z","duration_ms":2000,"rows_affected":10,"status":"success","sql_hash":"sql","skip_hash":"logic-key","upstream_freshness":null,"bytes_scanned":null,"bytes_written":null,"tenant":null,"recipe_hash":"recipe-abc","input_hash":"input-def","input_proof_class":"heuristic","env_hash":"env-ghi","hash_scheme":"v1","output_column_hashes":null}"#;
         const PROV_GOLDEN: &str = r#"{"run_id":"run-1","model_name":"fct_orders","input_hash":"input-def","skip_hash":"logic-key","model_ir_canonical_json":"{\"a\":1}","upstreams":[{"kind":"watermark","upstream_key":"cat.sch.src","max_ts":"2024-01-01T00:00:00Z","row_count":42}],"output_blake3":["out-hash"],"output_path":["s3://b/p.parquet"],"proof_class":"heuristic","recorded_at":"2024-01-01T12:00:00Z"}"#;
         assert_eq!(exec_json, EXEC_GOLDEN, "ModelExecution wire format drifted");
         assert_eq!(
@@ -6516,13 +6616,14 @@ mod tests {
         // is an on-disk break that needs a `CURRENT_SCHEMA_VERSION` bump + a
         // migration path, not just an edit here.
         //
-        // v11 bumps the version for the recipe-identity triple added to the
-        // `ModelExecution` blob. The table set below is deliberately unchanged
-        // — v11 adds no tables, only serde-defaulted blob fields — so the
-        // forward-compat path is the existing default-on-missing behaviour
-        // (guarded by `test_v10_model_execution_forward_deserializes_recipe_identity_none`
+        // v12 bumps the version for the `output_column_hashes` field added to
+        // the `ModelExecution` blob. The table set below is deliberately
+        // unchanged — v12 adds no tables, only a serde-defaulted blob field —
+        // so the forward-compat path is the existing default-on-missing
+        // behaviour (guarded by
+        // `test_v11_model_execution_forward_deserializes_output_column_hashes_none`
         // and the `open_with_policy_*` mismatch tests), not a new migration.
-        const EXPECTED_VERSION: u32 = 11;
+        const EXPECTED_VERSION: u32 = 12;
         const EXPECTED_TABLES: &[&str] = &[
             "branches",
             "check_history",

--- a/engine/crates/rocky-core/tests/e2e.rs
+++ b/engine/crates/rocky-core/tests/e2e.rs
@@ -475,6 +475,7 @@ fn test_run_history_flow() {
                 input_proof_class: None,
                 env_hash: None,
                 hash_scheme: None,
+                output_column_hashes: None,
             },
             ModelExecution {
                 model_name: "customers".to_string(),
@@ -494,6 +495,7 @@ fn test_run_history_flow() {
                 input_proof_class: None,
                 env_hash: None,
                 hash_scheme: None,
+                output_column_hashes: None,
             },
         ],
         trigger: RunTrigger::Manual,

--- a/engine/crates/rocky-iceberg/src/uniform_writer/mod.rs
+++ b/engine/crates/rocky-iceberg/src/uniform_writer/mod.rs
@@ -24,10 +24,13 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use arrow::array::RecordBatch;
+use arrow::array::{ArrayRef, RecordBatch};
+use arrow::datatypes::{Field, Schema};
+use arrow::ipc::writer::StreamWriter;
 use bytes::Bytes;
 use object_store::path::Path;
 use object_store::{ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload};
+use rocky_core::state::ColumnHash;
 
 pub mod commit;
 pub mod discover;
@@ -102,9 +105,64 @@ pub struct UniformTableState {
 pub struct WriteResult {
     pub file_path: String,
     pub blake3_hash: String,
+    /// Per-output-column content hashes over the written Arrow columns, in
+    /// table column order (see [`rocky_core::state::ColumnHash`]). Computed
+    /// on a genuine build (fresh bytes written); **empty** on a zero-copy
+    /// point-to reuse, which references a prior run's already-written bytes
+    /// and does not recompute them. The whole-body `blake3_hash` above is
+    /// table-granular; these are the per-column signal.
+    pub column_hashes: Vec<ColumnHash>,
     pub commit_version: u64,
     pub num_records: usize,
     pub size_bytes: u64,
+}
+
+/// Compute per-column content hashes for a written [`RecordBatch`], in the
+/// batch's column order.
+///
+/// One [`ColumnHash`] per column. The hash is over the column's serialized
+/// content (type + values), **not** its schema/name — so a schema-stable
+/// value change flips the hash while a rename does not. No normalization in
+/// v1: the column is hashed as written, so the hash is order-sensitive (the
+/// documented over-sensitivity — a mismatch can only ever force a safe
+/// rebuild, never a wrong skip).
+///
+/// # Errors
+///
+/// [`UniformWriterError::Arrow`] if a column cannot be Arrow-IPC-serialized
+/// (not expected for the content-addressed writer's supported types).
+fn compute_column_hashes(batch: &RecordBatch) -> Result<Vec<ColumnHash>> {
+    let schema = batch.schema();
+    let mut out = Vec::with_capacity(batch.num_columns());
+    for (idx, array) in batch.columns().iter().enumerate() {
+        let field = schema.field(idx);
+        out.push(ColumnHash {
+            column: field.name().to_string(),
+            hash: hash_arrow_column(field, array)?,
+        });
+    }
+    Ok(out)
+}
+
+/// blake3 (hex) of a single Arrow column's serialized content.
+///
+/// The column is wrapped in a one-field [`RecordBatch`] — with the field name
+/// normalized to a constant so the hash is over content + type, not the name —
+/// and serialized via Arrow IPC. IPC is a deterministic, type-uniform encoding
+/// that re-bases any slice offset, so the same logical array always hashes the
+/// same regardless of how it was sliced. Padding differences and null-slot
+/// bytes are hashed as-is (no normalization in v1).
+fn hash_arrow_column(field: &Field, array: &ArrayRef) -> Result<String> {
+    let norm_field = Field::new("col", field.data_type().clone(), field.is_nullable());
+    let schema = Arc::new(Schema::new(vec![norm_field]));
+    let one_col = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::clone(array)])?;
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut writer = StreamWriter::try_new(&mut buf, &schema)?;
+        writer.write(&one_col)?;
+        writer.finish()?;
+    }
+    Ok(blake3::hash(&buf).to_hex().to_string())
 }
 
 /// Inputs to a content-addressed *point-to* commit
@@ -433,6 +491,10 @@ impl UniformWriter {
             return Ok(WriteResult {
                 file_path: parquet_path.to_string(),
                 blake3_hash: pointer.blake3_hash.clone(),
+                // Point-to reuse references R's already-written bytes; no
+                // Arrow batch is in hand to hash, so no per-column hashes are
+                // recomputed. R's own successful build recorded them.
+                column_hashes: Vec::new(),
                 commit_version: existing_version,
                 num_records: pointer.num_records,
                 size_bytes: pointer.size_bytes,
@@ -465,6 +527,8 @@ impl UniformWriter {
                     return Ok(WriteResult {
                         file_path: parquet_path.to_string(),
                         blake3_hash: pointer.blake3_hash.clone(),
+                        // Point-to reuse: no fresh Arrow batch to hash.
+                        column_hashes: Vec::new(),
                         commit_version: target_version,
                         num_records: pointer.num_records,
                         size_bytes: pointer.size_bytes,
@@ -491,6 +555,8 @@ impl UniformWriter {
                         return Ok(WriteResult {
                             file_path: parquet_path.to_string(),
                             blake3_hash: pointer.blake3_hash.clone(),
+                            // Point-to reuse: no fresh Arrow batch to hash.
+                            column_hashes: Vec::new(),
                             commit_version: existing_version,
                             num_records: pointer.num_records,
                             size_bytes: pointer.size_bytes,
@@ -550,6 +616,11 @@ impl UniformWriter {
         // 1. Build deterministic Parquet bytes from the input batch.
         let parquet_bytes = parquet_builder::build_parquet(&batch, &state)?;
         let hash = blake3::hash(&parquet_bytes).to_hex().to_string();
+        // Per-column content hashes over the same in-memory Arrow batch,
+        // computed in this pass (the batch is held right here, immediately
+        // before the whole-body blake3 above). Captured on every genuine
+        // build; nothing consults them yet.
+        let column_hashes = compute_column_hashes(&batch)?;
         let add_file_path = path_for_hash(&hash);
         let file_size = parquet_bytes.len() as u64;
         let prefix = self.config.prefix.trim_end_matches('/').to_string();
@@ -614,6 +685,7 @@ impl UniformWriter {
                     return Ok(WriteResult {
                         file_path: parquet_path.to_string(),
                         blake3_hash: hash,
+                        column_hashes: column_hashes.clone(),
                         commit_version: target_version,
                         num_records: batch.num_rows(),
                         size_bytes: file_size,
@@ -639,6 +711,7 @@ impl UniformWriter {
                         return Ok(WriteResult {
                             file_path: parquet_path.to_string(),
                             blake3_hash: hash,
+                            column_hashes: column_hashes.clone(),
                             commit_version: existing_version,
                             num_records: batch.num_rows(),
                             size_bytes: file_size,
@@ -1154,6 +1227,47 @@ mod tests {
         RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(names)]).unwrap()
     }
 
+    #[test]
+    fn compute_column_hashes_is_deterministic_and_value_sensitive() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int64Array::from(vec![1_i64, 2, 3])) as ArrayRef,
+                Arc::new(StringArray::from(vec!["a", "b", "c"])) as ArrayRef,
+            ],
+        )
+        .unwrap();
+
+        // One hash per column, in table column order, keyed by name.
+        let h1 = compute_column_hashes(&batch).unwrap();
+        assert_eq!(h1.len(), 2);
+        assert_eq!(h1[0].column, "id");
+        assert_eq!(h1[1].column, "name");
+        assert!(h1.iter().all(|c| !c.hash.is_empty()));
+
+        // Deterministic: identical content hashes identically.
+        let h2 = compute_column_hashes(&batch).unwrap();
+        assert_eq!(h1, h2);
+
+        // Value-sensitive: changing one column's data (schema unchanged) flips
+        // that column's hash and leaves the other column's hash untouched.
+        let mutated = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1_i64, 2, 3])) as ArrayRef,
+                Arc::new(StringArray::from(vec!["a", "b", "CHANGED"])) as ArrayRef,
+            ],
+        )
+        .unwrap();
+        let h3 = compute_column_hashes(&mutated).unwrap();
+        assert_eq!(h3[0].hash, h1[0].hash, "unchanged column keeps its hash");
+        assert_ne!(h3[1].hash, h1[1].hash, "changed column's hash moves");
+    }
+
     #[tokio::test]
     async fn write_batch_round_trip_against_in_memory_store() {
         let store: Arc<InMemory> = Arc::new(InMemory::new());
@@ -1187,6 +1301,21 @@ mod tests {
         assert!(result.size_bytes > 0);
         assert!(!result.blake3_hash.is_empty());
         assert!(result.file_path.ends_with(".parquet"));
+
+        // Per-column content hashes are computed on the genuine build path,
+        // from the real Arrow columns, in table column order — one per column,
+        // keyed by name, each a non-empty hex blake3.
+        let cols: Vec<&str> = result
+            .column_hashes
+            .iter()
+            .map(|c| c.column.as_str())
+            .collect();
+        assert_eq!(cols, vec!["id", "name"]);
+        assert!(result.column_hashes.iter().all(|c| !c.hash.is_empty()));
+        assert_ne!(
+            result.column_hashes[0].hash, result.column_hashes[1].hash,
+            "distinct columns must hash distinctly"
+        );
 
         // The Parquet file + the new commit should be there.
         let log_path = object_store::path::Path::from(format!(
@@ -1266,6 +1395,17 @@ mod tests {
         assert_eq!(pr.commit_version, 1);
         assert_eq!(pr.blake3_hash, r.blake3_hash, "shared bytes — same blake3");
         assert_eq!(pr.num_records, r.num_records);
+        // R's genuine build computed per-column hashes; the zero-copy point-to
+        // recomputes none (it holds no Arrow batch — R's own build recorded
+        // them). Empty here degrades to a safe rebuild in the later skip gate.
+        assert!(
+            !r.column_hashes.is_empty(),
+            "the build recorded column hashes"
+        );
+        assert!(
+            pr.column_hashes.is_empty(),
+            "point-to reuse recomputes no column hashes"
+        );
 
         // B's _delta_log/...001.json references the SAME content-addressed
         // path R wrote (the file name; the prefix differs per table).

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -570,6 +570,7 @@ fn seed_run_history(models_dir: &Path) {
             input_proof_class: None,
             env_hash: None,
             hash_scheme: None,
+            output_column_hashes: None,
         }],
         trigger: RunTrigger::Manual,
         config_hash: "cfg".to_string(),

--- a/engine/rocky/tests/replay_check.rs
+++ b/engine/rocky/tests/replay_check.rs
@@ -141,6 +141,7 @@ fn model_exec(name: &str) -> ModelExecution {
         input_proof_class: None,
         env_hash: None,
         hash_scheme: None,
+        output_column_hashes: None,
     }
 }
 

--- a/integrations/dagster/tests/fixtures_generated/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor.json
@@ -17,7 +17,7 @@
     {
       "name": "state_schema",
       "status": "healthy",
-      "message": "state schema v11 matches this binary",
+      "message": "state schema v12 matches this binary",
       "duration_ms": 0
     },
     {

--- a/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
@@ -17,7 +17,7 @@
     {
       "name": "state_schema",
       "status": "healthy",
-      "message": "state schema v11 matches this binary",
+      "message": "state schema v12 matches this binary",
       "duration_ms": 0
     },
     {

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 11,
-  "schema_version_on_disk": 11
+  "schema_version_supported": 12,
+  "schema_version_on_disk": 12
 }

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 11,
-  "schema_version_on_disk": 11
+  "schema_version_supported": 12,
+  "schema_version_on_disk": 12
 }

--- a/integrations/dagster/tests/fixtures_generated/state.json
+++ b/integrations/dagster/tests/fixtures_generated/state.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 11,
-  "schema_version_on_disk": 11
+  "schema_version_supported": 12,
+  "schema_version_on_disk": 12
 }


### PR DESCRIPTION
## What

Captures **per-output-column content hashes** on the content-addressed write path and persists them on each model's execution record. This is the *producer* half of the substrate a future sound "an upstream changed, but the columns this consumer actually reads did not → skip it" decision needs. The existing whole-output blake3 is table-granular — any change to any column flips it — so it cannot answer the per-column question; a schema diff cannot see a value-only change at all. A per-column content hash can.

**Captured only — nothing consults these hashes yet.** No skip decision, no gate, no consumer-side baseline consults them. This PR is pure additive data capture: it is inert by construction.

## Changes

- **`rocky-iceberg` (`UniformWriter`)** — computes one blake3 per written Arrow column (over the column's serialized content + type, in table column order) in the same in-memory pass that already hashes the whole parquet body, returned on `WriteResult.column_hashes`. The column is hashed **as written, no normalization**: the hash is intentionally over-sensitive (row-order/encoding differences make it differ even when the logical content matches), so a mismatch can only ever force a *safe rebuild*, never a wrong skip. Empty on a zero-copy point-to reuse (no fresh bytes are hashed — the reused run's own build recorded its hashes) and on partitioned tables (per-file fold deferred; unpartitioned first).
- **`rocky-core` (state)** — new state-internal `ColumnHash { column, hash }` and `ModelExecution.output_column_hashes: Option<Vec<ColumnHash>>`, carried from the runner through the materialization output onto the persisted record. Serde-defaulted; `CURRENT_SCHEMA_VERSION` bumped **11 → 12** with a forward-deserialize guard, mirroring the existing additive-blob pattern (the recipe-identity fields). Never part of any `*Output` JSON schema, so it carries no codegen.
- **`rocky-cli`** — plumbs `WriteResult.column_hashes` → `ContentAddressedRunSummary` → the materialization carrier → `to_run_record` → `ModelExecution`. Every non-content-addressed path records `None`.
- Regenerated dagster fixtures (state schema version `11 → 12` — the only fixture delta).

## Scope

Scoped to the content-addressed write path. Off that path the field stays `None` — the feature does not exist there. Reuse and partitioned builds record `None` (both degrade to a safe rebuild once a skip gate is added later).

## Reachability / verification (honest, two-ended)

The content-addressed write path is `s3://`-only, so a creds-free playground run never reaches it. This PR therefore does **not** claim "a playground run shows hashes." Instead it proves each end through real code with tests, and is explicit about the seam:

- **Computation → `WriteResult`** (real code path): `write_batch_round_trip_against_in_memory_store` drives the actual `UniformWriter::write_batch` against an in-memory object store and asserts `column_hashes` land on `WriteResult` with the real column names, in order, each a distinct non-empty hash. `compute_column_hashes_is_deterministic_and_value_sensitive` proves determinism + that a schema-stable value change to one column moves *that* column's hash and leaves the others untouched. `point_to_recover_then_commit_into_fresh_table` proves a reuse recomputes none.
- **Stamping → `ModelExecution`** (unit test): `to_run_record_carries_output_column_hashes_onto_model_execution` asserts a carrier's hashes flow onto the persisted `ModelExecution`.
- **Forward-compat**: `test_v11_model_execution_forward_deserializes_output_column_hashes_none` + a round-trip test; the pinned ledger golden and the on-disk-version pin were updated deliberately with the bump.
- **The `s3://` glue between those two ends** (`run_content_addressed` `WriteResult`→summary and `run.rs` summary→carrier) is plain field assignment, **review-only** — not exercised end-to-end here (no Databricks live-verify in this PR).

## Gates

- `cargo fmt --check` clean · `cargo clippy --all-targets` clean · full `cargo test` workspace green (102 test binaries, 0 failures)
- `just codegen` drift-clean (no schema/type change — the field is state-internal)
- `just regen-fixtures` diff is **only** the schema version `11 → 12`
- dagster pytest (fixture-consuming tests) green