### PR TITLE
feat(engine/rocky-core): record consumer-side per-column baseline

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -4801,6 +4801,19 @@ pub(crate) async fn execute_models(
     let mut reuse_outputs: std::collections::HashMap<String, String> =
         std::collections::HashMap::new();
 
+    // Producer-side per-column output hashes for every content-addressed model
+    // built earlier in THIS run, keyed by target `catalog.schema.table` full
+    // name (as `reuse_outputs` is). A later content-addressed model reads this
+    // to record what its consumed columns hashed to at build time — the
+    // consumer-side per-column baseline (schema v13, record-only). Populated
+    // independently of `[reuse]` (the consumer baseline is content-addressed
+    // path, not reuse, scoped); empty and untouched when no content-addressed
+    // model produces column hashes.
+    let mut built_output_hashes: std::collections::HashMap<
+        String,
+        Vec<rocky_core::state::ColumnHash>,
+    > = std::collections::HashMap::new();
+
     // Static lookup built once when reuse is on: every lowercased identity a
     // model can be UNAMBIGUOUSLY *read by* in SQL → that model's target
     // `catalog.schema.table` full name. Lets the read-set resolver map a table
@@ -4817,6 +4830,19 @@ pub(crate) async fn execute_models(
     } else {
         Default::default()
     };
+
+    // The same read-by → target-full lookup, always built: the consumer-side
+    // per-column baseline is scoped to the content-addressed path, which runs
+    // with or without `[reuse]`, so it can't borrow the reuse-gated map above.
+    // Cheap (one entry per model name + identity) and only consulted when a
+    // content-addressed model records its baseline.
+    let baseline_target_by_model = build_reuse_target_by_model(
+        compile_result
+            .project
+            .models
+            .iter()
+            .map(|m| (m.config.name.as_str(), &m.config.target)),
+    );
 
     // Pre-create target schemas when the caller requested auto-create.
     // Mirrors the replication path's per-source loop (see the
@@ -5189,6 +5215,19 @@ pub(crate) async fn execute_models(
                 match summary {
                     Ok(summary) => {
                         let duration_ms = model_start.elapsed().as_millis() as u64;
+                        // Consumer-side per-column baseline (schema v13,
+                        // record-only). For each upstream this model provably
+                        // consumes, record the columns `consumed(D, U)` paired
+                        // with `U`'s producer output-column hashes as observed
+                        // at THIS build — what `D` read, not producer-now-vs-
+                        // prior (Fork 2). `None` when the consumed set isn't
+                        // provably complete (⇒ a safe rebuild in the later
+                        // gate). Nothing consults it yet.
+                        let consumed_column_baseline = compute_consumer_baseline(
+                            &model_ir.sql,
+                            &baseline_target_by_model,
+                            &built_output_hashes,
+                        );
                         output.materializations.push(MaterializationOutput {
                             asset_key,
                             rows_copied: Some(summary.num_rows as u64),
@@ -5225,7 +5264,27 @@ pub(crate) async fn execute_models(
                             // only; nothing consults it yet.
                             output_column_hashes: (!summary.output_column_hashes.is_empty())
                                 .then(|| summary.output_column_hashes.clone()),
+                            // The consumer-side per-column baseline computed
+                            // above; routed onto `ModelExecution.upstream_freshness`
+                            // by `to_run_record`.
+                            consumed_column_baseline,
                         });
+                        // Make this model's producer column hashes visible to
+                        // later content-addressed models that consume it, so a
+                        // downstream can record what it read from this upstream.
+                        // Recorded only when the build produced hashes: a
+                        // genuine unpartitioned build always does; a point-to
+                        // reuse carries the referenced run's recorded hashes
+                        // when present; a partitioned build produces none (the
+                        // per-file fold is deferred). An absent entry degrades a
+                        // downstream baseline to a safe rebuild. Keyed by target
+                        // full name as `reuse_outputs` is.
+                        if !summary.output_column_hashes.is_empty() {
+                            built_output_hashes.insert(
+                                target_table_full_name.clone(),
+                                summary.output_column_hashes.clone(),
+                            );
+                        }
                         // Per-model decision (reporting-only). A
                         // content_addressed model is never skip-eligible, so it
                         // is suppressed in the skip-gate loop above and owns its
@@ -5578,6 +5637,92 @@ where
         map.insert(name.to_lowercase(), target_full);
     }
     map
+}
+
+/// Compute the **consumer-side per-column baseline** for a content-addressed
+/// model `D` at build time: for every upstream `U` that `D` *provably* consumes,
+/// the columns `consumed(D, U)` paired with `U`'s producer output-column hashes
+/// as observed during this run.
+///
+/// This is the record-only half of T2's per-column skip substrate (schema v13).
+/// It is **consumer-side and local** (design Fork 2): it records what `D` read
+/// from each upstream *at this build*, reconstructible from the stored snapshot
+/// plus the current run — never a producer-now-vs-producer-prior inference.
+/// Nothing consults the result yet; the skip gate is a later phase.
+///
+/// Fails **closed** to `None` (no baseline ⇒ a safe rebuild in the later gate,
+/// never a wrong skip) whenever the consumed set can't be proven complete
+/// ([`rocky_sql::consumed_columns`] returns
+/// [`ForceBuild`](rocky_sql::consumed_columns::ConsumedColumns::ForceBuild)).
+///
+/// Arguments:
+/// - `sql` — `D`'s model SQL.
+/// - `target_by_model` — read-by identity (lowercased bare name or 3-part
+///   `catalog.schema.table`) → the producing model's target full name, from
+///   [`build_reuse_target_by_model`].
+/// - `built_output_hashes` — target full name → that upstream's producer
+///   output-column hashes recorded earlier in this run.
+///
+/// Each returned [`UpstreamSig`](rocky_core::state::UpstreamSig) carries only
+/// the column baseline (`max_ts` / `row_count` are `None` — freshness is the
+/// plain-strategy gate's concern, not this path). An upstream's
+/// `consumed_column_hashes` is:
+/// - `Some(hashes)` — the consumed columns resolved to a producer that recorded
+///   hashes this run and **every** consumed column matched (case-insensitively,
+///   since [`consumed_columns`](rocky_sql::consumed_columns) lowercases column
+///   names while the producer keeps the original Arrow field name);
+/// - `None` — the read didn't resolve to a project model (a raw source, or a
+///   catalog-ambiguous 2-part name absent from `target_by_model`), the upstream
+///   recorded no hashes this run (not built content-addressed, reused, or
+///   partitioned), or a consumed column had no matching producer hash. Recorded
+///   honestly so the later gate sees "consumed, but no column baseline ⇒ build".
+fn compute_consumer_baseline(
+    sql: &str,
+    target_by_model: &std::collections::HashMap<String, String>,
+    built_output_hashes: &std::collections::HashMap<String, Vec<rocky_core::state::ColumnHash>>,
+) -> Option<Vec<rocky_core::state::UpstreamSig>> {
+    use rocky_sql::consumed_columns::{ConsumedColumns, consumed_columns};
+
+    let ConsumedColumns::Complete(consumed) = consumed_columns(sql) else {
+        // Consumed set not provably complete ⇒ no baseline (fail closed).
+        return None;
+    };
+
+    let mut sigs = Vec::with_capacity(consumed.len());
+    for (source_key, cols) in &consumed {
+        let (upstream_key, consumed_column_hashes) = match target_by_model.get(source_key) {
+            Some(target_full) => {
+                // Filter the upstream's producer hashes to the consumed columns.
+                // Every consumed column must resolve to a producer hash, else
+                // this upstream can't back a column-level skip (fail closed to
+                // `None`). Case-insensitive: `cols` are lowercased,
+                // `ColumnHash.column` is the original Arrow field name.
+                let hashes = built_output_hashes.get(target_full).and_then(|producer| {
+                    let by_col: std::collections::HashMap<String, &rocky_core::state::ColumnHash> =
+                        producer
+                            .iter()
+                            .map(|ch| (ch.column.to_lowercase(), ch))
+                            .collect();
+                    let mut filtered = Vec::with_capacity(cols.len());
+                    for col in cols {
+                        filtered.push((*by_col.get(col)?).clone());
+                    }
+                    Some(filtered)
+                });
+                (target_full.clone(), hashes)
+            }
+            // Unresolved read (raw source / catalog-ambiguous): no column
+            // baseline for it, keyed by the name as written.
+            None => (source_key.clone(), None),
+        };
+        sigs.push(rocky_core::state::UpstreamSig {
+            upstream_key,
+            max_ts: None,
+            row_count: None,
+            consumed_column_hashes,
+        });
+    }
+    Some(sigs)
 }
 
 /// Resolve a content-addressed model's immediate upstreams to STRONG
@@ -6074,6 +6219,8 @@ async fn execute_one_plain_model(
         )),
         // Not the content-addressed write path — no in-process column bytes.
         output_column_hashes: None,
+        // Consumer baseline is content-addressed-path only.
+        consumed_column_baseline: None,
     })
 }
 
@@ -6507,6 +6654,8 @@ async fn run_one_partition(
             )),
             // Not the content-addressed write path — no in-process column bytes.
             output_column_hashes: None,
+            // Consumer baseline is content-addressed-path only.
+            consumed_column_baseline: None,
         }),
     }
 }
@@ -7416,6 +7565,8 @@ async fn process_table(
             )),
             // Not the content-addressed write path — no in-process column bytes.
             output_column_hashes: None,
+            // Consumer baseline is content-addressed-path only.
+            consumed_column_baseline: None,
         },
         drift_checked: true,
         drift_detected: drift_action,
@@ -12199,6 +12350,118 @@ merge_keys = ["id"]
             }
             other => panic!("expected a Content identity, got {other:?}"),
         }
+    }
+
+    // -- consumer-side per-column baseline (T2 P2, record-only) --------------
+    //
+    // These drive the PRODUCTION baseline computation
+    // (`compute_consumer_baseline`) over the PRODUCTION completeness guard
+    // (`rocky_sql::consumed_columns`) + the production resolver map
+    // (`build_reuse_target_by_model`), on real SQL — not a hand-faked consumed
+    // set — so the guard, the FROM→upstream resolution, and the
+    // case-insensitive producer-hash filter are all genuinely under test.
+
+    fn ch(column: &str, hash: &str) -> rocky_core::state::ColumnHash {
+        rocky_core::state::ColumnHash {
+            column: column.to_string(),
+            hash: hash.to_string(),
+        }
+    }
+
+    #[test]
+    fn consumer_baseline_records_only_consumed_columns_case_insensitively() {
+        // Upstream `u` produced three columns (ORIGINAL Arrow-field casing);
+        // the downstream projects `id`, filters on `name`, and never reads
+        // `email`. The baseline must carry `id` + `name` (consumed) and NOT
+        // `email`, matching case-insensitively (consumed_columns lowercases;
+        // the producer keeps original case) — the exact bug that would silently
+        // record an empty baseline and make the feature inert.
+        let t_u = target_cfg("cat", "sch", "u");
+        let target_by_model = build_reuse_target_by_model([("u", &t_u)]);
+
+        let mut built = std::collections::HashMap::new();
+        built.insert(
+            "cat.sch.u".to_string(),
+            vec![
+                ch("ID", "h_id"),
+                ch("Name", "h_name"),
+                ch("Email", "h_email"),
+            ],
+        );
+
+        let sigs = compute_consumer_baseline(
+            "SELECT id FROM u WHERE name = 'x'",
+            &target_by_model,
+            &built,
+        )
+        .expect("a provably-complete consumed set yields a baseline");
+
+        assert_eq!(sigs.len(), 1);
+        assert_eq!(sigs[0].upstream_key, "cat.sch.u");
+        // Freshness fields are not this path's concern.
+        assert_eq!(sigs[0].max_ts, None);
+        assert_eq!(sigs[0].row_count, None);
+        let cols = sigs[0]
+            .consumed_column_hashes
+            .as_ref()
+            .expect("consumed columns resolved to producer hashes");
+        assert_eq!(
+            cols,
+            &vec![ch("ID", "h_id"), ch("Name", "h_name")],
+            "records the producer hashes for the consumed columns (id + name), \
+             excludes the never-read `email`, matched case-insensitively"
+        );
+    }
+
+    #[test]
+    fn consumer_baseline_fails_closed_on_incomplete_consumed_set() {
+        // A `SELECT *` can't enumerate consumed columns ⇒ the guard force-builds
+        // ⇒ no baseline (None), which forces a safe rebuild in the later gate.
+        let t_u = target_cfg("cat", "sch", "u");
+        let target_by_model = build_reuse_target_by_model([("u", &t_u)]);
+        let mut built = std::collections::HashMap::new();
+        built.insert("cat.sch.u".to_string(), vec![ch("id", "h_id")]);
+
+        assert!(
+            compute_consumer_baseline("SELECT * FROM u", &target_by_model, &built).is_none(),
+            "an un-enumerable consumed set must yield no baseline (fail closed)"
+        );
+    }
+
+    #[test]
+    fn consumer_baseline_none_for_upstream_without_producer_hashes() {
+        // The downstream provably consumes `u.id`, but `u` recorded no producer
+        // hashes this run (not built content-addressed, reused, or partitioned).
+        // The upstream is recorded with `consumed_column_hashes: None` — honest
+        // "consumed, but no column baseline ⇒ the later gate must build".
+        let t_u = target_cfg("cat", "sch", "u");
+        let target_by_model = build_reuse_target_by_model([("u", &t_u)]);
+        let built = std::collections::HashMap::new(); // u produced no hashes
+
+        let sigs = compute_consumer_baseline("SELECT id FROM u", &target_by_model, &built)
+            .expect("consumed set is complete even when the upstream has no hashes");
+        assert_eq!(sigs.len(), 1);
+        assert_eq!(sigs[0].upstream_key, "cat.sch.u");
+        assert_eq!(sigs[0].consumed_column_hashes, None);
+    }
+
+    #[test]
+    fn consumer_baseline_none_when_a_consumed_column_is_missing_from_producer() {
+        // The downstream consumes `id` + `name`, but the producer recorded only
+        // `id` (a rename or a stale hash). Every consumed column must resolve or
+        // the upstream can't back a column skip — fail closed to `None`.
+        let t_u = target_cfg("cat", "sch", "u");
+        let target_by_model = build_reuse_target_by_model([("u", &t_u)]);
+        let mut built = std::collections::HashMap::new();
+        built.insert("cat.sch.u".to_string(), vec![ch("id", "h_id")]);
+
+        let sigs =
+            compute_consumer_baseline("SELECT id, name FROM u", &target_by_model, &built).unwrap();
+        assert_eq!(sigs.len(), 1);
+        assert_eq!(
+            sigs[0].consumed_column_hashes, None,
+            "a consumed column absent from the producer's hashes ⇒ no baseline for that upstream"
+        );
     }
 
     /// Runtime regression: a first run of an incremental transformation

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -877,6 +877,8 @@ pub async fn run_snapshot(
             )),
             // Not the content-addressed write path — no in-process column bytes.
             output_column_hashes: None,
+            // Consumer baseline is content-addressed-path only.
+            consumed_column_baseline: None,
         });
     } else {
         output.tables_failed = 1;

--- a/engine/crates/rocky-cli/src/commands/skip_gate.rs
+++ b/engine/crates/rocky-cli/src/commands/skip_gate.rs
@@ -504,6 +504,10 @@ impl<'a> SkipGate<'a> {
                 upstream_key: lname,
                 max_ts,
                 row_count,
+                // The plain-strategy skip gate captures freshness only; the
+                // consumer-side per-column baseline is content-addressed-path
+                // only (recorded by the content-addressed runner).
+                consumed_column_hashes: None,
             });
         }
         Some(sigs)

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -984,6 +984,21 @@ pub struct MaterializationOutput {
     #[serde(skip)]
     #[schemars(skip)]
     pub output_column_hashes: Option<Vec<rocky_core::state::ColumnHash>>,
+    /// State-internal consumer-side per-column baseline for this model, carried
+    /// so [`RunOutput::to_run_record`] can route it onto the persisted
+    /// [`rocky_core::state::ModelExecution::upstream_freshness`] as
+    /// [`UpstreamSig`](rocky_core::state::UpstreamSig) entries whose
+    /// `consumed_column_hashes` record what this model consumed from each
+    /// upstream at build time. Populated only by the content-addressed runner
+    /// on a genuine build whose consumed-column set is provably complete;
+    /// `None` everywhere else. Consumer-side and local (Fork 2), never
+    /// producer-now-vs-prior; captured only, nothing consults it yet.
+    ///
+    /// Never serialized and never part of the JSON schema (via `#[serde(skip)]`
+    /// and `#[schemars(skip)]`) — same pattern as [`Self::output_column_hashes`].
+    #[serde(skip)]
+    #[schemars(skip)]
+    pub consumed_column_baseline: Option<Vec<rocky_core::state::UpstreamSig>>,
 }
 
 /// State-internal skip-gate result for one materialized model, carried on
@@ -4624,10 +4639,19 @@ impl RunOutput {
                 // `None` whenever the gate is off or the model was not
                 // skip-eligible — its absence simply forces a rebuild next run.
                 skip_hash: mat.skip_internal.as_ref().and_then(|s| s.skip_hash.clone()),
+                // The consumer-side upstream baseline. A skip-eligible plain
+                // model carries its freshness signatures via `skip_internal`; a
+                // content-addressed model carries the per-column consumer
+                // baseline via `consumed_column_baseline`. A model is at most
+                // one of the two, so `or_else` picks whichever is present (both
+                // land on `upstream_freshness` as `UpstreamSig` entries). The
+                // per-column baseline is captured only — the skip gate never
+                // reads a content-addressed model's `upstream_freshness`.
                 upstream_freshness: mat
                     .skip_internal
                     .as_ref()
-                    .map(|s| s.upstream_freshness.clone()),
+                    .map(|s| s.upstream_freshness.clone())
+                    .or_else(|| mat.consumed_column_baseline.clone()),
                 bytes_scanned: mat.bytes_scanned,
                 bytes_written: mat.bytes_written,
                 tenant: mat.tenant.clone(),
@@ -5051,6 +5075,7 @@ mod cost_finalize_tests {
             skip_internal: None,
             recipe_identity: None,
             output_column_hashes: None,
+            consumed_column_baseline: None,
         }
     }
 
@@ -5266,6 +5291,7 @@ mod run_record_tests {
             skip_internal: None,
             recipe_identity: None,
             output_column_hashes: None,
+            consumed_column_baseline: None,
         }
     }
 
@@ -5328,6 +5354,56 @@ mod run_record_tests {
         assert_eq!(
             customers.finished_at,
             customers_start + chrono::Duration::milliseconds(800)
+        );
+    }
+
+    /// The content-addressed consumer baseline (`consumed_column_baseline`)
+    /// must land on the persisted `ModelExecution.upstream_freshness` — the
+    /// consumer-side per-column baseline (schema v13). A content-addressed
+    /// model has no `skip_internal`, so the `or_else` route in `to_run_record`
+    /// is what carries it. Proves the baseline is durable end-to-end.
+    #[test]
+    fn to_run_record_lands_consumer_baseline_on_upstream_freshness() {
+        let mut out = RunOutput::new(String::new(), 1_000, 1);
+        out.tables_copied = 1;
+        let started = fixed_start();
+        let mut m = mat(&["cat", "sch", "d"], 100, Some("sqlh"), started);
+        // Content-addressed model: no skip_internal, only the consumer baseline.
+        assert!(m.skip_internal.is_none());
+        m.consumed_column_baseline = Some(vec![rocky_core::state::UpstreamSig {
+            upstream_key: "cat.sch.u".to_string(),
+            max_ts: None,
+            row_count: None,
+            consumed_column_hashes: Some(vec![rocky_core::state::ColumnHash {
+                column: "id".to_string(),
+                hash: "h_id".to_string(),
+            }]),
+        }]);
+        out.materializations.push(m);
+
+        let record = out.to_run_record(
+            "run-baseline-1",
+            started,
+            started + chrono::Duration::seconds(1),
+            "cfg".to_string(),
+            RunTrigger::Manual,
+            RunStatus::Success,
+            RunRecordAudit::test_sentinels(),
+        );
+
+        let d = &record.models_executed[0];
+        let sigs = d
+            .upstream_freshness
+            .as_ref()
+            .expect("consumer baseline routed onto upstream_freshness");
+        assert_eq!(sigs.len(), 1);
+        assert_eq!(sigs[0].upstream_key, "cat.sch.u");
+        assert_eq!(
+            sigs[0].consumed_column_hashes,
+            Some(vec![rocky_core::state::ColumnHash {
+                column: "id".to_string(),
+                hash: "h_id".to_string(),
+            }])
         );
     }
 

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -233,7 +233,15 @@ pub const LOCAL_ONLY_TABLE_NAMES: &[&str] = &["schema_cache"];
 ///   with it `None` and a v12 blob back-reads cleanly on a v11 binary (serde
 ///   ignores the extra key). No new tables, no in-place migration. Guarded by
 ///   `test_v11_model_execution_forward_deserializes_output_column_hashes_none`.
-const CURRENT_SCHEMA_VERSION: u32 = 12;
+/// - **v13** — adds `consumed_column_hashes` (the consumer-side per-column
+///   baseline; see [`ColumnHash`]) to the [`UpstreamSig`] blob carried on
+///   [`ModelExecution::upstream_freshness`]. Pure additive blob-field change,
+///   same shape as the v12 field: the new field is `#[serde(default)]`, so a
+///   v12 `UpstreamSig` forward-deserializes with it `None` and a v13 blob
+///   back-reads cleanly on a v12 binary (serde ignores the extra key). No new
+///   tables, no in-place migration. Guarded by
+///   `test_v12_upstream_sig_forward_deserializes_consumed_column_hashes_none`.
+const CURRENT_SCHEMA_VERSION: u32 = 13;
 
 /// Errors from the embedded redb state store.
 #[derive(Debug, Error)]
@@ -1049,6 +1057,34 @@ pub struct UpstreamSig {
     /// the rowcount fallback is enabled. `None` otherwise.
     #[serde(default)]
     pub row_count: Option<u64>,
+
+    // --- Consumer-side column baseline (schema v13) ----------------------
+    /// The per-column content hashes this downstream **consumed** from this
+    /// upstream at its last successful build — the consumer-side baseline
+    /// (see [`ColumnHash`]). One entry per column in `consumed(D, U)` (the
+    /// columns the downstream provably reads from this upstream, per the
+    /// completeness guard), each carrying the upstream's producer output-column
+    /// hash ([`ModelExecution::output_column_hashes`]) as observed at build
+    /// time.
+    ///
+    /// This is **consumer-side and local**: it records what *this* model read
+    /// from *this* upstream, reconstructible from two stored snapshots plus the
+    /// current run — never a producer-now-vs-producer-prior inference. It
+    /// extends the freshness baseline this same `UpstreamSig` already stores
+    /// (`max_ts` / `row_count`) with column granularity, on the
+    /// content-addressed path only.
+    ///
+    /// `None` when the baseline was not captured: a pre-v13 record, a
+    /// non-content-addressed build, an upstream whose producer column hashes
+    /// were unavailable this build, or a downstream whose consumed-column set
+    /// could not be proven complete. An absent baseline can only ever force a
+    /// (safe) rebuild in the later skip gate, never a wrong skip. Captured
+    /// only; nothing consults it yet (the skip gate is a later phase).
+    /// State-internal — carries no codegen. Serde-defaulted so a pre-v13 blob
+    /// forward-deserializes with it `None`; guarded by
+    /// `test_v12_upstream_sig_forward_deserializes_consumed_column_hashes_none`.
+    #[serde(default)]
+    pub consumed_column_hashes: Option<Vec<ColumnHash>>,
 }
 
 /// A single output column's content hash, captured on a successful
@@ -4283,6 +4319,44 @@ mod tests {
         assert_eq!(exec.output_column_hashes, None);
     }
 
+    /// v12 → v13 forward-compat: an `UpstreamSig` blob written before
+    /// `consumed_column_hashes` existed (a full v12 freshness signature with no
+    /// `consumed_column_hashes` key) must forward-deserialize with the field
+    /// defaulting to `None`. Also asserts a v13 `UpstreamSig` carrying the new
+    /// field round-trips, so the consumer baseline survives a store→read cycle.
+    #[test]
+    fn test_v12_upstream_sig_forward_deserializes_consumed_column_hashes_none() {
+        let v12_blob = br#"{
+            "upstream_key": "cat.sch.orders",
+            "max_ts": "2024-01-01T00:00:00Z",
+            "row_count": 42
+        }"#;
+
+        let sig: UpstreamSig =
+            serde_json::from_slice(v12_blob).expect("pre-v13 UpstreamSig must forward-deserialize");
+
+        // Prior freshness fields preserved.
+        assert_eq!(sig.upstream_key, "cat.sch.orders");
+        assert_eq!(sig.row_count, Some(42));
+        // The new field defaults to None — a pre-v13 signature is treated as
+        // "no consumer column baseline recorded", never crashes the read.
+        assert_eq!(sig.consumed_column_hashes, None);
+
+        // A v13 signature carrying the consumer baseline round-trips.
+        let v13 = UpstreamSig {
+            upstream_key: "cat.sch.orders".to_string(),
+            max_ts: None,
+            row_count: None,
+            consumed_column_hashes: Some(vec![ColumnHash {
+                column: "id".to_string(),
+                hash: "col-hash".to_string(),
+            }]),
+        };
+        let json = serde_json::to_string(&v13).unwrap();
+        let back: UpstreamSig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v13);
+    }
+
     /// A v11 `ModelExecution` blob (carrying the triple) must back-read on a
     /// binary that predates it: serde ignores the unknown keys, so a v10 reader
     /// never breaks on a v11 row. Emulated by deserializing the full v11 shape
@@ -6616,14 +6690,14 @@ mod tests {
         // is an on-disk break that needs a `CURRENT_SCHEMA_VERSION` bump + a
         // migration path, not just an edit here.
         //
-        // v12 bumps the version for the `output_column_hashes` field added to
-        // the `ModelExecution` blob. The table set below is deliberately
-        // unchanged — v12 adds no tables, only a serde-defaulted blob field —
-        // so the forward-compat path is the existing default-on-missing
-        // behaviour (guarded by
-        // `test_v11_model_execution_forward_deserializes_output_column_hashes_none`
+        // v13 bumps the version for the `consumed_column_hashes` field added to
+        // the `UpstreamSig` blob (carried on `ModelExecution.upstream_freshness`).
+        // The table set below is deliberately unchanged — v13 adds no tables,
+        // only a serde-defaulted blob field — so the forward-compat path is the
+        // existing default-on-missing behaviour (guarded by
+        // `test_v12_upstream_sig_forward_deserializes_consumed_column_hashes_none`
         // and the `open_with_policy_*` mismatch tests), not a new migration.
-        const EXPECTED_VERSION: u32 = 12;
+        const EXPECTED_VERSION: u32 = 13;
         const EXPECTED_TABLES: &[&str] = &[
             "branches",
             "check_history",

--- a/integrations/dagster/tests/fixtures_generated/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor.json
@@ -17,7 +17,7 @@
     {
       "name": "state_schema",
       "status": "healthy",
-      "message": "state schema v12 matches this binary",
+      "message": "state schema v13 matches this binary",
       "duration_ms": 0
     },
     {

--- a/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
@@ -17,7 +17,7 @@
     {
       "name": "state_schema",
       "status": "healthy",
-      "message": "state schema v12 matches this binary",
+      "message": "state schema v13 matches this binary",
       "duration_ms": 0
     },
     {

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 12,
-  "schema_version_on_disk": 12
+  "schema_version_supported": 13,
+  "schema_version_on_disk": 13
 }

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 12,
-  "schema_version_on_disk": 12
+  "schema_version_supported": 13,
+  "schema_version_on_disk": 13
 }

--- a/integrations/dagster/tests/fixtures_generated/state.json
+++ b/integrations/dagster/tests/fixtures_generated/state.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 12,
-  "schema_version_on_disk": 12
+  "schema_version_supported": 13,
+  "schema_version_on_disk": 13
 }


### PR DESCRIPTION
## What

At content-addressed build time, record the **consumer-side per-column baseline**: for every upstream `U` that model `D` provably consumes, the columns `consumed(D, U)` paired with `U`'s producer output-column hashes as observed *at this build*. Stored on `ModelExecution.upstream_freshness` as `UpstreamSig` entries carrying a new serde-defaulted `consumed_column_hashes` field.

This is the consumer half of the per-column skip substrate. It builds on the consumed-column completeness guard (`rocky_sql::consumed_columns`) and the producer-side output-column hashes (`ModelExecution.output_column_hashes`), both already merged.

## Design fidelity (load-bearing)

- **Consumer-side and local.** The baseline records what `D` read from each upstream at its own build, keyed by `U`, filtered to `consumed(D, U)` — reconstructible from the stored snapshot plus the current run. It is **never** a producer-now-vs-producer-prior inference. `compute_consumer_baseline` sources `U`'s hashes only from models built *this* run; there is no read of `U`'s prior hashes anywhere.
- **Record-only, doubly fail-safe.** Nothing consults the baseline yet — no gate, no skip decision, no comparison. An absent baseline can only ever force a safe rebuild in a later phase, never a wrong skip. If a model ever flips content-addressed→plain between runs, the gate's `sig_unchanged` reads `max_ts`/`row_count` (both `None`) → build, and never touches `consumed_column_hashes`.
- **Fail closed.** The completeness guard yields no baseline (`None`) on any shape it can't prove (`SELECT *`, CTEs, subqueries, ambiguity). Producer hashes are matched **case-insensitively** (the guard lowercases column names; the producer keeps the original Arrow field name), and *every* consumed column must resolve or that upstream records no baseline.
- **Routing.** `to_run_record` routes the baseline onto `upstream_freshness` via `.or_else`. A model is never both skip-eligible (carries `skip_internal`) and content-addressed (carries the baseline) — `is_eligible` excludes content-addressed — so for non-CA models the field is `None` and existing behavior is byte-identical.
- Scoped to the content-addressed path; off it the field is `None`.

## Schema

State schema **v12 → v13** (additive, serde-defaulted): a pre-v13 `UpstreamSig` forward-deserializes with the field `None`, and a v13 blob back-reads cleanly on a v12 binary. Guarded by a forward-deserialize test, a v13 round-trip, and the `on_disk_state_schema_format_is_pinned` version tripwire. No codegen surface (the new fields are state-internal / `#[serde(skip)]#[schemars(skip)]`).

## Reachability (honest split)

The content-addressed write path is s3-only; a creds-free DuckDB run never reaches it, so no run *exercises* the wiring end-to-end. Following P1's posture:

- **Test-proven:** the baseline **computation** (real SQL → the production `consumed_columns` guard → the production resolver map → the case-insensitive `ColumnHash` filter, incl. the casing-trap and fail-closed cases); the baseline **landing** on `ModelExecution.upstream_freshness` via the production `to_run_record`; serde **persistence** (v13 round-trip + forward-deserialize).
- **Review-only:** the `run.rs` content-addressed write-loop wiring (calling `compute_consumer_baseline`, threading `built_output_hashes` across layers, stamping the field) — s3-gated, no run-level in-memory harness exists. This matches P1's stamping posture exactly.

## Gates

- `cargo fmt --check`, `cargo clippy --all-targets`: clean
- `cargo test --workspace`: 103 test binaries ok, 0 failures (7 new tests)
- `cargo check --all-features --all-targets`: clean
- `just codegen`: no schema/binding drift
- `just regen-fixtures`: diff is **only** the v12→v13 version bump (2 doctor `state_schema` messages + 3 `state.json` version fields) — the baseline is content-addressed-path-only, so nothing new lands in the replication-only playground fixtures.
