### PR TITLE
feat(engine/rocky-cli): content-addressed column-level skip gate (default-off)

### DIFF
--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -3069,6 +3069,11 @@
       "additionalProperties": false,
       "description": "`[reuse]` — opt-in auditable reuse for content-addressed models.\n\nWhen `enabled = true`, a successful run records, per model, an input-match index entry and an offline-verifiable provenance record (the model's logic key, upstream input identities, output blake3(s), and proof class). That spine is the *input* side; on a later run, an eligible model whose recomputed `input_hash` hits the index for a prior **strong** run may **point-to** that run's already-written parquet — a zero-copy commit that skips the SQL — provided every clause of the runner's fail-closed reuse decision holds. Any doubt builds.\n\n**Default-OFF.** `enabled = false` (the default) keeps `rocky run` byte- *and* cost-identical to before the spine existed: no extra normalize+hash work, no extra state write, no reuse decision. The point-to path is strong (byte-identical) only on the content-addressed/UniForm write path; experimental, opt-in.",
       "properties": {
+        "column_level": {
+          "default": false,
+          "description": "Opt-in **column-level skip** for content-addressed models. When `true`, an unpartitioned content-addressed model whose logic, environment, and every provably-consumed upstream column are unchanged since its last successful build is **skipped** — its SQL does not run and no new commit is written; the prior output stays authoritative. Skipping on a value change to a consumed column is precisely the silent-staleness bug this gate is built to avoid, so the decision is fail-closed: any unproven input (a non-deterministic model, a changed recipe/env, an un-enumerable consumed set, a missing or moved column hash) forces a build.\n\n**Default-OFF.** `false` (the default) keeps `rocky run` byte- and cost-identical: no column-level comparison runs and no model is skipped on this basis. Independent of [`Self::enabled`] (byte-level point-to reuse) — the two are orthogonal opt-ins on the content-addressed path. Experimental; off the content-addressed path the feature does not apply.",
+          "type": "boolean"
+        },
         "enabled": {
           "default": false,
           "description": "Master switch for auditable reuse: populates the input-match spine and arms the point-to decision. `false` (default) ⇒ the spine is never written, no per-model hashing cost is paid, and no model reuses.",
@@ -4192,6 +4197,7 @@
         }
       ],
       "default": {
+        "column_level": false,
         "enabled": false
       },
       "description": "Opt-in auditable reuse. Default-OFF: an absent `[reuse]` block keeps `rocky run` byte- and cost-identical (no per-model hashing, no extra state write). When enabled, an eligible content-addressed model whose inputs match a prior strong run may **point-to** that run's parquet (zero-copy) instead of re-executing its SQL — fail-closed to BUILD on any doubt. See [`ReuseConfig`]."

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -1885,6 +1885,12 @@ export interface RunRetryConfig {
  */
 export interface ReuseConfig {
   /**
+   * Opt-in **column-level skip** for content-addressed models. When `true`, an unpartitioned content-addressed model whose logic, environment, and every provably-consumed upstream column are unchanged since its last successful build is **skipped** — its SQL does not run and no new commit is written; the prior output stays authoritative. Skipping on a value change to a consumed column is precisely the silent-staleness bug this gate is built to avoid, so the decision is fail-closed: any unproven input (a non-deterministic model, a changed recipe/env, an un-enumerable consumed set, a missing or moved column hash) forces a build.
+   *
+   * **Default-OFF.** `false` (the default) keeps `rocky run` byte- and cost-identical: no column-level comparison runs and no model is skipped on this basis. Independent of [`Self::enabled`] (byte-level point-to reuse) — the two are orthogonal opt-ins on the content-addressed path. Experimental; off the content-addressed path the feature does not apply.
+   */
+  column_level?: boolean;
+  /**
    * Master switch for auditable reuse: populates the input-match spine and arms the point-to decision. `false` (default) ⇒ the spine is never written, no per-model hashing cost is paid, and no model reuses.
    */
   enabled?: boolean;

--- a/engine/crates/rocky-cli/src/commands/column_skip.rs
+++ b/engine/crates/rocky-cli/src/commands/column_skip.rs
@@ -1,0 +1,573 @@
+//! The opt-in content-addressed **column-level skip** decision.
+//!
+//! This is the *sound* half of the per-column skip substrate: "an upstream was
+//! rebuilt, but the specific columns this downstream actually consumes did NOT
+//! change → skip the downstream." It is the one decision nothing else in the
+//! engine can make soundly — the whole-output blake3 is table-granular, the
+//! breaking-change classifier is schema-only, and the freshness gate is
+//! watermark-only. Per-column content hashes over column *values* are what
+//! defeat the documented trap: a schema-stable `WHERE`/`JOIN`/`CASE` rewrite
+//! upstream that keeps the type byte-identical while moving the data still
+//! flips the consumed column's content hash ⇒ build.
+//!
+//! # Why this lives on the content-addressed surface, not the plain skip gate
+//!
+//! The two skip surfaces must not double-decide. The plain
+//! [`super::skip_gate`] adjudicates *plain*-strategy models (its `is_eligible`
+//! deliberately excludes `content_addressed`); the content-addressed runner
+//! ([`super::run_content_addressed`]) adjudicates *content-addressed* models
+//! (byte-level point-to reuse vs build). The column-level skip is a **third
+//! outcome of the content-addressed surface**, evaluated by the caller for a
+//! content-addressed model *before* the point-to reuse / build path: either it
+//! column-skips, or it falls through to that path. The two never both act on
+//! one model. This placement is forced, not chosen: the consumer-side baseline
+//! ([`rocky_core::state::UpstreamSig::consumed_column_hashes`]) and the
+//! producer output hashes ([`rocky_core::state::ModelExecution::output_column_hashes`])
+//! are only ever recorded for content-addressed models, so a column-level skip
+//! can only ever be decided for a content-addressed downstream.
+//!
+//! # The load-bearing safety rule
+//!
+//! A wrong skip is **silent production staleness** — the worst failure a
+//! transformation engine can have. So, like the plain gate, this decision is:
+//!
+//! - **default-OFF** (behind `[reuse] column_level = false`);
+//! - **fail-safe** — *every* missing, partial, or mismatched input resolves to
+//!   **build**. There is exactly one code path that yields [`ColumnSkipVerdict::Skip`],
+//!   and it requires every clause below to hold;
+//! - **over-sensitive by construction** (design Fork 4) — the per-column hash
+//!   is over the column's written values *as stored*, with no canonicalisation.
+//!   A row-order, encoding, or NULL-render difference makes the hash differ
+//!   even when the logical content is identical, so the decision errs toward a
+//!   redundant **build**, never a wrong skip. A concrete, intended consequence:
+//!   an **order-unstable producer never skips** — its column hash changes every
+//!   run, so a consumer's comparison never matches. That inertness is accepted,
+//!   not "fixed" (normalising columns would add cost and a new correctness
+//!   surface); the win lands for order-stable content-addressed producers,
+//!   which is the scoped target.
+//!
+//! # Clauses (skip IFF all hold)
+//!
+//! The caller pre-gates the shape (feature enabled, content-addressed,
+//! unpartitioned, a prior *successful* build exists) and resolves the inputs;
+//! [`decide_column_skip`] then requires, in order:
+//!
+//! - (1) the model's SQL is provably **deterministic** — else recomputing it
+//!   need not reproduce the prior output even with identical inputs;
+//! - (2) the model's **logic is unchanged** — its recipe hash (canonical
+//!   `ModelIr`) matches the prior build's (the content-addressed analog of the
+//!   plain gate's B2 logic-key clause; content-addressed models record a
+//!   `recipe_hash`, not a `skip_hash`);
+//! - (3) the **environment is unchanged** — its env hash (engine + adapter
+//!   identity) matches the prior build's, so "recompute equals prior" is not
+//!   silently invalidated by an engine/dialect change (a conservative extra
+//!   clause — its only failure direction is a safe rebuild);
+//! - (4) the **consumed-column set is provably complete** (design Fork 1 — the
+//!   [`rocky_sql::consumed_columns`] guard, surfaced here as a present
+//!   `current_baseline`); a `None` means it could not be enumerated ⇒ build;
+//! - (5) a **prior consumed-column baseline exists** to compare against;
+//! - (6) **every consumed column of every consumed upstream matches** the
+//!   prior baseline exactly (design Fork 2/3 — consumer-side, local, from two
+//!   stored snapshots plus this run; a built upstream is evaluated per this
+//!   downstream, not as one blanket verdict). Any absent, partial, or moved
+//!   hash ⇒ build.
+
+use std::collections::BTreeMap;
+
+use rocky_core::state::{ColumnHash, UpstreamSig};
+
+/// Why a content-addressed model must BUILD rather than column-skip — one
+/// variant per fail-closed clause.
+///
+/// Every variant is a *safe* outcome: BUILD always produces correct output.
+/// The variants exist for observability (logging *why* a column-skip was
+/// declined), never for control flow beyond "do not skip". Mirrors the
+/// fail-closed [`super::reuse_decision::BuildReason`] discipline: the reason is
+/// recorded at the decision point, so the surfaced justification cannot drift
+/// from what the decision did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColumnSkipReason {
+    /// (1) the model's SQL is not provably deterministic, so recomputing it
+    /// need not reproduce the prior output even with identical inputs.
+    NotDeterministic,
+    /// (2) the model's logic (canonical `ModelIr` recipe hash) changed since
+    /// the last build — the content-addressed analog of the plain gate's B2.
+    LogicChanged,
+    /// (3) the engine/adapter environment (env hash) changed since the last
+    /// build, so "recompute equals prior" can no longer be assumed.
+    EnvChanged,
+    /// (4) the consumed-column set could not be proven exhaustive (a `SELECT *`,
+    /// CTE, sub-query, ambiguous reference, or any shape the completeness guard
+    /// rejects) — the column-level analog of "upstreams not enumerable".
+    ConsumedColumnsNotEnumerable,
+    /// (5) no prior consumed-column baseline exists to compare against (a build
+    /// predating per-column hashing, a build where the guard failed, or an
+    /// upstream whose producer hashes were unavailable).
+    NoPriorColumnBaseline,
+    /// (6) the model provably consumes no upstream *column* (a source-less
+    /// query, or every read resolved to a raw source with no column hash) —
+    /// there is nothing whose stability could be proven, so fail closed.
+    NoConsumedColumns,
+    /// (6) a consumed upstream has no column hash *this run* — it was not built
+    /// content-addressed, was partitioned, or resolved to a raw source — so its
+    /// stability can't be proven.
+    MissingCurrentColumnHash,
+    /// (6) a consumed column's content hash changed since the last build — the
+    /// headline case the value hash exists to catch (incl. the over-sensitive
+    /// row-order/encoding differences that also, safely, force a build).
+    ConsumedColumnChanged,
+}
+
+impl ColumnSkipReason {
+    /// Stable lowercase token for structured logs / programmatic branching.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ColumnSkipReason::NotDeterministic => "not_deterministic",
+            ColumnSkipReason::LogicChanged => "logic_changed",
+            ColumnSkipReason::EnvChanged => "env_changed",
+            ColumnSkipReason::ConsumedColumnsNotEnumerable => "consumed_columns_not_enumerable",
+            ColumnSkipReason::NoPriorColumnBaseline => "no_prior_column_baseline",
+            ColumnSkipReason::NoConsumedColumns => "no_consumed_columns",
+            ColumnSkipReason::MissingCurrentColumnHash => "missing_current_column_hash",
+            ColumnSkipReason::ConsumedColumnChanged => "consumed_column_changed",
+        }
+    }
+
+    /// Short human-readable justification for the run output's per-model
+    /// `reason` field on a declined column-skip.
+    #[must_use]
+    pub fn message(self) -> &'static str {
+        match self {
+            ColumnSkipReason::NotDeterministic => {
+                "model SQL is not provably deterministic — cannot prove a recompute is identical"
+            }
+            ColumnSkipReason::LogicChanged => "model logic changed since last build",
+            ColumnSkipReason::EnvChanged => "engine/adapter environment changed since last build",
+            ColumnSkipReason::ConsumedColumnsNotEnumerable => {
+                "consumed columns not provably enumerable (e.g. SELECT *, CTE, or subquery)"
+            }
+            ColumnSkipReason::NoPriorColumnBaseline => {
+                "no prior consumed-column baseline to compare against"
+            }
+            ColumnSkipReason::NoConsumedColumns => "no provable consumed upstream columns",
+            ColumnSkipReason::MissingCurrentColumnHash => {
+                "a consumed upstream has no column hash this run"
+            }
+            ColumnSkipReason::ConsumedColumnChanged => {
+                "a consumed column's content changed since last build"
+            }
+        }
+    }
+}
+
+/// The single honest justification for a column-skip. There is exactly one
+/// skip path (all clauses held), so this is a constant rather than an enum
+/// variant — the caller stamps it on the per-model decision.
+pub const SKIP_MESSAGE: &str =
+    "upstream changed but the consumed columns are unchanged since last build";
+
+/// The fail-closed verdict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColumnSkipVerdict {
+    /// Do not column-skip — fall through to the content-addressed reuse/build
+    /// path. Carries the first-failing clause for observability.
+    Build(ColumnSkipReason),
+    /// Every clause held — the consumed columns are provably unchanged, so the
+    /// downstream's output would be identical to its last successful build. The
+    /// caller skips re-materialization and keeps the prior state authoritative.
+    Skip,
+}
+
+/// Already-resolved inputs to the **pure** decision. Every field is gathered by
+/// the caller (config read, SQL determinism scan, recipe/env recompute, a
+/// state-store read of the prior build, and the current consumed-column
+/// baseline computed the same way it is *recorded*), so the decision logic
+/// itself does no I/O and is fully unit-testable.
+///
+/// Field order mirrors clause order; an earlier-clause failure short-circuits
+/// before a later clause is consulted.
+pub struct ColumnSkipInputs<'a> {
+    /// (1) the model's SQL is provably deterministic.
+    pub deterministic: bool,
+    /// (2) the model's recipe hash equals the prior build's.
+    pub recipe_unchanged: bool,
+    /// (3) the model's env hash equals the prior build's.
+    pub env_unchanged: bool,
+    /// (4) the consumed-column baseline for *this* run — the columns this model
+    /// provably consumes from each upstream, paired with the upstream's current
+    /// output-column hashes (built this run, or the prior build's hashes for an
+    /// upstream that was itself skipped). `None` when the consumed set could not
+    /// be proven complete (design Fork 1 ⇒ build).
+    pub current_baseline: Option<&'a [UpstreamSig]>,
+    /// (5) the consumed-column baseline this model recorded at its last
+    /// successful build (the consumer-side snapshot it is compared against —
+    /// design Fork 2). `None` when no such baseline exists ⇒ build.
+    pub prior_baseline: Option<&'a [UpstreamSig]>,
+}
+
+/// Decide — purely — whether a content-addressed model may column-skip.
+///
+/// Evaluates the clauses in [module-doc](self) order; the **first** failing
+/// clause yields its [`ColumnSkipReason`]. Only an all-pass produces
+/// [`ColumnSkipVerdict::Skip`]. Performs **no I/O**: the caller resolves every
+/// input first, keeping this trust-critical logic small and exhaustively
+/// testable — each clause's false branch is a unit test, and the all-true
+/// branch is a unit test.
+#[must_use]
+pub fn decide_column_skip(inputs: &ColumnSkipInputs<'_>) -> ColumnSkipVerdict {
+    use ColumnSkipReason as R;
+    use ColumnSkipVerdict::{Build, Skip};
+
+    // (1) determinism.
+    if !inputs.deterministic {
+        return Build(R::NotDeterministic);
+    }
+    // (2) logic unchanged (B2 analog).
+    if !inputs.recipe_unchanged {
+        return Build(R::LogicChanged);
+    }
+    // (3) environment unchanged.
+    if !inputs.env_unchanged {
+        return Build(R::EnvChanged);
+    }
+    // (4) consumed set provably complete.
+    let Some(current) = inputs.current_baseline else {
+        return Build(R::ConsumedColumnsNotEnumerable);
+    };
+    // (5) a prior baseline to compare against.
+    let Some(prior) = inputs.prior_baseline else {
+        return Build(R::NoPriorColumnBaseline);
+    };
+    // A model that provably consumes no upstream column has nothing whose
+    // stability we could prove — fail closed rather than skip vacuously.
+    if current.is_empty() {
+        return Build(R::NoConsumedColumns);
+    }
+
+    // (6) every consumed upstream's every consumed column matches the prior
+    // baseline exactly. Any absent current hash, any upstream missing from the
+    // prior baseline, any moved hash ⇒ build. This is where a built upstream is
+    // adjudicated *for this downstream* (design Fork 3) rather than as one
+    // blanket verdict.
+    for cur in current {
+        let Some(cur_hashes) = cur.consumed_column_hashes.as_ref() else {
+            return Build(R::MissingCurrentColumnHash);
+        };
+        let Some(prior_sig) = prior.iter().find(|p| p.upstream_key == cur.upstream_key) else {
+            // A consumed upstream with no prior baseline entry — treat as a
+            // changed input (the set of upstreams this model reads shifted).
+            return Build(R::ConsumedColumnChanged);
+        };
+        let Some(prior_hashes) = prior_sig.consumed_column_hashes.as_ref() else {
+            return Build(R::NoPriorColumnBaseline);
+        };
+        if !column_hashes_equal(cur_hashes, prior_hashes) {
+            return Build(R::ConsumedColumnChanged);
+        }
+    }
+
+    // Symmetric coverage: a prior consumed upstream missing from the current
+    // baseline means the consumed set shrank — a logic change the recipe hash
+    // *should* already have caught, but a red surface never trusts a single
+    // signal. Fail closed.
+    for prior_sig in prior {
+        if prior_sig.consumed_column_hashes.is_some()
+            && !current
+                .iter()
+                .any(|c| c.upstream_key == prior_sig.upstream_key)
+        {
+            return Build(R::ConsumedColumnChanged);
+        }
+    }
+
+    Skip
+}
+
+/// Two consumed-column hash sets are equal iff they cover the **same columns**
+/// with the **same hashes**. Keyed case-insensitively on the column name (the
+/// consumed set is lowercased while a producer keeps the original Arrow field
+/// name), so a case-only rename is not mistaken for a change. A differing set
+/// of columns, or any single moved hash, is inequality ⇒ the caller builds.
+fn column_hashes_equal(a: &[ColumnHash], b: &[ColumnHash]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let index = |hs: &[ColumnHash]| -> BTreeMap<String, String> {
+        hs.iter()
+            .map(|c| (c.column.to_lowercase(), c.hash.clone()))
+            .collect()
+    };
+    let am = index(a);
+    // Distinct-column guarantee: if two entries collapsed on a case-insensitive
+    // key, the maps would be shorter than the slices and could compare equal
+    // spuriously. Require the map to preserve every entry on both sides.
+    if am.len() != a.len() {
+        return false;
+    }
+    let bm = index(b);
+    if bm.len() != b.len() {
+        return false;
+    }
+    am == bm
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ch(column: &str, hash: &str) -> ColumnHash {
+        ColumnHash {
+            column: column.to_string(),
+            hash: hash.to_string(),
+        }
+    }
+
+    /// A consumer baseline entry for `upstream` carrying the given consumed
+    /// column hashes.
+    fn sig(upstream: &str, cols: &[(&str, &str)]) -> UpstreamSig {
+        UpstreamSig {
+            upstream_key: upstream.to_string(),
+            max_ts: None,
+            row_count: None,
+            consumed_column_hashes: Some(cols.iter().map(|(c, h)| ch(c, h)).collect()),
+        }
+    }
+
+    /// The all-clauses-hold baseline the individual tests perturb.
+    fn base<'a>(current: &'a [UpstreamSig], prior: &'a [UpstreamSig]) -> ColumnSkipInputs<'a> {
+        ColumnSkipInputs {
+            deterministic: true,
+            recipe_unchanged: true,
+            env_unchanged: true,
+            current_baseline: Some(current),
+            prior_baseline: Some(prior),
+        }
+    }
+
+    #[test]
+    fn all_unchanged_skips() {
+        let current = vec![sig("cat.sch.u", &[("a", "h1"), ("b", "h2")])];
+        let prior = vec![sig("cat.sch.u", &[("a", "h1"), ("b", "h2")])];
+        assert_eq!(
+            decide_column_skip(&base(&current, &prior)),
+            ColumnSkipVerdict::Skip
+        );
+    }
+
+    /// THE TRAP: a schema-stable value change to a *consumed* column moves its
+    /// content hash ⇒ BUILD. The case the schema-diff classifier is blind to.
+    #[test]
+    fn consumed_column_value_change_builds() {
+        let current = vec![sig("cat.sch.u", &[("a", "MOVED"), ("b", "h2")])];
+        let prior = vec![sig("cat.sch.u", &[("a", "h1"), ("b", "h2")])];
+        assert_eq!(
+            decide_column_skip(&base(&current, &prior)),
+            ColumnSkipVerdict::Build(ColumnSkipReason::ConsumedColumnChanged)
+        );
+    }
+
+    /// The win: a change confined to a column this model does NOT consume never
+    /// enters the consumed baseline (the recorder filters to `consumed(D,U)`),
+    /// so the consumed columns still match ⇒ SKIP. Modelled here by identical
+    /// consumed baselines — the non-consumed column is simply absent from both.
+    #[test]
+    fn non_consumed_column_change_skips() {
+        let current = vec![sig("cat.sch.u", &[("a", "h1")])];
+        let prior = vec![sig("cat.sch.u", &[("a", "h1")])];
+        assert_eq!(
+            decide_column_skip(&base(&current, &prior)),
+            ColumnSkipVerdict::Skip
+        );
+    }
+
+    /// Over-sensitivity is the safe direction (design Fork 4): an order-unstable
+    /// producer's column hash changes every run, so the comparison never matches
+    /// ⇒ BUILD. Documents the accepted inertness — the feature never skips such a
+    /// producer, it does not silently skip it.
+    #[test]
+    fn order_unstable_producer_never_skips() {
+        // Same logical content, different stored order ⇒ different hash.
+        let current = vec![sig("cat.sch.u", &[("a", "hash_order_v2")])];
+        let prior = vec![sig("cat.sch.u", &[("a", "hash_order_v1")])];
+        assert_eq!(
+            decide_column_skip(&base(&current, &prior)),
+            ColumnSkipVerdict::Build(ColumnSkipReason::ConsumedColumnChanged)
+        );
+    }
+
+    #[test]
+    fn not_deterministic_builds() {
+        let current = vec![sig("cat.sch.u", &[("a", "h1")])];
+        let prior = vec![sig("cat.sch.u", &[("a", "h1")])];
+        let mut inputs = base(&current, &prior);
+        inputs.deterministic = false;
+        assert_eq!(
+            decide_column_skip(&inputs),
+            ColumnSkipVerdict::Build(ColumnSkipReason::NotDeterministic)
+        );
+    }
+
+    #[test]
+    fn logic_changed_builds() {
+        let current = vec![sig("cat.sch.u", &[("a", "h1")])];
+        let prior = vec![sig("cat.sch.u", &[("a", "h1")])];
+        let mut inputs = base(&current, &prior);
+        inputs.recipe_unchanged = false;
+        assert_eq!(
+            decide_column_skip(&inputs),
+            ColumnSkipVerdict::Build(ColumnSkipReason::LogicChanged)
+        );
+    }
+
+    #[test]
+    fn env_changed_builds() {
+        let current = vec![sig("cat.sch.u", &[("a", "h1")])];
+        let prior = vec![sig("cat.sch.u", &[("a", "h1")])];
+        let mut inputs = base(&current, &prior);
+        inputs.env_unchanged = false;
+        assert_eq!(
+            decide_column_skip(&inputs),
+            ColumnSkipVerdict::Build(ColumnSkipReason::EnvChanged)
+        );
+    }
+
+    #[test]
+    fn consumed_columns_not_enumerable_builds() {
+        let prior = vec![sig("cat.sch.u", &[("a", "h1")])];
+        let mut inputs = base(&prior, &prior);
+        inputs.current_baseline = None;
+        assert_eq!(
+            decide_column_skip(&inputs),
+            ColumnSkipVerdict::Build(ColumnSkipReason::ConsumedColumnsNotEnumerable)
+        );
+    }
+
+    #[test]
+    fn no_prior_baseline_builds() {
+        let current = vec![sig("cat.sch.u", &[("a", "h1")])];
+        let mut inputs = base(&current, &current);
+        inputs.prior_baseline = None;
+        assert_eq!(
+            decide_column_skip(&inputs),
+            ColumnSkipVerdict::Build(ColumnSkipReason::NoPriorColumnBaseline)
+        );
+    }
+
+    #[test]
+    fn empty_consumed_set_builds() {
+        let current: Vec<UpstreamSig> = vec![];
+        let prior: Vec<UpstreamSig> = vec![];
+        assert_eq!(
+            decide_column_skip(&base(&current, &prior)),
+            ColumnSkipVerdict::Build(ColumnSkipReason::NoConsumedColumns)
+        );
+    }
+
+    /// A consumed upstream that resolved to a raw source (no column hash this
+    /// run) can't be proven stable ⇒ BUILD.
+    #[test]
+    fn missing_current_column_hash_builds() {
+        let current = vec![UpstreamSig {
+            upstream_key: "raw_source".to_string(),
+            max_ts: None,
+            row_count: None,
+            consumed_column_hashes: None,
+        }];
+        let prior = vec![sig("raw_source", &[("a", "h1")])];
+        assert_eq!(
+            decide_column_skip(&base(&current, &prior)),
+            ColumnSkipVerdict::Build(ColumnSkipReason::MissingCurrentColumnHash)
+        );
+    }
+
+    /// A consumed upstream absent from the prior baseline is a changed input.
+    #[test]
+    fn upstream_absent_from_prior_builds() {
+        let current = vec![sig("cat.sch.u", &[("a", "h1")])];
+        let prior = vec![sig("cat.sch.other", &[("a", "h1")])];
+        assert_eq!(
+            decide_column_skip(&base(&current, &prior)),
+            ColumnSkipVerdict::Build(ColumnSkipReason::ConsumedColumnChanged)
+        );
+    }
+
+    /// A prior consumed upstream missing from the current baseline (the
+    /// consumed set shrank) fails the symmetric-coverage check ⇒ BUILD.
+    #[test]
+    fn prior_has_extra_consumed_upstream_builds() {
+        let current = vec![sig("cat.sch.u", &[("a", "h1")])];
+        let prior = vec![
+            sig("cat.sch.u", &[("a", "h1")]),
+            sig("cat.sch.v", &[("x", "h9")]),
+        ];
+        assert_eq!(
+            decide_column_skip(&base(&current, &prior)),
+            ColumnSkipVerdict::Build(ColumnSkipReason::ConsumedColumnChanged)
+        );
+    }
+
+    /// Multi-upstream: one consumed upstream unchanged, the other's consumed
+    /// column moved ⇒ BUILD (per-upstream evaluation; any changed consumed
+    /// upstream forces a build).
+    #[test]
+    fn multi_upstream_one_changed_builds() {
+        let current = vec![
+            sig("cat.sch.u1", &[("a", "h1")]),
+            sig("cat.sch.u2", &[("b", "MOVED")]),
+        ];
+        let prior = vec![
+            sig("cat.sch.u1", &[("a", "h1")]),
+            sig("cat.sch.u2", &[("b", "h2")]),
+        ];
+        assert_eq!(
+            decide_column_skip(&base(&current, &prior)),
+            ColumnSkipVerdict::Build(ColumnSkipReason::ConsumedColumnChanged)
+        );
+    }
+
+    /// A consumed column present in the prior baseline but absent this run
+    /// (differing column set) is inequality ⇒ BUILD.
+    #[test]
+    fn differing_consumed_column_set_builds() {
+        let current = vec![sig("cat.sch.u", &[("a", "h1")])];
+        let prior = vec![sig("cat.sch.u", &[("a", "h1"), ("b", "h2")])];
+        assert_eq!(
+            decide_column_skip(&base(&current, &prior)),
+            ColumnSkipVerdict::Build(ColumnSkipReason::ConsumedColumnChanged)
+        );
+    }
+
+    /// Every `ColumnSkipReason` carries a stable, distinct log token and a
+    /// non-empty human message. Guards against a silent reason-table drift (a
+    /// trust-sensitive surface: a misleading reason is worse than none).
+    #[test]
+    fn column_skip_reason_tables_are_stable_and_distinct() {
+        let all = [
+            ColumnSkipReason::NotDeterministic,
+            ColumnSkipReason::LogicChanged,
+            ColumnSkipReason::EnvChanged,
+            ColumnSkipReason::ConsumedColumnsNotEnumerable,
+            ColumnSkipReason::NoPriorColumnBaseline,
+            ColumnSkipReason::NoConsumedColumns,
+            ColumnSkipReason::MissingCurrentColumnHash,
+            ColumnSkipReason::ConsumedColumnChanged,
+        ];
+        let mut tokens = std::collections::HashSet::new();
+        for r in all {
+            assert!(!r.as_str().is_empty(), "as_str must be non-empty");
+            assert!(!r.message().is_empty(), "message must be non-empty");
+            assert!(
+                tokens.insert(r.as_str()),
+                "as_str token must be unique: {}",
+                r.as_str()
+            );
+        }
+        // Pin the load-bearing reason wording so a careless edit trips here.
+        assert_eq!(
+            ColumnSkipReason::ConsumedColumnChanged.message(),
+            "a consumed column's content changed since last build"
+        );
+        assert!(!SKIP_MESSAGE.is_empty());
+    }
+}

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -10,6 +10,7 @@ mod catalog;
 #[cfg(feature = "duckdb")]
 mod ci;
 mod ci_diff;
+mod column_skip;
 mod compact;
 mod compare;
 mod compile;

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1276,6 +1276,9 @@ pub async fn run(
             // suppresses the whole reuse path for this invocation — both the
             // point-to decision and the spine population it would feed.
             rocky_cfg.reuse.enabled && !skip_opts.no_reuse,
+            // Content-addressed column-level skip — its own `[reuse]` sub-key,
+            // orthogonal to the point-to switch above and to `--no-reuse`.
+            rocky_cfg.reuse.column_level,
             run_vars,
         )
         .await;
@@ -3747,6 +3750,9 @@ pub async fn run(
                     // Reuse is active iff `[reuse]` is enabled AND `--no-reuse`
                     // was not passed (clause 1 of the fail-closed decision).
                     rocky_cfg.reuse.enabled && !skip_opts.no_reuse,
+                    // Content-addressed column-level skip — its own `[reuse]`
+                    // sub-key, orthogonal to the point-to switch and `--no-reuse`.
+                    rocky_cfg.reuse.column_level,
                     run_vars,
                 )
                 .await?;
@@ -4644,6 +4650,14 @@ pub(crate) async fn execute_models(
     // populated AND an eligible model whose inputs match a prior strong run
     // points-to that run's parquet instead of executing its SQL.
     reuse_enabled: bool,
+    // Opt-in `[reuse] column_level`. When `true`, an unpartitioned
+    // content-addressed model whose logic, environment, and every
+    // provably-consumed upstream column are unchanged since its last successful
+    // build is column-skipped (SQL not run, prior output authoritative). When
+    // `false` (the default) no column-level comparison runs and the path is
+    // byte- and cost-identical. Fail-closed to build on any doubt; content-
+    // addressed path only.
+    column_level_enabled: bool,
     // Per-run variables (`rocky run --var name=value`). Threaded into the
     // compile config so `@var(name)` placeholders in model SQL resolve to the
     // supplied value (or inline default) before typecheck and SQL generation.
@@ -5132,6 +5146,65 @@ pub(crate) async fn execute_models(
 
         for &(idx, model_name, model) in &matched {
             let model_name: &str = model_name.as_str();
+
+            // Content-addressed column-level skip, default-OFF behind
+            // `[reuse] column_level`. Evaluated before the Built record and the
+            // reuse/build dispatch so a proven skip records `Skipped` and never
+            // runs the SQL. Content-addressed + unpartitioned only; any doubt
+            // builds. This is the content-addressed surface's third outcome —
+            // the plain skip gate never adjudicates a content-addressed model,
+            // so the two surfaces do not double-decide. The outer guard keeps
+            // the default path allocation-free (no `to_model_ir` when the flag
+            // is off).
+            if column_level_enabled
+                && matches!(
+                    model.config.strategy,
+                    rocky_core::models::StrategyConfig::ContentAddressed { .. }
+                )
+            {
+                let model_ir = model.to_model_ir();
+                if let ColumnSkipOutcome::Skip(prior_output_hashes) =
+                    try_content_addressed_column_skip(
+                        column_level_enabled,
+                        model_name,
+                        &model_ir,
+                        warehouse.dialect().name(),
+                        state_store,
+                        &baseline_target_by_model,
+                        &built_output_hashes,
+                    )
+                {
+                    // Record `Skipped` so a downstream in a later layer treats
+                    // this model as an unchanged input (its output equals its
+                    // last build). Surface the decision, bump the skipped
+                    // counter, and propagate the prior output hashes so a later
+                    // content-addressed consumer sees this upstream's current
+                    // output == its prior (design Fork 2).
+                    gate.record(model_name, super::skip_gate::Verdict::Skipped);
+                    output.tables_skipped += 1;
+                    output
+                        .model_decisions
+                        .push(crate::output::ModelDecisionOutput {
+                            model: model_name.to_string(),
+                            decision: crate::output::ModelDecision::Skip,
+                            reason: super::column_skip::SKIP_MESSAGE.to_string(),
+                        });
+                    if let Some(hashes) = prior_output_hashes {
+                        let target_full = format!(
+                            "{}.{}.{}",
+                            model_ir.target.catalog, model_ir.target.schema, model_ir.target.table,
+                        );
+                        built_output_hashes.insert(target_full, hashes);
+                    }
+                    info!(
+                        model = model_name,
+                        "column-skip: consumed columns unchanged since last build — \
+                         skipping content-addressed re-materialization (best-effort)"
+                    );
+                    continue;
+                }
+            }
+
             // Every model reached here is being built (the gate already
             // removed any skips). Record the Built verdict so a downstream in
             // a later layer treats it as a changed input. `content_addressed`
@@ -5723,6 +5796,114 @@ fn compute_consumer_baseline(
         });
     }
     Some(sigs)
+}
+
+/// Outcome of the content-addressed column-level skip pre-check.
+enum ColumnSkipOutcome {
+    /// Do not column-skip — fall through to the normal content-addressed
+    /// reuse/build path (which reports its own Build/Reused decision).
+    Build,
+    /// Column-skip: the model's output is provably unchanged since its last
+    /// successful build, so its SQL is not run and no new commit is written.
+    /// Carries the prior build's output-column hashes (if any) to propagate
+    /// into `built_output_hashes` so a later content-addressed consumer sees
+    /// this upstream's current output == its prior (a skipped upstream's output
+    /// equals its last build by construction — design Fork 2). `None` when the
+    /// prior build recorded no output hashes (a point-to reuse / partitioned
+    /// prior) — later consumers then safely rebuild against it.
+    Skip(Option<Vec<rocky_core::state::ColumnHash>>),
+}
+
+/// The **content-addressed column-level skip** pre-check (design Fork 3, the
+/// sound "an upstream changed but the consumed columns did not → skip" case).
+///
+/// Gathers the pre-resolved inputs and delegates the trust-critical decision to
+/// the pure [`super::column_skip::decide_column_skip`]. Content-addressed +
+/// unpartitioned only, behind `[reuse] column_level`; fail-closed to
+/// [`ColumnSkipOutcome::Build`] on any doubt — a missing state store, no prior
+/// success, a changed recipe/env, a non-deterministic model, an un-enumerable
+/// consumed set, or any moved/absent consumed-column hash.
+///
+/// This is evaluated by the caller *before* the content-addressed reuse/build
+/// dispatch, so the plain skip gate (which never adjudicates a content-addressed
+/// model) and this surface do not double-decide.
+fn try_content_addressed_column_skip(
+    column_level_enabled: bool,
+    model_name: &str,
+    model_ir: &ModelIr,
+    adapter_name: &str,
+    state_store: Option<&StateStore>,
+    baseline_target_by_model: &std::collections::HashMap<String, String>,
+    built_output_hashes: &std::collections::HashMap<String, Vec<rocky_core::state::ColumnHash>>,
+) -> ColumnSkipOutcome {
+    use super::column_skip::{ColumnSkipInputs, ColumnSkipVerdict, decide_column_skip};
+
+    if !column_level_enabled {
+        return ColumnSkipOutcome::Build;
+    }
+    // Content-addressed + unpartitioned only. A partitioned model records no
+    // producer column hashes (the per-file fold is deferred), so it can't be
+    // proven stable and is force-built in v1 (partitioned outputs are out of
+    // scope for this first cut).
+    let unpartitioned = matches!(
+        &model_ir.materialization,
+        MaterializationStrategy::ContentAddressed { partition_columns, .. }
+            if partition_columns.is_empty()
+    );
+    if !unpartitioned {
+        return ColumnSkipOutcome::Build;
+    }
+
+    // A prior *successful* build is the comparison baseline. Mirror the plain
+    // gate: the single latest execution, which must itself be a success (a more
+    // recent failure forces a rebuild).
+    let Some(store) = state_store else {
+        return ColumnSkipOutcome::Build;
+    };
+    let prior = match store.get_model_history(model_name, 1) {
+        Ok(mut history) => history.pop(),
+        Err(_) => return ColumnSkipOutcome::Build,
+    };
+    let Some(prior) = prior else {
+        return ColumnSkipOutcome::Build;
+    };
+    if prior.status != "success" {
+        return ColumnSkipOutcome::Build;
+    }
+
+    // Logic + environment unchanged (design B2 analog + a conservative env
+    // clause). Content-addressed models record a recipe hash (canonical
+    // `ModelIr`) and an env hash; an absent prior hash can't match ⇒ build.
+    let current = crate::output::recipe_identity_internal(model_ir, adapter_name);
+    let recipe_unchanged = prior.recipe_hash.as_deref() == Some(current.recipe_hash.as_str());
+    let env_unchanged = prior.env_hash.as_deref() == Some(current.env_hash.as_str());
+
+    // The current consumed-column baseline — computed the *same way* it is
+    // recorded (design Fork 2), so recording and comparison can't drift. `None`
+    // when the consumed set can't be proven complete (design Fork 1 ⇒ build).
+    let current_baseline =
+        compute_consumer_baseline(&model_ir.sql, baseline_target_by_model, built_output_hashes);
+
+    let inputs = ColumnSkipInputs {
+        deterministic: rocky_sql::determinism::is_deterministic(&model_ir.sql),
+        recipe_unchanged,
+        env_unchanged,
+        current_baseline: current_baseline.as_deref(),
+        prior_baseline: prior.upstream_freshness.as_deref(),
+    };
+
+    match decide_column_skip(&inputs) {
+        ColumnSkipVerdict::Skip => ColumnSkipOutcome::Skip(prior.output_column_hashes.clone()),
+        ColumnSkipVerdict::Build(reason) => {
+            debug!(
+                model = model_name,
+                reason = reason.as_str(),
+                detail = reason.message(),
+                "column-skip: declined (building)"
+            );
+            ColumnSkipOutcome::Build
+        }
+    }
 }
 
 /// Resolve a content-addressed model's immediate upstreams to STRONG
@@ -10189,6 +10370,7 @@ merge_keys = ["id"]
             &DeferOptions::default(),
             super::SkipGateConfig::off(),
             false,
+            false,
             &rocky_core::run_vars::RunVars::new(),
         )
         .await;
@@ -10256,6 +10438,7 @@ merge_keys = ["id"]
             false,
             &DeferOptions::default(),
             super::SkipGateConfig::off(),
+            false,
             false,
             &run_vars,
         )
@@ -10357,6 +10540,7 @@ merge_keys = ["id"]
             false,
             &defer_opts,
             super::SkipGateConfig::off(),
+            false,
             false,
             &rocky_core::run_vars::RunVars::new(),
         )
@@ -10473,6 +10657,7 @@ merge_keys = ["id"]
             false,
             &DeferOptions::default(),
             super::SkipGateConfig::off(),
+            false,
             false,
             &rocky_core::run_vars::RunVars::new(),
         )
@@ -10751,6 +10936,7 @@ merge_keys = ["id"]
                 &DeferOptions::default(),
                 super::SkipGateConfig::off(),
                 false,
+                false,
                 &rocky_core::run_vars::RunVars::new(),
             )
             .await
@@ -10870,6 +11056,7 @@ merge_keys = ["id"]
             false,
             &DeferOptions::default(),
             gate,
+            false,
             false,
             &rocky_core::run_vars::RunVars::new(),
         )
@@ -11837,6 +12024,7 @@ merge_keys = ["id"]
                 &DeferOptions::default(),
                 active_gate(true, 0),
                 false,
+                false,
                 &rocky_core::run_vars::RunVars::new(),
             )
             .await
@@ -12462,6 +12650,157 @@ merge_keys = ["id"]
             sigs[0].consumed_column_hashes, None,
             "a consumed column absent from the producer's hashes ⇒ no baseline for that upstream"
         );
+    }
+
+    // -- content-addressed column-level skip wiring --------------------------
+
+    /// Wiring proof for `try_content_addressed_column_skip`, end-to-end **minus
+    /// the s3 write**: a real `StateStore`, a real content-addressed `ModelIr`,
+    /// and the production recipe/env identity + consumed-column baseline
+    /// computations (not hand-faked). It drives the headline trap through the
+    /// whole decision path — same consumed-column hashes ⇒ SKIP; a moved
+    /// consumed-column hash ⇒ BUILD — proving the composition, not just the
+    /// pure `decide_column_skip` (which its own module tests exhaustively). The
+    /// s3 materialization glue is exercised only by review, per the
+    /// content-addressed path's creds-gated reachability.
+    #[test]
+    fn column_skip_wiring_skips_on_match_and_builds_on_consumed_change() {
+        use rocky_ir::{GovernanceConfig, TargetRef};
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = StateStore::open(&tmp.path().join("state")).unwrap();
+
+        // A content-addressed downstream `fct` that provably consumes `u.amount`.
+        let mut model_ir = ModelIr::transformation(
+            TargetRef {
+                catalog: "cat".into(),
+                schema: "sch".into(),
+                table: "fct".into(),
+            },
+            MaterializationStrategy::ContentAddressed {
+                storage_prefix: "s3://bucket/fct".into(),
+                partition_columns: vec![],
+            },
+            vec![],
+            "SELECT amount FROM u".into(),
+            GovernanceConfig {
+                permissions_file: None,
+                auto_create_catalogs: false,
+                auto_create_schemas: false,
+            },
+            None,
+            None,
+        );
+        model_ir.name = std::sync::Arc::from("fct");
+
+        let adapter = "duckdb";
+        let identity = crate::output::recipe_identity_internal(&model_ir, adapter);
+
+        // Upstream `u` (target cat.sch.u) produced `amount` this run.
+        let target_by_model = build_reuse_target_by_model([("u", &target_cfg("cat", "sch", "u"))]);
+        let mut built = std::collections::HashMap::new();
+        built.insert("cat.sch.u".to_string(), vec![ch("amount", "H_AMOUNT")]);
+
+        // The prior successful build recorded exactly the baseline the recorder
+        // would produce this run — computed the SAME way (the production fn), so
+        // recording and comparison provably can't drift.
+        let prior_baseline =
+            compute_consumer_baseline(&model_ir.sql, &target_by_model, &built).unwrap();
+        let now = chrono::DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap();
+        let prior_exec = rocky_core::state::ModelExecution {
+            model_name: "fct".to_string(),
+            started_at: now,
+            finished_at: now,
+            duration_ms: 0,
+            rows_affected: None,
+            status: "success".to_string(),
+            sql_hash: String::new(),
+            skip_hash: None,
+            upstream_freshness: Some(prior_baseline),
+            bytes_scanned: None,
+            bytes_written: None,
+            tenant: None,
+            recipe_hash: Some(identity.recipe_hash.clone()),
+            input_hash: None,
+            input_proof_class: None,
+            env_hash: Some(identity.env_hash.clone()),
+            hash_scheme: Some(identity.hash_scheme.clone()),
+            // fct's own OUTPUT hashes — propagated on a skip so a later
+            // content-addressed consumer sees fct's current output == its prior.
+            output_column_hashes: Some(vec![ch("amount", "H_FCT_OUT")]),
+        };
+        let run = rocky_core::state::RunRecord {
+            run_id: "run-1".to_string(),
+            started_at: now,
+            finished_at: now,
+            status: rocky_core::state::RunStatus::Success,
+            models_executed: vec![prior_exec],
+            trigger: rocky_core::state::RunTrigger::Manual,
+            config_hash: "cfg".to_string(),
+            triggering_identity: None,
+            session_source: rocky_core::state::SessionSource::Cli,
+            git_commit: None,
+            git_branch: None,
+            idempotency_key: None,
+            target_catalog: None,
+            hostname: "test".to_string(),
+            rocky_version: "test".to_string(),
+        };
+        store.record_run(&run).unwrap();
+
+        // (a) Consumed column unchanged ⇒ SKIP, propagating the prior OUTPUT
+        // hashes for downstreams (design Fork 2 — a skipped upstream's output
+        // equals its last build).
+        match try_content_addressed_column_skip(
+            true,
+            "fct",
+            &model_ir,
+            adapter,
+            Some(&store),
+            &target_by_model,
+            &built,
+        ) {
+            ColumnSkipOutcome::Skip(propagated) => assert_eq!(
+                propagated,
+                Some(vec![ch("amount", "H_FCT_OUT")]),
+                "a column-skip propagates the prior build's OUTPUT hashes"
+            ),
+            ColumnSkipOutcome::Build => panic!("consumed columns unchanged must column-skip"),
+        }
+
+        // (b) THE TRAP: the consumed column's content hash MOVED this run (a
+        // schema-stable value change upstream) ⇒ BUILD, never a wrong skip.
+        let mut moved = std::collections::HashMap::new();
+        moved.insert("cat.sch.u".to_string(), vec![ch("amount", "H_MOVED")]);
+        assert!(
+            matches!(
+                try_content_addressed_column_skip(
+                    true,
+                    "fct",
+                    &model_ir,
+                    adapter,
+                    Some(&store),
+                    &target_by_model,
+                    &moved,
+                ),
+                ColumnSkipOutcome::Build
+            ),
+            "a moved consumed-column hash must force a build (the headline trap)"
+        );
+
+        // (c) Flag off ⇒ never skips (the default path stays byte-identical).
+        assert!(matches!(
+            try_content_addressed_column_skip(
+                false,
+                "fct",
+                &model_ir,
+                adapter,
+                Some(&store),
+                &target_by_model,
+                &built,
+            ),
+            ColumnSkipOutcome::Build
+        ));
     }
 
     /// Runtime regression: a first run of an incremental transformation

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -119,6 +119,8 @@ pub async fn run_transformation(
             &super::run::DeferOptions::default(),
             skip_gate,
             rocky_cfg.reuse.enabled,
+            // Content-addressed column-level skip (its own `[reuse]` sub-key).
+            rocky_cfg.reuse.column_level,
             run_vars,
         )
         .await;

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -2437,6 +2437,25 @@ pub struct ReuseConfig {
     /// written, no per-model hashing cost is paid, and no model reuses.
     #[serde(default)]
     pub enabled: bool,
+
+    /// Opt-in **column-level skip** for content-addressed models. When `true`,
+    /// an unpartitioned content-addressed model whose logic, environment, and
+    /// every provably-consumed upstream column are unchanged since its last
+    /// successful build is **skipped** — its SQL does not run and no new commit
+    /// is written; the prior output stays authoritative. Skipping on a value
+    /// change to a consumed column is precisely the silent-staleness bug this
+    /// gate is built to avoid, so the decision is fail-closed: any unproven
+    /// input (a non-deterministic model, a changed recipe/env, an
+    /// un-enumerable consumed set, a missing or moved column hash) forces a
+    /// build.
+    ///
+    /// **Default-OFF.** `false` (the default) keeps `rocky run` byte- and
+    /// cost-identical: no column-level comparison runs and no model is skipped
+    /// on this basis. Independent of [`Self::enabled`] (byte-level point-to
+    /// reuse) — the two are orthogonal opt-ins on the content-addressed path.
+    /// Experimental; off the content-addressed path the feature does not apply.
+    #[serde(default)]
+    pub column_level: bool,
 }
 
 /// Who is attempting an action.

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -3068,6 +3068,11 @@
       "additionalProperties": false,
       "description": "`[reuse]` — opt-in auditable reuse for content-addressed models.\n\nWhen `enabled = true`, a successful run records, per model, an input-match index entry and an offline-verifiable provenance record (the model's logic key, upstream input identities, output blake3(s), and proof class). That spine is the *input* side; on a later run, an eligible model whose recomputed `input_hash` hits the index for a prior **strong** run may **point-to** that run's already-written parquet — a zero-copy commit that skips the SQL — provided every clause of the runner's fail-closed reuse decision holds. Any doubt builds.\n\n**Default-OFF.** `enabled = false` (the default) keeps `rocky run` byte- *and* cost-identical to before the spine existed: no extra normalize+hash work, no extra state write, no reuse decision. The point-to path is strong (byte-identical) only on the content-addressed/UniForm write path; experimental, opt-in.",
       "properties": {
+        "column_level": {
+          "default": false,
+          "description": "Opt-in **column-level skip** for content-addressed models. When `true`, an unpartitioned content-addressed model whose logic, environment, and every provably-consumed upstream column are unchanged since its last successful build is **skipped** — its SQL does not run and no new commit is written; the prior output stays authoritative. Skipping on a value change to a consumed column is precisely the silent-staleness bug this gate is built to avoid, so the decision is fail-closed: any unproven input (a non-deterministic model, a changed recipe/env, an un-enumerable consumed set, a missing or moved column hash) forces a build.\n\n**Default-OFF.** `false` (the default) keeps `rocky run` byte- and cost-identical: no column-level comparison runs and no model is skipped on this basis. Independent of [`Self::enabled`] (byte-level point-to reuse) — the two are orthogonal opt-ins on the content-addressed path. Experimental; off the content-addressed path the feature does not apply.",
+          "type": "boolean"
+        },
         "enabled": {
           "default": false,
           "description": "Master switch for auditable reuse: populates the input-match spine and arms the point-to decision. `false` (default) ⇒ the spine is never written, no per-model hashing cost is paid, and no model reuses.",
@@ -4191,6 +4196,7 @@
         }
       ],
       "default": {
+        "column_level": false,
         "enabled": false
       },
       "description": "Opt-in auditable reuse. Default-OFF: an absent `[reuse]` block keeps `rocky run` byte- and cost-identical (no per-model hashing, no extra state write). When enabled, an eligible content-addressed model whose inputs match a prior strong run may **point-to** that run's parquet (zero-copy) instead of re-executing its SQL — fail-closed to BUILD on any doubt. See [`ReuseConfig`]."

--- a/sdk/python/src/rocky_sdk/types_generated/rocky_project_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/rocky_project_schema.py
@@ -1200,6 +1200,12 @@ class ReuseConfig(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    column_level: bool | None = False
+    """
+    Opt-in **column-level skip** for content-addressed models. When `true`, an unpartitioned content-addressed model whose logic, environment, and every provably-consumed upstream column are unchanged since its last successful build is **skipped** — its SQL does not run and no new commit is written; the prior output stays authoritative. Skipping on a value change to a consumed column is precisely the silent-staleness bug this gate is built to avoid, so the decision is fail-closed: any unproven input (a non-deterministic model, a changed recipe/env, an un-enumerable consumed set, a missing or moved column hash) forces a build.
+
+    **Default-OFF.** `false` (the default) keeps `rocky run` byte- and cost-identical: no column-level comparison runs and no model is skipped on this basis. Independent of [`Self::enabled`] (byte-level point-to reuse) — the two are orthogonal opt-ins on the content-addressed path. Experimental; off the content-addressed path the feature does not apply.
+    """
     enabled: bool | None = False
     """
     Master switch for auditable reuse: populates the input-match spine and arms the point-to decision. `false` (default) ⇒ the spine is never written, no per-model hashing cost is paid, and no model reuses.
@@ -3523,7 +3529,9 @@ class RockyConfig(BaseModel):
 
     Unset (the default) preserves per-adapter semantics: each adapter still honours its own `retry.max_retries_per_run` independently. That's the backward-compatible path and stays the right choice when adapters have wildly different rate limits.
     """
-    reuse: ReuseConfig | None = Field({"enabled": False}, validate_default=True)
+    reuse: ReuseConfig | None = Field(
+        {"column_level": False, "enabled": False}, validate_default=True
+    )
     """
     Opt-in auditable reuse. Default-OFF: an absent `[reuse]` block keeps `rocky run` byte- and cost-identical (no per-model hashing, no extra state write). When enabled, an eligible content-addressed model whose inputs match a prior strong run may **point-to** that run's parquet (zero-copy) instead of re-executing its SQL — fail-closed to BUILD on any doubt. See [`ReuseConfig`].
     """


### PR DESCRIPTION
## What

Adds the sound **column-level skip** decision for content-addressed models: *"an upstream was rebuilt, but the specific columns this downstream actually consumes did not change → skip the downstream."* This is the one skip nothing else in the engine can make soundly — the whole-output blake3 is table-granular, the breaking-change classifier is schema-only, and the freshness gate is watermark-only. Per-column content hashes over column *values* defeat the headline trap: a schema-stable `WHERE`/`JOIN`/`CASE` rewrite upstream that keeps the type byte-identical while moving the data still flips the consumed column's content hash ⇒ build.

**Default-OFF** behind a new `[reuse] column_level = false`. When unset, `rocky run` is byte- and cost-identical: no column-level comparison runs, nothing is skipped on this basis.

## The two-skip-surfaces question, resolved

The decision lives on the **content-addressed surface**, not the plain skip gate — and this is forced by the data model, not a free choice:

- The consumer-side per-column baseline and the producer output-column hashes are recorded **only** for content-addressed models. So a column-level skip can only ever be decided for a content-addressed downstream; widening the plain gate would be inert (no baseline exists for plain models).
- The plain skip gate (plain strategies) and the content-addressed runner (point-to reuse vs build) already partition cleanly by strategy. The column-level skip is a **third outcome of the content-addressed surface**, evaluated *before* the reuse/build dispatch: a content-addressed model is either column-skipped, point-to reused, or built. The two surfaces never both act on one model — no double-decision.

## Fail-closed + over-sensitive (the safe direction)

Every doubt resolves to BUILD: a non-deterministic model, a changed recipe or environment hash, an un-enumerable consumed set (the completeness guard), a missing or moved consumed-column hash, an absent prior baseline. The hash is over the column's written values as-stored, with no canonicalisation — so a row-order/encoding/NULL-render difference forces a redundant build, never a wrong skip. A concrete, intended consequence documented in the code: an **order-unstable producer never skips**.

## Trap-test evidence

`decide_column_skip` is a pure, I/O-free function with an exhaustive unit suite, plus a StateStore-backed wiring test that drives the whole composition (real `ModelIr`, the production recipe/env identity and consumed-column baseline computations):

- schema-stable value change to a **consumed** column ⇒ **BUILD** (`consumed_column_value_change_builds`, and end-to-end in `column_skip_wiring_..._builds_on_consumed_change`)
- change confined to a **non-consumed** column ⇒ **SKIP** (`non_consumed_column_change_skips`)
- **order-unstable** producer (hash moves each run) ⇒ **never SKIP** (`order_unstable_producer_never_skips`)
- plus: not-deterministic / logic-changed / env-changed / no-prior-baseline / un-enumerable / missing-current-hash / multi-upstream-one-changed / symmetric-coverage ⇒ all BUILD

## Reachability

The content-addressed write path is s3-only (creds-gated). The **decision and its wiring** are proven by the unit + StateStore integration tests above (no object store needed — the column-skip check reads already-recorded hashes and runs before any write). The s3 materialization glue is verified by review; this PR makes **no** live-playground-skip claim, and the feature stays off until live-verified.

## Gates

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, full `cargo test` (834 pass, 0 fail), and `cargo check --all-features --all-targets` all green. No state-schema bump (compares already-recorded hashes). `just codegen` re-ran for the new config key (schema + Pydantic + TS regenerated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)