### PR TITLE
feat(engine): agent-policy conditions — max_downstreams ceiling + verify_after gate

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -11185,7 +11185,7 @@
             "type": "boolean"
           },
           "downstreams": {
-            "description": "Direct downstream-consumer count (informational; `max_downstreams` is parse-only in v0).",
+            "description": "Direct downstream-consumer count (models that `depends_on` this one). Informational — the `max_downstreams` ceiling reads [`Self::reachable_downstreams`].",
             "format": "uint64",
             "minimum": 0.0,
             "type": "integer"
@@ -11194,6 +11194,15 @@
             "description": "Medallion/semantic layer (the model's `layer` tag), if any.",
             "type": [
               "string",
+              "null"
+            ]
+          },
+          "reachable_downstreams": {
+            "description": "Transitive downstream reachability — the full blast radius (direct + indirect), excluding the model itself. This is what a rule's `max_downstreams` ceiling is compared against. `null` when the blast radius could not be computed (the ceiling then fails closed).",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
               "null"
             ]
           },

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -11254,7 +11254,7 @@
             "description": "Which capability this rule governs."
           },
           "conditions": {
-            "description": "Optional v1 conditional refinements. **Parsed and ignored in v0** — captured as opaque JSON so a config authored for v1 still loads."
+            "description": "Optional v1 conditional refinements not yet promoted to typed fields (`budget`, `window`). **Parsed and ignored** — captured as opaque JSON so a config authored against a later version still loads."
           },
           "effect": {
             "allOf": [
@@ -11286,6 +11286,13 @@
               "tags": {}
             },
             "description": "The models this rule covers. Defaults to the empty scope, which is *not* `any` — an all-default scope with no `any = true` matches nothing and is rejected at validation."
+          },
+          "verify_after": {
+            "description": "Post-apply verification: named checks that must pass after a mutation governed by this rule lands. Once the apply's run completes, each named check is confirmed against the run's executed checks; a failing **or absent** named check halts the apply (fail closed) and raises an alert. Auto-rollback runs only where a rollback substrate exists; today none does, so a failure is halt-only and the mutation stands until a human reverts it. Empty ⇒ no post-apply gate.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           }
         },
         "required": [

--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -2204,7 +2204,7 @@
           "description": "Which capability this rule governs."
         },
         "conditions": {
-          "description": "Optional v1 conditional refinements. **Parsed and ignored in v0** — captured as opaque JSON so a config authored for v1 still loads."
+          "description": "Optional v1 conditional refinements not yet promoted to typed fields (`budget`, `window`). **Parsed and ignored** — captured as opaque JSON so a config authored against a later version still loads."
         },
         "effect": {
           "allOf": [
@@ -2236,6 +2236,13 @@
             "tags": {}
           },
           "description": "The models this rule covers. Defaults to the empty scope, which is *not* `any` — an all-default scope with no `any = true` matches nothing and is rejected at validation."
+        },
+        "verify_after": {
+          "description": "Post-apply verification: named checks that must pass after a mutation governed by this rule lands. Once the apply's run completes, each named check is confirmed against the run's executed checks; a failing **or absent** named check halts the apply (fail closed) and raises an alert. Auto-rollback runs only where a rollback substrate exists; today none does, so a failure is halt-only and the mutation stands until a human reverts it. Empty ⇒ no post-apply gate.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "required": [

--- a/editors/vscode/src/types/generated/policy_check.ts
+++ b/editors/vscode/src/types/generated/policy_check.ts
@@ -86,13 +86,17 @@ export interface PolicyModelAttributes {
    */
   contracted: boolean;
   /**
-   * Direct downstream-consumer count (informational; `max_downstreams` is parse-only in v0).
+   * Direct downstream-consumer count (models that `depends_on` this one). Informational — the `max_downstreams` ceiling reads [`Self::reachable_downstreams`].
    */
   downstreams: number;
   /**
    * Medallion/semantic layer (the model's `layer` tag), if any.
    */
   layer?: string | null;
+  /**
+   * Transitive downstream reachability — the full blast radius (direct + indirect), excluding the model itself. This is what a rule's `max_downstreams` ceiling is compared against. `null` when the blast radius could not be computed (the ceiling then fails closed).
+   */
+  reachable_downstreams?: number | null;
   /**
    * Model-level governance tags.
    */

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -1797,7 +1797,7 @@ export interface PolicyRule {
    */
   capability: PolicyCapability;
   /**
-   * Optional v1 conditional refinements. **Parsed and ignored in v0** — captured as opaque JSON so a config authored for v1 still loads.
+   * Optional v1 conditional refinements not yet promoted to typed fields (`budget`, `window`). **Parsed and ignored** — captured as opaque JSON so a config authored against a later version still loads.
    */
   conditions?: {
     [k: string]: unknown;
@@ -1814,6 +1814,10 @@ export interface PolicyRule {
    * The models this rule covers. Defaults to the empty scope, which is *not* `any` — an all-default scope with no `any = true` matches nothing and is rejected at validation.
    */
   scope?: PolicyScope;
+  /**
+   * Post-apply verification: named checks that must pass after a mutation governed by this rule lands. Once the apply's run completes, each named check is confirmed against the run's executed checks; a failing **or absent** named check halts the apply (fail closed) and raises an alert. Auto-rollback runs only where a rollback substrate exists; today none does, so a failure is halt-only and the mutation stands until a human reverts it. Empty ⇒ no post-apply gate.
+   */
+  verify_after?: string[];
 }
 /**
  * Scope of a policy rule — the AND of every present predicate. A model matches the scope only when it satisfies *all* set keys.

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4084,6 +4084,7 @@ dependencies = [
  "toml",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -48,6 +48,7 @@ base64 = { workspace = true }
 notify = { workspace = true }
 blake3 = { workspace = true }
 hostname = { workspace = true }
+uuid = { workspace = true }
 toml = { workspace = true }
 arrow = { workspace = true }
 parquet = { workspace = true }

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -366,6 +366,10 @@ fn model_attributes(models_dir: &Path) -> BTreeMap<String, ModelAttributes> {
             .iter()
             .filter(|m| m.config.depends_on.iter().any(|d| d == &name))
             .count() as u64;
+        // Transitive blast radius for the `max_downstreams` ceiling. `None`
+        // when the model is absent from the compiled graph (fails closed).
+        let reachable_downstreams = super::audit::blast_radius_of(&result, &name)
+            .map(|(_direct, transitive)| transitive.len() as u64);
         out.insert(
             name.clone(),
             ModelAttributes {
@@ -375,6 +379,7 @@ fn model_attributes(models_dir: &Path) -> BTreeMap<String, ModelAttributes> {
                 layer,
                 contracted,
                 downstreams,
+                reachable_downstreams,
             },
         );
     }

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -152,17 +152,23 @@ async fn run_apply_run_plan(
     // human-authored plan resolves to `allow` (humans are never gated in v0).
     let models_dir = Path::new(run_plan.models_dir.as_deref().unwrap_or("models"));
     let touched = touched_models_for_run(&plan, &run_plan);
+    let principal = plan.resolved_principal();
     let gate = evaluate_apply_policy(
         config_path,
         plan_id,
-        plan.resolved_principal(),
+        principal,
         &touched,
         models_dir,
         state_path,
     );
     apply_policy_gate(root, plan_id, gate)?;
 
-    execute_run_plan(config_path, plan_id, run_plan, state_path, output_json).await
+    // Resolve the post-apply verification checks *before* the run plan is moved
+    // into execution (the run plan owns the models_dir the resolver reads).
+    let verify_checks = required_verify_after(config_path, principal, &touched, models_dir);
+
+    execute_run_plan(config_path, plan_id, run_plan, state_path, output_json).await?;
+    run_verify_after(plan_id, principal, &verify_checks, state_path)
 }
 
 /// Execute a deserialized [`RunPlan`] against the warehouse.
@@ -460,6 +466,9 @@ pub fn evaluate_apply_policy(
                 effect: decision.effect,
                 rule_id: decision.matched_rule,
                 reason: decision.reason.clone(),
+                // A plain evaluation row carries no verify_after; the
+                // post-apply verification writes its own custody row.
+                verify_after: Vec::new(),
             };
             if let Err(e) = store.record_policy_decision(&record) {
                 warn!(
@@ -612,6 +621,162 @@ fn apply_policy_gate(root: &Path, plan_id: &str, gate: PolicyGate) -> Result<()>
     }
 }
 
+/// The union of `verify_after` check names the winning rules require for a
+/// plan's *proceeding* models.
+///
+/// Re-evaluates the policy per touched model and, for every model that did
+/// **not** resolve to `deny` (a `deny` never reaches apply), collects the
+/// winning rule's `verify_after` list. Returns a sorted, de-duplicated set;
+/// empty when no `[policy]` block is configured or no matched rule carries a
+/// `verify_after` (the common case — no post-apply gate).
+fn required_verify_after(
+    config_path: &Path,
+    principal: PolicyPrincipal,
+    touched: &BTreeMap<String, PolicyCapability>,
+    models_dir: &Path,
+) -> Vec<String> {
+    let Ok(cfg) = rocky_core::config::load_rocky_config(config_path) else {
+        return Vec::new();
+    };
+    let Some(policy) = cfg.policy else {
+        return Vec::new();
+    };
+    let attrs_map = model_attributes(models_dir);
+    let mut names: BTreeSet<String> = BTreeSet::new();
+    for (model, capability) in touched {
+        let owned;
+        let attrs = match attrs_map.get(model) {
+            Some(a) => a,
+            None => {
+                owned = ModelAttributes {
+                    name: model.clone(),
+                    ..Default::default()
+                };
+                &owned
+            }
+        };
+        let decision = policy::evaluate(&policy, principal, *capability, attrs);
+        if decision.effect == PolicyEffect::Deny {
+            continue;
+        }
+        if let Some(idx) = decision.matched_rule
+            && let Some(rule) = policy.rules.get(idx)
+        {
+            names.extend(rule.verify_after.iter().cloned());
+        }
+    }
+    names.into_iter().collect()
+}
+
+/// Run the `verify_after` post-apply gate: confirm every named check ran and
+/// **passed** in the just-completed run, and record a verification custody
+/// entry either way.
+///
+/// Fail-closed: a named check that failed *or is absent* from the run's
+/// captured outcomes halts the apply. On success the custody entry records
+/// `effect = allow`; on failure it records `effect = deny`, an alert is raised,
+/// and an error is returned.
+///
+/// Auto-rollback runs only where a rollback substrate exists. None does today
+/// (the content-addressed / Iceberg pointer-swap path is object-store-only and
+/// has no local read-back), so a failed verification is **halt-only**: the
+/// mutation has already landed and stays in place until a human reverts it.
+/// That state is stated plainly in the error rather than papered over with a
+/// rollback that would not actually run.
+fn run_verify_after(
+    plan_id: &str,
+    principal: PolicyPrincipal,
+    required: &[String],
+    state_path: &Path,
+) -> Result<()> {
+    if required.is_empty() {
+        return Ok(());
+    }
+
+    let store = StateStore::open(state_path)
+        .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
+
+    // The apply's run just finished, so it is the most recent run on record.
+    let latest = store.list_runs(1).ok().and_then(|mut v| v.pop());
+    let outcomes: BTreeMap<&str, bool> = latest
+        .as_ref()
+        .map(|r| {
+            r.check_outcomes
+                .iter()
+                .map(|c| (c.name.as_str(), c.passed))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut failures: Vec<String> = Vec::new();
+    for name in required {
+        match outcomes.get(name.as_str()) {
+            Some(true) => {}
+            Some(false) => failures.push(format!("{name} (failed)")),
+            // Fail closed: a named check that did not run cannot be confirmed.
+            None => failures.push(format!("{name} (absent — did not run)")),
+        }
+    }
+    let passed = failures.is_empty();
+
+    let reason = if passed {
+        format!("verify_after passed: [{}]", required.join(", "))
+    } else {
+        format!(
+            "verify_after FAILED: {}. No rollback substrate available — the mutation stands; halt-only.",
+            failures.join("; ")
+        )
+    };
+    // Best-effort custody entry — the gate below is the safety boundary; the
+    // ledger is the trail.
+    let record = PolicyDecisionRecord {
+        timestamp: chrono::Utc::now(),
+        plan_id: plan_id.to_string(),
+        principal,
+        capability: PolicyCapability::Apply,
+        model: "*".to_string(),
+        effect: if passed {
+            PolicyEffect::Allow
+        } else {
+            PolicyEffect::Deny
+        },
+        rule_id: None,
+        reason: reason.clone(),
+        verify_after: required.to_vec(),
+    };
+    if let Err(e) = store.record_policy_decision(&record) {
+        warn!(
+            target: "rocky::policy",
+            error = %e,
+            "failed to record verify_after custody entry to the ledger (continuing)"
+        );
+    }
+
+    if passed {
+        eprintln!(
+            "verify_after: {} post-apply check(s) passed [{}].",
+            required.len(),
+            required.join(", ")
+        );
+        Ok(())
+    } else {
+        // Alert: a post-apply verification failure is an operational event, not
+        // a routine warning.
+        warn!(
+            target: "rocky::policy",
+            plan_id,
+            failures = %failures.join("; "),
+            "verify_after post-apply gate FAILED"
+        );
+        bail!(
+            "verify_after gate FAILED for plan '{plan_id}': {}. \
+             No rollback substrate is available, so the mutation HAS ALREADY LANDED and remains in \
+             place — it must be reverted manually. The failure is recorded in the policy-decision ledger.",
+            failures.join("; ")
+        )
+    }
+}
+
 /// Apply a `PlanKind::AiAuthored` plan.
 ///
 /// AI-authored plans carry a `RunPlan` payload identical in shape to a plain
@@ -651,10 +816,11 @@ async fn run_apply_ai_authored_plan(
     // constructed and the pre-policy-plane marker gate remains — byte-identical to today.
     let models_dir = Path::new(run_plan.models_dir.as_deref().unwrap_or("models"));
     let touched = touched_models_for_run(&plan, &run_plan);
+    let principal = plan.resolved_principal();
     let gate = evaluate_apply_policy(
         config_path,
         plan_id,
-        plan.resolved_principal(),
+        principal,
         &touched,
         models_dir,
         state_path,
@@ -673,7 +839,11 @@ async fn run_apply_ai_authored_plan(
         gate => apply_policy_gate(root, plan_id, gate)?,
     }
 
-    execute_run_plan(config_path, plan_id, run_plan, state_path, output_json).await
+    // Resolve the post-apply verification checks before the run plan is moved.
+    let verify_checks = required_verify_after(config_path, principal, &touched, models_dir);
+
+    execute_run_plan(config_path, plan_id, run_plan, state_path, output_json).await?;
+    run_verify_after(plan_id, principal, &verify_checks, state_path)
 }
 
 /// Apply a `PlanKind::Backfill` plan — a scoped, review-gated recovery run.
@@ -2513,5 +2683,104 @@ effect = "deny"
         };
         assert!(connector_matches_filter(&s, &pattern, "id", "duckdb_local"));
         assert!(!connector_matches_filter(&s, &pattern, "client", "acme"));
+    }
+
+    // ---------- verify_after post-apply gate ----------
+
+    fn record_run_with_checks(state_path: &Path, checks: &[(&str, bool)]) {
+        use rocky_core::state::{
+            CheckOutcome, RunRecord, RunStatus, RunTrigger, SessionSource, StateStore,
+        };
+        let store = StateStore::open(state_path).unwrap();
+        let now = chrono::Utc::now();
+        let record = RunRecord {
+            run_id: format!("run-{}", now.timestamp_nanos_opt().unwrap_or(0)),
+            started_at: now,
+            finished_at: now,
+            status: RunStatus::Success,
+            models_executed: vec![],
+            trigger: RunTrigger::Manual,
+            config_hash: "h".to_string(),
+            triggering_identity: None,
+            session_source: SessionSource::Cli,
+            git_commit: None,
+            git_branch: None,
+            idempotency_key: None,
+            target_catalog: None,
+            hostname: "test".to_string(),
+            rocky_version: "test".to_string(),
+            check_outcomes: checks
+                .iter()
+                .map(|(n, p)| CheckOutcome {
+                    name: n.to_string(),
+                    passed: *p,
+                })
+                .collect(),
+        };
+        store.record_run(&record).unwrap();
+    }
+
+    #[test]
+    fn verify_after_passes_when_all_named_checks_pass() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = dir.path().join("state.redb");
+        record_run_with_checks(&state, &[("row_count", true), ("not_null_keys", true)]);
+        let r = super::run_verify_after(
+            "plan-x",
+            PolicyPrincipal::Agent,
+            &["row_count".to_string(), "not_null_keys".to_string()],
+            &state,
+        );
+        assert!(
+            r.is_ok(),
+            "all named checks passed → verify_after ok: {r:?}"
+        );
+    }
+
+    #[test]
+    fn verify_after_halts_when_named_check_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = dir.path().join("state.redb");
+        record_run_with_checks(&state, &[("row_count", true), ("not_null_keys", false)]);
+        let err = super::run_verify_after(
+            "plan-x",
+            PolicyPrincipal::Agent,
+            &["not_null_keys".to_string()],
+            &state,
+        )
+        .expect_err("a failing named check halts the apply");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("verify_after gate FAILED") && msg.contains("not_null_keys"),
+            "{msg}"
+        );
+        // The halt-only state (no rollback substrate) must be stated plainly.
+        assert!(msg.contains("HAS ALREADY LANDED"), "halt-only state: {msg}");
+    }
+
+    #[test]
+    fn verify_after_fails_closed_when_named_check_absent() {
+        // A named check that did not run cannot be confirmed → halt (fail
+        // closed). This is the verify_after analog of the false-additive
+        // soundness direction.
+        let dir = tempfile::tempdir().unwrap();
+        let state = dir.path().join("state.redb");
+        record_run_with_checks(&state, &[("row_count", true)]);
+        let err = super::run_verify_after(
+            "plan-x",
+            PolicyPrincipal::Agent,
+            &["freshness".to_string()],
+            &state,
+        )
+        .expect_err("an absent named check fails closed");
+        assert!(err.to_string().contains("absent"), "{}", err);
+    }
+
+    #[test]
+    fn verify_after_empty_is_noop_even_without_a_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = dir.path().join("state.redb");
+        // No required checks → the gate is a no-op and never touches state.
+        assert!(super::run_verify_after("plan-x", PolicyPrincipal::Agent, &[], &state).is_ok());
     }
 }

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -167,8 +167,25 @@ async fn run_apply_run_plan(
     // into execution (the run plan owns the models_dir the resolver reads).
     let verify_checks = required_verify_after(config_path, principal, &touched, models_dir);
 
-    execute_run_plan(config_path, plan_id, run_plan, state_path, output_json).await?;
-    run_verify_after(plan_id, principal, &verify_checks, state_path)
+    // One unique id for this apply's run, threaded into execution and into the
+    // post-apply gate so the gate reads exactly this run, not "latest".
+    let apply_run_id = new_apply_run_id();
+    execute_run_plan(
+        config_path,
+        plan_id,
+        run_plan,
+        state_path,
+        output_json,
+        &apply_run_id,
+    )
+    .await?;
+    run_verify_after(
+        plan_id,
+        principal,
+        &verify_checks,
+        &apply_run_id,
+        state_path,
+    )
 }
 
 /// Execute a deserialized [`RunPlan`] against the warehouse.
@@ -187,6 +204,12 @@ async fn execute_run_plan(
     run_plan: RunPlan,
     state_path: &Path,
     output_json: bool,
+    // The unique run_id this apply forces `run` to record under, so the
+    // post-apply `verify_after` gate can resolve *this apply's own* run by id
+    // (see [`run_verify_after`]). The `--dag` early-return below does not thread
+    // it — a `dag` apply that also carries `verify_after` fails closed there
+    // because no run is recorded under this id.
+    apply_run_id: &str,
 ) -> Result<()> {
     // Build partition options from the persisted flags.
     let partition_opts = crate::commands::run::PartitionRunOptions {
@@ -284,6 +307,9 @@ async fn execute_run_plan(
         // Per-run `--var` values are not persisted on the plan; an
         // `@var()` model would compile-error on a two-step apply.
         &rocky_core::run_vars::RunVars::new(),
+        // Force `run` to record under this apply's unique id so the
+        // post-apply `verify_after` gate resolves this run (not "latest").
+        Some(apply_run_id),
     )
     .await
     .with_context(|| format!("rocky apply run plan '{plan_id}' failed"))?;
@@ -313,6 +339,15 @@ pub(crate) fn ai_plan_is_reviewed(root: &Path, plan_id: &str) -> bool {
 // ---------------------------------------------------------------------------
 // agent-policy plane — apply/promote enforcement (seams 2 & 3)
 // ---------------------------------------------------------------------------
+
+/// Mint a unique run_id for a two-step `rocky apply` so the run it drives
+/// records under an id no concurrent run can share. The post-apply
+/// `verify_after` gate resolves *this* id (see [`run_verify_after`]), which is
+/// what makes the gate immune to a sibling run finishing in between and being
+/// mistaken for this apply's run.
+fn new_apply_run_id() -> String {
+    format!("run-apply-{}", uuid::Uuid::new_v4())
+}
 
 /// A resolved agent-policy decision, aggregated most-restrictive across every
 /// model a plan touches.
@@ -669,13 +704,30 @@ fn required_verify_after(
 }
 
 /// Run the `verify_after` post-apply gate: confirm every named check ran and
-/// **passed** in the just-completed run, and record a verification custody
+/// **passed** in *this apply's own run*, and record a verification custody
 /// entry either way.
 ///
-/// Fail-closed: a named check that failed *or is absent* from the run's
-/// captured outcomes halts the apply. On success the custody entry records
-/// `effect = allow`; on failure it records `effect = deny`, an alert is raised,
-/// and an error is returned.
+/// `run_id` is the unique id this apply forced its run to record under (see
+/// [`new_apply_run_id`] / the `run_id_override` on `commands::run::run`). The
+/// gate resolves the run by that id via [`StateStore::get_run`] rather than
+/// reading "the latest run" — a concurrent run finishing in between must never
+/// be mistaken for this apply's run and satisfy its gate.
+///
+/// Fail-closed on three fronts:
+/// - **Run not found** for `run_id` (e.g. the run was skipped by idempotency,
+///   or a `--dag` apply never recorded under this id) ⇒ every required check is
+///   unverifiable ⇒ halt.
+/// - A named check that **failed** ⇒ halt.
+/// - A named check **absent** from the run's captured outcomes ⇒ halt.
+///
+/// Duplicate check names are aggregated with **AND**: per-table checks share a
+/// fixed name (e.g. `row_count` is emitted once per table), so a required check
+/// passes only if it ran at least once *and every occurrence passed*. A naive
+/// last-writer-wins map would let a later passing table mask an earlier failing
+/// one.
+///
+/// On success the custody entry records `effect = allow`; on failure it records
+/// `effect = deny`, an alert is raised, and an error is returned.
 ///
 /// Auto-rollback runs only where a rollback substrate exists. None does today
 /// (the content-addressed / Iceberg pointer-swap path is object-store-only and
@@ -687,6 +739,7 @@ fn run_verify_after(
     plan_id: &str,
     principal: PolicyPrincipal,
     required: &[String],
+    run_id: &str,
     state_path: &Path,
 ) -> Result<()> {
     if required.is_empty() {
@@ -696,25 +749,41 @@ fn run_verify_after(
     let store = StateStore::open(state_path)
         .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
 
-    // The apply's run just finished, so it is the most recent run on record.
-    let latest = store.list_runs(1).ok().and_then(|mut v| v.pop());
-    let outcomes: BTreeMap<&str, bool> = latest
-        .as_ref()
-        .map(|r| {
-            r.check_outcomes
-                .iter()
-                .map(|c| (c.name.as_str(), c.passed))
-                .collect()
-        })
-        .unwrap_or_default();
+    // Resolve *this apply's own* run by id (not "latest"). `None` means no run
+    // was recorded under this id — fail closed below (every check unverifiable).
+    let run = store
+        .get_run(run_id)
+        .with_context(|| format!("failed to read run '{run_id}' from state store"))?;
+
+    // AND-aggregate every occurrence of each check name: any `false` occurrence
+    // fails the name. Presence in the map ⇒ the check ran at least once.
+    let mut outcomes: BTreeMap<&str, bool> = BTreeMap::new();
+    if let Some(record) = run.as_ref() {
+        for c in &record.check_outcomes {
+            outcomes
+                .entry(c.name.as_str())
+                .and_modify(|passed| *passed &= c.passed)
+                .or_insert(c.passed);
+        }
+    }
 
     let mut failures: Vec<String> = Vec::new();
-    for name in required {
-        match outcomes.get(name.as_str()) {
-            Some(true) => {}
-            Some(false) => failures.push(format!("{name} (failed)")),
-            // Fail closed: a named check that did not run cannot be confirmed.
-            None => failures.push(format!("{name} (absent — did not run)")),
+    if run.is_none() {
+        // The run this apply produced could not be found — treat every required
+        // check as unverifiable and halt (fail closed).
+        for name in required {
+            failures.push(format!(
+                "{name} (apply run '{run_id}' not found — unverifiable)"
+            ));
+        }
+    } else {
+        for name in required {
+            match outcomes.get(name.as_str()) {
+                Some(true) => {}
+                Some(false) => failures.push(format!("{name} (failed)")),
+                // Fail closed: a named check that did not run cannot be confirmed.
+                None => failures.push(format!("{name} (absent — did not run)")),
+            }
         }
     }
     let passed = failures.is_empty();
@@ -842,8 +911,25 @@ async fn run_apply_ai_authored_plan(
     // Resolve the post-apply verification checks before the run plan is moved.
     let verify_checks = required_verify_after(config_path, principal, &touched, models_dir);
 
-    execute_run_plan(config_path, plan_id, run_plan, state_path, output_json).await?;
-    run_verify_after(plan_id, principal, &verify_checks, state_path)
+    // One unique id for this apply's run, threaded into execution and into the
+    // post-apply gate so the gate reads exactly this run, not "latest".
+    let apply_run_id = new_apply_run_id();
+    execute_run_plan(
+        config_path,
+        plan_id,
+        run_plan,
+        state_path,
+        output_json,
+        &apply_run_id,
+    )
+    .await?;
+    run_verify_after(
+        plan_id,
+        principal,
+        &verify_checks,
+        &apply_run_id,
+        state_path,
+    )
 }
 
 /// Apply a `PlanKind::Backfill` plan — a scoped, review-gated recovery run.
@@ -1097,6 +1183,8 @@ async fn run_apply_replication_plan(
         &crate::commands::run::SkipRunOptions::default(),
         // Replication apply runs no transformation models; vars are inert.
         &rocky_core::run_vars::RunVars::new(),
+        // Replication apply has no `verify_after` gate; mint the usual id.
+        None,
     )
     .await
     .with_context(|| format!("rocky apply replication plan '{plan_id}' failed"))?;
@@ -1506,6 +1594,9 @@ pub async fn run_apply_inline_for_run(
         defer_opts,
         skip_opts,
         run_vars,
+        // The inline `rocky run` path mints its own timestamp run_id; the
+        // two-step apply's verify_after gate is the only override consumer.
+        None,
     )
     .await
 }
@@ -2687,16 +2778,23 @@ effect = "deny"
 
     // ---------- verify_after post-apply gate ----------
 
-    fn record_run_with_checks(state_path: &Path, checks: &[(&str, bool)]) {
+    /// Record a run under an explicit `run_id` + `started_at`, so a test can
+    /// control which run is "latest" (by timestamp) independently of which run
+    /// it later asks `run_verify_after` to resolve (by id).
+    fn record_run_with_checks_id(
+        state_path: &Path,
+        run_id: &str,
+        started_at: chrono::DateTime<chrono::Utc>,
+        checks: &[(&str, bool)],
+    ) {
         use rocky_core::state::{
             CheckOutcome, RunRecord, RunStatus, RunTrigger, SessionSource, StateStore,
         };
         let store = StateStore::open(state_path).unwrap();
-        let now = chrono::Utc::now();
         let record = RunRecord {
-            run_id: format!("run-{}", now.timestamp_nanos_opt().unwrap_or(0)),
-            started_at: now,
-            finished_at: now,
+            run_id: run_id.to_string(),
+            started_at,
+            finished_at: started_at,
             status: RunStatus::Success,
             models_executed: vec![],
             trigger: RunTrigger::Manual,
@@ -2720,15 +2818,26 @@ effect = "deny"
         store.record_run(&record).unwrap();
     }
 
+    /// Record a run with a generated id and return that id so the caller can
+    /// thread it into `run_verify_after` (which now resolves the run by id).
+    fn record_run_with_checks(state_path: &Path, checks: &[(&str, bool)]) -> String {
+        let now = chrono::Utc::now();
+        let run_id = format!("run-{}", now.timestamp_nanos_opt().unwrap_or(0));
+        record_run_with_checks_id(state_path, &run_id, now, checks);
+        run_id
+    }
+
     #[test]
     fn verify_after_passes_when_all_named_checks_pass() {
         let dir = tempfile::tempdir().unwrap();
         let state = dir.path().join("state.redb");
-        record_run_with_checks(&state, &[("row_count", true), ("not_null_keys", true)]);
+        let run_id =
+            record_run_with_checks(&state, &[("row_count", true), ("not_null_keys", true)]);
         let r = super::run_verify_after(
             "plan-x",
             PolicyPrincipal::Agent,
             &["row_count".to_string(), "not_null_keys".to_string()],
+            &run_id,
             &state,
         );
         assert!(
@@ -2741,11 +2850,13 @@ effect = "deny"
     fn verify_after_halts_when_named_check_fails() {
         let dir = tempfile::tempdir().unwrap();
         let state = dir.path().join("state.redb");
-        record_run_with_checks(&state, &[("row_count", true), ("not_null_keys", false)]);
+        let run_id =
+            record_run_with_checks(&state, &[("row_count", true), ("not_null_keys", false)]);
         let err = super::run_verify_after(
             "plan-x",
             PolicyPrincipal::Agent,
             &["not_null_keys".to_string()],
+            &run_id,
             &state,
         )
         .expect_err("a failing named check halts the apply");
@@ -2765,11 +2876,12 @@ effect = "deny"
         // soundness direction.
         let dir = tempfile::tempdir().unwrap();
         let state = dir.path().join("state.redb");
-        record_run_with_checks(&state, &[("row_count", true)]);
+        let run_id = record_run_with_checks(&state, &[("row_count", true)]);
         let err = super::run_verify_after(
             "plan-x",
             PolicyPrincipal::Agent,
             &["freshness".to_string()],
+            &run_id,
             &state,
         )
         .expect_err("an absent named check fails closed");
@@ -2781,6 +2893,76 @@ effect = "deny"
         let dir = tempfile::tempdir().unwrap();
         let state = dir.path().join("state.redb");
         // No required checks → the gate is a no-op and never touches state.
-        assert!(super::run_verify_after("plan-x", PolicyPrincipal::Agent, &[], &state).is_ok());
+        assert!(
+            super::run_verify_after("plan-x", PolicyPrincipal::Agent, &[], "unused-id", &state)
+                .is_ok()
+        );
+    }
+
+    /// 🔴 Regression (false-verified): the gate must resolve *this apply's own*
+    /// run by id, NOT "the latest run". Two runs share the state store: run A
+    /// (this apply, older) failed its required check; a concurrent run B (newer,
+    /// "latest") passed the same-named check. If the gate read "latest" it would
+    /// verify against B and wrongly pass — so it MUST fail when handed A's id.
+    #[test]
+    fn verify_after_reads_this_applys_run_not_latest() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = dir.path().join("state.redb");
+
+        let older = chrono::Utc::now() - chrono::Duration::seconds(60); // A @ 10:00
+        let newer = chrono::Utc::now(); // B @ 10:01 (the "latest" by started_at)
+        // A is this apply's run: its required check FAILED.
+        record_run_with_checks_id(&state, "run-A", older, &[("row_count", false)]);
+        // B is a concurrent run that finished later: same check PASSED.
+        record_run_with_checks_id(&state, "run-B", newer, &[("row_count", true)]);
+
+        let err = super::run_verify_after(
+            "plan-x",
+            PolicyPrincipal::Agent,
+            &["row_count".to_string()],
+            "run-A",
+            &state,
+        )
+        .expect_err(
+            "the gate must fail against THIS apply's run (A, failed), not the latest run (B, passed)",
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("verify_after gate FAILED") && msg.contains("row_count"),
+            "must fail on A's failed check, got: {msg}"
+        );
+    }
+
+    /// 🔴 Regression (false-verified): duplicate check names must AND-aggregate.
+    /// Per-table checks share a fixed name (`row_count` per table), so a run's
+    /// outcomes can carry the same name failed *and* passed. A last-writer-wins
+    /// map would let the passing occurrence overwrite the failing one and the
+    /// gate would wrongly pass. Every occurrence must be AND-ed → fail.
+    #[test]
+    fn verify_after_duplicate_check_name_failed_then_passed_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = dir.path().join("state.redb");
+        // Same name, failed first then passed — order chosen so a naive
+        // last-writer-wins map would land on `true` and wrongly pass.
+        record_run_with_checks_id(
+            &state,
+            "run-dup",
+            chrono::Utc::now(),
+            &[("row_count", false), ("row_count", true)],
+        );
+
+        let err = super::run_verify_after(
+            "plan-x",
+            PolicyPrincipal::Agent,
+            &["row_count".to_string()],
+            "run-dup",
+            &state,
+        )
+        .expect_err("a failing occurrence of a duplicate check name must fail the gate");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("verify_after gate FAILED") && msg.contains("row_count"),
+            "duplicate-name AND-aggregation must surface the failure: {msg}"
+        );
     }
 }

--- a/engine/crates/rocky-cli/src/commands/audit.rs
+++ b/engine/crates/rocky-cli/src/commands/audit.rs
@@ -1054,6 +1054,7 @@ mod tests {
             effect,
             rule_id: Some(0),
             reason: "test".to_string(),
+            verify_after: Vec::new(),
         }
     }
 
@@ -1182,6 +1183,7 @@ mod tests {
             effect,
             rule_id,
             reason: "test".to_string(),
+            verify_after: Vec::new(),
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/brief.rs
+++ b/engine/crates/rocky-cli/src/commands/brief.rs
@@ -1053,6 +1053,7 @@ mod tests {
             effect,
             rule_id,
             reason: "test".to_string(),
+            verify_after: Vec::new(),
         }
     }
 
@@ -1097,6 +1098,7 @@ mod tests {
             target_catalog: None,
             hostname: "host".to_string(),
             rocky_version: "0.0.0-test".to_string(),
+            check_outcomes: Vec::new(),
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/catalog.rs
+++ b/engine/crates/rocky-cli/src/commands/catalog.rs
@@ -1221,6 +1221,7 @@ mod tests {
                 target_catalog: None,
                 hostname: "test-host".to_string(),
                 rocky_version: "test-version".to_string(),
+                check_outcomes: Vec::new(),
             }
         }
 

--- a/engine/crates/rocky-cli/src/commands/cost.rs
+++ b/engine/crates/rocky-cli/src/commands/cost.rs
@@ -537,6 +537,7 @@ mod tests {
             target_catalog: None,
             hostname: "cost-test-host".to_string(),
             rocky_version: "0.0.0-test".to_string(),
+            check_outcomes: Vec::new(),
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/gc.rs
+++ b/engine/crates/rocky-cli/src/commands/gc.rs
@@ -725,6 +725,7 @@ mod tests {
                 target_catalog: None,
                 hostname: "gc-test".to_string(),
                 rocky_version: "0.0.0-test".to_string(),
+                check_outcomes: Vec::new(),
             })
             .unwrap();
     }

--- a/engine/crates/rocky-cli/src/commands/history.rs
+++ b/engine/crates/rocky-cli/src/commands/history.rs
@@ -584,6 +584,7 @@ mod tests {
             target_catalog: Some("warehouse_main".to_string()),
             hostname: "dev-laptop".to_string(),
             rocky_version: "1.16.0".to_string(),
+            check_outcomes: Vec::new(),
         }
     }
 
@@ -670,6 +671,7 @@ mod tests {
             target_catalog: None,
             hostname: "host".to_string(),
             rocky_version: "0.0.0-test".to_string(),
+            check_outcomes: Vec::new(),
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/policy.rs
+++ b/engine/crates/rocky-cli/src/commands/policy.rs
@@ -69,6 +69,10 @@ pub fn run_policy_check(
         .iter()
         .filter(|m| m.config.depends_on.iter().any(|d| d == model_name))
         .count() as u64;
+    // Transitive blast radius for the `max_downstreams` ceiling. `None` when
+    // the model is absent from the compiled graph (the ceiling fails closed).
+    let reachable_downstreams = crate::commands::audit::blast_radius_of(&result, model_name)
+        .map(|(_direct, transitive)| transitive.len() as u64);
 
     let attrs = ModelAttributes {
         name: model.config.name.clone(),
@@ -77,6 +81,7 @@ pub fn run_policy_check(
         layer,
         contracted,
         downstreams,
+        reachable_downstreams,
     };
 
     let decision = policy::evaluate(&policy, principal, capability, &attrs);
@@ -96,6 +101,7 @@ pub fn run_policy_check(
             layer: attrs.layer,
             contracted: attrs.contracted,
             downstreams: attrs.downstreams,
+            reachable_downstreams: attrs.reachable_downstreams,
         },
     };
 
@@ -126,12 +132,17 @@ fn render_text(out: &PolicyCheckOutput) {
     } else {
         attrs.classifications.join(", ")
     };
+    let reachable = attrs
+        .reachable_downstreams
+        .map(|n| n.to_string())
+        .unwrap_or_else(|| "(uncomputable)".to_string());
     println!(
-        "  model: contracted={} layer={} classifications=[{}] downstreams={}",
+        "  model: contracted={} layer={} classifications=[{}] downstreams={} blast_radius={}",
         attrs.contracted,
         attrs.layer.as_deref().unwrap_or("(none)"),
         classifications,
         attrs.downstreams,
+        reachable,
     );
 }
 

--- a/engine/crates/rocky-cli/src/commands/preview.rs
+++ b/engine/crates/rocky-cli/src/commands/preview.rs
@@ -2298,6 +2298,7 @@ mod tests {
             target_catalog: None,
             hostname: "test".into(),
             rocky_version: "0.0.0-test".into(),
+            check_outcomes: Vec::new(),
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/replay.rs
+++ b/engine/crates/rocky-cli/src/commands/replay.rs
@@ -1290,6 +1290,7 @@ mod tests {
             target_catalog: None,
             hostname: "replay-test-host".to_string(),
             rocky_version: "0.0.0-test".to_string(),
+            check_outcomes: Vec::new(),
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/review.rs
+++ b/engine/crates/rocky-cli/src/commands/review.rs
@@ -663,6 +663,7 @@ mod tests {
             effect,
             rule_id: None,
             reason: "test".to_string(),
+            verify_after: Vec::new(),
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -13341,6 +13341,7 @@ merge_keys = ["id"]
             target_catalog: None,
             hostname: "test".to_string(),
             rocky_version: "test".to_string(),
+            check_outcomes: Vec::new(),
         };
         state.record_run(&failed).unwrap();
 
@@ -14544,6 +14545,7 @@ merge_keys = ["id"]
             target_catalog: None,
             hostname: "test".to_string(),
             rocky_version: "test".to_string(),
+            check_outcomes: Vec::new(),
         };
         store.record_run(&run).unwrap();
 
@@ -15374,6 +15376,7 @@ merge_keys = ["id"]
                 target_catalog: None,
                 hostname: "test".to_string(),
                 rocky_version: "test".to_string(),
+                check_outcomes: Vec::new(),
             };
             store.record_run(&run).unwrap();
 
@@ -15652,6 +15655,7 @@ merge_keys = ["id"]
                     target_catalog: None,
                     hostname: "test".to_string(),
                     rocky_version: "test".to_string(),
+                    check_outcomes: Vec::new(),
                 })
                 .unwrap();
 

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1095,6 +1095,13 @@ pub async fn run(
     // placeholders in model SQL at compile time. Empty ⇒ no `@var()` model
     // resolves and behavior is byte-identical.
     run_vars: &rocky_core::run_vars::RunVars,
+    // Caller-supplied run_id override. `None` (every caller except the two-step
+    // `rocky apply` path) mints the usual `run-{timestamp}` id, so behavior is
+    // byte-identical. `Some(id)` forces this run to record under exactly `id`
+    // at every persistence site — used by `rocky apply` so its post-apply
+    // `verify_after` gate can resolve *this apply's own* run (not "latest") by
+    // id, immune to a concurrent run finishing in between.
+    run_id_override: Option<&str>,
 ) -> Result<()> {
     // With `-o json` stdout is reserved for the JSON payload — route any
     // human-readable summary/progress line (e.g. a `depends_on` upstream
@@ -1113,7 +1120,9 @@ pub async fn run(
     // `IdempotencyEntry::run_id` == `RunRecord::run_id` so operators can
     // cross-reference a `skipped_by_run_id` directly against
     // `rocky history`.
-    let run_id = format!("run-{}", started_at.format("%Y%m%d-%H%M%S-%3f"));
+    let run_id = run_id_override
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("run-{}", started_at.format("%Y%m%d-%H%M%S-%3f")));
     // Record `run_id` on the `run` span declared by `#[tracing::instrument]`
     // above so every event nested under this scope (and emitted into the
     // JSONL trace file) carries the identifier in its `spans[]` chain.
@@ -9507,6 +9516,7 @@ adapter = "default"
             &DeferOptions::default(),
             &SkipRunOptions::default(),
             &rocky_core::run_vars::RunVars::new(),
+            None, // no run_id override — mint the usual timestamp id
         )
         .await
         .expect("transformation run should succeed");
@@ -9614,6 +9624,7 @@ schema = "mart"
             &DeferOptions::default(),
             &SkipRunOptions::default(),
             &rocky_core::run_vars::RunVars::new(),
+            None, // no run_id override — mint the usual timestamp id
         )
         .await
         .expect(

--- a/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
+++ b/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
@@ -285,6 +285,8 @@ impl NodeDispatcher for CliDispatcher {
                         // empty set so `@var()` models would compile-error rather
                         // than silently resolve under a DAG run.
                         &rocky_core::run_vars::RunVars::new(),
+                        // No run_id override — DAG sub-runs mint their own ids.
+                        None,
                     )
                     .await
                     .map_err(|e| e.to_string())

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -1025,6 +1025,7 @@ mod tests {
             &DeferOptions::default(),
             &skip_opts,
             &rocky_core::run_vars::RunVars::new(),
+            None, // no run_id override — mint the usual timestamp id
         )
         .await
         .expect("full-DAG transformation run should succeed");
@@ -1210,6 +1211,7 @@ auto_create_schemas = true
             &DeferOptions::default(),
             &SkipRunOptions::default(),
             &rocky_core::run_vars::RunVars::new(),
+            None, // no run_id override — mint the usual timestamp id
         )
         .await
         .expect("full-DAG transformation run with idempotency key should succeed");
@@ -1366,6 +1368,7 @@ auto_create_schemas = true
             &DeferOptions::default(),
             &SkipRunOptions::default(),
             &rocky_core::run_vars::RunVars::new(),
+            None, // no run_id override — mint the usual timestamp id
         )
         .await
         .expect("model-only run must reach the governance.tags apply path and succeed");
@@ -1440,6 +1443,7 @@ auto_create_schemas = true
             &DeferOptions::default(),
             &SkipRunOptions::default(),
             &rocky_core::run_vars::RunVars::new(),
+            None, // no run_id override — mint the usual timestamp id
         )
         .await;
 

--- a/engine/crates/rocky-cli/src/commands/run_watch.rs
+++ b/engine/crates/rocky-cli/src/commands/run_watch.rs
@@ -288,6 +288,8 @@ async fn iter_once(
         skip_opts,
         // `--watch` does not expose `--var` today; pass an empty set.
         &rocky_core::run_vars::RunVars::new(),
+        // `--watch` mints the usual timestamp run_id per iteration.
+        None,
     )
     .await;
     let elapsed_ms = started.elapsed().as_millis();

--- a/engine/crates/rocky-cli/src/commands/trace.rs
+++ b/engine/crates/rocky-cli/src/commands/trace.rs
@@ -283,6 +283,7 @@ mod tests {
             target_catalog: None,
             hostname: "trace-test-host".to_string(),
             rocky_version: "0.0.0-test".to_string(),
+            check_outcomes: Vec::new(),
         }
     }
 

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -4927,6 +4927,19 @@ impl RunOutput {
             });
         }
 
+        // Flatten every executed check's pass/fail across all tables so a later
+        // reader (the `verify_after` policy gate) can confirm a named check ran
+        // and passed without re-executing it.
+        let check_outcomes = self
+            .check_results
+            .iter()
+            .flat_map(|table| &table.checks)
+            .map(|c| rocky_core::state::CheckOutcome {
+                name: c.name.clone(),
+                passed: c.passed,
+            })
+            .collect();
+
         rocky_core::state::RunRecord {
             run_id: run_id.to_string(),
             started_at,
@@ -4943,6 +4956,7 @@ impl RunOutput {
             target_catalog: audit.target_catalog,
             hostname: audit.hostname,
             rocky_version: audit.rocky_version,
+            check_outcomes,
         }
     }
 

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -6519,9 +6519,16 @@ pub struct PolicyModelAttributes {
     /// Whether the model sits behind a contract (best-effort: a sibling
     /// `.contract.toml` exists).
     pub contracted: bool,
-    /// Direct downstream-consumer count (informational; `max_downstreams`
-    /// is parse-only in v0).
+    /// Direct downstream-consumer count (models that `depends_on` this one).
+    /// Informational — the `max_downstreams` ceiling reads
+    /// [`Self::reachable_downstreams`].
     pub downstreams: u64,
+    /// Transitive downstream reachability — the full blast radius (direct +
+    /// indirect), excluding the model itself. This is what a rule's
+    /// `max_downstreams` ceiling is compared against. `null` when the blast
+    /// radius could not be computed (the ceiling then fails closed).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reachable_downstreams: Option<u64>,
 }
 
 /// JSON output for `rocky audit` — the agent-policy decision ledger.

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -2776,8 +2776,18 @@ pub struct PolicyRule {
     pub scope: PolicyScope,
     /// The verdict when this rule matches.
     pub effect: PolicyEffect,
-    /// Optional v1 conditional refinements. **Parsed and ignored in v0** —
-    /// captured as opaque JSON so a config authored for v1 still loads.
+    /// Post-apply verification: named checks that must pass after a mutation
+    /// governed by this rule lands. Once the apply's run completes, each named
+    /// check is confirmed against the run's executed checks; a failing **or
+    /// absent** named check halts the apply (fail closed) and raises an alert.
+    /// Auto-rollback runs only where a rollback substrate exists; today none
+    /// does, so a failure is halt-only and the mutation stands until a human
+    /// reverts it. Empty ⇒ no post-apply gate.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub verify_after: Vec<String>,
+    /// Optional v1 conditional refinements not yet promoted to typed fields
+    /// (`budget`, `window`). **Parsed and ignored** — captured as opaque JSON
+    /// so a config authored against a later version still loads.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub conditions: Option<serde_json::Value>,
 }
@@ -5894,6 +5904,45 @@ conditions = { time_window = "business_hours" }
         );
         assert!(validate_policy(&cfg).is_empty());
         assert!(cfg.policy.unwrap().rules[0].conditions.is_some());
+    }
+
+    #[test]
+    fn policy_rule_parses_verify_after() {
+        // `verify_after` is a first-class rule field (not opaque `conditions`),
+        // so it parses under `deny_unknown_fields` and round-trips typed.
+        let cfg = parse(
+            r#"
+[policy]
+version = 1
+
+[[policy.rules]]
+principal = "agent"
+capability = "schema_change.additive"
+scope = { layer = "bronze" }
+effect = "allow"
+verify_after = ["row_count_drift", "not_null_keys"]
+"#,
+        );
+        assert!(validate_policy(&cfg).is_empty());
+        let rule = &cfg.policy.unwrap().rules[0];
+        assert_eq!(rule.verify_after, vec!["row_count_drift", "not_null_keys"]);
+    }
+
+    #[test]
+    fn policy_rule_without_verify_after_defaults_empty() {
+        let cfg = parse(
+            r#"
+[policy]
+version = 1
+
+[[policy.rules]]
+principal = "agent"
+capability = "apply"
+scope = { any = true }
+effect = "allow"
+"#,
+        );
+        assert!(cfg.policy.unwrap().rules[0].verify_after.is_empty());
     }
 
     #[test]

--- a/engine/crates/rocky-core/src/policy.rs
+++ b/engine/crates/rocky-core/src/policy.rs
@@ -33,6 +33,17 @@
 //!    `require_review` (fail-safe). A ceiling can therefore never let an
 //!    `allow` stand for an oversized or unverifiable blast radius; `deny` and
 //!    `require_review` rules are unaffected (`deny` is unconditional).
+//! 7. **Sticky `max_downstreams` safety cap.** A ceiling breach is *sticky*:
+//!    if **any** matched rule's `max_downstreams` was exceeded or uncomputable,
+//!    the final effect is capped to at least `require_review` — even when a
+//!    more-specific sibling `allow` (with no ceiling, or a superset of matched
+//!    constraints) would otherwise win the specificity contest and stand as an
+//!    ungated `allow`. This closes the false-allow where a broad sibling `allow`
+//!    *dominates* a ceilinged rule via the non-dominated filter and thereby lets
+//!    an oversized blast radius through. It is applied as a post-winner check:
+//!    it never softens a `deny` (deny is resolved first, before any winner) and
+//!    it never overrides the uncomputable-blast-radius fail-closed rule (both
+//!    point the same way — toward `require_review`).
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -442,8 +453,30 @@ pub fn evaluate(
         reason.push_str(degrade);
     }
 
+    // 7. Sticky `max_downstreams` safety cap (post-winner). A ceiling breach on
+    // ANY matched rule caps the final effect to at least `require_review`, even
+    // when a more-specific sibling `allow` won the specificity contest above.
+    // The winner's own `allow` is never ceiling-degraded — a degraded rule is
+    // already `require_review`, so `winner.effect == Allow` guarantees the cap
+    // reason comes from a *non-winning* breached candidate. Without this, a
+    // broad ungated `allow` that dominates a ceilinged sibling (superset of
+    // constraints, no ceiling) would let an oversized or unverifiable blast
+    // radius stand — the exact false-allow the ceiling exists to prevent.
+    let mut effect = winner.effect;
+    if effect == PolicyEffect::Allow
+        && let Some(breach) = candidates.iter().find(|c| c.degraded.is_some())
+    {
+        effect = PolicyEffect::RequireReview;
+        let detail = breach.degraded.as_deref().unwrap_or("ceiling breached");
+        reason.push_str(&format!(
+            "; sticky safety cap: max_downstreams ceiling breached on rule {} ({detail}) \
+             — allow capped to require_review",
+            breach.idx
+        ));
+    }
+
     PolicyDecision {
-        effect: winner.effect,
+        effect,
         matched_rule: Some(winner.idx),
         reason,
     }
@@ -1063,6 +1096,121 @@ mod tests {
         );
         assert_eq!(d.effect, PolicyEffect::RequireReview);
         assert_eq!(d.matched_rule, Some(1));
+    }
+
+    /// 🔴 Sticky safety cap — the load-bearing false-allow fix. A ceilinged
+    /// `allow` (rule 0, `max_downstreams=5`) is *dominated* by a more-specific
+    /// ungated sibling `allow` (rule 1, a strict-superset scope with no
+    /// ceiling). The non-dominated filter drops the degraded rule 0, so the
+    /// winner is rule 1's ungated `allow`. Without the sticky cap this yields
+    /// `allow` for a blast radius of 20 that a matching ceiling of 5 forbids.
+    /// The cap must force the final effect to `require_review`.
+    #[test]
+    fn sticky_cap_more_specific_sibling_allow_cannot_bypass_breached_ceiling() {
+        let attrs = ModelAttributes {
+            name: "raw_events".to_string(),
+            layer: Some("bronze".to_string()),
+            classifications: BTreeSet::from(["public".to_string()]),
+            reachable_downstreams: Some(20),
+            ..Default::default()
+        };
+        // rule 0: allow {layer=bronze, max_downstreams=5}  ({Layer}, degrades)
+        // rule 1: allow {layer=bronze, classifications=[public]}
+        //         ({Layer, Classifications}) — strict superset dominates rule 0.
+        let p = policy(vec![
+            rule(
+                PolicyPrincipal::Agent,
+                PolicyCapability::SchemaChangeAdditive,
+                PolicyScope {
+                    layer: Some("bronze".to_string()),
+                    max_downstreams: Some(5),
+                    ..Default::default()
+                },
+                PolicyEffect::Allow,
+            ),
+            rule(
+                PolicyPrincipal::Agent,
+                PolicyCapability::SchemaChangeAdditive,
+                PolicyScope {
+                    layer: Some("bronze".to_string()),
+                    classifications: vec!["public".to_string()],
+                    ..Default::default()
+                },
+                PolicyEffect::Allow,
+            ),
+        ]);
+        let d = evaluate(
+            &p,
+            PolicyPrincipal::Agent,
+            PolicyCapability::SchemaChangeAdditive,
+            &attrs,
+        );
+        assert_eq!(
+            d.effect,
+            PolicyEffect::RequireReview,
+            "a breached ceiling on a matched rule must cap the final effect, \
+             even when a more-specific ungated sibling allow wins: {}",
+            d.reason
+        );
+        assert!(
+            d.reason.contains("sticky safety cap")
+                && d.reason.contains("max_downstreams=5 exceeded"),
+            "reason must name the sticky cap and the breach: {}",
+            d.reason
+        );
+    }
+
+    /// The cap is *only* a cap: a non-breached ceiling still allows. Same two
+    /// rules as above, but the blast radius (3) is within rule 0's ceiling (5),
+    /// so no candidate degraded and the more-specific sibling `allow` stands.
+    #[test]
+    fn sticky_cap_non_breached_ceiling_still_allows() {
+        let attrs = ModelAttributes {
+            name: "raw_events".to_string(),
+            layer: Some("bronze".to_string()),
+            classifications: BTreeSet::from(["public".to_string()]),
+            reachable_downstreams: Some(3),
+            ..Default::default()
+        };
+        let p = policy(vec![
+            rule(
+                PolicyPrincipal::Agent,
+                PolicyCapability::SchemaChangeAdditive,
+                PolicyScope {
+                    layer: Some("bronze".to_string()),
+                    max_downstreams: Some(5),
+                    ..Default::default()
+                },
+                PolicyEffect::Allow,
+            ),
+            rule(
+                PolicyPrincipal::Agent,
+                PolicyCapability::SchemaChangeAdditive,
+                PolicyScope {
+                    layer: Some("bronze".to_string()),
+                    classifications: vec!["public".to_string()],
+                    ..Default::default()
+                },
+                PolicyEffect::Allow,
+            ),
+        ]);
+        let d = evaluate(
+            &p,
+            PolicyPrincipal::Agent,
+            PolicyCapability::SchemaChangeAdditive,
+            &attrs,
+        );
+        assert_eq!(
+            d.effect,
+            PolicyEffect::Allow,
+            "a within-ceiling blast radius must still allow: {}",
+            d.reason
+        );
+        assert!(
+            !d.reason.contains("sticky safety cap"),
+            "no cap should fire when nothing breached: {}",
+            d.reason
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-core/src/policy.rs
+++ b/engine/crates/rocky-core/src/policy.rs
@@ -474,6 +474,7 @@ mod tests {
             capability,
             scope,
             effect,
+            verify_after: Vec::new(),
             conditions: None,
         }
     }

--- a/engine/crates/rocky-core/src/policy.rs
+++ b/engine/crates/rocky-core/src/policy.rs
@@ -25,6 +25,14 @@
 //! 5. **Default posture.** No rule matches ⇒ an `agent` on a mutating
 //!    capability falls to `default_agent_effect`; a `human` is never gated
 //!    (`allow`).
+//! 6. **`max_downstreams` degrades, never no-matches.** A rule may carry a
+//!    `scope.max_downstreams = N` blast-radius ceiling. It does **not** change
+//!    whether the rule's scope matches; instead, when the rule's effect is
+//!    `allow` and the target's transitive downstream reachability is either
+//!    over `N` **or** uncomputable, the matched effect degrades to
+//!    `require_review` (fail-safe). A ceiling can therefore never let an
+//!    `allow` stand for an oversized or unverifiable blast radius; `deny` and
+//!    `require_review` rules are unaffected (`deny` is unconditional).
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -113,9 +121,19 @@ pub struct ModelAttributes {
     /// Whether the model sits behind a contract (best-effort v0: a sibling
     /// `.contract.toml` exists).
     pub contracted: bool,
-    /// Downstream-consumer count. Surfaced for context; `scope.max_downstreams`
-    /// is parse-only in v0, so this does not affect matching.
+    /// Direct downstream-consumer count (models that `depends_on` this one).
+    /// Informational only — the `max_downstreams` ceiling reads
+    /// [`Self::reachable_downstreams`], the transitive blast radius.
     pub downstreams: u64,
+    /// Transitive downstream reachability — the count of every model in this
+    /// model's blast radius (direct + indirect), excluding itself. This is
+    /// what a rule's `max_downstreams` ceiling is compared against.
+    ///
+    /// `None` means the blast radius could **not** be computed (the model is
+    /// absent from the compiled graph, or the project did not compile). A
+    /// `max_downstreams` ceiling **fails closed** on `None`: it never grants
+    /// `allow`, because an uncounted blast radius is treated as too large.
+    pub reachable_downstreams: Option<u64>,
 }
 
 /// A single satisfied constraint contributed by a matching rule. The set
@@ -147,8 +165,10 @@ pub struct PolicyDecision {
 /// Returns the satisfied-constraint set for `scope` against `attrs`, or
 /// `None` when the scope is not satisfied (so the rule does not match).
 ///
-/// `scope.any` yields the empty set. `max_downstreams` is parse-only in
-/// v0 and never contributes a constraint or a match failure.
+/// `scope.any` yields the empty set. `max_downstreams` is **not** a scope
+/// predicate — it is a post-match condition evaluated in [`evaluate`] (it
+/// degrades an `allow`, it never turns a match into a no-match), so it never
+/// contributes a constraint or a match failure here.
 fn scope_constraints(scope: &PolicyScope, attrs: &ModelAttributes) -> Option<BTreeSet<Constraint>> {
     if scope.any {
         return Some(BTreeSet::new());
@@ -209,7 +229,8 @@ fn scope_constraints(scope: &PolicyScope, attrs: &ModelAttributes) -> Option<BTr
             return None;
         }
     }
-    // `max_downstreams` is parse-only in v0: neither required nor counted.
+    // `max_downstreams` is a post-match condition (evaluated in `evaluate`),
+    // not a scope predicate: never required, never counted here.
     Some(set)
 }
 
@@ -230,6 +251,49 @@ fn restrictiveness(effect: PolicyEffect) -> u8 {
         PolicyEffect::Allow => 0,
         PolicyEffect::RequireReview => 1,
         PolicyEffect::Deny => 2,
+    }
+}
+
+/// Apply a rule's `max_downstreams` blast-radius ceiling as a post-match
+/// condition. Returns the (possibly degraded) effect and, when a degrade
+/// happened, a human-readable reason.
+///
+/// The ceiling is a **narrowing guard on `allow`** and fails closed:
+///
+/// - No ceiling, or a non-`allow` effect → unchanged (`deny` /
+///   `require_review` are never softened; a `deny` ceiling is a no-op).
+/// - `allow` with the target's [`ModelAttributes::reachable_downstreams`]
+///   present and `≤ limit` → stays `allow`.
+/// - `allow` with reachability over the limit → degrades to
+///   `require_review`.
+/// - `allow` with reachability **uncomputable** (`None`) → degrades to
+///   `require_review` — an uncounted blast radius is treated as too large, so
+///   a ceiling can never grant `allow` when it cannot be verified.
+fn degrade_for_ceiling(
+    effect: PolicyEffect,
+    limit: Option<u64>,
+    attrs: &ModelAttributes,
+) -> (PolicyEffect, Option<String>) {
+    let Some(limit) = limit else {
+        return (effect, None);
+    };
+    if effect != PolicyEffect::Allow {
+        return (effect, None);
+    }
+    match attrs.reachable_downstreams {
+        Some(count) if count <= limit => (effect, None),
+        Some(count) => (
+            PolicyEffect::RequireReview,
+            Some(format!(
+                "max_downstreams={limit} exceeded (blast radius {count}) — allow degraded to require_review"
+            )),
+        ),
+        None => (
+            PolicyEffect::RequireReview,
+            Some(format!(
+                "max_downstreams={limit} unverifiable (blast radius uncomputable) — allow degraded to require_review"
+            )),
+        ),
     }
 }
 
@@ -256,6 +320,9 @@ pub fn evaluate(
         idx: usize,
         effect: PolicyEffect,
         constraints: BTreeSet<Constraint>,
+        /// Set when a `max_downstreams` ceiling degraded this rule's `allow`
+        /// to `require_review`; carried into the winning-rule reason string.
+        degraded: Option<String>,
     }
     let mut candidates: Vec<Candidate> = Vec::new();
     let mut first_deny: Option<usize> = None;
@@ -272,14 +339,22 @@ pub fn evaluate(
         if rule.capability.is_refinement() {
             constraints.insert(Constraint::CapabilityRefinement);
         }
-        // 2. Deny is a hard override — any deny match wins.
+        // 2. Deny is a hard override — any deny match wins. Keyed on the rule's
+        // *declared* effect: the `max_downstreams` degrade below only ever
+        // touches `allow`, so a `deny` is never softened away.
         if rule.effect == PolicyEffect::Deny {
             first_deny.get_or_insert(idx);
         }
+        // 6. `max_downstreams` ceiling — a post-match condition that degrades
+        // an `allow` (never a no-match). Fail-closed: an oversized OR
+        // uncomputable blast radius degrades the `allow` to `require_review`.
+        let (effect, degraded) =
+            degrade_for_ceiling(rule.effect, rule.scope.max_downstreams, attrs);
         candidates.push(Candidate {
             idx,
-            effect: rule.effect,
+            effect,
             constraints,
+            degraded,
         });
     }
 
@@ -336,7 +411,7 @@ pub fn evaluate(
         })
         .expect("non_dominated is non-empty when candidates is non-empty");
 
-    let reason = if non_dominated.len() == 1 {
+    let mut reason = if non_dominated.len() == 1 {
         format!(
             "{} by rule {} (most-specific match)",
             effect_label(winner.effect),
@@ -362,6 +437,10 @@ pub fn evaluate(
             )
         }
     };
+    if let Some(degrade) = &winner.degraded {
+        reason.push_str("; ");
+        reason.push_str(degrade);
+    }
 
     PolicyDecision {
         effect: winner.effect,
@@ -854,6 +933,135 @@ mod tests {
     fn effect_rank_orders_deny_over_review_over_allow() {
         assert!(effect_rank(PolicyEffect::Deny) > effect_rank(PolicyEffect::RequireReview));
         assert!(effect_rank(PolicyEffect::RequireReview) > effect_rank(PolicyEffect::Allow));
+    }
+
+    // ---------- max_downstreams ceiling (§1.4, degrade-not-no-match) ----------
+
+    fn bronze_additive_model(reachable: Option<u64>) -> ModelAttributes {
+        ModelAttributes {
+            name: "raw_events".to_string(),
+            layer: Some("bronze".to_string()),
+            reachable_downstreams: reachable,
+            ..Default::default()
+        }
+    }
+
+    /// An `allow …{max_downstreams=5}` rule on a bronze additive model.
+    fn ceilinged_allow_policy() -> PolicyConfig {
+        policy(vec![rule(
+            PolicyPrincipal::Agent,
+            PolicyCapability::SchemaChangeAdditive,
+            PolicyScope {
+                layer: Some("bronze".to_string()),
+                max_downstreams: Some(5),
+                ..Default::default()
+            },
+            PolicyEffect::Allow,
+        )])
+    }
+
+    #[test]
+    fn max_downstreams_within_ceiling_allows() {
+        let d = evaluate(
+            &ceilinged_allow_policy(),
+            PolicyPrincipal::Agent,
+            PolicyCapability::SchemaChangeAdditive,
+            &bronze_additive_model(Some(3)),
+        );
+        assert_eq!(d.effect, PolicyEffect::Allow);
+        assert_eq!(d.matched_rule, Some(0));
+    }
+
+    #[test]
+    fn max_downstreams_exceeded_degrades_to_require_review() {
+        let d = evaluate(
+            &ceilinged_allow_policy(),
+            PolicyPrincipal::Agent,
+            PolicyCapability::SchemaChangeAdditive,
+            &bronze_additive_model(Some(20)),
+        );
+        // The load-bearing soundness invariant: an over-limit blast radius can
+        // never yield `allow`.
+        assert_eq!(d.effect, PolicyEffect::RequireReview);
+        assert!(
+            d.reason.contains("max_downstreams=5 exceeded"),
+            "{}",
+            d.reason
+        );
+    }
+
+    #[test]
+    fn max_downstreams_unverifiable_degrades_to_require_review() {
+        // Reachability uncomputable (model absent from the compiled graph):
+        // fail closed — the ceiling never grants `allow` when it can't verify.
+        let d = evaluate(
+            &ceilinged_allow_policy(),
+            PolicyPrincipal::Agent,
+            PolicyCapability::SchemaChangeAdditive,
+            &bronze_additive_model(None),
+        );
+        assert_eq!(d.effect, PolicyEffect::RequireReview);
+        assert!(d.reason.contains("unverifiable"), "{}", d.reason);
+    }
+
+    #[test]
+    fn max_downstreams_does_not_soften_a_deny() {
+        // A `deny` carrying a ceiling stays `deny` regardless of blast radius —
+        // the degrade only ever touches `allow`.
+        let p = policy(vec![rule(
+            PolicyPrincipal::Agent,
+            PolicyCapability::Apply,
+            PolicyScope {
+                layer: Some("bronze".to_string()),
+                max_downstreams: Some(5),
+                ..Default::default()
+            },
+            PolicyEffect::Deny,
+        )]);
+        let d = evaluate(
+            &p,
+            PolicyPrincipal::Agent,
+            PolicyCapability::Apply,
+            &bronze_additive_model(Some(9999)),
+        );
+        assert_eq!(d.effect, PolicyEffect::Deny);
+    }
+
+    #[test]
+    fn ceilinged_allow_does_not_leak_via_equal_specificity_sibling() {
+        // A broad ceilingless `allow` next to an equally-specific ceilinged
+        // `allow` must not grant `allow` for an oversized blast radius: the
+        // ceilinged rule degrades to `require_review` and, being equally
+        // specific, wins the tie on most-restrictive-effect.
+        let p = policy(vec![
+            rule(
+                PolicyPrincipal::Agent,
+                PolicyCapability::SchemaChangeAdditive,
+                PolicyScope {
+                    layer: Some("bronze".to_string()),
+                    ..Default::default()
+                },
+                PolicyEffect::Allow,
+            ),
+            rule(
+                PolicyPrincipal::Agent,
+                PolicyCapability::SchemaChangeAdditive,
+                PolicyScope {
+                    layer: Some("bronze".to_string()),
+                    max_downstreams: Some(5),
+                    ..Default::default()
+                },
+                PolicyEffect::Allow,
+            ),
+        ]);
+        let d = evaluate(
+            &p,
+            PolicyPrincipal::Agent,
+            PolicyCapability::SchemaChangeAdditive,
+            &bronze_additive_model(Some(20)),
+        );
+        assert_eq!(d.effect, PolicyEffect::RequireReview);
+        assert_eq!(d.matched_rule, Some(1));
     }
 
     #[test]

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -282,7 +282,16 @@ pub const LOCAL_ONLY_TABLE_NAMES: &[&str] = &["schema_cache"];
 ///   `test_v15_model_execution_forward_deserializes_attempts_empty`. The bump
 ///   exists so the on-disk version tracks the record-shape addition and the
 ///   `[state] on_schema_mismatch` handling engages as usual; no blob walk.
-const CURRENT_SCHEMA_VERSION: u32 = 16;
+/// - **v17** — adds two serde-additive *fields* for the policy plane's
+///   `verify_after` post-apply gate: [`RunRecord::check_outcomes`] (per-check
+///   pass/fail captured on every run) and [`PolicyDecisionRecord::verify_after`]
+///   (the named checks a verification custody row required). Neither is a table
+///   change — the redb table set is unchanged (`EXPECTED_TABLES` is untouched).
+///   A v16 blob (which lacks the fields) forward-deserializes with both empty,
+///   guarded by `test_v16_run_record_forward_deserializes_check_outcomes_empty`.
+///   The bump tracks the record-shape addition so `[state] on_schema_mismatch`
+///   engages as usual; no blob walk.
+const CURRENT_SCHEMA_VERSION: u32 = 17;
 
 /// Errors from the embedded redb state store.
 #[derive(Debug, Error)]
@@ -1429,6 +1438,26 @@ pub struct RunRecord {
     /// `"unknown"` version string.
     #[serde(default = "default_rocky_version_sentinel")]
     pub rocky_version: String,
+
+    /// Per-check pass/fail outcomes this run produced, one entry per executed
+    /// data-quality check (flattened across every model). Empty on pre-v17
+    /// records and on runs that ran no checks. Consumed by the policy plane's
+    /// `verify_after` post-apply gate to confirm named checks passed.
+    #[serde(default)]
+    pub check_outcomes: Vec<CheckOutcome>,
+}
+
+/// One executed data-quality check's pass/fail outcome, captured on a
+/// [`RunRecord`] so a later reader (the `verify_after` policy gate) can confirm
+/// a named check ran and passed without re-executing it.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct CheckOutcome {
+    /// The check's name (e.g. `row_count`, `not_null:email`), matching the
+    /// `CheckResult.name` the run emitted and the names a `verify_after` rule
+    /// lists.
+    pub name: String,
+    /// Whether the check passed.
+    pub passed: bool,
 }
 
 /// Default-value contract for `RunRecord.hostname` on v5→v6 upgrade.
@@ -3383,6 +3412,13 @@ pub struct PolicyDecisionRecord {
     /// Human-readable explanation of how the effect was reached.
     #[serde(default)]
     pub reason: String,
+    /// Named checks a `verify_after` condition required post-apply. Empty on a
+    /// plain evaluation row; non-empty on a **post-apply verification custody**
+    /// row, where `effect` records the verification verdict (`allow` = every
+    /// named check passed, `deny` = a named check failed or was absent and the
+    /// apply halted) and `reason` states the outcome and rollback status.
+    #[serde(default)]
+    pub verify_after: Vec<String>,
 }
 
 /// One row in the input-match index ([`INPUT_INDEX`]).
@@ -4354,7 +4390,48 @@ mod tests {
             target_catalog: None,
             hostname: "test-host".to_string(),
             rocky_version: "0.0.0-test".to_string(),
+            check_outcomes: Vec::new(),
         }
+    }
+
+    /// v16 → v17 forward-compat: a `RunRecord` blob written before the
+    /// `check_outcomes` field existed (no `check_outcomes` key) must
+    /// forward-deserialize with the outcomes defaulting to empty — never crash
+    /// the read. Also asserts a v17 record carrying outcomes round-trips.
+    #[test]
+    fn test_v16_run_record_forward_deserializes_check_outcomes_empty() {
+        // A full v16 record serialized with `check_outcomes` stripped.
+        let mut value = serde_json::to_value(minimal_run_record("run-v16", vec![]))
+            .expect("serialize run record");
+        value
+            .as_object_mut()
+            .expect("record is an object")
+            .remove("check_outcomes");
+        let blob = serde_json::to_vec(&value).expect("reserialize without field");
+
+        let record: RunRecord =
+            serde_json::from_slice(&blob).expect("pre-v17 RunRecord must forward-deserialize");
+        assert_eq!(record.run_id, "run-v16");
+        assert!(
+            record.check_outcomes.is_empty(),
+            "a pre-v17 record reads back with no check outcomes"
+        );
+
+        // A v17 record carrying outcomes round-trips losslessly.
+        let mut with_outcomes = minimal_run_record("run-v17", vec![]);
+        with_outcomes.check_outcomes = vec![
+            CheckOutcome {
+                name: "row_count".to_string(),
+                passed: true,
+            },
+            CheckOutcome {
+                name: "not_null:email".to_string(),
+                passed: false,
+            },
+        ];
+        let round: RunRecord =
+            serde_json::from_slice(&serde_json::to_vec(&with_outcomes).unwrap()).unwrap();
+        assert_eq!(round.check_outcomes, with_outcomes.check_outcomes);
     }
 
     #[test]
@@ -6792,6 +6869,7 @@ mod tests {
             effect: PolicyEffect::Allow,
             rule_id: Some(1),
             reason: "allow by rule 1".to_string(),
+            verify_after: Vec::new(),
         };
         let later = PolicyDecisionRecord {
             timestamp: chrono::DateTime::parse_from_rfc3339("2026-07-07T11:00:00Z")
@@ -6804,6 +6882,7 @@ mod tests {
             effect: PolicyEffect::Deny,
             rule_id: Some(0),
             reason: "denied by rule 0 (deny overrides)".to_string(),
+            verify_after: Vec::new(),
         };
         // Insert out of order; the ledger must return them chronologically.
         store.record_policy_decision(&later).unwrap();
@@ -7231,9 +7310,11 @@ mod tests {
         // v16 adds `ModelExecution.attempts` (the classified-retry trail). That
         // is a serde-additive *field* on a blob — the redb table set does NOT
         // change, so EXPECTED_TABLES below is untouched; only the version moves.
-        // A v15 blob forward-deserializes with the trail empty (guarded by
-        // `test_v15_model_execution_forward_deserializes_attempts_empty`).
-        const EXPECTED_VERSION: u32 = 16;
+        // v17 adds the `verify_after` post-apply-gate fields (`RunRecord::
+        // check_outcomes`, `PolicyDecisionRecord::verify_after`), also
+        // serde-additive fields — guarded by
+        // `test_v16_run_record_forward_deserializes_check_outcomes_empty`.
+        const EXPECTED_VERSION: u32 = 17;
         const EXPECTED_TABLES: &[&str] = &[
             "branches",
             "check_history",

--- a/engine/crates/rocky-core/tests/e2e.rs
+++ b/engine/crates/rocky-core/tests/e2e.rs
@@ -510,6 +510,7 @@ fn test_run_history_flow() {
         target_catalog: None,
         hostname: "e2e-test-host".to_string(),
         rocky_version: "0.0.0-e2e".to_string(),
+        check_outcomes: Vec::new(),
     };
 
     store.record_run(&run).unwrap();

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -1273,6 +1273,7 @@ fn seed_run_history(models_dir: &Path) {
         target_catalog: None,
         hostname: "test-host".to_string(),
         rocky_version: "0.0.0-test".to_string(),
+        check_outcomes: Vec::new(),
     };
     store.record_run(&run).expect("record run");
 

--- a/engine/rocky/tests/replay_check.rs
+++ b/engine/rocky/tests/replay_check.rs
@@ -165,6 +165,7 @@ fn record_run(store: &StateStore, models: &[&str]) {
             target_catalog: None,
             hostname: "replay-check-test".to_string(),
             rocky_version: "0.0.0-test".to_string(),
+            check_outcomes: Vec::new(),
         })
         .expect("record run");
 }

--- a/engine/rocky/tests/replay_dag.rs
+++ b/engine/rocky/tests/replay_dag.rs
@@ -187,6 +187,7 @@ fn record_run(store: &StateStore, models: &[&str]) {
             target_catalog: None,
             hostname: "replay-dag-test".to_string(),
             rocky_version: "0.0.0-test".to_string(),
+            check_outcomes: Vec::new(),
         })
         .expect("record run");
 }

--- a/engine/rocky/tests/replay_execute.rs
+++ b/engine/rocky/tests/replay_execute.rs
@@ -169,6 +169,7 @@ fn record_run(store: &StateStore, models: &[&str]) {
             target_catalog: None,
             hostname: "replay-execute-test".to_string(),
             rocky_version: "0.0.0-test".to_string(),
+            check_outcomes: Vec::new(),
         })
         .expect("record run");
 }

--- a/integrations/dagster/tests/fixtures_generated/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor.json
@@ -17,7 +17,7 @@
     {
       "name": "state_schema",
       "status": "healthy",
-      "message": "state schema v16 matches this binary",
+      "message": "state schema v17 matches this binary",
       "duration_ms": 0
     },
     {

--- a/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
@@ -17,7 +17,7 @@
     {
       "name": "state_schema",
       "status": "healthy",
-      "message": "state schema v16 matches this binary",
+      "message": "state schema v17 matches this binary",
       "duration_ms": 0
     },
     {

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 16,
-  "schema_version_on_disk": 16
+  "schema_version_supported": 17,
+  "schema_version_on_disk": 17
 }

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 16,
-  "schema_version_on_disk": 16
+  "schema_version_supported": 17,
+  "schema_version_on_disk": 17
 }

--- a/integrations/dagster/tests/fixtures_generated/state.json
+++ b/integrations/dagster/tests/fixtures_generated/state.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 16,
-  "schema_version_on_disk": 16
+  "schema_version_supported": 17,
+  "schema_version_on_disk": 17
 }

--- a/schemas/policy_check.schema.json
+++ b/schemas/policy_check.schema.json
@@ -124,7 +124,7 @@
           "type": "boolean"
         },
         "downstreams": {
-          "description": "Direct downstream-consumer count (informational; `max_downstreams` is parse-only in v0).",
+          "description": "Direct downstream-consumer count (models that `depends_on` this one). Informational — the `max_downstreams` ceiling reads [`Self::reachable_downstreams`].",
           "format": "uint64",
           "minimum": 0.0,
           "type": "integer"
@@ -133,6 +133,15 @@
           "description": "Medallion/semantic layer (the model's `layer` tag), if any.",
           "type": [
             "string",
+            "null"
+          ]
+        },
+        "reachable_downstreams": {
+          "description": "Transitive downstream reachability — the full blast radius (direct + indirect), excluding the model itself. This is what a rule's `max_downstreams` ceiling is compared against. `null` when the blast radius could not be computed (the ceiling then fails closed).",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
             "null"
           ]
         },

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -2203,7 +2203,7 @@
           "description": "Which capability this rule governs."
         },
         "conditions": {
-          "description": "Optional v1 conditional refinements. **Parsed and ignored in v0** — captured as opaque JSON so a config authored for v1 still loads."
+          "description": "Optional v1 conditional refinements not yet promoted to typed fields (`budget`, `window`). **Parsed and ignored** — captured as opaque JSON so a config authored against a later version still loads."
         },
         "effect": {
           "allOf": [
@@ -2235,6 +2235,13 @@
             "tags": {}
           },
           "description": "The models this rule covers. Defaults to the empty scope, which is *not* `any` — an all-default scope with no `any = true` matches nothing and is rejected at validation."
+        },
+        "verify_after": {
+          "description": "Post-apply verification: named checks that must pass after a mutation governed by this rule lands. Once the apply's run completes, each named check is confirmed against the run's executed checks; a failing **or absent** named check halts the apply (fail closed) and raises an alert. Auto-rollback runs only where a rollback substrate exists; today none does, so a failure is halt-only and the mutation stands until a human reverts it. Empty ⇒ no post-apply gate.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "required": [

--- a/sdk/python/src/rocky_sdk/types_generated/policy_check_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/policy_check_schema.py
@@ -135,11 +135,15 @@ class PolicyModelAttributes(BaseModel):
     """
     downstreams: conint(ge=0)
     """
-    Direct downstream-consumer count (informational; `max_downstreams` is parse-only in v0).
+    Direct downstream-consumer count (models that `depends_on` this one). Informational — the `max_downstreams` ceiling reads [`Self::reachable_downstreams`].
     """
     layer: str | None = None
     """
     Medallion/semantic layer (the model's `layer` tag), if any.
+    """
+    reachable_downstreams: conint(ge=0) | None = None
+    """
+    Transitive downstream reachability — the full blast radius (direct + indirect), excluding the model itself. This is what a rule's `max_downstreams` ceiling is compared against. `null` when the blast radius could not be computed (the ceiling then fails closed).
     """
     tags: dict[str, str]
     """

--- a/sdk/python/src/rocky_sdk/types_generated/rocky_project_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/rocky_project_schema.py
@@ -2065,7 +2065,7 @@ class PolicyRule(BaseModel):
     """
     conditions: Any | None = None
     """
-    Optional v1 conditional refinements. **Parsed and ignored in v0** — captured as opaque JSON so a config authored for v1 still loads.
+    Optional v1 conditional refinements not yet promoted to typed fields (`budget`, `window`). **Parsed and ignored** — captured as opaque JSON so a config authored against a later version still loads.
     """
     effect: PolicyEffect13 | PolicyEffect14 | PolicyEffect15
     """
@@ -2087,6 +2087,10 @@ class PolicyRule(BaseModel):
     )
     """
     The models this rule covers. Defaults to the empty scope, which is *not* `any` — an all-default scope with no `any = true` matches nothing and is rejected at validation.
+    """
+    verify_after: list[str] | None = None
+    """
+    Post-apply verification: named checks that must pass after a mutation governed by this rule lands. Once the apply's run completes, each named check is confirmed against the run's executed checks; a failing **or absent** named check halts the apply (fail closed) and raises an alert. Auto-rollback runs only where a rollback substrate exists; today none does, so a failure is halt-only and the mutation stands until a human reverts it. Empty ⇒ no post-apply gate.
     """
 
 


### PR DESCRIPTION
Two conditional refinements on top of the agent policy plane. Both are additive and default-off: absent any `[policy]` conditions, behavior is byte-identical to today.

## `max_downstreams` — blast-radius ceiling

A policy rule may carry `scope.max_downstreams = N`. It is a post-match condition on the target model's blast radius, not a scope predicate: when the rule's effect is `allow` and the model's transitive downstream reachability is over `N` — or cannot be computed — the matched effect degrades to `require_review`. `deny` and `require_review` rules are unaffected.

It fails closed: an uncomputable blast radius is treated as too large, so a ceiling can never let an `allow` stand for an oversized or unverifiable reach. Reachability is the transitive downstream closure of the compiled graph, surfaced as `reachable_downstreams` on the checked model's attributes and echoed in `rocky policy check`.

Composes with most-restrictive-effect resolution, so a sibling ceilingless `allow` cannot leak an oversized reach through.

## `verify_after` — post-apply check gate

A rule may carry `verify_after = ["check_a", ...]`. When a governed mutation is applied, the named checks are confirmed against the just-completed run once it lands: every named check must be present and passed. A check that failed — or is absent from the run — halts the apply (fail closed) and raises an alert; a passing set proceeds and prints a confirmation. Either outcome writes a verification custody entry to the policy-decision ledger.

Runs now capture per-check pass/fail on the run record, so the gate reads named results without re-executing them. The state schema bumps to add two serde-additive fields (the table set is unchanged; a pre-bump record reads back with both empty).

Auto-rollback runs only where a rollback substrate exists. None does today, so a failed verification is halt-only: the mutation has already landed and stays in place until a human reverts it — stated plainly in the error rather than papered over with a rollback that would not run.

## Tests

- Evaluator: `max_downstreams` within / over / unverifiable → `allow` / `require_review` / `require_review`; degrade composes with most-restrictive resolution so a ceilingless sibling can't leak `allow`.
- `verify_after`: pass, halt-on-failure, fail-closed-on-absent, and no-op; config parsing; schema forward-compatibility.
- Driven end-to-end through the real CLI on the DuckDB playground — `rocky policy check` for the ceiling degrade, and `plan` → `apply` for all three `verify_after` paths (pass, fail-halt, absent-fail-closed) with the custody entries in the ledger.

Codegen cascade run for the `rocky policy check` output field.