### PR TITLE
chore: release engine v1.57.0, sdk v0.2.0, dagster v1.55.0, vscode v1.34.0

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.34.0] — 2026-07-08
+
+### Added
+
+- **Generated TypeScript types for the engine-v1.57.0 output surface** — replay (`replay_check`, `replay_execute`), recipe history, agent policy (`policy_check`, `audit`), the governor's `brief`, and the `rocky serve` job/meta/error types. Additive; the LSP client and existing commands are unchanged. (#1033–#1052)
+
+### Fixed
+
+- **Pin `@types/vscode` to the `engines.vscode` floor** so `vsce package` succeeds during the release build. (#1015)
+
 ## [1.33.5] — 2026-07-02
 
 > 1.33.4 was tagged but never published — its release build failed at `vsce package`

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocky",
-  "version": "1.33.5",
+  "version": "1.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocky",
-      "version": "1.33.5",
+      "version": "1.34.0",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^10.1.0"
@@ -2303,9 +2303,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2323,9 +2320,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2343,9 +2337,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2363,9 +2354,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.33.5",
+  "version": "1.34.0",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.57.0] - 2026-07-08
+
+A large feature release: an enforcing **agent policy plane**, **recipe identity** on every execution, **replay** re-execution, sound **per-column content hashing**, an embedder-grade **engine API** with a job model, the **governor's brief**, and a standalone **recipe-manifest verifier**. All additive — absent the new opt-in config (`[policy]`, `[reuse] column_level`), behavior is unchanged.
+
+### Added
+
+- **Agent policy plane — "IAM for data agents."** A `[policy]` block declares `(principal, capability, scope) → effect` rules; the evaluator resolves them per-model with a deny-override, most-specific-wins (most-restrictive on incomparable), fail-closed classification. `rocky policy check` explains a verdict; enforcement wires into `apply`/`promote` (generalizing the AI-authored review gate) and the MCP `propose` tool, which returns a structured `{code, message, remediation_hint}` denial naming the rule. Every decision is recorded to a `POLICY_DECISIONS` ledger, queryable with `rocky audit`. A denied propose writes no plan; a legacy AI-authored plan still requires review. Absent `[policy]`, behavior is byte-identical to before. (#1043, #1048, #1050)
+- **Recipe identity on every execution.** Each materialization records the `(recipe_hash, input_hash, env_hash)` triple plus a versioned `hash_scheme`, with an honest `input_proof_class` (`strong` vs `heuristic`) so a freshness-derived input hash is never presented as a content claim. Surfaced on `history`/`trace`/`catalog` records and via `rocky history --recipe <hash>` — every execution of that exact program. (#1033, #1039)
+- **Replay re-execution.** `rocky replay --at <run> --check` classifies each recorded model as replayable or not from the ledger alone; `--execute --verify` re-runs a model (or, with no `--model`, the whole run in topological order, each downstream reading its *replayed* upstream) on an ephemeral engine and blake3-compares to the recording. Fail-safe verdicts; nothing materialized to production; nondeterministic models are flagged, not chased. (#1035, #1038, #1041)
+- **Per-column content hashing (T2).** A consumed-column completeness guard (fail-closed on `SELECT *`/CTEs/ambiguity), producer-side output-column hashes and a consumer-side baseline recorded on the content-addressed path, and a **sound content-addressed column-level skip gate** — a rebuilt upstream is skipped for a downstream only when the columns it consumes are byte-identical to its baseline. Default-OFF behind `[reuse] column_level`; every uncertainty fails closed to BUILD. (#1034, #1037, #1042, #1046)
+- **Engine API (`rocky serve --api`).** The `/api/v1` routes now serve canonical `*Output` bytes identical to the CLI's `--output json` (a golden parity test enforces it), with a `{code, message, remediation_hint}` error envelope, a computed `/meta` (engine + schema versions, capabilities), and a **job model** — `POST /api/v1/jobs/{run|plan|apply}` → `202`, `GET /jobs/{id}` with the canonical output embedded, one-mutating-job-at-a-time (`409 mutation_in_progress`), and persisted job status so a restarted sidecar reports honestly. (#1044, #1047)
+- **`rocky brief` — the governor's estate digest.** A typed digest composed template-first from the ledger (agent activity, escalations, runs, drift, freshness, quality, cost/budget), every line carrying ledger citations, fail-closed sections, markdown or JSON. (#1052)
+- **Recipe-manifest v0.1 spec + `rocky-verify`.** A vendor-neutral manifest schema (every field mapped to shipped recording code) and a dependency-light standalone verifier that validates a manifest and byte-checks recorded hashes offline — no engine required. (#1051)
+- **Agent interface hardening.** A structured `{code, message, remediation_hint, policy_rule?}` error contract across the MCP tools, and a versioned agent-conformance eval suite (`engine/evals/`) scoring an agent's grounding/authoring over the MCP surface. (#1036, #1032)
+- **Replication `prune_unchanged`.** Skip-unchanged source pruning on the replication path. (#1024)
+
+### Fixed
+
+- **`rocky plan` honors `merge` + `table_overrides` on replication.** The plan preview ignored per-table strategy and column overrides on the replication path. (#1023)
+
 ## [1.56.0] - 2026-07-02
 
 ### Added

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.56.0"
+version = "1.57.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.56.0"
+version = "1.57.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.56.0"
+version = "1.57.0"
 dependencies = [
  "indexmap",
  "reqwest 0.12.28",
@@ -3964,7 +3964,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.56.0"
+version = "1.57.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3981,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.56.0"
+version = "1.57.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4009,7 +4009,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.56.0"
+version = "1.57.0"
 dependencies = [
  "redis",
  "serde",
@@ -4021,7 +4021,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.56.0"
+version = "1.57.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -4032,7 +4032,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.56.0"
+version = "1.57.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4087,7 +4087,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.56.0"
+version = "1.57.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.56.0"
+version = "1.57.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4154,7 +4154,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.56.0"
+version = "1.57.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4180,7 +4180,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.56.0"
+version = "1.57.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4199,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.56.0"
+version = "1.57.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4217,7 +4217,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.56.0"
+version = "1.57.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.56.0"
+version = "1.57.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4273,7 +4273,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.56.0"
+version = "1.57.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -4286,7 +4286,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.56.0"
+version = "1.57.0"
 dependencies = [
  "logos",
  "miette",
@@ -4298,7 +4298,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.56.0"
+version = "1.57.0"
 dependencies = [
  "rocky-server",
  "rustls",
@@ -4307,7 +4307,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.56.0"
+version = "1.57.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4332,7 +4332,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.56.0"
+version = "1.57.0"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4350,7 +4350,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.56.0"
+version = "1.57.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4379,7 +4379,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.56.0"
+version = "1.57.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -4406,7 +4406,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.56.0"
+version = "1.57.0"
 dependencies = [
  "miette",
  "regex",
@@ -4419,7 +4419,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.56.0"
+version = "1.57.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4456,7 +4456,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.56.0"
+version = "1.57.0"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.56.0"
+version = "1.57.0"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.56.0"
+version = "1.57.0"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.56.0"
+version = "1.57.0"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.56.0"
+version = "1.57.0"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.56.0"
+version = "1.57.0"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.56.0"
+version = "1.57.0"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.56.0"
+version = "1.57.0"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.56.0"
+version = "1.57.0"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.56.0"
+version = "1.57.0"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.56.0"
+version = "1.57.0"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.56.0"
+version = "1.57.0"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.56.0"
+version = "1.57.0"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.56.0"
+version = "1.57.0"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.56.0"
+version = "1.57.0"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.56.0"
+version = "1.57.0"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.56.0"
+version = "1.57.0"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.56.0"
+version = "1.57.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.56.0"
+version = "1.57.0"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.56.0"
+version = "1.57.0"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.56.0"
+version = "1.57.0"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.56.0"
+version = "1.57.0"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.56.0"
+version = "1.57.0"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.56.0"
+version = "1.57.0"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.56.0"
+version = "1.57.0"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.56.0"
+version = "1.57.0"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.55.0] — 2026-07-08
+
+### Changed
+
+- **Floors on `rocky-sdk>=0.2.0`** to pick up the generated types for the engine-v1.57.0 output surface (replay, recipe history, agent policy, `brief`, and the `rocky serve` job/meta/error types), re-exported through `dagster_rocky.types`. (#1033–#1052)
+
+### Fixed
+
+- **Pruned-table handling for `prune_unchanged` runs.** A replication run that pruned an unchanged source table is now mapped to its asset/check status correctly instead of surfacing as a missing materialization. (#1025)
+
 ## [1.54.1] — 2026-07-02
 
 ### Fixed

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.54.1"
+version = "1.55.0"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"
@@ -23,7 +23,7 @@ dependencies = [
     # package; RockyResource is a thin Dagster adapter over RockyClient. In-repo
     # dev/CI resolves this from the local path (see [tool.uv.sources]); the
     # published wheel floors on the released SDK.
-    "rocky-sdk>=0.1.7",
+    "rocky-sdk>=0.2.0",
     # Floor matches the version CI actually resolves and tests (uv.lock). The
     # RockyComponent path uses dagster.components.* APIs from preview namespaces,
     # so we advertise a tested floor rather than an older, never-exercised one.

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-07-08
+
+### Added
+
+- **Generated types for the engine-v1.57.0 output surface.** New Pydantic models track the CLI's new JSON outputs: replay (`replay_check`, `replay_execute`), recipe history (`recipe_history`), the agent-policy plane (`policy_check`, `audit`), the governor's `brief`, and the `rocky serve` API surface (`job_status`, `meta`, `error_envelope`). The recipe-identity triple (`recipe_hash`/`input_hash`/`input_proof_class`/`env_hash`/`hash_scheme`) now populates on the `history()` / `catalog()` result models. All additive — existing calls are unchanged; the new models are available to import. (#1033–#1052)
+
 ## [0.1.7] — 2026-07-02
 
 ### Added

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rocky-sdk"
-version = "0.1.7"
+version = "0.2.0"
 description = "Typed Python client for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.1.7"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Quad-cut release of the five-wave feature pile (#1023–#1052).

**Versions:** engine 1.56.0→1.57.0 (25 crates), rocky-sdk 0.1.7→0.2.0, dagster-rocky 1.54.1→1.55.0 (floor raised to `rocky-sdk>=0.2.0`), VS Code 1.33.5→1.34.0.

**Engine highlights:** agent policy plane (config + evaluator + enforcement at apply/promote/MCP + `rocky audit` ledger), recipe identity + `rocky history --recipe`, replay `--check`/`--execute`/DAG, per-column content hashing + sound column-level skip gate (default-OFF), engine `/api/v1` parity + job model, `rocky brief`, recipe-manifest spec + `rocky-verify`. All additive; absent `[policy]`/`[reuse] column_level`, behavior is unchanged. Full detail in `engine/CHANGELOG.md`.

SDK/dagster/vscode bumps track the generated bindings for the new output surface (+ the #1025 dagster prune fix, #1015 vscode packaging fix). No source drift — codegen + regen-fixtures verified clean against the version bump.

**Tag order after merge (per the SDK-before-dagster rule):** `sdk-v0.2.0` → `engine-v1.57.0` → `dagster-v1.55.0` → `vscode-v1.34.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)