### PR TITLE
docs(engine): fix stale rocky-core dag.rs reference in AGENTS.md

### DIFF
--- a/engine/AGENTS.md
+++ b/engine/AGENTS.md
@@ -46,7 +46,8 @@ engine/                         # this directory, inside the rocky monorepo
 │   │   │   ├── catalog.rs      # Catalog/schema lifecycle management
 │   │   │   ├── checks.rs       # Inline data quality checks
 │   │   │   ├── contracts.rs    # Data contracts (required/protected columns)
-│   │   │   ├── dag.rs          # DAG resolution for model dependencies
+│   │   │   ├── unified_dag.rs  # Unified ELT DAG — one graph across all pipeline stages
+│   │   │   ├── dag_executor.rs # DAG-driven execution in dependency order (+ dag_status.rs live status)
 │   │   │   ├── models.rs       # SQL model loading (sidecar .sql + .toml)
 │   │   │   ├── hooks/          # Pipeline lifecycle hooks (commands, webhooks, templates, presets)
 │   │   │   ├── optimize.rs     # Cost model + materialization strategy recommendations


### PR DESCRIPTION
`engine/AGENTS.md`'s crate-structure listing pointed to `rocky-core/src/dag.rs`, which does not exist. rocky-core's DAG code is `unified_dag.rs` / `dag_executor.rs` / `dag_status.rs`; the DAG primitives (`DagNode`, `topological_sort`, `execution_layers`) live in `rocky-ir/src/dag.rs` (already listed correctly).

This is the drift that seeded a dead-path reference in the Codex review profile (#1045) — fixing it at the source so the next reader isn't sent to a nonexistent file.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)