### PR TITLE
feat(engine): policy-gated auto-apply of additive source drift (default-off)

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -14070,6 +14070,11 @@
         "additionalProperties": false,
         "description": "`[resilience]` — the run loop's classified-retry policy.\n\nThis is a **distinct layer** from the per-adapter `[adapter.*.retry]` (which retries individual statements inside a connector) and from the run-level `[retry]` budget ([`RunRetryConfig`], which caps connector retries). `[resilience]` governs whether the run loop re-runs a whole *model* whose materialization failed, classifying the failure via [`crate::failure_class::FailureClass`] and retrying only a *proven* transient one.\n\n# Not default-OFF, but conservative\n\nUnlike the skip / reuse gates, this layer is **on by default** — a model that fails transiently today *will* be retried once this ships. The lever that keeps that safe is [`Self::transient_max_retries`] (default `2`): a small, bounded budget with capped exponential backoff. Set `transient_max_retries = 0` (or `enabled = false`) to restore the prior single-attempt behaviour, e.g. in CI where a fast-fail is preferred.\n\nPermanent and Unknown failures are **never** retried regardless of these settings — that is a property of the classifier, not of this config.",
         "properties": {
+          "auto_apply_additive_drift": {
+            "default": false,
+            "description": "Opt in to policy-governed auto-apply of **additive** source drift. Default `false` — a run detecting a new nullable upstream column evolves the target exactly as it does today (unconditionally), with no policy gate. When `true`, any drift mutation must first clear the policy plane: only a *provably additive* change with an `allow` verdict for the `schema_change.additive` capability is auto-applied; anything else (a drop, retype, narrowing, or a scope without the grant) is refused and left for review rather than mutated. Has no effect unless a `[policy]` block grants the capability, so both the opt-in **and** a policy rule are required to change behaviour.",
+            "type": "boolean"
+          },
           "backoff_multiplier": {
             "default": 2.0,
             "description": "Multiplier applied to the backoff after each retry.",
@@ -14735,6 +14740,7 @@
               }
             ],
             "default": {
+              "auto_apply_additive_drift": false,
               "backoff_multiplier": 2.0,
               "circuit_breaker_threshold": 3,
               "contain_failures": false,

--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -3139,6 +3139,11 @@
       "additionalProperties": false,
       "description": "`[resilience]` — the run loop's classified-retry policy.\n\nThis is a **distinct layer** from the per-adapter `[adapter.*.retry]` (which retries individual statements inside a connector) and from the run-level `[retry]` budget ([`RunRetryConfig`], which caps connector retries). `[resilience]` governs whether the run loop re-runs a whole *model* whose materialization failed, classifying the failure via [`crate::failure_class::FailureClass`] and retrying only a *proven* transient one.\n\n# Not default-OFF, but conservative\n\nUnlike the skip / reuse gates, this layer is **on by default** — a model that fails transiently today *will* be retried once this ships. The lever that keeps that safe is [`Self::transient_max_retries`] (default `2`): a small, bounded budget with capped exponential backoff. Set `transient_max_retries = 0` (or `enabled = false`) to restore the prior single-attempt behaviour, e.g. in CI where a fast-fail is preferred.\n\nPermanent and Unknown failures are **never** retried regardless of these settings — that is a property of the classifier, not of this config.",
       "properties": {
+        "auto_apply_additive_drift": {
+          "default": false,
+          "description": "Opt in to policy-governed auto-apply of **additive** source drift. Default `false` — a run detecting a new nullable upstream column evolves the target exactly as it does today (unconditionally), with no policy gate. When `true`, any drift mutation must first clear the policy plane: only a *provably additive* change with an `allow` verdict for the `schema_change.additive` capability is auto-applied; anything else (a drop, retype, narrowing, or a scope without the grant) is refused and left for review rather than mutated. Has no effect unless a `[policy]` block grants the capability, so both the opt-in **and** a policy rule are required to change behaviour.",
+          "type": "boolean"
+        },
         "backoff_multiplier": {
           "default": 2.0,
           "description": "Multiplier applied to the backoff after each retry.",
@@ -4387,6 +4392,7 @@
         }
       ],
       "default": {
+        "auto_apply_additive_drift": false,
         "backoff_multiplier": 2.0,
         "circuit_breaker_threshold": 3,
         "contain_failures": false,

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -1966,6 +1966,10 @@ export interface PortabilityConfig {
  */
 export interface ResilienceConfig {
   /**
+   * Opt in to policy-governed auto-apply of **additive** source drift. Default `false` — a run detecting a new nullable upstream column evolves the target exactly as it does today (unconditionally), with no policy gate. When `true`, any drift mutation must first clear the policy plane: only a *provably additive* change with an `allow` verdict for the `schema_change.additive` capability is auto-applied; anything else (a drop, retype, narrowing, or a scope without the grant) is refused and left for review rather than mutated. Has no effect unless a `[policy]` block grants the capability, so both the opt-in **and** a policy rule are required to change behaviour.
+   */
+  auto_apply_additive_drift?: boolean;
+  /**
    * Multiplier applied to the backoff after each retry.
    */
   backoff_multiplier?: number;

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -531,6 +531,8 @@ pub fn evaluate_apply_policy(
                 // A plain evaluation row carries no verify_after; the
                 // post-apply verification writes its own custody row.
                 verify_after: Vec::new(),
+                // Ordinary apply/promote evaluation — no auto-apply custody.
+                auto_apply: None,
             };
             if let Err(e) = store.record_policy_decision(&record) {
                 warn!(
@@ -839,6 +841,7 @@ fn run_verify_after(
         rule_id: None,
         reason: reason.clone(),
         verify_after: required.to_vec(),
+        auto_apply: None,
     };
     if let Err(e) = store.record_policy_decision(&record) {
         warn!(

--- a/engine/crates/rocky-cli/src/commands/audit.rs
+++ b/engine/crates/rocky-cli/src/commands/audit.rs
@@ -1055,6 +1055,7 @@ mod tests {
             rule_id: Some(0),
             reason: "test".to_string(),
             verify_after: Vec::new(),
+            auto_apply: None,
         }
     }
 
@@ -1184,6 +1185,7 @@ mod tests {
             rule_id,
             reason: "test".to_string(),
             verify_after: Vec::new(),
+            auto_apply: None,
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/brief.rs
+++ b/engine/crates/rocky-cli/src/commands/brief.rs
@@ -1183,6 +1183,7 @@ mod tests {
             rule_id,
             reason: "test".to_string(),
             verify_after: Vec::new(),
+            auto_apply: None,
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/drift_governance.rs
+++ b/engine/crates/rocky-cli/src/commands/drift_governance.rs
@@ -86,7 +86,24 @@ impl DriftGovernor {
         if !cfg.resilience.auto_apply_additive_drift {
             return None;
         }
-        let policy = cfg.policy.as_ref()?;
+        // The opt-in is on. A missing `[policy]` block grants nothing — but it
+        // must NOT disable governance, or the pre-existing drift path would
+        // mutate UNGOVERNED (fail-open: a breaking retype would silently apply).
+        // Govern with a no-grant, fail-closed posture instead: the effect is
+        // `require_review`, so `is_auto_apply_eligible` refuses every drift until
+        // a `[policy]` rule explicitly grants `schema_change.additive`.
+        let Some(policy) = cfg.policy.as_ref() else {
+            return Some(Self {
+                run_id: run_id.to_string(),
+                effect: PolicyEffect::RequireReview,
+                matched_rule: None,
+                policy_reason:
+                    "auto-apply is enabled but no [policy] block grants schema_change.additive"
+                        .to_string(),
+                verify_after: Vec::new(),
+                contracted: false,
+            });
+        };
         let attrs = ModelAttributes {
             name: model_name.to_string(),
             ..Default::default()
@@ -361,12 +378,149 @@ pub(crate) fn finalize_drift_verify_after(store: Option<&StateStore>, run_id: &s
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rocky_core::config::ResilienceConfig;
     use rocky_core::state::CheckOutcome;
 
     fn temp_store() -> (StateStore, tempfile::TempDir) {
         let dir = tempfile::TempDir::new().unwrap();
         let store = StateStore::open(&dir.path().join("state.redb")).unwrap();
         (store, dir)
+    }
+
+    /// A config with the auto-apply opt-in ON and no `[policy]` block — the
+    /// exact shape the fail-open regression guards.
+    fn cfg_opt_in_no_policy() -> RockyConfig {
+        RockyConfig {
+            state: Default::default(),
+            adapters: Default::default(),
+            pipelines: Default::default(),
+            hooks: Default::default(),
+            cost: Default::default(),
+            budget: Default::default(),
+            schema_evolution: Default::default(),
+            retry: None,
+            portability: Default::default(),
+            cache: Default::default(),
+            mask: Default::default(),
+            classifications: Default::default(),
+            roles: Default::default(),
+            ai: Default::default(),
+            branch: Default::default(),
+            freshness: Default::default(),
+            imports: Default::default(),
+            run: Default::default(),
+            reuse: Default::default(),
+            policy: None,
+            resilience: ResilienceConfig {
+                auto_apply_additive_drift: true,
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn opt_in_without_policy_governs_fail_closed_not_open() {
+        // Codex red-team regression (fail-OPEN → fail-CLOSED): with the opt-in
+        // ON but NO `[policy]` block, `build` must still return a governor with
+        // a no-grant, require-review posture — never `None`. Returning `None`
+        // skipped governance entirely and let the pre-existing drift path mutate
+        // a breaking change ungoverned. Pre-fix, `build` returned `None` and the
+        // `.expect` below panics; post-fix it governs and refuses.
+        let cfg = cfg_opt_in_no_policy();
+        let gov = DriftGovernor::build(&cfg, "run-x", "wh.raw.orders")
+            .expect("opt-in on ⇒ a governor must exist even without a [policy] block");
+        assert_eq!(
+            gov.effect,
+            PolicyEffect::RequireReview,
+            "no [policy] grant ⇒ every drift is refused to require-review"
+        );
+    }
+
+    fn tref() -> rocky_ir::TableRef {
+        rocky_ir::TableRef {
+            catalog: "wh".to_string(),
+            schema: "raw".to_string(),
+            table: "orders".to_string(),
+        }
+    }
+
+    fn additive_add_drift() -> DriftResult {
+        DriftResult {
+            table: tref(),
+            drifted_columns: Vec::new(),
+            action: rocky_ir::DriftAction::Ignore,
+            added_columns: vec![rocky_ir::ColumnInfo {
+                name: "email".to_string(),
+                data_type: "VARCHAR".to_string(),
+                nullable: true,
+            }],
+            grace_period_columns: Vec::new(),
+            columns_to_drop: Vec::new(),
+        }
+    }
+
+    fn breaking_retype_drift() -> DriftResult {
+        DriftResult {
+            table: tref(),
+            drifted_columns: vec![rocky_ir::DriftedColumn {
+                name: "amount".to_string(),
+                source_type: "VARCHAR".to_string(),
+                target_type: "INT".to_string(),
+            }],
+            action: rocky_ir::DriftAction::DropAndRecreate,
+            added_columns: Vec::new(),
+            grace_period_columns: Vec::new(),
+            columns_to_drop: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn no_policy_governor_refuses_every_drift_at_the_run_loop() {
+        // Re-red-team Q5: prove the full fail-closed property end-to-end, not
+        // just that `build` returns a governor. With the opt-in on and no
+        // [policy] block, `govern` must REFUSE every drift the run loop would
+        // otherwise apply — a breaking retype AND a plain additive add (no
+        // grant ⇒ nothing auto-applies) — recording a require-review custody
+        // row and never authorising a mutation.
+        let cfg = cfg_opt_in_no_policy();
+        let gov = DriftGovernor::build(&cfg, "run-x", "wh.raw.orders").expect("governor present");
+        let (store, _d) = temp_store();
+        let state = Mutex::new(store);
+
+        // A breaking retype is refused (fails the additive proof first).
+        let d = gov
+            .govern(&breaking_retype_drift(), "wh.raw.orders", &state)
+            .await;
+        assert!(
+            matches!(d, GovernDecision::Refuse(_)),
+            "a breaking retype must be refused"
+        );
+
+        // A plain additive add is ALSO refused: additive-ness passes, but there
+        // is no policy grant, so `effect != Allow` refuses it too.
+        let d = gov
+            .govern(&additive_add_drift(), "wh.raw.orders", &state)
+            .await;
+        assert!(
+            matches!(d, GovernDecision::Refuse(_)),
+            "an additive add must be refused when no [policy] rule grants it"
+        );
+
+        // Both refusals recorded a require-review custody row; nothing applied.
+        let decisions = state.lock().await.list_policy_decisions().unwrap();
+        assert_eq!(decisions.len(), 2, "one custody row per governed drift");
+        assert!(
+            decisions
+                .iter()
+                .all(|r| r.effect == PolicyEffect::RequireReview),
+            "no-grant refusals record require-review, not allow/deny"
+        );
+        assert!(
+            decisions
+                .iter()
+                .all(|r| r.auto_apply.as_ref().is_some_and(|a| !a.applied)),
+            "nothing was auto-applied"
+        );
     }
 
     fn applied_decision(run_id: &str, model: &str, checks: &[&str]) -> PolicyDecisionRecord {

--- a/engine/crates/rocky-cli/src/commands/drift_governance.rs
+++ b/engine/crates/rocky-cli/src/commands/drift_governance.rs
@@ -1,0 +1,494 @@
+//! Run-loop governance for auto-applying additive source drift.
+//!
+//! Default-off. When `[resilience] auto_apply_additive_drift = true` **and** a
+//! `[policy]` rule grants the `schema_change.additive` capability for a
+//! table's scope, the replication run loop may migrate a target on its own
+//! authority — but only for a *provably additive* change. Every drift
+//! mutation the run would otherwise apply unconditionally is first routed
+//! through [`DriftGovernor::govern`], which:
+//!
+//! 1. converts the detected [`DriftResult`] to typed breaking-change findings,
+//! 2. classifies them and asks [`rocky_core::auto_apply::is_auto_apply_eligible`]
+//!    whether the change is provably additive, contract-clean, and
+//!    policy-allowed,
+//! 3. records a custody entry either way, and
+//! 4. returns [`GovernDecision::Apply`] (proceed with the mutation) or
+//!    [`GovernDecision::Refuse`] (do **not** mutate — the run surfaces a
+//!    require-review failure for that table).
+//!
+//! After the run, [`finalize_drift_verify_after`] runs the post-apply
+//! `verify_after` gate over every table that was auto-migrated: it reads the
+//! run's recorded check outcomes and halts (recording a `deny` custody row) if
+//! a required check failed or did not run. There is no rollback substrate on a
+//! plain warehouse target, so a failed verification is halt-only — the
+//! migration has already landed and stays until a human reverts it.
+
+use anyhow::{Result, bail};
+use tokio::sync::Mutex;
+use tracing::warn;
+
+use rocky_core::auto_apply::{self, RefuseReason};
+use rocky_core::breaking_change::BreakingFinding;
+use rocky_core::config::{PolicyCapability, PolicyEffect, PolicyPrincipal, RockyConfig};
+use rocky_core::policy::{self, ModelAttributes};
+use rocky_core::state::{AutoApplyCustody, PolicyDecisionRecord, StateStore};
+use rocky_ir::DriftResult;
+
+/// The wire spelling of a change-classification capability, for custody rows.
+fn capability_wire(cap: PolicyCapability) -> &'static str {
+    match cap {
+        PolicyCapability::SchemaChangeAdditive => "schema_change.additive",
+        PolicyCapability::SchemaChangeBreaking => "schema_change.breaking",
+        PolicyCapability::ValueChange => "value_change",
+        _ => "apply",
+    }
+}
+
+/// The outcome of governing one detected drift.
+pub(crate) enum GovernDecision {
+    /// Provably additive + policy-allowed — the caller proceeds with the
+    /// mutation exactly as the ungoverned path would.
+    Apply,
+    /// Not eligible — the caller must **not** mutate. The string is an
+    /// operator-facing reason; the run surfaces it as a require-review failure.
+    Refuse(String),
+}
+
+/// Per-table governor for additive-drift auto-apply, built once per table when
+/// the opt-in is set. Carries the policy verdict for `schema_change.additive`
+/// on that table's scope so [`Self::govern`] can combine it with the actual
+/// detected drift.
+///
+/// Present on a [`TableTask`](super::run) only when both the config opt-in and
+/// a `[policy]` block are configured; absent it, the drift path is untouched
+/// and byte-identical to today.
+#[derive(Debug, Clone)]
+pub(crate) struct DriftGovernor {
+    run_id: String,
+    effect: PolicyEffect,
+    matched_rule: Option<usize>,
+    policy_reason: String,
+    verify_after: Vec<String>,
+    contracted: bool,
+}
+
+impl DriftGovernor {
+    /// Build the governor for one table, or `None` when auto-apply is not
+    /// enabled for this run (the flag is off or no `[policy]` block exists).
+    ///
+    /// A replication (bronze) target is not a compiled model, so it is
+    /// evaluated against a bare-named [`ModelAttributes`] — the policy scope
+    /// matches on the table name, tags/classifications/layer are empty, and
+    /// the blast radius is uncomputable (a `max_downstreams` ceiling therefore
+    /// fails closed inside the evaluator). `contracted` is `false`: the
+    /// bronze layer sits behind no contract.
+    pub(crate) fn build(cfg: &RockyConfig, run_id: &str, model_name: &str) -> Option<Self> {
+        if !cfg.resilience.auto_apply_additive_drift {
+            return None;
+        }
+        let policy = cfg.policy.as_ref()?;
+        let attrs = ModelAttributes {
+            name: model_name.to_string(),
+            ..Default::default()
+        };
+        let decision = policy::evaluate(
+            policy,
+            PolicyPrincipal::Agent,
+            PolicyCapability::SchemaChangeAdditive,
+            &attrs,
+        );
+        let verify_after = decision
+            .matched_rule
+            .and_then(|i| policy.rules.get(i))
+            .map(|r| r.verify_after.clone())
+            .unwrap_or_default();
+        Some(Self {
+            run_id: run_id.to_string(),
+            effect: decision.effect,
+            matched_rule: decision.matched_rule,
+            policy_reason: decision.reason,
+            verify_after,
+            contracted: false,
+        })
+    }
+
+    /// Govern one detected drift: classify, decide, and record custody.
+    ///
+    /// `model` is the fully-qualified target name the custody row is attributed
+    /// to. Writes exactly one decision row (applied or refused) via the shared
+    /// state store, then returns the decision. Fail-closed: anything not
+    /// provably additive+allowed is a [`GovernDecision::Refuse`].
+    pub(crate) async fn govern(
+        &self,
+        drift: &DriftResult,
+        model: &str,
+        state: &Mutex<StateStore>,
+    ) -> GovernDecision {
+        let findings = auto_apply::drift_findings(drift, model);
+        let refs: Vec<&BreakingFinding> = findings.iter().collect();
+        let classification = policy::classify_model_findings(&refs);
+        let verdict = auto_apply::is_auto_apply_eligible(
+            &findings,
+            classification,
+            self.effect,
+            self.contracted,
+        );
+        let applied = verdict.is_apply();
+        let summary = auto_apply::drift_summary(drift);
+
+        let (effect, reason) = if applied {
+            (
+                PolicyEffect::Allow,
+                format!(
+                    "auto-applied additive drift on '{model}' ({summary}); {}",
+                    self.policy_reason
+                ),
+            )
+        } else {
+            let detail = verdict
+                .refuse_reason()
+                .map(RefuseReason::to_string)
+                .unwrap_or_default();
+            // A hard `deny` is preserved; every other refusal is a
+            // require-review fallback (fail-safe, never a silent apply).
+            let effect = match verdict.refuse_reason() {
+                Some(RefuseReason::PolicyNotAllow(PolicyEffect::Deny)) => PolicyEffect::Deny,
+                _ => PolicyEffect::RequireReview,
+            };
+            (
+                effect,
+                format!("auto-apply of drift on '{model}' refused: {detail} ({summary})"),
+            )
+        };
+
+        let record = PolicyDecisionRecord {
+            timestamp: chrono::Utc::now(),
+            plan_id: decision_plan_id(&self.run_id),
+            principal: PolicyPrincipal::Agent,
+            capability: PolicyCapability::SchemaChangeAdditive,
+            model: model.to_string(),
+            effect,
+            rule_id: self.matched_rule,
+            reason: reason.clone(),
+            // The applied row carries the checks the post-run gate must
+            // confirm; a refused row applied nothing, so it carries none.
+            verify_after: if applied {
+                self.verify_after.clone()
+            } else {
+                Vec::new()
+            },
+            auto_apply: Some(AutoApplyCustody {
+                drift_summary: summary,
+                classification: capability_wire(classification).to_string(),
+                applied,
+                // No rollback substrate on a plain warehouse target — a failed
+                // verification is halt-only. A content-addressed / Iceberg
+                // target would capture a snapshot pointer here (see
+                // `revert_pointer_for`); that path is object-store-only and not
+                // reachable on this drive.
+                revert_pointer: revert_pointer_for(),
+            }),
+        };
+        {
+            let guard = state.lock().await;
+            if let Err(e) = guard.record_policy_decision(&record) {
+                warn!(
+                    target: "rocky::policy",
+                    error = %e,
+                    model,
+                    "failed to record auto-apply custody entry (continuing)"
+                );
+            }
+        }
+
+        if applied {
+            GovernDecision::Apply
+        } else {
+            GovernDecision::Refuse(reason)
+        }
+    }
+}
+
+/// The revert pointer captured before an auto-applied migration, when a
+/// rollback substrate exists.
+///
+/// A content-addressed / Iceberg target would return the current snapshot
+/// pointer so a failed `verify_after` could restore it with a metadata-only
+/// pointer swap. The replication drift path mutates a plain warehouse table
+/// (`ALTER TABLE ADD COLUMN`) with no such substrate, so this is always
+/// `None` here and a failed verification is halt-only. Kept as a seam so the
+/// substrate-present path can fill it in without reshaping the custody record.
+fn revert_pointer_for() -> Option<String> {
+    None
+}
+
+/// The `plan_id` under which this run's auto-apply *decision* rows are filed.
+fn decision_plan_id(run_id: &str) -> String {
+    format!("autoapply:{run_id}")
+}
+
+/// The `plan_id` under which this run's post-apply *verification* rows are
+/// filed (kept distinct from the decision rows so a re-scan never confuses
+/// the two).
+fn verify_plan_id(run_id: &str) -> String {
+    format!("autoapply-verify:{run_id}")
+}
+
+/// Run the post-apply `verify_after` gate over every table this run
+/// auto-migrated.
+///
+/// Reads the run's recorded [`check_outcomes`](rocky_core::state::RunRecord)
+/// — the same pass/fail the two-step `rocky apply` gate reads — and, for each
+/// applied auto-heal that required named checks, confirms every required check
+/// ran and passed. Duplicate check names (a per-table check emitted once per
+/// table) are AND-aggregated, so a required check passes only if every
+/// occurrence passed. Records an `allow`/`deny` verification custody row per
+/// table and returns `Err` (halting the run) when any required check failed or
+/// was absent — the migration already landed and, with no rollback substrate,
+/// stays in place until a human reverts it.
+///
+/// A no-op when the store is unavailable or nothing was auto-applied.
+pub(crate) fn finalize_drift_verify_after(store: Option<&StateStore>, run_id: &str) -> Result<()> {
+    let Some(store) = store else {
+        return Ok(());
+    };
+    let Ok(decisions) = store.list_policy_decisions() else {
+        return Ok(());
+    };
+    let decision_plan = decision_plan_id(run_id);
+    let healed: Vec<&PolicyDecisionRecord> = decisions
+        .iter()
+        .filter(|d| {
+            d.plan_id == decision_plan
+                && d.auto_apply.as_ref().is_some_and(|a| a.applied)
+                && !d.verify_after.is_empty()
+        })
+        .collect();
+    if healed.is_empty() {
+        return Ok(());
+    }
+
+    // AND-aggregate this run's recorded check outcomes by name. A run recorded
+    // under this id must exist (the finalizer runs after `record_run`); an
+    // absent run leaves the map empty ⇒ every required check reads as "absent"
+    // ⇒ fail closed.
+    let outcomes = match store.get_run(run_id) {
+        Ok(Some(record)) => {
+            let mut map: std::collections::BTreeMap<&str, bool> = std::collections::BTreeMap::new();
+            for c in &record.check_outcomes {
+                map.entry(c.name.as_str())
+                    .and_modify(|p| *p &= c.passed)
+                    .or_insert(c.passed);
+            }
+            map.into_iter()
+                .map(|(k, v)| (k.to_string(), v))
+                .collect::<std::collections::BTreeMap<String, bool>>()
+        }
+        _ => std::collections::BTreeMap::new(),
+    };
+
+    let verify_plan = verify_plan_id(run_id);
+    let mut halted: Vec<String> = Vec::new();
+    for d in healed {
+        let mut failures: Vec<String> = Vec::new();
+        for name in &d.verify_after {
+            match outcomes.get(name) {
+                Some(true) => {}
+                Some(false) => failures.push(format!("{name} (failed)")),
+                None => failures.push(format!("{name} (absent — did not run)")),
+            }
+        }
+        let passed = failures.is_empty();
+        let reason = if passed {
+            format!(
+                "verify_after passed for auto-applied drift on '{}': [{}]",
+                d.model,
+                d.verify_after.join(", ")
+            )
+        } else {
+            format!(
+                "verify_after FAILED for auto-applied drift on '{}': {}. No rollback substrate — \
+                 the migration stands; halt-only.",
+                d.model,
+                failures.join("; ")
+            )
+        };
+        let record = PolicyDecisionRecord {
+            timestamp: chrono::Utc::now(),
+            plan_id: verify_plan.clone(),
+            principal: PolicyPrincipal::Agent,
+            capability: PolicyCapability::SchemaChangeAdditive,
+            model: d.model.clone(),
+            effect: if passed {
+                PolicyEffect::Allow
+            } else {
+                PolicyEffect::Deny
+            },
+            rule_id: None,
+            reason: reason.clone(),
+            verify_after: d.verify_after.clone(),
+            auto_apply: d.auto_apply.clone(),
+        };
+        if let Err(e) = store.record_policy_decision(&record) {
+            warn!(
+                target: "rocky::policy",
+                error = %e,
+                "failed to record verify_after custody entry (continuing)"
+            );
+        }
+        if !passed {
+            warn!(
+                target: "rocky::policy",
+                model = %d.model,
+                failures = %failures.join("; "),
+                "verify_after post-apply gate FAILED for auto-applied drift"
+            );
+            halted.push(reason);
+        }
+    }
+
+    if !halted.is_empty() {
+        bail!(
+            "verify_after gate FAILED after auto-applying additive drift: {}. The migration(s) \
+             already landed and remain in place (no rollback substrate on this backend); revert \
+             manually. The failure is recorded in the policy-decision ledger.",
+            halted.join("; ")
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rocky_core::state::CheckOutcome;
+
+    fn temp_store() -> (StateStore, tempfile::TempDir) {
+        let dir = tempfile::TempDir::new().unwrap();
+        let store = StateStore::open(&dir.path().join("state.redb")).unwrap();
+        (store, dir)
+    }
+
+    fn applied_decision(run_id: &str, model: &str, checks: &[&str]) -> PolicyDecisionRecord {
+        PolicyDecisionRecord {
+            timestamp: chrono::Utc::now(),
+            plan_id: decision_plan_id(run_id),
+            principal: PolicyPrincipal::Agent,
+            capability: PolicyCapability::SchemaChangeAdditive,
+            model: model.to_string(),
+            effect: PolicyEffect::Allow,
+            rule_id: Some(0),
+            reason: "auto-applied".to_string(),
+            verify_after: checks.iter().map(ToString::to_string).collect(),
+            auto_apply: Some(AutoApplyCustody {
+                drift_summary: "added nullable column 'email' (VARCHAR)".to_string(),
+                classification: "schema_change.additive".to_string(),
+                applied: true,
+                revert_pointer: None,
+            }),
+        }
+    }
+
+    fn run_with_checks(run_id: &str, checks: &[(&str, bool)]) -> rocky_core::state::RunRecord {
+        rocky_core::state::RunRecord {
+            run_id: run_id.to_string(),
+            started_at: chrono::Utc::now(),
+            finished_at: chrono::Utc::now(),
+            status: rocky_core::state::RunStatus::Success,
+            models_executed: Vec::new(),
+            trigger: rocky_core::state::RunTrigger::Manual,
+            config_hash: String::new(),
+            triggering_identity: None,
+            session_source: rocky_core::state::SessionSource::Cli,
+            git_commit: None,
+            git_branch: None,
+            idempotency_key: None,
+            target_catalog: None,
+            hostname: "test".to_string(),
+            rocky_version: "test".to_string(),
+            check_outcomes: checks
+                .iter()
+                .map(|(n, p)| CheckOutcome {
+                    name: n.to_string(),
+                    passed: *p,
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn no_auto_heals_is_ok() {
+        let (store, _d) = temp_store();
+        assert!(finalize_drift_verify_after(Some(&store), "run-1").is_ok());
+    }
+
+    #[test]
+    fn passing_verify_after_records_allow_and_succeeds() {
+        let (store, _d) = temp_store();
+        store
+            .record_policy_decision(&applied_decision("run-1", "wh.raw.orders", &["row_count"]))
+            .unwrap();
+        store
+            .record_run(&run_with_checks("run-1", &[("row_count", true)]))
+            .unwrap();
+        assert!(finalize_drift_verify_after(Some(&store), "run-1").is_ok());
+        // A verification custody row was written with effect=allow.
+        let all = store.list_policy_decisions().unwrap();
+        let verify = verify_plan_id("run-1");
+        let v = all
+            .iter()
+            .find(|d| d.plan_id == verify)
+            .expect("verify row");
+        assert_eq!(v.effect, PolicyEffect::Allow);
+    }
+
+    #[test]
+    fn failing_verify_after_halts_and_records_deny() {
+        let (store, _d) = temp_store();
+        store
+            .record_policy_decision(&applied_decision("run-2", "wh.raw.orders", &["row_count"]))
+            .unwrap();
+        store
+            .record_run(&run_with_checks("run-2", &[("row_count", false)]))
+            .unwrap();
+        let err = finalize_drift_verify_after(Some(&store), "run-2").unwrap_err();
+        assert!(
+            err.to_string().contains("verify_after gate FAILED"),
+            "{err}"
+        );
+        let all = store.list_policy_decisions().unwrap();
+        let verify = verify_plan_id("run-2");
+        let v = all
+            .iter()
+            .find(|d| d.plan_id == verify)
+            .expect("verify row");
+        assert_eq!(v.effect, PolicyEffect::Deny);
+    }
+
+    #[test]
+    fn absent_required_check_halts() {
+        // The required check never ran ⇒ fail closed (halt).
+        let (store, _d) = temp_store();
+        store
+            .record_policy_decision(&applied_decision("run-3", "wh.raw.orders", &["row_count"]))
+            .unwrap();
+        store.record_run(&run_with_checks("run-3", &[])).unwrap();
+        assert!(finalize_drift_verify_after(Some(&store), "run-3").is_err());
+    }
+
+    #[test]
+    fn duplicate_check_names_and_aggregate() {
+        // Same check emitted twice, one failing ⇒ the name fails (AND).
+        let (store, _d) = temp_store();
+        store
+            .record_policy_decision(&applied_decision("run-4", "wh.raw.orders", &["row_count"]))
+            .unwrap();
+        store
+            .record_run(&run_with_checks(
+                "run-4",
+                &[("row_count", true), ("row_count", false)],
+            ))
+            .unwrap();
+        assert!(finalize_drift_verify_after(Some(&store), "run-4").is_err());
+    }
+}

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -25,6 +25,7 @@ mod dag;
 mod discover;
 mod docs;
 mod doctor;
+mod drift_governance;
 mod emit_sql;
 mod estimate;
 mod export_openapi;

--- a/engine/crates/rocky-cli/src/commands/policy.rs
+++ b/engine/crates/rocky-cli/src/commands/policy.rs
@@ -364,6 +364,9 @@ pub fn run_policy_freeze(
             rule_id: None,
             reason: reason.clone(),
             verify_after: Vec::new(),
+            // A freeze/unfreeze is a policy-change decision, not a drift
+            // auto-apply, so it carries no auto-apply custody.
+            auto_apply: None,
         };
         store
             .record_policy_decision(&record)

--- a/engine/crates/rocky-cli/src/commands/review.rs
+++ b/engine/crates/rocky-cli/src/commands/review.rs
@@ -664,6 +664,7 @@ mod tests {
             rule_id: None,
             reason: "test".to_string(),
             verify_after: Vec::new(),
+            auto_apply: None,
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -298,6 +298,11 @@ struct TableTask {
     /// strategy so per-table overrides apply ahead of pipeline-level
     /// defaults.
     effective_override: ResolvedTableOverride,
+    /// Policy-governed additive-drift auto-apply gate for this table.
+    /// `Some` only when `[resilience] auto_apply_additive_drift` is set and a
+    /// `[policy]` block is configured; `None` otherwise, in which case the
+    /// drift path runs unconditionally exactly as before (default-off).
+    auto_apply_gate: Option<super::drift_governance::DriftGovernor>,
 }
 
 /// CLI selection state for `time_interval` partition execution.
@@ -2147,6 +2152,14 @@ pub async fn run(
                     prefetched_source_cols: None,
                     prefetched_target_cols: None,
                     effective_override,
+                    // Default-off: `None` unless the opt-in + a `[policy]`
+                    // block are both configured. Scoped by the logical table
+                    // name so a `[policy]` rule can target `models = [...]`.
+                    auto_apply_gate: super::drift_governance::DriftGovernor::build(
+                        &rocky_cfg,
+                        &run_id,
+                        &table.name,
+                    ),
                 });
             }
             if skipped_source_missing > 0 {
@@ -4081,6 +4094,16 @@ pub async fn run(
     )
     .await;
 
+    // Post-apply `verify_after` gate for any additive drift this run
+    // auto-applied. Writes an allow/deny verification custody row per healed
+    // table and yields `Err` when a required check failed or did not run —
+    // propagated at the happy-path exit so an otherwise-green run halts. There
+    // is no rollback substrate on a plain warehouse target, so a failed
+    // verification is halt-only: the migration stands until a human reverts it.
+    // A no-op when nothing was auto-applied (default-off runs never hit it).
+    let verify_after_result =
+        super::drift_governance::finalize_drift_verify_after(state_store.as_ref(), &run_id);
+
     // Fire the `on_budget_breach` hook for each recorded breach so
     // shell hooks / webhooks configured via `[hook.on_budget_breach]`
     // see the breach alongside the bus event.
@@ -4211,6 +4234,10 @@ pub async fn run(
     // drained, so subscribers see the breach event before the CLI
     // exits non-zero.
     budget_result?;
+
+    // Halt an otherwise-green run when a post-apply `verify_after` gate on an
+    // auto-applied additive migration failed (custody already recorded above).
+    verify_after_result?;
 
         Ok(())
     }
@@ -7813,6 +7840,35 @@ async fn process_table(
 
     if target_exists {
         let drift_result = drift::detect_drift(&target_table, &source_cols, &target_cols, dialect);
+
+        // Governed additive-drift auto-apply (default-off). When the opt-in +
+        // a `[policy]` grant are configured (`task.auto_apply_gate` is `Some`),
+        // any drift mutation the branches below would apply is first routed
+        // through the policy plane: only a provably additive, policy-allowed
+        // change proceeds; anything else is refused here and surfaced as a
+        // require-review failure for this table — the target is left untouched.
+        // Absent the gate this is skipped entirely and behaviour is identical.
+        if let Some(gate) = &task.auto_apply_gate {
+            let would_mutate = drift_result.action != DriftAction::Ignore
+                || !drift_result.added_columns.is_empty();
+            if would_mutate {
+                match gate
+                    .govern(&drift_result, &target_table.full_name(), state)
+                    .await
+                {
+                    super::drift_governance::GovernDecision::Apply => {}
+                    super::drift_governance::GovernDecision::Refuse(reason) => {
+                        anyhow::bail!(
+                            "additive-drift auto-apply refused for {}: {reason}. The target was \
+                             NOT modified — grant `schema_change.additive` for this scope to \
+                             auto-apply it, or apply the migration under review.",
+                            target_table.full_name()
+                        );
+                    }
+                }
+            }
+        }
+
         if drift_result.action == DriftAction::DropAndRecreate {
             info!(
                 table = target_table.full_name(),

--- a/engine/crates/rocky-core/src/auto_apply.rs
+++ b/engine/crates/rocky-core/src/auto_apply.rs
@@ -1,0 +1,649 @@
+//! Eligibility gate for policy-governed auto-apply of additive source drift.
+//!
+//! When an upstream source gains a new nullable column, the run loop can
+//! migrate the target table (an `ALTER TABLE ADD COLUMN`) on its own — but
+//! *only* when the change is provably additive and a policy rule grants the
+//! `schema_change.additive` capability for that scope. This module owns the
+//! single predicate that decides whether a detected drift may be applied
+//! automatically, and it is deliberately the **only** place that answer is
+//! computed.
+//!
+//! # The one dangerous direction
+//!
+//! A breaking change misclassified as additive and auto-applied is a silent
+//! downstream break. So [`is_auto_apply_eligible`] fails closed at every gate:
+//! it returns [`AutoApplyVerdict::Apply`] only when *all* of the following
+//! hold, and [`AutoApplyVerdict::Refuse`] otherwise (⇒ fall back to
+//! propose / require-review):
+//!
+//! 1. The diff is non-empty (an empty diff cannot *prove* additive).
+//! 2. Every finding is a nullable column addition or a new model — proven
+//!    from the diff itself, independent of the caller-supplied
+//!    classification, so a wrong classification can never let a drop / retype
+//!    / narrowing through.
+//! 3. The classification is [`PolicyCapability::SchemaChangeAdditive`]
+//!    (defence in depth — it is derived from the same findings).
+//! 4. The model does not sit behind a contract (a contract boundary is never
+//!    crossed automatically).
+//! 5. The policy verdict for `schema_change.additive` is
+//!    [`PolicyEffect::Allow`].
+//!
+//! A false rebuild costs compute; a false auto-apply costs correctness — so
+//! anything not provably additive stays behind review.
+
+use std::fmt;
+
+use rocky_ir::{DriftAction, DriftResult};
+
+use crate::breaking_change::{BreakingChange, BreakingFinding, BreakingSeverity};
+use crate::config::{PolicyCapability, PolicyEffect};
+
+/// Why a detected drift was refused for auto-apply. Each variant is a
+/// fail-closed exit from [`is_auto_apply_eligible`]; the display string is
+/// suitable for an operator-facing message and for the custody ledger.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RefuseReason {
+    /// The diff was empty — additive-ness cannot be proven, so refuse.
+    NoFindings,
+    /// At least one finding is not a nullable column addition or a new model
+    /// (e.g. a dropped, retyped, narrowed, or non-null column) — not additive.
+    NotAdditive,
+    /// The change classification was not `schema_change.additive`.
+    ClassificationNotAdditive(PolicyCapability),
+    /// The model sits behind a contract; a contract boundary is never crossed
+    /// automatically.
+    ContractBoundary,
+    /// The policy verdict for `schema_change.additive` was not `allow`.
+    PolicyNotAllow(PolicyEffect),
+}
+
+impl fmt::Display for RefuseReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RefuseReason::NoFindings => {
+                write!(
+                    f,
+                    "no schema-diff findings — additive change cannot be proven"
+                )
+            }
+            RefuseReason::NotAdditive => write!(
+                f,
+                "drift is not provably additive (a drop, retype, narrowing, or non-null \
+                 addition was present)"
+            ),
+            RefuseReason::ClassificationNotAdditive(cap) => {
+                write!(
+                    f,
+                    "change classified as {cap:?}, not schema_change.additive"
+                )
+            }
+            RefuseReason::ContractBoundary => {
+                write!(
+                    f,
+                    "model is behind a contract — a contract boundary is not crossed automatically"
+                )
+            }
+            RefuseReason::PolicyNotAllow(effect) => {
+                write!(
+                    f,
+                    "policy resolved schema_change.additive to {effect:?}, not allow"
+                )
+            }
+        }
+    }
+}
+
+/// The resolved decision for a detected drift.
+///
+/// [`Apply`](AutoApplyVerdict::Apply) is the *only* value that authorises an
+/// automatic warehouse mutation; every other outcome is a
+/// [`Refuse`](AutoApplyVerdict::Refuse) carrying the fail-closed reason.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AutoApplyVerdict {
+    /// Provably additive, contract-clean, and policy-allowed — auto-apply may
+    /// proceed.
+    Apply,
+    /// Not eligible for auto-apply; fall back to propose / require-review.
+    Refuse(RefuseReason),
+}
+
+impl AutoApplyVerdict {
+    /// `true` only for [`AutoApplyVerdict::Apply`].
+    pub fn is_apply(&self) -> bool {
+        matches!(self, AutoApplyVerdict::Apply)
+    }
+
+    /// The refusal reason, or `None` when the verdict is `Apply`.
+    pub fn refuse_reason(&self) -> Option<&RefuseReason> {
+        match self {
+            AutoApplyVerdict::Apply => None,
+            AutoApplyVerdict::Refuse(r) => Some(r),
+        }
+    }
+}
+
+/// Decide whether a detected schema drift may be auto-applied.
+///
+/// This is the soundness surface for governed auto-apply. It fails closed:
+/// the caller-supplied `classification` and `effect` are *necessary* but never
+/// *sufficient* — additive-ness is re-proven from `findings` here, so a
+/// mislabelled breaking diff can never be applied even if `classification`
+/// says additive and `effect` says allow.
+///
+/// See the module docs for the full gate ordering.
+pub fn is_auto_apply_eligible(
+    findings: &[BreakingFinding],
+    classification: PolicyCapability,
+    effect: PolicyEffect,
+    contracted: bool,
+) -> AutoApplyVerdict {
+    // 1. An empty diff cannot prove an additive change.
+    if findings.is_empty() {
+        return AutoApplyVerdict::Refuse(RefuseReason::NoFindings);
+    }
+    // 2. Prove additive-ness from the diff itself, before trusting any label.
+    if !findings.iter().all(is_additive_finding) {
+        return AutoApplyVerdict::Refuse(RefuseReason::NotAdditive);
+    }
+    // 3. The classification must agree (defence in depth).
+    if classification != PolicyCapability::SchemaChangeAdditive {
+        return AutoApplyVerdict::Refuse(RefuseReason::ClassificationNotAdditive(classification));
+    }
+    // 4. Never cross a contract boundary automatically.
+    if contracted {
+        return AutoApplyVerdict::Refuse(RefuseReason::ContractBoundary);
+    }
+    // 5. Policy must grant the additive capability.
+    if effect != PolicyEffect::Allow {
+        return AutoApplyVerdict::Refuse(RefuseReason::PolicyNotAllow(effect));
+    }
+    AutoApplyVerdict::Apply
+}
+
+/// A single finding is additive iff it is a *nullable* column addition or a
+/// brand-new model — and its severity is [`BreakingSeverity::Info`]. A
+/// non-null addition (a `Warning`) is not safe to apply blind (it needs a
+/// default for existing rows), and every other change kind is non-additive.
+fn is_additive_finding(finding: &BreakingFinding) -> bool {
+    finding.severity == BreakingSeverity::Info
+        && matches!(
+            finding.change,
+            BreakingChange::ColumnAdded { nullable: true, .. } | BreakingChange::ModelAdded { .. }
+        )
+}
+
+/// Translate a detected [`DriftResult`] into the typed
+/// [`BreakingFinding`]s the classifier and the eligibility gate consume, so
+/// source→target replication drift is judged by the exact same machinery as
+/// a model-level `ci-diff`.
+///
+/// Every non-additive aspect of the drift is surfaced as a non-additive
+/// finding, so a diff that reaches [`is_auto_apply_eligible`] all-additive is
+/// genuinely a pure addition:
+///
+/// - `added_columns` → [`BreakingChange::ColumnAdded`] (additive only when
+///   nullable).
+/// - `drifted_columns` (type changes) → [`BreakingChange::ColumnTypeChanged`],
+///   always `Breaking`: a type change is never additive, and without the
+///   typed IR here we fail closed rather than guess a safe widening.
+/// - `columns_to_drop` and `grace_period_columns` (source-side removals) →
+///   [`BreakingChange::ColumnDropped`], `Breaking`.
+///
+/// `model` is the identifier the findings are attributed to (the target
+/// table's name); it only labels the findings.
+pub fn drift_findings(drift: &DriftResult, model: &str) -> Vec<BreakingFinding> {
+    let mut findings = Vec::new();
+
+    for col in &drift.added_columns {
+        let severity = if col.nullable {
+            BreakingSeverity::Info
+        } else {
+            BreakingSeverity::Warning
+        };
+        findings.push(BreakingFinding {
+            change: BreakingChange::ColumnAdded {
+                model: model.to_string(),
+                column: col.name.clone(),
+                data_type: col.data_type.clone(),
+                nullable: col.nullable,
+            },
+            severity,
+        });
+    }
+
+    for col in &drift.drifted_columns {
+        findings.push(BreakingFinding {
+            change: BreakingChange::ColumnTypeChanged {
+                model: model.to_string(),
+                column: col.name.clone(),
+                old_type: col.target_type.clone(),
+                new_type: col.source_type.clone(),
+                // No typed IR at the replication boundary — treat any type
+                // change as the more-severe narrowing so it can never be
+                // mistaken for additive.
+                narrowing: true,
+            },
+            severity: BreakingSeverity::Breaking,
+        });
+    }
+
+    for col in &drift.columns_to_drop {
+        findings.push(BreakingFinding {
+            change: BreakingChange::ColumnDropped {
+                model: model.to_string(),
+                column: col.to_string(),
+                data_type: String::new(),
+            },
+            severity: BreakingSeverity::Breaking,
+        });
+    }
+
+    for col in &drift.grace_period_columns {
+        findings.push(BreakingFinding {
+            change: BreakingChange::ColumnDropped {
+                model: model.to_string(),
+                column: col.name.clone(),
+                data_type: col.data_type.clone(),
+            },
+            severity: BreakingSeverity::Breaking,
+        });
+    }
+
+    findings
+}
+
+/// A one-line, human-readable summary of what a drift would change, for the
+/// custody ledger and operator messages. Names the additive columns first,
+/// then any non-additive aspects.
+pub fn drift_summary(drift: &DriftResult) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    for col in &drift.added_columns {
+        let nullness = if col.nullable { "nullable" } else { "not-null" };
+        parts.push(format!(
+            "added {nullness} column '{}' ({})",
+            col.name, col.data_type
+        ));
+    }
+    for col in &drift.drifted_columns {
+        parts.push(format!(
+            "column '{}' type {} → {}",
+            col.name, col.target_type, col.source_type
+        ));
+    }
+    for col in &drift.columns_to_drop {
+        parts.push(format!("dropped column '{col}'"));
+    }
+    for col in &drift.grace_period_columns {
+        parts.push(format!("source removed column '{}' (grace)", col.name));
+    }
+    if matches!(drift.action, DriftAction::DropAndRecreate) && parts.is_empty() {
+        parts.push("incompatible change requiring drop-and-recreate".to_string());
+    }
+    if parts.is_empty() {
+        "no schema change".to_string()
+    } else {
+        parts.join("; ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rocky_ir::{ColumnInfo, DriftAction, DriftResult, DriftedColumn, TableRef};
+
+    fn tref() -> TableRef {
+        TableRef {
+            catalog: "wh".to_string(),
+            schema: "raw".to_string(),
+            table: "orders".to_string(),
+        }
+    }
+
+    fn added_col_drift(name: &str, ty: &str, nullable: bool) -> DriftResult {
+        DriftResult {
+            table: tref(),
+            drifted_columns: Vec::new(),
+            action: DriftAction::Ignore,
+            added_columns: vec![ColumnInfo {
+                name: name.to_string(),
+                data_type: ty.to_string(),
+                nullable,
+            }],
+            grace_period_columns: Vec::new(),
+            columns_to_drop: Vec::new(),
+        }
+    }
+
+    fn retype_drift() -> DriftResult {
+        DriftResult {
+            table: tref(),
+            drifted_columns: vec![DriftedColumn {
+                name: "amount".to_string(),
+                source_type: "INT".to_string(),
+                target_type: "BIGINT".to_string(),
+            }],
+            action: DriftAction::DropAndRecreate,
+            added_columns: Vec::new(),
+            grace_period_columns: Vec::new(),
+            columns_to_drop: Vec::new(),
+        }
+    }
+
+    // ---- drift_findings mapping ----
+
+    #[test]
+    fn added_nullable_column_maps_to_info_additive() {
+        let f = drift_findings(&added_col_drift("email", "VARCHAR", true), "orders");
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].severity, BreakingSeverity::Info);
+        assert!(is_additive_finding(&f[0]));
+    }
+
+    #[test]
+    fn added_not_null_column_maps_to_warning_not_additive() {
+        let f = drift_findings(&added_col_drift("email", "VARCHAR", false), "orders");
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].severity, BreakingSeverity::Warning);
+        assert!(!is_additive_finding(&f[0]));
+    }
+
+    #[test]
+    fn type_change_maps_to_breaking() {
+        let f = drift_findings(&retype_drift(), "orders");
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].severity, BreakingSeverity::Breaking);
+        assert!(matches!(
+            f[0].change,
+            BreakingChange::ColumnTypeChanged {
+                narrowing: true,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn columns_to_drop_map_to_breaking_drops() {
+        let mut d = added_col_drift("email", "VARCHAR", true);
+        d.columns_to_drop = vec![std::sync::Arc::from("legacy")];
+        let f = drift_findings(&d, "orders");
+        // one additive add + one breaking drop
+        assert_eq!(f.len(), 2);
+        assert!(
+            f.iter()
+                .any(|x| matches!(x.change, BreakingChange::ColumnDropped { .. })
+                    && x.severity == BreakingSeverity::Breaking)
+        );
+    }
+
+    // ---- the soundness predicate ----
+
+    fn additive() -> Vec<BreakingFinding> {
+        drift_findings(&added_col_drift("email", "VARCHAR", true), "orders")
+    }
+
+    #[test]
+    fn pure_additive_allowed_is_apply() {
+        let v = is_auto_apply_eligible(
+            &additive(),
+            PolicyCapability::SchemaChangeAdditive,
+            PolicyEffect::Allow,
+            false,
+        );
+        assert_eq!(v, AutoApplyVerdict::Apply);
+        assert!(v.is_apply());
+    }
+
+    #[test]
+    fn model_added_allowed_is_apply() {
+        let findings = vec![BreakingFinding {
+            change: BreakingChange::ModelAdded {
+                model: "new_table".to_string(),
+            },
+            severity: BreakingSeverity::Info,
+        }];
+        assert_eq!(
+            is_auto_apply_eligible(
+                &findings,
+                PolicyCapability::SchemaChangeAdditive,
+                PolicyEffect::Allow,
+                false,
+            ),
+            AutoApplyVerdict::Apply
+        );
+    }
+
+    // --- non-vacuous: breaking diffs must refuse even when policy allows ---
+
+    #[test]
+    fn type_change_refused_even_when_policy_allows() {
+        // The load-bearing test: a retyped column is a breaking diff. Even
+        // when the caller passes `Allow`, auto-apply must refuse.
+        let findings = drift_findings(&retype_drift(), "orders");
+        let v = is_auto_apply_eligible(
+            &findings,
+            // Deliberately mislabel it additive to prove the diff-level gate
+            // catches it regardless of the classification.
+            PolicyCapability::SchemaChangeAdditive,
+            PolicyEffect::Allow,
+            false,
+        );
+        assert!(!v.is_apply());
+        assert_eq!(v.refuse_reason(), Some(&RefuseReason::NotAdditive));
+    }
+
+    #[test]
+    fn column_drop_refused_even_when_policy_allows() {
+        let findings = vec![BreakingFinding {
+            change: BreakingChange::ColumnDropped {
+                model: "orders".to_string(),
+                column: "amount".to_string(),
+                data_type: "BIGINT".to_string(),
+            },
+            severity: BreakingSeverity::Breaking,
+        }];
+        let v = is_auto_apply_eligible(
+            &findings,
+            PolicyCapability::SchemaChangeAdditive,
+            PolicyEffect::Allow,
+            false,
+        );
+        assert_eq!(v.refuse_reason(), Some(&RefuseReason::NotAdditive));
+    }
+
+    #[test]
+    fn narrowing_type_change_refused_even_when_policy_allows() {
+        let findings = vec![BreakingFinding {
+            change: BreakingChange::ColumnTypeChanged {
+                model: "orders".to_string(),
+                column: "amount".to_string(),
+                old_type: "BIGINT".to_string(),
+                new_type: "INT".to_string(),
+                narrowing: true,
+            },
+            severity: BreakingSeverity::Breaking,
+        }];
+        assert_eq!(
+            is_auto_apply_eligible(
+                &findings,
+                PolicyCapability::SchemaChangeAdditive,
+                PolicyEffect::Allow,
+                false,
+            )
+            .refuse_reason(),
+            Some(&RefuseReason::NotAdditive)
+        );
+    }
+
+    #[test]
+    fn non_null_addition_refused_even_when_policy_allows() {
+        let findings = drift_findings(&added_col_drift("email", "VARCHAR", false), "orders");
+        assert_eq!(
+            is_auto_apply_eligible(
+                &findings,
+                PolicyCapability::SchemaChangeAdditive,
+                PolicyEffect::Allow,
+                false,
+            )
+            .refuse_reason(),
+            Some(&RefuseReason::NotAdditive)
+        );
+    }
+
+    #[test]
+    fn mixed_additive_and_breaking_refused() {
+        // A drift that adds a nullable column AND retypes another is not pure.
+        let mut d = added_col_drift("email", "VARCHAR", true);
+        d.drifted_columns = vec![DriftedColumn {
+            name: "amount".to_string(),
+            source_type: "INT".to_string(),
+            target_type: "BIGINT".to_string(),
+        }];
+        d.action = DriftAction::DropAndRecreate;
+        let findings = drift_findings(&d, "orders");
+        assert_eq!(
+            is_auto_apply_eligible(
+                &findings,
+                PolicyCapability::SchemaChangeAdditive,
+                PolicyEffect::Allow,
+                false,
+            )
+            .refuse_reason(),
+            Some(&RefuseReason::NotAdditive)
+        );
+    }
+
+    #[test]
+    fn grace_period_drop_refused() {
+        let mut d = added_col_drift("email", "VARCHAR", true);
+        d.grace_period_columns = vec![rocky_ir::GracePeriodColumn {
+            name: "legacy".to_string(),
+            data_type: "VARCHAR".to_string(),
+            first_seen_at: chrono::Utc::now(),
+            expires_at: chrono::Utc::now(),
+            days_remaining: 3,
+        }];
+        let findings = drift_findings(&d, "orders");
+        assert!(
+            !is_auto_apply_eligible(
+                &findings,
+                PolicyCapability::SchemaChangeAdditive,
+                PolicyEffect::Allow,
+                false,
+            )
+            .is_apply()
+        );
+    }
+
+    // --- the necessary-but-not-sufficient gates ---
+
+    #[test]
+    fn additive_but_require_review_refused() {
+        assert_eq!(
+            is_auto_apply_eligible(
+                &additive(),
+                PolicyCapability::SchemaChangeAdditive,
+                PolicyEffect::RequireReview,
+                false,
+            )
+            .refuse_reason(),
+            Some(&RefuseReason::PolicyNotAllow(PolicyEffect::RequireReview))
+        );
+    }
+
+    #[test]
+    fn additive_but_denied_refused() {
+        assert_eq!(
+            is_auto_apply_eligible(
+                &additive(),
+                PolicyCapability::SchemaChangeAdditive,
+                PolicyEffect::Deny,
+                false,
+            )
+            .refuse_reason(),
+            Some(&RefuseReason::PolicyNotAllow(PolicyEffect::Deny))
+        );
+    }
+
+    #[test]
+    fn additive_but_contracted_refused() {
+        assert_eq!(
+            is_auto_apply_eligible(
+                &additive(),
+                PolicyCapability::SchemaChangeAdditive,
+                PolicyEffect::Allow,
+                true,
+            )
+            .refuse_reason(),
+            Some(&RefuseReason::ContractBoundary)
+        );
+    }
+
+    #[test]
+    fn additive_diff_but_breaking_classification_refused() {
+        // Defence in depth: even a genuinely additive diff refuses when the
+        // classification disagrees (a caller bug must not open the gate).
+        assert_eq!(
+            is_auto_apply_eligible(
+                &additive(),
+                PolicyCapability::SchemaChangeBreaking,
+                PolicyEffect::Allow,
+                false,
+            )
+            .refuse_reason(),
+            Some(&RefuseReason::ClassificationNotAdditive(
+                PolicyCapability::SchemaChangeBreaking
+            ))
+        );
+    }
+
+    #[test]
+    fn empty_diff_refused() {
+        assert_eq!(
+            is_auto_apply_eligible(
+                &[],
+                PolicyCapability::SchemaChangeAdditive,
+                PolicyEffect::Allow,
+                false,
+            )
+            .refuse_reason(),
+            Some(&RefuseReason::NoFindings)
+        );
+    }
+
+    // --- classification agreement with the shared classifier ---
+
+    #[test]
+    fn additive_findings_classify_as_additive() {
+        let findings = additive();
+        let refs: Vec<&BreakingFinding> = findings.iter().collect();
+        assert_eq!(
+            crate::policy::classify_model_findings(&refs),
+            PolicyCapability::SchemaChangeAdditive
+        );
+    }
+
+    #[test]
+    fn drop_recreate_findings_classify_as_breaking() {
+        let findings = drift_findings(&retype_drift(), "orders");
+        let refs: Vec<&BreakingFinding> = findings.iter().collect();
+        assert_eq!(
+            crate::policy::classify_model_findings(&refs),
+            PolicyCapability::SchemaChangeBreaking
+        );
+    }
+
+    // --- summary ---
+
+    #[test]
+    fn summary_names_additive_column() {
+        let s = drift_summary(&added_col_drift("email", "VARCHAR", true));
+        assert!(s.contains("added nullable column 'email'"), "{s}");
+    }
+
+    #[test]
+    fn summary_names_type_change() {
+        let s = drift_summary(&retype_drift());
+        assert!(s.contains("amount"), "{s}");
+        assert!(s.contains("BIGINT"), "{s}");
+    }
+}

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -963,6 +963,18 @@ pub struct ResilienceConfig {
     /// dependency graph, contain-more on any doubt).
     #[serde(default = "default_contain_failures")]
     pub contain_failures: bool,
+    /// Opt in to policy-governed auto-apply of **additive** source drift.
+    /// Default `false` — a run detecting a new nullable upstream column
+    /// evolves the target exactly as it does today (unconditionally), with no
+    /// policy gate. When `true`, any drift mutation must first clear the
+    /// policy plane: only a *provably additive* change with an `allow` verdict
+    /// for the `schema_change.additive` capability is auto-applied; anything
+    /// else (a drop, retype, narrowing, or a scope without the grant) is
+    /// refused and left for review rather than mutated. Has no effect unless a
+    /// `[policy]` block grants the capability, so both the opt-in **and** a
+    /// policy rule are required to change behaviour.
+    #[serde(default = "default_auto_apply_additive_drift")]
+    pub auto_apply_additive_drift: bool,
 }
 
 impl ResilienceConfig {
@@ -996,6 +1008,7 @@ impl Default for ResilienceConfig {
             circuit_breaker_threshold: default_resilience_breaker_threshold(),
             max_retries_per_run: default_resilience_max_retries_per_run(),
             contain_failures: default_contain_failures(),
+            auto_apply_additive_drift: default_auto_apply_additive_drift(),
         }
     }
 }
@@ -1019,6 +1032,9 @@ fn default_resilience_max_retries_per_run() -> Option<u32> {
     Some(8)
 }
 fn default_contain_failures() -> bool {
+    false
+}
+fn default_auto_apply_additive_drift() -> bool {
     false
 }
 

--- a/engine/crates/rocky-core/src/lib.rs
+++ b/engine/crates/rocky-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod access;
 pub mod adapter_capability;
 pub mod arrow_loader;
+pub mod auto_apply;
 pub mod breaking_change;
 pub mod bridge;
 pub mod catalog;

--- a/engine/crates/rocky-core/src/policy.rs
+++ b/engine/crates/rocky-core/src/policy.rs
@@ -1615,6 +1615,7 @@ mod tests {
             rule_id,
             reason: "plain".to_string(),
             verify_after: Vec::new(),
+            auto_apply: None,
         }
     }
 
@@ -1631,6 +1632,7 @@ mod tests {
             rule_id: None,
             reason: "verify_after FAILED".to_string(),
             verify_after: vec!["row_count_drift".to_string()],
+            auto_apply: None,
         }
     }
 
@@ -1646,6 +1648,7 @@ mod tests {
             rule_id: None,
             reason: "verify_after passed".to_string(),
             verify_after: vec!["row_count_drift".to_string()],
+            auto_apply: None,
         }
     }
 
@@ -1669,6 +1672,7 @@ mod tests {
             rule_id: None,
             reason: "freeze".to_string(),
             verify_after: Vec::new(),
+            auto_apply: None,
         }
     }
 

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -291,7 +291,17 @@ pub const LOCAL_ONLY_TABLE_NAMES: &[&str] = &["schema_cache"];
 ///   guarded by `test_v16_run_record_forward_deserializes_check_outcomes_empty`.
 ///   The bump tracks the record-shape addition so `[state] on_schema_mismatch`
 ///   engages as usual; no blob walk.
-const CURRENT_SCHEMA_VERSION: u32 = 17;
+/// - **v18** — adds the serde-additive [`PolicyDecisionRecord::auto_apply`]
+///   custody field ([`AutoApplyCustody`]) for the governed additive-drift
+///   auto-apply path: what drift the run auto-applied (or refused), its
+///   classification, and a revert pointer where a rollback substrate exists.
+///   Not a table change — the redb table set is unchanged (`EXPECTED_TABLES`
+///   is untouched). A v17 blob (which lacks the field) forward-deserializes
+///   with it `None`, guarded by
+///   `test_v17_policy_decision_forward_deserializes_auto_apply_none`. The bump
+///   tracks the record-shape addition so `[state] on_schema_mismatch` engages
+///   as usual; no blob walk.
+const CURRENT_SCHEMA_VERSION: u32 = 18;
 
 /// Errors from the embedded redb state store.
 #[derive(Debug, Error)]
@@ -3419,6 +3429,42 @@ pub struct PolicyDecisionRecord {
     /// apply halted) and `reason` states the outcome and rollback status.
     #[serde(default)]
     pub verify_after: Vec<String>,
+    /// Custody detail for a governed auto-apply of additive source drift.
+    /// Present only on rows the auto-apply path writes; `None` on ordinary
+    /// apply/promote evaluations. Serde-defaulted so a pre-v18 row
+    /// forward-deserializes with it absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_apply: Option<AutoApplyCustody>,
+}
+
+/// Custody detail attached to a [`PolicyDecisionRecord`] when the run loop
+/// auto-applies (or refuses) additive source drift on its own authority.
+///
+/// Records what the run auto-applied (or refused): a human-readable drift
+/// summary, the change classification the eligibility gate resolved, whether
+/// the migration was applied, and — where a rollback substrate exists — the
+/// pointer a revert would restore. On backends with no rollback substrate
+/// (e.g. DuckDB) `revert_pointer` is `None` and a failed post-apply
+/// verification is halt-only: the mutation stands until a human reverts it.
+///
+/// Forward-compatible via `#[serde(default)]` on any field added later.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct AutoApplyCustody {
+    /// Human-readable summary of the drift (e.g. `added nullable column
+    /// 'email' (VARCHAR)`).
+    pub drift_summary: String,
+    /// The change classification the eligibility gate resolved
+    /// (e.g. `schema_change.additive`, `schema_change.breaking`).
+    pub classification: String,
+    /// `true` when the migration was auto-applied; `false` when it was refused
+    /// and left for review.
+    pub applied: bool,
+    /// Pointer to the pre-mutation state a rollback could restore, when a
+    /// rollback substrate exists (a content-addressed / Iceberg snapshot).
+    /// `None` on substrates with no rollback — the mutation is halt-only on a
+    /// verification failure.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revert_pointer: Option<String>,
 }
 
 /// One row in the input-match index ([`INPUT_INDEX`]).
@@ -6870,6 +6916,7 @@ mod tests {
             rule_id: Some(1),
             reason: "allow by rule 1".to_string(),
             verify_after: Vec::new(),
+            auto_apply: None,
         };
         let later = PolicyDecisionRecord {
             timestamp: chrono::DateTime::parse_from_rfc3339("2026-07-07T11:00:00Z")
@@ -6883,6 +6930,7 @@ mod tests {
             rule_id: Some(0),
             reason: "denied by rule 0 (deny overrides)".to_string(),
             verify_after: Vec::new(),
+            auto_apply: None,
         };
         // Insert out of order; the ledger must return them chronologically.
         store.record_policy_decision(&later).unwrap();
@@ -6892,6 +6940,53 @@ mod tests {
         assert_eq!(all.len(), 2);
         assert_eq!(all[0], earlier, "oldest decision first");
         assert_eq!(all[1], later);
+    }
+
+    #[test]
+    fn test_v17_policy_decision_forward_deserializes_auto_apply_none() {
+        use crate::config::{PolicyCapability, PolicyEffect, PolicyPrincipal};
+
+        // A full v17 record serialized with `auto_apply` stripped.
+        let record = PolicyDecisionRecord {
+            timestamp: chrono::DateTime::parse_from_rfc3339("2026-07-07T10:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            plan_id: "plan_v17".to_string(),
+            principal: PolicyPrincipal::Agent,
+            capability: PolicyCapability::SchemaChangeAdditive,
+            model: "raw_events".to_string(),
+            effect: PolicyEffect::Allow,
+            rule_id: Some(1),
+            reason: "allow by rule 1".to_string(),
+            verify_after: Vec::new(),
+            auto_apply: None,
+        };
+        let mut value = serde_json::to_value(&record).expect("serialize record");
+        value
+            .as_object_mut()
+            .expect("record is an object")
+            .remove("auto_apply");
+        let blob = serde_json::to_vec(&value).expect("reserialize without field");
+
+        let read: PolicyDecisionRecord = serde_json::from_slice(&blob)
+            .expect("pre-v18 PolicyDecisionRecord must forward-deserialize");
+        assert_eq!(read.plan_id, "plan_v17");
+        assert!(
+            read.auto_apply.is_none(),
+            "a pre-v18 record reads back with no auto-apply custody"
+        );
+
+        // A v18 record carrying custody round-trips losslessly.
+        let mut with_custody = record.clone();
+        with_custody.auto_apply = Some(AutoApplyCustody {
+            drift_summary: "added nullable column 'email' (VARCHAR)".to_string(),
+            classification: "schema_change.additive".to_string(),
+            applied: true,
+            revert_pointer: None,
+        });
+        let round: PolicyDecisionRecord =
+            serde_json::from_slice(&serde_json::to_vec(&with_custody).unwrap()).unwrap();
+        assert_eq!(round.auto_apply, with_custody.auto_apply);
     }
 
     #[test]
@@ -7314,7 +7409,11 @@ mod tests {
         // check_outcomes`, `PolicyDecisionRecord::verify_after`), also
         // serde-additive fields — guarded by
         // `test_v16_run_record_forward_deserializes_check_outcomes_empty`.
-        const EXPECTED_VERSION: u32 = 17;
+        // v18 adds `PolicyDecisionRecord::auto_apply` (the governed
+        // additive-drift auto-apply custody), another serde-additive field —
+        // the redb table set is untouched, only the version moves; guarded by
+        // `test_v17_policy_decision_forward_deserializes_auto_apply_none`.
+        const EXPECTED_VERSION: u32 = 18;
         const EXPECTED_TABLES: &[&str] = &[
             "branches",
             "check_history",

--- a/integrations/dagster/tests/fixtures_generated/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor.json
@@ -17,7 +17,7 @@
     {
       "name": "state_schema",
       "status": "healthy",
-      "message": "state schema v17 matches this binary",
+      "message": "state schema v18 matches this binary",
       "duration_ms": 0
     },
     {

--- a/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
@@ -17,7 +17,7 @@
     {
       "name": "state_schema",
       "status": "healthy",
-      "message": "state schema v17 matches this binary",
+      "message": "state schema v18 matches this binary",
       "duration_ms": 0
     },
     {

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 17,
-  "schema_version_on_disk": 17
+  "schema_version_supported": 18,
+  "schema_version_on_disk": 18
 }

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 17,
-  "schema_version_on_disk": 17
+  "schema_version_supported": 18,
+  "schema_version_on_disk": 18
 }

--- a/integrations/dagster/tests/fixtures_generated/state.json
+++ b/integrations/dagster/tests/fixtures_generated/state.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 17,
-  "schema_version_on_disk": 17
+  "schema_version_supported": 18,
+  "schema_version_on_disk": 18
 }

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -3138,6 +3138,11 @@
       "additionalProperties": false,
       "description": "`[resilience]` — the run loop's classified-retry policy.\n\nThis is a **distinct layer** from the per-adapter `[adapter.*.retry]` (which retries individual statements inside a connector) and from the run-level `[retry]` budget ([`RunRetryConfig`], which caps connector retries). `[resilience]` governs whether the run loop re-runs a whole *model* whose materialization failed, classifying the failure via [`crate::failure_class::FailureClass`] and retrying only a *proven* transient one.\n\n# Not default-OFF, but conservative\n\nUnlike the skip / reuse gates, this layer is **on by default** — a model that fails transiently today *will* be retried once this ships. The lever that keeps that safe is [`Self::transient_max_retries`] (default `2`): a small, bounded budget with capped exponential backoff. Set `transient_max_retries = 0` (or `enabled = false`) to restore the prior single-attempt behaviour, e.g. in CI where a fast-fail is preferred.\n\nPermanent and Unknown failures are **never** retried regardless of these settings — that is a property of the classifier, not of this config.",
       "properties": {
+        "auto_apply_additive_drift": {
+          "default": false,
+          "description": "Opt in to policy-governed auto-apply of **additive** source drift. Default `false` — a run detecting a new nullable upstream column evolves the target exactly as it does today (unconditionally), with no policy gate. When `true`, any drift mutation must first clear the policy plane: only a *provably additive* change with an `allow` verdict for the `schema_change.additive` capability is auto-applied; anything else (a drop, retype, narrowing, or a scope without the grant) is refused and left for review rather than mutated. Has no effect unless a `[policy]` block grants the capability, so both the opt-in **and** a policy rule are required to change behaviour.",
+          "type": "boolean"
+        },
         "backoff_multiplier": {
           "default": 2.0,
           "description": "Multiplier applied to the backoff after each retry.",
@@ -4386,6 +4391,7 @@
         }
       ],
       "default": {
+        "auto_apply_additive_drift": false,
         "backoff_multiplier": 2.0,
         "circuit_breaker_threshold": 3,
         "contain_failures": false,

--- a/sdk/python/src/rocky_sdk/types_generated/rocky_project_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/rocky_project_schema.py
@@ -1246,6 +1246,10 @@ class ResilienceConfig(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    auto_apply_additive_drift: bool | None = False
+    """
+    Opt in to policy-governed auto-apply of **additive** source drift. Default `false` — a run detecting a new nullable upstream column evolves the target exactly as it does today (unconditionally), with no policy gate. When `true`, any drift mutation must first clear the policy plane: only a *provably additive* change with an `allow` verdict for the `schema_change.additive` capability is auto-applied; anything else (a drop, retype, narrowing, or a scope without the grant) is refused and left for review rather than mutated. Has no effect unless a `[policy]` block grants the capability, so both the opt-in **and** a policy rule are required to change behaviour.
+    """
     backoff_multiplier: float | None = 2.0
     """
     Multiplier applied to the backoff after each retry.
@@ -3681,6 +3685,7 @@ class RockyConfig(BaseModel):
     """
     resilience: ResilienceConfig | None = Field(
         {
+            "auto_apply_additive_drift": False,
             "backoff_multiplier": 2.0,
             "circuit_breaker_threshold": 3,
             "contain_failures": False,


### PR DESCRIPTION
## What

Adds a **default-off, policy-governed auto-apply of additive source drift** to the replication run loop — the first rung on the self-healing ladder that mutates a warehouse schema on its own authority. When a run detects that an upstream source gained a new **nullable** column, and both an opt-in and a policy grant are configured, the engine applies the `ALTER TABLE ADD COLUMN` migration itself, records a custody entry, and runs a post-apply `verify_after` gate. Anything not *provably* additive (a drop, retype, narrowing, non-null addition, or a scope without the grant) is **refused** and left for review — never auto-applied.

## Why

Detect → fail honestly → explain → propose was already shipped; this is the first "act under policy" step. It is deliberately narrow: it applies the mechanical additive migration the drift already describes, and never rewrites SQL to fix data (that stays behind propose + review).

## Enable surface (minimal)

Two things must both be present, or behaviour is byte-identical to today:

1. **`[resilience] auto_apply_additive_drift = true`** — one new config key (default `false`).
2. A **`[policy]`** rule granting the existing `schema_change.additive` capability for the table's scope with `effect = "allow"`.

```toml
[resilience]
auto_apply_additive_drift = true

[[policy.rules]]
principal = "agent"
capability = "schema_change.additive"
scope = { any = true }
effect = "allow"
# optional: verify_after = ["row_count"]  — a required post-apply check
```

No new CLI verb: R3 reuses the existing policy evaluator, the `schema_change.additive` capability, the `verify_after` condition, and the policy-decision (custody) ledger. The new config key is justified because the policy grant alone should not silently change the run loop's mutation behaviour — the opt-in is the operator's explicit "yes, self-heal."

## The eligibility predicate is the soundness surface

`rocky_core::auto_apply::is_auto_apply_eligible(findings, classification, effect, contracted)` is the single place the answer is computed. It **fails closed** and re-proves additive-ness *from the diff itself* — the caller's classification and policy verdict are necessary but never sufficient, so a mislabelled breaking diff can never be applied. `Apply` requires all of:

1. non-empty diff (empty cannot prove additive),
2. every finding is a *nullable* column addition or a new model (proven from the diff),
3. classification is `schema_change.additive` (defence in depth),
4. the model is not behind a contract (no contract boundary crossed automatically),
5. the policy verdict is `allow`.

Non-vacuous tests feed it breaking diffs (dropped / retyped / narrowed / non-null-added / grace-period-drop) **with `effect = allow`** and assert `Refuse` every time — this is exactly where a green suite can lie.

## Reuses existing machinery (no forks)

The only new logic is the eligibility predicate and the thin run-loop wiring. Everything else is reused: the drift detector (`detect_drift` → `DriftResult`), the breaking-change classifier (`diff_project_ir` finding types + `classify_model_findings`), the policy evaluator (`policy::evaluate`, the `schema_change.additive` capability, and its `verify_after` condition), and the policy-decision / custody ledger (`record_policy_decision` / `list_policy_decisions`). `DriftResult` is translated into the same `BreakingFinding` types the model-level `ci-diff` produces, so replication drift is judged by the exact same classifier. The replication drift path already applied additive `ADD COLUMN` unconditionally; this change only *governs* that mutation when the opt-in is set.

## Schema v17 → v18

`PolicyDecisionRecord` gains a serde-defaulted `auto_apply: Option<AutoApplyCustody>` field (drift summary, classification, applied flag, revert pointer). `CURRENT_SCHEMA_VERSION` bumped to **18** following the v16/v17 additive-field pattern — the redb table set is untouched, a v17 blob forward-deserializes with the field `None` (guarded by `test_v17_policy_decision_forward_deserializes_auto_apply_none`), and `[state] on_schema_mismatch` engages as usual. **`just regen-fixtures` was run** to recapture the doctor + state dagster fixtures at v18, in addition to `just codegen` (the new `[resilience]` key flows into the exported `rocky_project` schema → Pydantic + TypeScript + OpenAPI).

## Split-reachability honesty — what I drove vs. what is code-only

Driven creds-free on the DuckDB playground, through the real CLI:

- **Additive auto-apply**: source gains a nullable `email` column → run migrates the target (`email` present) → `rocky audit` shows the `allow` / `schema_change.additive` custody row naming the drift.
- **Breaking refused**: source retypes `amount` (`DECIMAL → VARCHAR`) → run exits non-zero, target **unchanged**, custody row `require_review`, message names the non-additive reason. Refused even though the policy grants `schema_change.additive`.
- **Default-off byte-identical**: with the flag absent, the same breaking drift is auto-applied ungoverned (drop-and-recreate, exit 0) and **zero** custody rows are written.
- **`verify_after` gate**: with `verify_after = ["row_count"]`, the applied migration writes a second `allow` verification custody row; the aggregation is unit-tested for the fail / absent / duplicate-name cases (fail ⇒ run halts, `deny` custody).

**Not driven — code-reviewed only:** there is **no rollback substrate** on a plain warehouse target, so a failed `verify_after` is **halt-only** — the migration has already landed and stays until a human reverts it, stated plainly in the error, the code, and the custody reason. The custody record carries a `revert_pointer` field and `revert_pointer_for()` is the documented seam where a content-addressed / Iceberg target would capture a snapshot pointer for a metadata-only pointer-swap rollback. That path is object-store-only and **is not implemented or driven here** — I do not claim rollback works.

## Fail-closed guarantees

- Ineligible ⇒ propose / require-review, never a silent apply. A hard `deny` is preserved; every other refusal degrades to `require_review`.
- `verify_after` fails closed: a required check that failed **or did not run** halts the run (AND-aggregated across duplicate check names).
- Replication targets are not compiled models, so they are evaluated against a bare-named `ModelAttributes` — an uncomputable blast radius makes any `max_downstreams` ceiling fail closed inside the evaluator.

## Gates

`cargo fmt --check`, `cargo clippy --all-targets --all-features`, `cargo test --workspace`, `cargo test --no-run` (test targets compile with the v18 field) — all green. `just codegen` + `just regen-fixtures` committed. No `Co-Authored-By`; GPG-signed.
