### PR TITLE
feat(engine): classified retry at the run loop ([resilience])

### DIFF
--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -2999,6 +2999,67 @@
       ],
       "type": "object"
     },
+    "ResilienceConfig": {
+      "additionalProperties": false,
+      "description": "`[resilience]` — the run loop's classified-retry policy.\n\nThis is a **distinct layer** from the per-adapter `[adapter.*.retry]` (which retries individual statements inside a connector) and from the run-level `[retry]` budget ([`RunRetryConfig`], which caps connector retries). `[resilience]` governs whether the run loop re-runs a whole *model* whose materialization failed, classifying the failure via [`crate::failure_class::FailureClass`] and retrying only a *proven* transient one.\n\n# Not default-OFF, but conservative\n\nUnlike the skip / reuse gates, this layer is **on by default** — a model that fails transiently today *will* be retried once this ships. The lever that keeps that safe is [`Self::transient_max_retries`] (default `2`): a small, bounded budget with capped exponential backoff. Set `transient_max_retries = 0` (or `enabled = false`) to restore the prior single-attempt behaviour, e.g. in CI where a fast-fail is preferred.\n\nPermanent and Unknown failures are **never** retried regardless of these settings — that is a property of the classifier, not of this config.",
+      "properties": {
+        "backoff_multiplier": {
+          "default": 2.0,
+          "description": "Multiplier applied to the backoff after each retry.",
+          "format": "double",
+          "type": "number"
+        },
+        "circuit_breaker_threshold": {
+          "default": 3,
+          "description": "Trip the run-loop breaker after this many *consecutive* transient model failures; once tripped, no further model is retried for the rest of the run (they still get their one attempt). Default: `3`. `0` disables the breaker.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "enabled": {
+          "default": true,
+          "description": "Master switch for run-loop classified retry. Default `true`. When `false`, every model is attempted exactly once (no classification, no backoff) — the behaviour before this layer existed.",
+          "type": "boolean"
+        },
+        "initial_backoff_ms": {
+          "default": 500,
+          "description": "Initial backoff (ms) before the first retry.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "jitter": {
+          "default": true,
+          "description": "Add ±25 % jitter so concurrent runs don't retry in lockstep.",
+          "type": "boolean"
+        },
+        "max_backoff_ms": {
+          "default": 30000,
+          "description": "Maximum backoff (ms) — caps the exponential growth.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "max_retries_per_run": {
+          "default": 8,
+          "description": "Optional ceiling on the *total* number of retries across all models in one run — a global budget separate from the per-adapter one. Default `Some(8)`: a conservative cap so one flaky layer can't spin the whole run. `None` removes the ceiling (per-model `transient_max_retries` is then the only bound); `Some(0)` forbids all retries.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "transient_max_retries": {
+          "default": 2,
+          "description": "Maximum re-runs of a model that failed with a *transient* class. Conservative default: `2` (so at most three attempts total). `0` disables retry while leaving the classifier active for observability.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
     "RetryConfig": {
       "additionalProperties": false,
       "description": "Retry policy for transient warehouse errors (HTTP 429/503, rate limits, timeouts).\n\nRocky retries transient errors with exponential backoff and optional jitter to prevent thundering herd across concurrent runs.",
@@ -4177,6 +4238,24 @@
         "target_dialect": null
       },
       "description": "Dialect-portability lint configuration. Consumed by `rocky compile` to drive P001 (and, when wired, future) diagnostics. The CLI's `--target-dialect` flag, when set, takes precedence over [`PortabilityConfig::target_dialect`]."
+    },
+    "resilience": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResilienceConfig"
+        }
+      ],
+      "default": {
+        "backoff_multiplier": 2.0,
+        "circuit_breaker_threshold": 3,
+        "enabled": true,
+        "initial_backoff_ms": 500,
+        "jitter": true,
+        "max_backoff_ms": 30000,
+        "max_retries_per_run": 8,
+        "transient_max_retries": 2
+      },
+      "description": "`[resilience]` — the run loop's classified-retry policy. Governs whether a model whose materialization fails *transiently* is re-run, with a conservative bounded budget and capped backoff. On by default (a transient failure is retried), but every knob is small and explicit; see [`ResilienceConfig`]. Permanent / Unknown failures never retry."
     },
     "retry": {
       "anyOf": [

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -459,6 +459,10 @@ export interface RockyConfig {
    */
   portability?: PortabilityConfig;
   /**
+   * `[resilience]` — the run loop's classified-retry policy. Governs whether a model whose materialization fails *transiently* is re-run, with a conservative bounded budget and capped backoff. On by default (a transient failure is retried), but every knob is small and explicit; see [`ResilienceConfig`]. Permanent / Unknown failures never retry.
+   */
+  resilience?: ResilienceConfig;
+  /**
    * Run-level retry budget shared across every adapter for this run.
    *
    * When set, `rocky run` builds a single [`crate::retry_budget::RetryBudget`] from [`RunRetryConfig::max_retries_per_run`] and passes it to every connector via `with_retry_budget(...)`. One bad table that burns through retries on adapter A then has less budget available for adapter B's retries — the protection §P2.7 added within a single adapter now extends across the whole run.
@@ -1866,6 +1870,51 @@ export interface PortabilityConfig {
    * Target dialect for the portability lint. When unset, no lint runs (matches the wave-1 "flag opt-in" behavior). The CLI flag overrides this if both are present.
    */
   target_dialect?: Dialect | null;
+}
+/**
+ * `[resilience]` — the run loop's classified-retry policy.
+ *
+ * This is a **distinct layer** from the per-adapter `[adapter.*.retry]` (which retries individual statements inside a connector) and from the run-level `[retry]` budget ([`RunRetryConfig`], which caps connector retries). `[resilience]` governs whether the run loop re-runs a whole *model* whose materialization failed, classifying the failure via [`crate::failure_class::FailureClass`] and retrying only a *proven* transient one.
+ *
+ * # Not default-OFF, but conservative
+ *
+ * Unlike the skip / reuse gates, this layer is **on by default** — a model that fails transiently today *will* be retried once this ships. The lever that keeps that safe is [`Self::transient_max_retries`] (default `2`): a small, bounded budget with capped exponential backoff. Set `transient_max_retries = 0` (or `enabled = false`) to restore the prior single-attempt behaviour, e.g. in CI where a fast-fail is preferred.
+ *
+ * Permanent and Unknown failures are **never** retried regardless of these settings — that is a property of the classifier, not of this config.
+ */
+export interface ResilienceConfig {
+  /**
+   * Multiplier applied to the backoff after each retry.
+   */
+  backoff_multiplier?: number;
+  /**
+   * Trip the run-loop breaker after this many *consecutive* transient model failures; once tripped, no further model is retried for the rest of the run (they still get their one attempt). Default: `3`. `0` disables the breaker.
+   */
+  circuit_breaker_threshold?: number;
+  /**
+   * Master switch for run-loop classified retry. Default `true`. When `false`, every model is attempted exactly once (no classification, no backoff) — the behaviour before this layer existed.
+   */
+  enabled?: boolean;
+  /**
+   * Initial backoff (ms) before the first retry.
+   */
+  initial_backoff_ms?: number;
+  /**
+   * Add ±25 % jitter so concurrent runs don't retry in lockstep.
+   */
+  jitter?: boolean;
+  /**
+   * Maximum backoff (ms) — caps the exponential growth.
+   */
+  max_backoff_ms?: number;
+  /**
+   * Optional ceiling on the *total* number of retries across all models in one run — a global budget separate from the per-adapter one. Default `Some(8)`: a conservative cap so one flaky layer can't spin the whole run. `None` removes the ceiling (per-model `transient_max_retries` is then the only bound); `Some(0)` forbids all retries.
+   */
+  max_retries_per_run?: number | null;
+  /**
+   * Maximum re-runs of a model that failed with a *transient* class. Conservative default: `2` (so at most three attempts total). `0` disables retry while leaving the classifier active for observability.
+   */
+  transient_max_retries?: number;
 }
 /**
  * Top-level retry configuration applied across every adapter for this run. See [`RockyConfig::retry`] for the cross-adapter semantics this unlocks.

--- a/editors/vscode/src/types/generated/run.ts
+++ b/editors/vscode/src/types/generated/run.ts
@@ -333,6 +333,10 @@ export interface ExecutionSummary {
 export interface MaterializationOutput {
   asset_key: string[];
   /**
+   * The classified-retry attempt trail for this materialization: one [`AttemptRecord`](rocky_core::state::AttemptRecord) per try. Empty (and omitted from JSON) for a clean first-try success — the run loop only stamps a trail once a retry actually happened, so a non-retried build's output stays byte-identical to before this layer shipped. [`RunOutput::to_run_record`] copies this verbatim onto the persisted `ModelExecution.attempts` — one attempt type on both the wire and the state record.
+   */
+  attempts?: AttemptRecord[];
+  /**
    * Adapter-reported bytes figure used for cost accounting, summed across all statements executed for this materialization. This is the *billing-relevant* number per adapter, not literal scan volume — so anyone comparing this to a warehouse console should know which column lines up.
    *
    * - **BigQuery:** `statistics.query.totalBytesBilled` (with the 10 MB per-query minimum already applied) — matches the BigQuery console's "Bytes billed" field, **not** "Bytes processed". Fed straight into [`rocky_core::cost::compute_observed_cost_usd`] to produce `cost_usd`. - **Databricks:** when populated, byte count from the statement-execution manifest (`total_byte_count`); `None` today until the manifest plumbing lands. - **Snowflake:** `None` — deferred by design (QUERY_HISTORY round-trip cost; Snowflake cost is duration × DBU, not bytes-driven). - **DuckDB:** `None` — no billed-bytes concept.
@@ -367,6 +371,44 @@ export interface MaterializationOutput {
    * Tenant this materialization is attributed to, taken from the discover-time schema-pattern `{tenant}` component. Present only for replication pipelines whose schema pattern declares a `{tenant}` placeholder; transformation / `time_interval` models and non-tenant patterns leave it `None`. Carried onto the persisted `rocky_core::state::ModelExecution` by [`RunOutput::to_run_record`] so `rocky cost --by tenant` can roll per-model cost up to a tenant dimension. Omitted from JSON when `None` so non-tenant outputs stay byte-identical.
    */
   tenant?: string | null;
+  [k: string]: unknown;
+}
+/**
+ * One attempt at materializing a model, recorded when the run loop's classified-retry layer is active.
+ *
+ * A model that succeeds on the first try records a single attempt; a model that failed transiently and was re-run records one entry per attempt, the last of which is the outcome that stuck. The trail is **execution metadata** — it lives on [`ModelExecution`] alongside the identity hashes, never inside them, so a retried-then-succeeded execution stays byte-indistinguishable downstream from a first-try success (same `recipe_hash` / `input_hash` / output hash).
+ *
+ * Reused verbatim on `MaterializationOutput.attempts` (the run-JSON surface), so it derives `JsonSchema`; that is the one attempt type on both the wire and the state record.
+ */
+export interface AttemptRecord {
+  /**
+   * 1-based attempt index. Attempt 1 is the first try; 2+ are retries.
+   */
+  attempt: number;
+  /**
+   * Milliseconds slept as backoff *after* this attempt before the next retry. `None` on the final (kept) attempt and on any attempt that was not followed by a retry.
+   */
+  backoff_ms?: number | null;
+  /**
+   * Wall-clock duration of this attempt, in milliseconds.
+   */
+  duration_ms: number;
+  /**
+   * The failure message (truncated), for a failed attempt; `None` on success.
+   */
+  error?: string | null;
+  /**
+   * The run-loop [`FailureClass`](crate::failure_class::FailureClass) label (`"transient"` / `"permanent"` / `"unknown"`) for a failed attempt; `None` on a successful attempt.
+   */
+  failure_class?: string | null;
+  /**
+   * `"success"` or `"failed"`.
+   */
+  outcome: string;
+  /**
+   * The transient sub-kind label (`"network"`, `"timeout"`, …) when the failure was transient; `None` otherwise.
+   */
+  transient_kind?: string | null;
   [k: string]: unknown;
 }
 export interface MaterializationMetadata {

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Classified retry at the run loop (`[resilience]`).** A model whose materialization fails is now classified — via each adapter's own retryable judgement, hoisted into a unified `FailureClass { Transient(kind), Permanent, Unknown }` — and a *proven* transient failure is re-run within a small bounded budget with capped exponential backoff. Every retry is recorded as an attempt trail on the execution record and surfaced in the run's JSON output. **Behavior change:** this is on by default, so a transient failure that fails a run today (a warehouse warming up, a 429, a connection reset, a lock conflict) will now be retried instead. The default budget is deliberately small (`transient_max_retries = 2`); set `transient_max_retries = 0` or `enabled = false` under `[resilience]` to restore the prior single-attempt behavior (e.g. in CI where a fast-fail is preferred). **Permanent** failures (a rejected statement, a type/contract error) and **Unknown** failures (an error the adapter doesn't recognise) are never retried — fail closed. Retry is allow-by-default under the agent-policy plane; only an explicit `capability = "retry"` rule gates it. State schema bumps to v16 (additive `attempts` field on the execution record; pre-v16 records read back with an empty trail).
+
 ## [1.57.0] - 2026-07-08
 
 A large feature release: an enforcing **agent policy plane**, **recipe identity** on every execution, **replay** re-execution, sound **per-column content hashing**, an embedder-grade **engine API** with a job model, the **governor's brief**, and a standalone **recipe-manifest verifier**. All additive — absent the new opt-in config (`[policy]`, `[reuse] column_level`), behavior is unchanged.

--- a/engine/crates/rocky-bigquery/src/connector.rs
+++ b/engine/crates/rocky-bigquery/src/connector.rs
@@ -9,6 +9,7 @@ use tokio::time::Instant;
 use tracing::{Instrument, Span, debug, field, info_span, warn};
 
 use rocky_core::config::RetryConfig;
+use rocky_core::failure_class::{FailureClass, TransientKind};
 use rocky_core::retry::compute_backoff;
 use rocky_core::retry_budget::RetryBudget;
 use rocky_core::traits::{
@@ -899,6 +900,10 @@ impl WarehouseAdapter for BigQueryAdapter {
             .map_err(AdapterError::new)
     }
 
+    fn classify_failure(&self, err: &AdapterError) -> FailureClass {
+        classify_bigquery_failure(err)
+    }
+
     async fn execute_statement_with_stats(&self, sql: &str) -> AdapterResult<ExecutionStats> {
         let mut response = self.run_query(sql).await.map_err(AdapterError::new)?;
 
@@ -1649,7 +1654,7 @@ struct ErrorProto {
 ///   on retry.
 /// - A poll-loop [`BigQueryError::Timeout`] — the job already ran to the
 ///   deadline; re-submitting it is a fresh statement's concern.
-fn is_transient(err: &BigQueryError) -> bool {
+pub(crate) fn is_transient(err: &BigQueryError) -> bool {
     match err {
         BigQueryError::ApiError { status, .. } => {
             // `status` is the reqwest `StatusCode` `Display` form, e.g.
@@ -1668,6 +1673,40 @@ fn is_transient(err: &BigQueryError) -> bool {
         | BigQueryError::RetryBudgetExhausted { .. }
         | BigQueryError::StorageRead(_) => false,
     }
+}
+
+/// Classify a BigQuery [`AdapterError`] for the run loop's classified-retry
+/// layer, reusing the connector's own [`is_transient`] judgement so the run
+/// loop and the connector agree by construction.
+///
+/// Downcasts to a [`BigQueryError`]: transient ⇒ [`FailureClass::Transient`]
+/// with a kind read from the HTTP shape; not transient (a job/type error, auth,
+/// budget exhaustion) ⇒ [`FailureClass::Permanent`]; not a [`BigQueryError`] ⇒
+/// [`FailureClass::Unknown`] (fail closed).
+#[must_use]
+pub(crate) fn classify_bigquery_failure(err: &AdapterError) -> FailureClass {
+    let Some(bq_err) = err.inner().downcast_ref::<BigQueryError>() else {
+        return FailureClass::Unknown;
+    };
+    if !is_transient(bq_err) {
+        return FailureClass::Permanent;
+    }
+    let kind = match bq_err {
+        BigQueryError::ApiError { status, .. } => {
+            let code = status
+                .split_whitespace()
+                .next()
+                .and_then(|c| c.parse::<u16>().ok());
+            match code {
+                Some(429) => TransientKind::RateLimit,
+                _ => TransientKind::Network,
+            }
+        }
+        BigQueryError::Http(e) if e.is_timeout() => TransientKind::Timeout,
+        BigQueryError::Http(_) => TransientKind::Network,
+        _ => TransientKind::Other,
+    };
+    FailureClass::Transient(kind)
 }
 
 /// Top-level `statistics` block on a BigQuery job response. Only the
@@ -2123,5 +2162,43 @@ mod tests {
         assert!(!is_transient(&BigQueryError::RetryBudgetExhausted {
             limit: 1
         }));
+    }
+
+    /// The run-loop classifier hoists `is_transient`: a 429 becomes a
+    /// rate-limited Transient, a 5xx a network Transient, a job/type error
+    /// Permanent, and a non-`BigQueryError` boxed error `Unknown`. A permanent
+    /// error is never marked retryable (the dangerous direction).
+    #[test]
+    fn classify_bigquery_failure_maps_three_ways() {
+        let rate_limited = classify_bigquery_failure(&AdapterError::new(BigQueryError::ApiError {
+            status: "429 Too Many Requests".into(),
+            message: "slow down".into(),
+        }));
+        assert_eq!(
+            rate_limited,
+            FailureClass::Transient(TransientKind::RateLimit)
+        );
+
+        let unavailable = classify_bigquery_failure(&AdapterError::new(BigQueryError::ApiError {
+            status: "503 Service Unavailable".into(),
+            message: "x".into(),
+        }));
+        assert_eq!(unavailable, FailureClass::Transient(TransientKind::Network));
+
+        let job_err = classify_bigquery_failure(&AdapterError::new(BigQueryError::JobError {
+            reason: "invalidQuery".into(),
+            message: "bad column".into(),
+        }));
+        assert_eq!(job_err, FailureClass::Permanent);
+        assert!(!job_err.is_retryable());
+
+        let budget =
+            classify_bigquery_failure(&AdapterError::new(BigQueryError::RetryBudgetExhausted {
+                limit: 1,
+            }));
+        assert_eq!(budget, FailureClass::Permanent);
+
+        let unknown = classify_bigquery_failure(&AdapterError::msg("not a bigquery error"));
+        assert_eq!(unknown, FailureClass::Unknown);
     }
 }

--- a/engine/crates/rocky-cli/src/commands/brief.rs
+++ b/engine/crates/rocky-cli/src/commands/brief.rs
@@ -1076,6 +1076,7 @@ mod tests {
             env_hash: None,
             hash_scheme: None,
             output_column_hashes: None,
+            attempts: Vec::new(),
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/catalog.rs
+++ b/engine/crates/rocky-cli/src/commands/catalog.rs
@@ -1249,6 +1249,7 @@ mod tests {
                 env_hash: None,
                 hash_scheme: None,
                 output_column_hashes: None,
+                attempts: Vec::new(),
             }
         }
     }

--- a/engine/crates/rocky-cli/src/commands/cost.rs
+++ b/engine/crates/rocky-cli/src/commands/cost.rs
@@ -514,6 +514,7 @@ mod tests {
             env_hash: None,
             hash_scheme: None,
             output_column_hashes: None,
+            attempts: Vec::new(),
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/history.rs
+++ b/engine/crates/rocky-cli/src/commands/history.rs
@@ -572,6 +572,7 @@ mod tests {
                 env_hash: None,
                 hash_scheme: None,
                 output_column_hashes: None,
+                attempts: Vec::new(),
             }],
             trigger: RunTrigger::Manual,
             config_hash: "cfg-hash".to_string(),
@@ -745,6 +746,7 @@ mod tests {
             env_hash: None,
             hash_scheme: None,
             output_column_hashes: None,
+            attempts: Vec::new(),
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -51,6 +51,7 @@ mod profile;
 mod profile_storage;
 mod publish_ir;
 mod replay;
+mod resilience;
 mod retention_status;
 mod reuse_decision;
 mod review;

--- a/engine/crates/rocky-cli/src/commands/preview.rs
+++ b/engine/crates/rocky-cli/src/commands/preview.rs
@@ -2272,6 +2272,7 @@ mod tests {
             env_hash: None,
             hash_scheme: None,
             output_column_hashes: None,
+            attempts: Vec::new(),
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/replay.rs
+++ b/engine/crates/rocky-cli/src/commands/replay.rs
@@ -1265,6 +1265,7 @@ mod tests {
                 env_hash: None,
                 hash_scheme: None,
                 output_column_hashes: None,
+                attempts: Vec::new(),
             })
             .collect();
         RunRecord {

--- a/engine/crates/rocky-cli/src/commands/resilience.rs
+++ b/engine/crates/rocky-cli/src/commands/resilience.rs
@@ -1,0 +1,689 @@
+//! Run-loop classified retry — the run's bounded, recorded self-heal.
+//!
+//! When a model's materialization fails, the run loop asks the adapter what
+//! kind of failure it was (via
+//! [`WarehouseAdapter::classify_failure`](rocky_core::traits::WarehouseAdapter::classify_failure))
+//! and re-runs the model only when the failure is a *proven* transient one,
+//! within a small bounded budget with capped backoff. Every attempt is
+//! recorded so a retried-then-succeeded model carries an honest trail.
+//!
+//! # Soundness
+//!
+//! The classifier is the soundness surface. Two failure directions are safe by
+//! construction here:
+//!
+//! - [`FailureClass::Permanent`] / [`FailureClass::Unknown`] ⇒ **never
+//!   retried** (fail closed). A type / contract error re-runs to the same
+//!   failure, so retrying it is noise; an unrecognised error is the dangerous
+//!   direction, so it stays put.
+//! - The attempt trail is **execution metadata**. It is stamped onto the
+//!   returned [`MaterializationOutput::attempts`] and rides onto
+//!   `ModelExecution.attempts`, never into the recipe / input / output identity
+//!   hashes. A model that failed once then succeeded produces byte-identical
+//!   identity to a clean first-try run.
+
+use std::time::{Duration, Instant};
+
+use rocky_core::circuit_breaker::CircuitBreaker;
+use rocky_core::config::{PolicyCapability, PolicyEffect, PolicyPrincipal, ResilienceConfig};
+use rocky_core::failure_class::FailureClass;
+use rocky_core::policy::{ModelAttributes, evaluate};
+use rocky_core::retry::compute_backoff;
+use rocky_core::retry_budget::RetryBudget;
+use rocky_core::state::AttemptRecord;
+use rocky_core::traits::{AdapterError, WarehouseAdapter};
+use tracing::warn;
+
+use crate::output::MaterializationOutput;
+
+/// Longest error message stored on an [`AttemptRecord`]; longer messages are
+/// truncated so the state blob stays bounded.
+const MAX_ATTEMPT_ERROR_LEN: usize = 500;
+
+/// The resolved policy + budget the run loop applies to one run's retries.
+///
+/// Built once per run in `execute_models` and shared (by reference) across
+/// every model — the [`RetryBudget`] and [`CircuitBreaker`] carry interior
+/// atomics, so a cap or a trip is observed run-wide even under the intra-layer
+/// concurrent path.
+pub(crate) struct ResiliencePlan<'a> {
+    /// The `[resilience]` knobs (retry count, backoff, jitter).
+    pub cfg: &'a ResilienceConfig,
+    /// Whether the agent-policy plane permits the `retry` capability for this
+    /// run. Allow-by-default (see [`retry_policy_allows`]).
+    pub policy_allows_retry: bool,
+    /// Run-level ceiling on total retries across all models.
+    pub budget: &'a RetryBudget,
+    /// Run-level consecutive-transient-failure breaker; `None` disables it
+    /// (`circuit_breaker_threshold = 0`).
+    pub breaker: Option<&'a CircuitBreaker>,
+}
+
+/// Decide whether the agent-policy plane permits run-loop retry.
+///
+/// **Allow-by-default.** Absent a `[policy]` block, or when no explicit
+/// `capability = "retry"` rule matches, retry is allowed — this is the
+/// conservative-autonomy posture the default policy gallery documents. Only an
+/// operator who writes an explicit `retry` rule (deny / require_review) gates
+/// it; the run loop then honours that verdict.
+pub(crate) fn retry_policy_allows(config: &rocky_core::config::RockyConfig) -> bool {
+    let Some(policy) = &config.policy else {
+        return true;
+    };
+    let decision = evaluate(
+        policy,
+        PolicyPrincipal::Agent,
+        PolicyCapability::Retry,
+        &ModelAttributes::default(),
+    );
+    match decision.matched_rule {
+        // No explicit retry rule — allow-by-default (ignore the generic agent
+        // posture; retry is not a mutating capability that should fall to
+        // `default_agent_effect`).
+        None => true,
+        // An explicit `retry` rule matched — honour it.
+        Some(_) => decision.effect == PolicyEffect::Allow,
+    }
+}
+
+/// Run `attempt_fn` under the classified-retry policy, returning the eventual
+/// [`MaterializationOutput`] (with its attempt trail stamped when a retry
+/// occurred) or the terminal error.
+///
+/// `attempt_fn` is invoked once per attempt; it should re-run the whole model
+/// materialization each time (a fresh timing clock is taken internally). Only
+/// a [`FailureClass::Transient`] verdict — within the per-model budget, the
+/// run-level budget, the breaker, and the policy gate — triggers a retry.
+pub(crate) async fn run_model_with_retry<F, Fut>(
+    plan: &ResiliencePlan<'_>,
+    warehouse: &dyn WarehouseAdapter,
+    model_name: &str,
+    mut attempt_fn: F,
+) -> anyhow::Result<MaterializationOutput>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<MaterializationOutput>>,
+{
+    let backoff_cfg = plan.cfg.backoff_config();
+    let mut trail: Vec<AttemptRecord> = Vec::new();
+    let mut attempt_no: u32 = 0;
+
+    loop {
+        attempt_no += 1;
+        let started = Instant::now();
+        match attempt_fn().await {
+            Ok(mut mat) => {
+                let duration_ms = started.elapsed().as_millis() as u64;
+                // A success closes the breaker (resets the consecutive count).
+                if let Some(breaker) = plan.breaker {
+                    breaker.record_success();
+                }
+                // Only surface a trail when a retry actually happened — a clean
+                // first-try success stays byte-identical to pre-retry output.
+                if attempt_no > 1 {
+                    trail.push(AttemptRecord {
+                        attempt: attempt_no,
+                        outcome: "success".to_string(),
+                        failure_class: None,
+                        transient_kind: None,
+                        error: None,
+                        backoff_ms: None,
+                        duration_ms,
+                    });
+                    mat.attempts = std::mem::take(&mut trail);
+                }
+                return Ok(mat);
+            }
+            Err(err) => {
+                let duration_ms = started.elapsed().as_millis() as u64;
+                let class = classify_anyhow(&err, warehouse);
+                // Run-loop retryability: transient AND not auth. A survived
+                // auth/permission failure is terminal here (the connector owns
+                // credential recovery); see `FailureClass::is_run_retryable`.
+                let run_retryable = class.is_run_retryable();
+
+                // Record this transient failure into the run-level breaker
+                // *before* the gate reads it, so the failure that crosses the
+                // threshold blocks its own retry (not the next one), and
+                // concurrent failures serialize through the breaker's atomic
+                // counter instead of all passing a stale pre-record `check()`.
+                // A non-run-retryable failure never counts (it isn't retried
+                // and isn't a "transient failure" for breaker purposes).
+                let breaker_ok = match (run_retryable, plan.breaker) {
+                    (true, Some(breaker)) => {
+                        breaker.record_failure(&truncate_error(&err));
+                        !breaker.is_tripped()
+                    }
+                    _ => true,
+                };
+                let within_budget = attempt_no <= plan.cfg.transient_max_retries;
+                let want_retry = plan.cfg.enabled
+                    && run_retryable
+                    && plan.policy_allows_retry
+                    && within_budget
+                    && breaker_ok;
+                // Consume the run-level budget only once every other gate has
+                // passed (short-circuit keeps the decrement side-effect-free
+                // otherwise).
+                let do_retry = want_retry && plan.budget.try_consume();
+
+                if do_retry {
+                    let backoff_ms = compute_backoff(&backoff_cfg, attempt_no - 1);
+                    trail.push(AttemptRecord {
+                        attempt: attempt_no,
+                        outcome: "failed".to_string(),
+                        failure_class: Some(class.label().to_string()),
+                        transient_kind: class.transient_kind_label().map(str::to_string),
+                        error: Some(truncate_error(&err)),
+                        backoff_ms: Some(backoff_ms),
+                        duration_ms,
+                    });
+                    warn!(
+                        model = model_name,
+                        attempt = attempt_no,
+                        class = class.label(),
+                        kind = class.transient_kind_label().unwrap_or(""),
+                        backoff_ms,
+                        "transient model failure — retrying after backoff"
+                    );
+                    if backoff_ms > 0 {
+                        tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+                    }
+                    continue;
+                }
+
+                // Terminal: permanent / unknown, budget exhausted, breaker
+                // tripped, or policy-gated. The trail is not surfaced (no
+                // materialization is produced); the error propagates as before.
+                return Err(err);
+            }
+        }
+    }
+}
+
+/// Extract a [`FailureClass`] from an `anyhow` error chain by finding the
+/// adapter's [`AdapterError`] and asking the adapter to classify it.
+///
+/// The run loop wraps adapter errors with `.context(...)`, so the
+/// [`AdapterError`] is a *cause*, not the outermost error — walk the chain.
+/// No [`AdapterError`] in the chain ⇒ [`FailureClass::Unknown`] (fail closed).
+pub(crate) fn classify_anyhow(
+    err: &anyhow::Error,
+    warehouse: &dyn WarehouseAdapter,
+) -> FailureClass {
+    for cause in err.chain() {
+        if let Some(adapter_err) = cause.downcast_ref::<AdapterError>() {
+            return warehouse.classify_failure(adapter_err);
+        }
+    }
+    FailureClass::Unknown
+}
+
+/// Render an error to a single bounded line for the attempt trail.
+fn truncate_error(err: &anyhow::Error) -> String {
+    let mut msg = format!("{err:#}");
+    if msg.len() > MAX_ATTEMPT_ERROR_LEN {
+        msg.truncate(MAX_ATTEMPT_ERROR_LEN);
+        msg.push('…');
+    }
+    msg
+}
+
+// The fault-injection tests reuse the real DuckDB dialect + classifier, which
+// live behind the default `duckdb` feature. Gate on it so a
+// `--no-default-features` build still compiles this module.
+#[cfg(all(test, feature = "duckdb"))]
+mod tests {
+    use super::*;
+    use rocky_core::failure_class::TransientKind;
+    use rocky_duckdb::adapter::classify_duckdb_failure;
+    use rocky_duckdb::dialect::DuckDbSqlDialect;
+
+    /// A fault-injecting adapter: the first `fail_transient_times` calls to
+    /// `execute_statement` return a transient error, then it succeeds. Used to
+    /// drive the retry loop without a live warehouse.
+    struct FlakyAdapter {
+        remaining_transient_failures: std::sync::atomic::AtomicU32,
+        dialect: DuckDbSqlDialect,
+    }
+
+    impl FlakyAdapter {
+        fn new(fail_transient_times: u32) -> Self {
+            Self {
+                remaining_transient_failures: std::sync::atomic::AtomicU32::new(
+                    fail_transient_times,
+                ),
+                dialect: DuckDbSqlDialect,
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl WarehouseAdapter for FlakyAdapter {
+        fn dialect(&self) -> &dyn rocky_core::traits::SqlDialect {
+            &self.dialect
+        }
+        async fn execute_statement(&self, _sql: &str) -> rocky_core::traits::AdapterResult<()> {
+            use std::sync::atomic::Ordering;
+            if self.remaining_transient_failures.load(Ordering::SeqCst) > 0 {
+                self.remaining_transient_failures
+                    .fetch_sub(1, Ordering::SeqCst);
+                return Err(AdapterError::msg("Could not set lock on file: busy"));
+            }
+            Ok(())
+        }
+        async fn execute_query(
+            &self,
+            _sql: &str,
+        ) -> rocky_core::traits::AdapterResult<rocky_core::traits::QueryResult> {
+            Ok(rocky_core::traits::QueryResult {
+                columns: vec![],
+                rows: vec![],
+            })
+        }
+        async fn describe_table(
+            &self,
+            _table: &rocky_ir::TableRef,
+        ) -> rocky_core::traits::AdapterResult<Vec<rocky_ir::ColumnInfo>> {
+            Ok(vec![])
+        }
+        // The classifier under test: our injected lock error is transient.
+        fn classify_failure(&self, err: &AdapterError) -> FailureClass {
+            classify_duckdb_failure(err)
+        }
+    }
+
+    fn sample_mat() -> MaterializationOutput {
+        MaterializationOutput {
+            asset_key: vec!["main".into(), "orders".into()],
+            rows_copied: None,
+            duration_ms: 1,
+            started_at: chrono::Utc::now(),
+            metadata: crate::output::MaterializationMetadata {
+                strategy: "full_refresh".into(),
+                watermark: None,
+                target_table_full_name: Some("cat.main.orders".into()),
+                sql_hash: Some("h".into()),
+                column_count: None,
+                compile_time_ms: None,
+            },
+            partition: None,
+            cost_usd: None,
+            bytes_scanned: None,
+            bytes_written: None,
+            tenant: None,
+            job_ids: vec![],
+            attempts: Vec::new(),
+            skip_internal: None,
+            recipe_identity: None,
+            output_column_hashes: None,
+            consumed_column_baseline: None,
+        }
+    }
+
+    fn plan_for<'a>(
+        cfg: &'a ResilienceConfig,
+        budget: &'a RetryBudget,
+        breaker: Option<&'a CircuitBreaker>,
+    ) -> ResiliencePlan<'a> {
+        ResiliencePlan {
+            cfg,
+            policy_allows_retry: true,
+            budget,
+            breaker,
+        }
+    }
+
+    /// A model that fails twice transiently then succeeds completes, and the
+    /// stamped trail names the two failed attempts + the successful third.
+    #[tokio::test]
+    async fn flaky_then_success_records_attempt_trail() {
+        let adapter = FlakyAdapter::new(2);
+        let cfg = ResilienceConfig {
+            initial_backoff_ms: 0,
+            jitter: false,
+            ..Default::default()
+        };
+        let budget = RetryBudget::from_config(cfg.max_retries_per_run);
+        let breaker = CircuitBreaker::new(cfg.circuit_breaker_threshold);
+        let plan = plan_for(&cfg, &budget, Some(&breaker));
+
+        let mat = run_model_with_retry(&plan, &adapter, "orders", || {
+            let adapter = &adapter;
+            async move {
+                adapter
+                    .execute_statement("CREATE TABLE orders AS SELECT 1")
+                    .await
+                    .map(|()| sample_mat())
+                    .map_err(|e| anyhow::Error::from(e).context("model 'orders' failed"))
+            }
+        })
+        .await
+        .expect("model should recover after transient failures");
+
+        assert_eq!(mat.attempts.len(), 3, "two failures + one success");
+        assert_eq!(mat.attempts[0].outcome, "failed");
+        assert_eq!(mat.attempts[0].failure_class.as_deref(), Some("transient"));
+        assert_eq!(
+            mat.attempts[0].transient_kind.as_deref(),
+            Some(TransientKind::ServerBusy.label())
+        );
+        assert_eq!(mat.attempts[2].outcome, "success");
+        assert_eq!(mat.attempts[2].attempt, 3);
+    }
+
+    /// A clean first-try success surfaces no trail — output stays byte-identical
+    /// to the pre-retry path.
+    #[tokio::test]
+    async fn clean_first_try_has_empty_trail() {
+        let adapter = FlakyAdapter::new(0);
+        let cfg = ResilienceConfig::default();
+        let budget = RetryBudget::from_config(cfg.max_retries_per_run);
+        let plan = plan_for(&cfg, &budget, None);
+
+        let mat = run_model_with_retry(&plan, &adapter, "orders", || {
+            let adapter = &adapter;
+            async move {
+                adapter
+                    .execute_statement("CREATE TABLE orders AS SELECT 1")
+                    .await
+                    .map(|()| sample_mat())
+                    .map_err(anyhow::Error::from)
+            }
+        })
+        .await
+        .unwrap();
+        assert!(mat.attempts.is_empty());
+    }
+
+    /// The per-model budget bounds retries: 5 transient failures with
+    /// `transient_max_retries = 2` still fails terminally (3 attempts total).
+    #[tokio::test]
+    async fn exhausts_budget_and_fails_terminally() {
+        let adapter = FlakyAdapter::new(5);
+        let cfg = ResilienceConfig {
+            transient_max_retries: 2,
+            initial_backoff_ms: 0,
+            jitter: false,
+            ..Default::default()
+        };
+        let budget = RetryBudget::unbounded();
+        let plan = plan_for(&cfg, &budget, None);
+
+        let attempts = std::sync::atomic::AtomicU32::new(0);
+        let result = run_model_with_retry(&plan, &adapter, "orders", || {
+            attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let adapter = &adapter;
+            async move {
+                adapter
+                    .execute_statement("x")
+                    .await
+                    .map(|()| sample_mat())
+                    .map_err(anyhow::Error::from)
+            }
+        })
+        .await;
+        assert!(result.is_err());
+        // 1 initial + 2 retries = 3 invocations, then it gives up.
+        assert_eq!(attempts.load(std::sync::atomic::Ordering::SeqCst), 3);
+    }
+
+    /// A permanent failure is never retried — a single attempt, then the error.
+    #[tokio::test]
+    async fn permanent_failure_not_retried() {
+        struct PermAdapter(DuckDbSqlDialect);
+        #[async_trait::async_trait]
+        impl WarehouseAdapter for PermAdapter {
+            fn dialect(&self) -> &dyn rocky_core::traits::SqlDialect {
+                &self.0
+            }
+            async fn execute_statement(&self, _sql: &str) -> rocky_core::traits::AdapterResult<()> {
+                Err(AdapterError::msg("Catalog Error: table does not exist"))
+            }
+            async fn execute_query(
+                &self,
+                _sql: &str,
+            ) -> rocky_core::traits::AdapterResult<rocky_core::traits::QueryResult> {
+                unreachable!()
+            }
+            async fn describe_table(
+                &self,
+                _t: &rocky_ir::TableRef,
+            ) -> rocky_core::traits::AdapterResult<Vec<rocky_ir::ColumnInfo>> {
+                Ok(vec![])
+            }
+            fn classify_failure(&self, err: &AdapterError) -> FailureClass {
+                classify_duckdb_failure(err)
+            }
+        }
+        let adapter = PermAdapter(DuckDbSqlDialect);
+        let cfg = ResilienceConfig {
+            initial_backoff_ms: 0,
+            jitter: false,
+            ..Default::default()
+        };
+        let budget = RetryBudget::unbounded();
+        let plan = plan_for(&cfg, &budget, None);
+
+        let attempts = std::sync::atomic::AtomicU32::new(0);
+        let result = run_model_with_retry(&plan, &adapter, "orders", || {
+            attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let adapter = &adapter;
+            async move {
+                adapter
+                    .execute_statement("x")
+                    .await
+                    .map(|()| sample_mat())
+                    .map_err(anyhow::Error::from)
+            }
+        })
+        .await;
+        assert!(result.is_err());
+        assert_eq!(
+            attempts.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "a permanent failure must not be retried"
+        );
+    }
+
+    /// `enabled = false` restores single-attempt behaviour even for a transient
+    /// failure.
+    #[tokio::test]
+    async fn disabled_does_not_retry() {
+        let adapter = FlakyAdapter::new(1);
+        let cfg = ResilienceConfig {
+            enabled: false,
+            ..Default::default()
+        };
+        let budget = RetryBudget::unbounded();
+        let plan = plan_for(&cfg, &budget, None);
+        let result = run_model_with_retry(&plan, &adapter, "orders", || {
+            let adapter = &adapter;
+            async move {
+                adapter
+                    .execute_statement("x")
+                    .await
+                    .map(|()| sample_mat())
+                    .map_err(anyhow::Error::from)
+            }
+        })
+        .await;
+        assert!(
+            result.is_err(),
+            "disabled ⇒ the one transient failure sticks"
+        );
+    }
+
+    /// Policy gating off ⇒ no retry even for a transient failure.
+    #[tokio::test]
+    async fn policy_denied_does_not_retry() {
+        let adapter = FlakyAdapter::new(1);
+        let cfg = ResilienceConfig {
+            initial_backoff_ms: 0,
+            jitter: false,
+            ..Default::default()
+        };
+        let budget = RetryBudget::unbounded();
+        let plan = ResiliencePlan {
+            cfg: &cfg,
+            policy_allows_retry: false,
+            budget: &budget,
+            breaker: None,
+        };
+        let result = run_model_with_retry(&plan, &adapter, "orders", || {
+            let adapter = &adapter;
+            async move {
+                adapter
+                    .execute_statement("x")
+                    .await
+                    .map(|()| sample_mat())
+                    .map_err(anyhow::Error::from)
+            }
+        })
+        .await;
+        assert!(result.is_err());
+    }
+
+    /// Drive a model through the retry helper, counting how many times the
+    /// materialization was actually attempted.
+    async fn count_attempts(plan: &ResiliencePlan<'_>, adapter: &FlakyAdapter, name: &str) -> u32 {
+        let calls = std::sync::atomic::AtomicU32::new(0);
+        let _ = run_model_with_retry(plan, adapter, name, || {
+            calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let adapter = &adapter;
+            async move {
+                adapter
+                    .execute_statement("x")
+                    .await
+                    .map(|()| sample_mat())
+                    .map_err(anyhow::Error::from)
+            }
+        })
+        .await;
+        calls.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    /// 🔴 Breaker ordering (record-before-check): with `circuit_breaker_threshold
+    /// = 1`, the FIRST transient failure trips the breaker and blocks its own
+    /// retry — the model is attempted exactly once. Under the pre-fix
+    /// check-before-record order this failure's retry slipped through (the
+    /// breaker was always one failure late).
+    #[tokio::test]
+    async fn breaker_threshold_one_blocks_the_first_retry() {
+        let adapter = FlakyAdapter::new(5); // would otherwise keep failing
+        let cfg = ResilienceConfig {
+            transient_max_retries: 5, // budget is not the bound under test
+            initial_backoff_ms: 0,
+            jitter: false,
+            circuit_breaker_threshold: 1,
+            ..Default::default()
+        };
+        let budget = RetryBudget::unbounded();
+        let breaker = CircuitBreaker::new(1);
+        let plan = plan_for(&cfg, &budget, Some(&breaker));
+
+        assert_eq!(
+            count_attempts(&plan, &adapter, "orders").await,
+            1,
+            "threshold=1 must block the first transient failure's own retry"
+        );
+    }
+
+    /// 🔴 The run-level breaker is shared across models (by reference, with an
+    /// atomic counter — the same instance the intra-layer concurrent path
+    /// holds). Once consecutive transient failures cross the threshold, no
+    /// further model is retried for the rest of the run. With threshold=2 and
+    /// two always-failing models: the first exhausts one retry then trips the
+    /// breaker on its 2nd failure (2 attempts); the second sees an already-open
+    /// breaker and is attempted once (0 retries). N failures past the threshold
+    /// do NOT all retry.
+    #[tokio::test]
+    async fn shared_breaker_stops_run_wide_retries_after_threshold() {
+        let cfg = ResilienceConfig {
+            transient_max_retries: 5,
+            initial_backoff_ms: 0,
+            jitter: false,
+            circuit_breaker_threshold: 2,
+            ..Default::default()
+        };
+        let budget = RetryBudget::unbounded();
+        let breaker = CircuitBreaker::new(2);
+        let plan = plan_for(&cfg, &budget, Some(&breaker));
+
+        let model_a = FlakyAdapter::new(100);
+        let model_b = FlakyAdapter::new(100);
+        assert_eq!(
+            count_attempts(&plan, &model_a, "a").await,
+            2,
+            "model A retries once, then its 2nd failure trips the breaker"
+        );
+        assert_eq!(
+            count_attempts(&plan, &model_b, "b").await,
+            1,
+            "model B sees the tripped breaker and is not retried"
+        );
+    }
+
+    /// 🔴 Auth exclusion: an auth/permission failure that survived the adapter's
+    /// own token-refresh retry and reached the run loop is terminal — the run
+    /// loop must not re-run a permission denial. A single attempt, then the
+    /// error.
+    #[tokio::test]
+    async fn run_loop_does_not_retry_survived_auth_failure() {
+        struct AuthAdapter(DuckDbSqlDialect);
+        #[async_trait::async_trait]
+        impl WarehouseAdapter for AuthAdapter {
+            fn dialect(&self) -> &dyn rocky_core::traits::SqlDialect {
+                &self.0
+            }
+            async fn execute_statement(&self, _sql: &str) -> rocky_core::traits::AdapterResult<()> {
+                Err(AdapterError::msg("API error 403: permission denied"))
+            }
+            async fn execute_query(
+                &self,
+                _sql: &str,
+            ) -> rocky_core::traits::AdapterResult<rocky_core::traits::QueryResult> {
+                unreachable!()
+            }
+            async fn describe_table(
+                &self,
+                _t: &rocky_ir::TableRef,
+            ) -> rocky_core::traits::AdapterResult<Vec<rocky_ir::ColumnInfo>> {
+                Ok(vec![])
+            }
+            // Survived-auth classified transient-auth (as an adapter's own
+            // token-refresh judgement would) — the run loop must still refuse.
+            fn classify_failure(&self, _err: &AdapterError) -> FailureClass {
+                FailureClass::Transient(TransientKind::Auth)
+            }
+        }
+        let adapter = AuthAdapter(DuckDbSqlDialect);
+        let cfg = ResilienceConfig {
+            initial_backoff_ms: 0,
+            jitter: false,
+            ..Default::default()
+        };
+        let budget = RetryBudget::unbounded();
+        let plan = plan_for(&cfg, &budget, None);
+
+        let calls = std::sync::atomic::AtomicU32::new(0);
+        let result = run_model_with_retry(&plan, &adapter, "orders", || {
+            calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let adapter = &adapter;
+            async move {
+                adapter
+                    .execute_statement("x")
+                    .await
+                    .map(|()| sample_mat())
+                    .map_err(anyhow::Error::from)
+            }
+        })
+        .await;
+        assert!(result.is_err());
+        assert_eq!(
+            calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "a survived auth/permission failure must not be retried at the run loop"
+        );
+    }
+}

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1280,6 +1280,8 @@ pub async fn run(
             // orthogonal to the point-to switch above and to `--no-reuse`.
             rocky_cfg.reuse.column_level,
             run_vars,
+            rocky_cfg.resilience.clone(),
+            super::resilience::retry_policy_allows(&rocky_cfg),
         )
         .await;
 
@@ -3754,6 +3756,8 @@ pub async fn run(
                     // sub-key, orthogonal to the point-to switch and `--no-reuse`.
                     rocky_cfg.reuse.column_level,
                     run_vars,
+                    rocky_cfg.resilience.clone(),
+                    super::resilience::retry_policy_allows(&rocky_cfg),
                 )
                 .await?;
                 Ok(())
@@ -4664,8 +4668,34 @@ pub(crate) async fn execute_models(
     // Empty for the call sites that don't expose `--var` (watch / dag / local
     // / tests).
     run_vars: &rocky_core::run_vars::RunVars,
+    // `[resilience]` — the run loop's classified-retry policy. Governs whether a
+    // model whose materialization fails *transiently* is re-run (bounded budget,
+    // capped backoff). On by default; a Permanent / Unknown failure never
+    // retries. Passed by value (cheap `Clone`) so call sites don't juggle a
+    // borrow of the `RockyConfig`.
+    resilience: rocky_core::config::ResilienceConfig,
+    // Whether the agent-policy plane permits the `retry` capability for this
+    // run (allow-by-default; only an explicit `capability = "retry"` policy rule
+    // gates it). Resolved once by the caller from `[policy]`.
+    retry_policy_allows: bool,
 ) -> Result<()> {
     info!(models_dir = %models_dir.display(), "compiling and executing transformation models");
+
+    // Build the run-scoped classified-retry plan once. The budget + breaker
+    // carry interior atomics, so their caps are observed across the whole run
+    // (serial or intra-layer concurrent). `circuit_breaker_threshold = 0`
+    // disables the breaker.
+    let retry_budget =
+        rocky_core::retry_budget::RetryBudget::from_config(resilience.max_retries_per_run);
+    let retry_breaker = (resilience.circuit_breaker_threshold > 0).then(|| {
+        rocky_core::circuit_breaker::CircuitBreaker::new(resilience.circuit_breaker_threshold)
+    });
+    let resilience_plan = super::resilience::ResiliencePlan {
+        cfg: &resilience,
+        policy_allows_retry: retry_policy_allows,
+        budget: &retry_budget,
+        breaker: retry_breaker.as_ref(),
+    };
 
     // Load the persisted schema cache directly from the live
     // `StateStore` — no round-trip through
@@ -5062,19 +5092,31 @@ pub(crate) async fn execute_models(
             let matched_ref = &matched;
             let mut layer_results: Vec<(usize, &String, Result<MaterializationOutput>)> =
                 futures::stream::iter(0..matched.len())
-                    .map(|idx| async move {
-                        let (_, name, model) = matched_ref[idx];
-                        let model_start = Instant::now();
-                        let r = execute_one_plain_model(
-                            model,
-                            warehouse,
-                            dialect,
-                            name,
-                            model_start,
-                            exec_ctx,
-                        )
-                        .await;
-                        (idx, name, r)
+                    .map(|idx| {
+                        let plan = &resilience_plan;
+                        async move {
+                            let (_, name, model) = matched_ref[idx];
+                            // Classified retry wraps each attempt: a fresh
+                            // timing clock per try, transient-only re-run,
+                            // attempt trail stamped onto the output.
+                            let r = super::resilience::run_model_with_retry(
+                                plan,
+                                warehouse,
+                                name,
+                                || {
+                                    execute_one_plain_model(
+                                        model,
+                                        warehouse,
+                                        dialect,
+                                        name,
+                                        Instant::now(),
+                                        exec_ctx,
+                                    )
+                                },
+                            )
+                            .await;
+                            (idx, name, r)
+                        }
                     })
                     .buffer_unordered(concurrency)
                     .collect()
@@ -5303,6 +5345,7 @@ pub(crate) async fn execute_models(
                         );
                         output.materializations.push(MaterializationOutput {
                             asset_key,
+                            attempts: Vec::new(),
                             rows_copied: Some(summary.num_rows as u64),
                             duration_ms,
                             started_at: model_started_at,
@@ -5597,14 +5640,26 @@ pub(crate) async fn execute_models(
 
             // Plain single-statement strategy: delegate to the shared
             // helper so the serial and intra-layer concurrent paths produce
-            // identical output by construction.
-            match execute_one_plain_model(
-                model,
+            // identical output by construction. Wrapped in classified retry:
+            // a transient failure re-runs the model (bounded), recording an
+            // attempt trail on the output. Each attempt takes a fresh timing
+            // clock inside the retry helper; the loop's `model_start` binding is
+            // still consumed by the sibling content-addressed / time_interval
+            // branches above.
+            match super::resilience::run_model_with_retry(
+                &resilience_plan,
                 warehouse,
-                dialect,
                 model_name,
-                model_start,
-                exec_ctx,
+                || {
+                    execute_one_plain_model(
+                        model,
+                        warehouse,
+                        dialect,
+                        model_name,
+                        Instant::now(),
+                        exec_ctx,
+                    )
+                },
             )
             .await
             {
@@ -6371,6 +6426,7 @@ async fn execute_one_plain_model(
     ];
     Ok(MaterializationOutput {
         asset_key,
+        attempts: Vec::new(),
         rows_copied: None,
         duration_ms: model_duration_ms,
         started_at: model_started_at,
@@ -6802,6 +6858,7 @@ async fn run_one_partition(
         partition_key: key.clone(),
         outcome: Ok(MaterializationOutput {
             asset_key: asset_key.to_vec(),
+            attempts: Vec::new(),
             rows_copied: None,
             duration_ms: record.duration_ms,
             started_at: partition_started_at,
@@ -7713,6 +7770,7 @@ async fn process_table(
     Ok(TableOutcome::Materialized(Box::new(TableResult {
         materialization: MaterializationOutput {
             asset_key: asset_key.clone(),
+            attempts: Vec::new(),
             rows_copied: None,
             duration_ms: table_duration,
             started_at: table_started_at,
@@ -10372,6 +10430,8 @@ merge_keys = ["id"]
             false,
             false,
             &rocky_core::run_vars::RunVars::new(),
+            rocky_core::config::ResilienceConfig::default(),
+            true,
         )
         .await;
         (output, result)
@@ -10441,6 +10501,8 @@ merge_keys = ["id"]
             false,
             false,
             &run_vars,
+            rocky_core::config::ResilienceConfig::default(),
+            true,
         )
         .await
         .expect("run with --var should succeed");
@@ -10543,6 +10605,8 @@ merge_keys = ["id"]
             false,
             false,
             &rocky_core::run_vars::RunVars::new(),
+            rocky_core::config::ResilienceConfig::default(),
+            true,
         )
         .await
         .expect("deferred run must succeed");
@@ -10660,6 +10724,8 @@ merge_keys = ["id"]
             false,
             false,
             &rocky_core::run_vars::RunVars::new(),
+            rocky_core::config::ResilienceConfig::default(),
+            true,
         )
         .await;
 
@@ -10938,6 +11004,8 @@ merge_keys = ["id"]
                 false,
                 false,
                 &rocky_core::run_vars::RunVars::new(),
+                rocky_core::config::ResilienceConfig::default(),
+                true,
             )
             .await
             .expect("backfill run must succeed on serial DuckDB under --parallel");
@@ -11059,6 +11127,8 @@ merge_keys = ["id"]
             false,
             false,
             &rocky_core::run_vars::RunVars::new(),
+            rocky_core::config::ResilienceConfig::default(),
+            true,
         )
         .await
         .expect("gate run must succeed");
@@ -11578,6 +11648,7 @@ merge_keys = ["id"]
                 env_hash: None,
                 hash_scheme: None,
                 output_column_hashes: None,
+                attempts: Vec::new(),
             }],
             trigger: rocky_core::state::RunTrigger::Manual,
             config_hash: "cfg".to_string(),
@@ -12026,6 +12097,8 @@ merge_keys = ["id"]
                 false,
                 false,
                 &rocky_core::run_vars::RunVars::new(),
+                rocky_core::config::ResilienceConfig::default(),
+                true,
             )
             .await
             .unwrap();
@@ -12728,6 +12801,7 @@ merge_keys = ["id"]
             // fct's own OUTPUT hashes — propagated on a skip so a later
             // content-addressed consumer sees fct's current output == its prior.
             output_column_hashes: Some(vec![ch("amount", "H_FCT_OUT")]),
+            attempts: Vec::new(),
         };
         let run = rocky_core::state::RunRecord {
             run_id: "run-1".to_string(),
@@ -12923,6 +12997,237 @@ table = "fct_events"
             count_target(&adapter).await,
             source_rows * 2,
             "second run reuses the existing table and appends through the INSERT path"
+        );
+    }
+
+    /// End-to-end reachability + the load-bearing identity invariant for
+    /// classified retry.
+    ///
+    /// Drives the REAL `execute_one_plain_model` runtime path through the
+    /// run-loop retry helper against in-memory DuckDB, with a fault-injecting
+    /// adapter that fails the model's first materialization statement with a
+    /// *transient* error (a DuckDB lock message) then delegates.
+    ///
+    /// Proves two things:
+    /// 1. **Reachability** — a flaky run that used to fail now completes, and
+    ///    the recovered `MaterializationOutput` carries an attempt trail
+    ///    (one failed attempt + the successful retry).
+    /// 2. **🔴 Identity invariant** — the retried-then-succeeded build produces
+    ///    a byte-identical recipe identity (`recipe_hash` / `env_hash` /
+    ///    `hash_scheme`) and byte-identical materialized data to a clean
+    ///    first-try build. Attempt history is execution metadata; it never
+    ///    leaks into the identity a downstream `history --recipe` / replay /
+    ///    verify reads.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn flaky_transient_run_recovers_with_trail_and_identical_identity() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        use std::time::Instant;
+
+        use async_trait::async_trait;
+        use rocky_core::models::load_model_pair;
+        use rocky_core::traits::{
+            AdapterError, AdapterResult, ExecutionStats, QueryResult, SqlDialect, WarehouseAdapter,
+        };
+        use rocky_duckdb::adapter::{DuckDbWarehouseAdapter, classify_duckdb_failure};
+        use rocky_duckdb::dialect::DuckDbSqlDialect;
+
+        // A fault-injecting adapter: the first `fail_next` calls to
+        // `execute_statement_with_stats` return a transient DuckDB lock error;
+        // every other call (and every other method) delegates to real DuckDB.
+        struct FlakyDuckDb<'a> {
+            inner: &'a DuckDbWarehouseAdapter,
+            fail_next: AtomicU32,
+        }
+        #[async_trait]
+        impl WarehouseAdapter for FlakyDuckDb<'_> {
+            fn dialect(&self) -> &dyn SqlDialect {
+                self.inner.dialect()
+            }
+            async fn execute_statement(&self, sql: &str) -> AdapterResult<()> {
+                self.inner.execute_statement(sql).await
+            }
+            async fn execute_statement_with_stats(
+                &self,
+                sql: &str,
+            ) -> AdapterResult<ExecutionStats> {
+                if self.fail_next.load(Ordering::SeqCst) > 0 {
+                    self.fail_next.fetch_sub(1, Ordering::SeqCst);
+                    // A transient DuckDB message → classified `Transient`.
+                    return Err(AdapterError::msg(
+                        "IO Error: Could not set lock on file \"poc.duckdb\"",
+                    ));
+                }
+                self.inner.execute_statement_with_stats(sql).await
+            }
+            async fn execute_query(&self, sql: &str) -> AdapterResult<QueryResult> {
+                self.inner.execute_query(sql).await
+            }
+            async fn describe_table(
+                &self,
+                table: &rocky_ir::TableRef,
+            ) -> AdapterResult<Vec<rocky_ir::ColumnInfo>> {
+                self.inner.describe_table(table).await
+            }
+            fn classify_failure(
+                &self,
+                err: &AdapterError,
+            ) -> rocky_core::failure_class::FailureClass {
+                classify_duckdb_failure(err)
+            }
+        }
+
+        let inner = DuckDbWarehouseAdapter::in_memory().unwrap();
+        for ddl in [
+            "CREATE SCHEMA src",
+            "CREATE SCHEMA tgt",
+            "CREATE TABLE src.events (id INTEGER, region VARCHAR)",
+            "INSERT INTO src.events VALUES (1, 'a'), (2, 'b'), (3, 'c')",
+        ] {
+            inner.execute_statement(ddl).await.unwrap();
+        }
+
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("fct.toml"),
+            "name = \"fct\"\n\n[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"\"\nschema = \"tgt\"\ntable = \"fct\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("fct.sql"),
+            "SELECT id, region FROM src.events",
+        )
+        .unwrap();
+        let model = load_model_pair(
+            &dir.path().join("fct.sql"),
+            &dir.path().join("fct.toml"),
+            None,
+        )
+        .expect("load model");
+
+        let dialect = DuckDbSqlDialect;
+        let typed_models = indexmap::IndexMap::new();
+        let model_timings = std::collections::HashMap::new();
+        let surrogate_keys = std::collections::HashMap::new();
+        let exec_ctx = super::ExecutionContext {
+            typed_models: &typed_models,
+            model_timings: &model_timings,
+            surrogate_keys: &surrogate_keys,
+        };
+
+        // Conservative resilience config with zero backoff so the test is fast;
+        // one injected transient failure is within the default `2` budget.
+        let cfg = rocky_core::config::ResilienceConfig {
+            initial_backoff_ms: 0,
+            jitter: false,
+            ..Default::default()
+        };
+        let budget = rocky_core::retry_budget::RetryBudget::from_config(cfg.max_retries_per_run);
+        let plan = crate::commands::resilience::ResiliencePlan {
+            cfg: &cfg,
+            policy_allows_retry: true,
+            budget: &budget,
+            breaker: None,
+        };
+
+        async fn dump(adapter: &DuckDbWarehouseAdapter) -> Vec<Vec<serde_json::Value>> {
+            adapter
+                .execute_query("SELECT id, region FROM tgt.fct ORDER BY id")
+                .await
+                .expect("dump target")
+                .rows
+        }
+
+        // --- Clean first-try build (no injected failures). ---
+        let clean_adapter = FlakyDuckDb {
+            inner: &inner,
+            fail_next: AtomicU32::new(0),
+        };
+        let mat_clean =
+            crate::commands::resilience::run_model_with_retry(&plan, &clean_adapter, "fct", || {
+                super::execute_one_plain_model(
+                    &model,
+                    &clean_adapter as &dyn WarehouseAdapter,
+                    &dialect as &dyn SqlDialect,
+                    "fct",
+                    Instant::now(),
+                    exec_ctx,
+                )
+            })
+            .await
+            .expect("clean build succeeds");
+        assert!(
+            mat_clean.attempts.is_empty(),
+            "a clean first-try success carries no attempt trail"
+        );
+        let clean_rows = dump(&inner).await;
+
+        // Reset the target so the flaky build re-materializes from scratch.
+        inner.execute_statement("DROP TABLE tgt.fct").await.unwrap();
+
+        // --- Flaky build: first materialization statement fails transiently. ---
+        let flaky_adapter = FlakyDuckDb {
+            inner: &inner,
+            fail_next: AtomicU32::new(1),
+        };
+        let mat_flaky =
+            crate::commands::resilience::run_model_with_retry(&plan, &flaky_adapter, "fct", || {
+                super::execute_one_plain_model(
+                    &model,
+                    &flaky_adapter as &dyn WarehouseAdapter,
+                    &dialect as &dyn SqlDialect,
+                    "fct",
+                    Instant::now(),
+                    exec_ctx,
+                )
+            })
+            .await
+            .expect("flaky build recovers after a transient failure");
+
+        // (1) Reachability: recovered, with an honest attempt trail.
+        assert_eq!(
+            mat_flaky.attempts.len(),
+            2,
+            "one failed attempt + the successful retry"
+        );
+        assert_eq!(mat_flaky.attempts[0].outcome, "failed");
+        assert_eq!(
+            mat_flaky.attempts[0].failure_class.as_deref(),
+            Some("transient")
+        );
+        assert_eq!(
+            mat_flaky.attempts[0].transient_kind.as_deref(),
+            Some("server_busy")
+        );
+        assert_eq!(mat_flaky.attempts[1].outcome, "success");
+        let flaky_rows = dump(&inner).await;
+
+        // (2) 🔴 Identity invariant: recipe identity + materialized data are
+        // byte-identical to the clean build; only the attempt trail differs.
+        let id_clean = mat_clean
+            .recipe_identity
+            .as_ref()
+            .expect("clean recipe identity");
+        let id_flaky = mat_flaky
+            .recipe_identity
+            .as_ref()
+            .expect("flaky recipe identity");
+        assert_eq!(
+            id_clean.recipe_hash, id_flaky.recipe_hash,
+            "recipe_hash must be identical — retry never touches program identity"
+        );
+        assert_eq!(id_clean.env_hash, id_flaky.env_hash, "env_hash identical");
+        assert_eq!(
+            id_clean.hash_scheme, id_flaky.hash_scheme,
+            "hash scheme identical"
+        );
+        assert_eq!(
+            mat_clean.metadata.sql_hash, mat_flaky.metadata.sql_hash,
+            "sql fingerprint identical"
+        );
+        assert_eq!(
+            clean_rows, flaky_rows,
+            "the retried-then-succeeded build materializes byte-identical data"
         );
     }
 }

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -122,6 +122,8 @@ pub async fn run_transformation(
             // Content-addressed column-level skip (its own `[reuse]` sub-key).
             rocky_cfg.reuse.column_level,
             run_vars,
+            rocky_cfg.resilience.clone(),
+            super::resilience::retry_policy_allows(rocky_cfg),
         )
         .await;
 
@@ -846,6 +848,7 @@ pub async fn run_snapshot(
     if tables_failed == 0 {
         output.tables_copied = 1;
         output.materializations.push(MaterializationOutput {
+            attempts: Vec::new(),
             asset_key: vec![
                 pipeline.target.catalog.clone(),
                 pipeline.target.schema.clone(),

--- a/engine/crates/rocky-cli/src/commands/trace.rs
+++ b/engine/crates/rocky-cli/src/commands/trace.rs
@@ -253,6 +253,7 @@ mod tests {
             env_hash: None,
             hash_scheme: None,
             output_column_hashes: None,
+            attempts: Vec::new(),
         }
     }
 

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -949,6 +949,16 @@ pub struct MaterializationOutput {
     /// (Databricks, Snowflake).
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub job_ids: Vec<String>,
+    /// The classified-retry attempt trail for this materialization: one
+    /// [`AttemptRecord`](rocky_core::state::AttemptRecord) per try. Empty
+    /// (and omitted from JSON) for a clean first-try success — the run loop
+    /// only stamps a trail once a retry actually happened, so a non-retried
+    /// build's output stays byte-identical to before this layer shipped.
+    /// [`RunOutput::to_run_record`] copies this verbatim onto the persisted
+    /// `ModelExecution.attempts` — one attempt type on both the wire and the
+    /// state record.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub attempts: Vec<rocky_core::state::AttemptRecord>,
     /// State-internal skip-gate outputs, co-located with the model they
     /// describe so [`RunOutput::to_run_record`] can copy them onto the
     /// persisted `ModelExecution` without a second name-keyed map. Stamped
@@ -4669,6 +4679,11 @@ impl RunOutput {
                 // content-addressed runner on a genuine unpartitioned build;
                 // `None` on every other path (carried straight through).
                 output_column_hashes: mat.output_column_hashes.clone(),
+                // Classified-retry attempt trail (schema v16). Execution
+                // metadata — carried alongside the identity hashes above,
+                // never inside them, so a retried-then-succeeded build stays
+                // byte-indistinguishable downstream from a first-try success.
+                attempts: mat.attempts.clone(),
             });
         }
 
@@ -4703,6 +4718,11 @@ impl RunOutput {
                 hash_scheme: None,
                 // A failed execution recorded no output columns.
                 output_column_hashes: None,
+                // A run-level error entry (no per-model materialization)
+                // carries no attempt trail; the failing model's own attempts,
+                // when the retry layer produced them, ride on its
+                // `MaterializationOutput` instead.
+                attempts: Vec::new(),
             });
         }
 
@@ -5055,6 +5075,7 @@ mod cost_finalize_tests {
     fn mat(asset_key: &[&str], duration_ms: u64) -> MaterializationOutput {
         MaterializationOutput {
             asset_key: asset_key.iter().map(|s| (*s).to_string()).collect(),
+            attempts: Vec::new(),
             rows_copied: None,
             duration_ms,
             started_at: Utc::now(),
@@ -5271,6 +5292,7 @@ mod run_record_tests {
     ) -> MaterializationOutput {
         MaterializationOutput {
             asset_key: asset_key.iter().map(|s| (*s).to_string()).collect(),
+            attempts: Vec::new(),
             rows_copied: Some(42),
             duration_ms,
             started_at,
@@ -5359,6 +5381,96 @@ mod run_record_tests {
 
     /// The content-addressed consumer baseline (`consumed_column_baseline`)
     /// must land on the persisted `ModelExecution.upstream_freshness` — the
+    /// 🔴 The load-bearing identity invariant for classified retry, at the
+    /// state-write boundary: an execution that carries an attempt trail
+    /// produces byte-identical *identity* to one that doesn't — attempt history
+    /// rides on `ModelExecution.attempts` alongside the identity fields, never
+    /// inside them.
+    #[test]
+    fn to_run_record_keeps_attempt_trail_out_of_identity() {
+        use rocky_core::state::AttemptRecord;
+
+        let started = fixed_start();
+        let identity = RecipeIdentityInternal {
+            recipe_hash: "recipe-abc".to_string(),
+            env_hash: "env-def".to_string(),
+            hash_scheme: "v1".to_string(),
+        };
+        let out_cols = Some(vec![rocky_core::state::ColumnHash {
+            column: "amount".to_string(),
+            hash: "out-hash".to_string(),
+        }]);
+
+        // Two materializations identical in every identity-bearing field; one
+        // recovered after a transient retry (so it carries a trail), the other
+        // a clean first try (empty trail).
+        let build_mat = |attempts: Vec<AttemptRecord>| {
+            let mut m = mat(&["s", "orders"], 1_000, Some("sql-xyz"), started);
+            m.recipe_identity = Some(identity.clone());
+            m.output_column_hashes = out_cols.clone();
+            m.attempts = attempts;
+            m
+        };
+        let clean = build_mat(Vec::new());
+        let retried = build_mat(vec![
+            AttemptRecord {
+                attempt: 1,
+                outcome: "failed".to_string(),
+                failure_class: Some("transient".to_string()),
+                transient_kind: Some("server_busy".to_string()),
+                error: Some("lock".to_string()),
+                backoff_ms: Some(0),
+                duration_ms: 3,
+            },
+            AttemptRecord {
+                attempt: 2,
+                outcome: "success".to_string(),
+                failure_class: None,
+                transient_kind: None,
+                error: None,
+                backoff_ms: None,
+                duration_ms: 5,
+            },
+        ]);
+
+        let to_exec = |m: MaterializationOutput| {
+            let mut out = RunOutput::new(String::new(), 1_000, 1);
+            out.tables_copied = 1;
+            out.materializations.push(m);
+            out.to_run_record(
+                "run-id",
+                started,
+                started + chrono::Duration::seconds(1),
+                "cfg".to_string(),
+                RunTrigger::Manual,
+                RunStatus::Success,
+                RunRecordAudit::test_sentinels(),
+            )
+            .models_executed
+            .remove(0)
+        };
+        let clean_exec = to_exec(clean);
+        let retried_exec = to_exec(retried);
+
+        // Identity fields byte-identical across the two.
+        assert_eq!(clean_exec.recipe_hash, retried_exec.recipe_hash);
+        assert_eq!(clean_exec.input_hash, retried_exec.input_hash);
+        assert_eq!(clean_exec.env_hash, retried_exec.env_hash);
+        assert_eq!(clean_exec.hash_scheme, retried_exec.hash_scheme);
+        assert_eq!(clean_exec.sql_hash, retried_exec.sql_hash);
+        assert_eq!(
+            clean_exec.output_column_hashes,
+            retried_exec.output_column_hashes
+        );
+        // Only the attempt trail differs — and it is faithfully carried through.
+        assert!(clean_exec.attempts.is_empty());
+        assert_eq!(retried_exec.attempts.len(), 2);
+        assert_eq!(
+            retried_exec.attempts[0].failure_class.as_deref(),
+            Some("transient")
+        );
+    }
+
     /// consumer-side per-column baseline (schema v13). A content-addressed
     /// model has no `skip_internal`, so the `or_else` route in `to_run_record`
     /// is what carries it. Proves the baseline is durable end-to-end.

--- a/engine/crates/rocky-core/src/bridge.rs
+++ b/engine/crates/rocky-core/src/bridge.rs
@@ -317,6 +317,7 @@ mod tests {
             run: Default::default(),
             reuse: Default::default(),
             policy: None,
+            resilience: Default::default(),
         }
     }
 

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -878,6 +878,120 @@ fn default_jitter() -> bool {
     true
 }
 
+/// `[resilience]` — the run loop's classified-retry policy.
+///
+/// This is a **distinct layer** from the per-adapter `[adapter.*.retry]`
+/// (which retries individual statements inside a connector) and from the
+/// run-level `[retry]` budget ([`RunRetryConfig`], which caps connector
+/// retries). `[resilience]` governs whether the run loop re-runs a whole
+/// *model* whose materialization failed, classifying the failure via
+/// [`crate::failure_class::FailureClass`] and retrying only a *proven*
+/// transient one.
+///
+/// # Not default-OFF, but conservative
+///
+/// Unlike the skip / reuse gates, this layer is **on by default** — a model
+/// that fails transiently today *will* be retried once this ships. The lever
+/// that keeps that safe is [`Self::transient_max_retries`] (default `2`): a
+/// small, bounded budget with capped exponential backoff. Set
+/// `transient_max_retries = 0` (or `enabled = false`) to restore the prior
+/// single-attempt behaviour, e.g. in CI where a fast-fail is preferred.
+///
+/// Permanent and Unknown failures are **never** retried regardless of these
+/// settings — that is a property of the classifier, not of this config.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ResilienceConfig {
+    /// Master switch for run-loop classified retry. Default `true`. When
+    /// `false`, every model is attempted exactly once (no classification, no
+    /// backoff) — the behaviour before this layer existed.
+    #[serde(default = "default_resilience_enabled")]
+    pub enabled: bool,
+    /// Maximum re-runs of a model that failed with a *transient* class.
+    /// Conservative default: `2` (so at most three attempts total). `0`
+    /// disables retry while leaving the classifier active for observability.
+    #[serde(default = "default_transient_max_retries")]
+    pub transient_max_retries: u32,
+    /// Initial backoff (ms) before the first retry.
+    #[serde(default = "default_resilience_initial_backoff_ms")]
+    pub initial_backoff_ms: u64,
+    /// Maximum backoff (ms) — caps the exponential growth.
+    #[serde(default = "default_resilience_max_backoff_ms")]
+    pub max_backoff_ms: u64,
+    /// Multiplier applied to the backoff after each retry.
+    #[serde(default = "default_backoff_multiplier")]
+    pub backoff_multiplier: f64,
+    /// Add ±25 % jitter so concurrent runs don't retry in lockstep.
+    #[serde(default = "default_jitter")]
+    pub jitter: bool,
+    /// Trip the run-loop breaker after this many *consecutive* transient
+    /// model failures; once tripped, no further model is retried for the rest
+    /// of the run (they still get their one attempt). Default: `3`. `0`
+    /// disables the breaker.
+    #[serde(default = "default_resilience_breaker_threshold")]
+    pub circuit_breaker_threshold: u32,
+    /// Optional ceiling on the *total* number of retries across all models in
+    /// one run — a global budget separate from the per-adapter one. Default
+    /// `Some(8)`: a conservative cap so one flaky layer can't spin the whole
+    /// run. `None` removes the ceiling (per-model `transient_max_retries` is
+    /// then the only bound); `Some(0)` forbids all retries.
+    #[serde(default = "default_resilience_max_retries_per_run")]
+    pub max_retries_per_run: Option<u32>,
+}
+
+impl ResilienceConfig {
+    /// Project this policy's backoff knobs onto a [`RetryConfig`] so the run
+    /// loop can reuse the shared [`crate::retry::compute_backoff`] helper —
+    /// one backoff implementation across adapters and the run loop.
+    #[must_use]
+    pub fn backoff_config(&self) -> RetryConfig {
+        RetryConfig {
+            max_retries: self.transient_max_retries,
+            initial_backoff_ms: self.initial_backoff_ms,
+            max_backoff_ms: self.max_backoff_ms,
+            backoff_multiplier: self.backoff_multiplier,
+            jitter: self.jitter,
+            circuit_breaker_threshold: self.circuit_breaker_threshold,
+            circuit_breaker_recovery_timeout_secs: None,
+            max_retries_per_run: self.max_retries_per_run,
+        }
+    }
+}
+
+impl Default for ResilienceConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_resilience_enabled(),
+            transient_max_retries: default_transient_max_retries(),
+            initial_backoff_ms: default_resilience_initial_backoff_ms(),
+            max_backoff_ms: default_resilience_max_backoff_ms(),
+            backoff_multiplier: default_backoff_multiplier(),
+            jitter: default_jitter(),
+            circuit_breaker_threshold: default_resilience_breaker_threshold(),
+            max_retries_per_run: default_resilience_max_retries_per_run(),
+        }
+    }
+}
+
+fn default_resilience_enabled() -> bool {
+    true
+}
+fn default_transient_max_retries() -> u32 {
+    2
+}
+fn default_resilience_initial_backoff_ms() -> u64 {
+    500
+}
+fn default_resilience_max_backoff_ms() -> u64 {
+    30_000
+}
+fn default_resilience_breaker_threshold() -> u32 {
+    3
+}
+fn default_resilience_max_retries_per_run() -> Option<u32> {
+    Some(8)
+}
+
 /// Schema pattern configuration from TOML, converted to [`SchemaPattern`] at runtime.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -2376,6 +2490,14 @@ pub struct RockyConfig {
     /// [`PolicyConfig`] and [`crate::policy`] for the evaluator.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policy: Option<PolicyConfig>,
+
+    /// `[resilience]` — the run loop's classified-retry policy. Governs
+    /// whether a model whose materialization fails *transiently* is re-run,
+    /// with a conservative bounded budget and capped backoff. On by default
+    /// (a transient failure is retried), but every knob is small and explicit;
+    /// see [`ResilienceConfig`]. Permanent / Unknown failures never retry.
+    #[serde(default)]
+    pub resilience: ResilienceConfig,
 }
 
 /// `[run]` — opt-in tuning for the model-skip gate.

--- a/engine/crates/rocky-core/src/cross_engine.rs
+++ b/engine/crates/rocky-core/src/cross_engine.rs
@@ -595,6 +595,7 @@ mod tests {
             run: Default::default(),
             reuse: Default::default(),
             policy: None,
+            resilience: Default::default(),
         }
     }
 

--- a/engine/crates/rocky-core/src/docs.rs
+++ b/engine/crates/rocky-core/src/docs.rs
@@ -744,6 +744,7 @@ mod tests {
             run: Default::default(),
             reuse: Default::default(),
             policy: None,
+            resilience: Default::default(),
         };
 
         let models = vec![
@@ -842,6 +843,7 @@ mod tests {
             run: Default::default(),
             reuse: Default::default(),
             policy: None,
+            resilience: Default::default(),
         };
 
         let models = vec![Model {
@@ -942,6 +944,7 @@ mod tests {
             run: Default::default(),
             reuse: Default::default(),
             policy: None,
+            resilience: Default::default(),
         };
 
         let index = build_doc_index(&[], &config, None, None);

--- a/engine/crates/rocky-core/src/failure_class.rs
+++ b/engine/crates/rocky-core/src/failure_class.rs
@@ -1,0 +1,169 @@
+//! Run-loop failure classification for classified retry.
+//!
+//! Unifies the per-adapter "is this error worth retrying?" judgement into a
+//! single three-way verdict the run loop reads to decide whether to re-run a
+//! failed model. Each adapter already knows its own retryable set (HTTP 5xx,
+//! rate limits, connection resets, warehouse warm-up, lock contention, …);
+//! [`crate::traits::WarehouseAdapter::classify_failure`] hoists that judgement
+//! into the common vocabulary defined here so the run loop never re-derives it
+//! by string-matching.
+//!
+//! # Fail-closed
+//!
+//! Only [`FailureClass::Transient`] is retried. [`FailureClass::Permanent`]
+//! (a rejected statement, a type / contract error) and [`FailureClass::Unknown`]
+//! (an error the adapter does not recognise) never retry: retrying a permanent
+//! failure is noise, and a misclassified-transient is the dangerous direction,
+//! so anything not *proven* transient stays put. The default trait
+//! implementation returns [`FailureClass::Unknown`], so an adapter that has not
+//! opted in never has its failures retried.
+
+/// The run loop's three-way verdict on a failed model execution.
+///
+/// Derived from the adapter's own error taxonomy via
+/// [`crate::traits::WarehouseAdapter::classify_failure`]. Only
+/// [`Self::Transient`] is retryable; the other two fail closed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailureClass {
+    /// A blip the adapter expects to clear on its own — safe to re-run the
+    /// model. Carries a finer [`TransientKind`] for the attempt trail.
+    Transient(TransientKind),
+    /// A deterministic rejection — invalid SQL, a schema / contract / type
+    /// error, a rate-budget exhaustion. Re-running produces the same failure,
+    /// so the run loop never retries it.
+    Permanent,
+    /// The adapter did not recognise the error. Fail closed: never retried.
+    Unknown,
+}
+
+/// A finer label for a [`FailureClass::Transient`] verdict, recorded on the
+/// attempt trail so an operator can see *why* an attempt was retried without
+/// re-parsing the error text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransientKind {
+    /// Connection reset, DNS flake, or a 5xx — a network-level blip.
+    Network,
+    /// A per-request or global deadline expired.
+    Timeout,
+    /// A 429 or adapter-specific throttle signal.
+    RateLimit,
+    /// A token expiry a fresh credential exchange is expected to clear.
+    Auth,
+    /// The warehouse is warming, temporarily unavailable, or the target is
+    /// under lock / conflict contention.
+    ServerBusy,
+    /// An adapter-recognised transient that doesn't fit a finer bucket.
+    Other,
+}
+
+impl FailureClass {
+    /// Whether this class is the retryable *variant* — `true` only for
+    /// [`Self::Transient`]. This is the pure classification predicate (used by
+    /// the adapter classification tests); the run loop's retry decision is the
+    /// stricter [`Self::is_run_retryable`].
+    #[must_use]
+    pub fn is_retryable(self) -> bool {
+        matches!(self, Self::Transient(_))
+    }
+
+    /// Whether the **run loop** may retry a model that failed with this class.
+    ///
+    /// Stricter than [`Self::is_retryable`]: a [`TransientKind::Auth`] failure
+    /// that survived the adapter's own token-refresh retry and reached the run
+    /// loop is a genuine bad-credentials / permission-denied *at the run
+    /// level* — the connector owns credential recovery (its internal retry
+    /// already dropped the auth cache and re-minted once), so re-running the
+    /// whole model would just replay the same denial. Retrying a permission
+    /// failure is the dangerous false-`Transient` direction the design forbids,
+    /// so auth is treated as terminal here. Every other transient class is
+    /// run-retryable.
+    #[must_use]
+    pub fn is_run_retryable(self) -> bool {
+        matches!(self, Self::Transient(kind) if !matches!(kind, TransientKind::Auth))
+    }
+
+    /// The stable string tag recorded on the attempt trail (`"transient"` /
+    /// `"permanent"` / `"unknown"`).
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Transient(_) => "transient",
+            Self::Permanent => "permanent",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    /// The transient sub-kind tag, or `None` for a non-transient class.
+    #[must_use]
+    pub fn transient_kind_label(self) -> Option<&'static str> {
+        match self {
+            Self::Transient(kind) => Some(kind.label()),
+            Self::Permanent | Self::Unknown => None,
+        }
+    }
+}
+
+impl TransientKind {
+    /// The stable string tag recorded on the attempt trail.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Network => "network",
+            Self::Timeout => "timeout",
+            Self::RateLimit => "rate_limit",
+            Self::Auth => "auth",
+            Self::ServerBusy => "server_busy",
+            Self::Other => "other",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_transient_is_retryable() {
+        assert!(FailureClass::Transient(TransientKind::Network).is_retryable());
+        assert!(FailureClass::Transient(TransientKind::Timeout).is_retryable());
+        assert!(!FailureClass::Permanent.is_retryable());
+        assert!(!FailureClass::Unknown.is_retryable());
+    }
+
+    #[test]
+    fn auth_is_transient_variant_but_not_run_retryable() {
+        let auth = FailureClass::Transient(TransientKind::Auth);
+        // It IS the transient variant (the error was auth-transient at the
+        // connector) …
+        assert!(auth.is_retryable());
+        // … but the RUN LOOP must not re-run a survived permission denial.
+        assert!(!auth.is_run_retryable());
+        // Every other transient class stays run-retryable.
+        for kind in [
+            TransientKind::Network,
+            TransientKind::Timeout,
+            TransientKind::RateLimit,
+            TransientKind::ServerBusy,
+            TransientKind::Other,
+        ] {
+            assert!(FailureClass::Transient(kind).is_run_retryable());
+        }
+        assert!(!FailureClass::Permanent.is_run_retryable());
+        assert!(!FailureClass::Unknown.is_run_retryable());
+    }
+
+    #[test]
+    fn labels_are_stable() {
+        assert_eq!(FailureClass::Permanent.label(), "permanent");
+        assert_eq!(FailureClass::Unknown.label(), "unknown");
+        assert_eq!(
+            FailureClass::Transient(TransientKind::RateLimit).label(),
+            "transient"
+        );
+        assert_eq!(
+            FailureClass::Transient(TransientKind::RateLimit).transient_kind_label(),
+            Some("rate_limit")
+        );
+        assert_eq!(FailureClass::Permanent.transient_kind_label(), None);
+    }
+}

--- a/engine/crates/rocky-core/src/lib.rs
+++ b/engine/crates/rocky-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod dag_status;
 pub mod dedup_analysis;
 pub mod docs;
 pub mod drift;
+pub mod failure_class;
 pub mod hooks;
 pub mod idempotency;
 pub mod imports;

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -275,7 +275,14 @@ pub const LOCAL_ONLY_TABLE_NAMES: &[&str] = &["schema_cache"];
 ///   change: v14 databases auto-create the empty table on next open and stamp
 ///   themselves as v15. No blob migration needed; existing tables are
 ///   untouched. Empty until a `rocky serve` sidecar submits a job.
-const CURRENT_SCHEMA_VERSION: u32 = 15;
+/// - **v16** — adds the [`ModelExecution::attempts`] classified-retry trail.
+///   A pure serde-additive *field* change, not a table change: the redb table
+///   set is unchanged (`EXPECTED_TABLES` is untouched). A v15 blob (which lacks
+///   the field) forward-deserializes with the trail empty, guarded by
+///   `test_v15_model_execution_forward_deserializes_attempts_empty`. The bump
+///   exists so the on-disk version tracks the record-shape addition and the
+///   `[state] on_schema_mismatch` handling engages as usual; no blob walk.
+const CURRENT_SCHEMA_VERSION: u32 = 16;
 
 /// Errors from the embedded redb state store.
 #[derive(Debug, Error)]
@@ -1146,6 +1153,50 @@ pub struct ColumnHash {
     pub hash: String,
 }
 
+/// One attempt at materializing a model, recorded when the run loop's
+/// classified-retry layer is active.
+///
+/// A model that succeeds on the first try records a single attempt; a model
+/// that failed transiently and was re-run records one entry per attempt, the
+/// last of which is the outcome that stuck. The trail is **execution
+/// metadata** — it lives on [`ModelExecution`] alongside the identity hashes,
+/// never inside them, so a retried-then-succeeded execution stays
+/// byte-indistinguishable downstream from a first-try success (same
+/// `recipe_hash` / `input_hash` / output hash).
+///
+/// Reused verbatim on `MaterializationOutput.attempts` (the run-JSON surface),
+/// so it derives `JsonSchema`; that is the one attempt type on both the wire
+/// and the state record.
+#[derive(
+    Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema,
+)]
+pub struct AttemptRecord {
+    /// 1-based attempt index. Attempt 1 is the first try; 2+ are retries.
+    pub attempt: u32,
+    /// `"success"` or `"failed"`.
+    pub outcome: String,
+    /// The run-loop [`FailureClass`](crate::failure_class::FailureClass) label
+    /// (`"transient"` / `"permanent"` / `"unknown"`) for a failed attempt;
+    /// `None` on a successful attempt.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_class: Option<String>,
+    /// The transient sub-kind label (`"network"`, `"timeout"`, …) when the
+    /// failure was transient; `None` otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transient_kind: Option<String>,
+    /// The failure message (truncated), for a failed attempt; `None` on
+    /// success.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// Milliseconds slept as backoff *after* this attempt before the next
+    /// retry. `None` on the final (kept) attempt and on any attempt that was
+    /// not followed by a retry.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backoff_ms: Option<u64>,
+    /// Wall-clock duration of this attempt, in milliseconds.
+    pub duration_ms: u64,
+}
+
 /// Execution record for a single model within a run.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ModelExecution {
@@ -1269,6 +1320,28 @@ pub struct ModelExecution {
     /// `test_v11_model_execution_forward_deserializes_output_column_hashes_none`.
     #[serde(default)]
     pub output_column_hashes: Option<Vec<ColumnHash>>,
+
+    // --- Attempt history (schema v16) ------------------------------------
+    /// The classified-retry attempt trail for this execution: one
+    /// [`AttemptRecord`] per try. Empty for records written before v16, for
+    /// executions the retry layer never touched, and (by construction) for a
+    /// single-attempt success where the trail carries no extra signal — the
+    /// producer only stamps a trail once a retry actually occurred.
+    ///
+    /// **Execution metadata, never identity.** This field rides *alongside*
+    /// `recipe_hash` / `input_hash` / `output_column_hashes`, never inside
+    /// them, exactly like the governance audit trail rides outside `plan_id`.
+    /// A model that failed once then succeeded records its retries here while
+    /// producing byte-identical identity hashes to a clean first-try run, so
+    /// replay, the column-skip gate, and `rocky-verify` are all unaffected.
+    ///
+    /// Serde-defaulted (and omitted when empty) so a pre-v16 blob
+    /// forward-deserializes with it empty AND a no-retry record's ledger bytes
+    /// stay byte-identical to before v16 — the common case carries no trail.
+    /// Guarded by `test_v15_model_execution_forward_deserializes_attempts_empty`
+    /// and the `ledger_record_serialization_pinned` golden.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attempts: Vec<AttemptRecord>,
 }
 
 /// A complete pipeline run record.
@@ -4282,6 +4355,7 @@ mod tests {
                 env_hash: None,
                 hash_scheme: None,
                 output_column_hashes: None,
+                attempts: Vec::new(),
             }],
         );
         store.record_run(&run).unwrap();
@@ -4329,6 +4403,7 @@ mod tests {
                     env_hash: None,
                     hash_scheme: None,
                     output_column_hashes: None,
+                    attempts: Vec::new(),
                 },
                 ModelExecution {
                     model_name: "customers".to_string(),
@@ -4349,6 +4424,7 @@ mod tests {
                     env_hash: None,
                     hash_scheme: None,
                     output_column_hashes: None,
+                    attempts: Vec::new(),
                 },
             ],
         );
@@ -4384,6 +4460,7 @@ mod tests {
                     env_hash: None,
                     hash_scheme: None,
                     output_column_hashes: None,
+                    attempts: Vec::new(),
                 }],
             );
             store.record_run(&run).unwrap();
@@ -4580,6 +4657,72 @@ mod tests {
         assert_eq!(exec.output_column_hashes, None);
     }
 
+    /// v15 → v16 forward-compat: a `ModelExecution` blob written before the
+    /// classified-retry `attempts` field existed (a full v15 record with no
+    /// `attempts` key) must forward-deserialize with the trail defaulting to
+    /// empty — never crash the read. Also asserts a v16 record carrying a trail
+    /// round-trips, so the attempt history survives a store→read cycle.
+    #[test]
+    fn test_v15_model_execution_forward_deserializes_attempts_empty() {
+        let v15_blob = br#"{
+            "model_name": "orders",
+            "started_at": "2024-01-01T12:00:00Z",
+            "finished_at": "2024-01-01T12:00:02Z",
+            "duration_ms": 2000,
+            "rows_affected": 5000,
+            "status": "success",
+            "sql_hash": "legacy-sql-hash",
+            "skip_hash": "logic-key",
+            "upstream_freshness": null,
+            "bytes_scanned": 4096,
+            "bytes_written": 2048,
+            "tenant": "acme",
+            "recipe_hash": "rh",
+            "input_hash": "ih",
+            "input_proof_class": "heuristic",
+            "env_hash": "eh",
+            "hash_scheme": "v1",
+            "output_column_hashes": null
+        }"#;
+
+        let exec: ModelExecution = serde_json::from_slice(v15_blob)
+            .expect("pre-v16 ModelExecution must forward-deserialize");
+
+        // Prior fields preserved; the new trail defaults to empty.
+        assert_eq!(exec.model_name, "orders");
+        assert_eq!(exec.recipe_hash.as_deref(), Some("rh"));
+        assert!(
+            exec.attempts.is_empty(),
+            "a pre-v16 record reads back with no attempt trail"
+        );
+
+        // A v16 record carrying a trail round-trips losslessly.
+        let mut with_trail = exec;
+        with_trail.attempts = vec![
+            AttemptRecord {
+                attempt: 1,
+                outcome: "failed".to_string(),
+                failure_class: Some("transient".to_string()),
+                transient_kind: Some("rate_limit".to_string()),
+                error: Some("429".to_string()),
+                backoff_ms: Some(500),
+                duration_ms: 12,
+            },
+            AttemptRecord {
+                attempt: 2,
+                outcome: "success".to_string(),
+                failure_class: None,
+                transient_kind: None,
+                error: None,
+                backoff_ms: None,
+                duration_ms: 20,
+            },
+        ];
+        let json = serde_json::to_string(&with_trail).unwrap();
+        let back: ModelExecution = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.attempts, with_trail.attempts);
+    }
+
     /// v12 → v13 forward-compat: an `UpstreamSig` blob written before
     /// `consumed_column_hashes` existed (a full v12 freshness signature with no
     /// `consumed_column_hashes` key) must forward-deserialize with the field
@@ -4646,6 +4789,7 @@ mod tests {
                 column: "id".to_string(),
                 hash: "col-hash".to_string(),
             }]),
+            attempts: Vec::new(),
         };
         let json = serde_json::to_string(&exec).unwrap();
         let back: ModelExecution = serde_json::from_str(&json).unwrap();
@@ -4697,6 +4841,7 @@ mod tests {
             env_hash: Some("env-ghi".to_string()),
             hash_scheme: Some("v1".to_string()),
             output_column_hashes: None,
+            attempts: Vec::new(),
         };
         let exec_json = serde_json::to_string(&exec).unwrap();
 
@@ -7056,7 +7201,13 @@ mod tests {
         // v15 adds the `jobs` table for the `rocky serve` HTTP job model. Same
         // additive shape: a v14 database auto-creates the empty `jobs` table on
         // next open and stamps itself v15, guarded by the same mismatch tests.
-        const EXPECTED_VERSION: u32 = 15;
+        //
+        // v16 adds `ModelExecution.attempts` (the classified-retry trail). That
+        // is a serde-additive *field* on a blob — the redb table set does NOT
+        // change, so EXPECTED_TABLES below is untouched; only the version moves.
+        // A v15 blob forward-deserializes with the trail empty (guarded by
+        // `test_v15_model_execution_forward_deserializes_attempts_empty`).
+        const EXPECTED_VERSION: u32 = 16;
         const EXPECTED_TABLES: &[&str] = &[
             "branches",
             "check_history",

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -334,6 +334,25 @@ pub trait WarehouseAdapter: Send + Sync {
             .map(|()| ExecutionStats::default())
     }
 
+    /// Classify an error this adapter returned into a run-loop
+    /// [`FailureClass`](crate::failure_class::FailureClass).
+    ///
+    /// The run loop calls this to decide whether a failed model is worth
+    /// re-running: only [`FailureClass::Transient`] is retried;
+    /// [`FailureClass::Permanent`] and [`FailureClass::Unknown`] fail closed.
+    ///
+    /// The default is [`FailureClass::Unknown`] — an adapter that has not
+    /// opted in never has its failures retried. Adapters override this to map
+    /// their own error taxonomy (the same retryable set their connector-level
+    /// retry loop already uses) onto the shared vocabulary.
+    ///
+    /// [`FailureClass::Transient`]: crate::failure_class::FailureClass::Transient
+    /// [`FailureClass::Permanent`]: crate::failure_class::FailureClass::Permanent
+    /// [`FailureClass::Unknown`]: crate::failure_class::FailureClass::Unknown
+    fn classify_failure(&self, _err: &AdapterError) -> crate::failure_class::FailureClass {
+        crate::failure_class::FailureClass::Unknown
+    }
+
     /// Execute a SQL query and return rows.
     async fn execute_query(&self, sql: &str) -> AdapterResult<QueryResult>;
 

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -937,6 +937,7 @@ mod tests {
             run: Default::default(),
             reuse: Default::default(),
             policy: None,
+            resilience: Default::default(),
         }
     }
 

--- a/engine/crates/rocky-core/tests/e2e.rs
+++ b/engine/crates/rocky-core/tests/e2e.rs
@@ -476,6 +476,7 @@ fn test_run_history_flow() {
                 env_hash: None,
                 hash_scheme: None,
                 output_column_hashes: None,
+                attempts: Vec::new(),
             },
             ModelExecution {
                 model_name: "customers".to_string(),
@@ -496,6 +497,7 @@ fn test_run_history_flow() {
                 env_hash: None,
                 hash_scheme: None,
                 output_column_hashes: None,
+                attempts: Vec::new(),
             },
         ],
         trigger: RunTrigger::Manual,

--- a/engine/crates/rocky-databricks/src/adapter.rs
+++ b/engine/crates/rocky-databricks/src/adapter.rs
@@ -142,6 +142,10 @@ impl WarehouseAdapter for DatabricksWarehouseAdapter {
             .map_err(AdapterError::new)
     }
 
+    fn classify_failure(&self, err: &AdapterError) -> rocky_core::failure_class::FailureClass {
+        crate::connector::classify_connector_failure(err)
+    }
+
     async fn execute_statement_with_stats(&self, sql: &str) -> AdapterResult<ExecutionStats> {
         // `total_byte_count` from the Databricks manifest is the
         // byte count Databricks natively reports for a statement —

--- a/engine/crates/rocky-databricks/src/connector.rs
+++ b/engine/crates/rocky-databricks/src/connector.rs
@@ -1,4 +1,6 @@
 use rocky_core::circuit_breaker::{CircuitBreaker, TransitionOutcome};
+use rocky_core::failure_class::{FailureClass, TransientKind};
+use rocky_core::traits::AdapterError;
 use std::time::Duration;
 
 use arrow::record_batch::RecordBatch;
@@ -1163,7 +1165,7 @@ fn check_terminal_state(response: StatementResponse) -> Result<StatementResponse
 /// - Network connection or timeout errors
 /// - Databricks-specific: warehouse starting, rate limits, temporary unavailability
 /// - Statement execution timeouts (may succeed on retry with a warmed-up warehouse)
-fn is_transient(err: &ConnectorError) -> bool {
+pub(crate) fn is_transient(err: &ConnectorError) -> bool {
     match err {
         // 401 and 403 are transient-on-first-retry — the connector drops
         // the OAuth cache before retrying, so a server-expired token is
@@ -1201,7 +1203,7 @@ fn is_transient(err: &ConnectorError) -> bool {
 /// `PipelineEvent` — §P2.8. Feeds the event-bus emission from the retry
 /// loop so downstream observers (metrics, Dagster) can distinguish
 /// transient from terminal without string-matching.
-fn classify_error(err: &ConnectorError) -> ErrorClass {
+pub(crate) fn classify_error(err: &ConnectorError) -> ErrorClass {
     match err {
         ConnectorError::ApiError { status: 401, .. } => ErrorClass::Auth,
         ConnectorError::ApiError { status: 429, .. } => ErrorClass::RateLimit,
@@ -1228,6 +1230,59 @@ fn classify_error(err: &ConnectorError) -> ErrorClass {
         | ConnectorError::UnexpectedState { .. }
         | ConnectorError::NoArrowChunks { .. }
         | ConnectorError::Arrow(_) => ErrorClass::Permanent,
+    }
+}
+
+/// Map an [`ErrorClass`] to a run-loop [`TransientKind`]. Only meaningful for
+/// the transient branch; the non-transient variants map to `Other`
+/// defensively (they never co-occur with `is_transient` returning `true`).
+fn transient_kind_of(class: ErrorClass) -> TransientKind {
+    match class {
+        ErrorClass::Timeout => TransientKind::Timeout,
+        ErrorClass::RateLimit => TransientKind::RateLimit,
+        ErrorClass::Auth => TransientKind::Auth,
+        ErrorClass::Transient => TransientKind::Network,
+        ErrorClass::Config | ErrorClass::Permanent => TransientKind::Other,
+    }
+}
+
+/// Classify a Databricks [`AdapterError`] for the run loop's classified-retry
+/// layer, reusing the connector's own [`is_transient`] judgement (the exact
+/// predicate its per-statement retry loop uses) so the run loop and the
+/// connector agree by construction.
+///
+/// - The error downcasts to a [`ConnectorError`] and `is_transient` ⇒
+///   [`FailureClass::Transient`] with a kind from [`classify_error`].
+/// - It downcasts but is not transient ⇒ [`FailureClass::Permanent`].
+/// - It is not a [`ConnectorError`] at all (some other boxed error) ⇒
+///   [`FailureClass::Unknown`] — fail closed, never retried.
+#[must_use]
+pub(crate) fn classify_connector_failure(err: &AdapterError) -> FailureClass {
+    let Some(connector_err) = err.inner().downcast_ref::<ConnectorError>() else {
+        return FailureClass::Unknown;
+    };
+    // An auth / permission status (401 Unauthorized, 403 Forbidden) is
+    // `is_transient` *only* so the connector's own retry loop drops the OAuth
+    // cache and re-mints a token once. A 401/403 that SURVIVES that retry and
+    // reaches the run loop is a genuine bad-credentials / permission-denied,
+    // so it must map to the `Auth` kind — which the run loop treats as
+    // terminal (`FailureClass::is_run_retryable`). Guard this ahead of the
+    // generic path because `classify_error` maps 403 to `Permanent` (a valid
+    // ErrorClass), which would otherwise surface as a run-retryable
+    // `Transient(Other)`.
+    if matches!(
+        connector_err,
+        ConnectorError::ApiError {
+            status: 401 | 403,
+            ..
+        }
+    ) {
+        return FailureClass::Transient(TransientKind::Auth);
+    }
+    if is_transient(connector_err) {
+        FailureClass::Transient(transient_kind_of(classify_error(connector_err)))
+    } else {
+        FailureClass::Permanent
     }
 }
 
@@ -1326,6 +1381,107 @@ fn poll_delay(attempt: usize) -> Duration {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The run-loop classifier hoists the connector's own `is_transient`
+    /// judgement: retryable API/statement errors become `Transient` with the
+    /// right kind, deterministic rejections become `Permanent`, and — the
+    /// dangerous direction — a permanent error is never marked retryable.
+    #[test]
+    fn classify_connector_failure_maps_transient_and_permanent() {
+        // 503 / 429 / timeout / warehouse-warming are transient.
+        let transient_cases = [
+            (
+                ConnectorError::ApiError {
+                    status: 503,
+                    body: "unavailable".to_string(),
+                },
+                TransientKind::Network,
+            ),
+            (
+                ConnectorError::ApiError {
+                    status: 429,
+                    body: "slow down".to_string(),
+                },
+                TransientKind::RateLimit,
+            ),
+            (
+                ConnectorError::Timeout {
+                    id: "s1".to_string(),
+                    seconds: 30,
+                },
+                TransientKind::Timeout,
+            ),
+            (
+                ConnectorError::StatementFailed {
+                    id: "s2".to_string(),
+                    message: "WAREHOUSE IS STARTING".to_string(),
+                },
+                TransientKind::Network,
+            ),
+        ];
+        for (err, kind) in transient_cases {
+            let msg = err.to_string();
+            let class = classify_connector_failure(&AdapterError::new(err));
+            assert_eq!(
+                class,
+                FailureClass::Transient(kind),
+                "should be transient: {msg}"
+            );
+            assert!(class.is_retryable());
+        }
+
+        // A rejected statement (bad SQL) and a 400 are permanent — never retry.
+        let permanent_cases = [
+            ConnectorError::StatementFailed {
+                id: "s3".to_string(),
+                message: "TABLE_OR_VIEW_NOT_FOUND".to_string(),
+            },
+            ConnectorError::ApiError {
+                status: 400,
+                body: "bad request".to_string(),
+            },
+        ];
+        for err in permanent_cases {
+            let msg = err.to_string();
+            let class = classify_connector_failure(&AdapterError::new(err));
+            assert_eq!(class, FailureClass::Permanent, "should be permanent: {msg}");
+            assert!(!class.is_retryable(), "must not retry: {msg}");
+        }
+    }
+
+    /// A boxed error that is *not* a `ConnectorError` fails closed to
+    /// `Unknown` — never retried.
+    #[test]
+    fn classify_non_connector_error_is_unknown() {
+        let err = AdapterError::msg("some unrelated boxed error");
+        assert_eq!(classify_connector_failure(&err), FailureClass::Unknown);
+        assert!(!classify_connector_failure(&err).is_retryable());
+    }
+
+    /// A 401/403 that survived the connector's own token-refresh retry maps to
+    /// the `Auth` kind, which the run loop treats as terminal — a survived
+    /// permission denial is never re-run. (403 in particular would otherwise
+    /// surface as a run-retryable `Transient(Other)` since `classify_error`
+    /// maps it to `Permanent`.)
+    #[test]
+    fn survived_auth_status_is_not_run_retryable() {
+        for status in [401u16, 403] {
+            let err = AdapterError::new(ConnectorError::ApiError {
+                status,
+                body: "denied".to_string(),
+            });
+            let class = classify_connector_failure(&err);
+            assert_eq!(
+                class,
+                FailureClass::Transient(TransientKind::Auth),
+                "{status} should classify as auth-kind"
+            );
+            assert!(
+                !class.is_run_retryable(),
+                "{status} must not be retried at the run loop"
+            );
+        }
+    }
 
     #[test]
     fn test_warehouse_id_from_http_path() {

--- a/engine/crates/rocky-duckdb/src/adapter.rs
+++ b/engine/crates/rocky-duckdb/src/adapter.rs
@@ -14,6 +14,7 @@ use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use tokio::task::spawn_blocking;
 
+use rocky_core::failure_class::{FailureClass, TransientKind};
 use rocky_core::traits::{
     AdapterError, AdapterResult, ExplainResult, QueryResult, SqlDialect, WarehouseAdapter,
 };
@@ -146,6 +147,10 @@ impl WarehouseAdapter for DuckDbWarehouseAdapter {
         .map_err(|e| join_error(&e))?
     }
 
+    fn classify_failure(&self, err: &AdapterError) -> FailureClass {
+        classify_duckdb_failure(err)
+    }
+
     async fn fetch_arrow_batch(&self, sql: &str) -> AdapterResult<RecordBatch> {
         // `duckdb 1.10503` pins workspace `arrow 58`, so `query_arrow`
         // returns batches directly type-compatible with the trait's
@@ -275,9 +280,95 @@ fn join_error(e: &tokio::task::JoinError) -> AdapterError {
     AdapterError::msg(format!("duckdb blocking task failed: {e}"))
 }
 
+/// Classify a DuckDB adapter error for the run loop's classified-retry layer.
+///
+/// DuckDB runs in-process, so almost every failure is a *deterministic* SQL or
+/// logic error that re-running would reproduce verbatim — those are
+/// [`FailureClass::Permanent`] and must not be retried. The one genuinely
+/// transient class is file-lock / write-conflict contention when several
+/// processes (or writers) share one database file: those clear on their own,
+/// so they are [`FailureClass::Transient`]. This never returns `Unknown`: an
+/// in-process error the phrase-set doesn't recognise is treated as permanent,
+/// which fails closed (no retry) — the safe direction.
+#[must_use]
+pub fn classify_duckdb_failure(err: &AdapterError) -> FailureClass {
+    // Match on the rendered message (uppercased) — DuckDB surfaces contention
+    // as opaque `duckdb::Error` variants whose text is the reliable signal.
+    let msg = err.to_string().to_uppercase();
+    let is_lock_contention = msg.contains("COULD NOT SET LOCK ON FILE")
+        || msg.contains("CONFLICTING LOCK")
+        || msg.contains("DATABASE IS LOCKED")
+        || msg.contains("COULD NOT OBTAIN A LOCK")
+        // Optimistic-concurrency write conflicts under concurrent writers.
+        || msg.contains("WRITE-WRITE CONFLICT")
+        || msg.contains("CONFLICT ON TUPLE")
+        || msg.contains("TRANSACTIONCONTEXT ERROR");
+    if is_lock_contention {
+        FailureClass::Transient(TransientKind::ServerBusy)
+    } else {
+        FailureClass::Permanent
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn classify_lock_contention_is_transient() {
+        for phrase in [
+            "IO Error: Could not set lock on file \"poc.duckdb\": Resource temporarily unavailable",
+            "database is locked",
+            "Conflicting lock is held",
+            "TransactionContext Error: Write-write conflict on tuple",
+        ] {
+            let err = AdapterError::msg(phrase.to_string());
+            assert_eq!(
+                classify_duckdb_failure(&err),
+                FailureClass::Transient(TransientKind::ServerBusy),
+                "phrase should classify transient: {phrase}"
+            );
+            assert!(classify_duckdb_failure(&err).is_retryable());
+        }
+    }
+
+    #[test]
+    fn classify_sql_and_logic_errors_are_permanent_never_retried() {
+        for phrase in [
+            "Catalog Error: Table with name orders does not exist!",
+            "Binder Error: Referenced column \"missing\" not found",
+            "Parser Error: syntax error at or near \"SELCT\"",
+            "Conversion Error: Could not convert string 'x' to INT32",
+            "Constraint Error: NOT NULL constraint failed",
+        ] {
+            let err = AdapterError::msg(phrase.to_string());
+            let class = classify_duckdb_failure(&err);
+            assert_eq!(
+                class,
+                FailureClass::Permanent,
+                "phrase should classify permanent: {phrase}"
+            );
+            // The dangerous direction — a permanent error must never retry.
+            assert!(!class.is_retryable(), "must not retry: {phrase}");
+        }
+    }
+
+    #[test]
+    fn duckdb_classify_never_returns_unknown() {
+        // In-process: an unrecognised error is deterministic ⇒ permanent, not
+        // unknown, so it still fails closed to no-retry.
+        let err = AdapterError::msg("some entirely novel duckdb message".to_string());
+        assert_eq!(classify_duckdb_failure(&err), FailureClass::Permanent);
+    }
+
+    #[test]
+    fn adapter_trait_method_delegates_to_classifier() {
+        let adapter = DuckDbWarehouseAdapter::in_memory().unwrap();
+        let transient = AdapterError::msg("Could not set lock on file".to_string());
+        assert!(adapter.classify_failure(&transient).is_retryable());
+        let permanent = AdapterError::msg("Catalog Error: no such table".to_string());
+        assert!(!adapter.classify_failure(&permanent).is_retryable());
+    }
 
     #[tokio::test]
     async fn test_adapter_execute_statement() {

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -994,6 +994,7 @@ fn seed_run_history(models_dir: &Path) {
             env_hash: None,
             hash_scheme: None,
             output_column_hashes: None,
+            attempts: Vec::new(),
         }],
         trigger: RunTrigger::Manual,
         config_hash: "cfg".to_string(),

--- a/engine/crates/rocky-snowflake/src/adapter.rs
+++ b/engine/crates/rocky-snowflake/src/adapter.rs
@@ -70,6 +70,10 @@ impl WarehouseAdapter for SnowflakeWarehouseAdapter {
             .map_err(AdapterError::new)
     }
 
+    fn classify_failure(&self, err: &AdapterError) -> rocky_core::failure_class::FailureClass {
+        crate::connector::classify_connector_failure(err)
+    }
+
     // `execute_statement_with_stats` intentionally NOT overridden.
     //
     // Snowflake does not return `bytes_scanned` in the immediate SQL API

--- a/engine/crates/rocky-snowflake/src/connector.rs
+++ b/engine/crates/rocky-snowflake/src/connector.rs
@@ -13,7 +13,9 @@ use std::time::Duration;
 use reqwest::{Client, RequestBuilder};
 use rocky_core::circuit_breaker::{CircuitBreaker, TransitionOutcome};
 use rocky_core::config::RetryConfig;
+use rocky_core::failure_class::{FailureClass, TransientKind};
 use rocky_core::retry::compute_backoff;
+use rocky_core::traits::AdapterError;
 use rocky_observe::events::{
     ErrorClass, PipelineEvent, global_event_bus, record_span_event, set_current_span_error,
 };
@@ -679,7 +681,7 @@ fn check_terminal(response: StatementResponse) -> Result<StatementResponse, Conn
 }
 
 /// Classifies whether a connector error is transient and worth retrying.
-fn is_transient(err: &ConnectorError) -> bool {
+pub(crate) fn is_transient(err: &ConnectorError) -> bool {
     match err {
         // 401 is transient-on-first-retry — the connector drops the auth
         // cache before retrying, so a stale cached JWT replays as a fresh
@@ -708,7 +710,7 @@ fn is_transient(err: &ConnectorError) -> bool {
 
 /// Maps `ConnectorError` to the structured [`ErrorClass`] surfaced on
 /// retry `PipelineEvent`s (§P2.8).
-fn classify_error(err: &ConnectorError) -> ErrorClass {
+pub(crate) fn classify_error(err: &ConnectorError) -> ErrorClass {
     match err {
         ConnectorError::ApiError { status: 401, .. } => ErrorClass::Auth,
         ConnectorError::ApiError { status: 429, .. } => ErrorClass::RateLimit,
@@ -734,9 +736,125 @@ fn classify_error(err: &ConnectorError) -> ErrorClass {
     }
 }
 
+/// Map an [`ErrorClass`] to a run-loop [`TransientKind`] (only meaningful for
+/// the transient branch; non-transient variants map to `Other` defensively).
+fn transient_kind_of(class: ErrorClass) -> TransientKind {
+    match class {
+        ErrorClass::Timeout => TransientKind::Timeout,
+        ErrorClass::RateLimit => TransientKind::RateLimit,
+        ErrorClass::Auth => TransientKind::Auth,
+        ErrorClass::Transient => TransientKind::Network,
+        ErrorClass::Config | ErrorClass::Permanent => TransientKind::Other,
+    }
+}
+
+/// Classify a Snowflake [`AdapterError`] for the run loop's classified-retry
+/// layer, reusing the connector's own [`is_transient`] judgement so the run
+/// loop and the connector agree by construction.
+///
+/// Downcasts to a [`ConnectorError`]: transient ⇒ [`FailureClass::Transient`]
+/// (kind from [`classify_error`]); not transient ⇒ [`FailureClass::Permanent`];
+/// not a [`ConnectorError`] ⇒ [`FailureClass::Unknown`] (fail closed).
+#[must_use]
+pub(crate) fn classify_connector_failure(err: &AdapterError) -> FailureClass {
+    let Some(connector_err) = err.inner().downcast_ref::<ConnectorError>() else {
+        return FailureClass::Unknown;
+    };
+    if is_transient(connector_err) {
+        FailureClass::Transient(transient_kind_of(classify_error(connector_err)))
+    } else {
+        FailureClass::Permanent
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The run-loop classifier hoists the connector's own `is_transient`
+    /// judgement: 429 / 503 / throttle become `Transient`, a rejected
+    /// statement or 400 becomes `Permanent`, and a permanent error is never
+    /// marked retryable (the dangerous direction).
+    #[test]
+    fn classify_connector_failure_maps_transient_and_permanent() {
+        let transient_cases = [
+            (
+                ConnectorError::ApiError {
+                    status: 503,
+                    body: "unavailable".to_string(),
+                },
+                TransientKind::Network,
+            ),
+            (
+                ConnectorError::ApiError {
+                    status: 429,
+                    body: "rate limited".to_string(),
+                },
+                TransientKind::RateLimit,
+            ),
+            (
+                ConnectorError::StatementFailed {
+                    handle: "s1".to_string(),
+                    message: "000630: Statement throttled".to_string(),
+                },
+                TransientKind::Network,
+            ),
+        ];
+        for (err, kind) in transient_cases {
+            let msg = err.to_string();
+            let class = classify_connector_failure(&AdapterError::new(err));
+            assert_eq!(
+                class,
+                FailureClass::Transient(kind),
+                "should be transient: {msg}"
+            );
+            assert!(class.is_retryable());
+        }
+
+        let permanent_cases = [
+            ConnectorError::StatementFailed {
+                handle: "s2".to_string(),
+                message: "002003: Object 'ORDERS' does not exist".to_string(),
+            },
+            ConnectorError::ApiError {
+                status: 400,
+                body: "bad request".to_string(),
+            },
+        ];
+        for err in permanent_cases {
+            let msg = err.to_string();
+            let class = classify_connector_failure(&AdapterError::new(err));
+            assert_eq!(class, FailureClass::Permanent, "should be permanent: {msg}");
+            assert!(!class.is_retryable(), "must not retry: {msg}");
+        }
+    }
+
+    /// A non-`ConnectorError` boxed error fails closed to `Unknown`.
+    #[test]
+    fn classify_non_connector_error_is_unknown() {
+        let err = AdapterError::msg("some unrelated boxed error");
+        assert_eq!(classify_connector_failure(&err), FailureClass::Unknown);
+    }
+
+    /// A survived 401 maps to the `Auth` kind and a 403 to `Permanent`; both
+    /// are terminal at the run loop (a survived permission failure is never
+    /// re-run).
+    #[test]
+    fn survived_auth_and_permission_are_not_run_retryable() {
+        let auth = classify_connector_failure(&AdapterError::new(ConnectorError::ApiError {
+            status: 401,
+            body: "expired".to_string(),
+        }));
+        assert_eq!(auth, FailureClass::Transient(TransientKind::Auth));
+        assert!(!auth.is_run_retryable());
+
+        let forbidden = classify_connector_failure(&AdapterError::new(ConnectorError::ApiError {
+            status: 403,
+            body: "forbidden".to_string(),
+        }));
+        assert_eq!(forbidden, FailureClass::Permanent);
+        assert!(!forbidden.is_run_retryable());
+    }
 
     #[test]
     fn test_count_statements_single() {

--- a/engine/rocky/tests/replay_check.rs
+++ b/engine/rocky/tests/replay_check.rs
@@ -142,6 +142,7 @@ fn model_exec(name: &str) -> ModelExecution {
         env_hash: None,
         hash_scheme: None,
         output_column_hashes: None,
+        attempts: Vec::new(),
     }
 }
 

--- a/engine/rocky/tests/replay_dag.rs
+++ b/engine/rocky/tests/replay_dag.rs
@@ -161,6 +161,7 @@ fn model_exec(name: &str) -> ModelExecution {
         env_hash: None,
         hash_scheme: None,
         output_column_hashes: None,
+        attempts: Vec::new(),
     }
 }
 

--- a/engine/rocky/tests/replay_execute.rs
+++ b/engine/rocky/tests/replay_execute.rs
@@ -146,6 +146,7 @@ fn model_exec(name: &str) -> ModelExecution {
         env_hash: None,
         hash_scheme: None,
         output_column_hashes: None,
+        attempts: Vec::new(),
     }
 }
 

--- a/integrations/dagster/tests/fixtures_generated/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor.json
@@ -17,7 +17,7 @@
     {
       "name": "state_schema",
       "status": "healthy",
-      "message": "state schema v15 matches this binary",
+      "message": "state schema v16 matches this binary",
       "duration_ms": 0
     },
     {

--- a/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
@@ -17,7 +17,7 @@
     {
       "name": "state_schema",
       "status": "healthy",
-      "message": "state schema v15 matches this binary",
+      "message": "state schema v16 matches this binary",
       "duration_ms": 0
     },
     {

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 15,
-  "schema_version_on_disk": 15
+  "schema_version_supported": 16,
+  "schema_version_on_disk": 16
 }

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 15,
-  "schema_version_on_disk": 15
+  "schema_version_supported": 16,
+  "schema_version_on_disk": 16
 }

--- a/integrations/dagster/tests/fixtures_generated/state.json
+++ b/integrations/dagster/tests/fixtures_generated/state.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 15,
-  "schema_version_on_disk": 15
+  "schema_version_supported": 16,
+  "schema_version_on_disk": 16
 }

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -2998,6 +2998,67 @@
       ],
       "type": "object"
     },
+    "ResilienceConfig": {
+      "additionalProperties": false,
+      "description": "`[resilience]` — the run loop's classified-retry policy.\n\nThis is a **distinct layer** from the per-adapter `[adapter.*.retry]` (which retries individual statements inside a connector) and from the run-level `[retry]` budget ([`RunRetryConfig`], which caps connector retries). `[resilience]` governs whether the run loop re-runs a whole *model* whose materialization failed, classifying the failure via [`crate::failure_class::FailureClass`] and retrying only a *proven* transient one.\n\n# Not default-OFF, but conservative\n\nUnlike the skip / reuse gates, this layer is **on by default** — a model that fails transiently today *will* be retried once this ships. The lever that keeps that safe is [`Self::transient_max_retries`] (default `2`): a small, bounded budget with capped exponential backoff. Set `transient_max_retries = 0` (or `enabled = false`) to restore the prior single-attempt behaviour, e.g. in CI where a fast-fail is preferred.\n\nPermanent and Unknown failures are **never** retried regardless of these settings — that is a property of the classifier, not of this config.",
+      "properties": {
+        "backoff_multiplier": {
+          "default": 2.0,
+          "description": "Multiplier applied to the backoff after each retry.",
+          "format": "double",
+          "type": "number"
+        },
+        "circuit_breaker_threshold": {
+          "default": 3,
+          "description": "Trip the run-loop breaker after this many *consecutive* transient model failures; once tripped, no further model is retried for the rest of the run (they still get their one attempt). Default: `3`. `0` disables the breaker.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "enabled": {
+          "default": true,
+          "description": "Master switch for run-loop classified retry. Default `true`. When `false`, every model is attempted exactly once (no classification, no backoff) — the behaviour before this layer existed.",
+          "type": "boolean"
+        },
+        "initial_backoff_ms": {
+          "default": 500,
+          "description": "Initial backoff (ms) before the first retry.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "jitter": {
+          "default": true,
+          "description": "Add ±25 % jitter so concurrent runs don't retry in lockstep.",
+          "type": "boolean"
+        },
+        "max_backoff_ms": {
+          "default": 30000,
+          "description": "Maximum backoff (ms) — caps the exponential growth.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "max_retries_per_run": {
+          "default": 8,
+          "description": "Optional ceiling on the *total* number of retries across all models in one run — a global budget separate from the per-adapter one. Default `Some(8)`: a conservative cap so one flaky layer can't spin the whole run. `None` removes the ceiling (per-model `transient_max_retries` is then the only bound); `Some(0)` forbids all retries.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "transient_max_retries": {
+          "default": 2,
+          "description": "Maximum re-runs of a model that failed with a *transient* class. Conservative default: `2` (so at most three attempts total). `0` disables retry while leaving the classifier active for observability.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
     "RetryConfig": {
       "additionalProperties": false,
       "description": "Retry policy for transient warehouse errors (HTTP 429/503, rate limits, timeouts).\n\nRocky retries transient errors with exponential backoff and optional jitter to prevent thundering herd across concurrent runs.",
@@ -4176,6 +4237,24 @@
         "target_dialect": null
       },
       "description": "Dialect-portability lint configuration. Consumed by `rocky compile` to drive P001 (and, when wired, future) diagnostics. The CLI's `--target-dialect` flag, when set, takes precedence over [`PortabilityConfig::target_dialect`]."
+    },
+    "resilience": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResilienceConfig"
+        }
+      ],
+      "default": {
+        "backoff_multiplier": 2.0,
+        "circuit_breaker_threshold": 3,
+        "enabled": true,
+        "initial_backoff_ms": 500,
+        "jitter": true,
+        "max_backoff_ms": 30000,
+        "max_retries_per_run": 8,
+        "transient_max_retries": 2
+      },
+      "description": "`[resilience]` — the run loop's classified-retry policy. Governs whether a model whose materialization fails *transiently* is re-run, with a conservative bounded budget and capped backoff. On by default (a transient failure is retried), but every knob is small and explicit; see [`ResilienceConfig`]. Permanent / Unknown failures never retry."
     },
     "retry": {
       "anyOf": [

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -33,6 +33,63 @@
       ],
       "type": "object"
     },
+    "AttemptRecord": {
+      "description": "One attempt at materializing a model, recorded when the run loop's classified-retry layer is active.\n\nA model that succeeds on the first try records a single attempt; a model that failed transiently and was re-run records one entry per attempt, the last of which is the outcome that stuck. The trail is **execution metadata** — it lives on [`ModelExecution`] alongside the identity hashes, never inside them, so a retried-then-succeeded execution stays byte-indistinguishable downstream from a first-try success (same `recipe_hash` / `input_hash` / output hash).\n\nReused verbatim on `MaterializationOutput.attempts` (the run-JSON surface), so it derives `JsonSchema`; that is the one attempt type on both the wire and the state record.",
+      "properties": {
+        "attempt": {
+          "description": "1-based attempt index. Attempt 1 is the first try; 2+ are retries.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "backoff_ms": {
+          "description": "Milliseconds slept as backoff *after* this attempt before the next retry. `None` on the final (kept) attempt and on any attempt that was not followed by a retry.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "duration_ms": {
+          "description": "Wall-clock duration of this attempt, in milliseconds.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "error": {
+          "description": "The failure message (truncated), for a failed attempt; `None` on success.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "failure_class": {
+          "description": "The run-loop [`FailureClass`](crate::failure_class::FailureClass) label (`\"transient\"` / `\"permanent\"` / `\"unknown\"`) for a failed attempt; `None` on a successful attempt.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "outcome": {
+          "description": "`\"success\"` or `\"failed\"`.",
+          "type": "string"
+        },
+        "transient_kind": {
+          "description": "The transient sub-kind label (`\"network\"`, `\"timeout\"`, …) when the failure was transient; `None` otherwise.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "attempt",
+        "duration_ms",
+        "outcome"
+      ],
+      "type": "object"
+    },
     "BudgetBreachOutput": {
       "description": "One budget breach surfaced on [`RunOutput::budget_breaches`].\n\nKept as a CLI-side struct (rather than re-using [`rocky_core::config::BudgetBreach`]) so the JSON schema lives alongside the other `rocky run` output types. The fields mirror `BudgetBreach` one-to-one.",
       "properties": {
@@ -491,6 +548,13 @@
         "asset_key": {
           "items": {
             "type": "string"
+          },
+          "type": "array"
+        },
+        "attempts": {
+          "description": "The classified-retry attempt trail for this materialization: one [`AttemptRecord`](rocky_core::state::AttemptRecord) per try. Empty (and omitted from JSON) for a clean first-try success — the run loop only stamps a trail once a retry actually happened, so a non-retried build's output stays byte-identical to before this layer shipped. [`RunOutput::to_run_record`] copies this verbatim onto the persisted `ModelExecution.attempts` — one attempt type on both the wire and the state record.",
+          "items": {
+            "$ref": "#/definitions/AttemptRecord"
           },
           "type": "array"
         },

--- a/sdk/python/src/rocky_sdk/types_generated/rocky_project_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/rocky_project_schema.py
@@ -1140,6 +1140,56 @@ class RequiredColumn(BaseModel):
     """
 
 
+class ResilienceConfig(BaseModel):
+    """
+    `[resilience]` — the run loop's classified-retry policy.
+
+    This is a **distinct layer** from the per-adapter `[adapter.*.retry]` (which retries individual statements inside a connector) and from the run-level `[retry]` budget ([`RunRetryConfig`], which caps connector retries). `[resilience]` governs whether the run loop re-runs a whole *model* whose materialization failed, classifying the failure via [`crate::failure_class::FailureClass`] and retrying only a *proven* transient one.
+
+    # Not default-OFF, but conservative
+
+    Unlike the skip / reuse gates, this layer is **on by default** — a model that fails transiently today *will* be retried once this ships. The lever that keeps that safe is [`Self::transient_max_retries`] (default `2`): a small, bounded budget with capped exponential backoff. Set `transient_max_retries = 0` (or `enabled = false`) to restore the prior single-attempt behaviour, e.g. in CI where a fast-fail is preferred.
+
+    Permanent and Unknown failures are **never** retried regardless of these settings — that is a property of the classifier, not of this config.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    backoff_multiplier: float | None = 2.0
+    """
+    Multiplier applied to the backoff after each retry.
+    """
+    circuit_breaker_threshold: conint(ge=0) | None = 3
+    """
+    Trip the run-loop breaker after this many *consecutive* transient model failures; once tripped, no further model is retried for the rest of the run (they still get their one attempt). Default: `3`. `0` disables the breaker.
+    """
+    enabled: bool | None = True
+    """
+    Master switch for run-loop classified retry. Default `true`. When `false`, every model is attempted exactly once (no classification, no backoff) — the behaviour before this layer existed.
+    """
+    initial_backoff_ms: conint(ge=0) | None = 500
+    """
+    Initial backoff (ms) before the first retry.
+    """
+    jitter: bool | None = True
+    """
+    Add ±25 % jitter so concurrent runs don't retry in lockstep.
+    """
+    max_backoff_ms: conint(ge=0) | None = 30000
+    """
+    Maximum backoff (ms) — caps the exponential growth.
+    """
+    max_retries_per_run: conint(ge=0) | None = 8
+    """
+    Optional ceiling on the *total* number of retries across all models in one run — a global budget separate from the per-adapter one. Default `Some(8)`: a conservative cap so one flaky layer can't spin the whole run. `None` removes the ceiling (per-model `transient_max_retries` is then the only bound); `Some(0)` forbids all retries.
+    """
+    transient_max_retries: conint(ge=0) | None = 2
+    """
+    Maximum re-runs of a model that failed with a *transient* class. Conservative default: `2` (so at most three attempts total). `0` disables retry while leaving the classifier active for observability.
+    """
+
+
 class RetryConfig(BaseModel):
     """
     Retry policy for transient warehouse errors (HTTP 429/503, rate limits, timeouts).
@@ -3520,6 +3570,22 @@ class RockyConfig(BaseModel):
     )
     """
     Dialect-portability lint configuration. Consumed by `rocky compile` to drive P001 (and, when wired, future) diagnostics. The CLI's `--target-dialect` flag, when set, takes precedence over [`PortabilityConfig::target_dialect`].
+    """
+    resilience: ResilienceConfig | None = Field(
+        {
+            "backoff_multiplier": 2.0,
+            "circuit_breaker_threshold": 3,
+            "enabled": True,
+            "initial_backoff_ms": 500,
+            "jitter": True,
+            "max_backoff_ms": 30000,
+            "max_retries_per_run": 8,
+            "transient_max_retries": 2,
+        },
+        validate_default=True,
+    )
+    """
+    `[resilience]` — the run loop's classified-retry policy. Governs whether a model whose materialization fails *transiently* is re-run, with a conservative bounded budget and capped backoff. On by default (a transient failure is retried), but every knob is small and explicit; see [`ResilienceConfig`]. Permanent / Unknown failures never retry.
     """
     retry: RunRetryConfig | None = None
     """

--- a/sdk/python/src/rocky_sdk/types_generated/run_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/run_schema.py
@@ -20,6 +20,45 @@ class AnomalyOutput(BaseModel):
     table: str
 
 
+class AttemptRecord(BaseModel):
+    """
+    One attempt at materializing a model, recorded when the run loop's classified-retry layer is active.
+
+    A model that succeeds on the first try records a single attempt; a model that failed transiently and was re-run records one entry per attempt, the last of which is the outcome that stuck. The trail is **execution metadata** — it lives on [`ModelExecution`] alongside the identity hashes, never inside them, so a retried-then-succeeded execution stays byte-indistinguishable downstream from a first-try success (same `recipe_hash` / `input_hash` / output hash).
+
+    Reused verbatim on `MaterializationOutput.attempts` (the run-JSON surface), so it derives `JsonSchema`; that is the one attempt type on both the wire and the state record.
+    """
+
+    attempt: conint(ge=0)
+    """
+    1-based attempt index. Attempt 1 is the first try; 2+ are retries.
+    """
+    backoff_ms: conint(ge=0) | None = None
+    """
+    Milliseconds slept as backoff *after* this attempt before the next retry. `None` on the final (kept) attempt and on any attempt that was not followed by a retry.
+    """
+    duration_ms: conint(ge=0)
+    """
+    Wall-clock duration of this attempt, in milliseconds.
+    """
+    error: str | None = None
+    """
+    The failure message (truncated), for a failed attempt; `None` on success.
+    """
+    failure_class: str | None = None
+    """
+    The run-loop [`FailureClass`](crate::failure_class::FailureClass) label (`"transient"` / `"permanent"` / `"unknown"`) for a failed attempt; `None` on a successful attempt.
+    """
+    outcome: str
+    """
+    `"success"` or `"failed"`.
+    """
+    transient_kind: str | None = None
+    """
+    The transient sub-kind label (`"network"`, `"timeout"`, …) when the failure was transient; `None` otherwise.
+    """
+
+
 class BudgetBreachOutput(BaseModel):
     """
     One budget breach surfaced on [`RunOutput::budget_breaches`].
@@ -599,6 +638,10 @@ class CheckResult7(BaseModel):
 
 class MaterializationOutput(BaseModel):
     asset_key: list[str]
+    attempts: list[AttemptRecord] | None = None
+    """
+    The classified-retry attempt trail for this materialization: one [`AttemptRecord`](rocky_core::state::AttemptRecord) per try. Empty (and omitted from JSON) for a clean first-try success — the run loop only stamps a trail once a retry actually happened, so a non-retried build's output stays byte-identical to before this layer shipped. [`RunOutput::to_run_record`] copies this verbatim onto the persisted `ModelExecution.attempts` — one attempt type on both the wire and the state record.
+    """
     bytes_scanned: conint(ge=0) | None = None
     """
     Adapter-reported bytes figure used for cost accounting, summed across all statements executed for this materialization. This is the *billing-relevant* number per adapter, not literal scan volume — so anyone comparing this to a warehouse console should know which column lines up.


### PR DESCRIPTION
## What

Adds **classified retry at the run loop** — the first rung of the self-healing ladder: bounded, compiled, recorded retry. A model whose materialization fails is classified via each adapter's own retryable judgement, hoisted into a unified `FailureClass { Transient(kind), Permanent, Unknown }`, and a *proven*-transient failure is re-run within a small bounded budget with capped exponential backoff. Every retry is recorded as an attempt trail on the execution record and surfaced in the run JSON output.

## ⚠️ Behavior change

This is **on by default**. A transient failure that fails a run today (warehouse warming up, a 429, a connection reset, a DuckDB lock conflict) will now be **retried** instead of failing the run. The lever that keeps this safe is a deliberately small default budget — `transient_max_retries = 2`. Set `transient_max_retries = 0` (or `enabled = false`) under `[resilience]` to restore the prior single-attempt behavior (e.g. in CI where a fast-fail is preferred). Flagged in the CHANGELOG `[Unreleased]`.

## Soundness (the classifier is the surface)

- **Permanent** (a rejected statement, a type/contract error) ⇒ **never retried** — retrying a deterministic rejection is noise.
- **Unknown** (an error the adapter doesn't recognise) ⇒ **never retried** — fail closed; the false-`Transient` direction is the dangerous one, so anything not *proven* transient stays put. The `WarehouseAdapter::classify_failure` default is `Unknown`.

## 🔴 Load-bearing invariant — attempt history stays OUT of the three identity hashes

Attempt history is **execution metadata** on `ModelExecution`, alongside `recipe_hash` / `input_hash` / `output_column_hashes`, never inside them (exactly like `principal` rides outside `plan_id`). A fail-once-then-succeed build produces byte-identical recipe identity + materialized output to a clean first-try run. **Proven two ways:**
- `to_run_record_keeps_attempt_trail_out_of_identity` (state-write boundary: identical recipe/input/env/hash_scheme/sql_hash/output_column_hashes, only `attempts` differs).
- `flaky_transient_run_recovers_with_trail_and_identical_identity` (end-to-end: a fault-injecting adapter over real DuckDB drives the real `execute_one_plain_model` through the retry helper; the recovered build has identical `recipe_hash` / `env_hash` / `hash_scheme` + byte-identical materialized rows to a clean build, and a 2-entry attempt trail).

## Reachability (creds-free honesty)

- **DuckDB is the only creds-free adapter** — its classification (lock/conflict contention ⇒ Transient, everything else ⇒ Permanent, never Unknown) is unit-tested.
- **Databricks / Snowflake / BigQuery** reuse their existing `is_transient` connector judgement; the pure mapping is unit-tested, but the **retryable SETS themselves are review-only** — not live-verified in this PR.
- End-to-end: a failing-then-passing test adapter drives a flaky run that used to fail → now completes with an attempt trail (the E2E test above).

## Schema bump v15 → v16

Additive `attempts` field on `ModelExecution` — serde-defaulted and omitted-when-empty, so a no-retry record's ledger bytes are byte-identical to v15. `EXPECTED_TABLES` unchanged (it's a field, not a table); version + guard bumped; serde-forward-deserialize test added (`test_v15_model_execution_forward_deserializes_attempts_empty`). `just codegen` + `just regen-fixtures` run — the fixture diff is **only** the v15→v16 surfaces (doctor message + `state` schema versions).

## Gates

`cargo fmt --check`, `cargo clippy --all-targets`, full `cargo test`, `cargo check --all-features --all-targets`, codegen + regen-fixtures — all green.

## Merge order

Lone schema-bumper (v15→v16) — lands **first**; the other self-heal rungs rebase onto v16 once. Rebased onto latest `origin/main` (auto-merged the `rocky-mcp/tests/roundtrip.rs` overlap with #1054; roundtrip test re-verified green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)