### PR TITLE
chore: release engine v1.61.0

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.61.0] - 2026-07-09
+
 ### Changed
 
 - **Content-addressed column-level skip is now on by default (`[reuse] column_level`).** An unpartitioned content-addressed model whose logic, environment, and every provably-consumed upstream column are unchanged since its last successful build is now **skipped** by default — its SQL does not run and no new commit is written; the prior output stays authoritative. The decision is fail-closed: any unproven input (a non-deterministic model, a changed recipe/env, an un-enumerable consumed set, a missing or moved column hash, or an ambiguous producer-column key) forces a build. This affects **only** the content-addressed materialization path and is inert on the common non-content-addressed run. Set `column_level = false` under `[reuse]` to restore the always-build behavior. The default was flipped after a live S3/UniForm verification of the skip-on-unchanged / build-on-changed decision on a real content-addressed table.

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "indexmap",
  "reqwest 0.12.28",
@@ -3964,7 +3964,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3981,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4009,7 +4009,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "redis",
  "serde",
@@ -4021,7 +4021,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -4032,7 +4032,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -4116,7 +4116,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4156,7 +4156,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4202,7 +4202,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4220,7 +4220,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4251,7 +4251,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -4289,7 +4289,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "logos",
  "miette",
@@ -4301,7 +4301,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "rocky-server",
  "rustls",
@@ -4310,7 +4310,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4335,7 +4335,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4353,7 +4353,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4382,7 +4382,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -4409,7 +4409,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "miette",
  "regex",
@@ -4422,7 +4422,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4459,7 +4459,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.60.0"
+version = "1.61.0"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.60.0"
+version = "1.61.0"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.60.0"
+version = "1.61.0"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.60.0"
+version = "1.61.0"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.60.0"
+version = "1.61.0"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.60.0"
+version = "1.61.0"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.60.0"
+version = "1.61.0"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.60.0"
+version = "1.61.0"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.60.0"
+version = "1.61.0"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.60.0"
+version = "1.61.0"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.60.0"
+version = "1.61.0"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.60.0"
+version = "1.61.0"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.60.0"
+version = "1.61.0"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.60.0"
+version = "1.61.0"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.60.0"
+version = "1.61.0"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.60.0"
+version = "1.61.0"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.60.0"
+version = "1.61.0"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.60.0"
+version = "1.61.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.60.0"
+version = "1.61.0"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.60.0"
+version = "1.61.0"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.60.0"
+version = "1.61.0"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.60.0"
+version = "1.61.0"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.60.0"
+version = "1.61.0"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.60.0"
+version = "1.61.0"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.60.0"
+version = "1.61.0"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.60.0"
+version = "1.61.0"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Engine-only release for the content-addressed column-level-skip default flip (#1071).

- **engine 1.60.0 → 1.61.0** (25 crates lockstep + Cargo.lock relock).
- `[reuse] column_level` now **default-ON** — content-addressed models skip a rebuild when every provably-consumed upstream column is unchanged; fail-closed on any doubt; opt out with `column_level = false`. Flipped after a 3× live S3/UniForm verification.
- sdk/dagster/vscode **not cut** (only the config-schema binding regenerated, no functional change).

Tag `engine-v1.61.0` on the merged commit.