### PR TITLE
chore: release engine v1.59.0, sdk v0.3.1, dagster v1.56.0

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.59.0] - 2026-07-09
+
+### Added
+
+- **Recipe-identity attestation travels in Databricks table metadata, verifiable offline.** On a Databricks (Delta) materialization Rocky writes the recipe-identity triple it already records — `program_hash`, `env_hash`, `hash_scheme`, plus the input-match keys when the run observed its inputs — into the table's `TBLPROPERTIES` under a vendor-neutral `recipe_manifest.*` namespace. The write is a post-create `ALTER TABLE … SET TBLPROPERTIES`, deliberately separate from the CREATE DDL so it never enters the IR the recipe hash is computed over (hash-neutral by construction). A generic `SHOW TBLPROPERTIES` read-back reconstitutes a standalone `rocky-manifest v0.1` document that the engine-free `rocky-verify` validates offline. DuckDB, Snowflake, and BigQuery inherit a silent no-op via the new `write_recipe_manifest` governance hook; only Databricks implements the carrier. On a managed (non-content-addressed) run the manifest carries the identity triple but no output byte-hashes, so offline verification is structural, not byte-identity. (#1062)
+
+- **`rocky export-openapi` — an OpenAPI 3.1 document for the `rocky serve` HTTP API.** Assembles a single OpenAPI 3.1 document from the same typed JSON-schema registry that backs the CLI plus the `/api/v1` route table: shared components are deduplicated, Draft-07 schemas are bridged to the 2020-12 dialect, `$ref`s are rewritten, and the document is validated against the OpenAPI 3.1 meta-schema before it is written. The artifact is published at `docs/public/openapi.json` and drift-gated in CI alongside the other codegen. Paired with a new **Embedding Rocky** guide covering the four integration patterns (subprocess, SDK, MCP, serve API), the async job model, `/meta` feature detection, the schema-stability promise, and the single-tenant sidecar posture. (#1064)
+
+### Fixed
+
+- **Column-level sound-skip now fails closed on a case-folding producer-column collision.** The consumer-baseline builder folded producer output-column names to lowercase, so two columns differing only by case (for example `id` and `ID`) collapsed to one key and a consumed column could resolve to whichever entry won the insert. If the consumed column changed but its case-colliding sibling did not, the gate compared the unchanged sibling and could skip a genuinely-changed column. The baseline now fails closed on the collision — no column baseline for that upstream, so the model builds — mirroring the guard already present in the per-column hash comparison. The per-column skip gate remains default-off (`[reuse] column_level`). (#1063)
+
 ## [1.58.0] - 2026-07-08
 
 ### Added

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "indexmap",
  "reqwest 0.12.28",
@@ -3964,7 +3964,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3981,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4009,7 +4009,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "redis",
  "serde",
@@ -4021,7 +4021,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -4032,7 +4032,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4088,7 +4088,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -4115,7 +4115,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4155,7 +4155,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4182,7 +4182,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4201,7 +4201,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4219,7 +4219,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4250,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4275,7 +4275,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -4288,7 +4288,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "logos",
  "miette",
@@ -4300,7 +4300,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "rocky-server",
  "rustls",
@@ -4309,7 +4309,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4334,7 +4334,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4352,7 +4352,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -4408,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "miette",
  "regex",
@@ -4421,7 +4421,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4458,7 +4458,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.58.0"
+version = "1.59.0"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.58.0"
+version = "1.59.0"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.58.0"
+version = "1.59.0"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.58.0"
+version = "1.59.0"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.58.0"
+version = "1.59.0"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.58.0"
+version = "1.59.0"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.58.0"
+version = "1.59.0"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.58.0"
+version = "1.59.0"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.58.0"
+version = "1.59.0"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.58.0"
+version = "1.59.0"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.58.0"
+version = "1.59.0"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.58.0"
+version = "1.59.0"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.58.0"
+version = "1.59.0"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.58.0"
+version = "1.59.0"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.58.0"
+version = "1.59.0"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.58.0"
+version = "1.59.0"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.58.0"
+version = "1.59.0"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.58.0"
+version = "1.59.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.58.0"
+version = "1.59.0"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.58.0"
+version = "1.59.0"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.58.0"
+version = "1.59.0"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.58.0"
+version = "1.59.0"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.58.0"
+version = "1.59.0"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.58.0"
+version = "1.59.0"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.58.0"
+version = "1.59.0"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.58.0"
+version = "1.59.0"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.56.0] — 2026-07-09
+
 ### Added
 
-- **Model-failure containment surfaces as Dagster asset observations.** When a `rocky run` withholds models because an upstream failed (the `contained[]` blast radius, emitted under `[resilience] contain_failures`), each withheld model now gets a `dg.AssetObservation` carrying the containment reason (`rocky/contained`, `rocky/blocked_by`, `rocky/unblock_hint`), and its declared checks report that reason instead of the generic "table not materialized" placeholder. A contained model is deliberately left unmaterialized — the inverse of the empty-output signalling pattern — so a same-run downstream correctly cascade-skips and the blast radius stays visible; it is never given a fake-green zero-row result, even with `satisfy_empty_outputs=True`. Buffered/streaming execution modes only. Requires a `rocky-sdk` version that surfaces `RunResult.contained`.
+- **Model-failure containment surfaces as Dagster asset observations.** When a `rocky run` withholds models because an upstream failed (the `contained[]` blast radius, emitted under `[resilience] contain_failures`), each withheld model now gets a `dg.AssetObservation` carrying the containment reason (`rocky/contained`, `rocky/blocked_by`, `rocky/unblock_hint`), and its declared checks report that reason instead of the generic "table not materialized" placeholder. A contained model is deliberately left unmaterialized — the inverse of the empty-output signalling pattern — so a same-run downstream correctly cascade-skips and the blast radius stays visible; it is never given a fake-green zero-row result, even with `satisfy_empty_outputs=True`. Buffered/streaming execution modes only. Requires `rocky-sdk>=0.3.1`, which surfaces `RunResult.contained` (the floor is raised accordingly).
 
 ## [1.55.0] — 2026-07-08
 

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.55.0"
+version = "1.56.0"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"
@@ -23,7 +23,7 @@ dependencies = [
     # package; RockyResource is a thin Dagster adapter over RockyClient. In-repo
     # dev/CI resolves this from the local path (see [tool.uv.sources]); the
     # published wheel floors on the released SDK.
-    "rocky-sdk>=0.2.0",
+    "rocky-sdk>=0.3.1",
     # Floor matches the version CI actually resolves and tests (uv.lock). The
     # RockyComponent path uses dagster.components.* APIs from preview namespaces,
     # so we advertise a tested floor rather than an older, never-exercised one.

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -220,7 +220,7 @@ wheels = [
 
 [[package]]
 name = "dagster-rocky"
-version = "1.55.0"
+version = "1.56.0"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },
@@ -910,7 +910,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "../../sdk/python" }
 dependencies = [
     { name = "pydantic" },

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] — 2026-07-09
+
 ### Fixed
 
 - **`RunResult.contained` now surfaces through `parse_rocky_output`.** The `contained[]` model-failure containment field shipped on the generated `RunOutput` in 0.3.0, but `parse_rocky_output` dispatches `run` to the hand-written `RunResult`, which did not declare the field — so Pydantic's default `extra="ignore"` silently dropped it. The hand-written `RunResult` now carries `contained: list[ContainedModel]` (empty when the engine omits it), so a consumer surfacing the withheld-model blast radius (e.g. `dagster-rocky`) reads the values instead of always seeing nothing.

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rocky-sdk"
-version = "0.3.0"
+version = "0.3.1"
 description = "Typed Python client for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Triple-cut release bundling the four feature PRs #1061–#1064.

## Artifacts

| Artifact | Version | Change |
|---|---|---|
| `rocky` (engine) | 1.58.0 → **1.59.0** | recipe-identity in Databricks `TBLPROPERTIES` + offline `rocky-verify` read-back (#1062); `rocky export-openapi` + Embedding Rocky guide (#1064); column-level sound-skip fails closed on a case-folding producer-column collision (#1063) |
| `rocky-sdk` | 0.3.0 → **0.3.1** | `RunResult.contained` now surfaces through parse dispatch (#1061) |
| `dagster-rocky` | 1.55.0 → **1.56.0** | model-failure containment surfaces as Dagster asset observations (#1061); `rocky-sdk` floor raised to `>=0.3.1` |

VS Code extension unchanged (no source delta).

## Release ordering

Tag after merge in the order **sdk → dagster → engine**: the published `dagster-rocky` wheel resolves `rocky-sdk` from PyPI, so `rocky-sdk 0.3.1` (which carries `RunResult.contained`) must be on PyPI before `dagster-rocky 1.56.0` raises its floor to it. Engine tag pushed last so it holds GitHub Latest with no isLatest race.

CHANGELOGs rolled for all three; engine's 25 crate versions bumped in lockstep + Cargo.lock relocked; both `uv.lock`s relocked.