### PR TITLE
feat(engine): write recipe-identity into Databricks table metadata + offline read-back verification

### DIFF
--- a/docs/src/content/docs/reference/rocky-manifest-spec.md
+++ b/docs/src/content/docs/reference/rocky-manifest-spec.md
@@ -119,7 +119,11 @@ The same manifest content can travel in more than one place:
 
 1. **A standalone file.** A `.json` document, suitable for an export bundle handed to an auditor or a downstream consumer. This is the form the reference verifier reads.
 2. **Alongside content-addressed artifacts.** On the content-addressed write path, the output bytes are already named by their BLAKE3 hash and recorded in the artifact ledger, which is what populates `output_hashes`.
-3. **Table-format metadata.** Embedding the identity in a table format's own commit metadata (for example Iceberg snapshot-summary properties or Delta commit info) is a natural carrier so the attestation travels with the table. Aligning those keys to these field names is future work and is not part of v0.1.
+3. **Table-format metadata.** Embedding the identity in a table's own warehouse-side metadata is a natural carrier, so the attestation travels with the table. Rocky writes it into Delta `TBLPROPERTIES`: each manifest field is carried under a vendor-neutral namespace prefix, `recipe_manifest.`, with the field's dotted path appended, for example `recipe_manifest.program_hash`, `recipe_manifest.env_hash`, `recipe_manifest.hash_scheme`, `recipe_manifest.inputs_hash`, `recipe_manifest.inputs_proof_class`, `recipe_manifest.manifest_version`, `recipe_manifest.producer.name`, `recipe_manifest.producer.version`, `recipe_manifest.subject.model`, `recipe_manifest.subject.run_id`, `recipe_manifest.subject.status`. The prefix is deliberately not a vendor brand such as `rocky.`: vendor identity belongs in the `producer` field, not the key, and a shared neutral namespace lets a reader glob the manifest keys and tell them apart from `delta.*` reserved properties and arbitrary user tags. The write is issued as a post-create `ALTER TABLE ... SET TBLPROPERTIES`, never folded into the CREATE, so it cannot perturb the IR the program hash is computed over.
+
+   A reader reverses that mapping — strip the prefix, split the remaining dotted path — to reconstitute a standalone manifest that `rocky-verify` checks offline. Note the boundary: a managed (non-content-addressed) run carries the identity triple but no `output_hashes`, so offline verification of a table-metadata manifest is schema validation only. It proves the carrier round-tripped and the triple is well-formed, not that the table's bytes are reproducible. Byte-verifiable teeth still live only in `output_hashes` on the content-addressed path.
+
+   The Delta `TBLPROPERTIES` carrier is where this ships today. Managed Iceberg rejects engine-managed property writes (`MANAGED_ICEBERG_OPERATION_NOT_SUPPORTED`), so the documented fallback for an Iceberg table is the snapshot-summary carrier, which remains future work.
 
 ## The reference verifier
 
@@ -157,5 +161,6 @@ It does not attest that re-running the program would reproduce the same output. 
 | Manifest derivable from `rocky history --recipe --output json` | Shipped |
 | `rocky-verify` schema validation and offline byte verification | Shipped |
 | `output_hashes` populated for a general (non-content-addressed) run | Not yet — output byte-hashes are recorded on the content-addressed write path only |
-| Table-format metadata carrier with these field names | Not yet — future work |
+| Table-format metadata carrier (Delta `TBLPROPERTIES` under the `recipe_manifest.` namespace) | Shipped for Delta — reconstitutes to a manifest `rocky-verify` validates offline (schema-only on a managed run) |
+| Table-format metadata carrier for Iceberg (snapshot-summary) | Not yet — managed Iceberg rejects engine-managed property writes; snapshot-summary carrier is future work |
 | Signature block for signed custody | Not yet — intentionally unspecified until the signing model lands |

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4169,6 +4169,7 @@ dependencies = [
  "rocky-ir",
  "rocky-observe",
  "rocky-sql",
+ "rocky-verify",
  "serde",
  "serde_json",
  "thiserror",

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1323,6 +1323,11 @@ pub async fn run(
                     Some(target_model),
                 )
                 .await;
+                // Write the recipe-identity attestation into the built table's
+                // warehouse metadata (Databricks Delta TBLPROPERTIES; no-op
+                // elsewhere). Reads the triple off the materialization; never
+                // recomputes it.
+                write_recipe_manifests(&output, governance_adapter.as_ref(), &run_id).await;
             }
             Err(e) => {
                 output.tables_failed += 1;
@@ -4038,6 +4043,13 @@ pub async fn run(
     output.populate_cost_summary(&adapter_type, &rocky_cfg.cost);
     let budget_result = output.check_and_record_budget(&rocky_cfg.budget, Some(&run_id));
 
+    // Write the recipe-identity attestation into each materialized table's
+    // warehouse metadata (Databricks Delta TBLPROPERTIES; no-op elsewhere).
+    // This single hook, keyed off `output.materializations`, covers every
+    // replication / transformation / time-interval model built by this
+    // pipeline path. Best-effort — never flips the run's exit code.
+    write_recipe_manifests(&output, governance_adapter.as_ref(), &run_id).await;
+
     // Persist the RunRecord so `rocky history`, `rocky replay`,
     // `rocky trace`, and `rocky cost` have real data to read.
     // Record-store failures never fail the command — the user's run
@@ -6407,6 +6419,64 @@ pub(crate) async fn apply_model_governance_tags(
     }
 }
 
+/// Write recipe-manifest attestations into warehouse table metadata for every
+/// model materialized this run.
+///
+/// Reads the recipe-identity triple straight off each
+/// [`MaterializationOutput::recipe_identity`](crate::output::MaterializationOutput)
+/// — never recomputing it — and hands the mapped `recipe_manifest.*` key set
+/// to [`GovernanceAdapter::write_recipe_manifest`], which issues a post-create
+/// `ALTER TABLE ... SET TBLPROPERTIES` on Databricks (Delta) and no-ops
+/// elsewhere.
+///
+/// Keyed off the universal `output.materializations` collection — which
+/// *every* materialization path pushes into (replication, transformation,
+/// time-interval, model-only) and every path stamps `recipe_identity` onto —
+/// so this single hook inherits all-path coverage rather than being patched
+/// into one site and silently missing the others.
+///
+/// Best-effort: a write failure warns but never fails the run (matching the
+/// per-model governance-tag application it sits alongside). No-ops on
+/// warehouses without a custom-property carrier via the trait default.
+pub(crate) async fn write_recipe_manifests(
+    output: &RunOutput,
+    governance_adapter: &dyn GovernanceAdapter,
+    run_id: &str,
+) {
+    let engine_version = env!("CARGO_PKG_VERSION");
+    for mat in &output.materializations {
+        let Some(props) = crate::output::recipe_manifest_properties(mat, run_id, engine_version)
+        else {
+            continue;
+        };
+        // The carrier needs a three-part `catalog.schema.table` target for the
+        // ALTER. Other key shapes (e.g. a DuckDB two-part key) are skipped —
+        // and DuckDB no-ops the write regardless.
+        let [catalog, schema, table] = mat.asset_key.as_slice() else {
+            debug!(
+                asset_key = ?mat.asset_key,
+                "skipping recipe-manifest write: asset key is not catalog.schema.table"
+            );
+            continue;
+        };
+        let target = rocky_ir::TableRef {
+            catalog: catalog.clone(),
+            schema: schema.clone(),
+            table: table.clone(),
+        };
+        if let Err(e) = governance_adapter
+            .write_recipe_manifest(&target, &props)
+            .await
+        {
+            warn!(
+                model = %mat.asset_key.join("."),
+                error = %e,
+                "recipe-manifest metadata write failed (best-effort; run not affected)"
+            );
+        }
+    }
+}
+
 pub(crate) fn governance_tag_target(
     strategy: &rocky_core::models::StrategyConfig,
     catalog: &str,
@@ -8330,6 +8400,151 @@ fn is_rate_limit_error(error_msg: &str) -> bool {
 mod tests {
     use super::*;
     use rocky_core::plan_partition::PartitionSelection;
+
+    /// A recording [`GovernanceAdapter`] that captures every
+    /// `write_recipe_manifest` call — the coverage-proof analogue of the
+    /// `set_tags`-recording `CountingGovernance` mock below.
+    struct RecordingRecipeGovernance {
+        writes: std::sync::Mutex<Vec<(String, BTreeMap<String, String>)>>,
+    }
+
+    #[async_trait::async_trait]
+    impl rocky_core::traits::GovernanceAdapter for RecordingRecipeGovernance {
+        async fn set_tags(
+            &self,
+            _target: &TagTarget,
+            _tags: &BTreeMap<String, String>,
+        ) -> rocky_core::traits::AdapterResult<()> {
+            Ok(())
+        }
+        async fn get_grants(
+            &self,
+            _target: &rocky_ir::ir::GrantTarget,
+        ) -> rocky_core::traits::AdapterResult<Vec<rocky_ir::ir::Grant>> {
+            Ok(vec![])
+        }
+        async fn apply_grants(
+            &self,
+            _grants: &[rocky_ir::ir::Grant],
+        ) -> rocky_core::traits::AdapterResult<()> {
+            Ok(())
+        }
+        async fn revoke_grants(
+            &self,
+            _grants: &[rocky_ir::ir::Grant],
+        ) -> rocky_core::traits::AdapterResult<()> {
+            Ok(())
+        }
+        async fn bind_workspace(
+            &self,
+            _catalog: &str,
+            _workspace_id: u64,
+            _binding_type: &str,
+        ) -> rocky_core::traits::AdapterResult<()> {
+            Ok(())
+        }
+        async fn set_isolation(
+            &self,
+            _catalog: &str,
+            _enabled: bool,
+        ) -> rocky_core::traits::AdapterResult<()> {
+            Ok(())
+        }
+        async fn write_recipe_manifest(
+            &self,
+            table: &rocky_ir::TableRef,
+            properties: &BTreeMap<String, String>,
+        ) -> rocky_core::traits::AdapterResult<()> {
+            self.writes
+                .lock()
+                .unwrap()
+                .push((table.full_name(), properties.clone()));
+            Ok(())
+        }
+    }
+
+    fn mat_for_manifest(
+        asset_key: &[&str],
+        identity: Option<crate::output::RecipeIdentityInternal>,
+    ) -> crate::output::MaterializationOutput {
+        crate::output::MaterializationOutput {
+            asset_key: asset_key.iter().map(|s| (*s).to_string()).collect(),
+            attempts: Vec::new(),
+            rows_copied: None,
+            duration_ms: 1,
+            started_at: Utc::now(),
+            metadata: crate::output::MaterializationMetadata {
+                strategy: "full_refresh".to_string(),
+                watermark: None,
+                target_table_full_name: None,
+                sql_hash: None,
+                column_count: None,
+                compile_time_ms: None,
+            },
+            partition: None,
+            cost_usd: None,
+            bytes_scanned: None,
+            bytes_written: None,
+            tenant: None,
+            job_ids: Vec::new(),
+            skip_internal: None,
+            recipe_identity: identity,
+            output_column_hashes: None,
+            consumed_column_baseline: None,
+        }
+    }
+
+    /// The all-paths coverage proof: `write_recipe_manifests` writes exactly
+    /// the materializations that stamped a recipe-identity (and skips those
+    /// that did not), keyed off the universal `output.materializations`
+    /// collection every run path pushes into. Creds-free — no warehouse.
+    #[tokio::test]
+    async fn write_recipe_manifests_writes_identity_bearing_and_skips_others() {
+        let identity = crate::output::RecipeIdentityInternal {
+            recipe_hash: "2148e619b51421f51cfb3fac423145fe245bbe409b74f31c22d703ab07453036"
+                .to_string(),
+            env_hash: "bbf2c2045328f738683a6336df5fa61b5f00076aeaed7c495c04f9d6991d92bd"
+                .to_string(),
+            hash_scheme: "v1".to_string(),
+        };
+        let mut output = RunOutput::new(String::new(), 1000, 3);
+        output.materializations.push(mat_for_manifest(
+            &["wh", "silver", "orders"],
+            Some(identity.clone()),
+        ));
+        output.materializations.push(mat_for_manifest(
+            &["wh", "silver", "customers"],
+            Some(identity.clone()),
+        ));
+        // Never stamped recipe_identity (a path that did not compute it) → skipped.
+        output
+            .materializations
+            .push(mat_for_manifest(&["wh", "silver", "no_identity"], None));
+
+        let gov = RecordingRecipeGovernance {
+            writes: std::sync::Mutex::new(Vec::new()),
+        };
+        write_recipe_manifests(&output, &gov, "run-cov").await;
+
+        let writes = gov.writes.lock().unwrap();
+        let tables: Vec<&str> = writes.iter().map(|(t, _)| t.as_str()).collect();
+        assert_eq!(
+            tables,
+            vec!["wh.silver.orders", "wh.silver.customers"],
+            "every identity-bearing model is written; the identity-less one is skipped"
+        );
+        let (_, props) = &writes[0];
+        assert_eq!(
+            props["recipe_manifest.program_hash"],
+            "2148e619b51421f51cfb3fac423145fe245bbe409b74f31c22d703ab07453036"
+        );
+        assert_eq!(props["recipe_manifest.producer.name"], "rocky");
+        assert_eq!(props["recipe_manifest.subject.run_id"], "run-cov");
+        assert_eq!(props["recipe_manifest.subject.model"], "orders");
+        // Default run observed no inputs → both-or-neither honesty invariant.
+        assert!(!props.contains_key("recipe_manifest.inputs_hash"));
+        assert!(!props.contains_key("recipe_manifest.inputs_proof_class"));
+    }
 
     #[test]
     fn governance_tag_target_dispatches_view_strategy_to_view() {

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -1136,6 +1136,73 @@ fn derive_input_identity(mat: &MaterializationOutput) -> (Option<String>, Option
     (Some(input_hash), Some(proof_class))
 }
 
+/// Build the `recipe_manifest.*` warehouse-metadata key-value set for one
+/// materialized model, ready to hand to
+/// [`GovernanceAdapter::write_recipe_manifest`](rocky_core::traits::GovernanceAdapter::write_recipe_manifest).
+///
+/// This is the **engine → manifest** name mapping applied at write time. It
+/// reads the recipe-identity triple stamped on
+/// [`MaterializationOutput::recipe_identity`] (never recomputing it) and folds
+/// in the manifest carrier fields, keying each under
+/// [`RECIPE_MANIFEST_TBLPROP_PREFIX`](rocky_core::catalog::RECIPE_MANIFEST_TBLPROP_PREFIX):
+///
+/// | manifest field | `recipe_manifest.*` key | source |
+/// |---|---|---|
+/// | `manifest_version` | `manifest_version` | constant `"0.1"` |
+/// | `hash_scheme` | `hash_scheme` | `recipe_identity.hash_scheme` |
+/// | `program_hash` | `program_hash` | `recipe_identity.recipe_hash` |
+/// | `env_hash` | `env_hash` | `recipe_identity.env_hash` |
+/// | `inputs_hash` | `inputs_hash` | `derive_input_identity` (omitted when `None`) |
+/// | `inputs_proof_class` | `inputs_proof_class` | `derive_input_identity` (travels with `inputs_hash`) |
+/// | `producer.name` | `producer.name` | constant `"rocky"` |
+/// | `producer.version` | `producer.version` | `engine_version` |
+/// | `subject.model` | `subject.model` | last segment of `asset_key` |
+/// | `subject.run_id` | `subject.run_id` | `run_id` |
+/// | `subject.status` | `subject.status` | `"success"` (a materialized model succeeded) |
+///
+/// The `inputs_hash` / `inputs_proof_class` pair is written **both or
+/// neither** — the manifest spec's honesty invariant. On a default
+/// (non-`--skip-unchanged`, non-reuse) run neither is present, matching a
+/// managed Databricks run that observes no content-hashed inputs.
+///
+/// Returns `None` when the materialization carries no recipe-identity (a path
+/// that did not stamp it) or has no `asset_key` to name the subject — the
+/// caller then skips the write for that model.
+pub(crate) fn recipe_manifest_properties(
+    mat: &MaterializationOutput,
+    run_id: &str,
+    engine_version: &str,
+) -> Option<std::collections::BTreeMap<String, String>> {
+    let identity = mat.recipe_identity.as_ref()?;
+    let model = mat.asset_key.last()?;
+
+    let prefix = rocky_core::catalog::RECIPE_MANIFEST_TBLPROP_PREFIX;
+    let mut props = std::collections::BTreeMap::new();
+    let mut put = |field: &str, value: String| {
+        props.insert(format!("{prefix}{field}"), value);
+    };
+
+    put("manifest_version", "0.1".to_string());
+    put("hash_scheme", identity.hash_scheme.clone());
+    put("program_hash", identity.recipe_hash.clone());
+    put("env_hash", identity.env_hash.clone());
+
+    let (input_hash, proof_class) = derive_input_identity(mat);
+    // Both-or-neither: the manifest spec's dependentRequired invariant.
+    if let (Some(ih), Some(pc)) = (input_hash, proof_class) {
+        put("inputs_hash", ih);
+        put("inputs_proof_class", pc);
+    }
+
+    put("producer.name", "rocky".to_string());
+    put("producer.version", engine_version.to_string());
+    put("subject.model", model.clone());
+    put("subject.run_id", run_id.to_string());
+    put("subject.status", "success".to_string());
+
+    Some(props)
+}
+
 /// The per-model build decision the engine made this run — what the
 /// skip-gate and content-addressed reuse machinery actually decided.
 ///
@@ -5125,6 +5192,82 @@ mod cost_finalize_tests {
             output_column_hashes: None,
             consumed_column_baseline: None,
         }
+    }
+
+    fn sample_identity() -> RecipeIdentityInternal {
+        RecipeIdentityInternal {
+            recipe_hash: "2148e619b51421f51cfb3fac423145fe245bbe409b74f31c22d703ab07453036"
+                .to_string(),
+            env_hash: "bbf2c2045328f738683a6336df5fa61b5f00076aeaed7c495c04f9d6991d92bd"
+                .to_string(),
+            hash_scheme: "v1".to_string(),
+        }
+    }
+
+    #[test]
+    fn recipe_manifest_properties_none_without_identity() {
+        let m = mat(&["wh", "silver", "orders"], 100);
+        assert!(
+            super::recipe_manifest_properties(&m, "run-1", "1.58.0").is_none(),
+            "a materialization without recipe_identity yields no manifest props"
+        );
+    }
+
+    #[test]
+    fn recipe_manifest_properties_default_run_omits_inputs() {
+        // Default run path: recipe_identity stamped, but skip_internal is None
+        // (no observed inputs) — inputs_hash/inputs_proof_class must both be
+        // absent, matching a managed Databricks run.
+        let mut m = mat(&["wh", "silver", "orders"], 100);
+        m.recipe_identity = Some(sample_identity());
+        let props = super::recipe_manifest_properties(&m, "run-42", "1.58.0").unwrap();
+
+        assert_eq!(props["recipe_manifest.manifest_version"], "0.1");
+        assert_eq!(props["recipe_manifest.hash_scheme"], "v1");
+        assert_eq!(
+            props["recipe_manifest.program_hash"],
+            "2148e619b51421f51cfb3fac423145fe245bbe409b74f31c22d703ab07453036"
+        );
+        assert_eq!(
+            props["recipe_manifest.env_hash"],
+            "bbf2c2045328f738683a6336df5fa61b5f00076aeaed7c495c04f9d6991d92bd"
+        );
+        assert_eq!(props["recipe_manifest.producer.name"], "rocky");
+        assert_eq!(props["recipe_manifest.producer.version"], "1.58.0");
+        assert_eq!(props["recipe_manifest.subject.model"], "orders");
+        assert_eq!(props["recipe_manifest.subject.run_id"], "run-42");
+        assert_eq!(props["recipe_manifest.subject.status"], "success");
+        assert!(
+            !props.contains_key("recipe_manifest.inputs_hash"),
+            "no observed inputs → inputs_hash omitted"
+        );
+        assert!(
+            !props.contains_key("recipe_manifest.inputs_proof_class"),
+            "no observed inputs → inputs_proof_class omitted (both-or-neither)"
+        );
+    }
+
+    #[test]
+    fn recipe_manifest_properties_with_observed_inputs_writes_pair() {
+        // When the run observed inputs (skip-gate populated upstream
+        // signatures), inputs_hash + inputs_proof_class travel together.
+        let mut m = mat(&["wh", "silver", "orders"], 100);
+        m.recipe_identity = Some(sample_identity());
+        m.skip_internal = Some(ModelSkipState {
+            skip_hash: Some("skip-key-fixed".to_string()),
+            upstream_freshness: vec![rocky_core::state::UpstreamSig {
+                upstream_key: "wh.raw.events".to_string(),
+                max_ts: None,
+                row_count: Some(42),
+                consumed_column_hashes: None,
+            }],
+        });
+        let props = super::recipe_manifest_properties(&m, "run-7", "1.58.0").unwrap();
+        assert!(props.contains_key("recipe_manifest.inputs_hash"));
+        assert_eq!(
+            props["recipe_manifest.inputs_proof_class"], "heuristic",
+            "a watermark upstream is a heuristic (freshness, not byte-identity) claim"
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-core/src/catalog.rs
+++ b/engine/crates/rocky-core/src/catalog.rs
@@ -190,6 +190,78 @@ pub fn generate_show_delta_retention_sql(
     ))
 }
 
+/// Vendor-neutral namespace prefix for every recipe-manifest `TBLPROPERTIES`
+/// key Rocky writes into a table's warehouse-side metadata.
+///
+/// Each manifest field travels as `recipe_manifest.<field-path>` (e.g.
+/// `recipe_manifest.program_hash`, `recipe_manifest.producer.version`). The
+/// prefix is deliberately **not** a vendor brand like `rocky.` — vendor
+/// identity belongs in the manifest's `producer` field, not in the key, so the
+/// key doesn't read as "lock-in via metadata". The shared namespace lets a
+/// reader glob these keys and distinguish them both from `delta.*` reserved
+/// properties and from arbitrary user tags.
+pub const RECIPE_MANIFEST_TBLPROP_PREFIX: &str = "recipe_manifest.";
+
+/// Generates `ALTER TABLE <catalog>.<schema>.<table> SET TBLPROPERTIES (...)`
+/// for an arbitrary set of validated key-value pairs.
+///
+/// This is the general-purpose `TBLPROPERTIES` writer that backs the
+/// recipe-manifest metadata carrier (keys under
+/// [`RECIPE_MANIFEST_TBLPROP_PREFIX`]). It mirrors
+/// [`generate_set_table_tags_sql`] — the clause syntax `('k' = 'v', ...)` is
+/// identical between `SET TAGS` and `SET TBLPROPERTIES` — but emits the
+/// property keyword instead.
+///
+/// This is issued as a **post-create** statement, deliberately separate from
+/// the CREATE DDL. The recipe-identity triple it carries is the BLAKE3 of the
+/// model's canonical IR; folding it into the CREATE's inline `TBLPROPERTIES`
+/// (which the IR's `format_options.table_properties` feeds) would make the
+/// identity self-referential. Writing it after the table exists keeps the
+/// hash-input surface untouched and the write hash-neutral by construction.
+///
+/// Returns `Ok(None)` when `properties` is empty, so callers skip the
+/// statement rather than emit a syntactically-empty `SET TBLPROPERTIES ()`.
+///
+/// Identifiers and every key/value are validated against Rocky's SQL
+/// allowlist (`rocky-sql/validation.rs`) before interpolation — never
+/// `format!` on unvalidated input.
+pub fn generate_set_tblproperties_sql(
+    catalog: &str,
+    schema: &str,
+    table: &str,
+    properties: &BTreeMap<String, String>,
+) -> Result<Option<String>, CatalogError> {
+    validation::validate_identifier(catalog)?;
+    validation::validate_identifier(schema)?;
+    validation::validate_identifier(table)?;
+    if properties.is_empty() {
+        return Ok(None);
+    }
+    let clause = format_tags(properties)?;
+    Ok(Some(format!(
+        "ALTER TABLE {catalog}.{schema}.{table} SET TBLPROPERTIES ({clause})"
+    )))
+}
+
+/// Generates `SHOW TBLPROPERTIES <catalog>.<schema>.<table>` (the full,
+/// unfiltered property set).
+///
+/// Unlike [`generate_show_delta_retention_sql`], which scopes the probe to the
+/// two Delta retention keys, this returns every property so the caller can
+/// glob the [`RECIPE_MANIFEST_TBLPROP_PREFIX`] keys back out — the read-back
+/// half of the recipe-manifest carrier round-trip. Identifiers are validated
+/// before interpolation.
+pub fn generate_show_all_tblproperties_sql(
+    catalog: &str,
+    schema: &str,
+    table: &str,
+) -> Result<String, CatalogError> {
+    validation::validate_identifier(catalog)?;
+    validation::validate_identifier(schema)?;
+    validation::validate_identifier(table)?;
+    Ok(format!("SHOW TBLPROPERTIES {catalog}.{schema}.{table}"))
+}
+
 /// Generates `SHOW SCHEMAS IN <catalog>`.
 pub fn generate_show_schemas_sql(catalog: &str) -> Result<String, CatalogError> {
     validation::validate_identifier(catalog)?;
@@ -421,6 +493,76 @@ mod tests {
         assert!(generate_show_delta_retention_sql("db; DROP", "s", "t").is_err());
         assert!(generate_show_delta_retention_sql("db", "s ace", "t").is_err());
         assert!(generate_show_delta_retention_sql("db", "s", "t' --").is_err());
+    }
+
+    #[test]
+    fn test_set_tblproperties_emits_sorted_pairs() {
+        let mut props = BTreeMap::new();
+        props.insert(
+            "recipe_manifest.program_hash".to_string(),
+            "2148e619b51421f51cfb3fac423145fe245bbe409b74f31c22d703ab07453036".to_string(),
+        );
+        props.insert("recipe_manifest.hash_scheme".to_string(), "v1".to_string());
+        props.insert(
+            "recipe_manifest.manifest_version".to_string(),
+            "0.1".to_string(),
+        );
+        let sql = generate_set_tblproperties_sql("wh", "silver", "orders", &props)
+            .unwrap()
+            .expect("non-empty properties yield a statement");
+        // BTreeMap guarantees the pairs are key-sorted, so the exact string is
+        // deterministic across runs.
+        assert_eq!(
+            sql,
+            "ALTER TABLE wh.silver.orders SET TBLPROPERTIES \
+('recipe_manifest.hash_scheme' = 'v1', \
+'recipe_manifest.manifest_version' = '0.1', \
+'recipe_manifest.program_hash' = '2148e619b51421f51cfb3fac423145fe245bbe409b74f31c22d703ab07453036')"
+        );
+    }
+
+    #[test]
+    fn test_set_tblproperties_empty_is_none() {
+        let props = BTreeMap::new();
+        assert!(
+            generate_set_tblproperties_sql("wh", "s", "t", &props)
+                .unwrap()
+                .is_none(),
+            "empty properties skip the statement rather than emit SET TBLPROPERTIES ()"
+        );
+    }
+
+    #[test]
+    fn test_set_tblproperties_rejects_bad_identifier() {
+        let mut props = BTreeMap::new();
+        props.insert("recipe_manifest.hash_scheme".to_string(), "v1".to_string());
+        assert!(generate_set_tblproperties_sql("db; DROP", "s", "t", &props).is_err());
+        assert!(generate_set_tblproperties_sql("db", "s ace", "t", &props).is_err());
+        assert!(generate_set_tblproperties_sql("db", "s", "t' --", &props).is_err());
+    }
+
+    #[test]
+    fn test_set_tblproperties_rejects_injection_in_value() {
+        // A value carrying a quote/semicolon must be rejected before it
+        // reaches the interpolated SQL, exactly like SET TAGS.
+        let mut props = BTreeMap::new();
+        props.insert(
+            "recipe_manifest.subject.model".to_string(),
+            "evil'; DROP TABLE--".to_string(),
+        );
+        assert!(generate_set_tblproperties_sql("wh", "s", "t", &props).is_err());
+    }
+
+    #[test]
+    fn test_show_all_tblproperties() {
+        let sql = generate_show_all_tblproperties_sql("wh", "silver", "orders").unwrap();
+        assert_eq!(sql, "SHOW TBLPROPERTIES wh.silver.orders");
+    }
+
+    #[test]
+    fn test_show_all_tblproperties_rejects_bad_identifier() {
+        assert!(generate_show_all_tblproperties_sql("db; DROP", "s", "t").is_err());
+        assert!(generate_show_all_tblproperties_sql("db", "s ace", "t").is_err());
     }
 
     #[test]

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -1516,6 +1516,49 @@ pub trait GovernanceAdapter: Send + Sync {
     async fn read_retention_days(&self, _table: &TableRef) -> AdapterResult<Option<u32>> {
         Ok(None)
     }
+
+    /// Write a recipe-manifest attestation into a table's warehouse-side
+    /// metadata.
+    ///
+    /// `properties` is a set of already-built `recipe_manifest.<field>` keys
+    /// (see
+    /// [`RECIPE_MANIFEST_TBLPROP_PREFIX`](crate::catalog::RECIPE_MANIFEST_TBLPROP_PREFIX))
+    /// carrying the recipe-identity triple plus manifest carrier fields
+    /// (`producer`, `subject`). Rocky calls this after a model materializes so
+    /// the attestation travels with the table and can be read back and verified
+    /// offline by [`rocky-verify`] with no engine installed.
+    ///
+    /// The write is issued as a post-create `ALTER TABLE ... SET TBLPROPERTIES`
+    /// on adapters that support it — deliberately **not** folded into the
+    /// CREATE DDL, whose inline properties feed the hashed IR. Writing after
+    /// creation keeps the identity hash-neutral.
+    ///
+    /// # Default: silent no-op
+    ///
+    /// Unlike the user-declared capabilities ([`Self::apply_column_tags`],
+    /// [`Self::apply_retention_policy`]) whose trait default *errors* to force
+    /// adapters to declare explicit semantics, the recipe-manifest write is an
+    /// **ambient engine attestation** the user did not opt into per-model. The
+    /// honest degrade on a warehouse without a custom-property carrier is to
+    /// skip it silently, so the default returns `Ok(())`. This is why the write
+    /// no-ops "automatically" on DuckDB (its [`NoopGovernanceAdapter`]),
+    /// Snowflake, and BigQuery without any per-adapter override — only
+    /// Databricks (Delta `TBLPROPERTIES`) implements it. The `rocky run` caller
+    /// treats a failure here as best-effort (warn, never fail the run).
+    ///
+    /// [`rocky-verify`]: https://rocky-data.dev/reference/rocky-manifest-spec/
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AdapterError`] on a network / auth / SQL failure for
+    /// adapters that implement the write. The default never errors.
+    async fn write_recipe_manifest(
+        &self,
+        _table: &TableRef,
+        _properties: &BTreeMap<String, String>,
+    ) -> AdapterResult<()> {
+        Ok(())
+    }
 }
 
 /// No-op governance adapter for warehouses that don't support catalog
@@ -1769,6 +1812,34 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("remove_workspace_binding"));
+    }
+
+    #[tokio::test]
+    async fn trait_default_write_recipe_manifest_is_ok_noop() {
+        // Unlike the workspace-binding primitives, the recipe-manifest write
+        // defaults to a silent no-op so it degrades gracefully on adapters
+        // without a custom-property carrier — MinimalGovernance inherits it.
+        let table = TableRef {
+            catalog: "c".into(),
+            schema: "s".into(),
+            table: "t".into(),
+        };
+        let mut props = BTreeMap::new();
+        props.insert("recipe_manifest.program_hash".to_string(), "ab".to_string());
+        assert!(
+            MinimalGovernance
+                .write_recipe_manifest(&table, &props)
+                .await
+                .is_ok()
+        );
+        // And the DuckDB-backing NoopGovernanceAdapter no-ops the same way,
+        // without any override of its own.
+        assert!(
+            NoopGovernanceAdapter
+                .write_recipe_manifest(&table, &props)
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -45,6 +45,12 @@ required-features = ["test-support"]
 [dev-dependencies]
 rocky-core = { path = "../rocky-core" }
 rocky-ir = { path = "../rocky-ir" }
+# rocky-verify is the standalone, no-engine-dep offline manifest verifier.
+# Used here (dev-only) to validate the reconstituted manifest against the
+# published rocky-manifest v0.1 schema in creds-free unit tests; it never
+# depends on this crate, so the graph stays acyclic and rocky-verify's purity
+# is untouched.
+rocky-verify = { path = "../rocky-verify" }
 arrow = { workspace = true }
 tokio = { workspace = true }
 wiremock = { workspace = true }

--- a/engine/crates/rocky-databricks/src/catalog.rs
+++ b/engine/crates/rocky-databricks/src/catalog.rs
@@ -166,6 +166,64 @@ impl<'a> CatalogManager<'a> {
         Ok(parse_delta_retention_rows(&result.rows))
     }
 
+    /// Writes a recipe-manifest attestation into a table's Delta
+    /// `TBLPROPERTIES` via a single post-create `ALTER TABLE ... SET
+    /// TBLPROPERTIES`.
+    ///
+    /// `properties` carries the pre-built `recipe_manifest.*` keys (see
+    /// [`rocky_core::catalog::RECIPE_MANIFEST_TBLPROP_PREFIX`]). The write is
+    /// deliberately separate from the CREATE DDL so it never perturbs the IR
+    /// the recipe hash is computed over. An empty map is a no-op.
+    ///
+    /// Backs
+    /// [`GovernanceAdapter::write_recipe_manifest`](rocky_core::traits::GovernanceAdapter::write_recipe_manifest)
+    /// on Databricks. Delta accepts arbitrary custom property keys; managed
+    /// Iceberg rejects engine-managed writes
+    /// (`MANAGED_ICEBERG_OPERATION_NOT_SUPPORTED`), so this carrier is a Delta
+    /// path — the snapshot-summary carrier is the documented Iceberg fallback.
+    pub async fn set_recipe_manifest_properties(
+        &self,
+        catalog: &str,
+        schema: &str,
+        table: &str,
+        properties: &BTreeMap<String, String>,
+    ) -> Result<(), CatalogManagerError> {
+        let Some(sql) =
+            catalog_sql::generate_set_tblproperties_sql(catalog, schema, table, properties)?
+        else {
+            return Ok(());
+        };
+        debug!(
+            catalog,
+            schema, table, "writing recipe-manifest TBLPROPERTIES"
+        );
+        self.connector.execute_statement(&sql).await?;
+        Ok(())
+    }
+
+    /// Reads back the `recipe_manifest.*` `TBLPROPERTIES` a prior
+    /// [`Self::set_recipe_manifest_properties`] wrote.
+    ///
+    /// Issues `SHOW TBLPROPERTIES <cat>.<schema>.<table>` and keeps only the
+    /// keys under [`rocky_core::catalog::RECIPE_MANIFEST_TBLPROP_PREFIX`] — the
+    /// read-back half of the offline-verification round-trip. Returns an empty
+    /// map when the table carries no recipe-manifest keys (e.g. it was never
+    /// written, or was produced by an older engine).
+    pub async fn get_recipe_manifest_properties(
+        &self,
+        catalog: &str,
+        schema: &str,
+        table: &str,
+    ) -> Result<BTreeMap<String, String>, CatalogManagerError> {
+        let sql = catalog_sql::generate_show_all_tblproperties_sql(catalog, schema, table)?;
+        debug!(
+            catalog,
+            schema, table, "reading recipe-manifest TBLPROPERTIES"
+        );
+        let result = self.connector.execute_sql(&sql).await?;
+        Ok(filter_recipe_manifest_rows(&result.rows))
+    }
+
     /// Lists schemas in a catalog.
     pub async fn list_schemas(&self, catalog: &str) -> Result<Vec<String>, CatalogManagerError> {
         let sql = catalog_sql::generate_show_schemas_sql(catalog)?;
@@ -323,6 +381,24 @@ fn parse_delta_retention_rows(rows: &[Vec<serde_json::Value>]) -> Option<u32> {
 /// Returns the first whitespace-split token that parses as `u32` (trimming
 /// a trailing `.0*` if present to handle the decimal form). Returns `None`
 /// if no token parses — the caller treats that as "no observation".
+/// Keeps only the `recipe_manifest.*` keys from a `SHOW TBLPROPERTIES`
+/// two-column (`key`, `value`) response, discarding `delta.*` reserved
+/// properties and any user tags.
+fn filter_recipe_manifest_rows(rows: &[Vec<serde_json::Value>]) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    for row in rows {
+        let Some(key) = row.first().and_then(|v| v.as_str()) else {
+            continue;
+        };
+        if !key.starts_with(catalog_sql::RECIPE_MANIFEST_TBLPROP_PREFIX) {
+            continue;
+        }
+        let value = row.get(1).and_then(|v| v.as_str()).unwrap_or_default();
+        out.insert(key.to_string(), value.to_string());
+    }
+    out
+}
+
 fn parse_delta_duration_days(value: &str) -> Option<u32> {
     for tok in value.split_whitespace() {
         // Handle the `"90.000000000"` decimal form by truncating at `.`
@@ -409,6 +485,37 @@ mod tests {
             ],
         ];
         assert_eq!(parse_delta_retention_rows(&rows), Some(120));
+    }
+
+    #[test]
+    fn filter_recipe_manifest_rows_keeps_only_prefixed_keys() {
+        let rows = vec![
+            vec![json!("delta.enableDeletionVectors"), json!("true")],
+            vec![
+                json!("recipe_manifest.program_hash"),
+                json!("2148e619b51421f51cfb3fac423145fe245bbe409b74f31c22d703ab07453036"),
+            ],
+            vec![json!("recipe_manifest.hash_scheme"), json!("v1")],
+            vec![json!("some_user_tag"), json!("whatever")],
+        ];
+        let got = filter_recipe_manifest_rows(&rows);
+        assert_eq!(got.len(), 2);
+        assert_eq!(
+            got.get("recipe_manifest.program_hash").map(String::as_str),
+            Some("2148e619b51421f51cfb3fac423145fe245bbe409b74f31c22d703ab07453036")
+        );
+        assert_eq!(
+            got.get("recipe_manifest.hash_scheme").map(String::as_str),
+            Some("v1")
+        );
+        assert!(!got.contains_key("delta.enableDeletionVectors"));
+        assert!(!got.contains_key("some_user_tag"));
+    }
+
+    #[test]
+    fn filter_recipe_manifest_rows_empty_when_none_present() {
+        let rows = vec![vec![json!("delta.minReaderVersion"), json!("1")]];
+        assert!(filter_recipe_manifest_rows(&rows).is_empty());
     }
 
     #[test]

--- a/engine/crates/rocky-databricks/src/governance.rs
+++ b/engine/crates/rocky-databricks/src/governance.rs
@@ -372,6 +372,29 @@ impl GovernanceAdapter for DatabricksGovernanceAdapter {
         .map_err(AdapterError::new)
     }
 
+    async fn write_recipe_manifest(
+        &self,
+        table: &TableRef,
+        properties: &BTreeMap<String, String>,
+    ) -> AdapterResult<()> {
+        if properties.is_empty() {
+            return Ok(());
+        }
+        // Post-create ALTER TABLE ... SET TBLPROPERTIES on the Delta table.
+        // Deliberately separate from the CREATE DDL so the recipe-identity
+        // triple this carries never perturbs the IR its own hash is computed
+        // over (the write is hash-neutral by construction).
+        let mgr = CatalogManager::new(&self.connector);
+        mgr.set_recipe_manifest_properties(
+            &table.catalog,
+            &table.schema,
+            table.table.as_str(),
+            properties,
+        )
+        .await
+        .map_err(AdapterError::new)
+    }
+
     async fn read_retention_days(&self, table: &TableRef) -> AdapterResult<Option<u32>> {
         // Reads the same Delta TBLPROPERTIES pair that `apply_retention_policy`
         // writes (`delta.logRetentionDuration` +

--- a/engine/crates/rocky-databricks/tests/recipe_manifest_tblproperties_live.rs
+++ b/engine/crates/rocky-databricks/tests/recipe_manifest_tblproperties_live.rs
@@ -1,0 +1,381 @@
+//! Recipe-manifest `TBLPROPERTIES` carrier: write → read-back → offline
+//! verification round-trip.
+//!
+//! Rocky writes the recipe-identity triple (plus manifest carrier fields) into
+//! a Delta table's `TBLPROPERTIES` under the vendor-neutral `recipe_manifest.*`
+//! namespace, as a post-create `ALTER TABLE ... SET TBLPROPERTIES` (never
+//! folded into the CREATE DDL, so the write stays hash-neutral). This test
+//! proves the carrier round-trips: the values read back via `SHOW
+//! TBLPROPERTIES` reconstitute into a `rocky-manifest v0.1` document that the
+//! standalone `rocky-verify` accepts, offline, with no engine.
+//!
+//! ## What this proves — and what it does NOT
+//!
+//! A managed (non-content-addressed) Databricks run emits the identity triple
+//! but **no `output_hashes`**, so `rocky-verify` here does **schema-validation
+//! only**: the BLAKE3 byte-check is a no-op, and a well-formed-but-wrong 64-hex
+//! hash would still pass. This test therefore proves **carrier fidelity**
+//! (what was written is what is read back and it forms a structurally valid,
+//! honesty-invariant-respecting manifest) — **not** that the table's bytes are
+//! reproducible. Byte-verifiable teeth live only in `output_hashes`, which is
+//! the content-addressed (s3-only) write path or the committed golden fixture.
+//!
+//! ## Live gating + housekeeping
+//!
+//! The round-trip test is `#[ignore]`-gated on the `ROCKY_TEST_DATABRICKS_*`
+//! sandbox env vars, mirroring `lakehouse_initial_ddl_live.rs`. It targets a
+//! **Delta** table: Delta accepts arbitrary custom property keys, while managed
+//! Iceberg rejects engine-managed writes
+//! (`MANAGED_ICEBERG_OPERATION_NOT_SUPPORTED`) — for Iceberg the documented
+//! fallback carrier is the snapshot-summary. Every schema it creates uses the
+//! `hcv2_` prefix and is dropped `CASCADE` on completion. No workspace
+//! identifiers are hardcoded. Run with:
+//!
+//! ```bash
+//! # Build the standalone verifier the round-trip shells out to first:
+//! cargo build --bin rocky-verify
+//! ROCKY_TEST_DATABRICKS_HOST=<host> \
+//! ROCKY_TEST_DATABRICKS_HTTP_PATH=<http-path> \
+//! ROCKY_TEST_DATABRICKS_TOKEN=<token> \
+//! ROCKY_TEST_DATABRICKS_CATALOG=hcv2_<catalog> \
+//! cargo test -p rocky-databricks --test recipe_manifest_tblproperties_live -- --ignored --nocapture
+//! ```
+//!
+//! The creds-free unit tests below (reconstitution + tamper) always run.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use rocky_databricks::adapter::DatabricksWarehouseAdapter;
+use rocky_databricks::auth::{Auth, AuthConfig};
+use rocky_databricks::catalog::CatalogManager;
+use rocky_databricks::connector::{ConnectorConfig, DatabricksConnector};
+
+// ---------------------------------------------------------------------------
+// Engine → manifest read-back mapping (pure; independent of the write side)
+// ---------------------------------------------------------------------------
+
+/// The `TBLPROPERTIES` namespace prefix the engine writes recipe-manifest keys
+/// under. Kept in lockstep with `rocky_core::catalog::RECIPE_MANIFEST_TBLPROP_PREFIX`.
+const RECIPE_MANIFEST_PREFIX: &str = "recipe_manifest.";
+
+/// Reconstitute a standalone `rocky-manifest v0.1` JSON document from the
+/// `recipe_manifest.*` `TBLPROPERTIES` read back off a table.
+///
+/// This is the reverse of the engine's write mapping: each key's dotted path
+/// (after the prefix) becomes a nested JSON path, so `recipe_manifest.program_hash`
+/// → `program_hash`, `recipe_manifest.producer.version` → `producer.version`,
+/// `recipe_manifest.subject.model` → `subject.model`. Keys absent from the map
+/// (notably `inputs_hash` / `inputs_proof_class` on a default run) are simply
+/// omitted — the spec's both-or-neither invariant falls out for free because
+/// the engine only ever writes the pair together.
+///
+/// A plain `BTreeMap` → `serde_json::Value` helper on purpose: no
+/// schema-registered `*Output` struct (which would drag in the codegen
+/// cascade), and `rocky-verify` itself is untouched.
+fn reconstitute_manifest(props: &BTreeMap<String, String>) -> serde_json::Value {
+    let mut root = serde_json::Map::new();
+    for (key, value) in props {
+        let Some(path) = key.strip_prefix(RECIPE_MANIFEST_PREFIX) else {
+            continue;
+        };
+        let segments: Vec<&str> = path.split('.').collect();
+        insert_nested(&mut root, &segments, value);
+    }
+    serde_json::Value::Object(root)
+}
+
+fn insert_nested(
+    obj: &mut serde_json::Map<String, serde_json::Value>,
+    segments: &[&str],
+    value: &str,
+) {
+    match segments {
+        [] => {}
+        [last] => {
+            obj.insert(
+                (*last).to_string(),
+                serde_json::Value::String(value.to_string()),
+            );
+        }
+        [head, rest @ ..] => {
+            let entry = obj
+                .entry((*head).to_string())
+                .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+            if let serde_json::Value::Object(inner) = entry {
+                insert_nested(inner, rest, value);
+            }
+        }
+    }
+}
+
+/// A representative recipe-manifest property set as the engine would write on a
+/// default Databricks run: identity triple + carrier fields, and no
+/// `inputs_*` (the run observed no content-hashed inputs).
+fn sample_recipe_manifest_props() -> BTreeMap<String, String> {
+    let mut props = BTreeMap::new();
+    let put = |props: &mut BTreeMap<String, String>, field: &str, value: &str| {
+        props.insert(
+            format!("{RECIPE_MANIFEST_PREFIX}{field}"),
+            value.to_string(),
+        );
+    };
+    put(&mut props, "manifest_version", "0.1");
+    put(&mut props, "hash_scheme", "v1");
+    put(
+        &mut props,
+        "program_hash",
+        "2148e619b51421f51cfb3fac423145fe245bbe409b74f31c22d703ab07453036",
+    );
+    put(
+        &mut props,
+        "env_hash",
+        "bbf2c2045328f738683a6336df5fa61b5f00076aeaed7c495c04f9d6991d92bd",
+    );
+    put(&mut props, "producer.name", "rocky");
+    put(&mut props, "producer.version", "1.58.0");
+    put(&mut props, "subject.model", "fct_events");
+    put(&mut props, "subject.run_id", "run-cov-0001");
+    put(&mut props, "subject.status", "success");
+    props
+}
+
+// ---------------------------------------------------------------------------
+// Creds-free unit tests (always run)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn reconstitute_roundtrip_validates_against_schema() {
+    let props = sample_recipe_manifest_props();
+    let manifest = reconstitute_manifest(&props);
+
+    // Structure: nested producer / subject reconstructed from dotted keys.
+    assert_eq!(manifest["manifest_version"], "0.1");
+    assert_eq!(
+        manifest["program_hash"],
+        props["recipe_manifest.program_hash"]
+    );
+    assert_eq!(manifest["producer"]["name"], "rocky");
+    assert_eq!(manifest["subject"]["model"], "fct_events");
+    // No inputs observed → neither key present (both-or-neither invariant).
+    assert!(manifest.get("inputs_hash").is_none());
+    assert!(manifest.get("inputs_proof_class").is_none());
+
+    // The reconstituted document is a valid rocky-manifest v0.1, checked by the
+    // standalone verifier's own schema — proving carrier fidelity offline.
+    let errors = rocky_verify::validate_schema(&manifest).expect("embedded schema compiles");
+    assert!(
+        errors.is_empty(),
+        "reconstituted manifest must validate: {errors:?}"
+    );
+}
+
+#[test]
+fn reconstitute_carries_inputs_pair_when_present() {
+    let mut props = sample_recipe_manifest_props();
+    props.insert(
+        "recipe_manifest.inputs_hash".to_string(),
+        "75ee2a328c52b2361aec2c1649cfd774e14ebbeb3f7e0bd99805e8e42c21b9c6".to_string(),
+    );
+    props.insert(
+        "recipe_manifest.inputs_proof_class".to_string(),
+        "heuristic".to_string(),
+    );
+    let manifest = reconstitute_manifest(&props);
+    assert_eq!(manifest["inputs_proof_class"], "heuristic");
+    let errors = rocky_verify::validate_schema(&manifest).expect("embedded schema compiles");
+    assert!(
+        errors.is_empty(),
+        "manifest with inputs pair must validate: {errors:?}"
+    );
+}
+
+#[test]
+fn tampered_manifest_fails_schema() {
+    // A malformed property value (a truncated, non-64-hex program_hash) must be
+    // rejected offline — the same tamper class the manifest-conformance
+    // tripwire and `fixtures/tampered/malformed-program-hash.json` cover. This
+    // is the negative half of the round-trip and needs no warehouse.
+    let mut props = sample_recipe_manifest_props();
+    props.insert(
+        "recipe_manifest.program_hash".to_string(),
+        "not-a-valid-hash".to_string(),
+    );
+    let manifest = reconstitute_manifest(&props);
+    let errors = rocky_verify::validate_schema(&manifest).expect("embedded schema compiles");
+    assert!(
+        !errors.is_empty(),
+        "a truncated program_hash must fail schema validation offline"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Live round-trip (#[ignore]; requires ROCKY_TEST_DATABRICKS_*)
+// ---------------------------------------------------------------------------
+
+/// Build an adapter + target catalog from the `ROCKY_TEST_DATABRICKS_*` sandbox
+/// env vars. Returns `None` (test skips) when the host/http-path aren't set.
+fn adapter_from_env() -> Option<(DatabricksWarehouseAdapter, String)> {
+    let host = std::env::var("ROCKY_TEST_DATABRICKS_HOST").ok()?;
+    let http_path = std::env::var("ROCKY_TEST_DATABRICKS_HTTP_PATH").ok()?;
+    let warehouse_id = ConnectorConfig::warehouse_id_from_http_path(&http_path)?;
+    let catalog = std::env::var("ROCKY_TEST_DATABRICKS_CATALOG").ok()?;
+
+    let auth = Auth::from_config(AuthConfig {
+        host: host.clone(),
+        token: std::env::var("ROCKY_TEST_DATABRICKS_TOKEN").ok(),
+        client_id: std::env::var("ROCKY_TEST_DATABRICKS_CLIENT_ID").ok(),
+        client_secret: std::env::var("ROCKY_TEST_DATABRICKS_CLIENT_SECRET").ok(),
+    })
+    .ok()?;
+
+    let config = ConnectorConfig {
+        host,
+        warehouse_id,
+        timeout: Duration::from_secs(180),
+        retry: Default::default(),
+    };
+    let connector = DatabricksConnector::new(config, auth);
+    Some((DatabricksWarehouseAdapter::new(connector), catalog))
+}
+
+fn schema_suffix() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros()
+}
+
+async fn create_schema(adapter: &DatabricksWarehouseAdapter, catalog: &str, schema: &str) {
+    adapter
+        .connector()
+        .execute_statement(&format!(
+            "CREATE SCHEMA IF NOT EXISTS `{catalog}`.`{schema}`"
+        ))
+        .await
+        .expect("create schema");
+}
+
+async fn drop_schema(adapter: &DatabricksWarehouseAdapter, catalog: &str, schema: &str) {
+    let _ = adapter
+        .connector()
+        .execute_statement(&format!(
+            "DROP SCHEMA IF EXISTS `{catalog}`.`{schema}` CASCADE"
+        ))
+        .await;
+}
+
+/// Locate the built `rocky-verify` binary the round-trip shells out to.
+/// Honors `ROCKY_VERIFY_BIN`, else looks in the workspace `target/{release,debug}`.
+fn locate_rocky_verify() -> PathBuf {
+    if let Ok(p) = std::env::var("ROCKY_VERIFY_BIN") {
+        return PathBuf::from(p);
+    }
+    // CARGO_MANIFEST_DIR = <workspace>/engine/crates/rocky-databricks
+    let target = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target");
+    for profile in ["release", "debug"] {
+        let candidate = target.join(profile).join("rocky-verify");
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+    panic!(
+        "rocky-verify binary not found under {}; build it first \
+         (`cargo build --bin rocky-verify`) or set ROCKY_VERIFY_BIN",
+        target.display()
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires ROCKY_TEST_DATABRICKS_* env vars; run with --ignored"]
+async fn live_recipe_manifest_tblproperties_roundtrip() {
+    let Some((adapter, catalog)) = adapter_from_env() else {
+        eprintln!("skipping: ROCKY_TEST_DATABRICKS_* not set");
+        return;
+    };
+    let verify_bin = locate_rocky_verify();
+
+    let suffix = schema_suffix();
+    let schema = format!("hcv2_manifest_{suffix}");
+    let table = "fct_events";
+    create_schema(&adapter, &catalog, &schema).await;
+
+    // A plain Delta table (default format). Delta accepts custom TBLPROPERTIES
+    // keys; the write below is a post-create ALTER, so it never touches the
+    // CREATE DDL / the hashed IR.
+    adapter
+        .connector()
+        .execute_statement(&format!(
+            "CREATE TABLE IF NOT EXISTS `{catalog}`.`{schema}`.`{table}` AS \
+             SELECT id AS id FROM range(0, 5)"
+        ))
+        .await
+        .expect("create delta table");
+
+    let mgr = CatalogManager::new(adapter.connector());
+    let written = sample_recipe_manifest_props();
+
+    // Write the recipe-manifest carrier, then read it straight back.
+    mgr.set_recipe_manifest_properties(&catalog, &schema, table, &written)
+        .await
+        .expect("write recipe-manifest TBLPROPERTIES");
+    let read_back = mgr
+        .get_recipe_manifest_properties(&catalog, &schema, table)
+        .await
+        .expect("read recipe-manifest TBLPROPERTIES");
+
+    // Reconstitute a standalone manifest + persist it for the CLI shell-out.
+    let manifest = reconstitute_manifest(&read_back);
+    let tmp = std::env::temp_dir().join(format!("rocky-manifest-{suffix}.json"));
+    std::fs::write(&tmp, serde_json::to_vec_pretty(&manifest).unwrap())
+        .expect("write manifest json");
+
+    // Shell out to the STANDALONE verifier — no engine — and capture its exit
+    // status before any teardown/assert so the schema is always dropped.
+    let verify_status = std::process::Command::new(&verify_bin)
+        .arg("verify")
+        .arg(&tmp)
+        .status()
+        .expect("spawn rocky-verify");
+
+    // --- teardown regardless of outcome, before assertions ---
+    drop_schema(&adapter, &catalog, &schema).await;
+    let _ = std::fs::remove_file(&tmp);
+
+    // Carrier fidelity: every written key came back byte-identical.
+    for (key, value) in &written {
+        assert_eq!(
+            read_back.get(key),
+            Some(value),
+            "TBLPROPERTIES value for {key} must round-trip unchanged"
+        );
+    }
+    // Structural validity: rocky-verify accepts the reconstituted manifest.
+    // (Schema-validation only — no output_hashes on a managed run, so this does
+    // NOT prove table byte-identity; see the module honesty note.)
+    assert!(
+        verify_status.success(),
+        "rocky-verify must accept the reconstituted manifest (exit 0); got {verify_status:?}"
+    );
+
+    // Negative: a tampered value must make the STANDALONE verifier fail.
+    let mut tampered = manifest.clone();
+    tampered["program_hash"] = serde_json::Value::String("not-a-valid-hash".to_string());
+    let tampered_path = std::env::temp_dir().join(format!("rocky-manifest-tampered-{suffix}.json"));
+    std::fs::write(
+        &tampered_path,
+        serde_json::to_vec_pretty(&tampered).unwrap(),
+    )
+    .expect("write tampered manifest");
+    let tampered_status = std::process::Command::new(&verify_bin)
+        .arg("verify")
+        .arg(&tampered_path)
+        .status()
+        .expect("spawn rocky-verify (tampered)");
+    let _ = std::fs::remove_file(&tampered_path);
+    assert!(
+        !tampered_status.success(),
+        "rocky-verify must reject a manifest with a malformed program_hash"
+    );
+}


### PR DESCRIPTION
## Summary

Writes the recipe-identity attestation into a Databricks (Delta) table's own warehouse metadata, and proves it round-trips through an offline read-back that the standalone `rocky-verify` accepts with no engine installed.

On every successful materialization Rocky already computes the recipe-identity triple (`recipe_hash`, `env_hash`, `hash_scheme`, plus an optional observed-inputs pair). This change carries that identity into the table's Delta `TBLPROPERTIES` so the attestation travels with the table, then reads it back and reconstitutes a standalone `rocky-manifest v0.1` document.

## What changed

- **`rocky-core`**
  - New general-purpose validated SQL generators: `generate_set_tblproperties_sql` (post-create `ALTER TABLE … SET TBLPROPERTIES`) and `generate_show_all_tblproperties_sql`. Identifiers and every key/value go through the same allowlist/injection guard as `SET TAGS`.
  - New `GovernanceAdapter::write_recipe_manifest` hook. It has a **default no-op** (`Ok(())`) so it degrades silently on warehouses without a custom-property carrier (DuckDB/Snowflake/BigQuery inherit the default); only Databricks overrides it. This is an ambient engine attestation the user did not opt into per-model, so a silent skip is the honest degrade — unlike the user-declared capabilities whose default errors.
- **`rocky-databricks`**
  - `CatalogManager::set_recipe_manifest_properties` / `get_recipe_manifest_properties` (the latter globs the `recipe_manifest.*` keys out of `SHOW TBLPROPERTIES`).
  - `DatabricksGovernanceAdapter::write_recipe_manifest` issues the post-create ALTER.
- **`rocky-cli`**
  - `recipe_manifest_properties(...)` maps a materialization's stamped identity onto the `recipe_manifest.*` key set (reads the triple off `MaterializationOutput`, never recomputes it).
  - `write_recipe_manifests(...)` iterates the universal `output.materializations` collection and writes each table's attestation. Wired at the model-only and pipeline completion points so it covers every materialization path (replication / transformation / time-interval / model-only). Best-effort — a write failure warns and never affects the run's exit code.
- **spec doc** — the `rocky-manifest` reference now specifies the Delta `TBLPROPERTIES` carrier convention and marks it shipped (schema-validation-only on a managed run; Iceberg snapshot-summary remains future work).

## The `recipe_manifest.` key convention

Each manifest field is carried as a `TBLPROPERTIES` key under a vendor-neutral namespace, with the field's dotted path appended:

```
recipe_manifest.manifest_version      recipe_manifest.program_hash
recipe_manifest.hash_scheme           recipe_manifest.env_hash
recipe_manifest.inputs_hash           recipe_manifest.inputs_proof_class
recipe_manifest.producer.name         recipe_manifest.producer.version
recipe_manifest.subject.model         recipe_manifest.subject.run_id
recipe_manifest.subject.status
```

The prefix is deliberately **not** a vendor brand (e.g. `rocky.`): vendor identity lives in the `producer` field, not the key. A shared neutral namespace lets a reader glob the manifest keys apart from `delta.*` reserved properties and user tags. `inputs_hash` / `inputs_proof_class` are written **both or neither** (the spec's honesty invariant); on a default managed run neither is present.

## Soundness

The write is a **post-create** `ALTER TABLE … SET TBLPROPERTIES`, never folded into the CREATE DDL. The recipe hash is the BLAKE3 of the model's canonical IR, whose `format_options.table_properties` feeds the CREATE's inline properties — so writing the identity inline would make it self-referential. Writing it after creation keeps the identity hash-neutral. The absolute-hex identity goldens still pass, confirming the hash path is untouched.

## What the offline verification proves — and does not

A managed (non-content-addressed) Databricks run carries the identity triple but **no `output_hashes`**, so offline verification of a table-metadata manifest is **schema-validation only**: it proves the carrier round-tripped and the triple is well-formed and honesty-invariant-respecting. It does **not** prove the table's bytes are reproducible — byte-verifiable teeth live only in `output_hashes` on the content-addressed path.

## Tests

- rocky-core: exact-SQL unit tests for the `SET`/`SHOW TBLPROPERTIES` generators + injection rejection; identity goldens still green.
- rocky-databricks: `filter_recipe_manifest_rows` unit tests; a creds-free reconstitution round-trip validated against the published schema via `rocky-verify`, plus a tamper (truncated hash) negative; and an `#[ignore]`-gated live Databricks round-trip (write → `SHOW TBLPROPERTIES` → reconstitute → shell out to the built `rocky-verify`, with `DROP SCHEMA … CASCADE` teardown).
- rocky-cli: mapping unit tests (default run omits the inputs pair; observed-inputs run writes it) and an all-paths coverage test driving `write_recipe_manifests` over a synthetic materializations set with a recording adapter.

The live Databricks test is `#[ignore]` and was **not** run here (no warehouse credentials in this environment); it is for the operator to run against the sandbox.

## Compatibility

No schema version bump, no new schema-registered output struct, no codegen surface change.
