### PR TITLE
chore: release engine v1.60.0 + sdk v0.4.0 + dagster v1.57.0 (Wave 9)

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.60.0] - 2026-07-09
+
+### Added
+
+- **`rocky gc --derivable --dry-run` — a reclamation inventory for provably-rebuildable artifacts.** A read-only report that joins the content-addressed artifact ledger with replay-check verdicts, refcounts, and recipe-identity triples to inventory which managed artifacts are *derivable* — recorded with a strong recipe, replayable and deterministic, unreferenced, policy-eligible, and past an age threshold (`--min-age-days`, default 7). Each candidate prints why it is (or isn't) safe to reclaim, and the report headlines the aggregate "X bytes / Y% of managed storage is derivable". This phase has **no deletion path** — every eligibility check fails closed and the command only ever reports. (#1067)
+
+- **`rocky backfill` — a scoped, review-gated recovery plan.** On a failure or gap (a freshness breach, or the withheld window of a contained run via `--from-last-run`; or an explicit `--model`), the engine composes a backfill plan: the affected models plus their downstream lineage closure, ordered dependency-first, scoped to the affected partition window (`--from`/`--to`), with a cost estimate from historical observations. The plan is persisted and emitted as JSON, and is **always review-gated regardless of policy** — a backfill re-runs existing recipes over a scoped window and can hide blast radius, so it always requires a human sign-off (`rocky review <plan> --approve`) before `rocky apply`. It never rewrites SQL. (#1068)
+
+- **Agent-policy v1 conditions — `max_downstreams` blast-radius ceiling and `verify_after` post-apply gate.** A `[[policy.rules]]` rule may now carry `max_downstreams = N`: an `allow` only stands when the target model's *transitive* downstream blast radius is ≤ N; an oversized **or uncomputable** blast radius degrades the allow to `require_review` (fail closed), and the ceiling is a **sticky safety cap** — it cannot be bypassed by a more-specific sibling `allow` that omits it. A rule may also carry `verify_after = ["check", …]`: after an apply mutates, the named checks must have passed in that apply's own run or the apply halts; a check that failed **or did not run** fails the gate. Where no rollback substrate exists the failure is honest halt-only (the mutation stands and must be reverted manually — never a fabricated rollback). State schema bumps to v17 (additive per-check outcomes on the run record + the decision record's `verify_after`; pre-v17 records read back empty). (#1069)
+
+### Fixed
+
+- **Column-level sound-skip now fails closed on an ambiguous case-colliding model key.** The consumer-baseline builder resolves each consumed upstream through a lowercased lookup map keyed by both the bare model name and the 3-part `catalog.schema.table`. The map was built last-writer-wins, so two distinct models whose name or target folds to the same key case-insensitively (for example `Orders` and `orders`) silently aliased — a consumer reading that key could compare the *wrong* producer's column hashes and skip on a genuine content change. An ambiguous key is now poisoned (removed) rather than resolved, so the read yields no column baseline and the gate builds. The per-column skip gate remains default-off (`[reuse] column_level`). (#1066)
+
 ## [1.59.0] - 2026-07-09
 
 ### Added

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "indexmap",
  "reqwest 0.12.28",
@@ -3964,7 +3964,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3981,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4009,7 +4009,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "redis",
  "serde",
@@ -4021,7 +4021,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -4032,7 +4032,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -4116,7 +4116,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4156,7 +4156,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4202,7 +4202,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4220,7 +4220,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4251,7 +4251,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -4289,7 +4289,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "logos",
  "miette",
@@ -4301,7 +4301,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "rocky-server",
  "rustls",
@@ -4310,7 +4310,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4335,7 +4335,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4353,7 +4353,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4382,7 +4382,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -4409,7 +4409,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "miette",
  "regex",
@@ -4422,7 +4422,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4459,7 +4459,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.59.0"
+version = "1.60.0"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.59.0"
+version = "1.60.0"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.59.0"
+version = "1.60.0"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.59.0"
+version = "1.60.0"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.59.0"
+version = "1.60.0"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.59.0"
+version = "1.60.0"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.59.0"
+version = "1.60.0"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.59.0"
+version = "1.60.0"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.59.0"
+version = "1.60.0"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.59.0"
+version = "1.60.0"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.59.0"
+version = "1.60.0"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.59.0"
+version = "1.60.0"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.59.0"
+version = "1.60.0"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.59.0"
+version = "1.60.0"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.59.0"
+version = "1.60.0"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.59.0"
+version = "1.60.0"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.59.0"
+version = "1.60.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.59.0"
+version = "1.60.0"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.59.0"
+version = "1.60.0"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.59.0"
+version = "1.60.0"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.59.0"
+version = "1.60.0"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.59.0"
+version = "1.60.0"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.59.0"
+version = "1.60.0"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.59.0"
+version = "1.60.0"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.59.0"
+version = "1.60.0"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.57.0] — 2026-07-09
+
+### Changed
+
+- **Floor raised to `rocky-sdk>=0.4.0`.** Picks up the SDK's generated types for the new `rocky gc --derivable`, `rocky backfill`, and policy-check surfaces, so a `dagster-rocky` consumer resolves them through `dagster_rocky.types` without relying on latest-SDK resolution. No behavior change in the integration itself.
+
 ## [1.56.0] — 2026-07-09
 
 ### Added

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.56.0"
+version = "1.57.0"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"
@@ -23,7 +23,7 @@ dependencies = [
     # package; RockyResource is a thin Dagster adapter over RockyClient. In-repo
     # dev/CI resolves this from the local path (see [tool.uv.sources]); the
     # published wheel floors on the released SDK.
-    "rocky-sdk>=0.3.1",
+    "rocky-sdk>=0.4.0",
     # Floor matches the version CI actually resolves and tests (uv.lock). The
     # RockyComponent path uses dagster.components.* APIs from preview namespaces,
     # so we advertise a tested floor rather than an older, never-exercised one.

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -220,7 +220,7 @@ wheels = [
 
 [[package]]
 name = "dagster-rocky"
-version = "1.56.0"
+version = "1.57.0"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },
@@ -910,7 +910,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "../../sdk/python" }
 dependencies = [
     { name = "pydantic" },

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-07-09
+
+### Added
+
+- **Generated types for the new CLI surfaces.** `rocky gc --derivable` (`GcReportOutput` + `GcCandidateOutput` / `GcCheckOutput` / `GcRebuildCostOutput`), `rocky backfill` (`BackfillOutput` + `BackfillCostEstimate` / `BackfillModelCost` / `BackfillPartitionScope`), and the new `reachable_downstreams` field on the policy-check model attributes. Additive — existing parses are unaffected.
+
 ## [0.3.1] — 2026-07-09
 
 ### Fixed

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rocky-sdk"
-version = "0.3.1"
+version = "0.4.0"
 description = "Typed Python client for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Triple-cut release of the Wave 9 feature pile.

## Artifacts
- **engine 1.59.0 → 1.60.0** (25 crates lockstep) — `gc --derivable` inventory (#1067), `rocky backfill` (#1068), agent-policy conditions `max_downstreams` + `verify_after` with **state schema v17** (#1069), column-skip ambiguous-key fail-closed fix (#1066).
- **rocky-sdk 0.3.1 → 0.4.0** — generated types for the new gc/backfill/policy-check surfaces (additive).
- **dagster-rocky 1.56.0 → 1.57.0** — floor raised to `rocky-sdk>=0.4.0` (no source change).

vscode not cut (no source change).

## Tag order after merge
sdk-v0.4.0 → (poll PyPI) → dagster-v1.57.0 → engine-v1.60.0 (last, for GitHub Latest).

## Notes
- All feature PRs adversarially verified; #1069's policy conditions had 3 soundness bugs found by a Codex red-team, fixed, and re-red-teamed clean before merge.
- Lockfiles relocked (Cargo.lock 25 members, both uv.locks). Changelogs updated for all three artifacts.