### PR TITLE
Surface model-failure containment blast-radius as Dagster asset observations

### DIFF
--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Model-failure containment surfaces as Dagster asset observations.** When a `rocky run` withholds models because an upstream failed (the `contained[]` blast radius, emitted under `[resilience] contain_failures`), each withheld model now gets a `dg.AssetObservation` carrying the containment reason (`rocky/contained`, `rocky/blocked_by`, `rocky/unblock_hint`), and its declared checks report that reason instead of the generic "table not materialized" placeholder. A contained model is deliberately left unmaterialized — the inverse of the empty-output signalling pattern — so a same-run downstream correctly cascade-skips and the blast radius stays visible; it is never given a fake-green zero-row result, even with `satisfy_empty_outputs=True`. Buffered/streaming execution modes only. Requires a `rocky-sdk` version that surfaces `RunResult.contained`.
+
 ## [1.55.0] — 2026-07-08
 
 ### Changed

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -31,6 +31,7 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Annotated, Literal
 
 import dagster as dg
@@ -77,6 +78,7 @@ from .sensor import rocky_source_sensor
 from .translator import RockyDagsterTranslator, strip_tenant_component
 from .types import (
     CompileResult,
+    ContainedModel,
     DagResult,
     Diagnostic,
     DiscoverResult,
@@ -161,7 +163,7 @@ def _engine_schema_mismatch_failure(command: str, exc: ValidationError) -> dg.Fa
 
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator
+    from collections.abc import Iterable, Iterator, Mapping
     from collections.abc import Set as AbstractSet
 
 #: Metadata key stamped on the zero-row ``MaterializeResult`` that the
@@ -2929,8 +2931,16 @@ def _emit_results(
     * :class:`dg.AssetCheckResult` — one per declared Rocky check, plus one
       ``row_count_anomaly`` (severity WARN) per Rocky-detected anomaly.
     * :class:`dg.AssetObservation` — one per drift action (ALTER COLUMN,
-      DROP+RECREATE, etc.). Drift is a structural change, not pass/fail,
-      so observation is the right primitive.
+      DROP+RECREATE, etc.), plus one per model withheld by failure containment
+      (``RunResult.contained`` — a model not built because an upstream failed
+      under ``[resilience] contain_failures``). Both are structural signals,
+      not pass/fail, so observation is the right primitive. A contained model
+      is deliberately left *unmaterialized* (the inverse of the empty-output
+      pass) so a same-run downstream cascade-skips and the blast radius stays
+      visible; the observation carries the ``rocky/blocked_by`` /
+      ``rocky/unblock_hint`` reason. This wiring is buffered/streaming only —
+      Pipes mode does not reach ``_emit_results``, and its wire cannot tell a
+      contained model apart from an absent one.
 
     When ``satisfy_empty_outputs`` is set, a final pass emits a zero-row
     :class:`dg.MaterializeResult` (marked
@@ -3082,6 +3092,52 @@ def _emit_results(
             yielded_checks.add(spec_key)
             yield anomaly_result
 
+    # Model-failure containment → AssetObservation. A model in ``contained``
+    # was withheld this run because an upstream failed (or was itself withheld)
+    # and ``[resilience] contain_failures`` continued the disjoint subgraphs —
+    # the blast radius of the failures in ``errors``. This is the deliberate
+    # INVERSE of the empty-output emission below: a contained model was NOT
+    # built, so we must NOT stamp a (fake-green) MaterializeResult on it. Left
+    # unmaterialized, a same-run downstream that depends on it correctly
+    # cascade-skips (``can_subset`` does not prune unyielded deps) — the blast
+    # radius stays visible instead of being masked. We surface the *reason*
+    # (blocked_by / unblock_hint) as an ``AssetObservation`` — the same
+    # non-materializing primitive used for drift — so the containment shows up
+    # on the asset timeline. ``contained.model`` is a single model name, so it
+    # resolves through the same string resolver as drift/anomaly. The resolved
+    # keys are collected so the guards below can (1) exclude them from the
+    # empty-output pass and (2) enrich their declared checks' placeholders.
+    #
+    # This only covers the buffered/streaming ``_emit_results`` path. Pipes mode
+    # (``execution_mode="pipes"``) never reaches here — it emits over the Pipes
+    # wire, which reports only what the engine copied and so cannot tell a
+    # contained model apart from an absent one (the same constraint
+    # ``_validate_satisfy_empty_outputs`` cites). dag_mode is a separate emission
+    # path. Neither is wired for containment.
+    contained_by_key: dict[dg.AssetKey, ContainedModel] = {}
+    for run_result in results:
+        for contained in run_result.contained:
+            asset_key = selected_resolver(contained.model)
+            if asset_key is None:
+                continue
+            if asset_key in contained_by_key:
+                # Same model withheld across two results in this op — keep the
+                # first, mirroring the first-wins dedup on materializations.
+                continue
+            contained_by_key[asset_key] = contained
+            yield dg.AssetObservation(
+                asset_key=asset_key,
+                description=(
+                    f"Withheld by failure containment — blocked by "
+                    f"{', '.join(contained.blocked_by) or 'an upstream failure'}"
+                ),
+                metadata={
+                    "rocky/contained": dg.MetadataValue.bool(True),
+                    "rocky/blocked_by": dg.MetadataValue.text(", ".join(contained.blocked_by)),
+                    "rocky/unblock_hint": dg.MetadataValue.text(contained.unblock_hint),
+                },
+            )
+
     # Empty-output satisfaction (opt-in). For a subset / partition run, emit
     # a zero-row MaterializeResult for every selected key that was neither
     # copied nor errored, so a same-run downstream depending on it isn't
@@ -3125,7 +3181,12 @@ def _emit_results(
             )
         else:
             errored_keys = {remap(err.asset_key) for r in results for err in r.errors}
-            empty_keys = selected_keys - materialized_keys - errored_keys
+            # Subtract contained keys too: a withheld model must stay
+            # unmaterialized so the downstream cascade-skips, exactly as an
+            # errored key does. Without this, the empty-output pass would stamp
+            # a fake-green zero-row MaterializeResult on it and mask the blast
+            # radius — the same invariant enforced for errored keys.
+            empty_keys = selected_keys - materialized_keys - errored_keys - set(contained_by_key)
             yield from _empty_output_results(empty_keys, pruned_keys)
     elif pruned_keys:
         # Pruning produced skipped tables but there is no empty-output pass to
@@ -3145,6 +3206,7 @@ def _emit_results(
         yielded_checks=yielded_checks,
         materialized_keys=materialized_keys,
         pruned_keys=pruned_keys,
+        contained_by_key=contained_by_key,
     )
 
 
@@ -3246,6 +3308,7 @@ def _emit_placeholder_checks(
     yielded_checks: set[tuple[dg.AssetKey, str]],
     materialized_keys: set[dg.AssetKey],
     pruned_keys: AbstractSet[dg.AssetKey] = frozenset(),
+    contained_by_key: Mapping[dg.AssetKey, ContainedModel] = MappingProxyType({}),
 ) -> Iterator[dg.AssetCheckResult]:
     """Emit placeholders for declared checks Rocky did not produce.
 
@@ -3257,11 +3320,35 @@ def _emit_placeholder_checks(
     ``passed=True`` with a "not re-checked" status rather than the WARN /
     ``passed=False`` placeholder an unmaterialized table would otherwise get —
     so pruning doesn't overwrite a passing check with a spurious failure.
+
+    A check on a model in ``contained_by_key`` was withheld by failure
+    containment (its upstream failed). It is unmaterialized, so it would
+    otherwise get the generic "table not materialized" WARN placeholder — which
+    says nothing about *why*. Instead it reports the containment reason
+    (``blocked_by`` / ``unblock_hint``) so the check surfaces the blast-radius
+    cause, mirroring the pruned-table special-case above. Still ``passed=False``
+    / WARN — the model was not built and the check did not run; the hard error
+    lives on the root-cause asset in ``errors``.
     """
     for cs in check_specs:
         if cs.asset_key not in selected_keys:
             continue
         if (cs.asset_key, cs.name) in yielded_checks:
+            continue
+
+        contained = contained_by_key.get(cs.asset_key)
+        if contained is not None:
+            blocked = ", ".join(contained.blocked_by) or "an upstream failure"
+            status = f"not checked: model withheld by failure containment (blocked by {blocked})"
+            if contained.unblock_hint:
+                status = f"{status} — {contained.unblock_hint}"
+            yield dg.AssetCheckResult(
+                asset_key=cs.asset_key,
+                check_name=cs.name,
+                passed=False,
+                severity=dg.AssetCheckSeverity.WARN,
+                metadata={"status": dg.MetadataValue.text(status)},
+            )
             continue
 
         if cs.asset_key in pruned_keys:

--- a/integrations/dagster/tests/test_empty_outputs.py
+++ b/integrations/dagster/tests/test_empty_outputs.py
@@ -41,6 +41,7 @@ def _run_result(
     errors: list[dict] | None = None,
     tables_failed: int | None = None,
     excluded_tables: list[dict] | None = None,
+    contained: list[dict] | None = None,
 ) -> RunResult:
     mats = materializations or []
     errs = errors or []
@@ -59,6 +60,7 @@ def _run_result(
             "check_results": [],
             "errors": errs,
             "excluded_tables": excluded_tables or [],
+            "contained": contained or [],
             "permissions": {
                 "grants_added": 0,
                 "grants_revoked": 0,
@@ -68,6 +70,10 @@ def _run_result(
             "drift": {"tables_checked": 0, "tables_drifted": 0, "actions_taken": []},
         }
     )
+
+
+def _contained(model: str, blocked_by: list[str], hint: str = "resolve upstream, re-run") -> dict:
+    return {"model": model, "blocked_by": blocked_by, "unblock_hint": hint}
 
 
 def _mat(name: str, rows: int = 10) -> dict:
@@ -569,3 +575,157 @@ def test_prune_without_satisfy_empty_outputs_warns(caplog):
             )
         )
     assert any("prune_unchanged skipped" in r.message for r in caplog.records)
+
+
+# --------------------------------------------------------------------------- #
+# Model-failure containment — a withheld model surfaces as an AssetObservation,
+# stays UNMATERIALIZED (the inverse of empty-output), and enriches its checks.
+# --------------------------------------------------------------------------- #
+
+
+def test_contained_model_emits_observation_and_is_not_fake_greened():
+    """A model withheld by failure containment yields an ``AssetObservation``
+    carrying the reason (blocked_by / unblock_hint) and is NOT stamped with an
+    empty MaterializeResult even with ``satisfy_empty_outputs=True`` — the blast
+    radius must stay visible, the deliberate inverse of empty-output. A
+    genuinely-absent sibling still IS satisfied, proving the guard is targeted."""
+    a_raw, b_raw, c_raw = (dg.AssetKey([x]) for x in ("a_raw", "b_raw", "c_raw"))
+    mapping = {("a_raw",): a_raw, ("b_raw",): b_raw, ("c_raw",): c_raw}
+    # a_raw copied; b_raw genuinely absent; c_raw withheld because `root` failed.
+    run_result = _run_result(
+        materializations=[_mat("a_raw")],
+        errors=[{"asset_key": ["root"], "error": "boom", "failure_kind": "query-rejected"}],
+        contained=[_contained("c_raw", ["root"], "fix root, then re-run")],
+    )
+
+    events = list(
+        _emit_results(
+            results=[run_result],
+            check_specs=[],
+            selected_keys={a_raw, b_raw, c_raw},
+            rocky_key_to_dagster_key=mapping,
+            satisfy_empty_outputs=True,
+        )
+    )
+
+    obs = [e for e in events if isinstance(e, dg.AssetObservation) and e.asset_key == c_raw]
+    assert len(obs) == 1
+    md = obs[0].metadata
+    assert md["rocky/contained"].value is True
+    assert md["rocky/blocked_by"].value == "root"
+    assert md["rocky/unblock_hint"].value == "fix root, then re-run"
+
+    # Guard 1: c_raw (contained) is NOT fake-greened; b_raw (absent) IS.
+    empty_keys = {
+        e.asset_key
+        for e in events
+        if isinstance(e, dg.MaterializeResult) and e.metadata.get(EMPTY_FOR_PARTITION_METADATA_KEY)
+    }
+    assert c_raw not in empty_keys
+    assert b_raw in empty_keys
+    # And no real materialization for c_raw either — it stays unmaterialized.
+    real = {
+        e.asset_key
+        for e in events
+        if isinstance(e, dg.MaterializeResult)
+        and not e.metadata.get(EMPTY_FOR_PARTITION_METADATA_KEY)
+    }
+    assert real == {a_raw}
+
+
+def test_contained_model_placeholder_check_reports_containment_reason():
+    """Guard 2: a declared check on a contained model reports the containment
+    reason (blocked_by + unblock_hint) instead of the generic "table not
+    materialized" WARN placeholder an unmaterialized table would otherwise get."""
+    c_raw = dg.AssetKey(["c_raw"])
+    mapping = {("c_raw",): c_raw}
+    run_result = _run_result(
+        errors=[{"asset_key": ["root"], "error": "boom", "failure_kind": "query-rejected"}],
+        contained=[_contained("c_raw", ["root"], "fix root, then re-run")],
+    )
+
+    events = list(
+        _emit_results(
+            results=[run_result],
+            check_specs=[dg.AssetCheckSpec(name="row_count", asset=c_raw)],
+            selected_keys={c_raw},
+            rocky_key_to_dagster_key=mapping,
+            satisfy_empty_outputs=True,
+        )
+    )
+
+    checks = [e for e in events if isinstance(e, dg.AssetCheckResult)]
+    assert len(checks) == 1
+    assert checks[0].asset_key == c_raw
+    assert checks[0].check_name == "row_count"
+    assert checks[0].passed is False
+    assert checks[0].severity == dg.AssetCheckSeverity.WARN
+    status = checks[0].metadata["status"].value
+    assert "failure containment" in status
+    assert "root" in status  # the blocked_by upstream is named
+    assert "fix root, then re-run" in status  # the unblock hint is appended
+    assert "table not materialized" not in status  # NOT the generic placeholder
+
+
+def test_contained_upstream_cascade_skips_downstream_even_with_flag():
+    """The discriminating end-to-end case, driven through ``dg.materialize``:
+    with ``satisfy_empty_outputs=True`` a contained upstream is left
+    unmaterialized (only observed), so a same-run downstream that depends on it
+    still cascade-skips. This proves both that an ``AssetObservation`` does NOT
+    satisfy a ``can_subset`` output and that Guard 1 holds — were the contained
+    key fake-greened, the downstream ``c`` would RUN instead of skip."""
+    a_raw, b_raw, c_raw = (dg.AssetKey([x]) for x in ("a_raw", "b_raw", "c_raw"))
+    mapping = {("a_raw",): a_raw, ("b_raw",): b_raw, ("c_raw",): c_raw}
+    run_result = _run_result(
+        materializations=[_mat("a_raw"), _mat("b_raw")],
+        errors=[{"asset_key": ["root"], "error": "boom", "failure_kind": "query-rejected"}],
+        contained=[_contained("c_raw", ["root"], "fix root, then re-run")],
+    )
+
+    @dg.multi_asset(
+        specs=[dg.AssetSpec("a_raw"), dg.AssetSpec("b_raw"), dg.AssetSpec("c_raw")],
+        can_subset=True,
+        name="up",
+    )
+    def up(context):
+        yield from _emit_results(
+            results=[run_result],
+            check_specs=[],
+            selected_keys=set(context.selected_asset_keys),
+            rocky_key_to_dagster_key=mapping,
+            satisfy_empty_outputs=True,
+        )
+
+    @dg.multi_asset(
+        specs=[
+            dg.AssetSpec("a", deps=["a_raw"]),
+            dg.AssetSpec("b", deps=["b_raw"]),
+            dg.AssetSpec("c", deps=["c_raw"]),
+        ],
+        can_subset=True,
+        name="down",
+    )
+    def down(context):
+        for k in context.selected_asset_keys:
+            yield dg.MaterializeResult(asset_key=k)
+
+    result = dg.materialize([up, down], raise_on_error=False)
+    assert result.success  # up succeeds; the run still reports SUCCESS
+
+    mats = list(result.get_asset_materialization_events())
+    keys = {e.asset_key.to_user_string() for e in mats}
+    # up copied a_raw/b_raw; c_raw is contained → NOT materialized (no empty stamp).
+    assert {"a_raw", "b_raw"} <= keys
+    assert "c_raw" not in keys
+    # down depends on the withheld c_raw, so it cascade-skips (produces nothing).
+    assert keys & {"a", "b", "c"} == set()
+
+    # The containment observation was recorded against c_raw.
+    obs = [e for e in result.all_events if e.event_type_value == "ASSET_OBSERVATION"]
+    contained_obs = [
+        e
+        for e in obs
+        if "rocky/contained" in (e.event_specific_data.asset_observation.metadata or {})
+    ]
+    assert len(contained_obs) == 1
+    assert contained_obs[0].event_specific_data.asset_observation.asset_key == c_raw

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`RunResult.contained` now surfaces through `parse_rocky_output`.** The `contained[]` model-failure containment field shipped on the generated `RunOutput` in 0.3.0, but `parse_rocky_output` dispatches `run` to the hand-written `RunResult`, which did not declare the field — so Pydantic's default `extra="ignore"` silently dropped it. The hand-written `RunResult` now carries `contained: list[ContainedModel]` (empty when the engine omits it), so a consumer surfacing the withheld-model blast radius (e.g. `dagster-rocky`) reads the values instead of always seeing nothing.
+
 ## [0.3.0] — 2026-07-08
 
 ### Added

--- a/sdk/python/src/rocky_sdk/types.py
+++ b/sdk/python/src/rocky_sdk/types.py
@@ -374,6 +374,33 @@ class MetricsSnapshot(BaseModel):
     query_duration_max_ms: int
 
 
+class ContainedModel(BaseModel):
+    """A model Rocky withheld this run because an upstream failed.
+
+    Emitted only under ``[resilience] contain_failures``: when a model (or one
+    of its upstreams) fails, the engine continues the disjoint subgraphs and
+    records every withheld model here — the blast radius of the failures named
+    in :attr:`RunResult.errors`. A withheld model was **not built**; its target
+    was left untouched. Empty (and omitted from the wire) for a default
+    fail-fast run and for any successful run.
+
+    Hand-written to match the wire field names emitted by the engine's
+    ``ContainedModelOutput``. It is not re-exported from the generated barrel,
+    so it lives here alongside the other hand-written run-output models. Kept in
+    sync with the generated schema by the ``contained[]`` parse test in
+    ``tests/test_types.py``.
+    """
+
+    #: The withheld model's name (matches the model entry in the project DAG).
+    model: str
+    #: The failed-or-withheld upstream(s) that reach this model — its direct
+    #: poisoned dependencies. The run's :attr:`RunResult.errors` carry the
+    #: root-cause detail.
+    blocked_by: list[str] = Field(default_factory=list)
+    #: Operator hint: resolve the named upstream failure(s), then re-run.
+    unblock_hint: str = ""
+
+
 class RunResult(BaseModel):
     version: str
     command: str
@@ -384,6 +411,16 @@ class RunResult(BaseModel):
     materializations: list[MaterializationInfo]
     check_results: list[TableCheckResult]
     errors: list[TableError] = []
+    #: Models withheld this run because an upstream failed (or was itself
+    #: withheld) and ``[resilience] contain_failures`` continued the disjoint
+    #: subgraphs — the blast radius of the failures in :attr:`errors`. Empty
+    #: (and omitted on the wire) for a default fail-fast run and for any
+    #: successful run. Without this field declared, Pydantic's default
+    #: ``extra="ignore"`` would silently drop the wire value (the runtime
+    #: ``RunResult`` is the hand-written dispatch target, not the generated
+    #: ``RunOutput``), so a consumer mapping it — e.g. dagster-rocky surfacing
+    #: the containment blast radius — would never see anything.
+    contained: list[ContainedModel] = Field(default_factory=list)
     #: Tables filtered out before execution because they don't exist in
     #: the source warehouse. Empty when nothing was excluded. The CLI
     #: skips serializing this field when empty, so it remains backwards

--- a/sdk/python/tests/test_types.py
+++ b/sdk/python/tests/test_types.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from rocky_sdk import CiResult, CompileResult, DiscoverResult, TestResult, parse_rocky_output
@@ -130,6 +132,81 @@ def test_run_result_threads_check_severity_through_table_checks():
         }
     )
     assert result.check_results[0].checks[0].severity == "warning"
+
+
+def test_run_result_threads_containment_blast_radius():
+    # Shadow-drift regression: `contained[]` is present on the *generated*
+    # `RunOutput`, but `parse_rocky_output` dispatches `run` to the hand-written
+    # `RunResult`. Without the field declared there, Pydantic's default
+    # `extra="ignore"` silently drops the wire value, so a consumer surfacing the
+    # containment blast radius (dagster-rocky) never sees it. This is the same
+    # class of drift the `CheckResult.severity` test above pins.
+    payload = json.dumps(
+        {
+            "version": "1.0.0",
+            "command": "run",
+            "filter": "all",
+            "duration_ms": 42,
+            "tables_copied": 1,
+            "tables_failed": 1,
+            "materializations": [],
+            "check_results": [],
+            "errors": [
+                {"asset_key": ["stg_orders"], "error": "boom", "failure_kind": "query-rejected"}
+            ],
+            "contained": [
+                {
+                    "model": "fct_orders",
+                    "blocked_by": ["stg_orders"],
+                    "unblock_hint": "resolve the stg_orders failure, then re-run",
+                },
+                {
+                    "model": "mart_revenue",
+                    "blocked_by": ["fct_orders"],
+                    "unblock_hint": "resolve the stg_orders failure, then re-run",
+                },
+            ],
+            "permissions": {
+                "grants_added": 0,
+                "grants_revoked": 0,
+                "catalogs_created": 0,
+                "schemas_created": 0,
+            },
+            "drift": {"tables_checked": 0, "tables_drifted": 0, "actions_taken": []},
+        }
+    )
+    result = parse_rocky_output(payload)
+    assert isinstance(result, RunResult)
+    assert [c.model for c in result.contained] == ["fct_orders", "mart_revenue"]
+    assert result.contained[0].blocked_by == ["stg_orders"]
+    assert result.contained[1].blocked_by == ["fct_orders"]
+    assert "re-run" in result.contained[0].unblock_hint
+
+
+def test_run_result_containment_defaults_empty_when_omitted():
+    # A default fail-fast / successful run omits `contained` on the wire; it must
+    # surface as an empty list, not raise.
+    payload = json.dumps(
+        {
+            "version": "1.0.0",
+            "command": "run",
+            "filter": "all",
+            "duration_ms": 1,
+            "tables_copied": 0,
+            "materializations": [],
+            "check_results": [],
+            "permissions": {
+                "grants_added": 0,
+                "grants_revoked": 0,
+                "catalogs_created": 0,
+                "schemas_created": 0,
+            },
+            "drift": {"tables_checked": 0, "tables_drifted": 0, "actions_taken": []},
+        }
+    )
+    result = parse_rocky_output(payload)
+    assert isinstance(result, RunResult)
+    assert result.contained == []
 
 
 def test_parse_rocky_output_rejects_non_object():


### PR DESCRIPTION
## What

Surface engine model-failure **containment** — the `contained[]` blast-radius manifest a `rocky run` emits under `[resilience] contain_failures` — in the Dagster integration. When an upstream fails and the engine continues the disjoint subgraphs, the models it withholds are now visible in Dagster instead of silently disappearing.

This is a coupled **rocky-sdk + dagster** change: the field could not reach Dagster until a shadow-drift bug at the SDK parse layer was fixed first.

## `fix(sdk)` — shadow-drift at the parse layer

`contained[]` shipped on the generated `RunOutput` (v0.3.0), but `parse_rocky_output` dispatches `run` to the **hand-written** `RunResult`, which never declared the field — so Pydantic's default `extra="ignore"` silently dropped it on the wire. A consumer reading the withheld-model blast radius always saw nothing.

- Add a minimal hand-written `ContainedModel` (`model`, `blocked_by`, `unblock_hint`) and `contained: list[ContainedModel]` on `RunResult` (empty when the engine omits it), matching the existing hand-written style — no re-alias of `RunResult` to the generated type.
- Regression test in `tests/test_types.py`: a run payload with a non-empty `contained[]` now parses through `parse_rocky_output` with the values populated. It fails without the fix (`AttributeError: 'RunResult' object has no attribute 'contained'`) and passes with it, plus an omitted-field default case.

## `feat(dagster)` — the mapping

In `_emit_results` (buffered/streaming path):

- **Observation:** each contained model resolves to its asset key (same string resolver as drift/anomaly) and emits a `dg.AssetObservation` with `rocky/contained`, `rocky/blocked_by`, `rocky/unblock_hint`. This mirrors the existing drift-observation choice.
- **Unmaterialized on purpose:** a contained model is left unmaterialized — the deliberate inverse of the empty-output signalling pattern — so a same-run downstream correctly cascade-skips and the blast radius stays visible.
- **Guard 1:** contained keys are subtracted from the `satisfy_empty_outputs` empty-key set, so a withheld model is never stamped with a fake-green zero-row `MaterializeResult`.
- **Guard 2:** a contained model's declared checks report the containment reason (blocked_by / unblock_hint) instead of the generic "table not materialized" placeholder.
- **Mode boundary:** buffered/streaming only. Pipes mode never reaches `_emit_results` and its wire cannot distinguish a contained model from an absent one; dag_mode is a separate emission path. Documented in the docstring/comments.

No engine change, no codegen, no schema/generated-types change. The in-repo uv path dependency resolves the local SDK; no `rocky-sdk>=` floor or version bump in this PR.

## Tests (creds-free — DuckDB/pytest only)

- SDK parse-dispatch regression (fails-before / passes-after, verified).
- Dagster: a contained model yields the observation with the reason metadata; is not fake-greened under `satisfy_empty_outputs=True`; its placeholder check reports the reason; and an end-to-end `dg.materialize` proving the `AssetObservation` does not satisfy a `can_subset` output so the downstream cascade-skips (verified against the installed dagster 1.13.10).

## Verification

- SDK: `pytest` 44 passed, `ruff check` clean, `ruff format --check` clean.
- Dagster: `pytest` 687 passed, `ruff check` clean, `ruff format --check` clean.