### PR TITLE
chore: release engine v1.63.0, sdk v0.6.0, dagster v1.59.0, vscode v1.34.3

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.34.3] — 2026-07-10
+
+### Added
+
+- **Generated TypeScript types for the engine-v1.63.0 output surface** — `rocky gc` plan + apply (`gc_plan`, `gc_apply`). Additive; the LSP client and existing commands are unchanged.
+
+
 ## [1.34.2] — 2026-07-10
 
 ### Added

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocky",
-  "version": "1.34.2",
+  "version": "1.34.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocky",
-      "version": "1.34.2",
+      "version": "1.34.3",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^10.1.0"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.34.2",
+  "version": "1.34.3",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.63.0] - 2026-07-10
+
+### Added
+
+- **Governor-side MCP tools** — `estate_brief`, `audit_query`, `scorecard`, and `review_queue` expose the decision/run ledger as typed, cited projections over the MCP surface, so an operator's own assistant can ask "what did agents do to finance models this week, and why was Tuesday's apply allowed?" and get grounded answers. `review_queue` carries a gated approve action, refused unless the plan is genuinely pending and confirmation is given. (#1077)
+- **`rocky gc` reclamation with deletion behind review.** `rocky gc --derivable` now writes a review-gated plan (alongside the existing `--dry-run` inventory); `rocky apply <plan>` re-derives eligibility against the live ledger and evicts only artifacts it can still prove are rebuildable — matched by full identity (run, model, file path, content hash) — committing a restore tombstone and retiring the ledger row in one transaction before a best-effort physical delete. Deletion is symmetric-caution gated: even a human gc goes through review, and policy can only tighten. Eligibility is hash-exact and fail-closed, so a derivability proof for one artifact can never authorize deleting another, and a stale or hand-authored plan is refused. (#1078)
+
+### Changed
+
+- State schema `v18 → v19`: an additive tombstones table recording each eviction's recipe identity and restore pointer. Additive — older state opens forward-compatibly.
+
+
 ## [1.62.0] - 2026-07-10
 
 ### Added

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "indexmap",
  "reqwest 0.12.28",
@@ -3964,7 +3964,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3981,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4009,7 +4009,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "redis",
  "serde",
@@ -4021,7 +4021,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -4032,7 +4032,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -4116,7 +4116,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4156,7 +4156,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4202,7 +4202,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4220,7 +4220,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4251,7 +4251,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -4289,7 +4289,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "logos",
  "miette",
@@ -4301,7 +4301,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "rocky-server",
  "rustls",
@@ -4310,7 +4310,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4335,7 +4335,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4353,7 +4353,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4382,7 +4382,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -4409,7 +4409,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "miette",
  "regex",
@@ -4422,7 +4422,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4459,7 +4459,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.62.0"
+version = "1.63.0"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.62.0"
+version = "1.63.0"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.62.0"
+version = "1.63.0"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.62.0"
+version = "1.63.0"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.62.0"
+version = "1.63.0"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.62.0"
+version = "1.63.0"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.62.0"
+version = "1.63.0"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.62.0"
+version = "1.63.0"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.62.0"
+version = "1.63.0"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.62.0"
+version = "1.63.0"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.62.0"
+version = "1.63.0"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.62.0"
+version = "1.63.0"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.62.0"
+version = "1.63.0"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.62.0"
+version = "1.63.0"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.62.0"
+version = "1.63.0"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.62.0"
+version = "1.63.0"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.62.0"
+version = "1.63.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.62.0"
+version = "1.63.0"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.62.0"
+version = "1.63.0"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.62.0"
+version = "1.63.0"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.62.0"
+version = "1.63.0"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.62.0"
+version = "1.63.0"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.62.0"
+version = "1.63.0"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.62.0"
+version = "1.63.0"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.62.0"
+version = "1.63.0"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.59.0] — 2026-07-10
+
+### Changed
+
+- **Floor raised to `rocky-sdk>=0.6.0`.** Picks up the SDK's generated types for `rocky gc` plan + apply so a `dagster-rocky` consumer resolves them through `dagster_rocky.types` without relying on latest-SDK resolution. No behavior change in the integration itself.
+
+
 ## [1.58.0] — 2026-07-10
 
 ### Changed

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.58.0"
+version = "1.59.0"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"
@@ -23,7 +23,7 @@ dependencies = [
     # package; RockyResource is a thin Dagster adapter over RockyClient. In-repo
     # dev/CI resolves this from the local path (see [tool.uv.sources]); the
     # published wheel floors on the released SDK.
-    "rocky-sdk>=0.5.0",
+    "rocky-sdk>=0.6.0",
     # Floor matches the version CI actually resolves and tests (uv.lock). The
     # RockyComponent path uses dagster.components.* APIs from preview namespaces,
     # so we advertise a tested floor rather than an older, never-exercised one.

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -220,7 +220,7 @@ wheels = [
 
 [[package]]
 name = "dagster-rocky"
-version = "1.58.0"
+version = "1.59.0"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },
@@ -910,7 +910,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "../../sdk/python" }
 dependencies = [
     { name = "pydantic" },

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-07-10
+
+### Added
+
+- **Generated types for `rocky gc` plan + apply** (`gc_plan`, `gc_apply` and their nested candidate / tombstone shapes). Additive — existing parses are unaffected.
+
+
 ## [0.5.0] — 2026-07-10
 
 ### Added

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rocky-sdk"
-version = "0.5.0"
+version = "0.6.0"
 description = "Typed Python client for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Wave 11 quad-cut release.

| Artifact | Version | What |
|---|---|---|
| engine | 1.62.0 → **1.63.0** | governor-side MCP tools (#1077); `rocky gc` plan+apply+tombstone reclamation behind review (#1078); state schema v18→v19 |
| rocky-sdk | 0.5.0 → **0.6.0** | generated `gc_plan` / `gc_apply` types |
| dagster-rocky | 1.58.0 → **1.59.0** | floor → `rocky-sdk>=0.6.0` (no source change) |
| vscode | 1.34.2 → **1.34.3** | regenerated TypeScript bindings for gc plan/apply |

Version bumps + CHANGELOGs + lockfiles only; no `*Output` schema changes beyond the committed gc bindings (zero codegen drift). Tag order on merge: sdk → dagster → vscode → engine (engine last for GitHub Latest).