### PR TITLE
feat(engine/rocky-cli): model-failure containment — continue disjoint subgraphs on failure

### DIFF
--- a/docs/src/content/docs/advanced/failure-modes.md
+++ b/docs/src/content/docs/advanced/failure-modes.md
@@ -148,6 +148,25 @@ The dispatched adapter classifies its own failures:
 
 ---
 
+## Failure containment across the model graph
+
+By default a transformation run **fails fast**: the first model that fails stops the run, and models not yet built are skipped. Opt into *containment* to continue disjoint work instead:
+
+```toml
+[resilience]
+contain_failures = true   # default: false
+```
+
+With containment on, a failed model and its **downstream closure** are withheld while unrelated subtrees still materialize. The run reports `PartialFailure`, listing the withheld models on `RunOutput.contained[*]` (each naming what blocked it, with an unblock hint) and the failure causes on `RunOutput.errors[*]`. For a partitioned (`time_interval`) model, a failed partition withholds the model's downstream while its healthy partitions still land.
+
+**Guarantee scope.** Containment is *guaranteed* for dependencies declared via `ref()` and for physical reads Rocky can statically resolve — `schema.table`, `catalog.schema.table`, quoted or unquoted. Those are folded into both the withholding closure and the execution ordering, so a downstream of a failure is never built on its stale or missing output, and under `--parallel` a reader is scheduled strictly after every producer it reads.
+
+Reads Rocky **cannot enumerate** — a model built on a CTE, sub-query, or set operation — are handled on a **best-effort** basis identical to a normal fail-fast run. Such a model is still contained when it has a *known* failed upstream, but because its reads can't be resolved into an ordering edge, under `--parallel` a same-layer reader of a failing producer can materialize on stale data — exactly as a fail-fast run does in that case. This is a documented boundary, not a regression: containment never materializes anything a fail-fast run wouldn't. **Declare the dependency with `ref()` for a hard containment guarantee.**
+
+Default is off; the fail-fast behavior described in the sections above is unchanged unless you set `contain_failures = true`.
+
+---
+
 ## 6. State store failures
 
 **Definition.** Rocky's embedded state store (redb at `<models>/.rocky-state.redb` by default) holds watermarks, run history, branch state, and partition progress. Failures here either prevent a run from starting (lock contention, corruption) or quietly degrade an incremental run to an unintended full refresh (missing watermark).

--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -3016,6 +3016,11 @@
           "minimum": 0.0,
           "type": "integer"
         },
+        "contain_failures": {
+          "default": false,
+          "description": "Continue disjoint subgraphs when a model fails, instead of aborting the whole run at the first failure. Default `false` (fail-fast — the run stops at the first failing model, exactly as before this knob existed).\n\nWhen `true`, a failed model and its downstream closure are *withheld* (never built on the failure's stale/missing output), while unrelated subtrees still materialize; the run reports `PartialFailure` with a containment manifest naming what failed and its blast radius. This changes no data semantics — everything withheld is already withheld by today's fail-fast run; it only *narrows* the withholding to the actual blast radius. The closure is conservative (computed from the resolved dependency graph, contain-more on any doubt).",
+          "type": "boolean"
+        },
         "enabled": {
           "default": true,
           "description": "Master switch for run-loop classified retry. Default `true`. When `false`, every model is attempted exactly once (no classification, no backoff) — the behaviour before this layer existed.",
@@ -4248,6 +4253,7 @@
       "default": {
         "backoff_multiplier": 2.0,
         "circuit_breaker_threshold": 3,
+        "contain_failures": false,
         "enabled": true,
         "initial_backoff_ms": 500,
         "jitter": true,

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -1892,6 +1892,12 @@ export interface ResilienceConfig {
    */
   circuit_breaker_threshold?: number;
   /**
+   * Continue disjoint subgraphs when a model fails, instead of aborting the whole run at the first failure. Default `false` (fail-fast — the run stops at the first failing model, exactly as before this knob existed).
+   *
+   * When `true`, a failed model and its downstream closure are *withheld* (never built on the failure's stale/missing output), while unrelated subtrees still materialize; the run reports `PartialFailure` with a containment manifest naming what failed and its blast radius. This changes no data semantics — everything withheld is already withheld by today's fail-fast run; it only *narrows* the withholding to the actual blast radius. The closure is conservative (computed from the resolved dependency graph, contain-more on any doubt).
+   */
+  contain_failures?: boolean;
+  /**
    * Master switch for run-loop classified retry. Default `true`. When `false`, every model is attempted exactly once (no classification, no backoff) — the behaviour before this layer existed.
    */
   enabled?: boolean;

--- a/editors/vscode/src/types/generated/run.ts
+++ b/editors/vscode/src/types/generated/run.ts
@@ -118,6 +118,10 @@ export interface RunOutput {
   check_results: TableCheckOutput[];
   command: string;
   /**
+   * Models withheld this run because an upstream failed (or was itself withheld) and `[resilience] contain_failures` continued the disjoint subgraphs — the blast radius of the failures named in `errors[]`. Empty (and omitted) for a run that did not withhold anything: the default fail-fast run, and any successful run, record nothing here.
+   */
+  contained?: ContainedModelOutput[];
+  /**
    * Aggregate cost attribution across every materialization in this run (per-model entries + run totals). `None` for DuckDB-only pipelines or when no materializations produced a cost number.
    */
   cost_summary?: RunCostSummary | null;
@@ -211,6 +215,26 @@ export interface BudgetBreachOutput {
 export interface TableCheckOutput {
   asset_key: string[];
   checks: CheckResult[];
+  [k: string]: unknown;
+}
+/**
+ * One model withheld from a run because an upstream failed (or was itself withheld) and failure-containment continued the disjoint subgraphs.
+ *
+ * This is the blast radius of a failure — the run's `errors[]` name the root cause(s). A withheld model was **not built** this run: its target was left untouched (never rebuilt on a failed upstream's stale/missing output). This is model-graph containment, distinct from the quality pipeline's row-level `quarantine` surface.
+ */
+export interface ContainedModelOutput {
+  /**
+   * The failed-or-withheld upstream(s) that reach this model — its direct poisoned dependencies. The run's `errors[]` carry the root-cause detail.
+   */
+  blocked_by: string[];
+  /**
+   * The withheld model's name (matches the model entry in the project DAG).
+   */
+  model: string;
+  /**
+   * Operator hint: resolve the named upstream failure(s), then re-run.
+   */
+  unblock_hint: string;
   [k: string]: unknown;
 }
 /**

--- a/engine/crates/rocky-cli/src/commands/containment.rs
+++ b/engine/crates/rocky-cli/src/commands/containment.rs
@@ -106,28 +106,36 @@ impl ProducerIndex {
         }
     }
 
-    /// Resolve one lowercased physical read identity to a produced target.
+    /// Resolve one physical read identity to a produced target.
+    ///
+    /// The identity is first canonicalized ([`canonicalize_identifier`]) so a
+    /// quoted read (`"main"."orders_current"`, `` `main`.`orders_current` ``,
+    /// mixed) matches the clean producer keys — the producer side is built from
+    /// structured `config.target` parts and carries no quotes. A read that
+    /// cannot be cleanly canonicalized (unbalanced quotes, an empty segment, or
+    /// a quoted segment with an embedded dot that can't be slotted into the
+    /// `schema.table` index) resolves to [`ReadResolution::Ambiguous`] so the
+    /// reader **fails closed**.
     ///
     /// Only 2-part (`schema.table`) and 3-part (`catalog.schema.table`) reads
-    /// are physical-target shapes. A bare (0-dot) read is either a model name
+    /// are physical-target shapes. A bare (1-part) read is either a model name
     /// (already a `ref()` edge, handled by the caller) or an external table; a
     /// read with more than three parts is out of range. Both resolve to
     /// [`ReadResolution::External`].
     fn resolve(&self, read: &str) -> ReadResolution {
-        let parts: Vec<&str> = read.split('.').collect();
+        let Some(parts) = canonicalize_identifier(read) else {
+            // Un-canonicalizable — cannot attribute the read; fail closed.
+            return ReadResolution::Ambiguous;
+        };
         let candidates: &[String] = match parts.as_slice() {
             [catalog, schema, table] => self
                 .by_full
-                .get(&(
-                    (*catalog).to_string(),
-                    (*schema).to_string(),
-                    (*table).to_string(),
-                ))
+                .get(&(catalog.clone(), schema.clone(), table.clone()))
                 .map(Vec::as_slice)
                 .unwrap_or(&[]),
             [schema, table] => self
                 .by_schema_table
-                .get(&((*schema).to_string(), (*table).to_string()))
+                .get(&(schema.clone(), table.clone()))
                 .map(Vec::as_slice)
                 .unwrap_or(&[]),
             _ => &[],
@@ -138,6 +146,65 @@ impl ProducerIndex {
             _ => ReadResolution::Ambiguous,
         }
     }
+}
+
+/// Split a possibly-quoted SQL table identifier into its lowercased, unquoted
+/// parts, or `None` when it can't be cleanly canonicalized.
+///
+/// The read identity arrives from the SQL lineage walk, where sqlparser renders
+/// an `ObjectName` back to a string **with** its original quote characters
+/// (`"main"."orders_current"`), while the producer index keys are the clean,
+/// structured `config.target` parts. Matching therefore requires stripping the
+/// quotes the same way for the read side. Quote styles recognized: double-quote
+/// `"…"` (DuckDB / Snowflake / Postgres), backtick `` `…` `` (BigQuery /
+/// Databricks), bracket `[…]` (T-SQL). Inside a quoted segment a `.` is a
+/// literal, not a separator; a doubled closing quote (`""`, ` `` `) is an
+/// escaped quote character.
+///
+/// Returns `None` — so the caller **fails closed** — on any identity that can't
+/// be unambiguously slotted into the `schema.table` index: unbalanced quotes, an
+/// empty segment (`a..b`, a trailing dot), or a segment that after unquoting
+/// still contains a `.` (a quoted identifier with an embedded dot). Doing string
+/// surgery here rather than a naive `replace('"', "")` is deliberate — the naive
+/// form would mis-split a quoted identifier that legitimately contains a dot.
+fn canonicalize_identifier(read: &str) -> Option<Vec<String>> {
+    let mut parts: Vec<String> = Vec::new();
+    let mut cur = String::new();
+    let mut chars = read.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '"' | '`' | '[' => {
+                let close = if ch == '[' { ']' } else { ch };
+                loop {
+                    match chars.next() {
+                        // Unbalanced quote — cannot canonicalize.
+                        None => return None,
+                        Some(c) if c == close => {
+                            // A doubled closing quote (`""` / ` `` `) is an
+                            // escaped literal, not the end of the segment.
+                            // Brackets have no doubling convention.
+                            if close != ']' && chars.peek() == Some(&close) {
+                                chars.next();
+                                cur.push(close);
+                            } else {
+                                break;
+                            }
+                        }
+                        Some(c) => cur.push(c),
+                    }
+                }
+            }
+            '.' => parts.push(std::mem::take(&mut cur)),
+            c => cur.push(c),
+        }
+    }
+    parts.push(cur);
+    // An empty segment or an embedded dot (from a quoted identifier) can't be
+    // slotted into the `schema.table` index — fail closed.
+    if parts.iter().any(|p| p.is_empty() || p.contains('.')) {
+        return None;
+    }
+    Some(parts.into_iter().map(|p| p.to_lowercase()).collect())
 }
 
 /// Conservative, fail-closed downstream-closure tracker for one run.
@@ -390,6 +457,111 @@ mod tests {
         );
         led.poison("other");
         assert!(led.evaluate("m").is_none(), "external read must build");
+    }
+
+    /// Quoted physical reads (double-quote, backtick, and mixed) resolve to the
+    /// producer just like the unquoted form and are contained.
+    #[test]
+    fn quoted_physical_reads_are_contained() {
+        for read in [
+            "\"marts\".\"orders_current\"",         // double-quoted
+            "`marts`.`orders_current`",             // backtick-quoted
+            "marts.\"orders_current\"",             // mixed
+            "\"cat\".\"marts\".\"orders_current\"", // 3-part quoted
+        ] {
+            let mut led = ledger(
+                &[
+                    ("stage", &[], &[], true),
+                    ("rollup", &["anchor"], &[read], true),
+                    ("anchor", &[], &[], true),
+                ],
+                &[("stage", "cat", "marts", "orders_current")],
+            );
+            led.poison("stage");
+            let dec = led
+                .evaluate("rollup")
+                .unwrap_or_else(|| panic!("quoted read {read:?} must be contained"));
+            assert!(
+                dec.blocked_by.contains(&"stage".to_string()),
+                "quoted read {read:?} must name the producer: {:?}",
+                dec.blocked_by
+            );
+        }
+    }
+
+    /// A quoted read of a genuinely EXTERNAL table (no producer) is external —
+    /// it builds (not over-contained).
+    #[test]
+    fn quoted_external_read_builds() {
+        let mut led = ledger(
+            &[("m", &[], &["\"raw\".\"external\""], true)],
+            &[("other", "", "marts", "orders_current")],
+        );
+        led.poison("other");
+        assert!(
+            led.evaluate("m").is_none(),
+            "quoted external read must build"
+        );
+    }
+
+    /// An un-canonicalizable read (unbalanced quote, or a quoted segment with an
+    /// embedded dot) fails closed once a failure has occurred.
+    #[test]
+    fn uncanonicalizable_read_fails_closed() {
+        for read in ["\"main\".\"orders", "\"weird.name\""] {
+            let mut led = ledger(
+                &[
+                    ("bad", &[], &[], true),
+                    ("reader", &["anchor"], &[read], true),
+                    ("anchor", &[], &[], true),
+                ],
+                &[("p", "", "marts", "orders")],
+            );
+            led.poison("bad");
+            let dec = led
+                .evaluate("reader")
+                .unwrap_or_else(|| panic!("un-canonicalizable read {read:?} must fail closed"));
+            assert!(
+                dec.fail_closed,
+                "read {read:?} must trip the fail-closed belt"
+            );
+        }
+    }
+
+    /// Canonicalization unit cases: quote styles, mixed, escapes, and the
+    /// fail-closed (`None`) cases.
+    #[test]
+    fn canonicalize_identifier_cases() {
+        let parts = |v: &[&str]| Some(v.iter().copied().map(String::from).collect::<Vec<_>>());
+        assert_eq!(
+            canonicalize_identifier("main.orders"),
+            parts(&["main", "orders"])
+        );
+        assert_eq!(
+            canonicalize_identifier("\"MAIN\".\"Orders\""),
+            parts(&["main", "orders"]),
+            "quotes stripped and lowercased"
+        );
+        assert_eq!(
+            canonicalize_identifier("`cat`.`marts`.`t`"),
+            parts(&["cat", "marts", "t"])
+        );
+        assert_eq!(
+            canonicalize_identifier("main.\"orders\""),
+            parts(&["main", "orders"]),
+            "mixed quoting"
+        );
+        // Doubled quote = escaped literal quote within the segment.
+        assert_eq!(canonicalize_identifier("\"a\"\"b\""), parts(&["a\"b"]));
+        // Fail-closed cases.
+        assert_eq!(
+            canonicalize_identifier("\"main\".\"orders"),
+            None,
+            "unbalanced"
+        );
+        assert_eq!(canonicalize_identifier("\"we.ird\""), None, "embedded dot");
+        assert_eq!(canonicalize_identifier("a..b"), None, "empty segment");
+        assert_eq!(canonicalize_identifier(".orders"), None, "leading dot");
     }
 
     /// (c) Fail-closed belt: an unenumerable read set (not provably complete) is

--- a/engine/crates/rocky-cli/src/commands/containment.rs
+++ b/engine/crates/rocky-cli/src/commands/containment.rs
@@ -1,0 +1,268 @@
+//! Model-failure containment — continue disjoint subgraphs on failure.
+//!
+//! When a model's build fails, the run loop can *contain* the failure instead
+//! of aborting the whole run: the failed model and its downstream closure are
+//! withheld, while disjoint subgraphs still materialize. The run then reports a
+//! `PartialFailure` with a manifest naming what failed and its blast radius.
+//!
+//! # Naming (not row-quarantine)
+//!
+//! This is a different axis from the quality pipeline's *row*-quarantine
+//! (`rocky_core::quarantine`, `QuarantineMode::{Split,Tag,Drop}`,
+//! `__valid`/`__quarantine` tables), which splits bad *rows* out of one table.
+//! Containment operates on the *model graph*: it withholds whole downstream
+//! *models* when an upstream fails. The vocabulary here is deliberately
+//! distinct — `Contained` / "blocked by" — so a reader never confuses a
+//! withheld model with a quarantined row.
+//!
+//! # Soundness
+//!
+//! The closure is the soundness surface. The invariant: **a downstream of a
+//! failed model must never build on stale or missing input.** So the ledger is
+//! *conservative* — it withholds a model whenever any of its resolved upstreams
+//! is failed-or-withheld, contain-more on any doubt.
+//!
+//! Two facts make a direct-upstream check transitively complete:
+//!
+//! - The edge set is the *resolved* dependency graph
+//!   ([`rocky_ir::dag::DagNode::depends_on`] — explicit `depends_on` **merged
+//!   with** the SQL-`ref()`-derived deps the executor's layering was built
+//!   from). Using the executor's own edges means a model that lands in a later
+//!   layer *because of* an edge is contained by that same edge — no
+//!   SQL-only dependency slips through un-contained.
+//! - The caller evaluates models in topological order (layer by layer), marking
+//!   every withheld model into the poison set as it goes. So by the time a model
+//!   is considered, every ancestor that failed or was withheld is already in the
+//!   poison set, and `blocked_by` (a one-hop check against the poison set) sees
+//!   it.
+
+use std::collections::{BTreeSet, HashMap};
+
+use rocky_ir::dag::DagNode;
+
+/// Conservative downstream-closure tracker for one run.
+///
+/// Holds the resolved dependency edges (owned, cloned once from the project's
+/// `dag_nodes`) plus the *poison set*: the union of failed models and models
+/// withheld because an upstream was poisoned. A model is withheld iff any of
+/// its resolved upstreams is in the poison set.
+pub(crate) struct ContainmentLedger {
+    /// `model name → its resolved upstream model names` (explicit + SQL-derived,
+    /// the same edges the execution layering used).
+    deps: HashMap<String, Vec<String>>,
+    /// Failed ∪ withheld model names. A model whose upstream is in here is
+    /// withheld; the model itself is then added, extending the closure.
+    poison: BTreeSet<String>,
+}
+
+impl ContainmentLedger {
+    /// Build a ledger from the project's resolved DAG nodes.
+    ///
+    /// The edges are cloned into an owned map so the ledger carries no borrow
+    /// of the compile result — the run loop mutates `output` and other state
+    /// alongside it without lifetime entanglement. The clone is one small pass
+    /// over the node list, paid once per run.
+    pub(crate) fn from_dag_nodes(nodes: &[DagNode]) -> Self {
+        let deps = nodes
+            .iter()
+            .map(|n| (n.name.clone(), n.depends_on.clone()))
+            .collect();
+        Self {
+            deps,
+            poison: BTreeSet::new(),
+        }
+    }
+
+    /// Seed the poison set with already-known failed models (e.g. models that
+    /// failed to compile and were excluded from execution). Their downstreams
+    /// will be withheld just like a runtime failure's.
+    pub(crate) fn seed_failed<I>(&mut self, models: I)
+    where
+        I: IntoIterator<Item = String>,
+    {
+        self.poison.extend(models);
+    }
+
+    /// The poisoned upstreams that reach `model` — its *direct* failed-or-
+    /// withheld dependencies. Empty ⇒ the model is safe to build. Non-empty ⇒
+    /// the model must be withheld; the returned names are the operator's
+    /// "blocked by" list (the run's `errors[]` name the root cause).
+    ///
+    /// Sorted + de-duplicated for deterministic output.
+    pub(crate) fn blocked_by(&self, model: &str) -> Vec<String> {
+        let Some(deps) = self.deps.get(model) else {
+            return Vec::new();
+        };
+        let mut blockers: Vec<String> = deps
+            .iter()
+            .filter(|u| self.poison.contains(*u))
+            .cloned()
+            .collect();
+        blockers.sort();
+        blockers.dedup();
+        blockers
+    }
+
+    /// Add a model to the poison set — a failed cause *or* a withheld
+    /// downstream. Either way its own descendants must be withheld, so both
+    /// extend the closure identically.
+    pub(crate) fn poison(&mut self, model: &str) {
+        self.poison.insert(model.to_string());
+    }
+}
+
+/// A human-readable hint telling the operator how to clear a withheld model:
+/// resolve the named upstream failure(s), then re-run.
+pub(crate) fn unblock_hint(blocked_by: &[String]) -> String {
+    match blocked_by {
+        [] => "re-run once the upstream failure is resolved".to_string(),
+        [one] => format!("resolve upstream '{one}', then re-run"),
+        many => format!("resolve upstream(s) {}, then re-run", many.join(", ")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(name: &str, deps: &[&str]) -> DagNode {
+        DagNode {
+            name: name.to_string(),
+            depends_on: deps.iter().copied().map(String::from).collect(),
+        }
+    }
+
+    /// Drive the ledger over a topologically-ordered model list exactly as the
+    /// run loop does: a model with a poisoned upstream is withheld (and itself
+    /// poisoned); an already-failed model is seeded; everything else builds.
+    /// Returns `(built, withheld)` model-name sets.
+    fn simulate(
+        nodes: &[DagNode],
+        topo_order: &[&str],
+        failed: &[&str],
+    ) -> (Vec<String>, Vec<String>) {
+        let mut ledger = ContainmentLedger::from_dag_nodes(nodes);
+        let failed_set: BTreeSet<&str> = failed.iter().copied().collect();
+        let mut built = Vec::new();
+        let mut withheld = Vec::new();
+        for &name in topo_order {
+            // A model that is itself the failure: mark failed, don't build.
+            if failed_set.contains(name) {
+                ledger.poison(name);
+                continue;
+            }
+            let blockers = ledger.blocked_by(name);
+            if blockers.is_empty() {
+                built.push(name.to_string());
+            } else {
+                ledger.poison(name);
+                withheld.push(name.to_string());
+            }
+        }
+        (built, withheld)
+    }
+
+    /// (a) Disjoint subtrees still run. Graph: A→B and C→D are two independent
+    /// chains. A fails ⇒ B is withheld, but C and D (disjoint) still build.
+    #[test]
+    fn disjoint_subtree_still_builds() {
+        let nodes = [
+            node("A", &[]),
+            node("B", &["A"]),
+            node("C", &[]),
+            node("D", &["C"]),
+        ];
+        let (built, withheld) = simulate(&nodes, &["A", "C", "B", "D"], &["A"]);
+        assert_eq!(built, vec!["C", "D"], "the disjoint C→D subtree must build");
+        assert_eq!(withheld, vec!["B"], "only A's downstream is withheld");
+    }
+
+    /// (b) The full downstream closure of a failure is contained. Chain
+    /// A→B→C→D; A fails ⇒ B, C, and D are ALL withheld (transitive closure),
+    /// even though only B depends on A directly — C is withheld because B is
+    /// poisoned, D because C is.
+    #[test]
+    fn full_downstream_closure_is_contained() {
+        let nodes = [
+            node("A", &[]),
+            node("B", &["A"]),
+            node("C", &["B"]),
+            node("D", &["C"]),
+        ];
+        let (built, withheld) = simulate(&nodes, &["A", "B", "C", "D"], &["A"]);
+        assert!(built.is_empty(), "nothing survives A's failure in a chain");
+        assert_eq!(
+            withheld,
+            vec!["B", "C", "D"],
+            "the whole closure is withheld"
+        );
+    }
+
+    /// (c) A diamond: A→{B,C}→D. A fails ⇒ B, C, and their shared join D are
+    /// all withheld. D is blocked by BOTH B and C (both poisoned).
+    #[test]
+    fn diamond_closure_and_multi_blocker() {
+        let nodes = [
+            node("A", &[]),
+            node("B", &["A"]),
+            node("C", &["A"]),
+            node("D", &["B", "C"]),
+        ];
+        let mut ledger = ContainmentLedger::from_dag_nodes(&nodes);
+        ledger.poison("A"); // A failed
+        assert_eq!(ledger.blocked_by("B"), vec!["A"]);
+        ledger.poison("B");
+        assert_eq!(ledger.blocked_by("C"), vec!["A"]);
+        ledger.poison("C");
+        // D is reachable from A through two paths — both blockers surface.
+        assert_eq!(ledger.blocked_by("D"), vec!["B", "C"]);
+    }
+
+    /// A model whose upstreams are all healthy is never withheld.
+    #[test]
+    fn healthy_model_is_not_blocked() {
+        let nodes = [node("A", &[]), node("B", &["A"])];
+        let mut ledger = ContainmentLedger::from_dag_nodes(&nodes);
+        ledger.poison("A");
+        // B depends on A (poisoned) → blocked.
+        assert!(!ledger.blocked_by("B").is_empty());
+        // But a fresh sibling with no poisoned deps is clear.
+        assert!(ledger.blocked_by("A").is_empty());
+    }
+
+    /// A compile-failed model seeded up front withholds its runtime downstream
+    /// exactly like a runtime failure would — a compile error is a failure too.
+    #[test]
+    fn seeded_compile_failure_contains_downstream() {
+        let nodes = [node("bad", &[]), node("dep", &["bad"])];
+        let mut ledger = ContainmentLedger::from_dag_nodes(&nodes);
+        ledger.seed_failed(["bad".to_string()]);
+        assert_eq!(ledger.blocked_by("dep"), vec!["bad"]);
+    }
+
+    /// A poisoned *partitioned* cause blocks only its descendants, not a
+    /// disjoint sibling — the model-level rule the partition path relies on
+    /// (any failed partition poisons the whole model's downstream).
+    #[test]
+    fn partitioned_cause_blocks_only_descendants() {
+        let nodes = [
+            node("events", &[]), // partitioned model, one partition failed
+            node("rollup", &["events"]),
+            node("unrelated", &[]),
+        ];
+        let mut ledger = ContainmentLedger::from_dag_nodes(&nodes);
+        ledger.poison("events");
+        assert_eq!(ledger.blocked_by("rollup"), vec!["events"]);
+        assert!(
+            ledger.blocked_by("unrelated").is_empty(),
+            "a disjoint model must be unaffected by a partition failure elsewhere"
+        );
+    }
+
+    #[test]
+    fn unblock_hint_wording() {
+        assert!(unblock_hint(&["a".to_string()]).contains("resolve upstream 'a'"));
+        assert!(unblock_hint(&["a".to_string(), "b".to_string()]).contains("a, b"));
+        assert!(!unblock_hint(&[]).is_empty());
+    }
+}

--- a/engine/crates/rocky-cli/src/commands/containment.rs
+++ b/engine/crates/rocky-cli/src/commands/containment.rs
@@ -52,25 +52,39 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 /// Index of every model's produced target, for resolving a physical `FROM` /
 /// `JOIN` read back to the model that produces that table.
 ///
-/// Two lookups mirror how a physical read can be written:
+/// Three lookups mirror how a physical read can be written:
 /// - `by_full` — an explicit 3-part `catalog.schema.table` read matches a
 ///   producer's full target exactly.
 /// - `by_schema_table` — a 2-part `schema.table` read omits the catalog; it
-///   matches producers on `(schema, table)`. If more than one producer (in
-///   different catalogs) shares that `(schema, table)`, the read is *ambiguous*.
+///   matches producers on `(schema, table)`. More than one producer (across
+///   catalogs) sharing that `(schema, table)` is *ambiguous* → fail closed.
+/// - `by_table` — a bare 1-part read (`orders_current`) resolved via the
+///   session default schema. We do NOT model per-dialect `search_path`
+///   precisely (getting it wrong is the unsound direction); instead a bare read
+///   colliding with a producer's target table **in any schema** is treated as a
+///   *candidate* edge to each such producer, so the reader is contained iff at
+///   least one candidate producer is poisoned. This over-contains only when a
+///   bare read literally matches a failed producer's output table — the
+///   acceptable direction; a bare read matching no producer table is external.
 ///
 /// All keys are lowercased. A model appears once per lookup.
 pub(crate) struct ProducerIndex {
     by_full: HashMap<(String, String, String), Vec<String>>,
     by_schema_table: HashMap<(String, String), Vec<String>>,
+    by_table: HashMap<String, Vec<String>>,
 }
 
 /// How a single physical read resolves against the produced targets.
 enum ReadResolution {
-    /// Resolves to exactly one produced target — add a containment edge.
-    Edge(String),
-    /// Matches more than one produced target (multi-catalog `schema.table`) —
-    /// cannot be attributed, so the reader fails closed.
+    /// Resolves to one or more candidate producers — each is added as a
+    /// containment edge, so the reader is blocked iff at least one is poisoned.
+    /// Exactly one candidate for an unambiguous 2/3-part read; possibly several
+    /// for a bare 1-part read that collides with a producer target table across
+    /// schemas.
+    Edges(Vec<String>),
+    /// A qualified (2/3-part) read matching more than one produced target
+    /// (multi-catalog collision), or an un-canonicalizable identity — cannot be
+    /// attributed, so the reader fails closed.
     Ambiguous,
     /// Matches no produced target — a genuinely external table this run does
     /// not produce, which a run failure cannot make stale.
@@ -85,6 +99,7 @@ impl ProducerIndex {
     {
         let mut by_full: HashMap<(String, String, String), Vec<String>> = HashMap::new();
         let mut by_schema_table: HashMap<(String, String), Vec<String>> = HashMap::new();
+        let mut by_table: HashMap<String, Vec<String>> = HashMap::new();
         for (name, catalog, schema, table) in models {
             let (c, s, t) = (
                 catalog.to_lowercase(),
@@ -96,13 +111,15 @@ impl ProducerIndex {
                 .or_default()
                 .push(name.to_string());
             by_schema_table
-                .entry((s, t))
+                .entry((s, t.clone()))
                 .or_default()
                 .push(name.to_string());
+            by_table.entry(t).or_default().push(name.to_string());
         }
         Self {
             by_full,
             by_schema_table,
+            by_table,
         }
     }
 
@@ -117,33 +134,47 @@ impl ProducerIndex {
     /// `schema.table` index) resolves to [`ReadResolution::Ambiguous`] so the
     /// reader **fails closed**.
     ///
-    /// Only 2-part (`schema.table`) and 3-part (`catalog.schema.table`) reads
-    /// are physical-target shapes. A bare (1-part) read is either a model name
-    /// (already a `ref()` edge, handled by the caller) or an external table; a
-    /// read with more than three parts is out of range. Both resolve to
-    /// [`ReadResolution::External`].
+    /// A bare (1-part) read is resolved against producer target-table names
+    /// (`by_table`): a caller-known model name is skipped upstream (it is a
+    /// `ref()` edge), so a bare read that reaches here and matches a producer's
+    /// target table is a candidate edge to that producer. A qualified read
+    /// (2/3-part) resolves uniquely or is [`ReadResolution::Ambiguous`]; a read
+    /// with more than three parts is out of range → [`ReadResolution::External`].
     fn resolve(&self, read: &str) -> ReadResolution {
         let Some(parts) = canonicalize_identifier(read) else {
             // Un-canonicalizable — cannot attribute the read; fail closed.
             return ReadResolution::Ambiguous;
         };
-        let candidates: &[String] = match parts.as_slice() {
-            [catalog, schema, table] => self
-                .by_full
-                .get(&(catalog.clone(), schema.clone(), table.clone()))
-                .map(Vec::as_slice)
-                .unwrap_or(&[]),
-            [schema, table] => self
-                .by_schema_table
-                .get(&(schema.clone(), table.clone()))
-                .map(Vec::as_slice)
-                .unwrap_or(&[]),
-            _ => &[],
-        };
-        match candidates {
-            [] => ReadResolution::External,
-            [one] => ReadResolution::Edge(one.clone()),
-            _ => ReadResolution::Ambiguous,
+        match parts.as_slice() {
+            // Qualified reads must resolve to exactly one producer; a collision
+            // (duplicate exact target, or multi-catalog `schema.table`) can't be
+            // attributed, so it fails closed.
+            [catalog, schema, table] => Self::qualified(self.by_full.get(&(
+                catalog.clone(),
+                schema.clone(),
+                table.clone(),
+            ))),
+            [schema, table] => {
+                Self::qualified(self.by_schema_table.get(&(schema.clone(), table.clone())))
+            }
+            // Bare read: every producer whose target table matches is a
+            // candidate — contain iff at least one is poisoned. No match ⇒
+            // genuinely external ⇒ build (no over-containment).
+            [table] => match self.by_table.get(table) {
+                None => ReadResolution::External,
+                Some(candidates) => ReadResolution::Edges(candidates.clone()),
+            },
+            _ => ReadResolution::External,
+        }
+    }
+
+    /// Resolve a qualified (2/3-part) read: exactly one producer ⇒ an edge; a
+    /// collision ⇒ ambiguous (fail closed); none ⇒ external.
+    fn qualified(candidates: Option<&Vec<String>>) -> ReadResolution {
+        match candidates.map(Vec::as_slice) {
+            None | Some([]) => ReadResolution::External,
+            Some([one]) => ReadResolution::Edges(vec![one.clone()]),
+            Some(_) => ReadResolution::Ambiguous,
         }
     }
 }
@@ -272,14 +303,17 @@ impl ContainmentLedger {
                 continue;
             }
             match producers.resolve(read) {
-                // A physical read of another model's produced target.
-                ReadResolution::Edge(producer) if producer != name => {
-                    ups.insert(producer);
+                // A physical read of one-or-more producers' target(s). Each is a
+                // candidate edge (self-reads excluded); the model is blocked iff
+                // at least one candidate is poisoned.
+                ReadResolution::Edges(producers) => {
+                    for producer in producers {
+                        if producer != name {
+                            ups.insert(producer);
+                        }
+                    }
                 }
-                // A model reading its own target (e.g. incremental self-ref) is
-                // not a cross-model edge.
-                ReadResolution::Edge(_) => {}
-                // Cannot attribute the read to a single producer — fail closed.
+                // Cannot attribute the read to a bounded producer set — fail closed.
                 ReadResolution::Ambiguous => uncertain = true,
                 // Genuinely external — a run failure cannot make it stale.
                 ReadResolution::External => {}
@@ -457,6 +491,50 @@ mod tests {
         );
         led.poison("other");
         assert!(led.evaluate("m").is_none(), "external read must build");
+    }
+
+    /// A bare (1-part) read of a producer's target table (default-schema
+    /// resolution) is contained when that producer is poisoned — via `by_table`,
+    /// even though the producer's model name differs from its table name.
+    #[test]
+    fn bare_read_of_producer_table_is_contained() {
+        let mut led = ledger(
+            &[
+                ("stage", &[], &[], true),
+                ("rollup", &["anchor"], &["orders_current"], true),
+                ("anchor", &[], &[], true),
+            ],
+            &[("stage", "", "main", "orders_current")],
+        );
+        led.poison("stage");
+        let dec = led
+            .evaluate("rollup")
+            .expect("bare read of a failed producer's table ⇒ contained");
+        assert!(
+            !dec.fail_closed,
+            "resolved via a producer edge, not the belt"
+        );
+        assert!(dec.blocked_by.contains(&"stage".to_string()));
+    }
+
+    /// A bare read of a genuine external table (no producer has that table name)
+    /// builds — even when an unrelated failure has occurred. The bare-read
+    /// resolution must not over-contain every bare read whenever a run fails.
+    #[test]
+    fn bare_read_of_external_table_builds() {
+        let mut led = ledger(
+            &[
+                ("bad", &[], &[], true),
+                ("reader", &["anchor"], &["some_external"], true),
+                ("anchor", &[], &[], true),
+            ],
+            &[("stage", "", "main", "orders_current")], // no producer targets `some_external`
+        );
+        led.poison("bad");
+        assert!(
+            led.evaluate("reader").is_none(),
+            "a bare external read must build even under an unrelated failure"
+        );
     }
 
     /// Quoted physical reads (double-quote, backtick, and mixed) resolve to the

--- a/engine/crates/rocky-cli/src/commands/containment.rs
+++ b/engine/crates/rocky-cli/src/commands/containment.rs
@@ -42,10 +42,32 @@
 //!
 //! The closure is evaluated layer-by-layer in topological order, poisoning every
 //! withheld model as it goes, so a one-hop upstream check is transitively
-//! complete. Residual boundary: a physical read of a producer that is *not*
-//! topologically earlier is a pre-existing undeclared-dependency ordering issue
-//! (the read sees prior-run data regardless of containment) — declare the
-//! dependency via `ref()`/model name.
+//! complete. When `contain_failures` is on, execution layers are recomputed over
+//! this full edge set ([`ContainmentLedger::augmented_layers`]) so a reader is
+//! scheduled strictly after every producer it reads — closing the same-layer
+//! `--parallel` race for *resolvable* reads.
+//!
+//! # Guarantee scope
+//!
+//! Failure containment is **guaranteed** for dependencies declared via `ref()`
+//! and for physical reads Rocky can statically resolve — 2-part `schema.table`,
+//! 3-part `catalog.schema.table`, quoted or unquoted. Those are folded into both
+//! the closure and the execution ordering, so a downstream of a failure is never
+//! built on its stale/missing output.
+//!
+//! Reads Rocky **cannot enumerate** — a model built on a CTE, sub-query, or set
+//! operation, anything `rocky_sql::lineage_complete::lineage_is_provably_complete`
+//! rejects (an "uncertain" model) — are handled on a **best-effort** basis
+//! *identical to a normal fail-fast run*. An uncertain model with a known failed
+//! upstream is contained (the fail-closed belt in [`ContainmentLedger::evaluate`]),
+//! but because its reads yield no ordering edge, under `--parallel` a same-layer
+//! uncertain reader of a failing producer can still materialize on stale data —
+//! **exactly as plain fail-fast does** in that case (verified by the
+//! `containment_matches_fail_fast_for_same_layer_uncertain_read` parity test).
+//! This is a documented boundary, not a regression: the achievable guarantee is
+//! *containment never materializes anything fail-fast wouldn't*. Chasing the
+//! absolute bar would mean containing every CTE model, which would false-fail
+//! healthy projects. **Declare the dependency with `ref()` for a hard guarantee.**
 
 use std::collections::{BTreeSet, HashMap, HashSet};
 

--- a/engine/crates/rocky-cli/src/commands/containment.rs
+++ b/engine/crates/rocky-cli/src/commands/containment.rs
@@ -268,6 +268,18 @@ pub(crate) struct ContainmentDecision {
     pub fail_closed: bool,
 }
 
+/// Execution layers over the augmented containment graph, plus any models that
+/// couldn't be ordered because a physical/bare edge formed a cycle.
+pub(crate) struct LayerPlan {
+    /// Topological execution layers (longest-path) over ref ∪ physical ∪ bare
+    /// edges. A reader is strictly later than every producer it reads.
+    pub layers: Vec<Vec<String>>,
+    /// Models in — or downstream of — an augmented-graph cycle. They can't be
+    /// safely ordered, so the caller contains them (fail closed). Empty in the
+    /// common acyclic case.
+    pub cyclic: Vec<String>,
+}
+
 impl ContainmentLedger {
     pub(crate) fn new() -> Self {
         Self {
@@ -380,6 +392,81 @@ impl ContainmentLedger {
             });
         }
         None
+    }
+
+    /// Compute execution layers over the **full containment edge set** (ref()
+    /// deps ∪ resolved physical/bare-read producer edges), so a reader is
+    /// scheduled strictly after every producer it reads by any edge kind — the
+    /// ordering guarantee that closes the same-layer `--parallel` race.
+    ///
+    /// Longest-path layering ([`rocky_ir::dag::execution_layers`]) places a node
+    /// one layer after its deepest dependency, so no two models in the same
+    /// layer share a containment edge; combined with the executor's per-layer
+    /// barrier, every prior failure is poisoned before the next layer is
+    /// evaluated.
+    ///
+    /// **Cycle → fail closed.** A physical/bare edge can introduce a dependency
+    /// cycle the ref-graph lacked. Rather than let the topological sort silently
+    /// drop the cyclic nodes, they are returned in [`LayerPlan::cyclic`] (the
+    /// stuck set — the cycle plus everything downstream of it) for the caller to
+    /// *contain*, and only the acyclic remainder is layered.
+    pub(crate) fn augmented_layers(&self) -> LayerPlan {
+        use rocky_ir::dag::{self, DagError, DagNode};
+
+        // Augmented graph: each model's dependencies are its full containment
+        // upstream set, restricted to known models.
+        let node = |name: &str, ups: &[String]| DagNode {
+            name: name.to_string(),
+            depends_on: ups
+                .iter()
+                .filter(|u| self.known.contains(*u))
+                .cloned()
+                .collect(),
+        };
+        let nodes: Vec<DagNode> = self
+            .known
+            .iter()
+            .map(|m| node(m, self.upstreams.get(m).map(Vec::as_slice).unwrap_or(&[])))
+            .collect();
+
+        match dag::execution_layers(&nodes) {
+            Ok(layers) => LayerPlan {
+                layers,
+                cyclic: Vec::new(),
+            },
+            // The stuck set (cycle + downstream) can't be ordered — fail closed:
+            // contain it, and layer only the acyclic remainder.
+            Err(DagError::CyclicDependency { nodes: stuck }) => {
+                let stuck_set: HashSet<&str> = stuck.iter().map(String::as_str).collect();
+                let acyclic: Vec<DagNode> = nodes
+                    .iter()
+                    .filter(|n| !stuck_set.contains(n.name.as_str()))
+                    .map(|n| DagNode {
+                        name: n.name.clone(),
+                        depends_on: n
+                            .depends_on
+                            .iter()
+                            .filter(|d| !stuck_set.contains(d.as_str()))
+                            .cloned()
+                            .collect(),
+                    })
+                    .collect();
+                let layers = dag::execution_layers(&acyclic).unwrap_or_default();
+                let mut cyclic = stuck;
+                cyclic.sort();
+                LayerPlan { layers, cyclic }
+            }
+            // `UnknownDependency` cannot arise (deps are filtered to known
+            // models), but fail closed if it somehow does: contain everything.
+            Err(_) => {
+                let mut cyclic: Vec<String> = self.known.iter().cloned().collect();
+                cyclic.sort();
+                LayerPlan {
+                    layers: Vec::new(),
+                    cyclic,
+                }
+            }
+        }
     }
 }
 
@@ -737,5 +824,94 @@ mod tests {
         assert!(unblock_hint(&["a".to_string()], false).contains("resolve upstream 'a'"));
         assert!(unblock_hint(&["a".to_string(), "b".to_string()], true).contains("cannot prove"));
         assert!(!unblock_hint(&[], true).is_empty());
+    }
+
+    fn layer_of(plan: &LayerPlan, model: &str) -> Option<usize> {
+        plan.layers
+            .iter()
+            .position(|l| l.iter().any(|m| m == model))
+    }
+
+    /// Augmented layering orders a physical/bare reader strictly after its
+    /// producer, even with NO `ref()` edge between them — the ordering fix for
+    /// the same-layer `--parallel` race.
+    #[test]
+    fn augmented_layers_order_physical_reader_after_producer() {
+        // `rollup` has no ref dep on `stage`; it only physically reads its
+        // target `main.orders_current`. Ref-only layering would co-schedule
+        // them; augmented layering must not.
+        let led = ledger(
+            &[
+                ("stage", &[], &[], true),
+                ("rollup", &[], &["main.orders_current"], true),
+            ],
+            &[
+                ("stage", "", "main", "orders_current"),
+                ("rollup", "", "main", "rollup"),
+            ],
+        );
+        let plan = led.augmented_layers();
+        assert!(plan.cyclic.is_empty());
+        let (ls, lr) = (
+            layer_of(&plan, "stage").unwrap(),
+            layer_of(&plan, "rollup").unwrap(),
+        );
+        assert!(
+            lr > ls,
+            "reader (layer {lr}) must be strictly after producer (layer {ls})"
+        );
+    }
+
+    /// Invariant: no two models in the same augmented layer share a containment
+    /// edge (longest-path layering guarantees this; the executor relies on it so
+    /// prior-layer poison is fully known before a layer dispatches).
+    #[test]
+    fn augmented_layers_no_same_layer_shared_edge() {
+        let led = ledger(
+            &[
+                ("a", &[], &[], true),
+                ("b", &["a"], &["a"], true),               // ref edge a→b
+                ("c", &[], &["main.a_out"], true),         // physical edge a→c
+                ("d", &["b"], &["b", "main.c_out"], true), // ref b→d, physical c→d
+            ],
+            &[("a", "", "main", "a_out"), ("c", "", "main", "c_out")],
+        );
+        let plan = led.augmented_layers();
+        assert!(plan.cyclic.is_empty());
+        // For every layer, no pair shares an edge (neither is the other's
+        // upstream over the augmented graph).
+        for layer in &plan.layers {
+            for i in 0..layer.len() {
+                for j in (i + 1)..layer.len() {
+                    let (x, y) = (&layer[i], &layer[j]);
+                    let x_ups = led.upstreams.get(x).cloned().unwrap_or_default();
+                    let y_ups = led.upstreams.get(y).cloned().unwrap_or_default();
+                    assert!(
+                        !x_ups.contains(y) && !y_ups.contains(x),
+                        "same-layer pair {x:?},{y:?} shares a containment edge"
+                    );
+                }
+            }
+        }
+    }
+
+    /// A physical/bare edge that forms a cycle the ref-graph lacked → fail
+    /// closed: the stuck set is surfaced in `cyclic` (for the caller to
+    /// contain), not silently dropped or mis-ordered.
+    #[test]
+    fn augmented_layers_cycle_is_contained() {
+        // A refs B (edge B→A); B physically reads A's target `main.a` (edge
+        // A→B) ⇒ cycle A↔B.
+        let led = ledger(
+            &[("A", &["B"], &["b"], true), ("B", &[], &["main.a"], true)],
+            &[("A", "", "main", "a"), ("B", "", "main", "b")],
+        );
+        let plan = led.augmented_layers();
+        assert_eq!(plan.cyclic, vec!["A".to_string(), "B".to_string()]);
+        assert!(
+            plan.layers
+                .iter()
+                .all(|l| l.is_empty() || !l.contains(&"A".to_string()))
+        );
     }
 }

--- a/engine/crates/rocky-cli/src/commands/containment.rs
+++ b/engine/crates/rocky-cli/src/commands/containment.rs
@@ -8,74 +8,226 @@
 //! # Naming (not row-quarantine)
 //!
 //! This is a different axis from the quality pipeline's *row*-quarantine
-//! (`rocky_core::quarantine`, `QuarantineMode::{Split,Tag,Drop}`,
-//! `__valid`/`__quarantine` tables), which splits bad *rows* out of one table.
+//! (`rocky_core::quarantine`), which splits bad *rows* out of one table.
 //! Containment operates on the *model graph*: it withholds whole downstream
 //! *models* when an upstream fails. The vocabulary here is deliberately
 //! distinct — `Contained` / "blocked by" — so a reader never confuses a
 //! withheld model with a quarantined row.
 //!
-//! # Soundness
+//! # Soundness — the closure must be complete, not just the declared graph
 //!
-//! The closure is the soundness surface. The invariant: **a downstream of a
-//! failed model must never build on stale or missing input.** So the ledger is
-//! *conservative* — it withholds a model whenever any of its resolved upstreams
-//! is failed-or-withheld, contain-more on any doubt.
+//! The invariant is absolute: **a downstream of a failed model must never build
+//! on that failure's stale or missing output.** So the closure is *conservative
+//! and fail-closed*, and it does **not** trust the declared dependency graph
+//! (`dag_nodes`) as complete or authoritative. Two escape hatches make a naive
+//! `dag_nodes`-only closure unsound, and both are closed here:
 //!
-//! Two facts make a direct-upstream check transitively complete:
+//! 1. **Physical-table reads.** A raw-SQL model can read a producer's *target
+//!    table by physical name* (`marts.orders_current`) instead of by model name
+//!    (`ref(stage_orders)`). That read produces no `dag_nodes` edge, so a
+//!    `dag_nodes`-only closure would let the model build on the failed
+//!    producer's stale output. We therefore resolve every physical `FROM`/`JOIN`
+//!    read against the set of **produced targets** ([`ProducerIndex`]) and add
+//!    an implicit containment edge when a read matches a produced target — so a
+//!    model reading a failed model's output, by `ref()` *or* by physical name,
+//!    is withheld. A read that resolves to no produced target is a genuinely
+//!    external table this run does not produce, so a run failure cannot make it
+//!    stale — no edge, build allowed.
+//! 2. **Unprovable read sets.** If a model's reads cannot be fully enumerated
+//!    (`rocky_sql::lineage_complete::lineage_is_provably_complete` is `false` —
+//!    CTEs, sub-queries, set operations, unparseable SQL) or a physical read is
+//!    ambiguous (matches producers in more than one catalog), we cannot *prove*
+//!    the model is disjoint from the failure set. Such a model **fails closed**:
+//!    once any failure has occurred it is contained, never built.
 //!
-//! - The edge set is the *resolved* dependency graph
-//!   ([`rocky_ir::dag::DagNode::depends_on`] — explicit `depends_on` **merged
-//!   with** the SQL-`ref()`-derived deps the executor's layering was built
-//!   from). Using the executor's own edges means a model that lands in a later
-//!   layer *because of* an edge is contained by that same edge — no
-//!   SQL-only dependency slips through un-contained.
-//! - The caller evaluates models in topological order (layer by layer), marking
-//!   every withheld model into the poison set as it goes. So by the time a model
-//!   is considered, every ancestor that failed or was withheld is already in the
-//!   poison set, and `blocked_by` (a one-hop check against the poison set) sees
-//!   it.
+//! The closure is evaluated layer-by-layer in topological order, poisoning every
+//! withheld model as it goes, so a one-hop upstream check is transitively
+//! complete. Residual boundary: a physical read of a producer that is *not*
+//! topologically earlier is a pre-existing undeclared-dependency ordering issue
+//! (the read sees prior-run data regardless of containment) — declare the
+//! dependency via `ref()`/model name.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
-use rocky_ir::dag::DagNode;
-
-/// Conservative downstream-closure tracker for one run.
+/// Index of every model's produced target, for resolving a physical `FROM` /
+/// `JOIN` read back to the model that produces that table.
 ///
-/// Holds the resolved dependency edges (owned, cloned once from the project's
-/// `dag_nodes`) plus the *poison set*: the union of failed models and models
-/// withheld because an upstream was poisoned. A model is withheld iff any of
-/// its resolved upstreams is in the poison set.
+/// Two lookups mirror how a physical read can be written:
+/// - `by_full` — an explicit 3-part `catalog.schema.table` read matches a
+///   producer's full target exactly.
+/// - `by_schema_table` — a 2-part `schema.table` read omits the catalog; it
+///   matches producers on `(schema, table)`. If more than one producer (in
+///   different catalogs) shares that `(schema, table)`, the read is *ambiguous*.
+///
+/// All keys are lowercased. A model appears once per lookup.
+pub(crate) struct ProducerIndex {
+    by_full: HashMap<(String, String, String), Vec<String>>,
+    by_schema_table: HashMap<(String, String), Vec<String>>,
+}
+
+/// How a single physical read resolves against the produced targets.
+enum ReadResolution {
+    /// Resolves to exactly one produced target — add a containment edge.
+    Edge(String),
+    /// Matches more than one produced target (multi-catalog `schema.table`) —
+    /// cannot be attributed, so the reader fails closed.
+    Ambiguous,
+    /// Matches no produced target — a genuinely external table this run does
+    /// not produce, which a run failure cannot make stale.
+    External,
+}
+
+impl ProducerIndex {
+    /// Build from `(model_name, catalog, schema, table)` tuples.
+    pub(crate) fn build<'a, I>(models: I) -> Self
+    where
+        I: IntoIterator<Item = (&'a str, &'a str, &'a str, &'a str)>,
+    {
+        let mut by_full: HashMap<(String, String, String), Vec<String>> = HashMap::new();
+        let mut by_schema_table: HashMap<(String, String), Vec<String>> = HashMap::new();
+        for (name, catalog, schema, table) in models {
+            let (c, s, t) = (
+                catalog.to_lowercase(),
+                schema.to_lowercase(),
+                table.to_lowercase(),
+            );
+            by_full
+                .entry((c, s.clone(), t.clone()))
+                .or_default()
+                .push(name.to_string());
+            by_schema_table
+                .entry((s, t))
+                .or_default()
+                .push(name.to_string());
+        }
+        Self {
+            by_full,
+            by_schema_table,
+        }
+    }
+
+    /// Resolve one lowercased physical read identity to a produced target.
+    ///
+    /// Only 2-part (`schema.table`) and 3-part (`catalog.schema.table`) reads
+    /// are physical-target shapes. A bare (0-dot) read is either a model name
+    /// (already a `ref()` edge, handled by the caller) or an external table; a
+    /// read with more than three parts is out of range. Both resolve to
+    /// [`ReadResolution::External`].
+    fn resolve(&self, read: &str) -> ReadResolution {
+        let parts: Vec<&str> = read.split('.').collect();
+        let candidates: &[String] = match parts.as_slice() {
+            [catalog, schema, table] => self
+                .by_full
+                .get(&(
+                    (*catalog).to_string(),
+                    (*schema).to_string(),
+                    (*table).to_string(),
+                ))
+                .map(Vec::as_slice)
+                .unwrap_or(&[]),
+            [schema, table] => self
+                .by_schema_table
+                .get(&((*schema).to_string(), (*table).to_string()))
+                .map(Vec::as_slice)
+                .unwrap_or(&[]),
+            _ => &[],
+        };
+        match candidates {
+            [] => ReadResolution::External,
+            [one] => ReadResolution::Edge(one.clone()),
+            _ => ReadResolution::Ambiguous,
+        }
+    }
+}
+
+/// Conservative, fail-closed downstream-closure tracker for one run.
+///
+/// Holds, per model, its full containment-upstream set (`ref()` deps ∪ resolved
+/// physical-target edges) plus an `uncertain` flag for models whose disjointness
+/// from the failure set cannot be proven; and the *poison set* — the union of
+/// failed and withheld models.
 pub(crate) struct ContainmentLedger {
-    /// `model name → its resolved upstream model names` (explicit + SQL-derived,
-    /// the same edges the execution layering used).
-    deps: HashMap<String, Vec<String>>,
-    /// Failed ∪ withheld model names. A model whose upstream is in here is
-    /// withheld; the model itself is then added, extending the closure.
+    /// `model name → its containment upstreams` (ref-deps ∪ physical edges).
+    upstreams: HashMap<String, Vec<String>>,
+    /// Models whose read set could not be proven complete / unambiguous — they
+    /// fail closed once any failure has occurred.
+    uncertain: HashSet<String>,
+    /// Every model the ledger was told about (run-set coverage). A model queried
+    /// but never added is treated as uncertain (fail closed).
+    known: HashSet<String>,
+    /// Failed ∪ withheld model names.
     poison: BTreeSet<String>,
 }
 
+/// The verdict for one model: whether to withhold it, and why.
+pub(crate) struct ContainmentDecision {
+    /// The poisoned models that make it unsafe to build — a proven upstream
+    /// block names those upstreams; a fail-closed block names the current
+    /// failure set.
+    pub blocked_by: Vec<String>,
+    /// `true` when contained by the conservative belt (unprovable disjointness),
+    /// not by a proven poisoned upstream.
+    pub fail_closed: bool,
+}
+
 impl ContainmentLedger {
-    /// Build a ledger from the project's resolved DAG nodes.
-    ///
-    /// The edges are cloned into an owned map so the ledger carries no borrow
-    /// of the compile result — the run loop mutates `output` and other state
-    /// alongside it without lifetime entanglement. The clone is one small pass
-    /// over the node list, paid once per run.
-    pub(crate) fn from_dag_nodes(nodes: &[DagNode]) -> Self {
-        let deps = nodes
-            .iter()
-            .map(|n| (n.name.clone(), n.depends_on.clone()))
-            .collect();
+    pub(crate) fn new() -> Self {
         Self {
-            deps,
+            upstreams: HashMap::new(),
+            uncertain: HashSet::new(),
+            known: HashSet::new(),
             poison: BTreeSet::new(),
         }
     }
 
-    /// Seed the poison set with already-known failed models (e.g. models that
-    /// failed to compile and were excluded from execution). Their downstreams
-    /// will be withheld just like a runtime failure's.
+    /// Register one model with its `ref()` deps, its enumerated physical reads,
+    /// whether that read set is provably complete, and the producer index.
+    ///
+    /// Computes the model's full containment-upstream set (ref-deps ∪ physical
+    /// edges to produced targets) and marks it `uncertain` when the read set is
+    /// not provably complete or any physical read is ambiguous.
+    pub(crate) fn add_model(
+        &mut self,
+        name: &str,
+        ref_deps: &[String],
+        model_names: &HashSet<String>,
+        reads: &[String],
+        reads_complete: bool,
+        producers: &ProducerIndex,
+    ) {
+        self.known.insert(name.to_string());
+        let mut ups: BTreeSet<String> = ref_deps.iter().cloned().collect();
+        // A read set we cannot fully enumerate cannot prove disjointness.
+        let mut uncertain = !reads_complete;
+        for read in reads {
+            // A bare model-name read is already a `ref()` edge (in `ref_deps`).
+            if model_names.contains(read) {
+                continue;
+            }
+            match producers.resolve(read) {
+                // A physical read of another model's produced target.
+                ReadResolution::Edge(producer) if producer != name => {
+                    ups.insert(producer);
+                }
+                // A model reading its own target (e.g. incremental self-ref) is
+                // not a cross-model edge.
+                ReadResolution::Edge(_) => {}
+                // Cannot attribute the read to a single producer — fail closed.
+                ReadResolution::Ambiguous => uncertain = true,
+                // Genuinely external — a run failure cannot make it stale.
+                ReadResolution::External => {}
+            }
+        }
+        self.upstreams
+            .insert(name.to_string(), ups.into_iter().collect());
+        if uncertain {
+            self.uncertain.insert(name.to_string());
+        }
+    }
+
+    /// Seed the poison set with already-known failed models (e.g. compile
+    /// failures excluded from execution). Their downstreams are withheld like a
+    /// runtime failure's.
     pub(crate) fn seed_failed<I>(&mut self, models: I)
     where
         I: IntoIterator<Item = String>,
@@ -83,37 +235,67 @@ impl ContainmentLedger {
         self.poison.extend(models);
     }
 
-    /// The poisoned upstreams that reach `model` — its *direct* failed-or-
-    /// withheld dependencies. Empty ⇒ the model is safe to build. Non-empty ⇒
-    /// the model must be withheld; the returned names are the operator's
-    /// "blocked by" list (the run's `errors[]` name the root cause).
-    ///
-    /// Sorted + de-duplicated for deterministic output.
-    pub(crate) fn blocked_by(&self, model: &str) -> Vec<String> {
-        let Some(deps) = self.deps.get(model) else {
-            return Vec::new();
-        };
-        let mut blockers: Vec<String> = deps
-            .iter()
-            .filter(|u| self.poison.contains(*u))
-            .cloned()
-            .collect();
-        blockers.sort();
-        blockers.dedup();
-        blockers
-    }
-
     /// Add a model to the poison set — a failed cause *or* a withheld
-    /// downstream. Either way its own descendants must be withheld, so both
-    /// extend the closure identically.
+    /// downstream. Either way its descendants must be withheld, so both extend
+    /// the closure identically.
     pub(crate) fn poison(&mut self, model: &str) {
         self.poison.insert(model.to_string());
     }
+
+    /// Decide whether `model` must be withheld this run.
+    ///
+    /// - Any containment upstream (ref or physical) is poisoned ⇒ contained,
+    ///   naming those upstreams (`fail_closed = false`).
+    /// - Otherwise, if a failure has occurred (`poison` non-empty) and the model
+    ///   is *uncertain* — unprovable read set, an ambiguous read, or unknown to
+    ///   the ledger — ⇒ contained by the fail-closed belt, naming the current
+    ///   failure set (`fail_closed = true`).
+    /// - Otherwise ⇒ `None` (safe to build).
+    pub(crate) fn evaluate(&self, model: &str) -> Option<ContainmentDecision> {
+        let mut blockers: Vec<String> = self
+            .upstreams
+            .get(model)
+            .map(|ups| {
+                ups.iter()
+                    .filter(|u| self.poison.contains(*u))
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default();
+        if !blockers.is_empty() {
+            blockers.sort();
+            blockers.dedup();
+            return Some(ContainmentDecision {
+                blocked_by: blockers,
+                fail_closed: false,
+            });
+        }
+        let failure_occurred = !self.poison.is_empty();
+        let is_uncertain = self.uncertain.contains(model) || !self.known.contains(model);
+        if failure_occurred && is_uncertain {
+            return Some(ContainmentDecision {
+                blocked_by: self.poison.iter().cloned().collect(),
+                fail_closed: true,
+            });
+        }
+        None
+    }
 }
 
-/// A human-readable hint telling the operator how to clear a withheld model:
-/// resolve the named upstream failure(s), then re-run.
-pub(crate) fn unblock_hint(blocked_by: &[String]) -> String {
+/// A human-readable hint telling the operator how to clear a withheld model.
+pub(crate) fn unblock_hint(blocked_by: &[String], fail_closed: bool) -> String {
+    if fail_closed {
+        return match blocked_by {
+            [] => "contained conservatively while a failure is unresolved; \
+                   declare dependencies via ref()/model name and re-run"
+                .to_string(),
+            many => format!(
+                "contained conservatively: cannot prove this model is independent of the \
+                 failure(s) {}; declare dependencies via ref()/model name and re-run",
+                many.join(", ")
+            ),
+        };
+    }
     match blocked_by {
         [] => "re-run once the upstream failure is resolved".to_string(),
         [one] => format!("resolve upstream '{one}', then re-run"),
@@ -125,144 +307,185 @@ pub(crate) fn unblock_hint(blocked_by: &[String]) -> String {
 mod tests {
     use super::*;
 
-    fn node(name: &str, deps: &[&str]) -> DagNode {
-        DagNode {
-            name: name.to_string(),
-            depends_on: deps.iter().copied().map(String::from).collect(),
+    /// Build a ledger from `(name, ref_deps, sql_reads, reads_complete)` tuples
+    /// plus producer `(name, catalog, schema, table)` tuples, driving the same
+    /// path `execute_models` uses.
+    fn ledger(
+        models: &[(&str, &[&str], &[&str], bool)],
+        producers: &[(&str, &str, &str, &str)],
+    ) -> ContainmentLedger {
+        let index = ProducerIndex::build(producers.iter().copied());
+        let names: HashSet<String> = models.iter().map(|(n, ..)| n.to_string()).collect();
+        let mut led = ContainmentLedger::new();
+        for (name, deps, reads, complete) in models {
+            let deps: Vec<String> = deps.iter().copied().map(String::from).collect();
+            let reads: Vec<String> = reads.iter().map(|s| s.to_lowercase()).collect();
+            led.add_model(name, &deps, &names, &reads, *complete, &index);
         }
+        led
     }
 
-    /// Drive the ledger over a topologically-ordered model list exactly as the
-    /// run loop does: a model with a poisoned upstream is withheld (and itself
-    /// poisoned); an already-failed model is seeded; everything else builds.
-    /// Returns `(built, withheld)` model-name sets.
-    fn simulate(
-        nodes: &[DagNode],
-        topo_order: &[&str],
-        failed: &[&str],
-    ) -> (Vec<String>, Vec<String>) {
-        let mut ledger = ContainmentLedger::from_dag_nodes(nodes);
-        let failed_set: BTreeSet<&str> = failed.iter().copied().collect();
-        let mut built = Vec::new();
-        let mut withheld = Vec::new();
-        for &name in topo_order {
-            // A model that is itself the failure: mark failed, don't build.
-            if failed_set.contains(name) {
-                ledger.poison(name);
-                continue;
-            }
-            let blockers = ledger.blocked_by(name);
-            if blockers.is_empty() {
-                built.push(name.to_string());
-            } else {
-                ledger.poison(name);
-                withheld.push(name.to_string());
-            }
-        }
-        (built, withheld)
-    }
-
-    /// (a) Disjoint subtrees still run. Graph: A→B and C→D are two independent
-    /// chains. A fails ⇒ B is withheld, but C and D (disjoint) still build.
+    /// (a) Disjoint subtrees still run; the ref-declared downstream of a failure
+    /// is contained.
     #[test]
-    fn disjoint_subtree_still_builds() {
-        let nodes = [
-            node("A", &[]),
-            node("B", &["A"]),
-            node("C", &[]),
-            node("D", &["C"]),
-        ];
-        let (built, withheld) = simulate(&nodes, &["A", "C", "B", "D"], &["A"]);
-        assert_eq!(built, vec!["C", "D"], "the disjoint C→D subtree must build");
-        assert_eq!(withheld, vec!["B"], "only A's downstream is withheld");
-    }
-
-    /// (b) The full downstream closure of a failure is contained. Chain
-    /// A→B→C→D; A fails ⇒ B, C, and D are ALL withheld (transitive closure),
-    /// even though only B depends on A directly — C is withheld because B is
-    /// poisoned, D because C is.
-    #[test]
-    fn full_downstream_closure_is_contained() {
-        let nodes = [
-            node("A", &[]),
-            node("B", &["A"]),
-            node("C", &["B"]),
-            node("D", &["C"]),
-        ];
-        let (built, withheld) = simulate(&nodes, &["A", "B", "C", "D"], &["A"]);
-        assert!(built.is_empty(), "nothing survives A's failure in a chain");
-        assert_eq!(
-            withheld,
-            vec!["B", "C", "D"],
-            "the whole closure is withheld"
+    fn disjoint_subtree_builds_ref_downstream_contained() {
+        let mut led = ledger(
+            &[
+                ("A", &[], &[], true),
+                ("B", &["A"], &["a"], true),
+                ("C", &[], &[], true),
+                ("D", &["C"], &["c"], true),
+            ],
+            &[],
         );
+        led.poison("A");
+        assert!(led.evaluate("B").is_some(), "B depends on failed A");
+        assert!(led.evaluate("C").is_none(), "C is disjoint");
+        assert!(led.evaluate("D").is_none(), "D is disjoint");
     }
 
-    /// (c) A diamond: A→{B,C}→D. A fails ⇒ B, C, and their shared join D are
-    /// all withheld. D is blocked by BOTH B and C (both poisoned).
+    /// (b) Physical-table read of a failed producer's TARGET is contained even
+    /// with no `ref()` edge — the Finding-1 unit-level guard.
     #[test]
-    fn diamond_closure_and_multi_blocker() {
-        let nodes = [
-            node("A", &[]),
-            node("B", &["A"]),
-            node("C", &["A"]),
-            node("D", &["B", "C"]),
-        ];
-        let mut ledger = ContainmentLedger::from_dag_nodes(&nodes);
-        ledger.poison("A"); // A failed
-        assert_eq!(ledger.blocked_by("B"), vec!["A"]);
-        ledger.poison("B");
-        assert_eq!(ledger.blocked_by("C"), vec!["A"]);
-        ledger.poison("C");
-        // D is reachable from A through two paths — both blockers surface.
-        assert_eq!(ledger.blocked_by("D"), vec!["B", "C"]);
-    }
-
-    /// A model whose upstreams are all healthy is never withheld.
-    #[test]
-    fn healthy_model_is_not_blocked() {
-        let nodes = [node("A", &[]), node("B", &["A"])];
-        let mut ledger = ContainmentLedger::from_dag_nodes(&nodes);
-        ledger.poison("A");
-        // B depends on A (poisoned) → blocked.
-        assert!(!ledger.blocked_by("B").is_empty());
-        // But a fresh sibling with no poisoned deps is clear.
-        assert!(ledger.blocked_by("A").is_empty());
-    }
-
-    /// A compile-failed model seeded up front withholds its runtime downstream
-    /// exactly like a runtime failure would — a compile error is a failure too.
-    #[test]
-    fn seeded_compile_failure_contains_downstream() {
-        let nodes = [node("bad", &[]), node("dep", &["bad"])];
-        let mut ledger = ContainmentLedger::from_dag_nodes(&nodes);
-        ledger.seed_failed(["bad".to_string()]);
-        assert_eq!(ledger.blocked_by("dep"), vec!["bad"]);
-    }
-
-    /// A poisoned *partitioned* cause blocks only its descendants, not a
-    /// disjoint sibling — the model-level rule the partition path relies on
-    /// (any failed partition poisons the whole model's downstream).
-    #[test]
-    fn partitioned_cause_blocks_only_descendants() {
-        let nodes = [
-            node("events", &[]), // partitioned model, one partition failed
-            node("rollup", &["events"]),
-            node("unrelated", &[]),
-        ];
-        let mut ledger = ContainmentLedger::from_dag_nodes(&nodes);
-        ledger.poison("events");
-        assert_eq!(ledger.blocked_by("rollup"), vec!["events"]);
+    fn physical_target_read_is_contained() {
+        // `stage` produces `marts.orders_current`; `rollup` reads it by physical
+        // name (2-part) with no ref edge to `stage`.
+        let mut led = ledger(
+            &[
+                ("stage", &[], &["main.raw"], true),
+                (
+                    "rollup",
+                    &["anchor"],
+                    &["anchor", "marts.orders_current"],
+                    true,
+                ),
+                ("anchor", &[], &[], true),
+            ],
+            &[
+                ("stage", "", "marts", "orders_current"),
+                ("rollup", "", "marts", "rollup"),
+                ("anchor", "", "main", "anchor"),
+            ],
+        );
+        led.poison("stage");
+        let dec = led.evaluate("rollup").expect("rollup must be contained");
         assert!(
-            ledger.blocked_by("unrelated").is_empty(),
-            "a disjoint model must be unaffected by a partition failure elsewhere"
+            !dec.fail_closed,
+            "contained by a proven physical edge, not the belt"
         );
+        assert!(
+            dec.blocked_by.contains(&"stage".to_string()),
+            "the physical edge must name the producer: {:?}",
+            dec.blocked_by
+        );
+    }
+
+    /// A physical read that matches NO produced target is external — never
+    /// contained (a run failure can't make an external table stale).
+    #[test]
+    fn external_physical_read_is_not_contained() {
+        let mut led = ledger(
+            &[("m", &[], &["raw_db.orders"], true)],
+            &[("other", "", "marts", "orders_current")],
+        );
+        led.poison("other");
+        assert!(led.evaluate("m").is_none(), "external read must build");
+    }
+
+    /// (c) Fail-closed belt: an unenumerable read set (not provably complete) is
+    /// contained once any failure has occurred, never built — Finding-2 /
+    /// invariant-1 guard.
+    #[test]
+    fn unprovable_reads_fail_closed() {
+        let mut led = ledger(
+            &[
+                ("bad", &[], &[], true),
+                ("mystery", &["anchor"], &[], false), // reads NOT provably complete
+                ("anchor", &[], &[], true),
+            ],
+            &[],
+        );
+        // No failure yet ⇒ even an uncertain model may build.
+        assert!(led.evaluate("mystery").is_none(), "no failure ⇒ build");
+        led.poison("bad");
+        let dec = led
+            .evaluate("mystery")
+            .expect("uncertain ⇒ fail closed after a failure");
+        assert!(dec.fail_closed, "contained by the fail-closed belt");
+    }
+
+    /// An ambiguous physical read (matches producers in two catalogs) fails
+    /// closed once a failure has occurred.
+    #[test]
+    fn ambiguous_physical_read_fails_closed() {
+        let mut led = ledger(
+            &[
+                ("bad", &[], &[], true),
+                ("reader", &["anchor"], &["marts.orders"], true),
+                ("anchor", &[], &[], true),
+            ],
+            &[
+                ("p1", "cat_a", "marts", "orders"),
+                ("p2", "cat_b", "marts", "orders"),
+            ],
+        );
+        led.poison("bad");
+        let dec = led
+            .evaluate("reader")
+            .expect("ambiguous read ⇒ fail closed");
+        assert!(dec.fail_closed);
+    }
+
+    /// A model unknown to the ledger fails closed once a failure has occurred —
+    /// the coverage guarantee (Finding 2: never trust the map as total).
+    #[test]
+    fn unknown_model_fails_closed() {
+        let mut led = ledger(&[("known", &[], &[], true)], &[]);
+        // No poison ⇒ an unknown model is not spuriously contained.
+        assert!(led.evaluate("ghost").is_none());
+        led.poison("something");
+        let dec = led
+            .evaluate("ghost")
+            .expect("unknown model ⇒ fail closed after a failure");
+        assert!(
+            dec.fail_closed,
+            "a model absent from the edge map must fail closed"
+        );
+    }
+
+    /// The full downstream closure of a failure is contained transitively when
+    /// evaluated in topological order (poisoning as we go).
+    #[test]
+    fn full_closure_contained_in_topo_order() {
+        let mut led = ledger(
+            &[
+                ("A", &[], &[], true),
+                ("B", &["A"], &["a"], true),
+                ("C", &["B"], &["b"], true),
+            ],
+            &[],
+        );
+        led.poison("A");
+        assert!(led.evaluate("B").is_some());
+        led.poison("B"); // withheld B poisons its own downstream
+        assert!(led.evaluate("C").is_some());
+    }
+
+    /// A compile-failed model seeded up front contains its downstream.
+    #[test]
+    fn seeded_failure_contains_downstream() {
+        let mut led = ledger(
+            &[("bad", &[], &[], true), ("dep", &["bad"], &["bad"], true)],
+            &[],
+        );
+        led.seed_failed(["bad".to_string()]);
+        assert!(led.evaluate("dep").is_some());
     }
 
     #[test]
     fn unblock_hint_wording() {
-        assert!(unblock_hint(&["a".to_string()]).contains("resolve upstream 'a'"));
-        assert!(unblock_hint(&["a".to_string(), "b".to_string()]).contains("a, b"));
-        assert!(!unblock_hint(&[]).is_empty());
+        assert!(unblock_hint(&["a".to_string()], false).contains("resolve upstream 'a'"));
+        assert!(unblock_hint(&["a".to_string(), "b".to_string()], true).contains("cannot prove"));
+        assert!(!unblock_hint(&[], true).is_empty());
     }
 }

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -18,6 +18,7 @@ mod compare;
 mod compile;
 mod completions;
 mod compliance;
+mod containment;
 mod cost;
 mod dag;
 mod discover;

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -11232,6 +11232,82 @@ merge_keys = ["id"]
         );
     }
 
+    /// Bare unqualified read hardening: a model reading a failed producer's
+    /// target by BARE table name (`FROM orders_current`, resolved via the
+    /// default schema) — where the producer's model name differs from its table
+    /// name — must be contained. Fails on the pre-fix closure (a 1-part read was
+    /// treated as external); passes once bare reads resolve against producer
+    /// target-table names.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn containment_contains_bare_read_of_failed_producer_table() {
+        use rocky_core::traits::WarehouseAdapter;
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        let db = tmp.path().join("bare.duckdb");
+
+        // Pre-seed a STALE prior-run `main.orders_current`.
+        {
+            let seed = DuckDbWarehouseAdapter::open(&db).expect("seed open");
+            seed.execute_statement("CREATE TABLE main.orders_current AS SELECT 999 AS id")
+                .await
+                .unwrap();
+        }
+        write_plain_model(&models_dir, "anchor", "SELECT 1 AS v");
+        // Producer MODEL name (`stage_orders`) differs from its TABLE
+        // (`orders_current`), so a bare `orders_current` read is not a model
+        // name — it only resolves via the producer's target table.
+        write_model_with_target(
+            &models_dir,
+            "stage_orders",
+            "SELECT * FROM main.does_not_exist_xyz",
+            "main",
+            "orders_current",
+        );
+        // `rollup` reads the producer's target by BARE name (default schema).
+        write_model_with_target(
+            &models_dir,
+            "rollup",
+            "SELECT a.v FROM anchor a CROSS JOIN orders_current o",
+            "main",
+            "rollup",
+        );
+
+        let (out, result) = run_models_with_containment(&models_dir, &db).await;
+        result.expect("containment returns Ok — the failure is recorded, not thrown");
+
+        let built: std::collections::BTreeSet<String> = out
+            .materializations
+            .iter()
+            .map(|m| m.asset_key.last().cloned().unwrap_or_default())
+            .collect();
+        assert!(
+            !built.contains("rollup"),
+            "a BARE read of a failed producer's target table must NOT build"
+        );
+        let contained: Vec<&str> = out.contained.iter().map(|c| c.model.as_str()).collect();
+        assert!(
+            contained.contains(&"rollup"),
+            "rollup (bare read) must be contained: {contained:?}"
+        );
+        assert!(
+            out.contained
+                .iter()
+                .find(|c| c.model == "rollup")
+                .is_some_and(|c| c.blocked_by.iter().any(|b| b == "stage_orders")),
+            "rollup's blocker must name the producer via the bare-table edge: {:?}",
+            out.contained
+        );
+        let verify = DuckDbWarehouseAdapter::open(&db).expect("reopen");
+        assert!(
+            !table_exists(&verify, "rollup").await,
+            "the contained downstream must not exist"
+        );
+    }
+
     /// Finding 2 / fail-closed belt: a model whose read set is NOT provably
     /// complete (a CTE — the completeness gate rejects it) cannot be proven
     /// disjoint from a failure, so once any failure has occurred it must be

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -11470,6 +11470,98 @@ merge_keys = ["id"]
         );
     }
 
+    /// Seed a stale `main.orders_current` and write the same-layer *uncertain*
+    /// (CTE) project: `stage_orders` produces `main.orders_current` and fails;
+    /// `rollup` reads it through a CTE, so its read set is unenumerable
+    /// (`lineage_is_provably_complete` is false) and no ordering edge is derived.
+    async fn setup_same_layer_uncertain_project(
+        models_dir: &std::path::Path,
+        db: &std::path::Path,
+    ) {
+        use rocky_core::traits::WarehouseAdapter;
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+        {
+            let seed = DuckDbWarehouseAdapter::open(db).expect("seed open");
+            seed.execute_statement("CREATE TABLE main.orders_current AS SELECT 999 AS id")
+                .await
+                .unwrap();
+        }
+        write_model_with_target(
+            models_dir,
+            "stage_orders",
+            "SELECT * FROM main.missing_source",
+            "main",
+            "orders_current",
+        );
+        write_model_with_target(
+            models_dir,
+            "rollup",
+            "WITH x AS (SELECT id FROM main.orders_current) SELECT COUNT(*) AS n FROM x",
+            "main",
+            "rollup",
+        );
+    }
+
+    /// GUARANTEE-BOUNDARY parity (intentional, not a latent bug): for a read
+    /// Rocky cannot statically resolve — a CTE / anything `lineage_is_provably_
+    /// complete` rejects, i.e. an "uncertain" model — containment behaves
+    /// *identically* to a normal fail-fast run. Under `--parallel 2` a same-layer
+    /// uncertain reader of a failed producer materializes on stale data in BOTH
+    /// modes; that is a pre-existing property of parallel fail-fast, not a
+    /// containment regression.
+    ///
+    /// This test locks the achievable invariant — **containment never
+    /// materializes anything fail-fast wouldn't** (containment ⊆ fail-fast) — by
+    /// running the same project twice under `--parallel 2`, once with
+    /// `contain_failures = false` and once `= true`, and asserting identical
+    /// materialization sets. It will catch a future change that either
+    /// over-contains (would false-fail healthy CTE projects) or regresses below
+    /// fail-fast. Declaring the dependency via `ref()` lifts the read into the
+    /// resolved, guaranteed set (covered by the resolved-read tests above).
+    #[cfg(feature = "duckdb")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn containment_matches_fail_fast_for_same_layer_uncertain_read() {
+        let mat_set = |o: &RunOutput| -> std::collections::BTreeSet<String> {
+            o.materializations
+                .iter()
+                .map(|m| m.asset_key.last().cloned().unwrap_or_default())
+                .collect()
+        };
+
+        // Fail-fast (contain_failures = false), concurrency-capable, --parallel 2.
+        let ff = tempfile::TempDir::new().expect("temp dir");
+        let ff_models = ff.path().join("models");
+        std::fs::create_dir(&ff_models).unwrap();
+        let ff_db = ff.path().join("ff.duckdb");
+        setup_same_layer_uncertain_project(&ff_models, &ff_db).await;
+        let (out_ff, _) = run_models_against_duckdb(&ff_models, &ff_db, true, 2).await;
+
+        // Containment (contain_failures = true), --parallel 2.
+        let ct = tempfile::TempDir::new().expect("temp dir");
+        let ct_models = ct.path().join("models");
+        std::fs::create_dir(&ct_models).unwrap();
+        let ct_db = ct.path().join("ct.duckdb");
+        setup_same_layer_uncertain_project(&ct_models, &ct_db).await;
+        let (out_ct, _) = run_models_with_containment_parallel(&ct_models, &ct_db, 2).await;
+
+        assert_eq!(
+            mat_set(&out_ff),
+            mat_set(&out_ct),
+            "containment must not materialize anything fail-fast wouldn't for a same-layer \
+             uncertain (CTE) read — the achievable containment ⊆ fail-fast invariant"
+        );
+        assert!(
+            mat_set(&out_ct).contains("rollup"),
+            "the unenumerable (CTE) reader builds in BOTH modes — the documented best-effort \
+             boundary (declare the dep via ref() for a hard guarantee)"
+        );
+        assert!(
+            out_ct.contained.is_empty(),
+            "a same-layer uncertain read is fail-fast parity, NOT over-contained: {:?}",
+            out_ct.contained
+        );
+    }
+
     /// Earlier-layer residual (now closed): a physical reader placed in an
     /// EARLIER ref-layer than its physically-read producer (via an unrelated
     /// healthy dep chain) would build before the producer even runs. Augmented

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -4982,18 +4982,74 @@ pub(crate) async fn execute_models(
     let mut gate = super::skip_gate::SkipGate::new(skip_gate, &compile_result.project);
 
     // Failure-containment ledger (opt-in via `[resilience] contain_failures`).
-    // Tracks the downstream closure of every failed / withheld model over the
-    // *resolved* dependency graph (`dag_nodes` — the same edges the execution
-    // layering used, explicit `depends_on` merged with SQL-derived deps), so a
+    // Tracks the downstream closure of every failed / withheld model so a
     // disjoint subgraph can continue while a failure's blast radius is withheld.
-    // Seeded with the compile-failed models excluded above: a compile error is
-    // a failure, so its downstream is withheld rather than left to fail noisily
-    // on a missing table. When `contain_failures` is off the ledger is built
-    // (cheap) but never consulted, and the run keeps its historical fail-fast-
-    // at-first-failure behaviour byte-for-byte.
-    let mut containment =
-        super::containment::ContainmentLedger::from_dag_nodes(&compile_result.project.dag_nodes);
+    // The closure does NOT trust the declared graph (`dag_nodes`) as complete:
+    // it also folds physical-target reads (a raw-SQL model reading a producer's
+    // table by physical name, not by `ref()`) into the closure, and fails closed
+    // on any model whose reads can't be proven disjoint from the failure set —
+    // see `commands::containment`. Seeded with the compile-failed models
+    // excluded above (a compile error is a failure; its downstream is withheld).
+    //
+    // Built only when `contain_failures` is on (extracting each model's reads
+    // has a cost); when off the ledger stays empty and unconsulted, and the run
+    // keeps its historical fail-fast-at-first-failure behaviour byte-for-byte.
+    let mut containment = super::containment::ContainmentLedger::new();
     if resilience.contain_failures {
+        let producers = super::containment::ProducerIndex::build(
+            compile_result.project.models.iter().map(|m| {
+                (
+                    m.config.name.as_str(),
+                    m.config.target.catalog.as_str(),
+                    m.config.target.schema.as_str(),
+                    m.config.target.table.as_str(),
+                )
+            }),
+        );
+        let model_names: std::collections::HashSet<String> = compile_result
+            .project
+            .models
+            .iter()
+            .map(|m| m.config.name.clone())
+            .collect();
+        let dep_by_model: std::collections::HashMap<&str, &[String]> = compile_result
+            .project
+            .dag_nodes
+            .iter()
+            .map(|n| (n.name.as_str(), n.depends_on.as_slice()))
+            .collect();
+        for model in &compile_result.project.models {
+            let name = model.config.name.as_str();
+            let ref_deps = dep_by_model.get(name).copied().unwrap_or(&[]);
+            // Enumerate physical reads only when the read set is provably
+            // complete; otherwise the model fails closed (`reads_complete =
+            // false`), so it is withheld once a failure has occurred.
+            let (reads, reads_complete): (Vec<String>, bool) =
+                if rocky_sql::lineage_complete::lineage_is_provably_complete(&model.sql) {
+                    match rocky_sql::lineage::extract_lineage(&model.sql) {
+                        Ok(l) => (
+                            l.source_tables
+                                .iter()
+                                .map(|t| t.name.to_lowercase())
+                                .collect(),
+                            true,
+                        ),
+                        // Provably-complete said yes but extraction failed — fail
+                        // closed rather than trust an empty read set.
+                        Err(_) => (Vec::new(), false),
+                    }
+                } else {
+                    (Vec::new(), false)
+                };
+            containment.add_model(
+                name,
+                ref_deps,
+                &model_names,
+                &reads,
+                reads_complete,
+                &producers,
+            );
+        }
         containment.seed_failed(compile_failed_models.iter().cloned());
     }
 
@@ -5016,34 +5072,42 @@ pub(crate) async fn execute_models(
 
         // ---- failure containment (opt-in) ------------------------------
         // Before the skip gate and any build, withhold every model in this
-        // layer whose resolved upstream failed or was itself withheld. Layers
-        // are topologically ordered and every withheld model is poisoned as we
-        // go, so a one-hop `blocked_by` check is transitively complete. A
-        // withheld model is never adjudicated by the skip gate and never built
-        // (it would read a failed upstream's stale/missing output) — it is
-        // recorded on `output.contained` and poisons its own downstream.
-        // Identity no-op when `contain_failures` is off, keeping the default
-        // fail-fast path byte-identical.
+        // layer that `evaluate` deems unsafe: a proven poisoned upstream (ref OR
+        // physical-target read), or — fail closed — a model whose reads can't be
+        // proven disjoint from the failure set once any failure has occurred.
+        // Layers are topologically ordered and every withheld model is poisoned
+        // as we go, so a one-hop check is transitively complete. A withheld
+        // model is never adjudicated by the skip gate and never built (it would
+        // read a failure's stale/missing output) — it is recorded on
+        // `output.contained` and poisons its own downstream. Identity no-op when
+        // `contain_failures` is off, keeping the default fail-fast path
+        // byte-identical.
         let matched: Vec<(usize, &String, &rocky_core::models::Model)> =
             if resilience.contain_failures {
                 let mut buildable = Vec::with_capacity(matched.len());
                 for (_, name, model) in matched {
-                    let blocked_by = containment.blocked_by(name);
-                    if blocked_by.is_empty() {
-                        let dense_idx = buildable.len();
-                        buildable.push((dense_idx, name, model));
-                    } else {
-                        containment.poison(name);
-                        info!(
-                            model = name.as_str(),
-                            blocked_by = blocked_by.join(",").as_str(),
-                            "containment: upstream failed — withholding model (not built this run)"
-                        );
-                        output.contained.push(crate::output::ContainedModelOutput {
-                            model: name.to_string(),
-                            unblock_hint: super::containment::unblock_hint(&blocked_by),
-                            blocked_by,
-                        });
+                    match containment.evaluate(name) {
+                        None => {
+                            let dense_idx = buildable.len();
+                            buildable.push((dense_idx, name, model));
+                        }
+                        Some(decision) => {
+                            containment.poison(name);
+                            info!(
+                                model = name.as_str(),
+                                blocked_by = decision.blocked_by.join(",").as_str(),
+                                fail_closed = decision.fail_closed,
+                                "containment: withholding model (not built this run)"
+                            );
+                            output.contained.push(crate::output::ContainedModelOutput {
+                                model: name.to_string(),
+                                unblock_hint: super::containment::unblock_hint(
+                                    &decision.blocked_by,
+                                    decision.fail_closed,
+                                ),
+                                blocked_by: decision.blocked_by,
+                            });
+                        }
                     }
                 }
                 buildable
@@ -10989,6 +11053,176 @@ merge_keys = ["id"]
         assert!(
             !rollup_exists,
             "the contained downstream must not exist in `marts`"
+        );
+    }
+
+    /// Write a `full_refresh` model with an explicit `(schema, table)` target.
+    fn write_model_with_target(
+        dir: &std::path::Path,
+        name: &str,
+        sql: &str,
+        schema: &str,
+        table: &str,
+    ) {
+        std::fs::write(dir.join(format!("{name}.sql")), format!("{sql}\n"))
+            .expect("write model sql");
+        std::fs::write(
+            dir.join(format!("{name}.toml")),
+            format!(
+                "[strategy]\ntype = \"full_refresh\"\n\n\
+                 [target]\ncatalog = \"\"\nschema = \"{schema}\"\ntable = \"{table}\"\n"
+            ),
+        )
+        .expect("write model toml");
+    }
+
+    /// Finding 1 (physical-table read escapes containment). A raw-SQL model
+    /// that reads a failed producer's target **by physical name** (not by model
+    /// name), layered after the producer via an unrelated healthy dependency,
+    /// must be contained — it would otherwise build on the producer's stale
+    /// (un-refreshed) output.
+    ///
+    /// Fails on the pre-fix HEAD (the closure consulted only `dag_nodes`, so the
+    /// physical read had no edge and `rollup` built on stale data); passes once
+    /// physical-target reads are folded into the closure.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn containment_contains_physical_target_read_of_failed_producer() {
+        use rocky_core::traits::WarehouseAdapter;
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        let db = tmp.path().join("physical.duckdb");
+
+        // Pre-seed a STALE prior-run `main.orders_current` so the downstream can
+        // build on it (proving the stale-read hazard, not just a missing table).
+        {
+            let seed = DuckDbWarehouseAdapter::open(&db).expect("seed open");
+            seed.execute_statement("CREATE TABLE main.orders_current AS SELECT 999 AS id")
+                .await
+                .unwrap();
+        }
+
+        // Layer 0: `anchor` healthy; `stage_orders` produces `main.orders_current`
+        // but FAILS (missing source), so the stale table is never refreshed.
+        write_plain_model(&models_dir, "anchor", "SELECT 1 AS v");
+        write_model_with_target(
+            &models_dir,
+            "stage_orders",
+            "SELECT * FROM main.does_not_exist_xyz",
+            "main",
+            "orders_current",
+        );
+        // Layer 1 (via the healthy `anchor` ref): `rollup` reads the producer's
+        // target BY PHYSICAL NAME (`main.orders_current`), not `ref(stage_orders)`.
+        write_model_with_target(
+            &models_dir,
+            "rollup",
+            "SELECT a.v FROM anchor a CROSS JOIN main.orders_current o",
+            "main",
+            "rollup",
+        );
+
+        let (out, result) = run_models_with_containment(&models_dir, &db).await;
+        result.expect("containment returns Ok — the failure is recorded, not thrown");
+
+        let built: std::collections::BTreeSet<String> = out
+            .materializations
+            .iter()
+            .map(|m| m.asset_key.last().cloned().unwrap_or_default())
+            .collect();
+        assert!(
+            built.contains("anchor"),
+            "the healthy anchor builds: {built:?}"
+        );
+        assert!(
+            !built.contains("stage_orders"),
+            "the failed producer must not materialize"
+        );
+        // The core assertion: `rollup` must be CONTAINED, not built on stale data.
+        assert!(
+            !built.contains("rollup"),
+            "rollup read a failed producer's target by physical name — it must NOT build"
+        );
+        let contained: Vec<&str> = out.contained.iter().map(|c| c.model.as_str()).collect();
+        assert!(
+            contained.contains(&"rollup"),
+            "rollup must be contained (physical-target read of the failed producer): {contained:?}"
+        );
+        assert!(
+            out.contained
+                .iter()
+                .find(|c| c.model == "rollup")
+                .is_some_and(|c| c.blocked_by.iter().any(|b| b == "stage_orders")),
+            "rollup's blocker must name the failed producer via the physical edge: {:?}",
+            out.contained
+        );
+
+        // Soundness at the warehouse: rollup's target was never created.
+        let verify = DuckDbWarehouseAdapter::open(&db).expect("reopen");
+        assert!(
+            !table_exists(&verify, "rollup").await,
+            "the contained downstream must not exist"
+        );
+    }
+
+    /// Finding 2 / fail-closed belt: a model whose read set is NOT provably
+    /// complete (a CTE — the completeness gate rejects it) cannot be proven
+    /// disjoint from a failure, so once any failure has occurred it must be
+    /// contained, never built.
+    ///
+    /// Fails on the pre-fix HEAD (the closure consulted only `dag_nodes` deps,
+    /// so the unenumerable model built); passes once unanalyzable reads
+    /// fail closed.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn containment_fails_closed_on_unenumerable_reads() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        let db = tmp.path().join("failclosed.duckdb");
+
+        // Layer 0: `anchor` healthy; `bad` fails at runtime.
+        write_plain_model(&models_dir, "anchor", "SELECT 1 AS v");
+        write_plain_model(&models_dir, "bad", "SELECT * FROM main.does_not_exist_xyz");
+        // Layer 1 (explicit `depends_on = ["anchor"]`, so `bad`'s layer-0 failure
+        // is known when this is evaluated): `mystery` uses a CTE, so its read set
+        // is not provably complete — the closure cannot prove it is disjoint from
+        // `bad`, so it must fail closed once `bad` has failed.
+        std::fs::write(
+            models_dir.join("mystery.sql"),
+            "WITH x AS (SELECT v FROM anchor) SELECT v FROM x\n",
+        )
+        .unwrap();
+        std::fs::write(
+            models_dir.join("mystery.toml"),
+            "depends_on = [\"anchor\"]\n\n[strategy]\ntype = \"full_refresh\"\n\n\
+             [target]\ncatalog = \"\"\nschema = \"main\"\ntable = \"mystery\"\n",
+        )
+        .unwrap();
+
+        let (out, result) = run_models_with_containment(&models_dir, &db).await;
+        result.expect("containment returns Ok — the failure is recorded, not thrown");
+
+        let built: std::collections::BTreeSet<String> = out
+            .materializations
+            .iter()
+            .map(|m| m.asset_key.last().cloned().unwrap_or_default())
+            .collect();
+        assert!(
+            built.contains("anchor"),
+            "the healthy anchor builds: {built:?}"
+        );
+        assert!(
+            !built.contains("mystery"),
+            "an unenumerable-read model must fail closed once a failure occurred: {built:?}"
+        );
+        let contained: Vec<&str> = out.contained.iter().map(|c| c.model.as_str()).collect();
+        assert!(
+            contained.contains(&"mystery"),
+            "mystery must be contained (fail-closed on unprovable disjointness): {contained:?}"
         );
     }
 

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -5053,7 +5053,49 @@ pub(crate) async fn execute_models(
         containment.seed_failed(compile_failed_models.iter().cloned());
     }
 
-    for layer in &compile_result.project.layers {
+    // When containment is on, execution follows layers recomputed over the FULL
+    // containment edge set (ref ∪ physical ∪ bare), so a physical/bare reader is
+    // scheduled strictly after its producer — closing the same-layer `--parallel`
+    // race where a reader and its (about-to-fail) producer co-scheduled and the
+    // reader built on stale output. When off, the original ref-only layers are
+    // used, byte-for-byte. Any model stuck in an augmented-graph cycle is
+    // contained up front (fail closed) and recorded as a single run error so the
+    // run reports non-success.
+    let augmented_plan = resilience
+        .contain_failures
+        .then(|| containment.augmented_layers());
+    if let Some(plan) = &augmented_plan
+        && !plan.cyclic.is_empty()
+    {
+        for model in &plan.cyclic {
+            containment.poison(model);
+            output.contained.push(crate::output::ContainedModelOutput {
+                model: model.clone(),
+                blocked_by: Vec::new(),
+                unblock_hint: "a physical/bare-name read forms a dependency cycle; \
+                                   declare dependencies via ref() and break the cycle"
+                    .to_string(),
+            });
+        }
+        output.tables_failed += 1;
+        output.errors.push(crate::output::TableErrorOutput {
+            asset_key: vec!["<cycle>".to_string()],
+            error: format!(
+                "dependency cycle in the containment graph (physical/bare-name reads) — \
+                 withheld {} model(s): {}. Declare dependencies via ref() and remove the cycle.",
+                plan.cyclic.len(),
+                plan.cyclic.join(", "),
+            ),
+            failure_kind: crate::output::FailureKind::Unknown,
+            cooldown_seconds: None,
+        });
+    }
+    let execution_layers: &[Vec<String>] = match &augmented_plan {
+        Some(plan) => &plan.layers,
+        None => &compile_result.project.layers,
+    };
+
+    for layer in execution_layers {
         // Collect this layer's matched models (honouring the name filter),
         // tagged with their stable within-layer index so concurrent results
         // can be re-ordered to match serial output exactly.
@@ -10756,6 +10798,52 @@ merge_keys = ["id"]
         (output, result)
     }
 
+    /// Drive `execute_models` with containment on, a **concurrency-capable**
+    /// DuckDB adapter, and `--parallel N` — for exercising the intra-layer
+    /// concurrent path under containment.
+    async fn run_models_with_containment_parallel(
+        models_dir: &std::path::Path,
+        db_path: &std::path::Path,
+        parallel: u32,
+    ) -> (RunOutput, Result<()>) {
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+
+        let adapter = DuckDbWarehouseAdapter::open(db_path)
+            .expect("open duckdb")
+            .with_concurrent_for_test(true);
+        let opts = PartitionRunOptions {
+            parallel,
+            ..Default::default()
+        };
+        let mut output = RunOutput::new(String::new(), 0, parallel.max(1) as usize);
+        let resilience = rocky_core::config::ResilienceConfig {
+            contain_failures: true,
+            ..Default::default()
+        };
+        let result = super::execute_models(
+            models_dir,
+            &adapter as &dyn rocky_core::traits::WarehouseAdapter,
+            None,
+            &opts,
+            "test-run",
+            None,
+            &mut output,
+            None,
+            None,
+            &rocky_core::config::SchemaCacheConfig::default(),
+            false,
+            &DeferOptions::default(),
+            super::SkipGateConfig::off(),
+            false,
+            false,
+            &rocky_core::run_vars::RunVars::new(),
+            resilience,
+            true,
+        )
+        .await;
+        (output, result)
+    }
+
     /// Write the diamond/disjoint DAG the containment tests share:
     ///
     /// - `good_a` (layer 0) builds; `dep_of_good` (layer 1) reads it → builds.
@@ -11305,6 +11393,148 @@ merge_keys = ["id"]
         assert!(
             !table_exists(&verify, "rollup").await,
             "the contained downstream must not exist"
+        );
+    }
+
+    /// The `--parallel` same-layer race (headline): a physical reader with NO
+    /// `ref()` edge to its producer co-schedules with the producer in the same
+    /// ref-only layer, so under `--parallel 2` it builds on stale data while the
+    /// producer is still running, THEN the producer fails. Augmented re-layering
+    /// schedules the reader strictly after the producer, so it is contained.
+    /// Fails on the pre-re-layering HEAD; passes now.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn containment_contains_same_layer_physical_read_under_parallel() {
+        use rocky_core::traits::WarehouseAdapter;
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        let db = tmp.path().join("parrace.duckdb");
+
+        {
+            let seed = DuckDbWarehouseAdapter::open(&db).expect("seed open");
+            seed.execute_statement("CREATE TABLE main.orders_current AS SELECT 999 AS id")
+                .await
+                .unwrap();
+        }
+        // `stage_orders` + `rollup` have NO ref deps ⇒ same ref-only layer 0.
+        // `disjoint` is a healthy unrelated model (so the run is a PartialFailure,
+        // and to show disjoint work still lands under the race).
+        write_model_with_target(
+            &models_dir,
+            "stage_orders",
+            "SELECT * FROM main.missing_source",
+            "main",
+            "orders_current",
+        );
+        write_model_with_target(
+            &models_dir,
+            "rollup",
+            "SELECT COUNT(*) AS n FROM main.orders_current",
+            "main",
+            "rollup",
+        );
+        write_model_with_target(&models_dir, "disjoint", "SELECT 7 AS x", "main", "disjoint");
+
+        let (out, result) = run_models_with_containment_parallel(&models_dir, &db, 2).await;
+        result.expect("containment returns Ok — the failure is recorded, not thrown");
+
+        let built: std::collections::BTreeSet<String> = out
+            .materializations
+            .iter()
+            .map(|m| m.asset_key.last().cloned().unwrap_or_default())
+            .collect();
+        assert!(
+            built.contains("disjoint"),
+            "the disjoint model still builds: {built:?}"
+        );
+        assert!(
+            !built.contains("rollup"),
+            "rollup must be contained under the same-layer --parallel race, not built on stale data"
+        );
+        let contained: Vec<&str> = out.contained.iter().map(|c| c.model.as_str()).collect();
+        assert!(
+            contained.contains(&"rollup"),
+            "rollup must be contained (augmented re-layering ordered it after the producer): {contained:?}"
+        );
+        assert!(matches!(
+            out.derive_run_status(),
+            rocky_core::state::RunStatus::PartialFailure
+        ));
+        let verify = DuckDbWarehouseAdapter::open(&db).expect("reopen");
+        assert!(
+            !table_exists(&verify, "rollup").await,
+            "the contained reader must not exist"
+        );
+    }
+
+    /// Earlier-layer residual (now closed): a physical reader placed in an
+    /// EARLIER ref-layer than its physically-read producer (via an unrelated
+    /// healthy dep chain) would build before the producer even runs. Augmented
+    /// re-layering orders it strictly after the producer, so the producer's
+    /// failure contains it. Fails on the pre-re-layering HEAD; passes now.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn containment_reorders_earlier_layer_physical_reader() {
+        use rocky_core::traits::WarehouseAdapter;
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        let db = tmp.path().join("earlier.duckdb");
+
+        {
+            let seed = DuckDbWarehouseAdapter::open(&db).expect("seed open");
+            seed.execute_statement("CREATE TABLE main.orders_current AS SELECT 999 AS id")
+                .await
+                .unwrap();
+        }
+        // Push the producer into ref-layer 2 via a healthy chain up0 → up1.
+        write_plain_model(&models_dir, "anchor", "SELECT 1 AS v");
+        write_plain_model(&models_dir, "up0", "SELECT 1 AS v");
+        write_plain_model(&models_dir, "up1", "SELECT v FROM up0");
+        write_model_with_target(
+            &models_dir,
+            "stage_orders",
+            "SELECT v FROM up1 CROSS JOIN main.missing_source",
+            "main",
+            "orders_current",
+        );
+        // `reader` sits in ref-layer 1 (via `anchor`), EARLIER than the
+        // producer's ref-layer 2; it physically reads the producer's target.
+        write_model_with_target(
+            &models_dir,
+            "reader",
+            "SELECT a.v FROM anchor a CROSS JOIN main.orders_current o",
+            "main",
+            "reader",
+        );
+
+        let (out, result) = run_models_with_containment(&models_dir, &db).await;
+        result.expect("containment returns Ok");
+
+        let built: std::collections::BTreeSet<String> = out
+            .materializations
+            .iter()
+            .map(|m| m.asset_key.last().cloned().unwrap_or_default())
+            .collect();
+        assert!(built.contains("anchor") && built.contains("up0") && built.contains("up1"));
+        assert!(
+            !built.contains("reader"),
+            "an earlier-ref-layer physical reader must be re-ordered after its producer and contained"
+        );
+        let contained: Vec<&str> = out.contained.iter().map(|c| c.model.as_str()).collect();
+        assert!(
+            contained.contains(&"reader"),
+            "reader must be contained: {contained:?}"
+        );
+        let verify = DuckDbWarehouseAdapter::open(&db).expect("reopen");
+        assert!(
+            !table_exists(&verify, "reader").await,
+            "the contained reader must not exist"
         );
     }
 

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -11168,6 +11168,70 @@ merge_keys = ["id"]
         );
     }
 
+    /// Quoted-identifier hardening: a physical read written with QUOTED
+    /// identifiers (`"main"."orders_current"`) must resolve to the producer just
+    /// like the unquoted form — otherwise the quote characters survive into the
+    /// read identity, miss the producer index, and the reader builds on stale
+    /// data. Fails on the pre-quote-aware closure; passes after canonicalization.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn containment_contains_quoted_physical_read_of_failed_producer() {
+        use rocky_core::traits::WarehouseAdapter;
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        let db = tmp.path().join("quoted.duckdb");
+
+        // Pre-seed a STALE prior-run `main.orders_current`.
+        {
+            let seed = DuckDbWarehouseAdapter::open(&db).expect("seed open");
+            seed.execute_statement("CREATE TABLE main.orders_current AS SELECT 999 AS id")
+                .await
+                .unwrap();
+        }
+        write_plain_model(&models_dir, "anchor", "SELECT 1 AS v");
+        write_model_with_target(
+            &models_dir,
+            "stage_orders",
+            "SELECT * FROM main.does_not_exist_xyz",
+            "main",
+            "orders_current",
+        );
+        // `rollup` reads the producer's target with QUOTED identifiers.
+        write_model_with_target(
+            &models_dir,
+            "rollup",
+            "SELECT a.v FROM anchor a CROSS JOIN \"main\".\"orders_current\" o",
+            "main",
+            "rollup",
+        );
+
+        let (out, result) = run_models_with_containment(&models_dir, &db).await;
+        result.expect("containment returns Ok — the failure is recorded, not thrown");
+
+        let built: std::collections::BTreeSet<String> = out
+            .materializations
+            .iter()
+            .map(|m| m.asset_key.last().cloned().unwrap_or_default())
+            .collect();
+        assert!(
+            !built.contains("rollup"),
+            "a QUOTED physical read of a failed producer's target must NOT build"
+        );
+        let contained: Vec<&str> = out.contained.iter().map(|c| c.model.as_str()).collect();
+        assert!(
+            contained.contains(&"rollup"),
+            "rollup (quoted physical read) must be contained: {contained:?}"
+        );
+        let verify = DuckDbWarehouseAdapter::open(&db).expect("reopen");
+        assert!(
+            !table_exists(&verify, "rollup").await,
+            "the contained downstream must not exist"
+        );
+    }
+
     /// Finding 2 / fail-closed belt: a model whose read set is NOT provably
     /// complete (a CTE — the completeness gate rejects it) cannot be proven
     /// disjoint from a failure, so once any failure has occurred it must be

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -211,20 +211,30 @@ pub(crate) fn run_status_exit_result(output: &RunOutput, run_id: &str) -> Result
 /// `RunOutput::new` default of `success`). A clean run still derives
 /// `Success`; a copy-only failure behaves exactly as before.
 fn merge_replication_compile_and_copy_errors(output: &mut RunOutput, table_errors: &[TableError]) {
-    output
-        .errors
-        .retain(|e| e.failure_kind == crate::output::FailureKind::CompileError);
-    // Count distinct compile-failed models from the retained entries rather
-    // than inferring from `tables_failed`: the compile path records one
-    // `errors` entry per diagnostic but bumps `tables_failed` once per model,
-    // so count distinct asset_keys, not raw entries.
-    let compile_failed_count = output
+    // Retain `execute_models`' own records: compile failures (`CompileError`)
+    // and, when `[resilience] contain_failures` is on, contained-cause runtime
+    // failures (`Unknown` — the anyhow-erased bucket `record_contained_cause`
+    // uses). Copy failures arrive separately in `table_errors` and are appended
+    // below, so widening the retain never double-counts them. Byte-identical on
+    // the default fail-fast path: `execute_models` returns `Err` there, so no
+    // `Unknown` entry is ever present on `output.errors` before this merge.
+    output.errors.retain(|e| {
+        matches!(
+            e.failure_kind,
+            crate::output::FailureKind::CompileError | crate::output::FailureKind::Unknown
+        )
+    });
+    // Count distinct failed models from the retained entries rather than
+    // inferring from `tables_failed`: the compile path records one `errors`
+    // entry per diagnostic but bumps `tables_failed` once per model, so count
+    // distinct asset_keys, not raw entries.
+    let recorded_failed_count = output
         .errors
         .iter()
         .map(|e| e.asset_key.as_slice())
         .collect::<std::collections::BTreeSet<_>>()
         .len();
-    output.tables_failed = compile_failed_count + table_errors.len();
+    output.tables_failed = recorded_failed_count + table_errors.len();
     output
         .errors
         .extend(table_errors.iter().map(|e| TableErrorOutput {
@@ -4614,6 +4624,31 @@ fn apply_defer_rewrite(
     Ok(())
 }
 
+/// Record a model's runtime failure as a *contained cause*: bump the failure
+/// tally, push an `errors[]` entry keyed by the model, and poison the model in
+/// the containment ledger so its downstream closure is withheld.
+///
+/// Used only on the `[resilience] contain_failures` path — the fail-fast
+/// default returns `Err` from `execute_models` instead of continuing. The
+/// `errors[]` entry carries [`crate::output::FailureKind::Unknown`], the enum's
+/// own bucket for an `anyhow`-erased runtime error reaching this layer; the
+/// replication-path error merge retains it alongside compile failures.
+fn record_contained_cause(
+    output: &mut RunOutput,
+    containment: &mut super::containment::ContainmentLedger,
+    model_name: &str,
+    err: &anyhow::Error,
+) {
+    output.tables_failed += 1;
+    output.errors.push(crate::output::TableErrorOutput {
+        asset_key: vec![model_name.to_string()],
+        error: format!("{err:#}"),
+        failure_kind: crate::output::FailureKind::Unknown,
+        cooldown_seconds: None,
+    });
+    containment.poison(model_name);
+}
+
 #[tracing::instrument(skip_all, name = "execute_models")]
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_models(
@@ -4946,6 +4981,22 @@ pub(crate) async fn execute_models(
     // model exactly as before (no extra state reads / warehouse queries).
     let mut gate = super::skip_gate::SkipGate::new(skip_gate, &compile_result.project);
 
+    // Failure-containment ledger (opt-in via `[resilience] contain_failures`).
+    // Tracks the downstream closure of every failed / withheld model over the
+    // *resolved* dependency graph (`dag_nodes` — the same edges the execution
+    // layering used, explicit `depends_on` merged with SQL-derived deps), so a
+    // disjoint subgraph can continue while a failure's blast radius is withheld.
+    // Seeded with the compile-failed models excluded above: a compile error is
+    // a failure, so its downstream is withheld rather than left to fail noisily
+    // on a missing table. When `contain_failures` is off the ledger is built
+    // (cheap) but never consulted, and the run keeps its historical fail-fast-
+    // at-first-failure behaviour byte-for-byte.
+    let mut containment =
+        super::containment::ContainmentLedger::from_dag_nodes(&compile_result.project.dag_nodes);
+    if resilience.contain_failures {
+        containment.seed_failed(compile_failed_models.iter().cloned());
+    }
+
     for layer in &compile_result.project.layers {
         // Collect this layer's matched models (honouring the name filter),
         // tagged with their stable within-layer index so concurrent results
@@ -4962,6 +5013,43 @@ pub(crate) async fn execute_models(
             .enumerate()
             .map(|(idx, (name, model))| (idx, name, model))
             .collect();
+
+        // ---- failure containment (opt-in) ------------------------------
+        // Before the skip gate and any build, withhold every model in this
+        // layer whose resolved upstream failed or was itself withheld. Layers
+        // are topologically ordered and every withheld model is poisoned as we
+        // go, so a one-hop `blocked_by` check is transitively complete. A
+        // withheld model is never adjudicated by the skip gate and never built
+        // (it would read a failed upstream's stale/missing output) — it is
+        // recorded on `output.contained` and poisons its own downstream.
+        // Identity no-op when `contain_failures` is off, keeping the default
+        // fail-fast path byte-identical.
+        let matched: Vec<(usize, &String, &rocky_core::models::Model)> =
+            if resilience.contain_failures {
+                let mut buildable = Vec::with_capacity(matched.len());
+                for (_, name, model) in matched {
+                    let blocked_by = containment.blocked_by(name);
+                    if blocked_by.is_empty() {
+                        let dense_idx = buildable.len();
+                        buildable.push((dense_idx, name, model));
+                    } else {
+                        containment.poison(name);
+                        info!(
+                            model = name.as_str(),
+                            blocked_by = blocked_by.join(",").as_str(),
+                            "containment: upstream failed — withholding model (not built this run)"
+                        );
+                        output.contained.push(crate::output::ContainedModelOutput {
+                            model: name.to_string(),
+                            unblock_hint: super::containment::unblock_hint(&blocked_by),
+                            blocked_by,
+                        });
+                    }
+                }
+                buildable
+            } else {
+                matched
+            };
 
         // ---- skip gate (B2 ∧ B3) --------------------------------------
         // Evaluate the gate over this layer's matched set BEFORE dispatch, so
@@ -5163,7 +5251,24 @@ pub(crate) async fn execute_models(
                         models_executed += 1;
                     }
                     Err(e) => {
-                        if first_error.is_none() {
+                        // Containment: record + poison EVERY failure in the
+                        // layer (two models in one layer can have disjoint
+                        // downstream closures — poisoning only the first would
+                        // leave the second's downstream un-contained). Fail-fast
+                        // default keeps the historical first-error-only path.
+                        if resilience.contain_failures {
+                            if let (Some(reg), Some(pipe)) = (hook_registry, pipeline_name) {
+                                let _ = reg
+                                    .fire(&HookContext::model_error(
+                                        run_id,
+                                        pipe,
+                                        name,
+                                        &format!("{e:#}"),
+                                    ))
+                                    .await;
+                            }
+                            record_contained_cause(output, &mut containment, name, &e);
+                        } else if first_error.is_none() {
                             if let (Some(reg), Some(pipe)) = (hook_registry, pipeline_name) {
                                 let _ = reg
                                     .fire(&HookContext::model_error(
@@ -5180,6 +5285,9 @@ pub(crate) async fn execute_models(
                 }
             }
 
+            // Fail-fast default: surface the first failure and stop before any
+            // dependent layer. Under containment `first_error` stays `None` (each
+            // failure was recorded + poisoned above), so the run continues.
             if let Some(e) = first_error {
                 return Err(e);
             }
@@ -5577,6 +5685,12 @@ pub(crate) async fn execute_models(
                                 ))
                                 .await;
                         }
+                        // Containment: record + poison this content-addressed
+                        // model and continue disjoint work; fail-fast otherwise.
+                        if resilience.contain_failures {
+                            record_contained_cause(output, &mut containment, model_name, &e);
+                            continue;
+                        }
                         return Err(e);
                     }
                 }
@@ -5609,7 +5723,19 @@ pub(crate) async fn execute_models(
                         ))
                         .await;
                 }
-                time_interval_res?;
+                // Containment: a partitioned model whose run reported any failed
+                // partition has already materialized its healthy partitions (and
+                // marked only the failed one `Failed` in per-partition state).
+                // Record the cause (its error names the failing partition) and
+                // poison the model so downstream consumers of the incomplete
+                // table are withheld, then continue. Fail-fast otherwise.
+                if let Err(e) = time_interval_res {
+                    if resilience.contain_failures {
+                        record_contained_cause(output, &mut containment, model_name, &e);
+                        continue;
+                    }
+                    return Err(e);
+                }
                 // Per-model decision (reporting-only). time_interval is never
                 // skip-eligible, so it is suppressed in the skip-gate loop above
                 // and owns its `Build` entry here. Gated on the skip gate being
@@ -5702,15 +5828,25 @@ pub(crate) async fn execute_models(
                             ))
                             .await;
                     }
-                    return Err(e);
+                    // Containment: record + poison this model and continue
+                    // disjoint work; fail-fast (return) otherwise.
+                    if resilience.contain_failures {
+                        record_contained_cause(output, &mut containment, model_name, &e);
+                    } else {
+                        return Err(e);
+                    }
                 }
             }
         }
     }
 
-    // Flush the auditable-reuse spine in one transaction at end-of-run, only
-    // on the success path (a failed run returns early above and discards the
-    // accumulator — only fully-successful builds are indexed).
+    // Flush the auditable-reuse spine in one transaction at end-of-run. The
+    // accumulator only ever gains an entry from a *successfully-built*
+    // content-addressed model (the push lives in the build's `Ok` arm), so it
+    // is sound to flush even when this run also contained a failure: a
+    // fail-fast run returns before here (empty accumulator), and a
+    // containment run reaches here having indexed only its genuine successes —
+    // a withheld model never built and never pushed a spine entry.
     // Best-effort: a write failure logs and continues, mirroring the
     // `record_artifact` posture — the run itself is already durable.
     if reuse_enabled
@@ -8518,6 +8654,7 @@ mod tests {
             shadow: false,
             materializations: vec![],
             model_decisions: vec![],
+            contained: vec![],
             check_results: vec![],
             quarantine: vec![],
             anomalies: vec![],
@@ -10125,6 +10262,45 @@ merge_keys = ["id"]
         ));
     }
 
+    /// On the replication path with `[resilience] contain_failures = true`,
+    /// `execute_models` records a contained-cause runtime failure (`Unknown`
+    /// kind) on `output.errors` and returns `Ok`. The merge must retain that
+    /// entry — the pre-fix `retain(CompileError)` would have silently dropped
+    /// it, flipping a real failure back toward `Success` — and count it exactly
+    /// once alongside any copy failures (no double-count).
+    #[test]
+    fn merge_preserves_contained_cause_runtime_error() {
+        let mut out = RunOutput::new(String::new(), 0, 1);
+        // A disjoint model materialized (progress) → PartialFailure, not Failure.
+        out.tables_copied = 1;
+        out.tables_failed = 1;
+        out.errors.push(crate::output::TableErrorOutput {
+            asset_key: vec!["bad".to_string()],
+            error: "model 'bad' failed: warehouse rejected SQL".to_string(),
+            failure_kind: crate::output::FailureKind::Unknown,
+            cooldown_seconds: None,
+        });
+        // No copy failures on this run — the containment cause is the only one.
+        let no_copy_errors: Vec<TableError> = Vec::new();
+
+        super::merge_replication_compile_and_copy_errors(&mut out, &no_copy_errors);
+
+        assert_eq!(
+            out.tables_failed, 1,
+            "the contained-cause failure is counted once, not dropped"
+        );
+        assert_eq!(
+            out.errors.len(),
+            1,
+            "the Unknown-kind runtime failure survives the merge: {:?}",
+            out.errors
+        );
+        assert!(matches!(
+            out.status,
+            rocky_core::state::RunStatus::PartialFailure
+        ));
+    }
+
     /// End-to-end: a model declaring a `[[surrogate_key]]` block materializes a
     /// table that carries the injected, dialect-resolved hash column.
     #[cfg(feature = "duckdb")]
@@ -10435,6 +10611,385 @@ merge_keys = ["id"]
         )
         .await;
         (output, result)
+    }
+
+    /// Drive `execute_models` serially (DuckDB) with `[resilience]
+    /// contain_failures = true` — the failure-containment path under test.
+    async fn run_models_with_containment(
+        models_dir: &std::path::Path,
+        db_path: &std::path::Path,
+    ) -> (RunOutput, Result<()>) {
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+
+        let adapter = DuckDbWarehouseAdapter::open(db_path).expect("open duckdb");
+        let opts = PartitionRunOptions::default();
+        let mut output = RunOutput::new(String::new(), 0, 1);
+        let resilience = rocky_core::config::ResilienceConfig {
+            contain_failures: true,
+            ..Default::default()
+        };
+        let result = super::execute_models(
+            models_dir,
+            &adapter as &dyn rocky_core::traits::WarehouseAdapter,
+            None,
+            &opts,
+            "test-run",
+            None,
+            &mut output,
+            None,
+            None,
+            &rocky_core::config::SchemaCacheConfig::default(),
+            false,
+            &DeferOptions::default(),
+            super::SkipGateConfig::off(),
+            false,
+            false,
+            &rocky_core::run_vars::RunVars::new(),
+            resilience,
+            true,
+        )
+        .await;
+        (output, result)
+    }
+
+    /// Like [`run_models_with_containment`] but with caller-supplied partition
+    /// options (for driving a `time_interval` model across a partition window)
+    /// and `auto_create_schemas = true` (the fixtures target a fresh schema).
+    async fn run_models_with_containment_opts(
+        models_dir: &std::path::Path,
+        db_path: &std::path::Path,
+        opts: &PartitionRunOptions,
+    ) -> (RunOutput, Result<()>) {
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+
+        let adapter = DuckDbWarehouseAdapter::open(db_path).expect("open duckdb");
+        let mut output = RunOutput::new(String::new(), 0, 1);
+        let resilience = rocky_core::config::ResilienceConfig {
+            contain_failures: true,
+            ..Default::default()
+        };
+        let result = super::execute_models(
+            models_dir,
+            &adapter as &dyn rocky_core::traits::WarehouseAdapter,
+            None,
+            opts,
+            "test-run",
+            None,
+            &mut output,
+            None,
+            None,
+            &rocky_core::config::SchemaCacheConfig::default(),
+            true, // auto_create_schemas — the fixtures target `marts`
+            &DeferOptions::default(),
+            super::SkipGateConfig::off(),
+            false,
+            false,
+            &rocky_core::run_vars::RunVars::new(),
+            resilience,
+            true,
+        )
+        .await;
+        (output, result)
+    }
+
+    /// Write the diamond/disjoint DAG the containment tests share:
+    ///
+    /// - `good_a` (layer 0) builds; `dep_of_good` (layer 1) reads it → builds.
+    /// - `bad` (layer 0) fails at runtime (missing table); `dep_of_bad`
+    ///   (layer 1) reads `bad` via a bare SQL `ref()` with **no `depends_on`
+    ///   in its toml** → must be contained, proving the closure sources its
+    ///   edges from the resolved `dag_nodes`, not `config.depends_on`.
+    /// - `disjoint` (layer 0) shares no lineage with the failure → builds.
+    fn write_containment_dag(models_dir: &std::path::Path) {
+        write_plain_model(models_dir, "good_a", "SELECT 1 AS v");
+        write_plain_model(models_dir, "bad", "SELECT * FROM main.does_not_exist_xyz");
+        write_plain_model(models_dir, "disjoint", "SELECT 42 AS x");
+        write_plain_model(models_dir, "dep_of_bad", "SELECT * FROM bad");
+        write_plain_model(models_dir, "dep_of_good", "SELECT v FROM good_a");
+    }
+
+    /// Does `main.<name>` exist in the warehouse? Used by the containment test
+    /// to assert a contained model was never materialized.
+    async fn table_exists(
+        warehouse: &dyn rocky_core::traits::WarehouseAdapter,
+        name: &str,
+    ) -> bool {
+        warehouse
+            .execute_query(&format!(
+                "SELECT COUNT(*) FROM information_schema.tables \
+                 WHERE table_schema = 'main' AND table_name = '{name}'"
+            ))
+            .await
+            .ok()
+            .and_then(|r| r.rows.first()?.first()?.as_str().map(|s| s != "0"))
+            .unwrap_or(false)
+    }
+
+    /// Reachability guard for failure containment (`contain_failures = true`):
+    /// a runtime failure withholds only its downstream closure while disjoint
+    /// subgraphs still materialize, and the manifest names the blast radius.
+    ///
+    /// This is the run-path wiring proof — `execute_models` returns `Ok(())`
+    /// (failures recorded, not thrown), the healthy models materialize, the
+    /// failed model is on `errors[]`, and its SQL-`ref()`-only downstream is on
+    /// `contained[]` with `bad` as the blocker.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn containment_continues_disjoint_subtree_on_failure() {
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        write_containment_dag(&models_dir);
+
+        let db = tmp.path().join("contain.duckdb");
+        let (out, result) = run_models_with_containment(&models_dir, &db).await;
+
+        // Containment returns Ok — failures are recorded on `output`, not thrown.
+        result.expect("containment path returns Ok(()); failures are recorded, not thrown");
+
+        let built: std::collections::BTreeSet<String> = out
+            .materializations
+            .iter()
+            .map(|m| m.asset_key.last().cloned().unwrap_or_default())
+            .collect();
+        // (a) Disjoint + healthy-upstream subtrees still build.
+        assert!(
+            built.contains("good_a"),
+            "healthy layer-0 model builds: {built:?}"
+        );
+        assert!(
+            built.contains("disjoint"),
+            "disjoint subtree builds: {built:?}"
+        );
+        assert!(
+            built.contains("dep_of_good"),
+            "downstream of a healthy model builds: {built:?}"
+        );
+
+        // (b) The failure is recorded as a cause, not built.
+        assert!(
+            !built.contains("bad"),
+            "the failing model must not be materialized"
+        );
+        assert_eq!(out.tables_failed, 1, "exactly one model failed");
+        assert!(
+            out.errors
+                .iter()
+                .any(|e| e.asset_key.iter().any(|k| k == "bad")),
+            "errors[] must name the failed model: {:?}",
+            out.errors
+        );
+
+        // (c) The downstream closure of the failure is contained — and the
+        // blocker is the SQL-`ref()`-only edge to `bad` (dep_of_bad declared no
+        // `depends_on`), proving the closure reads `dag_nodes`, not config.
+        assert!(
+            !built.contains("dep_of_bad"),
+            "the failure's downstream must not build"
+        );
+        let contained: Vec<&str> = out.contained.iter().map(|c| c.model.as_str()).collect();
+        assert_eq!(
+            contained,
+            vec!["dep_of_bad"],
+            "dep_of_bad must be the sole contained model: {contained:?}"
+        );
+        assert_eq!(
+            out.contained[0].blocked_by,
+            vec!["bad".to_string()],
+            "the SQL-ref-only edge to `bad` must be the blocker (sourced from dag_nodes)"
+        );
+
+        // (d) Soundness at the warehouse: the contained model was never built
+        // on the failed upstream's missing output.
+        let verify = DuckDbWarehouseAdapter::open(&db).expect("reopen");
+        assert!(
+            !table_exists(&verify, "dep_of_bad").await,
+            "contained model must not exist in the warehouse"
+        );
+        assert!(
+            !table_exists(&verify, "bad").await,
+            "the failed model must not have materialized"
+        );
+        assert!(
+            table_exists(&verify, "dep_of_good").await,
+            "the healthy downstream must exist"
+        );
+    }
+
+    /// Default posture (`contain_failures = false`) is byte-identical fail-fast:
+    /// `execute_models` returns `Err` at the first failure and withholds
+    /// nothing on `contained[]`. This is the §7.6 default-OFF regression guard.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn containment_off_is_fail_fast() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        write_containment_dag(&models_dir);
+
+        let db = tmp.path().join("failfast.duckdb");
+        // `run_models_against_duckdb` uses `ResilienceConfig::default()`
+        // (contain_failures = false) — the default path.
+        let (out, result) = run_models_against_duckdb(&models_dir, &db, false, 1).await;
+
+        result.expect_err("default fail-fast: execute_models returns Err at the first failure");
+        assert!(
+            out.contained.is_empty(),
+            "the default path must never contain anything: {:?}",
+            out.contained
+        );
+    }
+
+    /// Partition-level containment: a `time_interval` model with one poisoned
+    /// partition still materializes its healthy partitions, is recorded as a
+    /// cause (its error naming the failing partition), and withholds a
+    /// downstream consumer of the now-incomplete target table.
+    ///
+    /// Guards the distinct `time_interval` catch-site in `execute_models` (the
+    /// `Err`-from-`execute_time_interval_model` branch), which the plain-model
+    /// containment test does not exercise.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn containment_isolates_failing_partition() {
+        use rocky_core::traits::WarehouseAdapter;
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        let db = tmp.path().join("partition.duckdb");
+
+        // Seed a raw source: two clean rows on 2026-04-04, one un-castable row
+        // ('BAD') on 2026-04-05 — so the 04-05 partition fails while 04-04 is
+        // healthy. Drop the connection before `execute_models` reopens the file.
+        {
+            let seed = DuckDbWarehouseAdapter::open(&db).expect("seed open");
+            seed.execute_statement("CREATE SCHEMA IF NOT EXISTS raw__orders")
+                .await
+                .unwrap();
+            seed.execute_statement(
+                "CREATE TABLE raw__orders.orders \
+                 (order_at TIMESTAMP, customer_id INTEGER, amount VARCHAR)",
+            )
+            .await
+            .unwrap();
+            seed.execute_statement(
+                "INSERT INTO raw__orders.orders VALUES \
+                 (TIMESTAMP '2026-04-04 09:00:00', 1, '10'), \
+                 (TIMESTAMP '2026-04-04 10:00:00', 2, '20'), \
+                 (TIMESTAMP '2026-04-05 09:00:00', 1, 'BAD')",
+            )
+            .await
+            .unwrap();
+        }
+
+        // `events`: a time_interval model whose SELECT casts `amount` to INT —
+        // the 04-05 window's 'BAD' row makes that partition fail.
+        std::fs::write(
+            models_dir.join("events.sql"),
+            "SELECT CAST(order_at AS DATE) AS order_date, customer_id, \
+             CAST(amount AS INTEGER) AS amt FROM raw__orders.orders \
+             WHERE order_at >= @start_date AND order_at < @end_date\n",
+        )
+        .unwrap();
+        std::fs::write(
+            models_dir.join("events.toml"),
+            "depends_on = []\n\n\
+             [[sources]]\ncatalog = \"\"\nschema = \"raw__orders\"\ntable = \"orders\"\n\n\
+             [strategy]\ntype = \"time_interval\"\ntime_column = \"order_date\"\n\
+             granularity = \"day\"\nfirst_partition = \"2026-04-04\"\nlookback = 0\n\n\
+             [target]\ncatalog = \"\"\nschema = \"marts\"\ntable = \"events\"\n",
+        )
+        .unwrap();
+        // `rollup`: a downstream reading `events` by model name (SQL-ref edge).
+        std::fs::write(
+            models_dir.join("rollup.sql"),
+            "SELECT SUM(amt) AS total FROM events\n",
+        )
+        .unwrap();
+        std::fs::write(
+            models_dir.join("rollup.toml"),
+            "[strategy]\ntype = \"full_refresh\"\n\n\
+             [target]\ncatalog = \"\"\nschema = \"marts\"\ntable = \"rollup\"\n",
+        )
+        .unwrap();
+
+        // Run BOTH partitions.
+        let opts = PartitionRunOptions {
+            from: Some("2026-04-04".into()),
+            to: Some("2026-04-05".into()),
+            ..Default::default()
+        };
+        let (out, result) = run_models_with_containment_opts(&models_dir, &db, &opts).await;
+
+        result.expect("containment returns Ok — the partition failure is recorded, not thrown");
+
+        // (a) The healthy partition materialized.
+        let events_parts: Vec<&str> = out
+            .materializations
+            .iter()
+            .filter(|m| m.asset_key.last().map(String::as_str) == Some("events"))
+            .filter_map(|m| m.partition.as_ref().map(|p| p.key.as_str()))
+            .collect();
+        assert_eq!(
+            events_parts,
+            vec!["2026-04-04"],
+            "only the healthy partition materializes: {events_parts:?}"
+        );
+        let summary = out
+            .partition_summaries
+            .iter()
+            .find(|s| s.model == "events")
+            .expect("events partition summary");
+        assert_eq!(summary.partitions_succeeded, 1);
+        assert_eq!(summary.partitions_failed, 1);
+
+        // (b) `events` is a cause, and the error names the failing partition.
+        assert_eq!(out.tables_failed, 1);
+        assert!(
+            out.errors.iter().any(
+                |e| e.asset_key.iter().any(|k| k == "events") && e.error.contains("2026-04-05")
+            ),
+            "errors[] must name the failing partition: {:?}",
+            out.errors
+        );
+
+        // (c) The downstream consumer of the incomplete table is contained.
+        let contained: Vec<&str> = out.contained.iter().map(|c| c.model.as_str()).collect();
+        assert_eq!(
+            contained,
+            vec!["rollup"],
+            "rollup must be contained: {contained:?}"
+        );
+        assert_eq!(out.contained[0].blocked_by, vec!["events".to_string()]);
+
+        // (d) Soundness at the warehouse: healthy rows landed, rollup absent.
+        let verify = DuckDbWarehouseAdapter::open(&db).expect("reopen");
+        let events_rows = verify
+            .execute_query("SELECT COUNT(*) FROM marts.events")
+            .await
+            .ok()
+            .and_then(|r| r.rows.first()?.first()?.as_str().map(str::to_string))
+            .unwrap_or_default();
+        assert_eq!(
+            events_rows, "2",
+            "only the two healthy-partition rows landed"
+        );
+        let rollup_exists = verify
+            .execute_query(
+                "SELECT COUNT(*) FROM information_schema.tables \
+                 WHERE table_schema = 'marts' AND table_name = 'rollup'",
+            )
+            .await
+            .ok()
+            .and_then(|r| r.rows.first()?.first()?.as_str().map(|s| s != "0"))
+            .unwrap_or(false);
+        assert!(
+            !rollup_exists,
+            "the contained downstream must not exist in `marts`"
+        );
     }
 
     /// End-to-end run-path coverage for `--var`: a model whose SQL references

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -268,6 +268,13 @@ pub struct RunOutput {
     /// omitted) for a default run, which stays byte-identical.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub model_decisions: Vec<ModelDecisionOutput>,
+    /// Models withheld this run because an upstream failed (or was itself
+    /// withheld) and `[resilience] contain_failures` continued the disjoint
+    /// subgraphs — the blast radius of the failures named in `errors[]`. Empty
+    /// (and omitted) for a run that did not withhold anything: the default
+    /// fail-fast run, and any successful run, record nothing here.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub contained: Vec<ContainedModelOutput>,
     pub check_results: Vec<TableCheckOutput>,
     /// Row-quarantine outcomes — one entry per table the quality
     /// pipeline quarantined. Empty for runs that did not use
@@ -1170,6 +1177,25 @@ pub struct ModelDecisionOutput {
     /// "not skip-eligible", "upstream data may have changed", "reused prior
     /// run's bytes (strong proof)").
     pub reason: String,
+}
+
+/// One model withheld from a run because an upstream failed (or was itself
+/// withheld) and failure-containment continued the disjoint subgraphs.
+///
+/// This is the blast radius of a failure — the run's `errors[]` name the root
+/// cause(s). A withheld model was **not built** this run: its target was left
+/// untouched (never rebuilt on a failed upstream's stale/missing output). This
+/// is model-graph containment, distinct from the quality pipeline's row-level
+/// `quarantine` surface.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ContainedModelOutput {
+    /// The withheld model's name (matches the model entry in the project DAG).
+    pub model: String,
+    /// The failed-or-withheld upstream(s) that reach this model — its direct
+    /// poisoned dependencies. The run's `errors[]` carry the root-cause detail.
+    pub blocked_by: Vec<String>,
+    /// Operator hint: resolve the named upstream failure(s), then re-run.
+    pub unblock_hint: String,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -4397,6 +4423,7 @@ impl RunOutput {
             shadow: false,
             materializations: vec![],
             model_decisions: vec![],
+            contained: vec![],
             check_results: vec![],
             quarantine: vec![],
             anomalies: vec![],

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -937,6 +937,20 @@ pub struct ResilienceConfig {
     /// then the only bound); `Some(0)` forbids all retries.
     #[serde(default = "default_resilience_max_retries_per_run")]
     pub max_retries_per_run: Option<u32>,
+    /// Continue disjoint subgraphs when a model fails, instead of aborting the
+    /// whole run at the first failure. Default `false` (fail-fast — the run
+    /// stops at the first failing model, exactly as before this knob existed).
+    ///
+    /// When `true`, a failed model and its downstream closure are *withheld*
+    /// (never built on the failure's stale/missing output), while unrelated
+    /// subtrees still materialize; the run reports `PartialFailure` with a
+    /// containment manifest naming what failed and its blast radius. This
+    /// changes no data semantics — everything withheld is already withheld by
+    /// today's fail-fast run; it only *narrows* the withholding to the actual
+    /// blast radius. The closure is conservative (computed from the resolved
+    /// dependency graph, contain-more on any doubt).
+    #[serde(default = "default_contain_failures")]
+    pub contain_failures: bool,
 }
 
 impl ResilienceConfig {
@@ -969,6 +983,7 @@ impl Default for ResilienceConfig {
             jitter: default_jitter(),
             circuit_breaker_threshold: default_resilience_breaker_threshold(),
             max_retries_per_run: default_resilience_max_retries_per_run(),
+            contain_failures: default_contain_failures(),
         }
     }
 }
@@ -990,6 +1005,9 @@ fn default_resilience_breaker_threshold() -> u32 {
 }
 fn default_resilience_max_retries_per_run() -> Option<u32> {
     Some(8)
+}
+fn default_contain_failures() -> bool {
+    false
 }
 
 /// Schema pattern configuration from TOML, converted to [`SchemaPattern`] at runtime.

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -3015,6 +3015,11 @@
           "minimum": 0.0,
           "type": "integer"
         },
+        "contain_failures": {
+          "default": false,
+          "description": "Continue disjoint subgraphs when a model fails, instead of aborting the whole run at the first failure. Default `false` (fail-fast — the run stops at the first failing model, exactly as before this knob existed).\n\nWhen `true`, a failed model and its downstream closure are *withheld* (never built on the failure's stale/missing output), while unrelated subtrees still materialize; the run reports `PartialFailure` with a containment manifest naming what failed and its blast radius. This changes no data semantics — everything withheld is already withheld by today's fail-fast run; it only *narrows* the withholding to the actual blast radius. The closure is conservative (computed from the resolved dependency graph, contain-more on any doubt).",
+          "type": "boolean"
+        },
         "enabled": {
           "default": true,
           "description": "Master switch for run-loop classified retry. Default `true`. When `false`, every model is attempted exactly once (no classification, no backoff) — the behaviour before this layer existed.",
@@ -4247,6 +4252,7 @@
       "default": {
         "backoff_multiplier": 2.0,
         "circuit_breaker_threshold": 3,
+        "contain_failures": false,
         "enabled": true,
         "initial_backoff_ms": 500,
         "jitter": true,

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -306,6 +306,32 @@
       ],
       "type": "object"
     },
+    "ContainedModelOutput": {
+      "description": "One model withheld from a run because an upstream failed (or was itself withheld) and failure-containment continued the disjoint subgraphs.\n\nThis is the blast radius of a failure — the run's `errors[]` name the root cause(s). A withheld model was **not built** this run: its target was left untouched (never rebuilt on a failed upstream's stale/missing output). This is model-graph containment, distinct from the quality pipeline's row-level `quarantine` surface.",
+      "properties": {
+        "blocked_by": {
+          "description": "The failed-or-withheld upstream(s) that reach this model — its direct poisoned dependencies. The run's `errors[]` carry the root-cause detail.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "model": {
+          "description": "The withheld model's name (matches the model entry in the project DAG).",
+          "type": "string"
+        },
+        "unblock_hint": {
+          "description": "Operator hint: resolve the named upstream failure(s), then re-run.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "blocked_by",
+        "model",
+        "unblock_hint"
+      ],
+      "type": "object"
+    },
     "DriftActionOutput": {
       "properties": {
         "action": {
@@ -1177,6 +1203,13 @@
     },
     "command": {
       "type": "string"
+    },
+    "contained": {
+      "description": "Models withheld this run because an upstream failed (or was itself withheld) and `[resilience] contain_failures` continued the disjoint subgraphs — the blast radius of the failures named in `errors[]`. Empty (and omitted) for a run that did not withhold anything: the default fail-fast run, and any successful run, record nothing here.",
+      "items": {
+        "$ref": "#/definitions/ContainedModelOutput"
+      },
+      "type": "array"
     },
     "cost_summary": {
       "anyOf": [

--- a/sdk/python/src/rocky_sdk/types_generated/rocky_project_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/rocky_project_schema.py
@@ -1164,6 +1164,12 @@ class ResilienceConfig(BaseModel):
     """
     Trip the run-loop breaker after this many *consecutive* transient model failures; once tripped, no further model is retried for the rest of the run (they still get their one attempt). Default: `3`. `0` disables the breaker.
     """
+    contain_failures: bool | None = False
+    """
+    Continue disjoint subgraphs when a model fails, instead of aborting the whole run at the first failure. Default `false` (fail-fast — the run stops at the first failing model, exactly as before this knob existed).
+
+    When `true`, a failed model and its downstream closure are *withheld* (never built on the failure's stale/missing output), while unrelated subtrees still materialize; the run reports `PartialFailure` with a containment manifest naming what failed and its blast radius. This changes no data semantics — everything withheld is already withheld by today's fail-fast run; it only *narrows* the withholding to the actual blast radius. The closure is conservative (computed from the resolved dependency graph, contain-more on any doubt).
+    """
     enabled: bool | None = True
     """
     Master switch for run-loop classified retry. Default `true`. When `false`, every model is attempted exactly once (no classification, no backoff) — the behaviour before this layer existed.
@@ -3575,6 +3581,7 @@ class RockyConfig(BaseModel):
         {
             "backoff_multiplier": 2.0,
             "circuit_breaker_threshold": 3,
+            "contain_failures": False,
             "enabled": True,
             "initial_backoff_ms": 500,
             "jitter": True,

--- a/sdk/python/src/rocky_sdk/types_generated/run_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/run_schema.py
@@ -74,6 +74,27 @@ class BudgetBreachOutput(BaseModel):
     """
 
 
+class ContainedModelOutput(BaseModel):
+    """
+    One model withheld from a run because an upstream failed (or was itself withheld) and failure-containment continued the disjoint subgraphs.
+
+    This is the blast radius of a failure — the run's `errors[]` name the root cause(s). A withheld model was **not built** this run: its target was left untouched (never rebuilt on a failed upstream's stale/missing output). This is model-graph containment, distinct from the quality pipeline's row-level `quarantine` surface.
+    """
+
+    blocked_by: list[str]
+    """
+    The failed-or-withheld upstream(s) that reach this model — its direct poisoned dependencies. The run's `errors[]` carry the root-cause detail.
+    """
+    model: str
+    """
+    The withheld model's name (matches the model entry in the project DAG).
+    """
+    unblock_hint: str
+    """
+    Operator hint: resolve the named upstream failure(s), then re-run.
+    """
+
+
 class DriftActionOutput(BaseModel):
     action: str
     reason: str
@@ -704,6 +725,10 @@ class RunOutput(BaseModel):
     """
     check_results: list[TableCheckOutput]
     command: str
+    contained: list[ContainedModelOutput] | None = None
+    """
+    Models withheld this run because an upstream failed (or was itself withheld) and `[resilience] contain_failures` continued the disjoint subgraphs — the blast radius of the failures named in `errors[]`. Empty (and omitted) for a run that did not withhold anything: the default fail-fast run, and any successful run, record nothing here.
+    """
     cost_summary: RunCostSummary | None = None
     """
     Aggregate cost attribution across every materialization in this run (per-model entries + run totals). `None` for DuckDB-only pipelines or when no materializations produced a cost number.


### PR DESCRIPTION
## What

Adds opt-in **model-failure containment** to `rocky run`. Today a model whose build fails aborts the whole run at the first failure (honest, post-#975). With the new `[resilience] contain_failures` knob enabled, a failure instead *contains*: the failed model and its downstream closure are **withheld**, disjoint subgraphs still materialize, and the run reports `PartialFailure` with a manifest of what failed and its blast radius.

```toml
[resilience]
contain_failures = true   # default false
```

## Naming — `Contained`, deliberately not "quarantine"

The word **quarantine** is already taken in this codebase for a *different* concept: row-quarantine in the quality pipeline (`rocky_core::quarantine`, `QuarantineMode::{Split,Tag,Drop}`, the `__valid`/`__quarantine` split tables, `QuarantineOutput`). That axis splits bad *rows* out of one table.

This feature is a different axis — model/subgraph **containment** on failure. Reusing "quarantine" would make run output ambiguous (a "quarantined" thing could be a row or a model). So the user-facing vocabulary here is **`Contained` / "blocked by"**, the config key is `contain_failures`, and the new types are namespaced (`ContainedModelOutput`, `commands::containment::ContainmentLedger`). A reader never confuses a withheld model with a quarantined row.

## Soundness (this is the load-bearing section)

**This changes no data semantics — it only narrows what a failure withholds.** Everything a contained run withholds is *already* withheld by today's fail-fast run (which withholds the entire rest of the DAG). Containment simply narrows the withholding from "everything after the first failure" to "the failure's actual blast radius", letting disjoint subgraphs proceed. Nothing that builds today stops building; nothing new is built on bad input.

The closure is **conservative and fail-closed**:

- **Edges come from the resolved dependency graph** (`Project::dag_nodes` — explicit `depends_on` **merged with** the SQL-`ref()`-derived deps), i.e. *the same edges the executor's layering is built from*. This was the critical choice: `resolve_dependencies` writes the merged set only into `dag_nodes`; `model.config.depends_on` stays explicit-only. Sourcing the closure from `config.depends_on` would miss SQL-`ref()`-only dependencies and let a downstream build on a failed upstream's stale/missing output. The committed test `containment_continues_disjoint_subtree_on_failure` asserts a model that reads another **by SQL `ref()` with no `depends_on` in its toml** is still contained.
- **Evaluated layer-by-layer in topological order**, poisoning every withheld model as it goes, so a one-hop upstream check (`blocked_by`) is transitively complete.
- **On any doubt, contain more, never less.** Compile-failed models seed the poison set, so their downstreams are withheld too rather than left to fail noisily on a missing table.

**Physical-table reads — CLOSED (was a noted boundary; a red-team pass confirmed it critical).** The closure no longer trusts `dag_nodes` as complete or authoritative. It resolves every physical `FROM`/`JOIN` read against the set of **produced targets** (`ProducerIndex`, 2- and 3-part matching) and folds a matching read in as an implicit containment edge — so a model reading a failed model's output, by `ref()` **or by physical name** (`marts.orders_current`), is withheld. A read that matches no produced target is a genuinely external table a run failure cannot make stale, so it adds no edge and the model may build. Belt-and-suspenders, the closure **fails closed** on residual doubt: a model whose reads are not provably complete (`lineage_is_provably_complete == false` — CTEs, sub-queries, set operations), whose physical read is ambiguous (matches producers in more than one catalog), or that is unknown to the ledger is contained once any failure has occurred — never built. Regression tests `containment_contains_physical_target_read_of_failed_producer` and `containment_fails_closed_on_unenumerable_reads` each fail on the pre-fix closure and pass now.

**Quoted-identifier hardening.** Physical reads are matched *quote-aware*: the SQL lineage walk renders a table's `ObjectName` back with its quote characters (`"main"."orders_current"`), so a naive split missed the clean producer keys and let a quoted read escape. `canonicalize_identifier` strips the quote styles Rocky's dialects use (double-quote, backtick, bracket), treats a `.` inside a quoted segment as a literal, and honors doubled-quote escapes; an identity that can't be cleanly canonicalized (unbalanced quotes, empty segment, embedded dot) fails closed. Regression test `containment_contains_quoted_physical_read_of_failed_producer` fails on the pre-fix closure and passes now, plus `canonicalize_identifier` unit cases.

**Bare-read hardening.** A bare unqualified read (`FROM orders_current`, resolved via the session default schema) where the producer's model name differs from its target table also escaped (a 1-part read matched neither the 3-part nor 2-part index → External). A `by_table` index (target table → producing models) now resolves bare reads: a bare read colliding with a producer's target table **in any schema** adds each such producer as a *candidate* edge, so the reader is contained iff at least one candidate is poisoned. This over-contains only in the acceptable direction (a bare read literally matching a failed producer's output table); per-dialect `search_path` is deliberately not modeled. A bare read matching no producer target table is genuinely external and still builds — even under an unrelated failure (`bare_read_of_external_table_builds`). Regression test `containment_contains_bare_read_of_failed_producer_table` fails on the pre-fix closure and passes now.

**Coverage (resolvable reads).** Every *statically resolvable* read identity is folded into the closure: bare / `schema.table` / `catalog.schema.table`, quoted or unquoted, resolve against produced targets; a qualified multi-target collision or an un-canonicalizable identity fails closed. Reads that can't be enumerated at all (CTEs, sub-queries, set operations) are the best-effort boundary — see **Guarantee scope** below.

**Ordering — augmented re-layering (closes the same-layer `--parallel` race for resolvable reads).** Containment edges were consulted only at `evaluate` time, but execution *layers* came from `ref()` deps only — a physical/bare reader with no `ref()` edge to its producer co-scheduled with the producer in the same layer, so under `--parallel 2` it built on stale data while the producer was still running, *then* the producer failed. When `contain_failures` is on, execution layers are now recomputed over the **full resolvable** containment edge set (ref ∪ resolved physical ∪ resolved bare) via longest-path layering, so every reader is scheduled strictly after every producer it *statically resolves*. (Unenumerable reads yield no edge — that's the best-effort boundary in **Guarantee scope**.) **Same-layer invariant:** longest-path layering guarantees no two models in one layer share a containment edge; combined with the executor's per-layer barrier, all prior-layer poison is known before the next layer is evaluated (asserted by `augmented_layers_no_same_layer_shared_edge`). **Cycle → fail closed:** a physical/bare edge can introduce a dependency cycle the ref-graph lacked; rather than let topo-sort silently drop the cyclic nodes, the whole stuck set (cycle + downstream) is contained and recorded as a single run error, and only the acyclic remainder is layered. When the flag is off, the original ref-only layers are used byte-for-byte. Regression tests `containment_contains_same_layer_physical_read_under_parallel` (headline, `--parallel 2`) and `containment_reorders_earlier_layer_physical_reader` each fail with the re-layering bypassed and pass now.

**Guarantee scope (honest).** Failure containment is **guaranteed** for dependencies declared via `ref()` and for physical reads Rocky can statically resolve — `schema.table`, `catalog.schema.table`, quoted or unquoted. Those are folded into both the withholding closure *and* the execution ordering, so a downstream of a failure is never built on its stale/missing output, and under `--parallel` a reader is scheduled strictly after every producer it reads.

Reads Rocky **cannot enumerate** — a model built on a CTE, sub-query, or set operation (anything `lineage_is_provably_complete` rejects → an "uncertain" model) — are handled on a **best-effort** basis *identical to a normal fail-fast run*. An uncertain model with a known failed upstream is contained (the fail-closed belt), but its reads yield no ordering edge, so under `--parallel` a same-layer uncertain reader of a failing producer can still materialize on stale data — **exactly as plain fail-fast does** (empirically verified: fail-fast builds the same stale row, same `PartialFailure`, same exit 2). This is a documented boundary, not a regression. The achievable invariant — *containment never materializes anything fail-fast wouldn't* (containment ⊆ fail-fast) — is locked by the parity test `containment_matches_fail_fast_for_same_layer_uncertain_read`, which runs the same same-layer CTE project twice (`contain_failures` off vs on, `--parallel 2`) and asserts identical materialization sets. Chasing the absolute bar would mean containing every CTE model, which would false-fail healthy projects. **Declare the dependency with `ref()` for a hard containment guarantee.**

**Residual boundary (declared):** containment is as complete as the executor's own layering *plus* the physical-target and fail-closed folds above. A physical read of a producer that is not topologically earlier is a pre-existing undeclared-dependency ordering issue (the read sees prior-run data regardless of containment) — **declare dependencies via `ref()` / model name** for correct ordering.

Because it is default-OFF and the ON path only ever *adds* successful builds (never removes one, never builds on bad input), the risk surface is small — but soundness discipline for this class of change still applies: it ships **default-OFF**, fail-closed, and regression-proven, and the default fail-fast path stays byte-identical (the pre-existing `parallel_mid_layer_failure_skips_downstream` test passes unchanged; the new `containment_off_is_fail_fast` guards it).

## Schema decision — run-output-only, no state-schema bump

The containment manifest is a **run-output surface**, not a persisted state record:

- New `RunOutput.contained: Vec<ContainedModelOutput>` (`{ model, blocked_by, unblock_hint }`), `#[serde(default, skip_serializing_if = "Vec::is_empty")]` so a clean run's JSON stays byte-identical.
- The failure *causes* reuse the existing `errors[]` surface. The failed model already persists as a `failure` `ModelExecution` via the existing `persist_run_record` path.
- **`CURRENT_SCHEMA_VERSION` stays at `16`.** `RunOutput` is a CLI-output type (codegen cascade), not a redb-persisted type — no new table, no `EXPECTED_TABLES` change, no version-qualified remote key. Persisting per-model contained state records is a deliberate follow-up, kept out to keep this rung's soundness surface small.

Codegen cascade regenerated and committed: `schemas/{run,rocky_project}.schema.json`, `sdk/python/.../{run,rocky_project}_schema.py`, `editors/vscode/src/types/generated/{run,rocky_project}.ts`. `just regen-fixtures` shows **zero** fixture diff (the skip-if-empty field keeps the replication POC output byte-identical).

## Reachability proof (driven end-to-end on the freshly-built binary)

**Model-level — a disjoint DAG, one runtime failure:** `bad` (missing table) fails; `dep_of_bad` reads `bad` via a bare SQL `ref()` (no `depends_on`); `good_a`, `disjoint`, `dep_of_good` are healthy.

```json
"status": "PartialFailure",  "tables_failed": 1,
"materializations": [ "...disjoint", "...good_a", "...dep_of_good" ],
"contained": [ { "model": "dep_of_bad", "blocked_by": ["bad"],
                 "unblock_hint": "resolve upstream 'bad', then re-run" } ],
"errors": [ { "asset_key": ["bad"], "error": "model 'bad' failed: ... does_not_exist_xyz ...",
              "failure_kind": "unknown" } ]
```

Exit 2 (PartialFailure sentinel). Warehouse after the run: `good_a`, `disjoint`, `dep_of_good` exist; `bad` and `dep_of_bad` do **not** — the contained model was never built on missing input.

**Partition-level — a `time_interval` model, one poisoned partition** (`CAST('BAD' AS INTEGER)` in the `2026-04-05` window; `2026-04-04` healthy) with a downstream `rollup` reading its target:

```json
"status": "PartialFailure",
"materializations": [ { "asset_key": ["","marts","events"], "partition": { "key": "2026-04-04" } } ],
"partition_summaries": [ { "model": "events", "partitions_planned": 2,
                           "partitions_succeeded": 1, "partitions_failed": 1 } ],
"contained": [ { "model": "rollup", "blocked_by": ["events"] } ],
"errors": [ { "asset_key": ["events"],
              "error": "... partition '2026-04-05' of model 'events' failed: ... 'BAD' to INT32 ..." } ]
```

Warehouse after: `marts.events` holds only the two healthy `2026-04-04` rows; `marts.rollup` does **not** exist. Healthy partitions land, the failing partition is named, the downstream consumer of the incomplete table is withheld.

**Physical-target read (the red-team repro, now fixed)** — `stage_orders` produces `main.orders_current` then fails; `rollup` reads `main.orders_current` **by physical name** (no `ref()`), layered after `stage_orders` via a healthy `anchor`; `disjoint` is unrelated:

```json
"status": "PartialFailure",  "tables_failed": 1,
"materializations": [ "...anchor", "...disjoint" ],
"errors": [ { "asset_key": ["stage_orders"], ... } ],
"contained": [ { "model": "rollup", "blocked_by": ["stage_orders"],
                 "unblock_hint": "resolve upstream 'stage_orders', then re-run" } ]
```

Warehouse after: `anchor`, `disjoint`, and the **stale** pre-seeded `orders_current` exist; `rollup` does **not** — it was never built on the failed producer's stale output. On the pre-fix closure `rollup` built (reading `999` from the stale table); now the physical-target edge contains it.

All flows are locked as committed DuckDB integration tests (`containment_continues_disjoint_subtree_on_failure`, `containment_isolates_failing_partition`, `containment_contains_physical_target_read_of_failed_producer`, `containment_fails_closed_on_unenumerable_reads`), plus `ProducerIndex`/`ContainmentLedger` unit tests (physical-edge resolution, external pass-through, ambiguity, unknown-model coverage, fail-closed belt, full-closure, partition isolation), and a merge-double-count guard (`merge_preserves_contained_cause_runtime_error`).

## Dagster note

The manifest is a dagster-consumable JSON shape (asset-key-addressable `errors[]` + `contained[]`). Wiring these to asset-level partial statuses (precedent: #863 empty-output signalling) is a documented follow-up; this PR lands the engine surface.

## Gates

- `cargo fmt -- --check` ✓
- `cargo clippy --all-targets --all-features` ✓ (0 warnings)
- `cargo test --workspace --all-features` ✓ (exit 0)
- `just codegen` ✓ zero-drift (bindings regenerated + committed)
- `just regen-fixtures` ✓ zero fixture diff

Do **not** merge yet — pending independent red-team review of the containment/closure logic.
