### PR TITLE
fix(engine): governor queue lists real pending plans; brief dedup; audit reads persisted verify rows

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -1308,20 +1308,35 @@
         "type": "object"
       },
       "AuditChainVerify": {
-        "description": "Verify-after link of the custody chain.\n\nPost-apply verification outcomes are not persisted to the state store today, so this link is always [`SectionAvailability::Unavailable`] with a note — never a smoothed-over \"verification passed\".",
+        "description": "Verify-after link of the custody chain.\n\nPost-apply verification outcomes are persisted to the decision ledger as custody rows with a non-empty `verify_after` check list — the two-step `rocky apply` gate writes one per verified apply, and the drift auto-apply path writes them under its `autoapply-verify:<run_id>` plan id. This link renders those rows for the subject's plan. When none exist the link says so plainly (\"not recorded\") — never a smoothed-over \"verification passed\".",
         "properties": {
           "availability": {
             "$ref": "#/components/schemas/SectionAvailability"
+          },
+          "entries": {
+            "description": "The verification outcomes, newest first.",
+            "items": {
+              "$ref": "#/components/schemas/AuditVerifyEntry"
+            },
+            "type": "array"
           },
           "note": {
             "type": [
               "string",
               "null"
             ]
+          },
+          "total": {
+            "description": "Count of verification custody rows found for the subject.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
           }
         },
         "required": [
-          "availability"
+          "availability",
+          "entries",
+          "total"
         ],
         "type": "object"
       },
@@ -1484,7 +1499,7 @@
         ]
       },
       "AuditForOutput": {
-        "description": "JSON output for `rocky audit --for <table|run|plan>` — the custody chain.\n\nA one-query drill-down assembled link by link from the data Rocky already records: who proposed the change and what the policy plane decided ([`Self::decisions`]), what the plan changed ([`Self::plan`]), which runs materialized it ([`Self::runs`]), what a post-apply verification found ([`Self::verify_after`]), and what sits downstream in its blast radius ([`Self::blast_radius`]).\n\nEvery link fails closed the same way the estate brief does: a link whose signal is genuinely not recorded renders [`SectionAvailability::Unavailable`] with a note, never a fabricated or assumed value. Notably, post-apply verification outcomes are not persisted anywhere today, so [`Self::verify_after`] is always `unavailable`; and the run ledger is not keyed to policy decisions, so a `run` selector cannot join back to a decision. The blast radius is recomputed from the current compiled graph (a live query, not a stored snapshot).",
+        "description": "JSON output for `rocky audit --for <table|run|plan>` — the custody chain.\n\nA one-query drill-down assembled link by link from the data Rocky already records: who proposed the change and what the policy plane decided ([`Self::decisions`]), what the plan changed ([`Self::plan`]), which runs materialized it ([`Self::runs`]), what a post-apply verification found ([`Self::verify_after`]), and what sits downstream in its blast radius ([`Self::blast_radius`]).\n\nEvery link fails closed the same way the estate brief does: a link whose signal is genuinely not recorded renders [`SectionAvailability::Unavailable`] with a note, never a fabricated or assumed value. Post-apply verification outcomes are persisted as decision-ledger custody rows (non-empty `verify_after`), so [`Self::verify_after`] renders them when they exist and says \"not recorded\" when none exist for the subject. The run ledger is not keyed to policy decisions, so a `run` selector cannot join back to a decision. The blast radius is recomputed from the current compiled graph (a live query, not a stored snapshot).",
         "properties": {
           "blast_radius": {
             "allOf": [
@@ -1543,7 +1558,7 @@
                 "$ref": "#/components/schemas/AuditChainVerify"
               }
             ],
-            "description": "What a post-apply verification found — not recorded today."
+            "description": "What a post-apply verification found — the verification custody rows recorded against the subject's plan."
           },
           "version": {
             "type": "string"
@@ -1640,7 +1655,7 @@
         "type": "object"
       },
       "AuditScorecardOutput": {
-        "description": "JSON output for `rocky audit --scorecard` — a trust-calibration digest.\n\nA decisions-by-group aggregation over the persisted policy-decision ledger, windowed by `--window`. It is the evidence base for widening or tightening autonomy, and it informs human judgment only — nothing here is wired to any automatic policy change.\n\nOnly metrics the ledger actually persists are computed. The ledger records one row per policy *evaluation* — `(principal, capability, model, effect, rule_id)` — and nothing about what happened *after* the decision. So verify-after outcomes, reverts, and escalation-resolution latency are not derivable; they are declared, once, in [`Self::unavailable_metrics`] as `unavailable` with the reason, never faked into a number. A ledger read failure renders the whole scorecard `unavailable` rather than a smoothed-over zero.",
+        "description": "JSON output for `rocky audit --scorecard` — a trust-calibration digest.\n\nA decisions-by-group aggregation over the persisted policy-decision ledger, windowed by `--window`. It is the evidence base for widening or tightening autonomy, and it informs human judgment only — nothing here is wired to any automatic policy change.\n\nOnly metrics the ledger actually persists are computed. Post-apply verification outcomes *are* persisted (custody rows with a non-empty `verify_after` check list), so [`Self::verify_after`] reports their pass rate when any fall in the window. Reverts and escalation-resolution latency are not persisted; they are declared in [`Self::unavailable_metrics`] as `unavailable` with the reason, never faked into a number — and `verify_after_pass_rate` joins that list only when no verification row falls in the window. A ledger read failure renders the whole scorecard `unavailable` rather than a smoothed-over zero.",
         "properties": {
           "availability": {
             "allOf": [
@@ -1681,11 +1696,22 @@
             "type": "integer"
           },
           "unavailable_metrics": {
-            "description": "Metrics the ledger does not persist, declared plainly rather than computed. Each is `unavailable` with the reason it cannot be derived.",
+            "description": "Metrics the persisted ledger cannot support for this window, declared plainly rather than computed. Each is `unavailable` with the reason it cannot be derived.",
             "items": {
               "$ref": "#/components/schemas/ScorecardUnavailableMetric"
             },
             "type": "array"
+          },
+          "verify_after": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ScorecardVerifyAfter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Aggregate of the post-apply verification custody rows in the window (rows with a non-empty `verify_after` check list). `null` when no verification row falls in the window — then `verify_after_pass_rate` is declared in [`Self::unavailable_metrics`] instead."
           },
           "version": {
             "type": "string"
@@ -1739,6 +1765,42 @@
             "type": "string"
           }
         ]
+      },
+      "AuditVerifyEntry": {
+        "description": "One post-apply verification outcome inside [`AuditChainVerify`] — a decision-ledger custody row with a non-empty `verify_after` check list.\n\nThe ledger records the required check names, the aggregate verdict (`allow` = every named check passed, `deny` = a check failed or was absent and the apply halted), and a human-readable reason; per-check pass/fail detail beyond that lives only in the reason string, which is rendered verbatim rather than re-parsed.",
+        "properties": {
+          "checks": {
+            "description": "The named post-apply checks the verification required.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "passed": {
+            "description": "Whether the verification passed (`allow` custody row) or failed (`deny`).",
+            "type": "boolean"
+          },
+          "plan_id": {
+            "description": "The plan id the custody row was filed under (the applied plan, or the auto-apply path's `autoapply-verify:<run_id>`).",
+            "type": "string"
+          },
+          "reason": {
+            "description": "The recorded outcome, verbatim from the custody row.",
+            "type": "string"
+          },
+          "timestamp": {
+            "description": "RFC 3339 timestamp when the verification outcome was recorded.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "checks",
+          "passed",
+          "plan_id",
+          "reason",
+          "timestamp"
+        ],
+        "type": "object"
       },
       "AutonomyBudget": {
         "additionalProperties": false,
@@ -14839,6 +14901,12 @@
           "command": {
             "type": "string"
           },
+          "excluded_non_plan_rows": {
+            "description": "Count of outstanding `require_review` ledger rows excluded from the queue because their `plan_id` resolves to no persisted plan file — decision-only custody rows (e.g. refused drafts, auto-apply evaluations) that nothing could approve. They stay in the audit ledger; they are just not approvable queue items.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
           "pending": {
             "description": "The pending escalations, highest-priority first.",
             "items": {
@@ -14862,6 +14930,7 @@
         },
         "required": [
           "command",
+          "excluded_non_plan_rows",
           "pending",
           "ranking",
           "total",
@@ -15916,7 +15985,7 @@
         "type": "object"
       },
       "ScorecardUnavailableMetric": {
-        "description": "A metric the scorecard cannot compute because the ledger does not persist its inputs.\n\nDeclared explicitly (not silently omitted) so the honesty is machine-readable: a consumer sees the metric name, that it is `unavailable`, and exactly why.",
+        "description": "A metric the scorecard cannot compute from the persisted ledger for this window.\n\nDeclared explicitly (not silently omitted) so the honesty is machine-readable: a consumer sees the metric name, that it is `unavailable`, and exactly why.",
         "properties": {
           "availability": {
             "allOf": [
@@ -15927,7 +15996,7 @@
             "description": "Always [`SectionAvailability::Unavailable`]."
           },
           "metric": {
-            "description": "The metric identifier (`verify_after_pass_rate`, `reverts`, `escalation_latency`).",
+            "description": "The metric identifier (`reverts`, `escalation_latency`, or `verify_after_pass_rate` when no verification row falls in the window).",
             "type": "string"
           },
           "note": {
@@ -15939,6 +16008,41 @@
           "availability",
           "metric",
           "note"
+        ],
+        "type": "object"
+      },
+      "ScorecardVerifyAfter": {
+        "description": "The verify-after aggregate inside an [`AuditScorecardOutput`]: pass/fail counts over the post-apply verification custody rows in the window.\n\nEach row's aggregate verdict is its recorded `effect` (`allow` = every named check passed, `deny` = a check failed or was absent and the apply halted), so the pass rate summarizes exactly what the ledger persists.",
+        "properties": {
+          "failed": {
+            "description": "Rows whose verdict was `deny` (a named check failed or was absent).",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "pass_rate": {
+            "description": "`passed / total`.",
+            "format": "double",
+            "type": "number"
+          },
+          "passed": {
+            "description": "Rows whose verdict was `allow` (every named check passed).",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "total": {
+            "description": "Verification custody rows in the window.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "failed",
+          "pass_rate",
+          "passed",
+          "total"
         ],
         "type": "object"
       },

--- a/editors/vscode/src/types/generated/audit_for.ts
+++ b/editors/vscode/src/types/generated/audit_for.ts
@@ -52,7 +52,7 @@ export type AuditSubjectKind = "model" | "run" | "plan";
  *
  * A one-query drill-down assembled link by link from the data Rocky already records: who proposed the change and what the policy plane decided ([`Self::decisions`]), what the plan changed ([`Self::plan`]), which runs materialized it ([`Self::runs`]), what a post-apply verification found ([`Self::verify_after`]), and what sits downstream in its blast radius ([`Self::blast_radius`]).
  *
- * Every link fails closed the same way the estate brief does: a link whose signal is genuinely not recorded renders [`SectionAvailability::Unavailable`] with a note, never a fabricated or assumed value. Notably, post-apply verification outcomes are not persisted anywhere today, so [`Self::verify_after`] is always `unavailable`; and the run ledger is not keyed to policy decisions, so a `run` selector cannot join back to a decision. The blast radius is recomputed from the current compiled graph (a live query, not a stored snapshot).
+ * Every link fails closed the same way the estate brief does: a link whose signal is genuinely not recorded renders [`SectionAvailability::Unavailable`] with a note, never a fabricated or assumed value. Post-apply verification outcomes are persisted as decision-ledger custody rows (non-empty `verify_after`), so [`Self::verify_after`] renders them when they exist and says "not recorded" when none exist for the subject. The run ledger is not keyed to policy decisions, so a `run` selector cannot join back to a decision. The blast radius is recomputed from the current compiled graph (a live query, not a stored snapshot).
  */
 export interface AuditForOutput {
   /**
@@ -85,7 +85,7 @@ export interface AuditForOutput {
    */
   subject_kind: AuditSubjectKind;
   /**
-   * What a post-apply verification found — not recorded today.
+   * What a post-apply verification found — the verification custody rows recorded against the subject's plan.
    */
   verify_after: AuditChainVerify;
   version: string;
@@ -235,10 +235,46 @@ export interface AuditRunEntry {
 /**
  * Verify-after link of the custody chain.
  *
- * Post-apply verification outcomes are not persisted to the state store today, so this link is always [`SectionAvailability::Unavailable`] with a note — never a smoothed-over "verification passed".
+ * Post-apply verification outcomes are persisted to the decision ledger as custody rows with a non-empty `verify_after` check list — the two-step `rocky apply` gate writes one per verified apply, and the drift auto-apply path writes them under its `autoapply-verify:<run_id>` plan id. This link renders those rows for the subject's plan. When none exist the link says so plainly ("not recorded") — never a smoothed-over "verification passed".
  */
 export interface AuditChainVerify {
   availability: SectionAvailability;
+  /**
+   * The verification outcomes, newest first.
+   */
+  entries: AuditVerifyEntry[];
   note?: string | null;
+  /**
+   * Count of verification custody rows found for the subject.
+   */
+  total: number;
+  [k: string]: unknown;
+}
+/**
+ * One post-apply verification outcome inside [`AuditChainVerify`] — a decision-ledger custody row with a non-empty `verify_after` check list.
+ *
+ * The ledger records the required check names, the aggregate verdict (`allow` = every named check passed, `deny` = a check failed or was absent and the apply halted), and a human-readable reason; per-check pass/fail detail beyond that lives only in the reason string, which is rendered verbatim rather than re-parsed.
+ */
+export interface AuditVerifyEntry {
+  /**
+   * The named post-apply checks the verification required.
+   */
+  checks: string[];
+  /**
+   * Whether the verification passed (`allow` custody row) or failed (`deny`).
+   */
+  passed: boolean;
+  /**
+   * The plan id the custody row was filed under (the applied plan, or the auto-apply path's `autoapply-verify:<run_id>`).
+   */
+  plan_id: string;
+  /**
+   * The recorded outcome, verbatim from the custody row.
+   */
+  reason: string;
+  /**
+   * RFC 3339 timestamp when the verification outcome was recorded.
+   */
+  timestamp: string;
   [k: string]: unknown;
 }

--- a/editors/vscode/src/types/generated/audit_scorecard.ts
+++ b/editors/vscode/src/types/generated/audit_scorecard.ts
@@ -23,7 +23,7 @@ export type ScorecardDimension = "principal" | "rule" | "scope";
  *
  * A decisions-by-group aggregation over the persisted policy-decision ledger, windowed by `--window`. It is the evidence base for widening or tightening autonomy, and it informs human judgment only — nothing here is wired to any automatic policy change.
  *
- * Only metrics the ledger actually persists are computed. The ledger records one row per policy *evaluation* — `(principal, capability, model, effect, rule_id)` — and nothing about what happened *after* the decision. So verify-after outcomes, reverts, and escalation-resolution latency are not derivable; they are declared, once, in [`Self::unavailable_metrics`] as `unavailable` with the reason, never faked into a number. A ledger read failure renders the whole scorecard `unavailable` rather than a smoothed-over zero.
+ * Only metrics the ledger actually persists are computed. Post-apply verification outcomes *are* persisted (custody rows with a non-empty `verify_after` check list), so [`Self::verify_after`] reports their pass rate when any fall in the window. Reverts and escalation-resolution latency are not persisted; they are declared in [`Self::unavailable_metrics`] as `unavailable` with the reason, never faked into a number — and `verify_after_pass_rate` joins that list only when no verification row falls in the window. A ledger read failure renders the whole scorecard `unavailable` rather than a smoothed-over zero.
  */
 export interface AuditScorecardOutput {
   /**
@@ -45,9 +45,13 @@ export interface AuditScorecardOutput {
    */
   total_decisions: number;
   /**
-   * Metrics the ledger does not persist, declared plainly rather than computed. Each is `unavailable` with the reason it cannot be derived.
+   * Metrics the persisted ledger cannot support for this window, declared plainly rather than computed. Each is `unavailable` with the reason it cannot be derived.
    */
   unavailable_metrics: ScorecardUnavailableMetric[];
+  /**
+   * Aggregate of the post-apply verification custody rows in the window (rows with a non-empty `verify_after` check list). `null` when no verification row falls in the window — then `verify_after_pass_rate` is declared in [`Self::unavailable_metrics`] instead.
+   */
+  verify_after?: ScorecardVerifyAfter | null;
   version: string;
   /**
    * The window as requested (`all`, `30d`, `24h`, …).
@@ -104,7 +108,7 @@ export interface ScorecardGroup {
   [k: string]: unknown;
 }
 /**
- * A metric the scorecard cannot compute because the ledger does not persist its inputs.
+ * A metric the scorecard cannot compute from the persisted ledger for this window.
  *
  * Declared explicitly (not silently omitted) so the honesty is machine-readable: a consumer sees the metric name, that it is `unavailable`, and exactly why.
  */
@@ -114,12 +118,36 @@ export interface ScorecardUnavailableMetric {
    */
   availability: SectionAvailability;
   /**
-   * The metric identifier (`verify_after_pass_rate`, `reverts`, `escalation_latency`).
+   * The metric identifier (`reverts`, `escalation_latency`, or `verify_after_pass_rate` when no verification row falls in the window).
    */
   metric: string;
   /**
    * Why the metric cannot be derived from the persisted ledger.
    */
   note: string;
+  [k: string]: unknown;
+}
+/**
+ * The verify-after aggregate inside an [`AuditScorecardOutput`]: pass/fail counts over the post-apply verification custody rows in the window.
+ *
+ * Each row's aggregate verdict is its recorded `effect` (`allow` = every named check passed, `deny` = a check failed or was absent and the apply halted), so the pass rate summarizes exactly what the ledger persists.
+ */
+export interface ScorecardVerifyAfter {
+  /**
+   * Rows whose verdict was `deny` (a named check failed or was absent).
+   */
+  failed: number;
+  /**
+   * `passed / total`.
+   */
+  pass_rate: number;
+  /**
+   * Rows whose verdict was `allow` (every named check passed).
+   */
+  passed: number;
+  /**
+   * Verification custody rows in the window.
+   */
+  total: number;
   [k: string]: unknown;
 }

--- a/editors/vscode/src/types/generated/review_queue.ts
+++ b/editors/vscode/src/types/generated/review_queue.ts
@@ -37,6 +37,10 @@ export type PolicyPrincipal = "human" | "agent";
 export interface ReviewQueueOutput {
   command: string;
   /**
+   * Count of outstanding `require_review` ledger rows excluded from the queue because their `plan_id` resolves to no persisted plan file — decision-only custody rows (e.g. refused drafts, auto-apply evaluations) that nothing could approve. They stay in the audit ledger; they are just not approvable queue items.
+   */
+  excluded_non_plan_rows: number;
+  /**
    * The pending escalations, highest-priority first.
    */
   pending: ReviewQueueEntry[];

--- a/engine/crates/rocky-cli/src/commands/audit.rs
+++ b/engine/crates/rocky-cli/src/commands/audit.rs
@@ -27,8 +27,8 @@ use rocky_core::state::{PolicyDecisionRecord, RunRecord, StateStore};
 use crate::output::{
     AuditChainBlastRadius, AuditChainDecisions, AuditChainPlan, AuditChainRuns, AuditChainVerify,
     AuditDecisionEntry, AuditForOutput, AuditOutput, AuditPlanChange, AuditRunEntry,
-    AuditScorecardOutput, AuditSubjectKind, ScorecardDimension, ScorecardGroup,
-    ScorecardUnavailableMetric, SectionAvailability, print_json,
+    AuditScorecardOutput, AuditSubjectKind, AuditVerifyEntry, ScorecardDimension, ScorecardGroup,
+    ScorecardUnavailableMetric, ScorecardVerifyAfter, SectionAvailability, print_json,
 };
 use crate::plan_store::read_plan;
 
@@ -187,7 +187,7 @@ pub fn compute_audit_for(
     let decisions_link = build_decisions_link(kind, selector, &decisions);
     let plan_link = build_plan_link(kind, selector, &decisions_link, root);
     let runs_link = build_runs_link(kind, selector, subject_run, &runs);
-    let verify_link = build_verify_link();
+    let verify_link = build_verify_link(kind, selector, &plan_link, &decisions);
 
     // Subject models for the blast radius: the model itself, the run's executed
     // models, or the plan's changed models.
@@ -234,7 +234,11 @@ pub fn compute_audit_for(
 
 /// Path a plan file would occupy — existence-checked without the
 /// dir-creating side effects of [`read_plan`].
-fn plan_file_path(root: &Path, plan_id: &str) -> PathBuf {
+///
+/// Shared with the review queue, which uses the same probe to drop
+/// decision-only custody rows (drafts, auto-apply evaluations) that resolve
+/// to no reviewable plan.
+pub(crate) fn plan_file_path(root: &Path, plan_id: &str) -> PathBuf {
     root.join(".rocky")
         .join("plans")
         .join(format!("{plan_id}.json"))
@@ -448,16 +452,79 @@ fn build_runs_link(
     }
 }
 
-/// The verify-after link is always unavailable: post-apply verification
-/// outcomes are not persisted to the state store today.
-fn build_verify_link() -> AuditChainVerify {
+/// The verify-after link: post-apply verification outcomes, read from the
+/// decision ledger's custody rows (state v17+ persists them with a non-empty
+/// `verify_after` check list).
+///
+/// The rows are keyed by plan id: the two-step `rocky apply` gate files its
+/// verification row under the applied plan's id, and the drift auto-apply
+/// path files its rows under `autoapply-verify:<run_id>`. A model subject
+/// therefore joins through its governing plan (the one the plan link
+/// resolved); a run subject joins through the auto-apply synthetic id. When
+/// no row matches, the link says so ("not recorded" for a subject with no
+/// resolvable plan; "no data" when the plan simply has no verification rows)
+/// — never a fabricated verdict.
+fn build_verify_link(
+    kind: AuditSubjectKind,
+    selector: &str,
+    plan_link: &AuditChainPlan,
+    decisions: &[PolicyDecisionRecord],
+) -> AuditChainVerify {
+    // Which plan id's custody rows count as this subject's verification?
+    let subject_plan_id: Option<String> = match kind {
+        AuditSubjectKind::Plan => Some(selector.to_string()),
+        AuditSubjectKind::Model => plan_link.plan_id.clone(),
+        AuditSubjectKind::Run => Some(format!("autoapply-verify:{selector}")),
+    };
+
+    let Some(subject_plan_id) = subject_plan_id else {
+        return AuditChainVerify {
+            availability: SectionAvailability::Unavailable,
+            note: Some(
+                "verification custody rows are keyed by plan id, and no plan governs this \
+                 subject, so no verify-after outcome can be joined to it"
+                    .to_string(),
+            ),
+            total: 0,
+            entries: Vec::new(),
+        };
+    };
+
+    let mut matched: Vec<&PolicyDecisionRecord> = decisions
+        .iter()
+        .filter(|d| d.plan_id == subject_plan_id && !d.verify_after.is_empty())
+        .collect();
+    // Newest first.
+    matched.sort_by_key(|d| std::cmp::Reverse(d.timestamp));
+
+    if matched.is_empty() {
+        return AuditChainVerify {
+            availability: SectionAvailability::NoData,
+            note: Some(format!(
+                "no post-apply verification outcome was recorded for plan '{subject_plan_id}' — \
+                 either its apply required no verify_after checks or it has not been applied"
+            )),
+            total: 0,
+            entries: Vec::new(),
+        };
+    }
+
+    let entries: Vec<AuditVerifyEntry> = matched
+        .into_iter()
+        .map(|d| AuditVerifyEntry {
+            timestamp: d.timestamp.to_rfc3339(),
+            plan_id: d.plan_id.clone(),
+            checks: d.verify_after.clone(),
+            passed: d.effect == PolicyEffect::Allow,
+            reason: d.reason.clone(),
+        })
+        .collect();
+
     AuditChainVerify {
-        availability: SectionAvailability::Unavailable,
-        note: Some(
-            "post-apply verification outcomes are not persisted to the state store, so the \
-             verify-after result for this subject is not recorded"
-                .to_string(),
-        ),
+        availability: SectionAvailability::Available,
+        note: None,
+        total: entries.len() as u64,
+        entries,
     }
 }
 
@@ -694,10 +761,24 @@ fn render_chain_text(out: &AuditForOutput) {
 
     // Verify-after.
     println!("\nverify-after — what verification found:");
-    println!(
-        "  {}",
-        status_line(&out.verify_after.availability, &out.verify_after.note)
-    );
+    match out.verify_after.availability {
+        SectionAvailability::Available => {
+            for v in &out.verify_after.entries {
+                let verdict = if v.passed { "PASSED" } else { "FAILED" };
+                println!(
+                    "  {} {} [{}] — {}",
+                    v.timestamp,
+                    verdict,
+                    v.checks.join(", "),
+                    v.reason,
+                );
+            }
+        }
+        _ => println!(
+            "  {}",
+            status_line(&out.verify_after.availability, &out.verify_after.note)
+        ),
+    }
 
     // Blast radius.
     println!("\nblast radius — what it touches downstream:");
@@ -797,7 +878,8 @@ pub fn compute_audit_scorecard(
             )),
             total_decisions: 0,
             groups: Vec::new(),
-            unavailable_metrics: scorecard_unavailable_metrics(),
+            verify_after: None,
+            unavailable_metrics: scorecard_unavailable_metrics(false),
         },
     };
     Ok(output)
@@ -969,6 +1051,8 @@ fn build_scorecard(
     // Busiest group first; deterministic tie-break on the label.
     groups.sort_by(|a, b| b.total.cmp(&a.total).then_with(|| a.key.cmp(&b.key)));
 
+    let verify_after = build_scorecard_verify_after(&windowed);
+
     let (availability, note) = if total_decisions == 0 {
         (
             SectionAvailability::NoData,
@@ -988,37 +1072,75 @@ fn build_scorecard(
         note,
         total_decisions,
         groups,
-        unavailable_metrics: scorecard_unavailable_metrics(),
+        unavailable_metrics: scorecard_unavailable_metrics(verify_after.is_some()),
+        verify_after,
     }
 }
 
-/// The scorecard metrics the ledger does not persist, each rendered
-/// `unavailable` with the reason. Declared once — never faked into a number.
-fn scorecard_unavailable_metrics() -> Vec<ScorecardUnavailableMetric> {
-    vec![
-        ScorecardUnavailableMetric {
+/// Aggregate the window's post-apply verification custody rows (non-empty
+/// `verify_after`) into a pass rate. `None` when no such row falls in the
+/// window — the caller then declares `verify_after_pass_rate` unavailable
+/// rather than reporting a rate over nothing.
+fn build_scorecard_verify_after(
+    windowed: &[&PolicyDecisionRecord],
+) -> Option<ScorecardVerifyAfter> {
+    let rows: Vec<&&PolicyDecisionRecord> = windowed
+        .iter()
+        .filter(|d| !d.verify_after.is_empty())
+        .collect();
+    if rows.is_empty() {
+        return None;
+    }
+    let total = rows.len() as u64;
+    let passed = rows
+        .iter()
+        .filter(|d| d.effect == PolicyEffect::Allow)
+        .count() as u64;
+    let failed = rows
+        .iter()
+        .filter(|d| d.effect == PolicyEffect::Deny)
+        .count() as u64;
+    Some(ScorecardVerifyAfter {
+        total,
+        passed,
+        failed,
+        pass_rate: passed as f64 / total as f64,
+    })
+}
+
+/// The scorecard metrics the persisted ledger cannot support for this window,
+/// each rendered `unavailable` with the reason — never faked into a number.
+///
+/// `verify_after_pass_rate` is computed from the verification custody rows
+/// when any fall in the window (`verify_recorded`); it is declared
+/// unavailable only when none do.
+fn scorecard_unavailable_metrics(verify_recorded: bool) -> Vec<ScorecardUnavailableMetric> {
+    let mut metrics = Vec::with_capacity(3);
+    if !verify_recorded {
+        metrics.push(ScorecardUnavailableMetric {
             metric: "verify_after_pass_rate".to_string(),
             availability: SectionAvailability::Unavailable,
-            note: "post-apply verification outcomes are not persisted to the state store, so a \
-                   verify-after pass rate cannot be computed"
+            note: "no post-apply verification custody row falls in the window, so a \
+                   verify-after pass rate cannot be computed over it"
                 .to_string(),
-        },
-        ScorecardUnavailableMetric {
-            metric: "reverts".to_string(),
-            availability: SectionAvailability::Unavailable,
-            note: "reverts / rollbacks of an applied change are not recorded to the ledger, so a \
-                   revert count cannot be computed"
-                .to_string(),
-        },
-        ScorecardUnavailableMetric {
-            metric: "escalation_latency".to_string(),
-            availability: SectionAvailability::Unavailable,
-            note: "the resolution of a require_review escalation is not recorded to the ledger \
-                   (an approval leaves only an on-disk plan marker, a denial records nothing), so \
-                   escalation latency cannot be computed"
-                .to_string(),
-        },
-    ]
+        });
+    }
+    metrics.push(ScorecardUnavailableMetric {
+        metric: "reverts".to_string(),
+        availability: SectionAvailability::Unavailable,
+        note: "reverts / rollbacks of an applied change are not recorded to the ledger, so a \
+               revert count cannot be computed"
+            .to_string(),
+    });
+    metrics.push(ScorecardUnavailableMetric {
+        metric: "escalation_latency".to_string(),
+        availability: SectionAvailability::Unavailable,
+        note: "the resolution of a require_review escalation is not recorded to the ledger \
+               (an approval leaves only an on-disk plan marker, a denial records nothing), so \
+               escalation latency cannot be computed"
+            .to_string(),
+    });
+    metrics
 }
 
 /// Render the scorecard as a concise human-readable report.
@@ -1049,6 +1171,16 @@ fn render_scorecard_text(out: &AuditScorecardOutput) {
             }
         }
         _ => println!("  {}", status_line(&out.availability, &out.note)),
+    }
+
+    if let Some(v) = &out.verify_after {
+        println!(
+            "\nverify-after: {:.1}% pass rate over {} verification row(s) [{} passed, {} failed]",
+            v.pass_rate * 100.0,
+            v.total,
+            v.passed,
+            v.failed,
+        );
     }
 
     // The honesty footer: what the ledger cannot support, stated plainly.
@@ -1174,11 +1306,149 @@ mod tests {
         assert_eq!(link.total, 0);
     }
 
+    /// A verification custody row: the shape `run_verify_after` (two-step
+    /// apply) and the drift auto-apply path persist — non-empty
+    /// `verify_after`, effect = the aggregate verdict.
+    fn verify_row(
+        secs: u32,
+        plan_id: &str,
+        effect: PolicyEffect,
+        checks: &[&str],
+        reason: &str,
+    ) -> PolicyDecisionRecord {
+        PolicyDecisionRecord {
+            timestamp: Utc.with_ymd_and_hms(2026, 7, 7, 0, 0, secs).unwrap(),
+            plan_id: plan_id.to_string(),
+            principal: PolicyPrincipal::Agent,
+            capability: PolicyCapability::Apply,
+            model: "*".to_string(),
+            effect,
+            rule_id: None,
+            reason: reason.to_string(),
+            verify_after: checks.iter().map(ToString::to_string).collect(),
+            auto_apply: None,
+        }
+    }
+
+    fn plan_link_naming(plan_id: Option<&str>) -> AuditChainPlan {
+        AuditChainPlan {
+            availability: SectionAvailability::Available,
+            note: None,
+            plan_id: plan_id.map(str::to_string),
+            principal: None,
+            kind: None,
+            diff_available: true,
+            changes: Vec::new(),
+        }
+    }
+
     #[test]
-    fn verify_after_is_always_unavailable() {
-        let link = build_verify_link();
-        assert_eq!(link.availability, SectionAvailability::Unavailable);
-        assert!(link.note.unwrap().contains("not persisted"));
+    fn verify_link_renders_persisted_rows_for_a_plan_subject() {
+        let decisions = vec![
+            // Plain evaluation row — not a verification outcome.
+            decision(1, "planA", "fct_orders", PolicyEffect::RequireReview),
+            verify_row(
+                2,
+                "planA",
+                PolicyEffect::Allow,
+                &["row_count", "not_null"],
+                "verify_after passed: [row_count, not_null]",
+            ),
+            verify_row(
+                3,
+                "planA",
+                PolicyEffect::Deny,
+                &["row_count"],
+                "verify_after FAILED: row_count (failed).",
+            ),
+            // Another plan's verification — out of scope.
+            verify_row(4, "planB", PolicyEffect::Allow, &["freshness"], "ok"),
+        ];
+        let link = build_verify_link(
+            AuditSubjectKind::Plan,
+            "planA",
+            &plan_link_naming(Some("planA")),
+            &decisions,
+        );
+        assert_eq!(link.availability, SectionAvailability::Available);
+        assert_eq!(link.total, 2);
+        // Newest first: the failed verification (secs=3) leads.
+        assert!(!link.entries[0].passed);
+        assert!(link.entries[0].reason.contains("FAILED"));
+        assert_eq!(link.entries[0].checks, vec!["row_count".to_string()]);
+        assert!(link.entries[1].passed);
+        assert_eq!(link.entries[1].checks.len(), 2);
+    }
+
+    #[test]
+    fn verify_link_for_a_model_joins_through_its_governing_plan() {
+        let decisions = vec![
+            decision(1, "planA", "fct_orders", PolicyEffect::Allow),
+            // The verification row carries model "*" — it is reachable from the
+            // model subject only through the governing plan id.
+            verify_row(
+                2,
+                "planA",
+                PolicyEffect::Allow,
+                &["row_count"],
+                "verify_after passed: [row_count]",
+            ),
+        ];
+        let link = build_verify_link(
+            AuditSubjectKind::Model,
+            "fct_orders",
+            &plan_link_naming(Some("planA")),
+            &decisions,
+        );
+        assert_eq!(link.availability, SectionAvailability::Available);
+        assert_eq!(link.total, 1);
+        assert!(link.entries[0].passed);
+
+        // No governing plan resolved → honest unavailable, not fabricated.
+        let none = build_verify_link(
+            AuditSubjectKind::Model,
+            "fct_orders",
+            &plan_link_naming(None),
+            &decisions,
+        );
+        assert_eq!(none.availability, SectionAvailability::Unavailable);
+        assert!(none.entries.is_empty());
+    }
+
+    #[test]
+    fn verify_link_for_a_run_joins_the_auto_apply_custody_rows() {
+        let decisions = vec![verify_row(
+            1,
+            "autoapply-verify:run-42",
+            PolicyEffect::Deny,
+            &["row_count"],
+            "verify_after FAILED: row_count (failed). No rollback substrate available.",
+        )];
+        let link = build_verify_link(
+            AuditSubjectKind::Run,
+            "run-42",
+            &plan_link_naming(None),
+            &decisions,
+        );
+        assert_eq!(link.availability, SectionAvailability::Available);
+        assert_eq!(link.total, 1);
+        assert!(!link.entries[0].passed);
+        assert_eq!(link.entries[0].plan_id, "autoapply-verify:run-42");
+    }
+
+    #[test]
+    fn verify_link_without_rows_stays_honestly_not_recorded() {
+        let decisions = vec![decision(1, "planA", "fct_orders", PolicyEffect::Allow)];
+        let link = build_verify_link(
+            AuditSubjectKind::Plan,
+            "planA",
+            &plan_link_naming(Some("planA")),
+            &decisions,
+        );
+        assert_eq!(link.availability, SectionAvailability::NoData);
+        assert_eq!(link.total, 0);
+        assert!(link.entries.is_empty());
+        assert!(link.note.unwrap().contains("no post-apply verification"));
     }
 
     #[test]
@@ -1370,8 +1640,11 @@ mod tests {
     }
 
     #[test]
-    fn scorecard_unavailable_metrics_are_the_three_unpersisted_and_all_unavailable() {
+    fn scorecard_unavailable_metrics_include_verify_only_when_no_rows_exist() {
+        // The seed carries no verification custody rows → the pass rate is
+        // honestly declared uncomputable, alongside the never-persisted two.
         let out = build_scorecard(ScorecardDimension::Principal, "all", None, &seed());
+        assert!(out.verify_after.is_none());
         let names: Vec<&str> = out
             .unavailable_metrics
             .iter()
@@ -1386,6 +1659,60 @@ mod tests {
             assert_eq!(m.availability, SectionAvailability::Unavailable);
             assert!(!m.note.is_empty());
         }
+    }
+
+    #[test]
+    fn scorecard_computes_verify_after_pass_rate_from_custody_rows() {
+        let mut decisions = seed();
+        decisions.push(verify_row(
+            11,
+            "p6",
+            PolicyEffect::Allow,
+            &["row_count"],
+            "verify_after passed: [row_count]",
+        ));
+        decisions.push(verify_row(
+            12,
+            "p6",
+            PolicyEffect::Allow,
+            &["not_null"],
+            "verify_after passed: [not_null]",
+        ));
+        decisions.push(verify_row(
+            13,
+            "p7",
+            PolicyEffect::Deny,
+            &["row_count"],
+            "verify_after FAILED: row_count (failed).",
+        ));
+
+        let out = build_scorecard(ScorecardDimension::Principal, "all", None, &decisions);
+        let v = out.verify_after.expect("verify rows exist in the window");
+        assert_eq!((v.total, v.passed, v.failed), (3, 2, 1));
+        assert!((v.pass_rate - 2.0 / 3.0).abs() < 1e-9);
+        // The pass rate is computed, so it is no longer declared unavailable.
+        assert!(
+            out.unavailable_metrics
+                .iter()
+                .all(|m| m.metric != "verify_after_pass_rate")
+        );
+
+        // Windowing applies to the verification rows too: a cutoff past them
+        // degrades back to the honest declaration.
+        let lo = Utc.with_ymd_and_hms(2026, 7, 7, 0, 0, 14).unwrap();
+        let windowed = build_scorecard(
+            ScorecardDimension::Principal,
+            "cutoff",
+            Some(lo),
+            &decisions,
+        );
+        assert!(windowed.verify_after.is_none());
+        assert!(
+            windowed
+                .unavailable_metrics
+                .iter()
+                .any(|m| m.metric == "verify_after_pass_rate")
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-cli/src/commands/backfill.rs
+++ b/engine/crates/rocky-cli/src/commands/backfill.rs
@@ -33,6 +33,7 @@ use rocky_core::state::StateStore;
 use rocky_ir::dag::{DagNode, execution_layers};
 
 use crate::commands::audit::{blast_radius_of, compile_project};
+use crate::commands::review::record_plan_review_escalation;
 use crate::output::{
     BackfillCostEstimate, BackfillModelCost, BackfillOutput, BackfillPartitionScope, RunPlan,
     print_json,
@@ -180,6 +181,9 @@ pub(crate) fn run_backfill_in(
 
     // 6. Cost estimate from historical observations (offline).
     let cost_estimate = estimate_cost(&ordered, store.as_ref(), config_path);
+    // The read handle drops here so the escalation write below can open its
+    // own handle on the same store.
+    drop(store);
 
     // 7. Persist the plan (always review-gated).
     let run_plan = build_run_plan(models_dir, &ordered, &layers, partition_from, partition_to);
@@ -198,6 +202,20 @@ pub(crate) fn run_backfill_in(
         capabilities,
     )
     .context("failed to persist the backfill plan")?;
+
+    // A backfill's apply bails on the missing review marker before
+    // `evaluate_apply_policy` could record anything, so record its escalation
+    // at creation — this one plan-level row is what puts it in the review
+    // queue (and in front of the governor's MCP approve path).
+    record_plan_review_escalation(
+        state_path,
+        &plan_id,
+        PolicyPrincipal::Agent,
+        PolicyCapability::Backfill,
+        &format!("backfill: {} model(s)", ordered.len()),
+        "backfill plan awaits review — backfills are unconditionally review-gated (blast \
+         radius hides in scoped rebuilds)",
+    );
 
     let message = format!(
         "composed a backfill of {} model(s) ({} seed → {} closure); review required before apply",
@@ -560,6 +578,91 @@ mod tests {
         assert!(est.total_cost_usd.is_none());
         assert_eq!(est.per_model.len(), 2);
         assert!(est.per_model.iter().all(|m| m.cost_usd.is_none()));
+    }
+
+    /// FIX: a backfill plan is unconditionally review-gated but its apply
+    /// bails before `evaluate_apply_policy` runs — so plan creation itself
+    /// must record the `require_review` ledger row that puts it in the
+    /// decision-driven review queue.
+    #[test]
+    fn backfill_plan_records_review_escalation_and_enters_queue() {
+        use rocky_core::config::PolicyEffect;
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let models_dir = root.join("models");
+        std::fs::create_dir_all(&models_dir).unwrap();
+        for (name, sql) in [
+            ("a", "SELECT id FROM source.raw.t"),
+            ("b", "SELECT id FROM a"),
+        ] {
+            std::fs::write(models_dir.join(format!("{name}.sql")), sql).unwrap();
+            std::fs::write(
+                models_dir.join(format!("{name}.toml")),
+                format!(
+                    "name = \"{name}\"\n\n[strategy]\ntype = \"full_refresh\"\n\n\
+                     [target]\ncatalog = \"c\"\nschema = \"s\"\ntable = \"{name}\"\n"
+                ),
+            )
+            .unwrap();
+        }
+        let state_path = root.join("state.redb");
+        let config_path = root.join("rocky.toml"); // absent — fine, degrades
+
+        run_backfill_in(
+            root,
+            &config_path,
+            &state_path,
+            &models_dir,
+            &["a".to_string()],
+            false,
+            None,
+            None,
+            true,
+            true,
+        )
+        .unwrap();
+
+        // The plan file landed under <root>/.rocky/plans.
+        let plans_dir = root.join(".rocky").join("plans");
+        let plan_id = std::fs::read_dir(&plans_dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter_map(|e| {
+                let name = e.file_name().into_string().ok()?;
+                name.strip_suffix(".json").map(str::to_string)
+            })
+            .next()
+            .expect("a backfill plan file must exist");
+
+        // Plan creation recorded exactly one plan-level escalation row.
+        let decisions = {
+            let store = StateStore::open_read_only(&state_path).unwrap();
+            store.list_policy_decisions().unwrap()
+        };
+        assert_eq!(decisions.len(), 1, "one plan-level row, not one per model");
+        let d = &decisions[0];
+        assert_eq!(d.plan_id, plan_id);
+        assert_eq!(d.effect, PolicyEffect::RequireReview);
+        assert_eq!(d.capability, PolicyCapability::Backfill);
+        assert_eq!(d.principal, PolicyPrincipal::Agent);
+        assert!(d.model.contains("2 model(s)"), "scope summary: {}", d.model);
+
+        // And the decision-driven review queue now lists the backfill.
+        let queue = crate::commands::review::compute_review_queue(
+            root,
+            &config_path,
+            &state_path,
+            &models_dir,
+        )
+        .unwrap();
+        assert_eq!(queue.total, 1);
+        assert_eq!(queue.pending[0].plan_id, plan_id);
+        assert_eq!(queue.excluded_non_plan_rows, 0);
+        assert_eq!(
+            queue.pending[0].approve_command,
+            format!("rocky review {plan_id} --approve")
+        );
     }
 
     /// The persisted `RunPlan` carries the closure, layers, partition window,

--- a/engine/crates/rocky-cli/src/commands/brief.rs
+++ b/engine/crates/rocky-cli/src/commands/brief.rs
@@ -33,6 +33,9 @@ use rocky_core::state::{
     DagChange, PolicyDecisionRecord, QualitySnapshot, RunRecord, RunStatus, RunTrigger, StateStore,
 };
 
+use crate::commands::apply::ai_plan_is_reviewed;
+use crate::commands::audit::plan_file_path;
+use crate::commands::review::select_outstanding;
 use crate::output::{
     BriefActiveFreeze, BriefAgentActivitySection, BriefAutonomySection, BriefBudgetStatus,
     BriefCostSection, BriefDecisionEntry, BriefDegradedRule, BriefDriftEntry, BriefDriftSection,
@@ -88,14 +91,17 @@ impl BriefSince {
 /// Markdown digest. The digest reads the state store at `state_path` and
 /// loads `rocky.toml` at `config_path` best-effort (only the cost section
 /// depends on the config, and it degrades gracefully when it can't be read).
+/// The project root (for the review markers and plan files the "Needs you"
+/// section checks) resolves from the process cwd, mirroring `rocky review`.
 pub fn run_brief(
     state_path: &Path,
     config_path: &Path,
     since: BriefSince,
     json: bool,
 ) -> Result<()> {
+    let root = std::env::current_dir().context("failed to get current working directory")?;
     let now = Utc::now();
-    let output = compute_brief(state_path, config_path, since, now)?;
+    let output = compute_brief(&root, state_path, config_path, since, now)?;
     emit(&output, json)?;
 
     // Advance the digest cursor only after a successful render, and only for
@@ -126,9 +132,15 @@ pub fn run_brief(
 /// conversational MCP surface can query the digest without consuming the Slack
 /// hook's `--since last` cursor.
 ///
+/// `root` locates the on-disk review markers and plan files the escalations
+/// section filters on — the same anchoring `compute_review_queue` uses; the
+/// CLI resolves it from the process cwd, the MCP server passes its project
+/// root.
+///
 /// Fails closed: an absent state store yields a fully `unavailable` digest
 /// rather than an error.
 pub fn compute_brief(
+    root: &Path,
     state_path: &Path,
     config_path: &Path,
     since: BriefSince,
@@ -175,7 +187,7 @@ pub fn compute_brief(
     windowed_decisions.sort_by_key(|d| Reverse(d.timestamp));
 
     let agent_activity = build_agent_activity(&windowed_decisions);
-    let escalations = build_escalations(&windowed_decisions);
+    let escalations = build_escalations(root, &windowed_decisions);
     let runs_section = build_runs(&windowed_runs);
     let drift = build_drift(&store, since_ts);
     let (freshness, quality) = build_freshness_and_quality(&store, &windowed_runs, since_ts);
@@ -292,12 +304,27 @@ fn build_agent_activity(decisions: &[&PolicyDecisionRecord]) -> BriefAgentActivi
     }
 }
 
-fn build_escalations(decisions: &[&PolicyDecisionRecord]) -> BriefEscalationsSection {
-    let pending: Vec<BriefDecisionEntry> = decisions
-        .iter()
-        .filter(|d| matches!(d.effect, PolicyEffect::RequireReview))
-        .map(|d| decision_entry(d))
-        .collect();
+/// The "Needs you" section: decisions **still** awaiting review.
+///
+/// Reuses the review queue's outstanding-selection core
+/// ([`select_outstanding`]) rather than re-listing every windowed
+/// `require_review` row, so the digest and `rocky review --queue` agree: one
+/// entry per `(plan_id, model)` (the newest row), already-approved plans
+/// dropped (their sign-off marker exists), and decision-only custody rows
+/// with no persisted plan dropped (nothing to approve). The raw per-effect
+/// counts stay in the agent-activity section, which reports history, not the
+/// outstanding workload.
+fn build_escalations(root: &Path, decisions: &[&PolicyDecisionRecord]) -> BriefEscalationsSection {
+    let (outstanding, _excluded_non_plan) = select_outstanding(
+        decisions.iter().copied(),
+        |plan_id| ai_plan_is_reviewed(root, plan_id),
+        |plan_id| plan_file_path(root, plan_id).exists(),
+    );
+
+    // Newest first — the section's declared "recency" ranking.
+    let mut outstanding = outstanding;
+    outstanding.sort_by_key(|d| Reverse(d.timestamp));
+    let pending: Vec<BriefDecisionEntry> = outstanding.into_iter().map(decision_entry).collect();
 
     if pending.is_empty() {
         return BriefEscalationsSection {
@@ -1319,8 +1346,24 @@ mod tests {
         assert!(section.note.is_some());
     }
 
+    /// Create the plan file the escalation filter probes for, so a synthetic
+    /// decision row renders as an approvable escalation.
+    fn seed_plan_file(root: &std::path::Path, plan_id: &str) {
+        let dir = root.join(".rocky").join("plans");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(format!("{plan_id}.json")), "{}").unwrap();
+    }
+
+    /// Write the sign-off marker `rocky review --approve` would leave.
+    fn seed_review_marker(root: &std::path::Path, plan_id: &str) {
+        let dir = root.join(".rocky").join("plans");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(format!("{plan_id}.reviewed.json")), "{}").unwrap();
+    }
+
     #[test]
     fn escalations_only_require_review() {
+        let root = tempfile::tempdir().unwrap();
         let d = [
             decision(
                 9,
@@ -1337,14 +1380,74 @@ mod tests {
                 None,
             ),
         ];
+        seed_plan_file(root.path(), &d[0].plan_id);
+        seed_plan_file(root.path(), &d[1].plan_id);
         let refs: Vec<&PolicyDecisionRecord> = d.iter().collect();
-        let section = build_escalations(&refs);
+        let section = build_escalations(root.path(), &refs);
         assert_eq!(section.availability, SectionAvailability::Available);
         assert_eq!(section.total, 1);
         assert_eq!(section.pending[0].model, "dim_customer");
         // The pending entry carries its ledger citations.
         assert!(section.pending[0].decision_ref.contains("dim_customer"));
         assert!(section.pending[0].plan_id.contains("dim_customer"));
+    }
+
+    /// FIX: "Needs you" reports the *outstanding* workload, not history — it
+    /// must agree with the review queue's selection: dedup to the newest row
+    /// per `(plan_id, model)`, drop already-approved plans, and drop
+    /// decision-only custody rows with no persisted plan.
+    #[test]
+    fn escalations_drop_reviewed_plans_planless_rows_and_duplicates() {
+        let root = tempfile::tempdir().unwrap();
+        let mut approved = decision(
+            8,
+            PolicyPrincipal::Agent,
+            PolicyEffect::RequireReview,
+            "fct_orders",
+            Some(0),
+        );
+        approved.plan_id = "planApproved".to_string();
+        seed_plan_file(root.path(), "planApproved");
+        seed_review_marker(root.path(), "planApproved");
+
+        let mut draft = decision(
+            9,
+            PolicyPrincipal::Agent,
+            PolicyEffect::RequireReview,
+            "orders_daily",
+            None,
+        );
+        draft.plan_id = "draft:orders_daily".to_string();
+
+        let mut pending_old = decision(
+            10,
+            PolicyPrincipal::Agent,
+            PolicyEffect::RequireReview,
+            "dim_customer",
+            None,
+        );
+        pending_old.plan_id = "planPending".to_string();
+        let mut pending_new = decision(
+            11,
+            PolicyPrincipal::Agent,
+            PolicyEffect::RequireReview,
+            "dim_customer",
+            None,
+        );
+        pending_new.plan_id = "planPending".to_string();
+        seed_plan_file(root.path(), "planPending");
+
+        let d = [approved, draft, pending_old, pending_new];
+        let refs: Vec<&PolicyDecisionRecord> = d.iter().collect();
+        let section = build_escalations(root.path(), &refs);
+
+        // One outstanding escalation: the newest planPending/dim_customer row.
+        assert_eq!(section.total, 1, "pending: {:?}", section.pending);
+        assert_eq!(section.pending[0].plan_id, "planPending");
+        assert_eq!(section.pending[0].timestamp, ts(11).to_rfc3339());
+        // The history counts are the agent-activity section's job and stay raw.
+        let activity = build_agent_activity(&refs);
+        assert_eq!(activity.require_review, 4);
     }
 
     #[test]
@@ -1377,6 +1480,7 @@ mod tests {
 
     #[test]
     fn markdown_leads_with_needs_you_and_cites() {
+        let root = tempfile::tempdir().unwrap();
         let d = [decision(
             11,
             PolicyPrincipal::Agent,
@@ -1384,6 +1488,7 @@ mod tests {
             "dim_customer",
             Some(3),
         )];
+        seed_plan_file(root.path(), &d[0].plan_id);
         let refs: Vec<&PolicyDecisionRecord> = d.iter().collect();
         let out = BriefOutput {
             version: "0".to_string(),
@@ -1392,7 +1497,7 @@ mod tests {
             since_mode: BriefSinceMode::Hours24,
             since_timestamp: Some(ts(1).to_rfc3339()),
             agent_activity: build_agent_activity(&refs),
-            escalations: build_escalations(&refs),
+            escalations: build_escalations(root.path(), &refs),
             runs: build_runs(&[]),
             drift: BriefDriftSection {
                 availability: SectionAvailability::Unavailable,

--- a/engine/crates/rocky-cli/src/commands/gc.rs
+++ b/engine/crates/rocky-cli/src/commands/gc.rs
@@ -57,7 +57,7 @@
 //! object-store delete ([`ObjectStoreEvictor`]) is s3-only and is
 //! **code-reviewed here, driven on the sandbox** — creds-free it defers.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::Path;
 
 use anyhow::{Context, Result, bail};
@@ -74,6 +74,7 @@ use rocky_core::state::{
 
 use crate::commands::apply::{PolicyGate, ai_plan_is_reviewed, evaluate_apply_policy};
 use crate::commands::replay::classify_model;
+use crate::commands::review::record_plan_review_escalation;
 use crate::output::{
     GcApplyOutput, GcCandidateOutput, GcCheckOutput, GcEvictedOutput, GcPlan, GcPlanEviction,
     GcPlanOutput, GcRebuildCostOutput, GcRefusedOutput, GcReportOutput, ReplayCheckModelOutput,
@@ -727,6 +728,22 @@ fn build_gc_plan(candidates: &[EvictionCandidate], min_age_days: i64) -> Option<
     })
 }
 
+/// The representative `model` field for the gc plan's single review-escalation
+/// ledger row — a plan-scope summary, since one reclamation plan spans many
+/// artifacts and models and one row per artifact would bloat the ledger.
+fn gc_plan_scope_summary(plan: &GcPlan) -> String {
+    let models: BTreeSet<&str> = plan
+        .evictions
+        .iter()
+        .map(|e| e.model_name.as_str())
+        .collect();
+    format!(
+        "gc: {} artifact(s) across {} model(s)",
+        plan.evictions.len(),
+        models.len()
+    )
+}
+
 /// Execute `rocky gc --derivable` in plan mode (no `--dry-run`): write a GC
 /// plan to the plan store. **Never deletes** — the plan is a scoped,
 /// review-gated proposal.
@@ -741,11 +758,28 @@ pub fn run_gc_plan(
     principal: PolicyPrincipal,
     json: bool,
 ) -> Result<()> {
-    let store = StateStore::open_read_only(state_path)
-        .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
+    let cwd = std::env::current_dir().context("failed to get current working directory")?;
+    run_gc_plan_in(&cwd, state_path, config_path, min_age_days, principal, json)
+}
+
+/// Inner implementation — takes an explicit `root` for the plans directory so
+/// tests can pass a temp dir without touching the process-global cwd.
+pub(crate) fn run_gc_plan_in(
+    root: &Path,
+    state_path: &Path,
+    config_path: &Path,
+    min_age_days: i64,
+    principal: PolicyPrincipal,
+    json: bool,
+) -> Result<()> {
     let adapter = load_adapter_cost(config_path);
-    let candidates =
-        gather_eviction_candidates(&store, adapter.as_ref(), Utc::now(), min_age_days)?;
+    let candidates = {
+        let store = StateStore::open_read_only(state_path)
+            .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
+        gather_eviction_candidates(&store, adapter.as_ref(), Utc::now(), min_age_days)?
+        // The read handle drops here so the escalation write below can open
+        // its own handle on the same store.
+    };
 
     let Some(plan) = build_gc_plan(&candidates, min_age_days) else {
         if json {
@@ -767,9 +801,22 @@ pub fn run_gc_plan(
         return Ok(());
     };
 
-    let cwd = std::env::current_dir().context("failed to get current working directory")?;
-    let plan_id = write_plan_with_principal(&cwd, PlanKind::Gc, &plan, principal)
+    let plan_id = write_plan_with_principal(root, PlanKind::Gc, &plan, principal)
         .context("failed to persist the gc plan")?;
+
+    // A gc plan never passes `evaluate_apply_policy` before its apply bails on
+    // the missing review marker, so record its escalation at creation — this
+    // one plan-level row is what puts it in the review queue (and in front of
+    // the governor's MCP approve path).
+    record_plan_review_escalation(
+        state_path,
+        &plan_id,
+        principal,
+        PolicyCapability::Gc,
+        &gc_plan_scope_summary(&plan),
+        "gc plan awaits review — deletion is unconditionally review-gated (even a human gc \
+         goes through review, never a direct delete)",
+    );
 
     let output = GcPlanOutput {
         version: VERSION.to_string(),
@@ -2167,6 +2214,72 @@ mod tests {
             .await
             .unwrap();
 
+        let store = StateStore::open(&state_path).unwrap();
+        assert_eq!(store.list_tombstones().unwrap().len(), 1);
+        assert_eq!(store.refcount_for_hash(HA).unwrap(), 0);
+    }
+
+    /// FIX: a gc plan must enter the decision-driven review queue at creation
+    /// (plan creation records its `require_review` escalation) and clear on
+    /// the same approve path the governor's MCP `review_queue` tool calls —
+    /// end to end: plan → queue lists it → approve → queue empties → apply
+    /// proceeds past the review gate.
+    #[tokio::test]
+    async fn gc_plan_enters_review_queue_and_clears_on_approve() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        let state_path = root.join("state.redb");
+        {
+            let store = StateStore::open(&state_path).unwrap();
+            let old = Utc::now() - Duration::days(30);
+            seed(&store, "r1", "orders", "SELECT 1 AS id", &[], HA, 500, old);
+            record_run(&store, "r1", "orders");
+        } // drop the seeding handle before the plan path opens its own
+
+        // A missing config leaves the policy plane unconfigured — the queue
+        // and the gates run off the ledger + plan files alone.
+        let config = root.join("rocky.toml");
+        let models_dir = root.join("models");
+
+        // 1. Create the reclamation plan.
+        run_gc_plan_in(root, &state_path, &config, 7, PolicyPrincipal::Human, true).unwrap();
+        let plans_dir = root.join(".rocky").join("plans");
+        let plan_id = std::fs::read_dir(&plans_dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter_map(|e| {
+                let name = e.file_name().into_string().ok()?;
+                name.strip_suffix(".json").map(str::to_string)
+            })
+            .next()
+            .expect("a gc plan file must exist");
+
+        // 2. The review queue lists it: the creation-time escalation row is in
+        //    the ledger and the plan file passes the existence filter.
+        let queue =
+            crate::commands::review::compute_review_queue(root, &config, &state_path, &models_dir)
+                .unwrap();
+        assert_eq!(queue.total, 1, "pending: {:?}", queue.pending);
+        assert_eq!(queue.pending[0].plan_id, plan_id);
+        assert_eq!(queue.pending[0].capability, PolicyCapability::Gc);
+        assert_eq!(queue.excluded_non_plan_rows, 0);
+
+        // 3. Approve through the exact core the MCP review_queue tool calls.
+        let review = crate::commands::review::compute_review(root, &config, &plan_id, "HEAD", true)
+            .await
+            .unwrap();
+        assert!(review.marker_written);
+
+        // 4. The queue empties — the marker filter clears the escalation.
+        let queue_after =
+            crate::commands::review::compute_review_queue(root, &config, &state_path, &models_dir)
+                .unwrap();
+        assert_eq!(queue_after.total, 0, "pending: {:?}", queue_after.pending);
+
+        // 5. Apply proceeds past the review gate and evicts behind a tombstone.
+        run_gc_apply_in(root, &config, &plan_id, &state_path, true)
+            .await
+            .unwrap();
         let store = StateStore::open(&state_path).unwrap();
         assert_eq!(store.list_tombstones().unwrap().len(), 1);
         assert_eq!(store.refcount_for_hash(HA).unwrap(), 0);

--- a/engine/crates/rocky-cli/src/commands/review.rs
+++ b/engine/crates/rocky-cli/src/commands/review.rs
@@ -21,17 +21,17 @@
 //! approval is informed.
 
 use std::collections::BTreeMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 use chrono::{DateTime, Utc};
 use rocky_core::breaking_change::{self, BreakingFinding};
-use rocky_core::config::{PolicyCapability, PolicyEffect};
+use rocky_core::config::{PolicyCapability, PolicyEffect, PolicyPrincipal};
 use rocky_core::state::{PolicyDecisionRecord, StateStore};
 use serde::{Deserialize, Serialize};
 
 use crate::commands::apply::{ai_plan_is_reviewed, review_marker_path};
-use crate::commands::audit::{blast_radius_of, compile_project};
+use crate::commands::audit::{blast_radius_of, compile_project, plan_file_path};
 use crate::output::{
     ApproverIdentity, ReviewOutput, ReviewQueueEntry, ReviewQueueOutput, RunPlan, print_json,
 };
@@ -158,9 +158,13 @@ pub async fn compute_review(
     let run_plan: RunPlan = serde_json::from_value(plan.payload.clone())
         .context("failed to deserialize plan payload")?;
 
-    let models_dir = run_plan.models_dir.as_deref().unwrap_or("models");
+    // Resolve the plan's models directory against the project `root`, never
+    // the process cwd — the governor's MCP server reviews from a cwd that is
+    // not the project, and a cwd-relative path would silently skip the
+    // breaking-change gate there.
+    let (models_dir, state_path) = review_gate_paths(root, run_plan.models_dir.as_deref());
 
-    let findings = compute_review_findings(config_path, Path::new(models_dir), base_ref);
+    let findings = compute_review_findings(config_path, &models_dir, &state_path, base_ref);
     let breaking_count = findings
         .as_ref()
         .map(|f| f.iter().filter(|x| x.is_breaking()).count())
@@ -321,6 +325,22 @@ fn build_message(
     }
 }
 
+/// Resolve the paths the review's breaking-change gate reads, anchored at the
+/// project `root` rather than the process cwd.
+///
+/// - `models_dir`: the plan's recorded models directory (default `models`),
+///   joined onto `root` (an already-absolute recorded path is used verbatim —
+///   `Path::join` replaces on absolute).
+/// - `state_path`: the schema-cache state store, resolved with the same
+///   [`rocky_core::state::resolve_state_path`] defaulting the CLI and the MCP
+///   server use (`<models_dir>/.rocky-state.redb` et al.) — not a hardcoded
+///   cwd-relative file.
+fn review_gate_paths(root: &Path, plan_models_dir: Option<&str>) -> (PathBuf, PathBuf) {
+    let models_dir = root.join(plan_models_dir.unwrap_or("models"));
+    let state_path = rocky_core::state::resolve_state_path(None, &models_dir).path;
+    (models_dir, state_path)
+}
+
 /// Compute the breaking-change findings between `base_ref` and the working
 /// tree, reusing the exact compile + classifier path that `rocky ci-diff`
 /// and the branch-promote gate use.
@@ -334,6 +354,7 @@ fn build_message(
 fn compute_review_findings(
     config_path: &Path,
     models_dir: &Path,
+    state_path: &Path,
     base_ref: &str,
 ) -> Option<Vec<BreakingFinding>> {
     use rocky_compiler::compile::{self, CompilerConfig};
@@ -354,8 +375,7 @@ fn compute_review_findings(
     let source_schemas = match rocky_core::config::load_rocky_config(config_path) {
         Ok(cfg) => {
             let schema_cfg = cfg.cache.schemas.with_ttl_override(None);
-            let state_path = std::path::PathBuf::from(".rocky/state.redb");
-            crate::source_schemas::load_cached_source_schemas(&schema_cfg, &state_path)
+            crate::source_schemas::load_cached_source_schemas(&schema_cfg, state_path)
         }
         Err(_) => std::collections::HashMap::new(),
     };
@@ -464,8 +484,9 @@ pub(crate) fn run_review_queue_in(
 ///
 /// The reusable core behind both `rocky review --queue` and the governor's
 /// `review_queue` MCP tool. `root` locates the sign-off markers that clear an
-/// escalation; the CLI resolves it from the process cwd, the MCP server passes
-/// its project root. Reads only — no stdout.
+/// escalation and the plan files that make one approvable; the CLI resolves it
+/// from the process cwd, the MCP server passes its project root. Reads only —
+/// no stdout.
 pub fn compute_review_queue(
     root: &Path,
     config_path: &Path,
@@ -482,13 +503,14 @@ pub fn compute_review_queue(
         Vec::new()
     };
 
-    let pending = build_queue(
+    let (pending, excluded_non_plan_rows) = build_queue(
         root,
         config_path,
         state_path,
         models_dir,
         &decisions,
         Utc::now(),
+        MAX_HISTORY_SCAN,
     );
 
     Ok(ReviewQueueOutput {
@@ -496,12 +518,17 @@ pub fn compute_review_queue(
         command: "review".to_string(),
         ranking: QUEUE_RANKING.to_string(),
         total: pending.len() as u64,
+        excluded_non_plan_rows,
         pending,
     })
 }
 
-/// Assemble the ranked queue from the decision ledger. Factored out so the
-/// ranking is unit-testable without a state store.
+/// Assemble the ranked queue from the decision ledger, scanning at most the
+/// `max_scan` **newest** ledger rows. Returns the ranked entries plus the
+/// count of outstanding escalations excluded because no plan file backs them.
+/// Factored out (with an injectable scan cap) so the ranking and the cap
+/// semantics are unit-testable without a state store.
+#[allow(clippy::too_many_arguments)]
 fn build_queue(
     root: &Path,
     config_path: &Path,
@@ -509,10 +536,18 @@ fn build_queue(
     models_dir: &Path,
     decisions: &[PolicyDecisionRecord],
     now: DateTime<Utc>,
-) -> Vec<ReviewQueueEntry> {
-    let outstanding = select_outstanding(decisions, |plan_id| ai_plan_is_reviewed(root, plan_id));
+    max_scan: usize,
+) -> (Vec<ReviewQueueEntry>, u64) {
+    // `list_policy_decisions` yields oldest-first; scan the NEWEST `max_scan`
+    // rows (matching `list_runs`' newest-first convention) so a long-lived
+    // ledger never ages genuinely-pending escalations out of the queue.
+    let (outstanding, excluded_non_plan) = select_outstanding(
+        decisions.iter().rev().take(max_scan),
+        |plan_id| ai_plan_is_reviewed(root, plan_id),
+        |plan_id| plan_file_path(root, plan_id).exists(),
+    );
     if outstanding.is_empty() {
-        return Vec::new();
+        return (Vec::new(), excluded_non_plan);
     }
 
     // One compile serves every model's blast radius. A compile failure leaves
@@ -555,25 +590,38 @@ fn build_queue(
             .then_with(|| a.plan_id.cmp(&b.plan_id))
             .then_with(|| a.model.cmp(&b.model))
     });
-    entries
+    (entries, excluded_non_plan)
 }
 
 /// The pending escalations to surface: the latest `require_review` decision
-/// per `(plan_id, model)` whose plan has not yet been signed off.
+/// per `(plan_id, model)` whose plan has not yet been signed off **and whose
+/// plan actually exists to be approved**.
 ///
 /// A re-evaluated plan appends a fresh ledger row each time, so the queue
 /// keeps only the newest row per `(plan_id, model)` — current state, not
 /// history — and drops any whose plan already carries a review marker
-/// (`is_reviewed`). Pure over the ledger + the marker predicate so the
-/// dedup/filter logic is testable without a state store.
-fn select_outstanding(
-    decisions: &[PolicyDecisionRecord],
+/// (`is_reviewed`).
+///
+/// Decision-only custody rows never map to a persisted plan: the MCP draft
+/// tools file refusals under `draft:*` / `draft-contract:*` / `draft-check:*`
+/// ids and the drift auto-apply path files evaluations under
+/// `autoapply:<run_id>`. Nothing can approve those (`rocky review` bails at
+/// `read_plan`), so surfacing them would pollute the queue with permanently
+/// unclearable entries. The `plan_exists` probe drops them from the *queue*
+/// while they remain in the *ledger* (the audit history); the count of
+/// dropped rows is returned so the queue can say so.
+///
+/// Pure over the ledger + the two predicates so the dedup/filter logic is
+/// testable without a state store. Accepts any iteration order — the dedup
+/// keeps the newest row per key regardless.
+pub(crate) fn select_outstanding<'a>(
+    decisions: impl IntoIterator<Item = &'a PolicyDecisionRecord>,
     is_reviewed: impl Fn(&str) -> bool,
-) -> Vec<&PolicyDecisionRecord> {
+    plan_exists: impl Fn(&str) -> bool,
+) -> (Vec<&'a PolicyDecisionRecord>, u64) {
     let mut latest: BTreeMap<(&str, &str), &PolicyDecisionRecord> = BTreeMap::new();
     for d in decisions
-        .iter()
-        .take(MAX_HISTORY_SCAN)
+        .into_iter()
         .filter(|d| d.effect == PolicyEffect::RequireReview)
     {
         latest
@@ -585,10 +633,65 @@ fn select_outstanding(
             })
             .or_insert(d);
     }
-    latest
+    let mut excluded_non_plan: u64 = 0;
+    let outstanding = latest
         .into_values()
         .filter(|d| !is_reviewed(&d.plan_id))
-        .collect()
+        .filter(|d| {
+            if plan_exists(&d.plan_id) {
+                true
+            } else {
+                excluded_non_plan += 1;
+                false
+            }
+        })
+        .collect();
+    (outstanding, excluded_non_plan)
+}
+
+/// Record the "this plan awaits review" escalation for an unconditionally
+/// review-gated plan (gc / backfill) at **plan creation**.
+///
+/// Those plans never pass through `evaluate_apply_policy` before their apply
+/// bails on the missing review marker, so without this row the decision-driven
+/// review queue (and the governor's MCP approve path) would never list them —
+/// even though `compute_review` was built to approve them. One plan-level row
+/// (a representative `model` summary, not one row per affected model) keeps
+/// the ledger lean.
+///
+/// Best-effort like every other ledger write: the review-marker gate at apply
+/// is the safety boundary, the ledger is the trail — a locked or unreadable
+/// state store must not fail plan creation.
+pub(crate) fn record_plan_review_escalation(
+    state_path: &Path,
+    plan_id: &str,
+    principal: PolicyPrincipal,
+    capability: PolicyCapability,
+    model: &str,
+    reason: &str,
+) {
+    let record = PolicyDecisionRecord {
+        timestamp: Utc::now(),
+        plan_id: plan_id.to_string(),
+        principal,
+        capability,
+        model: model.to_string(),
+        effect: PolicyEffect::RequireReview,
+        rule_id: None,
+        reason: reason.to_string(),
+        verify_after: Vec::new(),
+        auto_apply: None,
+    };
+    let written = StateStore::open(state_path).and_then(|s| s.record_policy_decision(&record));
+    if let Err(e) = written {
+        tracing::warn!(
+            target: "rocky::review",
+            plan_id,
+            error = %e,
+            "failed to record the plan's review escalation to the ledger (continuing) — \
+             the plan is still review-gated at apply, but the review queue will not list it"
+        );
+    }
 }
 
 /// Composite priority score: `(blast + 1) × classification_weight ×
@@ -618,12 +721,14 @@ fn classification_weight(capability: PolicyCapability) -> u32 {
 fn render_queue_text(out: &ReviewQueueOutput) {
     if out.pending.is_empty() {
         println!("review queue: no escalations awaiting review");
+        render_excluded_note(out.excluded_non_plan_rows);
         return;
     }
     println!(
         "review queue: {} escalation(s) awaiting review (ranked by {})",
         out.total, out.ranking
     );
+    render_excluded_note(out.excluded_non_plan_rows);
     for (i, e) in out.pending.iter().enumerate() {
         let blast = e
             .blast_radius
@@ -644,6 +749,17 @@ fn render_queue_text(out: &ReviewQueueOutput) {
         );
         println!("     {}", e.reason);
         println!("     approve: {}", e.approve_command);
+    }
+}
+
+/// One-line footnote for custody rows the queue excluded because no plan file
+/// backs them (nothing to approve). Silent when there are none.
+fn render_excluded_note(excluded: u64) {
+    if excluded > 0 {
+        println!(
+            "  ({excluded} decision-only custody row(s) excluded — no persisted plan to approve; \
+             they remain in `rocky audit`)"
+        );
     }
 }
 
@@ -842,14 +958,183 @@ mod tests {
             ),
         ];
 
-        let out = select_outstanding(&decisions, |plan_id| plan_id == "planReviewed");
+        let (out, excluded) =
+            select_outstanding(&decisions, |plan_id| plan_id == "planReviewed", |_| true);
 
         // Only planA/x survives: deny + allow excluded, planReviewed filtered.
         assert_eq!(out.len(), 1);
+        assert_eq!(excluded, 0);
         let d = out[0];
         assert_eq!(d.plan_id, "planA");
         assert_eq!(d.model, "x");
         // The newest of the two planA/x rows wins (the breaking one at secs=9).
         assert_eq!(d.capability, PolicyCapability::SchemaChangeBreaking);
+    }
+
+    /// FIX: decision-only custody rows (`draft:*`, `autoapply:*`, …) whose
+    /// plan_id resolves to no persisted plan must not render as approvable
+    /// queue items — `rocky review --approve` bails at `read_plan` for them,
+    /// so they would sit pending forever. They stay in the ledger; the queue
+    /// counts them out.
+    #[test]
+    fn select_outstanding_excludes_planless_custody_rows_and_counts_them() {
+        let decisions = vec![
+            qd(
+                1,
+                "draft:orders_daily",
+                "orders_daily",
+                PolicyEffect::RequireReview,
+                PolicyCapability::SchemaChangeBreaking,
+            ),
+            qd(
+                2,
+                "draft-contract:orders_daily",
+                "orders_daily",
+                PolicyEffect::RequireReview,
+                PolicyCapability::Apply,
+            ),
+            qd(
+                3,
+                "autoapply:run-abc",
+                "raw_events",
+                PolicyEffect::RequireReview,
+                PolicyCapability::SchemaChangeAdditive,
+            ),
+            // A real planned escalation — its plan file exists.
+            qd(
+                4,
+                "planReal",
+                "dim_customer",
+                PolicyEffect::RequireReview,
+                PolicyCapability::Apply,
+            ),
+        ];
+
+        let (out, excluded) =
+            select_outstanding(&decisions, |_| false, |plan_id| plan_id == "planReal");
+
+        assert_eq!(out.len(), 1, "only the plan-backed escalation surfaces");
+        assert_eq!(out[0].plan_id, "planReal");
+        assert_eq!(excluded, 3, "the three custody-only rows are counted out");
+    }
+
+    /// FIX: the scan cap must keep the NEWEST rows. `list_policy_decisions`
+    /// returns oldest-first, so a naive head-`take` would silently age the
+    /// newest genuinely-pending escalations out of a >cap ledger.
+    #[test]
+    fn queue_scan_cap_keeps_newest_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        // Every row references a real plan file so the existence filter is not
+        // what excludes anything here.
+        let plans_dir = root.join(".rocky").join("plans");
+        std::fs::create_dir_all(&plans_dir).unwrap();
+        std::fs::write(plans_dir.join("planX.json"), "{}").unwrap();
+
+        // Oldest-first ledger, one model per row (m1 oldest … m5 newest).
+        let decisions: Vec<PolicyDecisionRecord> = (1..=5)
+            .map(|i| {
+                qd(
+                    i,
+                    "planX",
+                    &format!("m{i}"),
+                    PolicyEffect::RequireReview,
+                    PolicyCapability::Apply,
+                )
+            })
+            .collect();
+
+        let now = Utc.with_ymd_and_hms(2026, 7, 7, 1, 0, 0).unwrap();
+        let (entries, excluded) = build_queue(
+            root,
+            &root.join("rocky.toml"),
+            &root.join("state.redb"),
+            &root.join("models"),
+            &decisions,
+            now,
+            2, // injected cap — production passes MAX_HISTORY_SCAN
+        );
+
+        assert_eq!(excluded, 0);
+        assert_eq!(entries.len(), 2, "only the capped scan window surfaces");
+        let models: Vec<&str> = entries.iter().map(|e| e.model.as_str()).collect();
+        assert!(
+            models.contains(&"m5"),
+            "the newest pending row must appear: {models:?}"
+        );
+        assert!(
+            models.contains(&"m4"),
+            "the second-newest pending row must appear: {models:?}"
+        );
+        assert!(
+            !models.contains(&"m1"),
+            "rows beyond the cap are the OLDEST, not the newest: {models:?}"
+        );
+    }
+
+    /// FIX: the review gate's paths anchor at the project root, not the
+    /// process cwd — a governor MCP approve runs from an unrelated cwd.
+    #[test]
+    fn review_gate_paths_resolve_against_root_not_cwd() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("models")).unwrap();
+
+        let (models_dir, state_path) = review_gate_paths(root, Some("models"));
+        assert_eq!(models_dir, root.join("models"));
+        assert!(
+            models_dir.is_dir(),
+            "root-joined models dir must be found regardless of cwd"
+        );
+        // The schema-cache state path follows the CLI/MCP default
+        // (`<models_dir>/.rocky-state.redb`), not the old hardcoded
+        // cwd-relative `.rocky/state.redb`.
+        assert_eq!(state_path, root.join("models").join(".rocky-state.redb"));
+
+        // An absolute recorded models_dir is used verbatim.
+        let (abs_dir, _) = review_gate_paths(
+            Path::new("/somewhere/else"),
+            Some(root.join("models").to_str().unwrap()),
+        );
+        assert_eq!(abs_dir, root.join("models"));
+
+        // Default when the plan recorded none.
+        let (default_dir, _) = review_gate_paths(root, None);
+        assert_eq!(default_dir, root.join("models"));
+    }
+
+    /// FIX: an approved plan's later apply-time re-evaluation rows (same
+    /// plan_id) must not resurrect it in the queue — the marker filter clears
+    /// every row of a reviewed plan, whatever model the row names.
+    #[test]
+    fn approved_plan_does_not_relist_after_apply_records_more_rows() {
+        let decisions = vec![
+            qd(
+                1,
+                "planB",
+                "a",
+                PolicyEffect::RequireReview,
+                PolicyCapability::Backfill,
+            ),
+            // Post-approval apply evaluated policy again and recorded fresh
+            // rows under the same plan.
+            qd(
+                5,
+                "planB",
+                "a",
+                PolicyEffect::RequireReview,
+                PolicyCapability::Backfill,
+            ),
+            qd(
+                6,
+                "planB",
+                "b",
+                PolicyEffect::RequireReview,
+                PolicyCapability::Backfill,
+            ),
+        ];
+        let (out, excluded) = select_outstanding(&decisions, |pid| pid == "planB", |_| true);
+        assert!(out.is_empty(), "a reviewed plan never re-lists: {out:?}");
+        assert_eq!(excluded, 0);
     }
 }

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -6447,6 +6447,12 @@ pub struct ReviewQueueOutput {
     pub ranking: String,
     /// Count of pending escalations in the queue.
     pub total: u64,
+    /// Count of outstanding `require_review` ledger rows excluded from the
+    /// queue because their `plan_id` resolves to no persisted plan file —
+    /// decision-only custody rows (e.g. refused drafts, auto-apply
+    /// evaluations) that nothing could approve. They stay in the audit
+    /// ledger; they are just not approvable queue items.
+    pub excluded_non_plan_rows: u64,
     /// The pending escalations, highest-priority first.
     pub pending: Vec<ReviewQueueEntry>,
 }
@@ -6696,9 +6702,10 @@ pub enum AuditSubjectKind {
 ///
 /// Every link fails closed the same way the estate brief does: a link whose
 /// signal is genuinely not recorded renders [`SectionAvailability::Unavailable`]
-/// with a note, never a fabricated or assumed value. Notably, post-apply
-/// verification outcomes are not persisted anywhere today, so
-/// [`Self::verify_after`] is always `unavailable`; and the run ledger is not
+/// with a note, never a fabricated or assumed value. Post-apply verification
+/// outcomes are persisted as decision-ledger custody rows (non-empty
+/// `verify_after`), so [`Self::verify_after`] renders them when they exist and
+/// says "not recorded" when none exist for the subject. The run ledger is not
 /// keyed to policy decisions, so a `run` selector cannot join back to a
 /// decision. The blast radius is recomputed from the current compiled graph
 /// (a live query, not a stored snapshot).
@@ -6722,7 +6729,8 @@ pub struct AuditForOutput {
     pub plan: AuditChainPlan,
     /// Runs that materialized the subject.
     pub runs: AuditChainRuns,
-    /// What a post-apply verification found — not recorded today.
+    /// What a post-apply verification found — the verification custody rows
+    /// recorded against the subject's plan.
     pub verify_after: AuditChainVerify,
     /// What sits downstream of the subject — the CLL blast radius.
     pub blast_radius: AuditChainBlastRadius,
@@ -6803,14 +6811,45 @@ pub struct AuditRunEntry {
 
 /// Verify-after link of the custody chain.
 ///
-/// Post-apply verification outcomes are not persisted to the state store
-/// today, so this link is always [`SectionAvailability::Unavailable`] with a
-/// note — never a smoothed-over "verification passed".
+/// Post-apply verification outcomes are persisted to the decision ledger as
+/// custody rows with a non-empty `verify_after` check list — the two-step
+/// `rocky apply` gate writes one per verified apply, and the drift auto-apply
+/// path writes them under its `autoapply-verify:<run_id>` plan id. This link
+/// renders those rows for the subject's plan. When none exist the link says
+/// so plainly ("not recorded") — never a smoothed-over "verification passed".
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct AuditChainVerify {
     pub availability: SectionAvailability,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
+    /// Count of verification custody rows found for the subject.
+    pub total: u64,
+    /// The verification outcomes, newest first.
+    pub entries: Vec<AuditVerifyEntry>,
+}
+
+/// One post-apply verification outcome inside [`AuditChainVerify`] — a
+/// decision-ledger custody row with a non-empty `verify_after` check list.
+///
+/// The ledger records the required check names, the aggregate verdict
+/// (`allow` = every named check passed, `deny` = a check failed or was absent
+/// and the apply halted), and a human-readable reason; per-check pass/fail
+/// detail beyond that lives only in the reason string, which is rendered
+/// verbatim rather than re-parsed.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct AuditVerifyEntry {
+    /// RFC 3339 timestamp when the verification outcome was recorded.
+    pub timestamp: String,
+    /// The plan id the custody row was filed under (the applied plan, or the
+    /// auto-apply path's `autoapply-verify:<run_id>`).
+    pub plan_id: String,
+    /// The named post-apply checks the verification required.
+    pub checks: Vec<String>,
+    /// Whether the verification passed (`allow` custody row) or failed
+    /// (`deny`).
+    pub passed: bool,
+    /// The recorded outcome, verbatim from the custody row.
+    pub reason: String,
 }
 
 /// Blast-radius link of the custody chain: the models that transitively
@@ -6860,14 +6899,16 @@ pub enum ScorecardDimension {
 /// autonomy, and it informs human judgment only — nothing here is wired to any
 /// automatic policy change.
 ///
-/// Only metrics the ledger actually persists are computed. The ledger records
-/// one row per policy *evaluation* — `(principal, capability, model, effect,
-/// rule_id)` — and nothing about what happened *after* the decision. So
-/// verify-after outcomes, reverts, and escalation-resolution latency are not
-/// derivable; they are declared, once, in [`Self::unavailable_metrics`] as
-/// `unavailable` with the reason, never faked into a number. A ledger read
-/// failure renders the whole scorecard `unavailable` rather than a
-/// smoothed-over zero.
+/// Only metrics the ledger actually persists are computed. Post-apply
+/// verification outcomes *are* persisted (custody rows with a non-empty
+/// `verify_after` check list), so [`Self::verify_after`] reports their pass
+/// rate when any fall in the window. Reverts and escalation-resolution
+/// latency are not persisted; they are declared in
+/// [`Self::unavailable_metrics`] as `unavailable` with the reason, never
+/// faked into a number — and `verify_after_pass_rate` joins that list only
+/// when no verification row falls in the window. A ledger read failure
+/// renders the whole scorecard `unavailable` rather than a smoothed-over
+/// zero.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct AuditScorecardOutput {
     pub version: String,
@@ -6889,9 +6930,34 @@ pub struct AuditScorecardOutput {
     pub total_decisions: u64,
     /// One row per group, ranked by decision count descending.
     pub groups: Vec<ScorecardGroup>,
-    /// Metrics the ledger does not persist, declared plainly rather than
-    /// computed. Each is `unavailable` with the reason it cannot be derived.
+    /// Aggregate of the post-apply verification custody rows in the window
+    /// (rows with a non-empty `verify_after` check list). `null` when no
+    /// verification row falls in the window — then `verify_after_pass_rate`
+    /// is declared in [`Self::unavailable_metrics`] instead.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verify_after: Option<ScorecardVerifyAfter>,
+    /// Metrics the persisted ledger cannot support for this window, declared
+    /// plainly rather than computed. Each is `unavailable` with the reason it
+    /// cannot be derived.
     pub unavailable_metrics: Vec<ScorecardUnavailableMetric>,
+}
+
+/// The verify-after aggregate inside an [`AuditScorecardOutput`]: pass/fail
+/// counts over the post-apply verification custody rows in the window.
+///
+/// Each row's aggregate verdict is its recorded `effect` (`allow` = every
+/// named check passed, `deny` = a check failed or was absent and the apply
+/// halted), so the pass rate summarizes exactly what the ledger persists.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ScorecardVerifyAfter {
+    /// Verification custody rows in the window.
+    pub total: u64,
+    /// Rows whose verdict was `allow` (every named check passed).
+    pub passed: u64,
+    /// Rows whose verdict was `deny` (a named check failed or was absent).
+    pub failed: u64,
+    /// `passed / total`.
+    pub pass_rate: f64,
 }
 
 /// One group's decision aggregate in an [`AuditScorecardOutput`].
@@ -6924,16 +6990,17 @@ pub struct ScorecardGroup {
     pub decision_refs: Vec<String>,
 }
 
-/// A metric the scorecard cannot compute because the ledger does not persist
-/// its inputs.
+/// A metric the scorecard cannot compute from the persisted ledger for this
+/// window.
 ///
 /// Declared explicitly (not silently omitted) so the honesty is
 /// machine-readable: a consumer sees the metric name, that it is `unavailable`,
 /// and exactly why.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct ScorecardUnavailableMetric {
-    /// The metric identifier (`verify_after_pass_rate`, `reverts`,
-    /// `escalation_latency`).
+    /// The metric identifier (`reverts`, `escalation_latency`, or
+    /// `verify_after_pass_rate` when no verification row falls in the
+    /// window).
     pub metric: String,
     /// Always [`SectionAvailability::Unavailable`].
     pub availability: SectionAvailability,

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -2475,6 +2475,7 @@ impl RockyMcpServer {
             }
         };
         let output = commands::compute_brief(
+            &self.root,
             &self.state_path(),
             &self.config_path,
             since,

--- a/schemas/audit_for.schema.json
+++ b/schemas/audit_for.schema.json
@@ -170,20 +170,35 @@
       "type": "object"
     },
     "AuditChainVerify": {
-      "description": "Verify-after link of the custody chain.\n\nPost-apply verification outcomes are not persisted to the state store today, so this link is always [`SectionAvailability::Unavailable`] with a note — never a smoothed-over \"verification passed\".",
+      "description": "Verify-after link of the custody chain.\n\nPost-apply verification outcomes are persisted to the decision ledger as custody rows with a non-empty `verify_after` check list — the two-step `rocky apply` gate writes one per verified apply, and the drift auto-apply path writes them under its `autoapply-verify:<run_id>` plan id. This link renders those rows for the subject's plan. When none exist the link says so plainly (\"not recorded\") — never a smoothed-over \"verification passed\".",
       "properties": {
         "availability": {
           "$ref": "#/definitions/SectionAvailability"
+        },
+        "entries": {
+          "description": "The verification outcomes, newest first.",
+          "items": {
+            "$ref": "#/definitions/AuditVerifyEntry"
+          },
+          "type": "array"
         },
         "note": {
           "type": [
             "string",
             "null"
           ]
+        },
+        "total": {
+          "description": "Count of verification custody rows found for the subject.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
         }
       },
       "required": [
-        "availability"
+        "availability",
+        "entries",
+        "total"
       ],
       "type": "object"
     },
@@ -328,6 +343,42 @@
           "type": "string"
         }
       ]
+    },
+    "AuditVerifyEntry": {
+      "description": "One post-apply verification outcome inside [`AuditChainVerify`] — a decision-ledger custody row with a non-empty `verify_after` check list.\n\nThe ledger records the required check names, the aggregate verdict (`allow` = every named check passed, `deny` = a check failed or was absent and the apply halted), and a human-readable reason; per-check pass/fail detail beyond that lives only in the reason string, which is rendered verbatim rather than re-parsed.",
+      "properties": {
+        "checks": {
+          "description": "The named post-apply checks the verification required.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "passed": {
+          "description": "Whether the verification passed (`allow` custody row) or failed (`deny`).",
+          "type": "boolean"
+        },
+        "plan_id": {
+          "description": "The plan id the custody row was filed under (the applied plan, or the auto-apply path's `autoapply-verify:<run_id>`).",
+          "type": "string"
+        },
+        "reason": {
+          "description": "The recorded outcome, verbatim from the custody row.",
+          "type": "string"
+        },
+        "timestamp": {
+          "description": "RFC 3339 timestamp when the verification outcome was recorded.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "checks",
+        "passed",
+        "plan_id",
+        "reason",
+        "timestamp"
+      ],
+      "type": "object"
     },
     "PolicyCapability": {
       "description": "The class of action a policy rule governs.\n\n`read` is always allowed (short-circuit). The mutating verbs (`propose` … `quarantine`) name coarse operations; `schema_change.additive`, `schema_change.breaking`, and `value_change` are *refinements* of the apply/promote verbs — a rule naming a bare verb (`apply`/`promote`) matches those refinements too, but a rule naming a refinement matches only that exact refinement.",
@@ -483,7 +534,7 @@
       ]
     }
   },
-  "description": "JSON output for `rocky audit --for <table|run|plan>` — the custody chain.\n\nA one-query drill-down assembled link by link from the data Rocky already records: who proposed the change and what the policy plane decided ([`Self::decisions`]), what the plan changed ([`Self::plan`]), which runs materialized it ([`Self::runs`]), what a post-apply verification found ([`Self::verify_after`]), and what sits downstream in its blast radius ([`Self::blast_radius`]).\n\nEvery link fails closed the same way the estate brief does: a link whose signal is genuinely not recorded renders [`SectionAvailability::Unavailable`] with a note, never a fabricated or assumed value. Notably, post-apply verification outcomes are not persisted anywhere today, so [`Self::verify_after`] is always `unavailable`; and the run ledger is not keyed to policy decisions, so a `run` selector cannot join back to a decision. The blast radius is recomputed from the current compiled graph (a live query, not a stored snapshot).",
+  "description": "JSON output for `rocky audit --for <table|run|plan>` — the custody chain.\n\nA one-query drill-down assembled link by link from the data Rocky already records: who proposed the change and what the policy plane decided ([`Self::decisions`]), what the plan changed ([`Self::plan`]), which runs materialized it ([`Self::runs`]), what a post-apply verification found ([`Self::verify_after`]), and what sits downstream in its blast radius ([`Self::blast_radius`]).\n\nEvery link fails closed the same way the estate brief does: a link whose signal is genuinely not recorded renders [`SectionAvailability::Unavailable`] with a note, never a fabricated or assumed value. Post-apply verification outcomes are persisted as decision-ledger custody rows (non-empty `verify_after`), so [`Self::verify_after`] renders them when they exist and says \"not recorded\" when none exist for the subject. The run ledger is not keyed to policy decisions, so a `run` selector cannot join back to a decision. The blast radius is recomputed from the current compiled graph (a live query, not a stored snapshot).",
   "properties": {
     "blast_radius": {
       "allOf": [
@@ -542,7 +593,7 @@
           "$ref": "#/definitions/AuditChainVerify"
         }
       ],
-      "description": "What a post-apply verification found — not recorded today."
+      "description": "What a post-apply verification found — the verification custody rows recorded against the subject's plan."
     },
     "version": {
       "type": "string"

--- a/schemas/audit_scorecard.schema.json
+++ b/schemas/audit_scorecard.schema.json
@@ -95,7 +95,7 @@
       "type": "object"
     },
     "ScorecardUnavailableMetric": {
-      "description": "A metric the scorecard cannot compute because the ledger does not persist its inputs.\n\nDeclared explicitly (not silently omitted) so the honesty is machine-readable: a consumer sees the metric name, that it is `unavailable`, and exactly why.",
+      "description": "A metric the scorecard cannot compute from the persisted ledger for this window.\n\nDeclared explicitly (not silently omitted) so the honesty is machine-readable: a consumer sees the metric name, that it is `unavailable`, and exactly why.",
       "properties": {
         "availability": {
           "allOf": [
@@ -106,7 +106,7 @@
           "description": "Always [`SectionAvailability::Unavailable`]."
         },
         "metric": {
-          "description": "The metric identifier (`verify_after_pass_rate`, `reverts`, `escalation_latency`).",
+          "description": "The metric identifier (`reverts`, `escalation_latency`, or `verify_after_pass_rate` when no verification row falls in the window).",
           "type": "string"
         },
         "note": {
@@ -118,6 +118,41 @@
         "availability",
         "metric",
         "note"
+      ],
+      "type": "object"
+    },
+    "ScorecardVerifyAfter": {
+      "description": "The verify-after aggregate inside an [`AuditScorecardOutput`]: pass/fail counts over the post-apply verification custody rows in the window.\n\nEach row's aggregate verdict is its recorded `effect` (`allow` = every named check passed, `deny` = a check failed or was absent and the apply halted), so the pass rate summarizes exactly what the ledger persists.",
+      "properties": {
+        "failed": {
+          "description": "Rows whose verdict was `deny` (a named check failed or was absent).",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "pass_rate": {
+          "description": "`passed / total`.",
+          "format": "double",
+          "type": "number"
+        },
+        "passed": {
+          "description": "Rows whose verdict was `allow` (every named check passed).",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "total": {
+          "description": "Verification custody rows in the window.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "failed",
+        "pass_rate",
+        "passed",
+        "total"
       ],
       "type": "object"
     },
@@ -148,7 +183,7 @@
       ]
     }
   },
-  "description": "JSON output for `rocky audit --scorecard` — a trust-calibration digest.\n\nA decisions-by-group aggregation over the persisted policy-decision ledger, windowed by `--window`. It is the evidence base for widening or tightening autonomy, and it informs human judgment only — nothing here is wired to any automatic policy change.\n\nOnly metrics the ledger actually persists are computed. The ledger records one row per policy *evaluation* — `(principal, capability, model, effect, rule_id)` — and nothing about what happened *after* the decision. So verify-after outcomes, reverts, and escalation-resolution latency are not derivable; they are declared, once, in [`Self::unavailable_metrics`] as `unavailable` with the reason, never faked into a number. A ledger read failure renders the whole scorecard `unavailable` rather than a smoothed-over zero.",
+  "description": "JSON output for `rocky audit --scorecard` — a trust-calibration digest.\n\nA decisions-by-group aggregation over the persisted policy-decision ledger, windowed by `--window`. It is the evidence base for widening or tightening autonomy, and it informs human judgment only — nothing here is wired to any automatic policy change.\n\nOnly metrics the ledger actually persists are computed. Post-apply verification outcomes *are* persisted (custody rows with a non-empty `verify_after` check list), so [`Self::verify_after`] reports their pass rate when any fall in the window. Reverts and escalation-resolution latency are not persisted; they are declared in [`Self::unavailable_metrics`] as `unavailable` with the reason, never faked into a number — and `verify_after_pass_rate` joins that list only when no verification row falls in the window. A ledger read failure renders the whole scorecard `unavailable` rather than a smoothed-over zero.",
   "properties": {
     "availability": {
       "allOf": [
@@ -189,11 +224,22 @@
       "type": "integer"
     },
     "unavailable_metrics": {
-      "description": "Metrics the ledger does not persist, declared plainly rather than computed. Each is `unavailable` with the reason it cannot be derived.",
+      "description": "Metrics the persisted ledger cannot support for this window, declared plainly rather than computed. Each is `unavailable` with the reason it cannot be derived.",
       "items": {
         "$ref": "#/definitions/ScorecardUnavailableMetric"
       },
       "type": "array"
+    },
+    "verify_after": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ScorecardVerifyAfter"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Aggregate of the post-apply verification custody rows in the window (rows with a non-empty `verify_after` check list). `null` when no verification row falls in the window — then `verify_after_pass_rate` is declared in [`Self::unavailable_metrics`] instead."
     },
     "version": {
       "type": "string"

--- a/schemas/review_queue.schema.json
+++ b/schemas/review_queue.schema.json
@@ -201,6 +201,12 @@
     "command": {
       "type": "string"
     },
+    "excluded_non_plan_rows": {
+      "description": "Count of outstanding `require_review` ledger rows excluded from the queue because their `plan_id` resolves to no persisted plan file — decision-only custody rows (e.g. refused drafts, auto-apply evaluations) that nothing could approve. They stay in the audit ledger; they are just not approvable queue items.",
+      "format": "uint64",
+      "minimum": 0.0,
+      "type": "integer"
+    },
     "pending": {
       "description": "The pending escalations, highest-priority first.",
       "items": {
@@ -224,6 +230,7 @@
   },
   "required": [
     "command",
+    "excluded_non_plan_rows",
     "pending",
     "ranking",
     "total",

--- a/sdk/python/src/rocky_sdk/types_generated/audit_for_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/audit_for_schema.py
@@ -47,6 +47,35 @@ class AuditSubjectKind3(StrEnum):
     plan = "plan"
 
 
+class AuditVerifyEntry(BaseModel):
+    """
+    One post-apply verification outcome inside [`AuditChainVerify`] — a decision-ledger custody row with a non-empty `verify_after` check list.
+
+    The ledger records the required check names, the aggregate verdict (`allow` = every named check passed, `deny` = a check failed or was absent and the apply halted), and a human-readable reason; per-check pass/fail detail beyond that lives only in the reason string, which is rendered verbatim rather than re-parsed.
+    """
+
+    checks: list[str]
+    """
+    The named post-apply checks the verification required.
+    """
+    passed: bool
+    """
+    Whether the verification passed (`allow` custody row) or failed (`deny`).
+    """
+    plan_id: str
+    """
+    The plan id the custody row was filed under (the applied plan, or the auto-apply path's `autoapply-verify:<run_id>`).
+    """
+    reason: str
+    """
+    The recorded outcome, verbatim from the custody row.
+    """
+    timestamp: str
+    """
+    RFC 3339 timestamp when the verification outcome was recorded.
+    """
+
+
 class PolicyCapability12(StrEnum):
     """
     Read model output / metadata. Always allowed.
@@ -252,7 +281,7 @@ class AuditChainVerify(BaseModel):
     """
     Verify-after link of the custody chain.
 
-    Post-apply verification outcomes are not persisted to the state store today, so this link is always [`SectionAvailability::Unavailable`] with a note — never a smoothed-over "verification passed".
+    Post-apply verification outcomes are persisted to the decision ledger as custody rows with a non-empty `verify_after` check list — the two-step `rocky apply` gate writes one per verified apply, and the drift auto-apply path writes them under its `autoapply-verify:<run_id>` plan id. This link renders those rows for the subject's plan. When none exist the link says so plainly ("not recorded") — never a smoothed-over "verification passed".
     """
 
     availability: SectionAvailability1 | SectionAvailability2 | SectionAvailability3
@@ -261,7 +290,15 @@ class AuditChainVerify(BaseModel):
 
     The digest is composed section-by-section from independent typed queries over the state store and the decision ledger. Each section fails closed: a query that returns nothing renders as [`SectionAvailability::NoData`], and a source that is not wired into the state store at all renders as [`SectionAvailability::Unavailable`] with a note — never as a smoothed-over "all clear". A brief that claims more than the ledger holds poisons the whole surface, so the marker is machine-readable, not prose.
     """
+    entries: list[AuditVerifyEntry]
+    """
+    The verification outcomes, newest first.
+    """
     note: str | None = None
+    total: conint(ge=0)
+    """
+    Count of verification custody rows found for the subject.
+    """
 
 
 class AuditDecisionEntry(BaseModel):
@@ -398,7 +435,7 @@ class AuditForOutput(BaseModel):
 
     A one-query drill-down assembled link by link from the data Rocky already records: who proposed the change and what the policy plane decided ([`Self::decisions`]), what the plan changed ([`Self::plan`]), which runs materialized it ([`Self::runs`]), what a post-apply verification found ([`Self::verify_after`]), and what sits downstream in its blast radius ([`Self::blast_radius`]).
 
-    Every link fails closed the same way the estate brief does: a link whose signal is genuinely not recorded renders [`SectionAvailability::Unavailable`] with a note, never a fabricated or assumed value. Notably, post-apply verification outcomes are not persisted anywhere today, so [`Self::verify_after`] is always `unavailable`; and the run ledger is not keyed to policy decisions, so a `run` selector cannot join back to a decision. The blast radius is recomputed from the current compiled graph (a live query, not a stored snapshot).
+    Every link fails closed the same way the estate brief does: a link whose signal is genuinely not recorded renders [`SectionAvailability::Unavailable`] with a note, never a fabricated or assumed value. Post-apply verification outcomes are persisted as decision-ledger custody rows (non-empty `verify_after`), so [`Self::verify_after`] renders them when they exist and says "not recorded" when none exist for the subject. The run ledger is not keyed to policy decisions, so a `run` selector cannot join back to a decision. The blast radius is recomputed from the current compiled graph (a live query, not a stored snapshot).
     """
 
     blast_radius: AuditChainBlastRadius
@@ -432,6 +469,6 @@ class AuditForOutput(BaseModel):
     """
     verify_after: AuditChainVerify
     """
-    What a post-apply verification found — not recorded today.
+    What a post-apply verification found — the verification custody rows recorded against the subject's plan.
     """
     version: str

--- a/sdk/python/src/rocky_sdk/types_generated/audit_scorecard_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/audit_scorecard_schema.py
@@ -77,6 +77,31 @@ class ScorecardGroup(BaseModel):
     """
 
 
+class ScorecardVerifyAfter(BaseModel):
+    """
+    The verify-after aggregate inside an [`AuditScorecardOutput`]: pass/fail counts over the post-apply verification custody rows in the window.
+
+    Each row's aggregate verdict is its recorded `effect` (`allow` = every named check passed, `deny` = a check failed or was absent and the apply halted), so the pass rate summarizes exactly what the ledger persists.
+    """
+
+    failed: conint(ge=0)
+    """
+    Rows whose verdict was `deny` (a named check failed or was absent).
+    """
+    pass_rate: float
+    """
+    `passed / total`.
+    """
+    passed: conint(ge=0)
+    """
+    Rows whose verdict was `allow` (every named check passed).
+    """
+    total: conint(ge=0)
+    """
+    Verification custody rows in the window.
+    """
+
+
 class SectionAvailability4(StrEnum):
     """
     The query ran and the section carries data for the window.
@@ -103,7 +128,7 @@ class SectionAvailability6(StrEnum):
 
 class ScorecardUnavailableMetric(BaseModel):
     """
-    A metric the scorecard cannot compute because the ledger does not persist its inputs.
+    A metric the scorecard cannot compute from the persisted ledger for this window.
 
     Declared explicitly (not silently omitted) so the honesty is machine-readable: a consumer sees the metric name, that it is `unavailable`, and exactly why.
     """
@@ -114,7 +139,7 @@ class ScorecardUnavailableMetric(BaseModel):
     """
     metric: str
     """
-    The metric identifier (`verify_after_pass_rate`, `reverts`, `escalation_latency`).
+    The metric identifier (`reverts`, `escalation_latency`, or `verify_after_pass_rate` when no verification row falls in the window).
     """
     note: str
     """
@@ -128,7 +153,7 @@ class AuditScorecardOutput(BaseModel):
 
     A decisions-by-group aggregation over the persisted policy-decision ledger, windowed by `--window`. It is the evidence base for widening or tightening autonomy, and it informs human judgment only — nothing here is wired to any automatic policy change.
 
-    Only metrics the ledger actually persists are computed. The ledger records one row per policy *evaluation* — `(principal, capability, model, effect, rule_id)` — and nothing about what happened *after* the decision. So verify-after outcomes, reverts, and escalation-resolution latency are not derivable; they are declared, once, in [`Self::unavailable_metrics`] as `unavailable` with the reason, never faked into a number. A ledger read failure renders the whole scorecard `unavailable` rather than a smoothed-over zero.
+    Only metrics the ledger actually persists are computed. Post-apply verification outcomes *are* persisted (custody rows with a non-empty `verify_after` check list), so [`Self::verify_after`] reports their pass rate when any fall in the window. Reverts and escalation-resolution latency are not persisted; they are declared in [`Self::unavailable_metrics`] as `unavailable` with the reason, never faked into a number — and `verify_after_pass_rate` joins that list only when no verification row falls in the window. A ledger read failure renders the whole scorecard `unavailable` rather than a smoothed-over zero.
     """
 
     availability: SectionAvailability4 | SectionAvailability5 | SectionAvailability6
@@ -151,7 +176,11 @@ class AuditScorecardOutput(BaseModel):
     """
     unavailable_metrics: list[ScorecardUnavailableMetric]
     """
-    Metrics the ledger does not persist, declared plainly rather than computed. Each is `unavailable` with the reason it cannot be derived.
+    Metrics the persisted ledger cannot support for this window, declared plainly rather than computed. Each is `unavailable` with the reason it cannot be derived.
+    """
+    verify_after: ScorecardVerifyAfter | None = None
+    """
+    Aggregate of the post-apply verification custody rows in the window (rows with a non-empty `verify_after` check list). `null` when no verification row falls in the window — then `verify_after_pass_rate` is declared in [`Self::unavailable_metrics`] instead.
     """
     version: str
     window: str

--- a/sdk/python/src/rocky_sdk/types_generated/review_queue_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/review_queue_schema.py
@@ -191,6 +191,10 @@ class ReviewQueueOutput(BaseModel):
     """
 
     command: str
+    excluded_non_plan_rows: conint(ge=0)
+    """
+    Count of outstanding `require_review` ledger rows excluded from the queue because their `plan_id` resolves to no persisted plan file — decision-only custody rows (e.g. refused drafts, auto-apply evaluations) that nothing could approve. They stay in the audit ledger; they are just not approvable queue items.
+    """
     pending: list[ReviewQueueEntry]
     """
     The pending escalations, highest-priority first.


### PR DESCRIPTION
The governor oversight surface — review queue, brief "Needs you", audit custody chain — diverged from the ledger it summarizes. A multi-reviewer audit found six correctness gaps; they share the queue's outstanding-selection core, so they land together.

## Fixes

1. **Queue no longer lists plan-less custody rows as permanent escalations.** Decision-only rows (`draft:*`, `draft-contract:*`, `draft-check:*`, `autoapply:<run_id>`) have no plan file, so `rocky review --approve` bails at `read_plan` and they sat pending forever (auto-apply refusals minting one id per run, ranked ever higher by staleness). `select_outstanding` now drops any deduped row whose `plan_id` resolves to no persisted plan and reports the excluded count; the rows stay in the audit ledger.

2. **Queue scan cap keeps the NEWEST rows.** `list_policy_decisions` is oldest-first, so the old `.take(cap)` aged the newest genuinely-pending escalations out of a >10k ledger (and MCP approve then refused them as not-in-queue). It now scans newest-first, matching `list_runs`. The cap is an injectable parameter so the semantics are unit-testable.

3. **Brief's "Needs you" stops over-reporting.** It listed every windowed `require_review` row with no dedup or marker/plan filter, so every already-approved-and-applied plan rendered "awaiting review". It now reuses the queue's outstanding-selection core, so the digest and `rocky review --queue` agree. Raw per-effect counts stay in `agent_activity`.

4. **Audit's verify-after link reads persisted outcomes.** `build_verify_link` unconditionally claimed outcomes "are not persisted", while the same response's decisions section already listed the verify custody rows (apply and the drift auto-apply path write them with non-empty `verify_after` since state v17). It now reads the subject plan's verification rows and renders pass/fail + the recorded reason; absent rows keep the honest "not recorded" note. The scorecard computes `verify_after_pass_rate` where rows exist and declares it unavailable only when none fall in the window.

5. **gc/backfill plans enter the review queue.** Their apply bails on the review-marker gate before `evaluate_apply_policy` could record a decision row, so the decision-driven queue never listed them — even though `compute_review_gc_plan` was built precisely so the governor could approve them. Plan creation now records one plan-level `require_review` escalation (a representative scope summary, `rule_id: None`, no `verify_after` — inert to autonomy-budget and freeze accounting). The queue lists them, `rocky review --approve` clears them, and the MCP `review_queue` approve path works end to end. Apply behavior is unchanged (marker gate first, policy `Deny` still tightens).

6. **`compute_review` resolves paths against the plan root, not process cwd.** The models dir was cwd-relative and the schema-cache state path was hardcoded `.rocky/state.redb` (also wrong vs the `models/.rocky-state.redb` default), so a governor MCP approve from a server whose cwd is not the project root silently skipped the breaking-change gate. Paths now resolve against `root` via `resolve_state_path`; the honest gate-skipped note stays for genuinely-missing dirs.

## Schema / codegen

Three schema-exposed structs gained fields — `ReviewQueueOutput.excluded_non_plan_rows`, `AuditChainVerify` (now carries `total` + `entries: Vec<AuditVerifyEntry>`), `AuditScorecardOutput.verify_after: Option<ScorecardVerifyAfter>`. `just codegen` regenerated `schemas/`, the SDK Pydantic bindings, the vscode TypeScript, and `openapi.json`. No state-schema bump — `PolicyDecisionRecord` is unchanged. `just regen-fixtures` produced no dagster fixture drift (the corpus is replication-only).

## Tests

Non-vacuous regression tests for every fix, in the existing seeded-store style:
- `select_outstanding_excludes_planless_custody_rows_and_counts_them`, `queue_scan_cap_keeps_newest_rows`, `review_gate_paths_resolve_against_root_not_cwd`, `approved_plan_does_not_relist_after_apply_records_more_rows` (review)
- `escalations_drop_reviewed_plans_planless_rows_and_duplicates` (brief)
- four `verify_link_*` tests + `scorecard_computes_verify_after_pass_rate_from_custody_rows` (audit)
- `backfill_plan_records_review_escalation_and_enters_queue`, `gc_plan_enters_review_queue_and_clears_on_approve` (the gc plan→queue→approve→apply end-to-end)

Verified from `engine/`: `cargo test --workspace`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check` all green.