### PR TITLE
feat(engine/rocky-mcp): governor-side MCP tools (estate_brief, audit_query, scorecard, review_queue)

### DIFF
--- a/engine/crates/rocky-cli/src/commands/audit.rs
+++ b/engine/crates/rocky-cli/src/commands/audit.rs
@@ -130,7 +130,29 @@ pub fn run_audit_for(
     output_json: bool,
 ) -> Result<()> {
     let root = std::env::current_dir().context("failed to get current working directory")?;
+    let output = compute_audit_for(&root, config_path, state_path, models_dir, selector)?;
 
+    if output_json {
+        print_json(&output)?;
+    } else {
+        render_chain_text(&output);
+    }
+    Ok(())
+}
+
+/// Assemble the custody chain for `selector` without rendering it.
+///
+/// The reusable core behind both `rocky audit --for` and the governor's
+/// `audit_query` MCP tool. `root` locates the on-disk plan files (the plan-vs-run
+/// vs-model subject disambiguation); the CLI resolves it from the process cwd,
+/// the MCP server passes its project root. Reads only — no mutation, no stdout.
+pub fn compute_audit_for(
+    root: &Path,
+    config_path: &Path,
+    state_path: &Path,
+    models_dir: &Path,
+    selector: &str,
+) -> Result<AuditForOutput> {
     let (decisions, runs): (Vec<PolicyDecisionRecord>, Vec<RunRecord>) = if state_path.exists() {
         let store = StateStore::open_read_only(state_path)
             .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
@@ -145,7 +167,7 @@ pub fn run_audit_for(
 
     // Resolve the subject kind (plan file > run id > model name).
     let is_hex64 = selector.len() == 64 && selector.chars().all(|c| c.is_ascii_hexdigit());
-    let plan_on_disk = is_hex64 && plan_file_path(&root, selector).exists();
+    let plan_on_disk = is_hex64 && plan_file_path(root, selector).exists();
     let run_match = runs.iter().any(|r| r.run_id == selector);
     let kind = if plan_on_disk {
         AuditSubjectKind::Plan
@@ -163,7 +185,7 @@ pub fn run_audit_for(
     };
 
     let decisions_link = build_decisions_link(kind, selector, &decisions);
-    let plan_link = build_plan_link(kind, selector, &decisions_link, &root);
+    let plan_link = build_plan_link(kind, selector, &decisions_link, root);
     let runs_link = build_runs_link(kind, selector, subject_run, &runs);
     let verify_link = build_verify_link();
 
@@ -196,7 +218,7 @@ pub fn run_audit_for(
         }
     };
 
-    let output = AuditForOutput {
+    Ok(AuditForOutput {
         version: VERSION.to_string(),
         command: "audit".to_string(),
         subject: selector.to_string(),
@@ -207,14 +229,7 @@ pub fn run_audit_for(
         runs: runs_link,
         verify_after: verify_link,
         blast_radius: blast_link,
-    };
-
-    if output_json {
-        print_json(&output)?;
-    } else {
-        render_chain_text(&output);
-    }
-    Ok(())
+    })
 }
 
 /// Path a plan file would occupy — existence-checked without the
@@ -742,6 +757,27 @@ pub fn run_audit_scorecard(
     window: Option<&str>,
     output_json: bool,
 ) -> Result<()> {
+    let output = compute_audit_scorecard(state_path, by, window)?;
+
+    if output_json {
+        print_json(&output)?;
+    } else {
+        render_scorecard_text(&output);
+    }
+    Ok(())
+}
+
+/// Aggregate the trust scorecard without rendering it.
+///
+/// The reusable core behind both `rocky audit --scorecard` and the governor's
+/// `scorecard` MCP tool. A malformed `--window` is a usage error (propagated);
+/// a ledger read failure renders the whole scorecard `unavailable` rather than a
+/// smoothed-over zero. Reads only — no stdout.
+pub fn compute_audit_scorecard(
+    state_path: &Path,
+    by: ScorecardDimension,
+    window: Option<&str>,
+) -> Result<AuditScorecardOutput> {
     let now = Utc::now();
     let window_label = window.unwrap_or("all").to_string();
     let window_start = parse_window(window, now)?;
@@ -764,13 +800,7 @@ pub fn run_audit_scorecard(
             unavailable_metrics: scorecard_unavailable_metrics(),
         },
     };
-
-    if output_json {
-        print_json(&output)?;
-    } else {
-        render_scorecard_text(&output);
-    }
-    Ok(())
+    Ok(output)
 }
 
 /// Read the decision ledger for a scorecard. An absent state file is not an

--- a/engine/crates/rocky-cli/src/commands/brief.rs
+++ b/engine/crates/rocky-cli/src/commands/brief.rs
@@ -95,25 +95,58 @@ pub fn run_brief(
     json: bool,
 ) -> Result<()> {
     let now = Utc::now();
+    let output = compute_brief(state_path, config_path, since, now)?;
+    emit(&output, json)?;
 
+    // Advance the digest cursor only after a successful render, and only for
+    // the `--since last` mode — the relative windows never touch it. Advancing
+    // to the same `now` the digest was composed at keeps the next `--since
+    // last` window contiguous. `compute_brief` opened the store read-only, so
+    // this is a separate short write (the read handle is already dropped).
+    if let BriefSince::Last = since
+        && state_path.exists()
+    {
+        let store = StateStore::open(state_path)
+            .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
+        store
+            .set_last_brief_at(now)
+            .context("failed to advance the brief cursor")?;
+    }
+
+    Ok(())
+}
+
+/// Compose the estate digest without rendering or advancing the cursor.
+///
+/// This is the reusable core behind both `rocky brief` and the governor's
+/// `estate_brief` MCP tool: it opens the state store **read-only**, projects
+/// every section over the `--since` window at the caller-supplied `now`, and
+/// returns the typed [`BriefOutput`]. It performs no I/O to stdout and never
+/// mutates the brief cursor — the cursor advance is [`run_brief`]'s job, so the
+/// conversational MCP surface can query the digest without consuming the Slack
+/// hook's `--since last` cursor.
+///
+/// Fails closed: an absent state store yields a fully `unavailable` digest
+/// rather than an error.
+pub fn compute_brief(
+    state_path: &Path,
+    config_path: &Path,
+    since: BriefSince,
+    now: DateTime<Utc>,
+) -> Result<BriefOutput> {
     // Fail closed on an absent state store: there is no history to project.
     if !state_path.exists() {
-        let output = empty_brief(
+        return Ok(empty_brief(
             now,
             since,
             None,
             "state store not found — no runs, decisions, or metrics have been recorded yet",
-        );
-        return emit(&output, json);
+        ));
     }
 
-    // `--since last` advances the digest cursor, so it needs write access;
-    // the relative windows are read-only.
-    let store = match since {
-        BriefSince::Last => StateStore::open(state_path),
-        _ => StateStore::open_read_only(state_path),
-    }
-    .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
+    // Read-only throughout — the cursor advance is the caller's concern.
+    let store = StateStore::open_read_only(state_path)
+        .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
 
     let since_ts: Option<DateTime<Utc>> = match since {
         BriefSince::Last => store
@@ -152,7 +185,7 @@ pub fn run_brief(
     // `--since` slice.
     let autonomy = build_autonomy(config_path, &decisions, now);
 
-    let output = BriefOutput {
+    Ok(BriefOutput {
         version: VERSION.to_string(),
         command: "brief".to_string(),
         generated_at: now.to_rfc3339(),
@@ -166,17 +199,7 @@ pub fn run_brief(
         quality,
         cost,
         autonomy,
-    };
-
-    // Advance the cursor only after a successful render, and only for the
-    // digest mode — relative windows never touch it.
-    if let BriefSince::Last = since {
-        store
-            .set_last_brief_at(now)
-            .context("failed to advance the brief cursor")?;
-    }
-
-    emit(&output, json)
+    })
 }
 
 /// True when `ts` falls at or after the window's lower bound. An unbounded

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -89,7 +89,9 @@ pub use ai::{
 pub use ai_contract::run_ai_contract;
 pub use apply::{PolicyGate, evaluate_apply_policy, run_apply, run_apply_inline_for_run};
 pub use archive::{run_archive, run_archive_apply, run_archive_catalog};
-pub use audit::{run_audit, run_audit_for, run_audit_scorecard};
+pub use audit::{
+    compute_audit_for, compute_audit_scorecard, run_audit, run_audit_for, run_audit_scorecard,
+};
 pub use backfill::run_backfill;
 #[cfg(feature = "duckdb")]
 pub use bench::run_bench;
@@ -97,7 +99,7 @@ pub use branch::{
     run_branch_approve, run_branch_compare, run_branch_create, run_branch_delete, run_branch_list,
     run_branch_promote, run_branch_promote_from_plan, run_branch_show,
 };
-pub use brief::{BriefSince, run_brief};
+pub use brief::{BriefSince, compute_brief, run_brief};
 pub use catalog::{
     CatalogFormat, compute_catalog_output, default_out_dir as catalog_default_out_dir, run_catalog,
 };
@@ -151,7 +153,7 @@ pub use profile_storage::run_profile_storage;
 pub use publish_ir::run_publish_ir;
 pub use replay::{run_replay, run_replay_check, run_replay_execute};
 pub use retention_status::run_retention_status;
-pub use review::{run_review, run_review_queue};
+pub use review::{compute_review, compute_review_queue, run_review, run_review_queue};
 // Re-exported so the `rocky` bin can build a clap ValueEnum for
 // `--target-dialect` without taking a direct dep on rocky-sql.
 pub use rocky_sql::transpile::Dialect;

--- a/engine/crates/rocky-cli/src/commands/review.rs
+++ b/engine/crates/rocky-cli/src/commands/review.rs
@@ -84,6 +84,43 @@ pub(crate) async fn run_review_in(
     approve: bool,
     output_json: bool,
 ) -> Result<()> {
+    let output = compute_review(root, config_path, plan_id, base_ref, approve).await?;
+
+    if output_json {
+        print_json(&output)?;
+    } else {
+        if let Some(ref message) = output.message {
+            println!("{message}");
+        }
+        if let Some(ref f) = output.breaking_changes {
+            let breaking: Vec<&BreakingFinding> = f.iter().filter(|x| x.is_breaking()).collect();
+            if !breaking.is_empty() {
+                println!("breaking changes ({}):", breaking.len());
+                for finding in breaking {
+                    println!("  - {:?}", finding.change);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Review (and optionally sign off on) an AI-authored / agent-authored plan,
+/// returning the typed [`ReviewOutput`] without rendering it.
+///
+/// The reusable core behind both `rocky review <plan-id>` and the governor's
+/// `review_queue` approve action. When `approve` is `true` it writes the
+/// sign-off marker at `<root>/.rocky/plans/<plan_id>.reviewed.json` (the same
+/// artifact `rocky apply` checks); the marker records the caller's git identity
+/// and timestamp. Errors (bails) when the plan is not reviewable. No stdout.
+pub async fn compute_review(
+    root: &Path,
+    config_path: &Path,
+    plan_id: &str,
+    base_ref: &str,
+    approve: bool,
+) -> Result<ReviewOutput> {
     let plan = read_plan(root, plan_id)
         .with_context(|| format!("failed to read plan '{plan_id}' for review"))?;
 
@@ -157,7 +194,7 @@ pub(crate) async fn run_review_in(
 
     let message = build_message(approve, breaking_count, &findings, plan_id);
 
-    let output = ReviewOutput {
+    Ok(ReviewOutput {
         version: VERSION.to_string(),
         command: "review".to_string(),
         plan_id: plan_id.to_string(),
@@ -165,25 +202,8 @@ pub(crate) async fn run_review_in(
         approved: approve,
         marker_written,
         breaking_changes: findings,
-        message: Some(message.clone()),
-    };
-
-    if output_json {
-        print_json(&output)?;
-    } else {
-        println!("{message}");
-        if let Some(ref f) = output.breaking_changes {
-            let breaking: Vec<&BreakingFinding> = f.iter().filter(|x| x.is_breaking()).collect();
-            if !breaking.is_empty() {
-                println!("breaking changes ({}):", breaking.len());
-                for finding in breaking {
-                    println!("  - {:?}", finding.change);
-                }
-            }
-        }
-    }
-
-    Ok(())
+        message: Some(message),
+    })
 }
 
 /// Build the human-readable summary line for the review outcome.
@@ -362,6 +382,28 @@ pub(crate) fn run_review_queue_in(
     models_dir: &Path,
     output_json: bool,
 ) -> Result<()> {
+    let output = compute_review_queue(root, config_path, state_path, models_dir)?;
+
+    if output_json {
+        print_json(&output)?;
+    } else {
+        render_queue_text(&output);
+    }
+    Ok(())
+}
+
+/// Build the ranked pending-review queue without rendering it.
+///
+/// The reusable core behind both `rocky review --queue` and the governor's
+/// `review_queue` MCP tool. `root` locates the sign-off markers that clear an
+/// escalation; the CLI resolves it from the process cwd, the MCP server passes
+/// its project root. Reads only — no stdout.
+pub fn compute_review_queue(
+    root: &Path,
+    config_path: &Path,
+    state_path: &Path,
+    models_dir: &Path,
+) -> Result<ReviewQueueOutput> {
     let decisions: Vec<PolicyDecisionRecord> = if state_path.exists() {
         let store = StateStore::open_read_only(state_path)
             .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
@@ -381,20 +423,13 @@ pub(crate) fn run_review_queue_in(
         Utc::now(),
     );
 
-    let output = ReviewQueueOutput {
+    Ok(ReviewQueueOutput {
         version: VERSION.to_string(),
         command: "review".to_string(),
         ranking: QUEUE_RANKING.to_string(),
         total: pending.len() as u64,
         pending,
-    };
-
-    if output_json {
-        print_json(&output)?;
-    } else {
-        render_queue_text(&output);
-    }
-    Ok(())
+    })
 }
 
 /// Assemble the ranked queue from the decision ledger. Factored out so the

--- a/engine/crates/rocky-mcp/src/result_types.rs
+++ b/engine/crates/rocky-mcp/src/result_types.rs
@@ -800,3 +800,57 @@ pub struct DriftPreviewResult {
     /// `"add_columns"`, `"alter_column_types"`, or `"drop_and_recreate"`.
     pub action: String,
 }
+
+// ---------------------------------------------------------------------------
+// Governor tools
+// ---------------------------------------------------------------------------
+//
+// The three read projections (`estate_brief`, `audit_query`, `scorecard`)
+// return the shipped `*Output` core re-serialized as a `serde_json::Value` —
+// the most faithful projection, preserving every ledger citation
+// (`run_id` / `plan_id` / `decision_ref`) with no lossy field-by-field
+// re-mapping. `review_queue` is the exception: it carries the queue **and** the
+// outcome of the gated approve action, so it needs a typed envelope.
+
+/// Result of the `review_queue` tool.
+///
+/// In the read mode (`approve_plan_id` unset) `approval` is `None` and `pending`
+/// carries the full ranked queue. In the approve mode it carries the
+/// [`ReviewApprovalOutcome`] and `pending` is re-listed *after* the sign-off, so
+/// the caller sees the just-approved escalation cleared.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ReviewQueueResult {
+    /// Number of escalations still awaiting review after this call.
+    pub total: u64,
+    /// Human-readable description of the queue ordering.
+    pub ranking: String,
+    /// The ranked pending escalations, each carrying its `decision_ref`,
+    /// `plan_id`, `blast_radius`, `score`, and `approve_command` citation — the
+    /// shipped `ReviewQueueOutput.pending` serialized verbatim so no citation is
+    /// dropped.
+    pub pending: serde_json::Value,
+    /// Present only when this call approved a plan.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approval: Option<ReviewApprovalOutcome>,
+}
+
+/// Outcome of the gated `review_queue` approve action.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ReviewApprovalOutcome {
+    /// The plan the sign-off marker was written for.
+    pub plan_id: String,
+    /// Whether the sign-off marker (`.rocky/plans/<plan_id>.reviewed.json`, the
+    /// artifact `rocky apply` checks) was written.
+    pub marker_written: bool,
+    /// Count of breaking-severity findings the sign-off covers (0 when the
+    /// breaking-change gate could not run — a non-git project or a compile
+    /// failure — which is not itself a blocker).
+    pub breaking_change_count: u64,
+    /// Human-readable summary of the review outcome.
+    pub message: String,
+    /// How this approval is attributed and its limits — an honest note that the
+    /// marker records the operator's git identity, not a cryptographically bound
+    /// principal. A signed human confirmation is a later step (F3-v2); today the
+    /// `confirm` argument stands in for that explicit human intent.
+    pub attribution: String,
+}

--- a/engine/crates/rocky-mcp/src/result_types.rs
+++ b/engine/crates/rocky-mcp/src/result_types.rs
@@ -850,7 +850,7 @@ pub struct ReviewApprovalOutcome {
     pub message: String,
     /// How this approval is attributed and its limits — an honest note that the
     /// marker records the operator's git identity, not a cryptographically bound
-    /// principal. A signed human confirmation is a later step (F3-v2); today the
+    /// principal. A signed human confirmation is a later step; today the
     /// `confirm` argument stands in for that explicit human intent.
     pub attribution: String,
 }

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -273,6 +273,56 @@ pub struct DriftPreviewArgs {
 }
 
 // ---------------------------------------------------------------------------
+// Governor tool parameter structs.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct EstateBriefArgs {
+    /// Time window for the digest: `"last"`, `"24h"`, or `"7d"`. Defaults to
+    /// `"7d"`. `"last"` reads the digest cursor **read-only** and never advances
+    /// it, so a conversational query does not consume the Slack/email hook's
+    /// `--since last` cursor.
+    #[serde(default)]
+    pub since: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct AuditQueryArgs {
+    /// The subject to trace the custody chain for: a model name, a run id, or a
+    /// 64-character plan id. The chain resolves principal → decision → plan →
+    /// diff → run → downstream blast radius, with each link failing closed to
+    /// `unavailable` rather than fabricating a value.
+    pub subject: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ScorecardArgs {
+    /// Grouping dimension: `"principal"`, `"rule"`, or `"scope"`. Defaults to
+    /// `"principal"`.
+    #[serde(default)]
+    pub by: Option<String>,
+    /// Window: `"all"` or a `"<N>d"` / `"<N>h"` duration (e.g. `"30d"`).
+    /// Defaults to all-time.
+    #[serde(default)]
+    pub window: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ReviewQueueArgs {
+    /// When set, APPROVE this pending plan_id instead of listing the queue. The
+    /// plan must be one currently awaiting review — call with this unset first
+    /// to see the pending plan_ids.
+    #[serde(default)]
+    pub approve_plan_id: Option<String>,
+    /// Explicit confirmation for the approve action. Approving writes a human
+    /// sign-off marker that unblocks `rocky apply`, so it is refused unless this
+    /// is `true`. Set it ONLY when the human has explicitly authorized approving
+    /// this exact plan — it stands in for that human intent.
+    #[serde(default)]
+    pub confirm: bool,
+}
+
+// ---------------------------------------------------------------------------
 // Prompt argument structs (schemars 1.x — rmcp's `Parameters<T>` bound).
 // MCP prompt arguments are string-typed on the wire; `Serialize` is part of
 // the prompt-macro contract (mirrors rmcp's own examples).
@@ -2392,6 +2442,280 @@ impl RockyMcpServer {
                 ))
             }
         }
+    }
+
+    // ------------------------- governor tools ------------------------------
+    // The human-oversight surface for an agent-operated estate — typed
+    // projections of the same decision/run ledger the worker-agent tools write
+    // to, so "what did agents do this week, and why was that apply allowed?" is
+    // a cited, conversational query. `estate_brief` / `audit_query` /
+    // `scorecard` are read-only; `review_queue` reads the pending queue and,
+    // behind an explicit `confirm`, writes the human sign-off marker. Every
+    // projection reuses the shipped `brief` / `audit` / `review` cores, so a
+    // section whose underlying query fails renders `unavailable` rather than a
+    // smoothed-over narrative — the ledger grounds, no LLM narrates here.
+
+    #[tool(
+        description = "The governor's estate digest: agent activity by principal (proposals, \
+         applies, denials with rule names), pending review escalations ranked, runs needing \
+         attention, drift observed vs auto-handled, freshness/quality, cost + autonomy-budget \
+         burn, and degraded/frozen rules — every line carrying a ledger citation \
+         (run_id/plan_id/decision_ref). Template-first: a section whose query fails renders \
+         `unavailable`, never a fabricated summary. `since` is `last` | `24h` | `7d` (default \
+         `7d`); reads are side-effect-free (never advances the `--since last` cursor)."
+    )]
+    async fn estate_brief(
+        &self,
+        params: Parameters<EstateBriefArgs>,
+    ) -> ToolResult<serde_json::Value> {
+        let since = match params.0.since.as_deref().unwrap_or("7d") {
+            "last" => commands::BriefSince::Last,
+            "24h" => commands::BriefSince::Hours24,
+            "7d" => commands::BriefSince::Days7,
+            other => {
+                return Err(ToolError::invalid_argument(
+                    format!("unknown since window '{other}'"),
+                    "Pass one of: last, 24h, 7d.",
+                ));
+            }
+        };
+        let output = commands::compute_brief(
+            &self.state_path(),
+            &self.config_path,
+            since,
+            chrono::Utc::now(),
+        )
+        .map_err(|e| {
+            ToolError::internal(
+                format!("{e:#}"),
+                "Could not read the state store to compose the digest; ensure the project's \
+                 state store is present and readable.",
+            )
+        })?;
+        let value = serde_json::to_value(&output).map_err(|e| {
+            ToolError::internal(
+                format!("failed to serialize the estate brief: {e}"),
+                "Retry; if it persists this is an internal serialization bug.",
+            )
+        })?;
+        Ok(Json(value))
+    }
+
+    #[tool(
+        description = "Trace the custody chain for a subject: a model name, a run id, or a \
+         64-character plan id. Returns the one-query drill-down — who proposed it (principal), \
+         what the policy plane decided (rule id + effect), what the plan changed (typed diff), \
+         which runs materialized it, what post-apply verification found, and the downstream \
+         blast radius. Each link fails closed: a link whose signal is genuinely not recorded \
+         renders `unavailable` with a note rather than a fabricated value. Read-only."
+    )]
+    async fn audit_query(
+        &self,
+        params: Parameters<AuditQueryArgs>,
+    ) -> ToolResult<serde_json::Value> {
+        let subject = params.0.subject;
+        if subject.trim().is_empty() {
+            return Err(ToolError::invalid_argument(
+                "subject is empty",
+                "Pass a model name, a run id, or a 64-character plan id to trace.",
+            ));
+        }
+        let output = commands::compute_audit_for(
+            &self.root,
+            &self.config_path,
+            &self.state_path(),
+            &self.models_dir,
+            &subject,
+        )
+        .map_err(|e| {
+            ToolError::internal(
+                format!("{e:#}"),
+                "Could not assemble the custody chain; ensure the project's state store is \
+                 present and readable.",
+            )
+        })?;
+        let value = serde_json::to_value(&output).map_err(|e| {
+            ToolError::internal(
+                format!("failed to serialize the custody chain: {e}"),
+                "Retry; if it persists this is an internal serialization bug.",
+            )
+        })?;
+        Ok(Json(value))
+    }
+
+    #[tool(
+        description = "The trust scorecard: a decisions-by-group aggregation over the policy \
+         ledger — acceptance rate, denial rate, and require-review rate per group. `by` is \
+         `principal` | `rule` | `scope` (default `principal`); `window` is `all` or a `<N>d` / \
+         `<N>h` duration (e.g. `30d`, default all-time). Only metrics the ledger actually \
+         persists are computed; verify-after / revert / escalation-latency metrics are declared \
+         `unavailable` with a reason, never faked. This informs human judgment — nothing here is \
+         wired to any automatic policy change. Read-only."
+    )]
+    async fn scorecard(&self, params: Parameters<ScorecardArgs>) -> ToolResult<serde_json::Value> {
+        let by = match params.0.by.as_deref().unwrap_or("principal") {
+            "principal" => rocky_cli::output::ScorecardDimension::Principal,
+            "rule" => rocky_cli::output::ScorecardDimension::Rule,
+            "scope" => rocky_cli::output::ScorecardDimension::Scope,
+            other => {
+                return Err(ToolError::invalid_argument(
+                    format!("unknown scorecard dimension '{other}'"),
+                    "Pass one of: principal, rule, scope.",
+                ));
+            }
+        };
+        // The only error path is a malformed `window` (a usage error); a ledger
+        // read failure renders the scorecard `unavailable` inside the core.
+        let output =
+            commands::compute_audit_scorecard(&self.state_path(), by, params.0.window.as_deref())
+                .map_err(|e| {
+                ToolError::invalid_argument(
+                    format!("{e:#}"),
+                    "Pass `window` as 'all' or a '<N>d' / '<N>h' duration (e.g. 30d).",
+                )
+            })?;
+        let value = serde_json::to_value(&output).map_err(|e| {
+            ToolError::internal(
+                format!("failed to serialize the scorecard: {e}"),
+                "Retry; if it persists this is an internal serialization bug.",
+            )
+        })?;
+        Ok(Json(value))
+    }
+
+    #[tool(
+        description = "The ranked pending-review queue, and a GATED approve action. With no \
+         `approve_plan_id`, lists every `require_review` escalation not yet signed off, ranked by \
+         blast_radius × classification × staleness, each carrying its decision_ref, plan_id, and \
+         `approve_command`. With `approve_plan_id` + `confirm=true`, writes the human sign-off \
+         marker that unblocks `rocky apply` for that plan — refused unless the plan is actually in \
+         the pending queue AND `confirm` is set (the require-review-grade confirmation stands in \
+         for explicit human intent). Policy applies to the governor's agent too: the approval is \
+         attributed to the operator's git identity, not a cryptographically bound principal (a \
+         signed human confirmation is a later step). Never approve on the user's behalf."
+    )]
+    async fn review_queue(
+        &self,
+        params: Parameters<ReviewQueueArgs>,
+    ) -> ToolResult<ReviewQueueResult> {
+        let args = params.0;
+        let state_path = self.state_path();
+
+        // Always compute the current queue first — it is both the read result
+        // and the guard that an approve targets a genuinely pending escalation.
+        let queue = commands::compute_review_queue(
+            &self.root,
+            &self.config_path,
+            &state_path,
+            &self.models_dir,
+        )
+        .map_err(|e| {
+            ToolError::internal(
+                format!("{e:#}"),
+                "Could not build the review queue; ensure the project's state store is present \
+                 and readable.",
+            )
+        })?;
+
+        let Some(plan_id) = args.approve_plan_id.as_deref() else {
+            // Read mode.
+            let pending = serde_json::to_value(&queue.pending).map_err(|e| {
+                ToolError::internal(
+                    format!("failed to serialize the review queue: {e}"),
+                    "Retry; if it persists this is an internal serialization bug.",
+                )
+            })?;
+            return Ok(Json(ReviewQueueResult {
+                total: queue.total,
+                ranking: queue.ranking,
+                pending,
+                approval: None,
+            }));
+        };
+
+        // The plan must be an outstanding escalation in THIS queue — not an
+        // arbitrary reviewable plan.
+        if !queue.pending.iter().any(|e| e.plan_id == plan_id) {
+            return Err(ToolError::invalid_argument(
+                format!("plan '{plan_id}' is not in the pending review queue"),
+                "Call review_queue with no approve_plan_id to see the plan_ids currently awaiting \
+                 review, then approve one of those.",
+            ));
+        }
+
+        // The gate: approving writes a human sign-off marker, so it requires an
+        // explicit, require-review-grade confirmation.
+        if !args.confirm {
+            return Err(ToolError::policy_review_required(
+                format!(
+                    "approving '{plan_id}' writes a human sign-off marker that unblocks \
+                     `rocky apply`; it requires explicit confirmation."
+                ),
+                "Re-call review_queue with confirm=true ONLY when the human has explicitly \
+                 authorized approving this exact plan. The approval is attributed to the \
+                 operator's git identity — never approve on the user's behalf.",
+                None,
+            ));
+        }
+
+        // Write the sign-off marker (the artifact `rocky apply` checks),
+        // attributed to the operator running this server. Reuses the exact
+        // `rocky review --approve` core; the breaking-change gate is best-effort
+        // and the marker writes regardless.
+        let review = commands::compute_review(&self.root, &self.config_path, plan_id, "HEAD", true)
+            .await
+            .map_err(|e| {
+                ToolError::internal(
+                    format!("{e:#}"),
+                    "Confirm the plan is an AI-authored or agent-authored plan and the project \
+                     directory is writable so the sign-off marker can be persisted.",
+                )
+            })?;
+
+        let breaking_change_count = review
+            .breaking_changes
+            .as_ref()
+            .map(|f| f.iter().filter(|x| x.is_breaking()).count() as u64)
+            .unwrap_or(0);
+        let approval = ReviewApprovalOutcome {
+            plan_id: plan_id.to_string(),
+            marker_written: review.marker_written,
+            breaking_change_count,
+            message: review.message.unwrap_or_default(),
+            attribution: "Recorded via the governor MCP surface and attributed to the operator's \
+                 git identity (name/email/host), not a cryptographically bound principal. A signed \
+                 human confirmation is a later step; the confirm flag stands in for explicit human \
+                 intent today."
+                .to_string(),
+        };
+
+        // Re-list the queue post-approval so the caller sees this escalation
+        // cleared by the marker just written.
+        let queue_after = commands::compute_review_queue(
+            &self.root,
+            &self.config_path,
+            &state_path,
+            &self.models_dir,
+        )
+        .map_err(|e| {
+            ToolError::internal(
+                format!("{e:#}"),
+                "The sign-off marker was written, but re-listing the queue failed; re-call \
+                 review_queue to see the current state.",
+            )
+        })?;
+        let pending = serde_json::to_value(&queue_after.pending).map_err(|e| {
+            ToolError::internal(
+                format!("failed to serialize the review queue: {e}"),
+                "Retry; if it persists this is an internal serialization bug.",
+            )
+        })?;
+        Ok(Json(ReviewQueueResult {
+            total: queue_after.total,
+            ranking: queue_after.ranking,
+            pending,
+            approval: Some(approval),
+        }))
     }
 
     /// Resolve the project's target warehouse adapter from `rocky.toml`.

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -421,6 +421,23 @@ effect = "require_review"
             .contains(&plan_id)
     );
 
+    // Approving a plan that is NOT in the pending queue is refused up front —
+    // the approve action only clears genuinely-pending escalations.
+    let bogus = serde_json::json!({ "approve_plan_id": "0".repeat(64), "confirm": true })
+        .as_object()
+        .unwrap()
+        .clone();
+    let bogus_res = client
+        .call_tool(CallToolRequestParams::new("review_queue").with_arguments(bogus))
+        .await
+        .expect("review_queue bogus approve returns a result");
+    assert_eq!(bogus_res.is_error, Some(true));
+    assert_eq!(
+        bogus_res.structured_content.expect("error envelope")["code"],
+        serde_json::json!("invalid_argument"),
+        "approving a non-pending plan is rejected even with confirm=true"
+    );
+
     // estate_brief surfaces the escalation + agent activity, cited.
     let brief = client
         .call_tool(CallToolRequestParams::new("estate_brief"))

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -80,6 +80,7 @@ async fn tools_list_returns_expected_set() {
         vec![
             "ai_contract",
             "ai_test",
+            "audit_query",
             "breaking_change",
             "catalog",
             "compile",
@@ -88,6 +89,7 @@ async fn tools_list_returns_expected_set() {
             "draft_contract",
             "draft_model",
             "drift_preview",
+            "estate_brief",
             "explain_model",
             "governance_preview",
             "history",
@@ -99,7 +101,9 @@ async fn tools_list_returns_expected_set() {
             "plan_preview",
             "profile_column",
             "propose",
+            "review_queue",
             "sample_rows",
+            "scorecard",
             "suggest_freshness_block",
             "test",
         ]
@@ -346,6 +350,201 @@ effect = "require_review"
     assert!(
         message.contains(plan_id) || hint.contains(plan_id),
         "the recorded plan_id is surfaced: message={message} hint={hint}"
+    );
+
+    client.cancel().await.unwrap();
+}
+
+/// End-to-end reachability for the four governor tools over the real stdio
+/// server: an agent `propose` under a `require_review` policy plants one
+/// escalation in the ledger, then every governor projection surfaces it with
+/// citations, the scorecard matches hand-computed truth, and the `review_queue`
+/// approve action is gated on an explicit confirmation before it writes the
+/// sign-off marker that unblocks `rocky apply`.
+#[tokio::test]
+async fn governor_tools_surface_escalation_and_gate_the_approve() {
+    let dir = TempDir::new().unwrap();
+    write_project_with_policy(
+        dir.path(),
+        &dir.path().join("test.duckdb"),
+        r#"[policy]
+version = 1
+default_agent_effect = "require_review"
+
+[[policy.rules]]
+principal = "agent"
+capability = "apply"
+scope = { any = true }
+effect = "require_review"
+"#,
+    );
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+
+    // An agent proposes → recorded as a require_review escalation in the ledger,
+    // and the AI-authored plan is persisted for a reviewer.
+    let _ = client
+        .call_tool(CallToolRequestParams::new("propose"))
+        .await
+        .expect("propose returns a result");
+    let plans = plan_files(dir.path());
+    assert_eq!(plans.len(), 1, "the propose persisted one plan for review");
+    let plan_id = plans[0].file_stem().unwrap().to_str().unwrap().to_string();
+
+    // review_queue (read) lists the escalation, cited.
+    let queue = client
+        .call_tool(CallToolRequestParams::new("review_queue"))
+        .await
+        .expect("review_queue call");
+    assert_ne!(
+        queue.is_error,
+        Some(true),
+        "listing the queue is not an error"
+    );
+    let sc = queue.structured_content.expect("queue structured content");
+    assert_eq!(sc["total"], serde_json::json!(1));
+    let pending = sc["pending"].as_array().unwrap();
+    assert_eq!(pending.len(), 1, "one escalation awaits review");
+    assert_eq!(pending[0]["plan_id"], serde_json::json!(plan_id));
+    assert_eq!(pending[0]["principal"], serde_json::json!("agent"));
+    assert!(
+        pending[0]["decision_ref"]
+            .as_str()
+            .unwrap()
+            .contains(&plan_id),
+        "the queue entry carries a ledger citation naming the plan"
+    );
+    assert!(
+        pending[0]["approve_command"]
+            .as_str()
+            .unwrap()
+            .contains(&plan_id)
+    );
+
+    // estate_brief surfaces the escalation + agent activity, cited.
+    let brief = client
+        .call_tool(CallToolRequestParams::new("estate_brief"))
+        .await
+        .expect("estate_brief call");
+    assert_ne!(brief.is_error, Some(true));
+    let bc = brief.structured_content.expect("brief structured content");
+    assert_eq!(
+        bc["agent_activity"]["require_review"],
+        serde_json::json!(1),
+        "the brief counts the agent escalation"
+    );
+    let escalations = bc["escalations"]["pending"].as_array().unwrap();
+    assert!(
+        escalations
+            .iter()
+            .any(|e| e["plan_id"] == serde_json::json!(plan_id)),
+        "the brief's escalations name the pending plan: {bc:?}"
+    );
+
+    // audit_query --for <plan_id> returns the resolved custody chain.
+    let audit_args = serde_json::json!({ "subject": plan_id })
+        .as_object()
+        .unwrap()
+        .clone();
+    let audit = client
+        .call_tool(CallToolRequestParams::new("audit_query").with_arguments(audit_args))
+        .await
+        .expect("audit_query call");
+    let ac = audit.structured_content.expect("audit structured content");
+    assert_eq!(ac["subject_kind"], serde_json::json!("plan"));
+    assert_eq!(ac["resolved"], serde_json::json!(true));
+    assert!(
+        ac["decisions"]["total"].as_u64().unwrap() >= 1,
+        "the custody chain carries the governing decision: {ac:?}"
+    );
+
+    // scorecard --by principal matches hand truth: 1 agent decision, all review.
+    let scorecard_args = serde_json::json!({ "by": "principal" })
+        .as_object()
+        .unwrap()
+        .clone();
+    let scorecard = client
+        .call_tool(CallToolRequestParams::new("scorecard").with_arguments(scorecard_args))
+        .await
+        .expect("scorecard call");
+    let sco = scorecard.structured_content.expect("scorecard content");
+    assert_eq!(sco["by"], serde_json::json!("principal"));
+    assert_eq!(sco["total_decisions"], serde_json::json!(1));
+    let groups = sco["groups"].as_array().unwrap();
+    let agent = groups
+        .iter()
+        .find(|g| g["key"] == serde_json::json!("agent"))
+        .expect("an agent group in the scorecard");
+    assert_eq!(agent["total"], serde_json::json!(1));
+    assert_eq!(agent["require_review"], serde_json::json!(1));
+    assert_eq!(agent["allow"], serde_json::json!(0));
+    assert_eq!(agent["deny"], serde_json::json!(0));
+    assert!(
+        (agent["review_rate"].as_f64().unwrap() - 1.0).abs() < 1e-9,
+        "escalation rate is 1.0: {agent:?}"
+    );
+
+    // review_queue approve WITHOUT confirm → the gate refuses.
+    let approve_no_confirm = serde_json::json!({ "approve_plan_id": plan_id })
+        .as_object()
+        .unwrap()
+        .clone();
+    let refused = client
+        .call_tool(CallToolRequestParams::new("review_queue").with_arguments(approve_no_confirm))
+        .await
+        .expect("review_queue approve (no confirm) returns a result");
+    assert_eq!(
+        refused.is_error,
+        Some(true),
+        "an unconfirmed approve is refused"
+    );
+    let err = refused
+        .structured_content
+        .expect("structured error envelope");
+    assert_eq!(err["code"], serde_json::json!("policy_review_required"));
+
+    // No sign-off marker before confirmation — the gate held.
+    let marker = dir
+        .path()
+        .join(".rocky")
+        .join("plans")
+        .join(format!("{plan_id}.reviewed.json"));
+    assert!(!marker.exists(), "no sign-off marker before confirmation");
+
+    // review_queue approve WITH confirm=true → writes the marker, attributed.
+    let approve = serde_json::json!({ "approve_plan_id": plan_id, "confirm": true })
+        .as_object()
+        .unwrap()
+        .clone();
+    let approved = client
+        .call_tool(CallToolRequestParams::new("review_queue").with_arguments(approve))
+        .await
+        .expect("review_queue approve call");
+    assert_ne!(
+        approved.is_error,
+        Some(true),
+        "a confirmed approve succeeds: {approved:?}"
+    );
+    let ap = approved.structured_content.expect("approval content");
+    assert_eq!(ap["approval"]["marker_written"], serde_json::json!(true));
+    assert_eq!(ap["approval"]["plan_id"], serde_json::json!(plan_id));
+    assert!(
+        ap["approval"]["attribution"]
+            .as_str()
+            .unwrap()
+            .contains("git identity"),
+        "the approval is honest that attribution is the operator's git identity"
+    );
+    assert_eq!(
+        ap["total"],
+        serde_json::json!(0),
+        "the approved escalation is cleared from the re-listed queue"
+    );
+
+    // The sign-off marker that unblocks `rocky apply` now exists on disk.
+    assert!(
+        marker.exists(),
+        "the confirmed approve wrote the sign-off marker"
     );
 
     client.cancel().await.unwrap();


### PR DESCRIPTION
## What

Adds four governor-side MCP tools to `rocky mcp`, so a human governing an agent-operated estate can ask their own assistant "what did agents do to finance models this week, and why was Tuesday's apply allowed?" and get a cited, conversational answer over the same decision/run ledger the worker-agent tools write to:

- **`estate_brief`** — the `rocky brief` digest: agent activity by principal (proposals, applies, denials with rule names), ranked pending escalations, runs needing attention, drift observed vs auto-handled, freshness/quality, cost + autonomy-budget burn, and degraded/frozen rules. Every line carries a ledger citation (`run_id`/`plan_id`/`decision_ref`).
- **`audit_query`** — the `rocky audit --for` custody chain for a table/run/plan: principal → decision → plan → typed diff → runs → downstream blast radius.
- **`scorecard`** — `rocky audit --scorecard --by principal|rule|scope --window`.
- **`review_queue`** — the ranked pending-review queue, plus a **gated approve** action.

## Why

The governor's primary console in the agent era is their own assistant. These are typed projections of the ledger — no new state, no schema change. Each reuses the shipped `brief`/`audit`/`review` cores rather than reimplementing them, so the projection stays honest: a section whose underlying query fails renders `unavailable`, never a smoothed-over narrative. There is no LLM narration inside the tools — the ledger grounds, templates render.

### The gated approve

`review_queue` with no `approve_plan_id` lists the queue. With `approve_plan_id` + `confirm=true` it writes the human sign-off marker that unblocks `rocky apply` for that plan — but only if the plan is genuinely in the pending queue **and** `confirm` is set. The confirmation is the gate (a require-review-grade confirmation standing in for explicit human intent); an unconfirmed approve returns a structured `policy_review_required` and writes nothing. The approval is attributed to the operator's git identity, and the result says so honestly — it is **not** a cryptographically bound principal. A signed human confirmation is a later step; there is no separate "approve" policy capability, so approve is not policy-gated beyond the confirmation + the pending-queue check.

## Implementation note (why the CLI cores changed)

`rocky mcp` speaks the protocol over stdout, and the reused cores (`run_brief`, `run_audit_for`, `run_audit_scorecard`, `run_review_queue_in`, `run_review_in`) print to stdout. Reaching any printing path from a tool call would corrupt the wire. So each grew a non-printing `compute_*` that returns the typed `*Output`; the `run_*` entry points now render that output and are otherwise behavior-identical (the `brief` `--since last` cursor still advances to the same instant the digest was composed at). The three read tools return the `*Output` re-serialized as JSON (`serde_json::Value`) rather than a hand-rolled lite re-projection — the most faithful projection, and it guarantees no ledger citation is dropped. `review_queue` keeps a small typed result to carry the approve outcome.

## Anchor drift found

The design notes were several releases stale; everything was re-located by symbol. Two notable drifts:

- **`ROCKY_PRINCIPAL` is vestigial.** It survives only as a stale comment in `apply.rs`; nothing actually reads it. The authoring principal resolves from the plan's stamp or its kind, and the MCP `propose` tool hardcodes `agent`. The only principals are `human` and `agent` — there is no distinct "governor principal" in the taxonomy, so the governor's agent operates as `agent` and its approve is attributed by git identity. Built nothing on `ROCKY_PRINCIPAL`.
- **The cores print; they don't return.** The notes implied callable output cores; in current code the `run_*` functions build the `*Output` then print it, which is why the `compute_*` split was necessary.

## No schema bump — confirmed

No `*Output` struct in `output.rs` was touched (`git diff` on `output.rs` and `schemas/` is empty). The redb state schema is untouched. MCP tool/result schemas are generated by rmcp at runtime and are not part of the committed-bindings codegen, so this needs no `just codegen`, no `just regen-fixtures`, and no Dagster/vscode binding regen.

## Reachability evidence

Driven end-to-end through the **real `rocky mcp` stdio server** (external process, JSON-RPC over stdin/stdout) on a DuckDB project with a `require_review` policy. An agent `propose` plants one escalation in the ledger; then:

```
== propose (is_error=True): policy_review_required

== review_queue (read) total=1 ranking=blast_radius × classification × staleness
   pending[0]: plan_id=7d54ed21dc052174... principal=agent model=orders
   decision_ref=2026-07-10T08:11:47.102230+00:00|7d54ed21dc052174fb255b50ea7...
   approve_command=rocky review 7d54ed21dc052174fb255b50ea7...
   blast_radius=0 score=3.00 staleness_s=0

== estate_brief agent_activity: total=1 allow=0 require_review=1 deny=0 (avail=available)
   escalations total=1 pending[0].plan_id=7d54ed21dc052174...
   escalations pending[0].decision_ref=2026-07-10T08:11:47.102230+00:00|7d54ed2...

== audit_query subject_kind=plan resolved=True decisions.total=1
   decision: principal=agent capability=schema_change.breaking effect=require_review model=orders
   blast_radius availability=no_data

== scorecard by=principal total_decisions=1
   agent group: total=1 allow=0 require_review=1 deny=0 acceptance=0.00 review_rate=1.00
   agent decision_refs=['2026-07-10T08:11:47.102230+00:00|7d54ed2...']
   unavailable_metrics=['verify_after_pass_rate', 'reverts', 'escalation_latency']

== review_queue approve (NO confirm) is_error=True code=policy_review_required
   marker exists before confirm? False

== review_queue approve (confirm=true) is_error=False
   approval.marker_written=True breaking_change_count=0
   approval.attribution=Recorded via the governor MCP surface and attributed to the operator's git identity ...
   queue total AFTER approve=0 (escalation cleared)
   marker exists after confirm? True
```

The scorecard matches hand-computed truth: one agent decision, all `require_review` → `review_rate = 1.00`, `acceptance = 0.00`, with the unpersisted metrics declared `unavailable` rather than faked. The same flow is pinned as an in-process integration test (`governor_tools_surface_escalation_and_gate_the_approve` in `roundtrip.rs`), driving the real `ServerHandler` over a duplex transport.

### Mixed-run digest

Repeating on a fixture that also has a real `rocky run` recorded, `estate_brief` composes the decision-derived and operational sections in one digest, with the unpopulated ones rendering their fail-closed states honestly rather than fabricating a number:

```
estate_brief AFTER a real `rocky run`:
  runs:           availability=available total=1 succeeded=1 failed=0
  agent_activity: availability=available total=1 require_review=1
  escalations:    total=1
  freshness=no_data quality=no_data drift=unavailable cost=available  (fail-closed, not fabricated)
```

The `review_queue` guard against approving a plan that is not in the pending queue is also pinned (`approve_plan_id` = an id not in the queue, `confirm=true` → `invalid_argument`, nothing written). The `runs`/`drift`/`freshness`/`quality`/`cost` populated paths are additionally covered by the brief core's own unit tests (`commands::brief::tests`), which the workspace run exercises.

One incidental observation while wiring the fixture: the CLI `run`/`history` resolve the state store cwd-relative, while `rocky mcp` roots it at the config's directory — so a `rocky run` invoked from outside the project directory writes to a different store than the server reads. Pre-existing (the other MCP tools share the same `self.state_path()`); not touched here.

## Gates

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` (rocky-cli + rocky-mcp, the only changed crates) — clean
- `cargo test --workspace` — 60 test binaries, 0 failures (rocky-mcp roundtrip 41 passed incl. the new governor test with its approve-gate + guard assertions; rocky-cli 979 lib tests incl. all brief/audit/review)
- Live `rocky mcp` stdio session — all four tools reachable; approve gate + marker verified on disk
