### PR TITLE
feat(playground): recipe-provenance POC + history --recipe docs

### DIFF
--- a/docs/src/content/docs/concepts/architecture-of-trust.md
+++ b/docs/src/content/docs/concepts/architecture-of-trust.md
@@ -99,6 +99,8 @@ Replay is two distinct things, and being precise about which one ships matters.
 
 The first is deterministic recording with ledger verification. Rocky records each run's per-model SQL hashes, row counts, bytes, and timings, and content-addresses the written artifacts so that the same inputs and code produce the same physical files. `rocky replay <run_id>` inspects that record and verifies it against the ledger. That ships today.
 
+Alongside the run record, every materialization stamps a recipe-identity triple: `recipe_hash` (a fingerprint of the model's canonical typed IR, so the same program hashes the same no matter when it ran), `input_hash` (the inputs it read), and `env_hash` (the engine, adapter, and dialect it ran under). `rocky history --recipe <hash>` answers the audit question directly — "what produced this, and every other time this exact program ran." The triple is honest about strength: an `input_hash` proven by an observed freshness signature is tagged `heuristic` and is never presented as a byte-content claim, while a content-addressed input is `strong`. This is an identity and audit primitive, not a reproducibility claim.
+
 The second is re-execution from the pinned record: replaying a past run by feeding the recorded inputs back through the engine to reproduce its outputs from scratch. That is the follow-up. It arrives on top of the content-addressed write path, and it is not what `rocky replay` does now.
 
 In short: deterministic recording and content-addressed verification today, re-execution from the record next.

--- a/examples/playground/README.md
+++ b/examples/playground/README.md
@@ -38,7 +38,7 @@ cd pocs/02-performance/01-incremental-watermark
 
 **Prerequisites:** Rocky CLI on PATH. Most POCs only need the [DuckDB CLI](https://duckdb.org) for seeding (`brew install duckdb`).
 
-**84 of 96 POCs run with no external credentials.** See each POC's README for prerequisites.
+**85 of 97 POCs run with no external credentials.** See each POC's README for prerequisites.
 
 ## The catalog
 
@@ -118,7 +118,7 @@ AI-powered model generation, intent extraction, schema sync, test generation, sc
 | [05-schema-grounded-validation](pocs/03-ai/05-schema-grounded-validation) | **Trust arc 5** — `ValidationContext` schema grounding + compile-verify retry loop |
 | [06-mcp-grounding](pocs/03-ai/06-mcp-grounding) | `rocky mcp` server — a schema-only model compiles but reconciles wrong; sampling the data via the MCP tools fixes it (creds-free `run.sh`) |
 
-### 04 — Governance (9 POCs · Databricks / DuckDB)
+### 04 — Governance (10 POCs · Databricks / DuckDB)
 
 Unity Catalog grants, schema patterns, workspace isolation, tagging, classification + masking, retention, auto-create schemas.
 
@@ -133,6 +133,7 @@ Unity Catalog grants, schema patterns, workspace isolation, tagging, classificat
 | [07-auto-create-schemas](pocs/04-governance/07-auto-create-schemas) | `[…target.governance] auto_create_schemas = true` on a transformation pipeline targeting a fresh schema (v1.29.0 parity fix) | none |
 | [08-cross-team-contracts](pocs/04-governance/08-cross-team-contracts) | Consumer imports a producer's published IR snapshot via `[imports.<name>]`; `rocky compile` fails with E030 when the producer drops a column the consumer reads (E033 on pin mismatch) | none |
 | [09-model-tags-inheritance](pocs/04-governance/09-model-tags-inheritance) | A config-group `[tags]` baseline inherited by members and overridden per-key by a model's own `[tags]`, surfaced on `rocky compile --output json` as `models_detail[].tags` | none |
+| [10-recipe-provenance](pocs/04-governance/10-recipe-provenance) | Every materialization records a recipe-identity triple (`recipe_hash`, `input_hash`, `env_hash`); `rocky history --recipe <hash>` returns every execution of that exact program — the "what produced this?" audit one-liner, honest about `heuristic` vs `strong` input proof | none |
 
 ### 05 — Orchestration (11 POCs · DuckDB / docker)
 

--- a/examples/playground/pocs/04-governance/10-recipe-provenance/README.md
+++ b/examples/playground/pocs/04-governance/10-recipe-provenance/README.md
@@ -1,0 +1,93 @@
+# 10-recipe-provenance — "what produced this?"
+
+> **Category:** 04-governance
+> **Credentials:** none (DuckDB)
+> **Runtime:** < 15s
+> **Rocky features:** recipe-identity triple (`recipe_hash`, `input_hash`, `env_hash`), `rocky history --recipe`
+
+## What it shows
+
+Every time Rocky materializes a model it records a **recipe-identity triple** onto
+that execution: `recipe_hash` (a fingerprint of the model's canonical typed IR —
+the exact program), `input_hash` (the resolved inputs it read), and `env_hash`
+(the engine + adapter + dialect it ran under), all tagged with a versioned
+`hash_scheme`. `rocky history --recipe <hash>` then answers the audit question
+directly: *"what produced this table, and every other time this exact program
+ran?"* This POC materializes one model twice and shows both executions returned
+under a single `recipe_hash`.
+
+## Why it's distinctive
+
+- The identity is keyed to the **program**, not the table name or a run id. Two
+  executions of the same SQL share one `recipe_hash` no matter when or how often
+  they ran; edit the SQL and the `recipe_hash` changes. That is the substrate for
+  memoization, audit, and reproducible-by-recipe time travel.
+- It is **honest about strength.** The `input_hash` here carries
+  `proof_class = heuristic` because the input was proven via an observed
+  freshness signature (rowcount), not a byte-for-byte content hash — so it is
+  never presented as a content claim. A content-addressed input would be
+  `strong`; a run that never observed its input records the triple as two-of-three
+  rather than fabricating one.
+
+## Layout
+
+```
+.
+├── README.md         this file
+├── rocky.toml        transformation pipeline; skip-unchanged on (populates input_hash)
+├── run.sh            two executions, then `history --recipe`
+├── models/
+│   ├── orders_clean.sql    the program the recipe_hash fingerprints
+│   └── orders_clean.toml   full_refresh sidecar
+└── data/
+    └── seed.sql      deterministic raw source
+```
+
+## Prerequisites
+
+- `rocky` on PATH (or set `ROCKY_BIN` to a built binary)
+- `duckdb` CLI for seeding (`brew install duckdb`)
+
+## Run
+
+```bash
+./run.sh
+```
+
+## Expected output
+
+```text
+=== the recipe-identity triple on orders_clean (from rocky history) ===
+    model=orders_clean
+    recipe_hash      = 2148e619b51421f5...07453036
+    input_hash       = 75ee2a328c52b236...c21b9c6  (proof_class=heuristic)
+    env_hash         = bbf2c204...991d92bd
+    hash_scheme      = v1
+
+=== what produced this? rocky history --recipe <hash> ===
+    executions of this exact program: 2
+      run=run-...-341  model=orders_clean  status=success
+      run=run-...-809  model=orders_clean  status=success
+
+POC complete: one recipe_hash, two executions — 'what produced this?' answered.
+```
+
+(Hashes are deterministic for a given engine build; the `env_hash` moves when the
+engine or adapter version does.)
+
+## What happened
+
+1. Execution #1 materialized `orders_clean` and stamped the recipe-identity
+   triple onto its `ModelExecution` record.
+2. 50 rows were appended and execution #2 ran the *same* SQL over the new input.
+   Same program ⇒ identical `recipe_hash`; different input ⇒ different `input_hash`.
+3. `rocky history` surfaces the triple on every model record, with the honest
+   `heuristic` input proof-class.
+4. `rocky history --recipe <hash>` returns both executions — every run of that
+   exact program.
+
+## Related
+
+- Concept: [Content-addressed run records](https://rocky-data.dev/concepts/content-addressed/)
+- Companion: the `02-performance/14-skip-unchanged` POC, whose observed-upstream
+  signature is what populates this triple's `input_hash`.

--- a/examples/playground/pocs/04-governance/10-recipe-provenance/data/seed.sql
+++ b/examples/playground/pocs/04-governance/10-recipe-provenance/data/seed.sql
@@ -1,0 +1,14 @@
+-- Deterministic raw source — no random() / now(), so the recipe_hash is
+-- reproducible across runs. run.sh appends rows between the two runs so both
+-- executions BUILD (and both therefore record the same recipe_hash under a
+-- different input).
+CREATE SCHEMA IF NOT EXISTS raw__orders;
+
+CREATE OR REPLACE TABLE raw__orders.orders AS
+SELECT
+    i                       AS order_id,
+    1 + (i % 25)            AS customer_id,
+    'complete'              AS status,
+    (i * 137) % 90000 + 500 AS amount_cents,
+    TIMESTAMP '2026-04-01' + INTERVAL (i * 3600) SECOND AS placed_at
+FROM generate_series(1, 200) AS t(i);

--- a/examples/playground/pocs/04-governance/10-recipe-provenance/models/orders_clean.sql
+++ b/examples/playground/pocs/04-governance/10-recipe-provenance/models/orders_clean.sql
@@ -1,0 +1,11 @@
+-- A plain deterministic SELECT over a bare source. Its canonical typed IR is
+-- what the recipe_hash fingerprints: change this SQL and the recipe_hash
+-- changes; leave it and every execution shares one recipe_hash, no matter how
+-- many times or when it ran.
+SELECT
+    order_id,
+    customer_id,
+    UPPER(status) AS status,
+    amount_cents,
+    placed_at
+FROM raw__orders.orders

--- a/examples/playground/pocs/04-governance/10-recipe-provenance/models/orders_clean.toml
+++ b/examples/playground/pocs/04-governance/10-recipe-provenance/models/orders_clean.toml
@@ -1,0 +1,6 @@
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "poc"
+schema = "main"

--- a/examples/playground/pocs/04-governance/10-recipe-provenance/rocky.toml
+++ b/examples/playground/pocs/04-governance/10-recipe-provenance/rocky.toml
@@ -1,0 +1,22 @@
+# 10-recipe-provenance — every materialization records a recipe-identity triple
+# (recipe_hash, input_hash, env_hash). `rocky history --recipe <hash>` then
+# answers "what produced this?" — every execution of that exact program.
+
+[adapter]
+type = "duckdb"
+path = "poc.duckdb"
+
+[pipeline.demo]
+type = "transformation"
+models = "models/**"
+
+[pipeline.demo.target.governance]
+auto_create_schemas = true
+
+# Turn on the skip-unchanged gate so each run observes its upstream signature.
+# That observation is what populates the input side of the triple — recorded
+# with an honest `heuristic` proof-class, never presented as a byte-content
+# claim. Without an observed input, the triple honestly records two-of-three.
+[run]
+skip_unchanged = true
+skip_rowcount_fallback = true

--- a/examples/playground/pocs/04-governance/10-recipe-provenance/run.sh
+++ b/examples/playground/pocs/04-governance/10-recipe-provenance/run.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# 10-recipe-provenance — "what produced this?" Every materialization records a
+# recipe-identity triple (recipe_hash, input_hash, env_hash). Two executions of
+# the same model share one recipe_hash; `rocky history --recipe <hash>` returns
+# every execution of that exact program.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+# Use the freshly-built engine binary by default (a bare `rocky` on PATH is
+# often a stale install that predates the recipe-identity triple / --recipe).
+ROCKY_BIN="${ROCKY_BIN:-$(git rev-parse --show-toplevel)/engine/target/release/rocky}"
+
+mkdir -p expected
+# Pin one state file so both runs record into the same ledger the --recipe
+# query then reads.
+STATE="$HERE/expected/state.redb"
+rm -f "$STATE" "$STATE.lock" poc.duckdb
+rm -f models/.rocky-state.redb models/.rocky-state.redb.lock
+
+rocky() { "$ROCKY_BIN" --state-path "$STATE" -c rocky.toml "$@"; }
+
+echo "=== seed the raw source ==="
+duckdb poc.duckdb < data/seed.sql
+
+# ---------------------------------------------------------------------------
+# Execution #1 — materialize orders_clean. This stamps the recipe-identity
+# triple onto the run's ModelExecution record.
+# ---------------------------------------------------------------------------
+echo
+echo "=== execution #1 — materialize orders_clean ==="
+rocky -o json run --skip-unchanged > expected/run1.json
+
+# ---------------------------------------------------------------------------
+# Append rows, then execution #2 — the SQL is unchanged, so the recipe_hash is
+# identical; only the input differs. Two executions of one exact program.
+# ---------------------------------------------------------------------------
+echo "=== append 50 orders, then execution #2 (same program, new input) ==="
+duckdb poc.duckdb "INSERT INTO raw__orders.orders
+    SELECT 200 + i, 1 + (i % 25), 'complete', (i * 91) % 90000 + 500,
+           TIMESTAMP '2026-05-01' + INTERVAL (i * 3600) SECOND
+    FROM generate_series(1, 50) AS t(i);"
+rocky -o json run --skip-unchanged > expected/run2.json
+
+# ---------------------------------------------------------------------------
+# The triple is on every model record. Read the recipe_hash off the history.
+# ---------------------------------------------------------------------------
+echo
+echo "=== the recipe-identity triple on orders_clean (from rocky history) ==="
+rocky -o json history > expected/history.json
+RECIPE_HASH=$(python3 -c "
+import json
+h = json.load(open('expected/history.json'))
+for run in h.get('runs', []):
+    for m in run.get('models', []):
+        ri = m.get('recipe_identity')
+        if ri and ri.get('recipe_hash'):
+            print(ri['recipe_hash']); raise SystemExit
+")
+python3 -c "
+import json
+h = json.load(open('expected/history.json'))
+for run in h.get('runs', []):
+    for m in run.get('models', []):
+        ri = m.get('recipe_identity')
+        if ri and ri.get('recipe_hash'):
+            print(f\"    model={m.get('model_name')}\")
+            print(f\"    recipe_hash      = {ri['recipe_hash']}\")
+            print(f\"    input_hash       = {ri.get('input_hash')}  (proof_class={ri.get('input_proof_class')})\")
+            print(f\"    env_hash         = {ri.get('env_hash')}\")
+            print(f\"    hash_scheme      = {ri.get('hash_scheme')}\")
+            raise SystemExit
+"
+
+echo
+echo "=== what produced this? rocky history --recipe <hash> ==="
+echo "    recipe_hash = ${RECIPE_HASH}"
+rocky -o json history --recipe "$RECIPE_HASH" > expected/recipe_history.json
+COUNT=$(python3 -c "import json; print(json.load(open('expected/recipe_history.json')).get('count', 0))")
+echo "    executions of this exact program: ${COUNT}"
+python3 -c "
+import json
+d = json.load(open('expected/recipe_history.json'))
+for e in d.get('executions', []):
+    print(f\"      run={e.get('run_id')}  model={e.get('model_name')}  status={e.get('status')}\")
+"
+
+# ---------------------------------------------------------------------------
+# Assertions — both executions of the same program are returned by --recipe.
+# ---------------------------------------------------------------------------
+[ -n "$RECIPE_HASH" ] || { echo "FAIL: no recipe_hash recorded on the model" >&2; exit 1; }
+[ "$COUNT" = "2" ] || { echo "FAIL: expected 2 executions of the recipe, got $COUNT" >&2; exit 1; }
+
+echo
+echo "POC complete: one recipe_hash, two executions — 'what produced this?' answered."


### PR DESCRIPTION
Adds a creds-free DuckDB POC demonstrating the recipe-identity artifact shipped in the recent provenance work:

- **`examples/playground/pocs/04-governance/10-recipe-provenance`** — materializes one model twice and shows `rocky history --recipe <hash>` returning both executions of that exact program, with the full triple (`recipe_hash`, `input_hash` labeled `heuristic`, `env_hash`, `hash_scheme`) surfaced on `rocky history`. Single `./run.sh`, no credentials, asserts the two-execution result.
- **Docs** — a short, honesty-graded note in the "Content-addressed writes and replay" concept section: the recipe-identity triple is an identity/audit primitive, not a reproducibility claim; the replay re-execution grade is left unchanged.
- POC catalog counts updated via `scripts/update-poc-counts.sh` (04-governance 9→10; 85/97 creds-free).

Verified: `./run.sh` exits 0 against a freshly-built binary; `RockyClient.history()` returns `recipe_identity` populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)