### PR TITLE
feat(engine/rocky-mcp): gate the propose tool through the agent-policy plane

### DIFF
--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -305,10 +305,14 @@ pub(crate) fn ai_plan_is_reviewed(root: &Path, plan_id: &str) -> bool {
 // agent-policy plane — apply/promote enforcement (seams 2 & 3)
 // ---------------------------------------------------------------------------
 
-/// The apply-time policy decision, aggregated most-restrictive across every
-/// model the plan touches.
+/// A resolved agent-policy decision, aggregated most-restrictive across every
+/// model a plan touches.
+///
+/// Produced by [`evaluate_apply_policy`] at each mutating enforcement point —
+/// `rocky apply`, promote, and the MCP `propose` gate — so all three share one
+/// per-model evaluation and one aggregation rule.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum PolicyGate {
+pub enum PolicyGate {
     /// No `[policy]` block in the config — the evaluator was never
     /// constructed. The caller falls back to its pre-policy-plane behaviour
     /// (AiAuthored → require a review marker; Run/Promote → ungated), so
@@ -377,14 +381,20 @@ fn model_attributes(models_dir: &Path) -> BTreeMap<String, ModelAttributes> {
 /// Evaluate the agent-policy plane over a plan's touched `(model, capability)`
 /// set and aggregate the most-restrictive effect. Records one
 /// [`PolicyDecisionRecord`] per evaluation to the ledger (best-effort — an
-/// audit-write failure never fails the apply; the *gate* is the safety
+/// audit-write failure never fails the caller; the *gate* is the safety
 /// boundary, the ledger is the trail).
+///
+/// Shared by the mutating enforcement points — `rocky apply`, promote, and the
+/// MCP `propose` gate — so each evaluates the same per-model rules with the same
+/// aggregation and records to the same ledger. `plan_id` is the id the decision
+/// is recorded against (the propose gate passes a deterministic id it may not
+/// persist).
 ///
 /// `touched` maps each governed model to the capability that was reviewed at
 /// propose time (the embedded classification, or `schema_change.breaking` when
 /// the classification was unavailable / fail-closed). An empty map means the
 /// plan changes nothing → `Allow`.
-fn evaluate_apply_policy(
+pub fn evaluate_apply_policy(
     config_path: &Path,
     plan_id: &str,
     principal: PolicyPrincipal,
@@ -499,16 +509,7 @@ fn touched_models_for_run(
     plan: &PersistedPlan,
     run_plan: &RunPlan,
 ) -> BTreeMap<String, PolicyCapability> {
-    let caps = plan.embedded_capabilities();
-    if caps.diff_available {
-        caps.changed
-    } else {
-        run_plan
-            .models
-            .iter()
-            .map(|m| (m.clone(), PolicyCapability::SchemaChangeBreaking))
-            .collect()
-    }
+    plan.embedded_capabilities().touched(&run_plan.models)
 }
 
 /// The `(model, capability)` set the policy plane evaluates for a `Promote`

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -80,7 +80,7 @@ pub use ai::{
     SchemaBuckets, build_schema_context, run_ai, run_ai_explain, run_ai_sync, run_ai_test,
 };
 pub use ai_contract::run_ai_contract;
-pub use apply::{run_apply, run_apply_inline_for_run};
+pub use apply::{PolicyGate, evaluate_apply_policy, run_apply, run_apply_inline_for_run};
 pub use archive::{run_archive, run_archive_apply, run_archive_catalog};
 pub use audit::run_audit;
 #[cfg(feature = "duckdb")]

--- a/engine/crates/rocky-cli/src/plan_store.rs
+++ b/engine/crates/rocky-cli/src/plan_store.rs
@@ -218,6 +218,29 @@ impl PersistedPlan {
     }
 }
 
+impl EmbeddedCapabilities {
+    /// The `(model, capability)` set the policy plane evaluates for a plan
+    /// covering `planned_models`.
+    ///
+    /// - Diff available at propose time → the embedded per-changed-model
+    ///   classification (unchanged models are absent and are not gated).
+    /// - Diff unavailable (skipped, or a legacy plan with no embed) → **every**
+    ///   planned model, classified `schema_change.breaking` (fail closed).
+    ///
+    /// The apply-time enforcement and the propose-time MCP gate share this so
+    /// the two evaluate the identical touched set for the same plan.
+    pub fn touched(&self, planned_models: &[String]) -> BTreeMap<String, PolicyCapability> {
+        if self.diff_available {
+            self.changed.clone()
+        } else {
+            planned_models
+                .iter()
+                .map(|m| (m.clone(), PolicyCapability::SchemaChangeBreaking))
+                .collect()
+        }
+    }
+}
+
 /// Default `format_version` for `PersistedPlan` when the field is absent
 /// on disk — kept at `1` so plans written before C-5 (which had no
 /// `format_version` field) read cleanly. `Run` / `Replication` /
@@ -298,6 +321,46 @@ pub fn write_plan_governed<T: Serialize>(
     write_plan_inner(root, kind, payload, 1, principal, Some(caps_value))
 }
 
+/// Compute the `plan_id` a governed `Run` / `AiAuthored` plan will carry,
+/// **without persisting it**.
+///
+/// Identical inputs to [`write_plan_governed`] yield an identical id — both
+/// route the payload through [`payload_with_capabilities`] and hash it with
+/// [`compute_plan_id`]. This lets a caller obtain the stable id *before*
+/// deciding whether to write: the MCP `propose` policy gate references the id
+/// in its audit record (and a review message) even for a plan it ultimately
+/// refuses to persist.
+pub fn governed_plan_id<T: Serialize>(
+    kind: &PlanKind,
+    payload: &T,
+    capabilities: &EmbeddedCapabilities,
+) -> Result<String> {
+    let caps_value =
+        serde_json::to_value(capabilities).context("failed to serialize embedded capabilities")?;
+    let payload_value = payload_with_capabilities(payload, Some(caps_value))?;
+    Ok(compute_plan_id(kind, &payload_value))
+}
+
+/// Serialize a plan `payload` to a JSON value, injecting the embedded
+/// change-classification (capability-embed) under `policy_capabilities` when
+/// present so it becomes part of `blake3({kind, payload})`.
+///
+/// Shared by [`write_plan_inner`] and [`governed_plan_id`] so an id computed
+/// ahead of a write matches the id the write produces.
+fn payload_with_capabilities<T: Serialize>(
+    payload: &T,
+    capabilities: Option<serde_json::Value>,
+) -> Result<serde_json::Value> {
+    let mut payload_value =
+        serde_json::to_value(payload).context("failed to serialize plan payload to JSON value")?;
+    if let Some(caps) = capabilities
+        && let serde_json::Value::Object(ref mut map) = payload_value
+    {
+        map.insert(POLICY_CAPABILITIES_KEY.to_string(), caps);
+    }
+    Ok(payload_value)
+}
+
 /// Persist a typed-IR `Compact` / `Archive` plan
 /// (`format_version = 2`).
 ///
@@ -330,18 +393,11 @@ fn write_plan_inner<T: Serialize>(
     principal: PolicyPrincipal,
     capabilities: Option<serde_json::Value>,
 ) -> Result<String> {
-    let mut payload_value =
-        serde_json::to_value(payload).context("failed to serialize plan payload to JSON value")?;
-
-    // Embed the propose-time change-classification (capability-embed) INTO the payload so it
-    // is part of `blake3({kind, payload})` — the reviewed capability binds to
-    // the `plan_id`. Only meaningful for object payloads (run/ai_authored);
-    // typed-IR compact/archive payloads never carry it.
-    if let Some(caps) = capabilities
-        && let serde_json::Value::Object(ref mut map) = payload_value
-    {
-        map.insert(POLICY_CAPABILITIES_KEY.to_string(), caps);
-    }
+    // Embed the propose-time change-classification (capability-embed) INTO the
+    // payload so it is part of `blake3({kind, payload})` — the reviewed
+    // capability binds to the `plan_id`. Only meaningful for object payloads
+    // (run/ai_authored); typed-IR compact/archive payloads never carry it.
+    let payload_value = payload_with_capabilities(payload, capabilities)?;
 
     let plan_id = compute_plan_id(&kind, &payload_value);
 

--- a/engine/crates/rocky-mcp/src/error.rs
+++ b/engine/crates/rocky-mcp/src/error.rs
@@ -53,15 +53,24 @@ pub enum ToolErrorCode {
     WarehouseError,
     /// An AI / LLM operation failed (client initialization or request).
     AiError,
+    /// The agent policy plane refused the proposed mutation outright (a hard
+    /// `deny`). Human review cannot satisfy it — the agent should re-scope
+    /// (e.g. propose to a branch) rather than retry. `policy_rule` names the
+    /// deciding rule.
+    PolicyDenied,
+    /// The agent policy plane requires human review before the proposed
+    /// mutation can apply. The plan was recorded; a human must approve it
+    /// (`rocky review <plan_id> --approve`) before `rocky apply`. `policy_rule`
+    /// names the deciding rule when one matched.
+    PolicyReviewRequired,
     /// An unexpected internal failure. `message` carries the detail.
     Internal,
 }
 
 /// The structured error envelope returned by a failing tool call.
 ///
-/// `policy_rule` is reserved for the agent policy plane (a future deny /
-/// require-review decision names the rule that produced it); it is absent on
-/// every error today.
+/// `policy_rule` is set by the agent policy plane on a deny / require-review
+/// decision (it names the deciding rule); it is absent on every other error.
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct ToolError {
     /// Stable error class the caller can branch on.
@@ -71,8 +80,11 @@ pub struct ToolError {
     /// A concrete next action that recovers from this error — the point of the
     /// envelope. Never empty.
     pub remediation_hint: String,
-    /// The policy rule behind a deny / require-review decision. Reserved for the
-    /// agent policy plane; always absent today.
+    /// The policy rule behind a deny / require-review decision. Set by the
+    /// agent policy plane on [`ToolErrorCode::PolicyDenied`] /
+    /// [`ToolErrorCode::PolicyReviewRequired`] (the deciding rule's id, or
+    /// absent when the default posture decided it); absent on every other
+    /// error.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub policy_rule: Option<String>,
 }
@@ -155,6 +167,50 @@ impl ToolError {
             message,
             "Verify ANTHROPIC_API_KEY is set in the server environment and the model is reachable, \
              then retry.",
+        )
+    }
+
+    /// Build an envelope that carries the deciding policy rule. Used by the two
+    /// policy-plane constructors; the rule id (or `None` for a default-posture
+    /// decision) rides in `policy_rule` so an agent can branch on it.
+    fn wrap_policy(
+        code: ToolErrorCode,
+        message: impl Into<String>,
+        remediation_hint: impl Into<String>,
+        policy_rule: Option<String>,
+    ) -> Json<Self> {
+        Json(Self {
+            code,
+            message: message.into(),
+            remediation_hint: remediation_hint.into(),
+            policy_rule,
+        })
+    }
+
+    /// The agent policy plane denied the proposed mutation (`deny`). A deny
+    /// cannot be satisfied by human review; `hint` should point at a re-scope
+    /// path (propose to a branch, drop the denied model).
+    pub fn policy_denied(
+        message: impl Into<String>,
+        hint: impl Into<String>,
+        policy_rule: Option<String>,
+    ) -> Json<Self> {
+        Self::wrap_policy(ToolErrorCode::PolicyDenied, message, hint, policy_rule)
+    }
+
+    /// The agent policy plane requires human review before the proposed
+    /// mutation can apply (`require_review`). The plan is recorded; `hint`
+    /// should point at the human review/apply path.
+    pub fn policy_review_required(
+        message: impl Into<String>,
+        hint: impl Into<String>,
+        policy_rule: Option<String>,
+    ) -> Json<Self> {
+        Self::wrap_policy(
+            ToolErrorCode::PolicyReviewRequired,
+            message,
+            hint,
+            policy_rule,
         )
     }
 

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -1698,12 +1698,11 @@ impl RockyMcpServer {
 
         let run_plan = build_ai_run_plan(params.0.model.clone(), &result);
 
-        // policy seam 1 + capability-embed: the `propose` tool is the sole MCP writer of plans.
-        // Stamp the `agent` principal explicitly (an AiAuthored plan is
-        // agent-authored by construction) and embed the propose-time
-        // change-classification so `rocky apply` evaluates the plan against the
-        // exact capabilities that were reviewed. A creds-free / non-git project
-        // fails closed (every model classified breaking).
+        // The `propose` tool is the sole MCP writer of plans; it always authors
+        // an AI-authored plan and therefore always acts as the `agent`
+        // principal. Embed the propose-time change-classification so the
+        // reviewed capabilities bind to the plan_id (a creds-free / non-git
+        // project fails closed — every model classified breaking).
         let state_path = self.state_path();
         let capabilities = rocky_cli::commands::compute_embedded_capabilities(
             &self.config_path,
@@ -1711,21 +1710,101 @@ impl RockyMcpServer {
             "main",
             Some(&state_path),
         );
-        let plan_id = rocky_cli::plan_store::write_plan_governed(
-            &self.root,
-            rocky_cli::plan_store::PlanKind::AiAuthored,
+
+        // Consult the agent-policy plane before persisting — the same per-model
+        // evaluation `rocky apply` runs — so an over-eager agent receives a
+        // structured, parseable verdict at propose time instead of a plan a
+        // later apply silently refuses. Absent a `[policy]` block this resolves
+        // to `NotConfigured` and behaviour is byte-identical to before the plane.
+        let touched = capabilities.touched(&run_plan.models);
+        // The deterministic id the plan will carry if written — recorded in the
+        // audit ledger (and named in a review message) even when a deny refuses
+        // to persist the plan.
+        let plan_id = rocky_cli::plan_store::governed_plan_id(
+            &rocky_cli::plan_store::PlanKind::AiAuthored,
             &run_plan,
-            rocky_core::config::PolicyPrincipal::Agent,
-            capabilities,
+            &capabilities,
         )
         .map_err(|e| {
             ToolError::internal(
-                format!("failed to write AI-authored plan: {e:#}"),
-                "Ensure the project directory is writable so the plan store can persist the plan.",
+                format!("failed to compute plan id: {e:#}"),
+                "Retry the propose; if it persists, verify the project compiles cleanly.",
             )
         })?;
+        let gate = rocky_cli::commands::evaluate_apply_policy(
+            &self.config_path,
+            &plan_id,
+            rocky_core::config::PolicyPrincipal::Agent,
+            &touched,
+            &self.models_dir,
+            &state_path,
+        );
 
-        Ok(Json(ProposeResult { plan_id, models }))
+        let write_plan = || {
+            rocky_cli::plan_store::write_plan_governed(
+                &self.root,
+                rocky_cli::plan_store::PlanKind::AiAuthored,
+                &run_plan,
+                rocky_core::config::PolicyPrincipal::Agent,
+                capabilities,
+            )
+            .map_err(|e| {
+                ToolError::internal(
+                    format!("failed to write AI-authored plan: {e:#}"),
+                    "Ensure the project directory is writable so the plan store can persist the \
+                     plan.",
+                )
+            })
+        };
+
+        match gate {
+            rocky_cli::commands::PolicyGate::NotConfigured
+            | rocky_cli::commands::PolicyGate::Allow => {
+                let plan_id = write_plan()?;
+                Ok(Json(ProposeResult { plan_id, models }))
+            }
+            rocky_cli::commands::PolicyGate::RequireReview {
+                model,
+                rule_id,
+                reason,
+            } => {
+                // Headed to human review — persist the plan so a reviewer can
+                // approve it, then return a structured signal the agent parses.
+                let plan_id = write_plan()?;
+                let named = rule_id.map(|r| format!(" (rule {r})")).unwrap_or_default();
+                Err(ToolError::policy_review_required(
+                    format!(
+                        "policy requires human review before this change can apply: \
+                         model '{model}'{named} — {reason}. The plan was recorded as {plan_id}."
+                    ),
+                    format!(
+                        "A human must run `rocky review {plan_id} --approve` then \
+                         `rocky apply {plan_id}`; never approve on the user's behalf."
+                    ),
+                    rule_id.map(|r| r.to_string()),
+                ))
+            }
+            rocky_cli::commands::PolicyGate::Deny {
+                model,
+                rule_id,
+                reason,
+            } => {
+                // A deny cannot be satisfied by review — do NOT persist the
+                // plan; the decision is already recorded in the audit ledger.
+                let named = rule_id.map(|r| format!(" (rule {r})")).unwrap_or_default();
+                Err(ToolError::policy_denied(
+                    format!(
+                        "policy denies proposing this change: model '{model}'{named} — {reason}. \
+                         A deny cannot be satisfied by human review, so no plan was recorded."
+                    ),
+                    "Re-scope the change so it no longer touches the denied model — propose to a \
+                     branch, or drop that model from the change. A denied change cannot be applied \
+                     even after review."
+                        .to_string(),
+                    rule_id.map(|r| r.to_string()),
+                ))
+            }
+        }
     }
 
     /// Resolve the project's target warehouse adapter from `rocky.toml`.

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -192,6 +192,162 @@ async fn propose_writes_ai_authored_plan() {
     client.cancel().await.unwrap();
 }
 
+/// Like [`write_project`] but appends a `[policy]` block so the `propose`
+/// agent-policy gate is exercised. The single `orders` model is unclassified
+/// and uncontracted, so an `{ any = true }` rule is the deterministic lever.
+fn write_project_with_policy(dir: &Path, db_path: &Path, policy: &str) {
+    write_project(dir, db_path);
+    let cfg_path = dir.join("rocky.toml");
+    let mut cfg = std::fs::read_to_string(&cfg_path).unwrap();
+    cfg.push('\n');
+    cfg.push_str(policy);
+    std::fs::write(&cfg_path, cfg).unwrap();
+}
+
+/// Whether `.rocky/plans` holds any persisted plan `*.json`.
+fn plan_files(dir: &Path) -> Vec<std::path::PathBuf> {
+    let plans_dir = dir.join(".rocky").join("plans");
+    let Ok(entries) = std::fs::read_dir(&plans_dir) else {
+        return Vec::new();
+    };
+    entries
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|x| x == "json"))
+        .collect()
+}
+
+/// The load-bearing policy-gate proof, creds-free and deterministic: a
+/// `[policy]` block that denies an agent apply makes `propose` return a
+/// parseable structured deny — `{code = "policy_denied", policy_rule, message,
+/// remediation_hint}` — naming the deciding rule. A deny does **not** persist
+/// the plan, and the decision is recorded in the audit ledger.
+#[tokio::test]
+async fn propose_denied_by_policy_returns_structured_error() {
+    let dir = TempDir::new().unwrap();
+    write_project_with_policy(
+        dir.path(),
+        &dir.path().join("test.duckdb"),
+        r#"[policy]
+version = 1
+default_agent_effect = "require_review"
+
+[[policy.rules]]
+principal = "agent"
+capability = "apply"
+scope = { any = true }
+effect = "deny"
+"#,
+    );
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+
+    let result = client
+        .call_tool(CallToolRequestParams::new("propose"))
+        .await
+        .expect("propose returns a result");
+
+    // Structured deny, over the wire: is_error + a parseable envelope.
+    assert_eq!(result.is_error, Some(true), "a denied propose is an error");
+    let err = result
+        .structured_content
+        .expect("a denied propose carries the structured error envelope");
+    assert_eq!(err["code"], serde_json::json!("policy_denied"));
+    assert_eq!(
+        err["policy_rule"],
+        serde_json::json!("0"),
+        "the envelope names the deciding rule: {err:?}"
+    );
+    let message = err["message"].as_str().unwrap();
+    assert!(
+        message.contains("orders"),
+        "message names the denied model: {message}"
+    );
+    let hint = err["remediation_hint"].as_str().unwrap();
+    assert!(
+        hint.contains("branch") || hint.contains("Re-scope"),
+        "remediation_hint points at a reroute: {hint}"
+    );
+
+    // A deny must NOT persist the plan — the decision is reserved for a human.
+    assert!(
+        plan_files(dir.path()).is_empty(),
+        "a denied propose must not write a plan file"
+    );
+
+    // The decision IS recorded in the audit ledger (queryable via `rocky audit`).
+    client.cancel().await.unwrap();
+    let state_path = rocky_core::state::resolve_state_path(None, &dir.path().join("models")).path;
+    let store = rocky_core::state::StateStore::open(&state_path).expect("open ledger");
+    let decisions = store.list_policy_decisions().expect("list decisions");
+    assert!(
+        decisions
+            .iter()
+            .any(|d| d.model == "orders" && d.effect == rocky_core::config::PolicyEffect::Deny),
+        "the propose-time deny is recorded in the ledger: {decisions:?}"
+    );
+}
+
+/// A `require_review` verdict at propose time still **persists** the plan (it is
+/// headed to human review) and returns a structured `policy_review_required`
+/// signal naming the rule and the recorded plan_id, so the agent surfaces the
+/// review/apply path to the user instead of applying autonomously.
+#[tokio::test]
+async fn propose_require_review_persists_plan_and_signals() {
+    let dir = TempDir::new().unwrap();
+    write_project_with_policy(
+        dir.path(),
+        &dir.path().join("test.duckdb"),
+        r#"[policy]
+version = 1
+default_agent_effect = "require_review"
+
+[[policy.rules]]
+principal = "agent"
+capability = "apply"
+scope = { any = true }
+effect = "require_review"
+"#,
+    );
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+
+    let result = client
+        .call_tool(CallToolRequestParams::new("propose"))
+        .await
+        .expect("propose returns a result");
+
+    assert_eq!(
+        result.is_error,
+        Some(true),
+        "require_review returns a structured signal the agent parses"
+    );
+    let err = result.structured_content.expect("structured envelope");
+    assert_eq!(err["code"], serde_json::json!("policy_review_required"));
+    assert_eq!(err["policy_rule"], serde_json::json!("0"));
+    let message = err["message"].as_str().unwrap();
+    let hint = err["remediation_hint"].as_str().unwrap();
+    assert!(
+        hint.contains("rocky review") && hint.contains("--approve"),
+        "remediation_hint points at the human review path: {hint}"
+    );
+
+    // require_review DOES persist the plan — it is on its way to a reviewer.
+    let plans = plan_files(dir.path());
+    assert_eq!(plans.len(), 1, "the plan was recorded for review");
+    let plan: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&plans[0]).unwrap()).unwrap();
+    assert_eq!(plan["kind"], serde_json::json!("ai_authored"));
+
+    // The recorded plan_id is surfaced to the agent so it can name it to the user.
+    let plan_id = plans[0].file_stem().unwrap().to_str().unwrap();
+    assert!(
+        message.contains(plan_id) || hint.contains(plan_id),
+        "the recorded plan_id is surfaced: message={message} hint={hint}"
+    );
+
+    client.cancel().await.unwrap();
+}
+
 #[tokio::test]
 async fn sample_rows_returns_capped_rows_on_duckdb() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## What

The MCP `propose` tool is the sole plan writer on the agent surface. It now consults the agent-policy plane over the plan's touched `(model, capability)` set — the **same per-model evaluation `rocky apply` runs** — before persisting, so an over-eager agent operating over `rocky mcp` gets a structured, parseable verdict at propose time instead of a plan a later apply silently refuses. Read-only tools stay ungated.

## Behavior

| Verdict | Plan persisted? | Return |
|---|---|---|
| `deny` | **No** — a deny cannot be satisfied by human review | structured `policy_denied` error naming the deciding rule + a reroute hint |
| `require_review` | **Yes** — it is headed to a reviewer | structured `policy_review_required` signal naming the rule, the recorded `plan_id`, and the review/apply path |
| `allow` / no `[policy]` block | Yes | unchanged — writes the plan, returns the result (byte-identical to before the plane) |

Every propose-time evaluation records a decision in the audit ledger (queryable via `rocky audit`), referencing a deterministic `plan_id` even when a deny refuses to persist the plan.

The structured errors ride the existing MCP error contract: `{ code, message, remediation_hint, policy_rule }`. Two new codes: `policy_denied`, `policy_review_required`. No state-schema change (reuses the evaluator + ledger). No `*Output` struct touched (MCP errors are not part of the codegen cascade).

## Implementation

- `propose` reuses the shared `evaluate_apply_policy` evaluator (promoted to `pub`), so propose / apply / promote all evaluate the same rules with the same most-restrictive aggregation and record to the same ledger.
- New `plan_store::governed_plan_id` computes the stable plan id ahead of the write, so the ledger (and a review message) can reference it even for a plan a deny never persists. Shares the payload-building path with the writer, so the pre-computed id provably matches the written one.
- `EmbeddedCapabilities::touched` centralizes the touched-set derivation shared by the apply path and the propose gate.

## Reachability proof (creds-free, deterministic)

`propose_denied_by_policy_returns_structured_error` drives the in-process MCP server with a `[policy]` block that denies an agent apply, calls `propose`, and asserts the wire result is `is_error: true` with a parseable envelope `{ code: "policy_denied", policy_rule: "0", message names the model, remediation_hint points at a reroute }`, that **no plan file was written**, and that the **deny is recorded in the ledger**. `propose_require_review_persists_plan_and_signals` proves the require_review path persists the plan and surfaces the `plan_id`.

## Gates

- `cargo clippy --all-targets` (rocky-cli / rocky-mcp / rocky-core): clean
- `cargo fmt --check`: clean
- `cargo test`: rocky-core + rocky-mcp full suites green; rocky-cli lib (852) + all integration test binaries green
