### PR TITLE
fix(sdk,engine): make client parsing match the real wire; close shadow drift; complete generated barrel

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -6736,7 +6736,6 @@
           }
         },
         "required": [
-          "adaptive_concurrency",
           "concurrency",
           "tables_failed",
           "tables_processed"
@@ -9988,8 +9987,6 @@
           }
         },
         "required": [
-          "alerts",
-          "column_trend",
           "command",
           "count",
           "model",
@@ -10853,7 +10850,6 @@
           }
         },
         "required": [
-          "batched_with",
           "end",
           "key",
           "start"
@@ -10912,7 +10908,6 @@
           "model",
           "partitions_failed",
           "partitions_planned",
-          "partitions_skipped",
           "partitions_succeeded"
         ],
         "type": "object"
@@ -12217,8 +12212,7 @@
         "required": [
           "rows_added",
           "rows_changed",
-          "rows_removed",
-          "samples"
+          "rows_removed"
         ],
         "type": "object"
       },
@@ -12710,7 +12704,6 @@
           }
         },
         "required": [
-          "changed_columns",
           "model_name",
           "reason"
         ],
@@ -12865,8 +12858,7 @@
         "required": [
           "rows_added",
           "rows_changed",
-          "rows_removed",
-          "samples"
+          "rows_removed"
         ],
         "type": "object"
       },
@@ -12920,11 +12912,6 @@
             "type": "array"
           }
         },
-        "required": [
-          "added_columns",
-          "removed_columns",
-          "type_changes"
-        ],
         "type": "object"
       },
       "ProfileColumnStats": {
@@ -13779,9 +13766,7 @@
         "required": [
           "asset_key",
           "mode",
-          "ok",
-          "quarantine_table",
-          "valid_table"
+          "ok"
         ],
         "type": "object"
       },
@@ -15744,24 +15729,18 @@
           }
         },
         "required": [
-          "anomalies",
           "check_results",
           "command",
           "drift",
           "duration_ms",
-          "errors",
           "execution",
           "filter",
           "interrupted",
           "materializations",
-          "partition_summaries",
           "permissions",
-          "quarantine",
-          "shadow",
           "status",
           "tables_copied",
           "tables_failed",
-          "tables_skipped",
           "version"
         ],
         "type": "object"

--- a/editors/vscode/src/types/generated/metrics.ts
+++ b/editors/vscode/src/types/generated/metrics.ts
@@ -11,9 +11,9 @@
  * All optional fields are present-or-absent depending on the flags (`--trend`, `--alerts`, `--column`). The empty case (no snapshots available) sets `message` and leaves the collections empty.
  */
 export interface MetricsOutput {
-  alerts: MetricsAlert[];
+  alerts?: MetricsAlert[];
   column?: string | null;
-  column_trend: ColumnTrendPoint[];
+  column_trend?: ColumnTrendPoint[];
   command: string;
   count: number;
   message?: string | null;

--- a/editors/vscode/src/types/generated/preview_create.ts
+++ b/editors/vscode/src/types/generated/preview_create.ts
@@ -71,7 +71,7 @@ export interface PreviewPrunedModel {
   /**
    * Columns the diff reports as changed on this model. Only populated when `reason = "changed"`.
    */
-  changed_columns: string[];
+  changed_columns?: string[];
   model_name: string;
   /**
    * `"changed"` for models the diff identified directly, or `"downstream_of_changed"` for models pulled in by column-level lineage from a changed model.

--- a/editors/vscode/src/types/generated/preview_diff.ts
+++ b/editors/vscode/src/types/generated/preview_diff.ts
@@ -64,7 +64,7 @@ export interface PreviewSampledRowDiff {
   /**
    * Up to `--max-samples` (default 5) representative changed rows for human review. Pure noise when sampling found no change.
    */
-  samples: PreviewRowSample[];
+  samples?: PreviewRowSample[];
   [k: string]: unknown;
 }
 /**
@@ -146,19 +146,19 @@ export interface PreviewBisectionRowDiff {
   /**
    * Up to `--max-samples` (default 5) representative changed rows surfaced from the leaves. Bisection samples only carry the primary key — column-level diffs are not retained on the kernel's leaf record. Empty when no rows differ.
    */
-  samples: PreviewRowSample[];
+  samples?: PreviewRowSample[];
   [k: string]: unknown;
 }
 /**
  * Column-level structural diff. Mirrors the shape produced by `rocky ci-diff` at the column granularity.
  */
 export interface PreviewStructuralDiff {
-  added_columns: string[];
-  removed_columns: string[];
+  added_columns?: string[];
+  removed_columns?: string[];
   /**
    * One entry per column whose type changed. Each carries `name`, `from`, `to`.
    */
-  type_changes: PreviewColumnTypeChange[];
+  type_changes?: PreviewColumnTypeChange[];
   [k: string]: unknown;
 }
 /**

--- a/editors/vscode/src/types/generated/run.ts
+++ b/editors/vscode/src/types/generated/run.ts
@@ -110,7 +110,7 @@ export type RunStatus = ("Success" | "PartialFailure" | "Failure") | "SkippedIde
  * JSON output for `rocky run`.
  */
 export interface RunOutput {
-  anomalies: AnomalyOutput[];
+  anomalies?: AnomalyOutput[];
   /**
    * Budget breaches detected at end of run. Empty when no `[budget]` block is configured or all configured limits were respected. Each breach is also emitted as a `budget_breach` [`rocky_observe::events::PipelineEvent`] and fires the `on_budget_breach` hook so subscribers see them live.
    */
@@ -127,7 +127,7 @@ export interface RunOutput {
   cost_summary?: RunCostSummary | null;
   drift: DriftSummary;
   duration_ms: number;
-  errors: TableErrorOutput[];
+  errors?: TableErrorOutput[];
   /**
    * Tables that the discovery adapter reported as enabled but that do not exist in the source warehouse (e.g. Fivetran has them configured but hasn't synced them, or they carry the `do_not_alter__` broken-table marker). Surfaced so orchestrators can flag the gap in their UIs instead of silently dropping the assets.
    */
@@ -155,7 +155,7 @@ export interface RunOutput {
   /**
    * Per-model partition execution summaries, present only when the run touched one or more `time_interval` models. Empty for runs that didn't execute any partitioned models.
    */
-  partition_summaries: PartitionSummary[];
+  partition_summaries?: PartitionSummary[];
   permissions: PermissionSummary;
   /**
    * Pipeline type that was executed (e.g., "replication").
@@ -164,12 +164,12 @@ export interface RunOutput {
   /**
    * Row-quarantine outcomes — one entry per table the quality pipeline quarantined. Empty for runs that did not use `[pipeline.x.checks.quarantine]`.
    */
-  quarantine: QuarantineOutput[];
+  quarantine?: QuarantineOutput[];
   resumed_from?: string | null;
   /**
    * True when running in shadow mode (targets rewritten).
    */
-  shadow: boolean;
+  shadow?: boolean;
   /**
    * Prior run whose idempotency key deflected this call, or the run currently holding the in-flight claim. Populated only when `status` is `skipped_idempotent` or `skipped_in_flight`.
    */
@@ -183,7 +183,7 @@ export interface RunOutput {
    * Total number of failed tables/models for the run, **including** pre-execution compile failures: a model that fails to type-check is counted here even though it never reached the execution phase. This is the authoritative failure count — consumers should key overall pass/fail on the top-level `tables_failed` / `status` / `errors`, not on `execution.tables_failed`, which counts only execution-phase (copy / runtime) failures and excludes models excluded before execution.
    */
   tables_failed: number;
-  tables_skipped: number;
+  tables_skipped?: number;
   version: string;
   [k: string]: unknown;
 }
@@ -337,7 +337,7 @@ export interface ExecutionSummary {
   /**
    * Whether adaptive concurrency (AIMD throttle) was enabled for this run.
    */
-  adaptive_concurrency: boolean;
+  adaptive_concurrency?: boolean;
   concurrency: number;
   /**
    * Final concurrency level at end of run (may differ from initial if adaptive concurrency adjusted it). Only present when adaptive concurrency is enabled.
@@ -462,7 +462,7 @@ export interface MaterializationMetadata {
  * `key` is the canonical Rocky partition key (e.g. `"2026-04-07"` for daily; `"2026-04-07T13"` for hourly). `start` / `end` are the half-open `[start, end)` window the SQL substituted for `@start_date` / `@end_date`. `batched_with` lists any additional partition keys that were merged into this batch when `batch_size > 1` — empty for the default one-partition-per-statement case.
  */
 export interface PartitionInfo {
-  batched_with: string[];
+  batched_with?: string[];
   end: string;
   key: string;
   start: string;
@@ -547,7 +547,7 @@ export interface PartitionSummary {
   /**
    * Partitions that were already `Computed` in the state store and skipped by the runtime (currently always 0; reserved for the `--missing` change-detection optimization).
    */
-  partitions_skipped: number;
+  partitions_skipped?: number;
   partitions_succeeded: number;
   [k: string]: unknown;
 }
@@ -583,7 +583,7 @@ export interface QuarantineOutput {
   /**
    * Fully-qualified name of the `__quarantine` output table. Empty for `mode = "drop"` (failing rows discarded) and `mode = "tag"`.
    */
-  quarantine_table: string;
+  quarantine_table?: string;
   /**
    * Number of rows in the `__quarantine` output, when the adapter can report it.
    */
@@ -595,6 +595,6 @@ export interface QuarantineOutput {
   /**
    * Fully-qualified `catalog.schema.table` name of the `__valid` output table. Empty for `mode = "tag"` (source is rewritten in place).
    */
-  valid_table: string;
+  valid_table?: string;
   [k: string]: unknown;
 }

--- a/editors/vscode/src/views/previewView.ts
+++ b/editors/vscode/src/views/previewView.ts
@@ -188,7 +188,9 @@ export class PreviewDiffModelNode extends vscode.TreeItem {
   ) {
     super(model.model_name, vscode.TreeItemCollapsibleState.None);
 
-    const { added_columns, removed_columns, type_changes } = model.structural;
+    const { type_changes } = model.structural;
+    const added_columns = model.structural.added_columns ?? [];
+    const removed_columns = model.structural.removed_columns ?? [];
     const hasAdded = added_columns.length > 0;
     const hasRemoved = removed_columns.length > 0;
     const hasTypeChanges = (type_changes?.length ?? 0) > 0;
@@ -491,7 +493,9 @@ function buildCostModelTooltip(delta: PreviewModelCostDelta): string {
 function buildDiffModelTooltip(model: PreviewModelDiff): string {
   const lines: string[] = [];
   lines.push(`Model: ${model.model_name}`);
-  const { added_columns, removed_columns, type_changes } = model.structural;
+  const { type_changes } = model.structural;
+  const added_columns = model.structural.added_columns ?? [];
+  const removed_columns = model.structural.removed_columns ?? [];
   if (added_columns.length > 0) {
     lines.push(`Added columns: ${added_columns.join(", ")}`);
   }
@@ -510,7 +514,9 @@ function formatModelDiffMarkdown(model: PreviewModelDiff): string {
   const lines: string[] = [];
   lines.push(`# Diff: ${model.model_name}`);
   lines.push("");
-  const { added_columns, removed_columns, type_changes } = model.structural;
+  const { type_changes } = model.structural;
+  const added_columns = model.structural.added_columns ?? [];
+  const removed_columns = model.structural.removed_columns ?? [];
   if (
     added_columns.length === 0 &&
     removed_columns.length === 0 &&
@@ -551,10 +557,11 @@ function formatModelDiffMarkdown(model: PreviewModelDiff): string {
           "> ⚠ Coverage warning: changes outside the sampling window may not be reflected.",
         );
       }
-      if (s.samples.length > 0) {
+      const samples = s.samples ?? [];
+      if (samples.length > 0) {
         lines.push("");
         lines.push("### Samples");
-        for (const sample of s.samples) {
+        for (const sample of samples) {
           lines.push(`**Row (pk=${sample.primary_key})**`);
           for (const change of sample.changes) {
             lines.push(

--- a/engine/AGENTS.md
+++ b/engine/AGENTS.md
@@ -270,8 +270,11 @@ rocky profile-storage                # Column encoding recommendations
 rocky archive                        # Partition archival
 rocky doctor                         # Aggregate health checks
 rocky compare                        # Shadow vs production comparison
-rocky drift                          # Schema drift detection
 ```
+
+Schema drift is not a standalone verb — there is no `rocky drift` command. Drift
+detection runs inside `rocky run` / `rocky plan` (surfaced on `RunOutput.drift`);
+see `drift.rs`.
 
 Global flags: `--config` (default: `rocky.toml`), `--output` (`json`|`table`), `--state-path` (default: `models/.rocky-state.redb`; an existing `.rocky-state.redb` in the current directory still works and emits a one-time deprecation warning)
 

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -246,7 +246,7 @@ pub struct RunOutput {
     /// `execution.tables_failed`, which counts only execution-phase (copy /
     /// runtime) failures and excludes models excluded before execution.
     pub tables_failed: usize,
-    #[serde(skip_serializing_if = "is_zero")]
+    #[serde(default, skip_serializing_if = "is_zero")]
     pub tables_skipped: usize,
     /// Tables that the discovery adapter reported as enabled but that do not
     /// exist in the source warehouse (e.g. Fivetran has them configured but
@@ -258,7 +258,7 @@ pub struct RunOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resumed_from: Option<String>,
     /// True when running in shadow mode (targets rewritten).
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub shadow: bool,
     pub materializations: Vec<MaterializationOutput>,
     /// Per-model build/skip/reuse decision + reason, surfaced for
@@ -279,11 +279,11 @@ pub struct RunOutput {
     /// Row-quarantine outcomes — one entry per table the quality
     /// pipeline quarantined. Empty for runs that did not use
     /// `[pipeline.x.checks.quarantine]`.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub quarantine: Vec<QuarantineOutput>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub anomalies: Vec<AnomalyOutput>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub errors: Vec<TableErrorOutput>,
     pub execution: ExecutionSummary,
     pub metrics: Option<MetricsSnapshot>,
@@ -292,7 +292,7 @@ pub struct RunOutput {
     /// Per-model partition execution summaries, present only when the run
     /// touched one or more `time_interval` models. Empty for runs that
     /// didn't execute any partitioned models.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub partition_summaries: Vec<PartitionSummary>,
     /// `true` when the run was cancelled by a SIGINT (Ctrl-C). Surfaced so
     /// orchestrators can distinguish "user interrupted" from "run failed".
@@ -456,7 +456,7 @@ pub struct ExecutionSummary {
     /// not this `execution.tables_failed`.
     pub tables_failed: usize,
     /// Whether adaptive concurrency (AIMD throttle) was enabled for this run.
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub adaptive_concurrency: bool,
     /// Final concurrency level at end of run (may differ from initial if
     /// adaptive concurrency adjusted it). Only present when adaptive
@@ -1309,7 +1309,7 @@ pub struct PartitionInfo {
     pub key: String,
     pub start: DateTime<Utc>,
     pub end: DateTime<Utc>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub batched_with: Vec<String>,
 }
 
@@ -1327,7 +1327,7 @@ pub struct PartitionSummary {
     /// Partitions that were already `Computed` in the state store and
     /// skipped by the runtime (currently always 0; reserved for the
     /// `--missing` change-detection optimization).
-    #[serde(skip_serializing_if = "is_zero")]
+    #[serde(default, skip_serializing_if = "is_zero")]
     pub partitions_skipped: usize,
 }
 
@@ -1357,11 +1357,11 @@ pub struct QuarantineOutput {
     /// Fully-qualified `catalog.schema.table` name of the `__valid`
     /// output table. Empty for `mode = "tag"` (source is rewritten in
     /// place).
-    #[serde(skip_serializing_if = "String::is_empty")]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub valid_table: String,
     /// Fully-qualified name of the `__quarantine` output table. Empty
     /// for `mode = "drop"` (failing rows discarded) and `mode = "tag"`.
-    #[serde(skip_serializing_if = "String::is_empty")]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub quarantine_table: String,
     /// Number of rows in the `__valid` output, when the adapter can
     /// report it.
@@ -2393,11 +2393,11 @@ pub struct MetricsOutput {
     pub model: String,
     pub snapshots: Vec<MetricsSnapshotEntry>,
     pub count: usize,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub alerts: Vec<MetricsAlert>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub column: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub column_trend: Vec<ColumnTrendPoint>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
@@ -8321,7 +8321,7 @@ pub struct PreviewPrunedModel {
     pub reason: String,
     /// Columns the diff reports as changed on this model. Only
     /// populated when `reason = "changed"`.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub changed_columns: Vec<String>,
 }
 
@@ -8438,7 +8438,7 @@ pub struct PreviewBisectionRowDiff {
     /// surfaced from the leaves. Bisection samples only carry the
     /// primary key — column-level diffs are not retained on the
     /// kernel's leaf record. Empty when no rows differ.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub samples: Vec<PreviewRowSample>,
 }
 
@@ -8499,13 +8499,13 @@ impl BisectionStatsOutput {
 /// `rocky ci-diff` at the column granularity.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct PreviewStructuralDiff {
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub added_columns: Vec<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub removed_columns: Vec<String>,
     /// One entry per column whose type changed. Each carries `name`,
     /// `from`, `to`.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub type_changes: Vec<PreviewColumnTypeChange>,
 }
 
@@ -8525,7 +8525,7 @@ pub struct PreviewSampledRowDiff {
     pub rows_changed: u64,
     /// Up to `--max-samples` (default 5) representative changed rows
     /// for human review. Pure noise when sampling found no change.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub samples: Vec<PreviewRowSample>,
 }
 

--- a/integrations/dagster/src/dagster_rocky/__init__.py
+++ b/integrations/dagster/src/dagster_rocky/__init__.py
@@ -112,11 +112,7 @@ from .types import (
     Diagnostic,
     DiscoverResult,
     DoctorResult,
-    DriftActionKind,
-    DriftDetectResult,
-    DriftedColumn,
     DriftInfo,
-    DriftTableResult,
     ExecutionSummary,
     FailedSourceOutput,
     FreshnessConfig,
@@ -322,11 +318,6 @@ __all__ = [
     "DoctorResult",
     "HealthCheck",
     "HealthStatus",
-    # Drift
-    "DriftDetectResult",
-    "DriftTableResult",
-    "DriftedColumn",
-    "DriftActionKind",
     # Governance (Waves B + C-2 — compliance + retention)
     "ComplianceOutput",
     "ComplianceException",

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -2885,19 +2885,18 @@ def _log_run_diagnostics(
     context: dg.AssetExecutionContext,
     result: RunResult,
 ) -> None:
-    """Log run-level errors and contract violations.
+    """Log run-level errors.
 
     Drift and anomalies are NOT logged here — they're emitted as
     structured Dagster events (``AssetObservation`` and ``AssetCheckResult``
     respectively) by :func:`_emit_results`. Logging them here too would
-    duplicate the signal in the Dagster UI.
+    duplicate the signal in the Dagster UI. (There is no run-level
+    ``contracts`` block on the wire — ``rocky run`` surfaces contract
+    outcomes through ``check_results``, not a top-level ``contracts`` field —
+    so the previously-dead contract-violation log was removed.)
     """
     for err in result.errors:
         context.log.error(f"Table failed: {err.error}")
-
-    if result.contracts is not None and not result.contracts.passed:
-        for violation in result.contracts.violations:
-            context.log.error(f"Contract violation: {violation.column} — {violation.message}")
 
 
 def _emit_results(

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -29,7 +29,7 @@ from typing import Annotated, Any, Literal
 import dagster as dg
 from pydantic import BaseModel, ConfigDict
 from rocky_sdk import RockyClient
-from rocky_sdk.client import DEFAULT_TIMEOUT_SECONDS, MIN_ROCKY_VERSION
+from rocky_sdk.client import DEFAULT_TIMEOUT_SECONDS, MIN_ROCKY_VERSION, ApplyResult
 from rocky_sdk.exceptions import (
     RockyBinaryNotFoundError,
     RockyCommandError,
@@ -46,7 +46,6 @@ from .types import (
     AiResult,
     AiSyncResult,
     AiTestResult,
-    ApplyOutput,
     ApproveOutput,
     BranchPromoteOutput,
     CatalogOutput,
@@ -814,8 +813,14 @@ class RockyResource(dg.ConfigurableResource):
         with _translating():
             return self._get_client().plan(filter, pipeline=pipeline, env=env)
 
-    def apply(self, plan_id: str) -> ApplyOutput:
-        """Run ``rocky apply <plan-id>`` and return the parsed envelope."""
+    def apply(self, plan_id: str) -> ApplyResult:
+        """Run ``rocky apply <plan-id>`` and return the parsed result.
+
+        ``rocky apply`` prints the plan-kind's own output (no wrapping
+        envelope), so the return type is the :data:`~rocky_sdk.client.ApplyResult`
+        union: run-shaped plans yield a :class:`RunResult`, a ``gc`` plan a
+        ``GcApplyOutput``, compact / archive / promote plans their own outputs.
+        """
         with _translating():
             return self._get_client().apply(plan_id)
 

--- a/integrations/dagster/tests/conftest.py
+++ b/integrations/dagster/tests/conftest.py
@@ -108,11 +108,6 @@ def doctor_json() -> str:
 
 
 @pytest.fixture
-def drift_json() -> str:
-    return json.dumps(scenarios.DRIFT)
-
-
-@pytest.fixture
 def compliance_json() -> str:
     return json.dumps(scenarios.COMPLIANCE)
 

--- a/integrations/dagster/tests/fixtures_generated/apply.json
+++ b/integrations/dagster/tests/fixtures_generated/apply.json
@@ -1,35 +1,77 @@
 {
   "version": "0.0.0-SENTINEL",
-  "command": "apply",
-  "plan_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-  "plan_kind": "run",
-  "success": true,
-  "result": {
-    "version": "0.0.0-SENTINEL",
-    "command": "run",
-    "status": "success",
-    "filter": "",
-    "duration_ms": 0,
-    "tables_copied": 0,
+  "command": "run",
+  "status": "Success",
+  "pipeline_type": "replication",
+  "filter": "source=orders",
+  "duration_ms": 0,
+  "tables_copied": 1,
+  "tables_failed": 0,
+  "materializations": [
+    {
+      "asset_key": [
+        "duckdb",
+        "orders",
+        "orders"
+      ],
+      "rows_copied": null,
+      "duration_ms": 0,
+      "started_at": "2000-01-01T00:00:00Z",
+      "metadata": {
+        "strategy": "full_refresh",
+        "watermark": "2000-01-01T00:00:00Z",
+        "target_table_full_name": "playground.staging__orders.orders"
+      },
+      "cost_usd": 0.0
+    }
+  ],
+  "check_results": [],
+  "execution": {
+    "concurrency": 4,
+    "tables_processed": 1,
+    "tables_failed": 0
+  },
+  "metrics": {
+    "tables_processed": 1,
     "tables_failed": 0,
-    "materializations": [],
-    "check_results": [],
-    "execution": {
-      "layers": 0,
-      "models": 0,
-      "total_duration_ms": 0
-    },
-    "metrics": null,
-    "permissions": {
-      "grants_applied": 0,
-      "grants_skipped": 0,
-      "grants_failed": 0
-    },
-    "drift": {
-      "tables_checked": 0,
-      "tables_drifted": 0,
-      "actions": []
-    },
-    "interrupted": false
+    "error_rate_pct": 0.0,
+    "statements_executed": 0,
+    "retries_attempted": 0,
+    "retries_succeeded": 0,
+    "anomalies_detected": 0,
+    "table_duration_p50_ms": 0,
+    "table_duration_p95_ms": 0,
+    "table_duration_max_ms": 0,
+    "query_duration_p50_ms": 0,
+    "query_duration_p95_ms": 0,
+    "query_duration_max_ms": 0
+  },
+  "permissions": {
+    "grants_added": 0,
+    "grants_revoked": 0,
+    "catalogs_created": 0,
+    "schemas_created": 1
+  },
+  "drift": {
+    "tables_checked": 1,
+    "tables_drifted": 0,
+    "actions_taken": []
+  },
+  "interrupted": false,
+  "cost_summary": {
+    "total_cost_usd": 0.0,
+    "total_duration_ms": 0,
+    "per_model": [
+      {
+        "asset_key": [
+          "duckdb",
+          "orders",
+          "orders"
+        ],
+        "duration_ms": 0,
+        "cost_usd": 0.0
+      }
+    ],
+    "adapter_type": "duckdb"
   }
 }

--- a/integrations/dagster/tests/scenarios.py
+++ b/integrations/dagster/tests/scenarios.py
@@ -365,37 +365,34 @@ PLAN_WITH_RUN_SPINE: dict[str, Any] = {
     "execution_layers": [["db.schema.users"], ["db.schema.orders"]],
 }
 
-# Apply output — wraps a run result with the plan_id envelope.
+# Apply output — ``rocky apply`` emits NO wrapping envelope. A ``gc`` plan's
+# apply prints ``command:"apply"`` with gc markers (``evicted`` / ``refused``),
+# which ``parse_rocky_output`` routes to the generated ``GcApplyOutput``.
+# Run-shaped plans (run / replication / ai_authored / backfill) print a bare
+# ``RunOutput`` with ``command:"run"`` instead — covered by the live
+# ``fixtures_generated/apply.json`` capture and the SDK client tests.
 APPLY: dict[str, Any] = {
     "version": "0.1.0",
     "command": "apply",
     "plan_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    "plan_kind": "run",
-    "success": True,
-    "result": {
-        "version": "0.1.0",
-        "command": "run",
-        "status": "success",
-        "filter": "client=acme",
-        "duration_ms": 1234,
-        "tables_copied": 2,
-        "tables_failed": 0,
-        "materializations": [],
-        "check_results": [],
-        "execution": {"layers": 1, "models": 2, "total_duration_ms": 1234},
-        "metrics": None,
-        "permissions": {
-            "grants_applied": 0,
-            "grants_skipped": 0,
-            "grants_failed": 0,
+    "evicted": [
+        {
+            "model_name": "stale_model",
+            "run_id": "run-2026-01-01-000000-001",
+            "blake3_hash": "deadbeefcafef00d",
+            "size_bytes": 4096,
+            "physical_reclaimed": True,
+            "physical_status": "reclaimed",
+            "tombstone_recorded": True,
         },
-        "drift": {
-            "tables_checked": 0,
-            "tables_drifted": 0,
-            "actions": [],
-        },
-        "interrupted": False,
-    },
+    ],
+    "refused": [],
+    "already_evicted": [],
+    "bytes_evicted": 4096,
+    "bytes_refused": 0,
+    "evicted_count": 1,
+    "refused_count": 0,
+    "notes": ["physical reclamation is object-store-only"],
 }
 
 # ---------------------------------------------------------------------------
@@ -692,30 +689,6 @@ DOCTOR: dict[str, Any] = {
         "Consider using 'tiered' state backend for distributed execution",
     ],
 }
-
-# ---------------------------------------------------------------------------
-# drift — one drifted column with type change, drop_and_recreate action
-# ---------------------------------------------------------------------------
-
-DRIFT: dict[str, Any] = {
-    "command": "drift",
-    "tables_checked": 3,
-    "tables_drifted": 1,
-    "results": [
-        {
-            "table": "acme_warehouse.staging__us_west__shopify.payments",
-            "drifted_columns": [
-                {
-                    "name": "status",
-                    "source_type": "STRING",
-                    "target_type": "INT",
-                },
-            ],
-            "action": "DropAndRecreate",
-        },
-    ],
-}
-
 
 # ---------------------------------------------------------------------------
 # compliance — governance Wave B rollup

--- a/integrations/dagster/tests/test_generated_fixtures.py
+++ b/integrations/dagster/tests/test_generated_fixtures.py
@@ -30,7 +30,6 @@ from pathlib import Path
 import pytest
 
 from dagster_rocky.types import (
-    ApplyOutput,
     CiResult,
     ColumnLineageResult,
     CompileResult,
@@ -38,6 +37,7 @@ from dagster_rocky.types import (
     DagResult,
     DiscoverResult,
     DoctorResult,
+    GcApplyOutput,
     HistoryResult,
     MetricsResult,
     ModelHistoryResult,
@@ -62,7 +62,10 @@ EXPECTED_TYPES: dict[str, type] = {
     "discover": DiscoverResult,
     "run": RunResult,
     "plan": PlanResult,
-    "apply": ApplyOutput,
+    # ``rocky apply`` prints the plan-kind's own output: a run / replication
+    # plan prints ``command:"run"`` (→ RunResult, keyed above), a ``gc`` plan
+    # prints ``command:"apply"`` with gc markers (→ GcApplyOutput).
+    "apply": GcApplyOutput,
     "state": StateResult,
     "compile": CompileResult,
     "test": TestResult,

--- a/integrations/dagster/tests/test_types.py
+++ b/integrations/dagster/tests/test_types.py
@@ -8,15 +8,13 @@ import pytest
 
 from dagster_rocky.types import (
     AiContractOutput,
-    ApplyOutput,
     CatalogOutput,
     CiResult,
     ColumnLineageResult,
     CompileResult,
     DiscoverResult,
     DoctorResult,
-    DriftActionKind,
-    DriftDetectResult,
+    GcApplyOutput,
     HealthStatus,
     HistoryResult,
     MetricsResult,
@@ -358,10 +356,6 @@ def test_parse_run(run_json: str):
     assert len(result.drift.actions_taken) == 1
     assert result.drift.actions_taken[0].action == "drop_and_recreate"
 
-    # Contracts
-    assert result.contracts is not None
-    assert result.contracts.passed is True
-
     # Anomalies
     assert len(result.anomalies) == 1
     assert result.anomalies[0].deviation_pct == 1.2
@@ -426,15 +420,16 @@ def test_parse_plan_with_run_spine(plan_with_run_spine_json: str):
 
 
 def test_parse_apply(apply_json: str):
-    """ApplyOutput envelope wrapping a run result."""
-    result = ApplyOutput.model_validate_json(apply_json)
+    """``rocky apply`` emits NO wrapping envelope. A ``gc`` plan's apply prints
+    ``command:"apply"`` with gc markers, which ``parse_rocky_output`` routes to
+    the generated ``GcApplyOutput`` (the old hand-written ``ApplyOutput`` envelope
+    the engine never emitted was removed)."""
+    result = GcApplyOutput.model_validate_json(apply_json)
     assert result.command == "apply"
     assert result.plan_id == "a" * 64
-    assert result.plan_kind == "run"
-    assert result.success is True
-    assert isinstance(result.result, dict)
-    assert result.result["command"] == "run"
-    assert isinstance(parse_rocky_output(apply_json), ApplyOutput)
+    assert result.evicted_count == 1
+    assert result.evicted[0].model_name == "stale_model"
+    assert isinstance(parse_rocky_output(apply_json), GcApplyOutput)
 
 
 def test_parse_state(state_json: str):
@@ -659,7 +654,7 @@ def test_parse_rocky_output_auto_detect(
     metrics_json: str,
     optimize_json: str,
     doctor_json: str,
-    drift_json: str,
+    apply_json: str,
     catalog_json: str,
 ):
     assert isinstance(parse_rocky_output(discover_json), DiscoverResult)
@@ -674,7 +669,7 @@ def test_parse_rocky_output_auto_detect(
     assert isinstance(parse_rocky_output(metrics_json), MetricsResult)
     assert isinstance(parse_rocky_output(optimize_json), OptimizeResult)
     assert isinstance(parse_rocky_output(doctor_json), DoctorResult)
-    assert isinstance(parse_rocky_output(drift_json), DriftDetectResult)
+    assert isinstance(parse_rocky_output(apply_json), GcApplyOutput)
     assert isinstance(parse_rocky_output(catalog_json), CatalogOutput)
 
 
@@ -694,19 +689,6 @@ def test_parse_non_dict_json_raises_value_error(payload: str):
     ValueError, not crash on ``.get`` with an uncaught AttributeError."""
     with pytest.raises(ValueError, match="not a JSON object"):
         parse_rocky_output(payload)
-
-
-def test_parse_drift_result(drift_json: str):
-    result = DriftDetectResult.model_validate_json(drift_json)
-    assert result.command == "drift"
-    assert result.tables_checked == 3
-    assert result.tables_drifted == 1
-    assert len(result.results) == 1
-    table_result = result.results[0]
-    assert table_result.action == DriftActionKind.drop_and_recreate
-    assert table_result.drifted_columns[0].name == "status"
-    assert table_result.drifted_columns[0].source_type == "STRING"
-    assert table_result.drifted_columns[0].target_type == "INT"
 
 
 def test_run_result_without_optional_fields():
@@ -732,7 +714,12 @@ def test_run_result_without_optional_fields():
     assert result.execution is None
     assert result.metrics is None
     assert result.anomalies == []
-    assert result.contracts is None
+    # New backfilled fields default cleanly on a minimal payload.
+    assert result.status is None
+    assert result.tables_skipped == 0
+    assert result.interrupted is False
+    assert result.quarantine == []
+    assert result.model_decisions == []
 
 
 def test_parse_doctor(doctor_json: str):

--- a/schemas/metrics.schema.json
+++ b/schemas/metrics.schema.json
@@ -146,8 +146,6 @@
     }
   },
   "required": [
-    "alerts",
-    "column_trend",
     "command",
     "count",
     "model",

--- a/schemas/preview_create.schema.json
+++ b/schemas/preview_create.schema.json
@@ -44,7 +44,6 @@
         }
       },
       "required": [
-        "changed_columns",
         "model_name",
         "reason"
       ],

--- a/schemas/preview_diff.schema.json
+++ b/schemas/preview_diff.schema.json
@@ -83,8 +83,7 @@
       "required": [
         "rows_added",
         "rows_changed",
-        "rows_removed",
-        "samples"
+        "rows_removed"
       ],
       "type": "object"
     },
@@ -296,8 +295,7 @@
       "required": [
         "rows_added",
         "rows_changed",
-        "rows_removed",
-        "samples"
+        "rows_removed"
       ],
       "type": "object"
     },
@@ -351,11 +349,6 @@
           "type": "array"
         }
       },
-      "required": [
-        "added_columns",
-        "removed_columns",
-        "type_changes"
-      ],
       "type": "object"
     }
   },

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -451,7 +451,6 @@
         }
       },
       "required": [
-        "adaptive_concurrency",
         "concurrency",
         "tables_failed",
         "tables_processed"
@@ -894,7 +893,6 @@
         }
       },
       "required": [
-        "batched_with",
         "end",
         "key",
         "start"
@@ -933,7 +931,6 @@
         "model",
         "partitions_failed",
         "partitions_planned",
-        "partitions_skipped",
         "partitions_succeeded"
       ],
       "type": "object"
@@ -1024,9 +1021,7 @@
       "required": [
         "asset_key",
         "mode",
-        "ok",
-        "quarantine_table",
-        "valid_table"
+        "ok"
       ],
       "type": "object"
     },
@@ -1360,24 +1355,18 @@
     }
   },
   "required": [
-    "anomalies",
     "check_results",
     "command",
     "drift",
     "duration_ms",
-    "errors",
     "execution",
     "filter",
     "interrupted",
     "materializations",
-    "partition_summaries",
     "permissions",
-    "quarantine",
-    "shadow",
     "status",
     "tables_copied",
     "tables_failed",
-    "tables_skipped",
     "version"
   ],
   "title": "RunOutput",

--- a/scripts/regen_fixtures.sh
+++ b/scripts/regen_fixtures.sh
@@ -106,6 +106,26 @@ capture dag dag --models models
 # so `rocky cost latest` rolls up real per-model durations / bytes / cost.
 capture cost cost latest
 
+# apply: `rocky apply` emits NO wrapping envelope — it prints the plan-kind's
+# own output. The 01-replication-basics POC is a replication pipeline, so a
+# fresh `rocky plan` + `rocky apply <plan_id>` prints a run-shaped `RunOutput`
+# (command:"run"). We plan first, extract the content-addressed plan_id, then
+# apply it and capture the result as apply.json — a live capture of what the
+# engine actually emits (replacing the old hand-made `{plan_id, plan_kind,
+# success, result}` envelope the engine never produced). Placed LAST in this
+# section because the apply performs another run, which would otherwise
+# pollute the history / optimize / cost captures above with an extra record.
+echo "==> apply (plan then apply)"
+_PLAN_JSON=$("$ROCKY" plan --filter source=orders 2>/dev/null || true)
+_PLAN_ID=$(printf '%s' "$_PLAN_JSON" \
+    | python3 -c "import sys, json; print(json.load(sys.stdin).get('plan_id', ''))" 2>/dev/null || true)
+if [[ -n "$_PLAN_ID" ]]; then
+    "$ROCKY" apply "$_PLAN_ID" 2>/dev/null > "$DEST/apply.json" || true
+    python3 "$NORMALIZER" "$DEST/apply.json"
+else
+    echo "==> WARNING: could not extract plan_id for apply capture; skipping apply.json" >&2
+fi
+
 # Drift detection requires the engine to detect schema changes against an
 # already-existing target. The 01-replication-basics POC always uses
 # full_refresh, so there's no drift to detect. We capture an empty drift

--- a/sdk/python/src/rocky_sdk/client.py
+++ b/sdk/python/src/rocky_sdk/client.py
@@ -52,12 +52,13 @@ from rocky_sdk.types import (
     AiResult,
     AiSyncResult,
     AiTestResult,
-    ApplyOutput,
     ApproveOutput,
+    ArchiveApplyOutput,
     BranchPromoteOutput,
     CatalogOutput,
     CiResult,
     ColumnLineageResult,
+    CompactApplyOutput,
     CompileResult,
     ComplianceOutput,
     ConformanceResult,
@@ -65,6 +66,7 @@ from rocky_sdk.types import (
     DagResult,
     DiscoverResult,
     DoctorResult,
+    GcApplyOutput,
     HistoryResult,
     MetricsResult,
     ModelHistoryResult,
@@ -77,6 +79,13 @@ from rocky_sdk.types import (
     StateResult,
     TestResult,
     ValidateMigrationResult,
+)
+
+# Return type of :meth:`RockyClient.apply`. ``rocky apply <plan-id>`` does not
+# emit a wrapping envelope — each plan kind prints its own output, so the parsed
+# result is a discriminated union over those shapes. See :func:`_parse_apply`.
+ApplyResult = (
+    RunResult | GcApplyOutput | CompactApplyOutput | ArchiveApplyOutput | BranchPromoteOutput
 )
 
 # Default subprocess timeout for any single Rocky CLI invocation. One hour is
@@ -162,6 +171,62 @@ def _parse_run_or_apply(output: str, *, command: str) -> RunResult:
         return _parse_rocky_json(json.dumps(inner), RunResult, command=command)
 
     return _parse_rocky_json(output, RunResult, command=command)
+
+
+def _parse_apply(output: str) -> ApplyResult:
+    """Parse ``rocky apply <plan-id>`` stdout by its actual ``command`` / shape.
+
+    ``rocky apply`` never emits a wrapping envelope. The apply path for each plan
+    kind prints its own output, discriminated by the top-level ``command`` field:
+
+    * ``"run"`` — run / replication / ai_authored / backfill plans →
+      :class:`RunResult`.
+    * ``"compact apply"`` → :class:`CompactApplyOutput`.
+    * ``"archive apply"`` → :class:`ArchiveApplyOutput`.
+    * ``"branch promote"`` → :class:`BranchPromoteOutput`.
+    * ``"apply"`` with gc markers (``evicted`` / ``refused``) →
+      :class:`GcApplyOutput`.
+
+    Anything else raises :class:`RockyOutputParseError` naming the received
+    ``command`` so a schema change surfaces loudly instead of silently
+    mis-parsing.
+    """
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as exc:
+        raise RockyOutputParseError(
+            "apply", stdout=output or "", parse_error=str(exc), kind="json"
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise RockyOutputParseError(
+            "apply",
+            stdout=output or "",
+            parse_error=f"apply output is not a JSON object: {payload!r}",
+            kind="validation",
+        )
+
+    command = payload.get("command", "")
+    if command == "run":
+        return _parse_rocky_json(output, RunResult, command="apply")
+    if command == "compact apply":
+        return _parse_rocky_json(output, CompactApplyOutput, command="apply")
+    if command == "archive apply":
+        return _parse_rocky_json(output, ArchiveApplyOutput, command="apply")
+    if command == "branch promote":
+        return _parse_rocky_json(output, BranchPromoteOutput, command="apply")
+    if command == "apply" and ("evicted" in payload or "refused" in payload):
+        return _parse_rocky_json(output, GcApplyOutput, command="apply")
+
+    raise RockyOutputParseError(
+        "apply",
+        stdout=output or "",
+        parse_error=(
+            f"unrecognized apply output (command={command!r}); expected one of "
+            "'run' / 'compact apply' / 'archive apply' / 'branch promote' / gc apply"
+        ),
+        kind="validation",
+    )
 
 
 def _validate_governance_override(override: dict | None) -> None:
@@ -720,17 +785,17 @@ class RockyClient:
             args.extend(["--env", env])
         return _parse_rocky_json(self.run_cli(args), PlanResult, command="plan")
 
-    def apply(self, plan_id: str) -> ApplyOutput:
-        """Run ``rocky apply <plan-id>`` and return the parsed envelope.
+    def apply(self, plan_id: str) -> ApplyResult:
+        """Run ``rocky apply <plan-id>`` and return the parsed result.
 
-        Reads ``.rocky/plans/<plan_id>.json`` and dispatches by kind (run /
-        replication / compact / archive / promote).
+        Reads ``.rocky/plans/<plan_id>.json`` and dispatches by kind. Each plan
+        kind's apply path prints its OWN output (there is no wrapping envelope),
+        so the return type is a discriminated union: run / replication /
+        ai_authored / backfill plans yield a :class:`RunResult`; a ``gc`` plan
+        yields a :class:`GcApplyOutput`; compact / archive / promote plans yield
+        their respective outputs. See :func:`_parse_apply`.
         """
-        return _parse_rocky_json(
-            self.run_cli(["apply", plan_id], allow_partial=True),
-            ApplyOutput,
-            command="apply",
-        )
+        return _parse_apply(self.run_cli(["apply", plan_id], allow_partial=True))
 
     def run(
         self,

--- a/sdk/python/src/rocky_sdk/types.py
+++ b/sdk/python/src/rocky_sdk/types.py
@@ -127,6 +127,9 @@ class DiscoverResult(BaseModel):
     #: ``report_new_sources``; empty otherwise. The first-ever discover of a
     #: pipeline establishes the baseline and reports none.
     new_sources: list[str] = []
+    #: Count of source schemas served from the discovery cache this run.
+    #: ``None`` for older binaries that don't emit it.
+    schemas_cached: int | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -205,6 +208,27 @@ class MaterializationInfo(BaseModel):
     #: the model's strategy is ``time_interval``. ``None`` for unpartitioned
     #: strategies (``full_refresh``, ``incremental``, ``merge``).
     partition: PartitionInfo | None = None
+    #: Wall-clock timestamp at which the engine began executing this model.
+    #: Present on the wire; ``None`` for older binaries that don't emit it.
+    started_at: datetime | None = None
+    #: Classified-retry attempt trail — one entry per try. Empty (and omitted
+    #: on the wire) for a clean first-try success. Without this declared,
+    #: Pydantic's ``extra="ignore"`` would drop it silently.
+    attempts: list[AttemptRecord] = Field(default_factory=list)
+    #: Observed dollar cost of this materialization. ``None`` for unbilled
+    #: warehouses (DuckDB) or when the adapter didn't report the inputs.
+    cost_usd: float | None = None
+    #: Adapter-reported billing-relevant bytes figure. ``None`` when the
+    #: adapter doesn't surface one.
+    bytes_scanned: int | None = None
+    #: Adapter-reported bytes-written figure. ``None`` on every adapter today.
+    bytes_written: int | None = None
+    #: Tenant this materialization is attributed to (from the discover-time
+    #: ``{tenant}`` schema-pattern component). ``None`` for non-tenant patterns.
+    tenant: str | None = None
+    #: Warehouse-side job identifiers for the SQL statements rocky issued.
+    #: Empty for adapters without a job concept (DuckDB).
+    job_ids: list[str] = Field(default_factory=list)
 
 
 class CheckResult(BaseModel):
@@ -233,6 +257,14 @@ class CheckResult(BaseModel):
     # Custom check fields
     query: str | None = None
     result_value: int | None = None
+    # Assertion (unit-test) check fields — the ``TestType`` discriminant plus
+    # the failing-row count. ``kind`` is snake_case (e.g. ``"not_null"``).
+    kind: str | None = None
+    failing_rows: int | None = None
+    # Cross-source-overlap check fields.
+    contributing_tables: list[str] | None = None
+    overlap_count: int | None = None
+    sample: list[str] | None = None
 
 
 class TableCheckResult(BaseModel):
@@ -354,6 +386,15 @@ class ExecutionSummary(BaseModel):
     concurrency: int
     tables_processed: int
     tables_failed: int
+    #: Whether adaptive concurrency (AIMD throttle) was enabled for this run.
+    #: ``None`` for older binaries that don't emit the field.
+    adaptive_concurrency: bool | None = None
+    #: Concurrency the AIMD throttle settled on by end of run. ``None`` when
+    #: adaptive concurrency was disabled or not reported.
+    final_concurrency: int | None = None
+    #: Count of rate-limit signals the throttle detected. ``None`` when not
+    #: reported.
+    rate_limits_detected: int | None = None
 
 
 class MetricsSnapshot(BaseModel):
@@ -404,13 +445,52 @@ class ContainedModel(BaseModel):
 class RunResult(BaseModel):
     version: str
     command: str
+    #: Whole-run status (``"Success"`` / ``"PartialFailure"`` / ``"Failure"`` /
+    #: ``"SkippedIdempotent"`` / ``"SkippedInFlight"``). Present on the wire;
+    #: ``None`` for older binaries that keyed pass/fail off counts alone.
+    status: str | None = None
     filter: str
     duration_ms: int
     tables_copied: int
     tables_failed: int = 0
+    #: Tables short-circuited via the idempotency key. Defaults to 0.
+    tables_skipped: int = 0
     materializations: list[MaterializationInfo]
     check_results: list[TableCheckResult]
     errors: list[TableError] = []
+    #: ``True`` when the run was cancelled by SIGINT (Ctrl-C). Always emitted
+    #: on the wire; defaults to ``False`` for older binaries.
+    interrupted: bool = False
+    #: ``True`` when the run executed in shadow mode (targets rewritten).
+    shadow: bool = False
+    #: Per-model build/skip/reuse decision + reason. Empty (and omitted on the
+    #: wire) for a default run; populated under ``--skip-unchanged`` / ``[reuse]``.
+    model_decisions: list[ModelDecisionOutput] = Field(default_factory=list)
+    #: Row-quarantine outcomes — one entry per table the quality pipeline
+    #: quarantined. Empty for runs that didn't use ``[checks.quarantine]``.
+    quarantine: list[QuarantineOutput] = Field(default_factory=list)
+    #: Aggregate cost attribution across every materialization in this run.
+    #: ``None`` for DuckDB-only pipelines or when nothing produced a cost number.
+    cost_summary: RunCostSummary | None = None
+    #: Budget breaches detected at end of run. Empty when no ``[budget]`` block
+    #: is configured or all limits were respected.
+    budget_breaches: list[BudgetBreachOutput] = Field(default_factory=list)
+    #: Soft warnings from the per-table override resolver — one entry per
+    #: ``[[table_overrides]]`` rule that matched nothing. Empty when no
+    #: overrides are declared.
+    override_warnings: list[OverrideWarningOutput] = Field(default_factory=list)
+    #: The ``--idempotency-key`` value this run was invoked with, echoed back.
+    #: ``None`` for runs that didn't pass the flag.
+    idempotency_key: str | None = None
+    #: Prior/in-flight run whose idempotency key deflected this call. Populated
+    #: only when ``status`` is ``skipped_idempotent`` / ``skipped_in_flight``.
+    skipped_by_run_id: str | None = None
+    #: Pipeline type that was executed (e.g. ``"replication"``). ``None`` for
+    #: older binaries that don't emit it.
+    pipeline_type: str | None = None
+    #: Run id this run resumed from, when invoked with ``--resume``. ``None``
+    #: for a fresh run.
+    resumed_from: str | None = None
     #: Models withheld this run because an upstream failed (or was itself
     #: withheld) and ``[resilience] contain_failures`` continued the disjoint
     #: subgraphs — the blast radius of the failures in :attr:`errors`. Empty
@@ -430,7 +510,6 @@ class RunResult(BaseModel):
     metrics: MetricsSnapshot | None = None
     permissions: PermissionInfo
     drift: DriftInfo
-    contracts: ContractResult | None = None
     anomalies: list[AnomalyResult] = []
     #: Per-model partition execution summaries, populated only when the
     #: run touched one or more ``time_interval`` models. Empty for runs
@@ -495,27 +574,27 @@ class PlanResult(BaseModel):
     created_at: datetime | None = None
     models: list[str] = []
     execution_layers: list[list[str]] = []
+    #: Semantic change-impact verdict from the typed-IR breaking-change
+    #: classifier, surfaced as decision support at plan time. Present only when
+    #: ``--semantic`` ran with a usable baseline. Kept as a loose ``dict`` — the
+    #: nested shape lives on the generated ``PlanOutput.breaking_verdict``.
+    breaking_verdict: dict | None = None
+    #: Budget diagnostics raised at plan time. Empty when no ``[budget]`` block
+    #: is configured.
+    budget_diagnostics: list[Diagnostic] = []
+    #: ``True`` when at least one ``budget_diagnostics`` entry is error-level.
+    has_budget_errors: bool = False
 
 
-class ApplyOutput(BaseModel):
-    """Output of ``rocky apply <plan-id>`` (Cluster 3 B Phase 2).
-
-    Envelope wrapping the inner apply result with a top-level ``plan_id``
-    so consumers can correlate the apply result back to the plan without
-    parsing the inner ``result`` payload.
-
-    ``result`` is a raw ``dict`` — its shape depends on ``plan_kind``:
-    - ``"compact"`` → ``CompactApplyOutput``
-    - ``"archive"`` → ``ArchiveApplyOutput``
-    - ``"run"``     → ``RunResult``
-    """
-
-    version: str
-    command: str
-    plan_id: str
-    plan_kind: str
-    success: bool
-    result: Any
+# ``rocky apply <plan-id>`` does NOT emit a wrapping envelope. The engine never
+# constructs the old ``{plan_id, plan_kind, success, result}`` shape — each plan
+# kind's apply path prints its OWN output: run-shaped kinds (run / replication /
+# ai_authored / backfill) print a ``RunOutput`` with ``command:"run"``; ``gc``
+# prints ``GcApplyOutput`` with ``command:"apply"``; compact / archive / promote
+# print their own outputs. ``RockyClient.apply()`` dispatches by that actual
+# ``command`` / shape (see ``rocky_sdk.client._parse_apply``). The dead
+# ``ApplyOutput`` shadow that used to live here was removed — it never once
+# validated a real engine payload.
 
 
 # ---------------------------------------------------------------------------
@@ -533,6 +612,12 @@ class StateResult(BaseModel):
     version: str
     command: str
     watermarks: list[WatermarkEntry]
+    #: State-schema version this binary supports. Lets an orchestrator startup
+    #: hook decide deploy compatibility structurally.
+    schema_version_supported: int | None = None
+    #: State-schema version currently on disk, or ``None`` when the store has
+    #: no persisted version yet.
+    schema_version_on_disk: int | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -596,6 +681,18 @@ class ModelDetail(BaseModel):
     strategy: dict[str, object]
     target: dict[str, str]
     freshness: ModelFreshnessConfig | None = None
+    #: Names of models this model directly depends on. Empty when the model
+    #: has no upstream dependencies.
+    depends_on: list[str] = Field(default_factory=list)
+    #: Source of the model's data contract (e.g. sidecar path), or ``None``.
+    contract_source: str | None = None
+    #: Heuristic cost estimate from DAG-aware cardinality propagation. Kept as
+    #: a loose ``dict`` — the nested shape lives on the generated
+    #: ``ModelDetail.cost_hint``. ``None`` when not computed.
+    cost_hint: dict | None = None
+    #: Hint that a ``full_refresh`` model could benefit from incremental
+    #: materialization. Loose ``dict``; ``None`` when not applicable.
+    incrementality_hint: dict | None = None
     #: Model-level governance tags — the model's own ``[tags]`` block merged
     #: over any config-group ``[tags]`` baseline (sidecar > group). Free-form
     #: ``{key: value}`` strings describing the model as a whole (``domain``,
@@ -614,6 +711,12 @@ class CompileResult(BaseModel):
     diagnostics: list[Diagnostic]
     has_errors: bool
     models_detail: list[ModelDetail] = []
+    #: Per-phase compile timings. Loose ``dict`` — the nested shape lives on
+    #: the generated ``CompileOutput.compile_timings``.
+    compile_timings: dict | None = None
+    #: Expanded SQL per model after macro substitution. Populated only when
+    #: ``--expand-macros`` is passed; ``{}`` otherwise.
+    expanded_sql: dict[str, str] = Field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -672,6 +775,10 @@ class ModelLineageResult(BaseModel):
     upstream: list[str]
     downstream: list[str]
     edges: list[LineageEdge]
+    #: Per-node metadata for the lineage graph (one entry per referenced
+    #: model). Loose ``dict`` entries — the nested shape lives on the generated
+    #: ``LineageOutput.nodes``. Empty when the engine doesn't emit node metadata.
+    nodes: list[dict] = Field(default_factory=list)
 
 
 class ColumnLineageResult(BaseModel):
@@ -682,6 +789,12 @@ class ColumnLineageResult(BaseModel):
     model: str
     column: str
     trace: list[LineageEdge]
+    #: Trace direction (``"upstream"`` / ``"downstream"``). ``None`` for older
+    #: binaries that don't emit it.
+    direction: str | None = None
+    #: Downstream consumers of the traced column. Empty when tracing upstream
+    #: or when the column has no downstream consumers.
+    downstream_consumers: list[QualifiedColumn] = Field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -766,6 +879,9 @@ class MetricsResult(BaseModel):
     alerts: list[dict] | None = None
     column: str | None = None
     column_trend: list[dict] | None = None
+    #: Human-readable status message (e.g. "no snapshots yet"). ``None`` when
+    #: the command has data to report.
+    message: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -793,6 +909,11 @@ class OptimizeResult(BaseModel):
     command: str
     recommendations: list[MaterializationCost]
     total_models_analyzed: int
+    #: Human-readable status message (e.g. "no models to analyze"). ``None``
+    #: when recommendations are present.
+    message: str | None = None
+    #: Advisory note on incrementality opportunities. ``None`` when not emitted.
+    incrementality_note: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -810,25 +931,20 @@ class AiResult(BaseModel):
     name: str
     source: str
     attempts: int
+    #: Path the generated model body was written to, when ``--save`` was used.
+    #: ``None`` for a dry run.
+    body_path: str | None = None
+    #: Path the intent sidecar was written to, when ``--save`` was used.
+    #: ``None`` for a dry run.
+    sidecar_path: str | None = None
 
 
-class AiSyncProposal(BaseModel):
-    """A proposed model update from ai-sync."""
-
-    model: str
-    intent: str
-    current_source: str
-    proposed_source: str
-    diff: str
-    upstream_changes: list[dict] = []
-
-
-class AiSyncResult(BaseModel):
-    """Output of ``rocky ai-sync``."""
-
-    version: str
-    command: str
-    proposals: list[AiSyncProposal] = []
+# ``AiSyncProposal`` / ``AiSyncResult`` were hand-written shadows. The proposal
+# shadow required a phantom ``current_source`` the engine has never put on the
+# wire (the real ``AiSyncProposal`` is ``{model, intent, diff, proposed_source}``),
+# so ``ai_sync`` raised whenever the proposals list was non-empty — the
+# empty-list happy path masked it. Both are now soft-swapped to the generated
+# ``AiSyncOutput`` / ``AiSyncProposal`` in the bridge block below.
 
 
 class AiExplanation(BaseModel):
@@ -894,6 +1010,20 @@ class ValidateMigrationResult(BaseModel):
     version: str
     command: str
     validations: list[ModelValidation] = []
+    #: Name of the dbt project that was validated. ``None`` when not reported.
+    project_name: str | None = None
+    #: dbt version detected in the source project. ``None`` when not reported.
+    dbt_version: str | None = None
+    #: Count of models successfully imported. Defaults to 0.
+    models_imported: int = 0
+    #: Count of models that failed to import. Defaults to 0.
+    models_failed: int = 0
+    #: Total tests across imported models. Defaults to 0.
+    total_tests: int = 0
+    #: Total contracts generated across imported models. Defaults to 0.
+    total_contracts: int = 0
+    #: Total warnings raised across imported models. Defaults to 0.
+    total_warnings: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -901,28 +1031,14 @@ class ValidateMigrationResult(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-class AdapterTestResult(BaseModel):
-    """A single conformance test result."""
-
-    name: str
-    category: str
-    status: str
-    message: str | None = None
-    duration_ms: int | None = None
-
-
-class ConformanceResult(BaseModel):
-    """Output of ``rocky test-adapter``."""
-
-    version: str
-    command: str
-    adapter: str
-    sdk_version: str
-    tests_run: int
-    tests_passed: int
-    tests_failed: int
-    tests_skipped: int
-    results: list[AdapterTestResult] = []
+# ``ConformanceResult`` / ``AdapterTestResult`` were hand-written shadows. The
+# ``ConformanceResult`` shadow required ``version`` / ``command`` that the real
+# ``rocky test-adapter`` payload does NOT carry, so ``test_adapter()`` raised on
+# ANY real output. Both are now soft-swapped to the generated
+# ``TestAdapterOutput`` / ``TestAdapterTestResult`` in the bridge block below.
+# ``test-adapter`` has no ``command`` key on the wire, so there is no
+# ``parse_rocky_output`` dispatch entry for it (the payload can't be routed by
+# command) — it's reachable only via the typed ``RockyClient.test_adapter()``.
 
 
 # ---------------------------------------------------------------------------
@@ -943,6 +1059,9 @@ class HealthCheck(BaseModel):
     status: HealthStatus
     message: str
     duration_ms: int
+    #: Structured ``[key, value]`` detail rows for this check. Empty when the
+    #: check reports no structured detail.
+    details: list[list[str]] = Field(default_factory=list)
 
 
 class DoctorResult(BaseModel):
@@ -1045,37 +1164,15 @@ class StateHealthResult(BaseModel):
 # ---------------------------------------------------------------------------
 # Drift output
 # ---------------------------------------------------------------------------
-
-
-class DriftedColumn(BaseModel):
-    """A column whose type differs between source and target."""
-
-    name: str
-    source_type: str
-    target_type: str
-
-
-class DriftActionKind(StrEnum):
-    drop_and_recreate = "DropAndRecreate"
-    alter_column_types = "AlterColumnTypes"
-    ignore = "Ignore"
-
-
-class DriftTableResult(BaseModel):
-    """Drift detection result for a single table."""
-
-    table: str
-    drifted_columns: list[DriftedColumn]
-    action: DriftActionKind
-
-
-class DriftDetectResult(BaseModel):
-    """Output of ``rocky drift --detect``."""
-
-    command: str
-    tables_checked: int
-    tables_drifted: int
-    results: list[DriftTableResult]
+#
+# There is no ``rocky drift`` subcommand — the binary rejects it. Drift
+# detection happens INSIDE ``rocky run`` / ``rocky plan`` and is surfaced on
+# ``RunResult.drift`` (a :class:`DriftInfo`). The hand-written
+# ``DriftDetectResult`` / ``DriftTableResult`` / ``DriftedColumn`` /
+# ``DriftActionKind`` shadows (and their ``"drift"`` dispatch entry) were
+# removed — the engine never emitted a ``{command:"drift", ...}`` payload for
+# them to parse. The generated ``drift_schema`` types stay (inert) for the
+# ``DriftOutput`` shape referenced by other outputs.
 
 
 # ---------------------------------------------------------------------------
@@ -1100,6 +1197,7 @@ from .types_generated import (  # noqa: E402, F401
     AiExplainOutput,
     AiGenerateOutput,
     AiSyncOutput,
+    AiSyncProposal,
     AiTestOutput,
     AnomalyOutput,
     ApprovalArtifact,
@@ -1151,6 +1249,7 @@ from .types_generated import (  # noqa: E402, F401
     ErrorEnvelope,
     FailedSourceOutput,
     FreshnessConfigOutput,
+    GcApplyOutput,
     HistoryOutput,
     JobStatus,
     LineageColumnChange,
@@ -1208,8 +1307,23 @@ from .types_generated import (  # noqa: E402, F401
     TableCheckOutput,
     TableErrorOutput,
     TableOutput,
+    TestAdapterOutput,
+    TestAdapterTestResult,
     TestFailure,
     TestOutput,
+)
+
+# Run-output nested types used to backfill the hand-written run models so the
+# runtime dispatch target (``RunResult`` / ``MaterializationInfo``) stops
+# silently dropping wire fields. Imported from the submodule because these
+# nested types are not part of the curated ``types_generated`` barrel.
+from .types_generated.run_schema import (  # noqa: E402, F401
+    AttemptRecord,
+    BudgetBreachOutput,
+    ModelDecisionOutput,
+    OverrideWarningOutput,
+    QuarantineOutput,
+    RunCostSummary,
 )
 
 # Python-flavored bridge aliases for the DAG output types.
@@ -1218,13 +1332,29 @@ DagNode = DagNodeOutput
 DagEdge = DagEdgeOutput
 
 # Soft-swap aliases — the hand-written ``HistoryResult`` /
-# ``ModelHistoryResult`` / ``OptimizeResult`` above diverged from what the
-# Rust CLI emits (they mirrored state-store shapes instead). Empty arrays
-# masked the drift until `rocky run` started persisting run records. The
-# generated types are the source of truth; keep the Result names as
-# exports so external consumers don't break.
+# ``ModelHistoryResult`` above diverged from what the Rust CLI emits (they
+# mirrored state-store shapes instead). Empty arrays masked the drift until
+# `rocky run` started persisting run records. The generated types are the
+# source of truth; keep the Result names as exports so external consumers
+# don't break. (``OptimizeResult`` is NOT swapped — it stays a hand-written
+# model above, now backfilled with the ``message`` / ``incrementality_note``
+# fields the wire carries.)
 HistoryResult = HistoryOutput
 ModelHistoryResult = ModelHistoryOutput
+
+# ``ConformanceResult`` / ``AdapterTestResult`` soft-swap — the hand-written
+# ``ConformanceResult`` required ``version`` / ``command`` the real
+# ``rocky test-adapter`` payload never carries, so the client raised on ANY
+# real output. The generated ``TestAdapterOutput`` / ``TestAdapterTestResult``
+# are the source of truth; keep the legacy names as aliases.
+ConformanceResult = TestAdapterOutput
+AdapterTestResult = TestAdapterTestResult
+
+# ``AiSyncResult`` / ``AiSyncProposal`` soft-swap — the hand-written proposal
+# required a phantom ``current_source`` never on the wire, so ``ai_sync``
+# raised whenever proposals were non-empty. The generated ``AiSyncOutput`` /
+# ``AiSyncProposal`` are the source of truth; keep the legacy names as aliases.
+AiSyncResult = AiSyncOutput
 
 # ``TestResult`` / ``CiResult`` had the same drift: both declared
 # ``failures: list[list[str]]`` (positional tuples), but the engine serializes
@@ -1267,7 +1397,6 @@ RockyOutput = (
     DiscoverResult
     | RunResult
     | PlanResult
-    | ApplyOutput
     | StateResult
     | ClearSchemaCacheOutput
     | CompileResult
@@ -1291,8 +1420,8 @@ RockyOutput = (
     | ValidateMigrationResult
     | ConformanceResult
     | DoctorResult
-    | DriftDetectResult
     | DagResult
+    | GcApplyOutput
     | ComplianceOutput
     | RetentionStatusOutput
     | CatalogOutput
@@ -1311,7 +1440,6 @@ _SIMPLE_DISPATCH: dict[str, type[BaseModel]] = {
     "discover": DiscoverResult,
     "run": RunResult,
     "plan": PlanResult,
-    "apply": ApplyOutput,
     "state": StateResult,
     "state-clear-schema-cache": ClearSchemaCacheOutput,
     "compile": CompileResult,
@@ -1329,10 +1457,14 @@ _SIMPLE_DISPATCH: dict[str, type[BaseModel]] = {
     "ai_test": AiTestResult,
     "ai_contract": AiContractOutput,
     "validate-migration": ValidateMigrationResult,
-    "test-adapter": ConformanceResult,
     "doctor": DoctorResult,
-    "drift": DriftDetectResult,
     "dag": DagResult,
+    # ``rocky apply`` on a gc plan prints ``{command:"apply", ...}`` with gc
+    # markers (``evicted`` / ``refused``). Run-shaped apply prints
+    # ``command:"run"`` (→ ``RunResult``); compact / archive / promote apply
+    # print their own commands, already routed above. ``RockyClient.apply()``
+    # additionally disambiguates by shape.
+    "apply": GcApplyOutput,
     "compliance": ComplianceOutput,
     "retention-status": RetentionStatusOutput,
     "catalog": CatalogOutput,

--- a/sdk/python/src/rocky_sdk/types_generated/__init__.py
+++ b/sdk/python/src/rocky_sdk/types_generated/__init__.py
@@ -89,9 +89,11 @@ from .compile_schema import (
 # Discover command
 from .discover_schema import (
     ChecksConfigOutput,
+    CollisionCandidateOutput,
     DiscoverOutput,
     FailedSourceOutput,
     FreshnessConfigOutput,
+    ResolvedCheckNameOutput,
     SourceOutput,
     TableOutput,
 )
@@ -138,14 +140,22 @@ from .optimize_schema import OptimizeOutput, OptimizeRecommendation
 # Plan command
 from .plan_schema import PlannedStatement, PlanOutput
 
-# Run command — canonical source for all the run-only nested types.
+# Run command — canonical source for all the run-only nested types (including
+# the shared ``BudgetBreachOutput`` / ``ExcludedTableOutput`` also referenced by
+# preview_cost / discover).
 from .run_schema import (
     AnomalyOutput,
+    BudgetBreachOutput,
+    ContainedModelOutput,
+    ExcludedTableOutput,
     ExecutionSummary,
     MaterializationMetadata,
     MaterializationOutput,
     MetricsSnapshot,
+    ModelDecisionOutput,
+    OverrideWarningOutput,
     PermissionSummary,
+    QuarantineOutput,
     RunOutput,
     TableCheckOutput,
     TableErrorOutput,
@@ -158,7 +168,13 @@ from .state_schema import StateOutput, WatermarkEntry
 from .state_clear_schema_cache_schema import ClearSchemaCacheOutput
 
 # Test command — canonical source for TestFailure
-from .test_schema import TestFailure, TestOutput
+from .test_schema import (
+    DeclarativeTestResult,
+    ModelTestResult,
+    TestFailure,
+    TestOutput,
+    UnitTestResult,
+)
 
 # Compare command
 from .compare_schema import CompareOutput, TableCompareResult
@@ -324,6 +340,7 @@ from .preview_create_schema import (
     PreviewPrunedModel,
 )
 from .preview_diff_schema import (
+    BisectionStatsOutput,
     PreviewColumnTypeChange,
     PreviewDiffOutput,
     PreviewDiffSummary,
@@ -335,10 +352,14 @@ from .preview_diff_schema import (
     PreviewStructuralDiff,
 )
 from .preview_cost_schema import (
+    PerModelBudgetBreachOutput,
     PreviewCostOutput,
     PreviewCostSummary,
     PreviewModelCostDelta,
 )
+
+# Preview rows (`rocky preview rows`)
+from .preview_rows_schema import PreviewRowsOutput
 
 # Fivetran state envelope — canonical shape written by
 # `rocky discover --emit-fivetran-state-to <PATH>` and the contract
@@ -354,6 +375,62 @@ from .rocky_fivetran_state_schema import (
     FivetranStateEnvelope,
     FivetranTableConfig,
 )
+
+# Governor surface — audit ledger + scorecard + policy plane + review queue.
+from .audit_schema import AuditDecisionEntry, AuditOutput
+from .audit_for_schema import (
+    AuditChainBlastRadius,
+    AuditChainDecisions,
+    AuditChainPlan,
+    AuditChainRuns,
+    AuditChainVerify,
+    AuditForOutput,
+    AuditPlanChange,
+    AuditRunEntry,
+)
+from .audit_scorecard_schema import (
+    AuditScorecardOutput,
+    ScorecardGroup,
+    ScorecardUnavailableMetric,
+)
+from .policy_check_schema import PolicyCheckOutput, PolicyModelAttributes
+from .policy_test_schema import PolicyTestOutput, PolicyTestResult
+from .policy_freeze_schema import PolicyFreezeEntry, PolicyFreezeOutput
+from .review_schema import ReviewOutput
+from .review_queue_schema import ReviewQueueEntry, ReviewQueueOutput
+
+# Seed / load — file-ingest + seed commands.
+from .seed_schema import SeedOutput, SeedTableOutput
+from .load_schema import ContractResult, ContractViolation, LoadFileOutput, LoadOutput
+
+# Estimate / profile — warehouse-cost estimate + column profiler.
+from .estimate_schema import EstimateOutput, ModelEstimate
+from .profile_schema import ProfileColumnStats, ProfileOutput
+
+# Trace / validate — run-timeline trace + config validation.
+from .trace_schema import TraceModelEntry, TraceOutput
+from .validate_schema import (
+    ValidateAdapterStatus,
+    ValidateMessage,
+    ValidateModelsStatus,
+    ValidateOutput,
+    ValidatePipelineStatus,
+)
+
+# DAG run — DAG-mode run summary.
+from .dag_run_schema import DagRunNodeOutput, DagRunOutput
+
+# Compact-dedup — cross-table dedup report.
+from .compact_dedup_schema import (
+    ByteCalibration,
+    CompactDedupOutput,
+    DedupPair,
+    DedupSummary,
+    TableDedupContribution,
+)
+
+# State-retention sweep — scheduled state GC report.
+from .state_retention_sweep_schema import RetentionSweepOutput
 
 __all__ = [
     # ai
@@ -593,4 +670,82 @@ __all__ = [
     "FivetranSchemaEntry",
     "FivetranTableConfig",
     "FivetranColumnConfig",
+    # lineage-diff (already imported above; add the missing __all__ entries)
+    "LineageColumnChange",
+    "LineageDiffOutput",
+    "LineageDiffResult",
+    # discover (nested command-output types)
+    "CollisionCandidateOutput",
+    "ResolvedCheckNameOutput",
+    # run (nested command-output types; canonical for the shared
+    # BudgetBreachOutput / ExcludedTableOutput also referenced elsewhere)
+    "BudgetBreachOutput",
+    "ContainedModelOutput",
+    "ExcludedTableOutput",
+    "ModelDecisionOutput",
+    "OverrideWarningOutput",
+    "QuarantineOutput",
+    # test (per-model / declarative / unit test result shapes)
+    "DeclarativeTestResult",
+    "ModelTestResult",
+    "UnitTestResult",
+    # preview (rows + diff/cost nested)
+    "PreviewRowsOutput",
+    "BisectionStatsOutput",
+    "PerModelBudgetBreachOutput",
+    # governor — audit ledger
+    "AuditOutput",
+    "AuditDecisionEntry",
+    "AuditForOutput",
+    "AuditRunEntry",
+    "AuditChainBlastRadius",
+    "AuditChainRuns",
+    "AuditChainVerify",
+    "AuditPlanChange",
+    "AuditChainDecisions",
+    "AuditChainPlan",
+    "AuditScorecardOutput",
+    "ScorecardGroup",
+    "ScorecardUnavailableMetric",
+    # governor — policy plane
+    "PolicyCheckOutput",
+    "PolicyModelAttributes",
+    "PolicyTestOutput",
+    "PolicyTestResult",
+    "PolicyFreezeOutput",
+    "PolicyFreezeEntry",
+    "ReviewOutput",
+    "ReviewQueueOutput",
+    "ReviewQueueEntry",
+    # seed / load
+    "SeedOutput",
+    "SeedTableOutput",
+    "LoadOutput",
+    "LoadFileOutput",
+    "ContractResult",
+    "ContractViolation",
+    # estimate / profile
+    "EstimateOutput",
+    "ModelEstimate",
+    "ProfileOutput",
+    "ProfileColumnStats",
+    # trace / validate
+    "TraceOutput",
+    "TraceModelEntry",
+    "ValidateOutput",
+    "ValidateAdapterStatus",
+    "ValidateMessage",
+    "ValidateModelsStatus",
+    "ValidatePipelineStatus",
+    # dag run
+    "DagRunOutput",
+    "DagRunNodeOutput",
+    # compact-dedup
+    "CompactDedupOutput",
+    "ByteCalibration",
+    "DedupPair",
+    "DedupSummary",
+    "TableDedupContribution",
+    # state-retention sweep
+    "RetentionSweepOutput",
 ]

--- a/sdk/python/src/rocky_sdk/types_generated/metrics_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/metrics_schema.py
@@ -36,9 +36,9 @@ class MetricsOutput(BaseModel):
     All optional fields are present-or-absent depending on the flags (`--trend`, `--alerts`, `--column`). The empty case (no snapshots available) sets `message` and leaves the collections empty.
     """
 
-    alerts: list[MetricsAlert]
+    alerts: list[MetricsAlert] | None = None
     column: str | None = None
-    column_trend: list[ColumnTrendPoint]
+    column_trend: list[ColumnTrendPoint] | None = None
     command: str
     count: conint(ge=0)
     message: str | None = None

--- a/sdk/python/src/rocky_sdk/types_generated/preview_create_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/preview_create_schema.py
@@ -24,7 +24,7 @@ class PreviewPrunedModel(BaseModel):
     One entry in [`PreviewCreateOutput::prune_set`].
     """
 
-    changed_columns: list[str]
+    changed_columns: list[str] | None = None
     """
     Columns the diff reports as changed on this model. Only populated when `reason = "changed"`.
     """

--- a/sdk/python/src/rocky_sdk/types_generated/preview_diff_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/preview_diff_schema.py
@@ -108,9 +108,9 @@ class PreviewStructuralDiff(BaseModel):
     Column-level structural diff. Mirrors the shape produced by `rocky ci-diff` at the column granularity.
     """
 
-    added_columns: list[str]
-    removed_columns: list[str]
-    type_changes: list[PreviewColumnTypeChange]
+    added_columns: list[str] | None = None
+    removed_columns: list[str] | None = None
+    type_changes: list[PreviewColumnTypeChange] | None = None
     """
     One entry per column whose type changed. Each carries `name`, `from`, `to`.
     """
@@ -136,7 +136,7 @@ class PreviewSampledRowDiff(BaseModel):
     rows_added: conint(ge=0)
     rows_changed: conint(ge=0)
     rows_removed: conint(ge=0)
-    samples: list[PreviewRowSample]
+    samples: list[PreviewRowSample] | None = None
     """
     Up to `--max-samples` (default 5) representative changed rows for human review. Pure noise when sampling found no change.
     """
@@ -150,7 +150,7 @@ class PreviewBisectionRowDiff(BaseModel):
     rows_added: conint(ge=0)
     rows_changed: conint(ge=0)
     rows_removed: conint(ge=0)
-    samples: list[PreviewRowSample]
+    samples: list[PreviewRowSample] | None = None
     """
     Up to `--max-samples` (default 5) representative changed rows surfaced from the leaves. Bisection samples only carry the primary key — column-level diffs are not retained on the kernel's leaf record. Empty when no rows differ.
     """

--- a/sdk/python/src/rocky_sdk/types_generated/run_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/run_schema.py
@@ -135,7 +135,7 @@ class ExecutionSummary(BaseModel):
     Summary of execution parallelism and throughput.
     """
 
-    adaptive_concurrency: bool
+    adaptive_concurrency: bool | None = None
     """
     Whether adaptive concurrency (AIMD throttle) was enabled for this run.
     """
@@ -357,7 +357,7 @@ class PartitionInfo(BaseModel):
     `key` is the canonical Rocky partition key (e.g. `"2026-04-07"` for daily; `"2026-04-07T13"` for hourly). `start` / `end` are the half-open `[start, end)` window the SQL substituted for `@start_date` / `@end_date`. `batched_with` lists any additional partition keys that were merged into this batch when `batch_size > 1` — empty for the default one-partition-per-statement case.
     """
 
-    batched_with: list[str]
+    batched_with: list[str] | None = None
     end: AwareDatetime
     key: str
     start: AwareDatetime
@@ -373,7 +373,7 @@ class PartitionSummary(BaseModel):
     model: str
     partitions_failed: conint(ge=0)
     partitions_planned: conint(ge=0)
-    partitions_skipped: conint(ge=0)
+    partitions_skipped: conint(ge=0) | None = None
     """
     Partitions that were already `Computed` in the state store and skipped by the runtime (currently always 0; reserved for the `--missing` change-detection optimization).
     """
@@ -410,7 +410,7 @@ class QuarantineOutput(BaseModel):
     """
     `true` when every quarantine statement executed successfully. `false` means a partial failure — inspect `error` for details.
     """
-    quarantine_table: str
+    quarantine_table: str | None = None
     """
     Fully-qualified name of the `__quarantine` output table. Empty for `mode = "drop"` (failing rows discarded) and `mode = "tag"`.
     """
@@ -422,7 +422,7 @@ class QuarantineOutput(BaseModel):
     """
     Number of rows in the `__valid` output, when the adapter can report it.
     """
-    valid_table: str
+    valid_table: str | None = None
     """
     Fully-qualified `catalog.schema.table` name of the `__valid` output table. Empty for `mode = "tag"` (source is rewritten in place).
     """
@@ -718,7 +718,7 @@ class RunOutput(BaseModel):
     JSON output for `rocky run`.
     """
 
-    anomalies: list[AnomalyOutput]
+    anomalies: list[AnomalyOutput] | None = None
     budget_breaches: list[BudgetBreachOutput] | None = None
     """
     Budget breaches detected at end of run. Empty when no `[budget]` block is configured or all configured limits were respected. Each breach is also emitted as a `budget_breach` [`rocky_observe::events::PipelineEvent`] and fires the `on_budget_breach` hook so subscribers see them live.
@@ -735,7 +735,7 @@ class RunOutput(BaseModel):
     """
     drift: DriftSummary
     duration_ms: conint(ge=0)
-    errors: list[TableErrorOutput]
+    errors: list[TableErrorOutput] | None = None
     excluded_tables: list[ExcludedTableOutput] | None = None
     """
     Tables that the discovery adapter reported as enabled but that do not exist in the source warehouse (e.g. Fivetran has them configured but hasn't synced them, or they carry the `do_not_alter__` broken-table marker). Surfaced so orchestrators can flag the gap in their UIs instead of silently dropping the assets.
@@ -760,7 +760,7 @@ class RunOutput(BaseModel):
     """
     Soft warnings raised by the per-table override resolver — one entry per `[[table_overrides]]` rule that matched zero `(connector, table)` pairs this run, or whose connector half resolved nothing. Discovery-time-only — the pipeline runs to completion regardless. Empty for runs whose pipeline declares no overrides.
     """
-    partition_summaries: list[PartitionSummary]
+    partition_summaries: list[PartitionSummary] | None = None
     """
     Per-model partition execution summaries, present only when the run touched one or more `time_interval` models. Empty for runs that didn't execute any partitioned models.
     """
@@ -769,12 +769,12 @@ class RunOutput(BaseModel):
     """
     Pipeline type that was executed (e.g., "replication").
     """
-    quarantine: list[QuarantineOutput]
+    quarantine: list[QuarantineOutput] | None = None
     """
     Row-quarantine outcomes — one entry per table the quality pipeline quarantined. Empty for runs that did not use `[pipeline.x.checks.quarantine]`.
     """
     resumed_from: str | None = None
-    shadow: bool
+    shadow: bool | None = None
     """
     True when running in shadow mode (targets rewritten).
     """
@@ -791,5 +791,5 @@ class RunOutput(BaseModel):
     """
     Total number of failed tables/models for the run, **including** pre-execution compile failures: a model that fails to type-check is counted here even though it never reached the execution phase. This is the authoritative failure count — consumers should key overall pass/fail on the top-level `tables_failed` / `status` / `errors`, not on `execution.tables_failed`, which counts only execution-phase (copy / runtime) failures and excludes models excluded before execution.
     """
-    tables_skipped: conint(ge=0)
+    tables_skipped: conint(ge=0) | None = None
     version: str

--- a/sdk/python/tests/test_barrel_completeness.py
+++ b/sdk/python/tests/test_barrel_completeness.py
@@ -1,0 +1,105 @@
+"""Guard that the ``types_generated`` barrel exports every command output type.
+
+``just codegen-sdk`` regenerates every ``types_generated/<command>_schema.py``
+module, but the curated barrel (``types_generated/__init__.py``) is restored
+from git HEAD on each run — the codegen pipeline does NOT re-derive it. So a
+new CLI command's generated module can silently fail to reach the barrel's
+public surface (the exact bug that left the whole governor surface —
+``audit`` / ``policy`` / ``review`` — and a dozen older commands unexported).
+
+This test is the enforcement point the pipeline lacks: it walks every generated
+module by AST and asserts every top-level command-output type (a class whose
+name ends in ``Output`` or ``Result``, excluding datamodel-code-generator's
+numbered enum-variant duplicates like ``PolicyEffect15``) has its NAME present
+in ``types_generated.__all__``.
+
+Name-based (not identity-based) so it tolerates the handful of shared nested
+types the generator materialises into more than one module (e.g.
+``ExcludedTableOutput`` in both ``discover_schema`` and ``run_schema``): the
+barrel re-exports one canonical binding and the name satisfies both.
+
+The two config-file schemas (``rocky_project_schema`` for ``rocky.toml`` and
+``adapter_config_schema``) define no ``*Output`` / ``*Result`` command types, so
+they are naturally out of scope — they are not CLI ``--output json`` payloads.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+import rocky_sdk.types_generated as barrel
+
+_GENERATED_DIR = Path(barrel.__file__).parent
+_VARIANT_SUFFIX = re.compile(r"\d+$")
+
+
+def _module_files() -> list[Path]:
+    return sorted(p for p in _GENERATED_DIR.glob("*.py") if p.stem != "__init__")
+
+
+def _terminal_output_classes(module_path: Path) -> list[str]:
+    """Top-level command-output class names defined in ``module_path``.
+
+    A command output is a class whose name ends in ``Output`` or ``Result`` and
+    is not one of datamodel-code-generator's numbered enum-variant duplicates
+    (``FooKind3``, ``PolicyEffect15``, …), which always carry a trailing digit.
+    """
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    return [
+        node.name
+        for node in tree.body
+        if isinstance(node, ast.ClassDef)
+        and (node.name.endswith("Output") or node.name.endswith("Result"))
+        and not _VARIANT_SUFFIX.search(node.name)
+    ]
+
+
+@pytest.mark.parametrize("module_path", _module_files(), ids=lambda p: p.stem)
+def test_module_command_outputs_are_barrel_exported(module_path: Path):
+    exported = set(barrel.__all__)
+    unexported = [name for name in _terminal_output_classes(module_path) if name not in exported]
+    assert not unexported, (
+        f"{module_path.name} defines command-output type(s) missing from "
+        f"types_generated.__all__: {sorted(unexported)}. Add an import + an "
+        f"__all__ entry to types_generated/__init__.py (the barrel is restored "
+        f"from git HEAD by `just codegen-sdk`, so it must be hand-maintained)."
+    )
+
+
+def test_all_exported_names_are_bound():
+    """Every name in ``__all__`` must resolve to a real attribute."""
+    unbound = [name for name in barrel.__all__ if not hasattr(barrel, name)]
+    assert not unbound, f"types_generated.__all__ lists unbound names: {unbound}"
+
+
+def test_all_has_no_duplicates():
+    """``__all__`` must not list the same name twice."""
+    seen: set[str] = set()
+    dupes: set[str] = set()
+    for name in barrel.__all__:
+        if name in seen:
+            dupes.add(name)
+        seen.add(name)
+    assert not dupes, f"types_generated.__all__ has duplicate entries: {sorted(dupes)}"
+
+
+def test_governor_surface_is_exported():
+    """Pin the specific regression: the governor command outputs must be present."""
+    exported = set(barrel.__all__)
+    governor = {
+        "AuditOutput",
+        "AuditForOutput",
+        "AuditScorecardOutput",
+        "PolicyCheckOutput",
+        "PolicyTestOutput",
+        "PolicyFreezeOutput",
+        "ReviewOutput",
+        "ReviewQueueOutput",
+    }
+    assert governor <= exported, (
+        f"governor outputs missing from barrel: {sorted(governor - exported)}"
+    )

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -6,6 +6,7 @@ mocked at ``rocky_sdk.client.subprocess``.
 from __future__ import annotations
 
 import io
+import json
 import signal
 from unittest.mock import MagicMock, patch
 
@@ -16,6 +17,7 @@ from rocky_sdk.exceptions import (
     RockyBinaryNotFoundError,
     RockyCommandError,
     RockyGovernanceError,
+    RockyOutputParseError,
     RockyPartialFailure,
     RockyServerError,
     RockyTimeoutError,
@@ -362,3 +364,203 @@ def test_http_error_raises_server_error():
         pytest.raises(RockyServerError),
     ):
         client.compile()
+
+
+# --------------------------------------------------------------------------- #
+# apply() — dispatch by real wire shape (there is NO wrapping envelope)
+# --------------------------------------------------------------------------- #
+
+# A run-shaped ``rocky apply`` output — what a run / replication / ai_authored /
+# backfill plan prints. Note ``command == "run"``, NOT ``"apply"``, and NO
+# ``{plan_id, plan_kind, success, result}`` envelope: the old ``ApplyOutput``
+# shadow required exactly that envelope and so never validated a real payload.
+_RUN_APPLY_JSON = json.dumps(
+    {
+        "version": "1.63.0",
+        "command": "run",
+        "status": "Success",
+        "filter": "source=orders",
+        "duration_ms": 42,
+        "tables_copied": 1,
+        "tables_failed": 0,
+        "tables_skipped": 0,
+        "materializations": [
+            {
+                "asset_key": ["db", "s", "orders"],
+                "rows_copied": 10,
+                "duration_ms": 5,
+                "metadata": {"strategy": "full_refresh"},
+                "started_at": "2026-01-01T00:00:00Z",
+                "attempts": [{"attempt": 1, "outcome": "success", "duration_ms": 5}],
+                "cost_usd": 0.0,
+                "job_ids": [],
+            }
+        ],
+        "check_results": [],
+        "errors": [],
+        "interrupted": False,
+        "shadow": False,
+        "permissions": {
+            "grants_added": 0,
+            "grants_revoked": 0,
+            "catalogs_created": 0,
+            "schemas_created": 0,
+        },
+        "drift": {"tables_checked": 1, "tables_drifted": 0, "actions_taken": []},
+        "execution": {
+            "concurrency": 1,
+            "tables_processed": 1,
+            "tables_failed": 0,
+            "adaptive_concurrency": False,
+        },
+    }
+)
+
+# A ``gc`` plan's apply output — ``command == "apply"`` WITH gc markers.
+_GC_APPLY_JSON = json.dumps(
+    {
+        "version": "1.63.0",
+        "command": "apply",
+        "plan_id": "a" * 64,
+        "evicted": [
+            {
+                "model_name": "stale_model",
+                "run_id": "run-1",
+                "blake3_hash": "deadbeef",
+                "size_bytes": 2048,
+                "physical_reclaimed": True,
+                "physical_status": "reclaimed",
+                "tombstone_recorded": True,
+            }
+        ],
+        "refused": [],
+        "already_evicted": [],
+        "bytes_evicted": 2048,
+        "bytes_refused": 0,
+        "evicted_count": 1,
+        "refused_count": 0,
+        "notes": ["physical reclamation is object-store-only"],
+    }
+)
+
+
+def _run_apply(client: RockyClient, stdout: str):
+    proc = _fake_popen(stdout=stdout, returncode=0)
+    with patch("rocky_sdk.client.subprocess.Popen", return_value=proc):
+        return client.apply("a" * 64)
+
+
+def test_apply_run_shaped_plan_returns_run_result():
+    """A run / replication plan apply prints a bare ``RunOutput`` (command="run").
+    ``apply()`` must parse it as a populated ``RunResult`` — the backfilled
+    ``status`` / ``tables_skipped`` / per-materialization ``attempts`` survive."""
+    from rocky_sdk.types import RunResult
+
+    result = _run_apply(_client(), _RUN_APPLY_JSON)
+    assert isinstance(result, RunResult)
+    assert result.command == "run"
+    assert result.status == "Success"
+    assert result.tables_copied == 1
+    assert result.materializations[0].attempts[0].attempt == 1
+    assert result.materializations[0].started_at is not None
+
+
+def test_apply_gc_plan_returns_gc_apply_output():
+    """A ``gc`` plan apply prints ``command:"apply"`` with gc markers →
+    ``GcApplyOutput`` (populated evicted list, not the empty happy path)."""
+    from rocky_sdk.types import GcApplyOutput
+
+    result = _run_apply(_client(), _GC_APPLY_JSON)
+    assert isinstance(result, GcApplyOutput)
+    assert result.evicted_count == 1
+    assert result.evicted[0].model_name == "stale_model"
+    assert result.bytes_evicted == 2048
+
+
+def test_apply_unknown_shape_raises_named_parse_error():
+    """An unrecognized apply shape raises a clear parse error naming the
+    received command instead of silently mis-parsing."""
+    result_json = json.dumps({"version": "1", "command": "totally-new-apply-kind"})
+    proc = _fake_popen(stdout=result_json, returncode=0)
+    with (
+        patch("rocky_sdk.client.subprocess.Popen", return_value=proc),
+        pytest.raises(RockyOutputParseError) as excinfo,
+    ):
+        _client().apply("a" * 64)
+    assert "totally-new-apply-kind" in excinfo.value.parse_error
+
+
+# --------------------------------------------------------------------------- #
+# test_adapter() — the ConformanceResult shadow raised on ANY real output
+# --------------------------------------------------------------------------- #
+
+
+def test_test_adapter_parses_real_conformance_payload():
+    """``rocky test-adapter`` output carries NO ``version`` / ``command`` keys,
+    so the old hand-written ``ConformanceResult`` (which required them) raised on
+    every real payload. The generated ``TestAdapterOutput`` alias parses it —
+    tested with a POPULATED results list, not the empty happy path."""
+    payload = json.dumps(
+        {
+            "adapter": "duckdb",
+            "sdk_version": "0.6.0",
+            "tests_run": 2,
+            "tests_passed": 1,
+            "tests_failed": 1,
+            "tests_skipped": 0,
+            "results": [
+                {
+                    "name": "connection",
+                    "category": "connection",
+                    "status": "passed",
+                    "duration_ms": 3,
+                },
+                {
+                    "name": "types",
+                    "category": "types",
+                    "status": "failed",
+                    "message": "unsupported type",
+                    "duration_ms": 5,
+                },
+            ],
+        }
+    )
+    proc = _fake_popen(stdout=payload, returncode=0)
+    with patch("rocky_sdk.client.subprocess.Popen", return_value=proc):
+        result = _client().test_adapter(adapter="duckdb")
+    assert result.adapter == "duckdb"
+    assert result.tests_failed == 1
+    assert result.results[1].status == "failed"
+    assert result.results[1].message == "unsupported type"
+
+
+# --------------------------------------------------------------------------- #
+# ai_sync() — the AiSyncProposal shadow required a phantom ``current_source``
+# --------------------------------------------------------------------------- #
+
+
+def test_ai_sync_parses_populated_proposals_without_phantom_field():
+    """A real ``AiSyncProposal`` is ``{model, intent, diff, proposed_source}`` —
+    no ``current_source``. The old shadow required ``current_source``, so
+    ``ai_sync`` raised whenever the proposals list was non-empty (the empty-list
+    happy path masked it). Tested with a POPULATED proposal."""
+    payload = json.dumps(
+        {
+            "version": "1.63.0",
+            "command": "ai_sync",
+            "proposals": [
+                {
+                    "model": "revenue",
+                    "intent": "add tax column",
+                    "diff": "@@ +tax",
+                    "proposed_source": "SELECT *, tax FROM raw",
+                }
+            ],
+        }
+    )
+    proc = _fake_popen(stdout=payload, returncode=0)
+    with patch("rocky_sdk.client.subprocess.Popen", return_value=proc):
+        result = _client().ai_sync()
+    assert len(result.proposals) == 1
+    assert result.proposals[0].model == "revenue"
+    assert result.proposals[0].proposed_source == "SELECT *, tax FROM raw"

--- a/sdk/python/tests/test_schema_parity.py
+++ b/sdk/python/tests/test_schema_parity.py
@@ -1,0 +1,186 @@
+"""Schema-parity guard: the runtime dispatch targets must not drop wire fields.
+
+Rocky's ``--output json`` payloads are validated by hand-written Pydantic models
+in :mod:`rocky_sdk.types` (the runtime dispatch targets that
+``parse_rocky_output`` and ``RockyClient``'s methods route to). Those models use
+``extra="ignore"`` for forward-compat, which means any wire field NOT declared
+on the model is silently dropped — a consumer mapping it (e.g. dagster-rocky
+surfacing a run's containment blast radius) would never see anything. That is
+exactly how the shadow-drift bug cluster (#924 / #1061) hid at scale.
+
+This test is the drift guard the codegen pipeline lacks for the hand-written
+layer: for every runtime dispatch target it loads the corresponding
+``schemas/<command>.schema.json`` and asserts every top-level schema property
+has a matching field on the target model, recursing one level into the known
+nested command-output objects (materialization items, check results, execution
+summary).
+
+Generated-type dispatch targets (soft-swapped aliases like ``TestResult`` /
+``HistoryResult``) are included too: they trivially pass because they are
+generated FROM the schema, so the guard also catches a future regression that
+un-aliases one back to a hand-written shadow.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from rocky_sdk import types as sdk_types
+from rocky_sdk.client import (
+    ApplyResult,  # noqa: F401  (documents the apply union is intentionally not a single model)
+)
+from rocky_sdk.types import _SIMPLE_DISPATCH
+
+
+def _schemas_dir() -> Path:
+    """Locate the repo-root ``schemas/`` directory from this test file."""
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / "schemas"
+        if (candidate / "run.schema.json").exists():
+            return candidate
+    raise FileNotFoundError("could not locate schemas/ above this test file")
+
+
+SCHEMAS = _schemas_dir()
+
+
+def _schema_top_level_props(schema_file: str) -> set[str]:
+    schema = json.loads((SCHEMAS / schema_file).read_text(encoding="utf-8"))
+    return _node_props(schema)
+
+
+def _definition_props(schema_file: str, definition: str) -> set[str]:
+    schema = json.loads((SCHEMAS / schema_file).read_text(encoding="utf-8"))
+    return _node_props(schema["definitions"][definition])
+
+
+def _node_props(node: dict) -> set[str]:
+    """Union of ``properties`` across a node and any ``anyOf`` / ``oneOf`` variants.
+
+    Several outputs (notably ``CheckResult``) carry a shared base plus a set of
+    variant property blocks; the wire can emit fields from any variant, so the
+    model must declare all of them.
+    """
+    props: set[str] = set(node.get("properties", {}))
+    for variant in node.get("anyOf", []) + node.get("oneOf", []):
+        props |= set(variant.get("properties", {}))
+    return props
+
+
+# Maps every ``parse_rocky_output`` dispatch command (and the two
+# shape-discriminated commands handled outside ``_SIMPLE_DISPATCH``) to the
+# schema file whose top-level shape the dispatch target must cover. Keeping this
+# explicit — command names are not 1:1 with schema filenames (``validate-migration``
+# → ``validate_migration``; ``ai_sync`` → ``ai_sync``) — while the coverage
+# assertion below pins it against the live dispatch table.
+_COMMAND_SCHEMA: dict[str, str] = {
+    "discover": "discover.schema.json",
+    "run": "run.schema.json",
+    "plan": "plan.schema.json",
+    "state": "state.schema.json",
+    "state-clear-schema-cache": "state_clear_schema_cache.schema.json",
+    "compile": "compile.schema.json",
+    "test": "test.schema.json",
+    "ci": "ci.schema.json",
+    "ci-diff": "ci_diff.schema.json",
+    "lineage-diff": "lineage_diff.schema.json",
+    "metrics": "metrics.schema.json",
+    "optimize": "optimize.schema.json",
+    "cost": "cost.schema.json",
+    "backfill": "backfill.schema.json",
+    "ai": "ai.schema.json",
+    "ai_sync": "ai_sync.schema.json",
+    "ai_explain": "ai_explain.schema.json",
+    "ai_test": "ai_test.schema.json",
+    "ai_contract": "ai_contract.schema.json",
+    "validate-migration": "validate_migration.schema.json",
+    "doctor": "doctor.schema.json",
+    "dag": "dag.schema.json",
+    "apply": "gc_apply.schema.json",
+    "compliance": "compliance.schema.json",
+    "retention-status": "retention_status.schema.json",
+    "catalog": "catalog.schema.json",
+    "branch approve": "branch_approve.schema.json",
+    "branch promote": "branch_promote.schema.json",
+    "plan promote": "plan_promote.schema.json",
+    "compact apply": "compact_apply.schema.json",
+    "archive apply": "archive_apply.schema.json",
+}
+
+# Client-only parse targets not routed by ``parse_rocky_output`` (their payloads
+# either carry no ``command`` key, or are shape-discriminated).
+_CLIENT_ONLY: dict[str, tuple[str, type]] = {
+    "test-adapter": ("test_adapter.schema.json", sdk_types.ConformanceResult),
+    "lineage-model": ("lineage.schema.json", sdk_types.ModelLineageResult),
+    "lineage-column": ("column_lineage.schema.json", sdk_types.ColumnLineageResult),
+    "history-all": ("history.schema.json", sdk_types.HistoryResult),
+    "history-model": ("model_history.schema.json", sdk_types.ModelHistoryResult),
+}
+
+
+def test_dispatch_table_is_fully_covered():
+    """Every ``_SIMPLE_DISPATCH`` command must have a parity schema mapping.
+
+    Adding a new dispatch command without a parity entry fails here, forcing the
+    author to wire the drift guard for it.
+    """
+    uncovered = set(_SIMPLE_DISPATCH) - set(_COMMAND_SCHEMA)
+    assert not uncovered, f"dispatch commands missing a parity schema mapping: {sorted(uncovered)}"
+
+
+def _model_fields(model: type) -> set[str]:
+    return set(model.model_fields)
+
+
+_DISPATCH_CASES = [
+    pytest.param(cmd, _COMMAND_SCHEMA[cmd], _SIMPLE_DISPATCH[cmd], id=f"dispatch:{cmd}")
+    for cmd in sorted(_SIMPLE_DISPATCH)
+]
+_CLIENT_CASES = [
+    pytest.param(key, schema, model, id=f"client:{key}")
+    for key, (schema, model) in sorted(_CLIENT_ONLY.items())
+]
+
+
+@pytest.mark.parametrize(("command", "schema_file", "model"), _DISPATCH_CASES + _CLIENT_CASES)
+def test_top_level_schema_props_have_model_fields(command: str, schema_file: str, model: type):
+    schema_props = _schema_top_level_props(schema_file)
+    missing = schema_props - _model_fields(model)
+    assert not missing, (
+        f"{model.__name__} (command {command!r}, schema {schema_file}) is missing "
+        f"fields for wire properties {sorted(missing)} — they would be silently "
+        f'dropped by Pydantic\'s extra="ignore". Declare them on the model.'
+    )
+
+
+# One-level recursion into the known nested command-output objects the spec
+# calls out. Each tuple: (schema_file, definition_name, target_nested_model).
+_NESTED_CASES = [
+    pytest.param(
+        "run.schema.json",
+        "MaterializationOutput",
+        sdk_types.MaterializationInfo,
+        id="nested:materialization",
+    ),
+    pytest.param("run.schema.json", "CheckResult", sdk_types.CheckResult, id="nested:check_result"),
+    pytest.param(
+        "run.schema.json",
+        "ExecutionSummary",
+        sdk_types.ExecutionSummary,
+        id="nested:execution_summary",
+    ),
+]
+
+
+@pytest.mark.parametrize(("schema_file", "definition", "model"), _NESTED_CASES)
+def test_nested_schema_props_have_model_fields(schema_file: str, definition: str, model: type):
+    schema_props = _definition_props(schema_file, definition)
+    missing = schema_props - _model_fields(model)
+    assert not missing, (
+        f"{model.__name__} (nested {definition} in {schema_file}) is missing fields "
+        f"for wire properties {sorted(missing)} — they would be silently dropped."
+    )


### PR DESCRIPTION
## Problem

The Python SDK's hand-written "shadow" models in `rocky_sdk/types.py` drifted from the engine's `--output json` wire format, and runtime dispatch routes to **those shadows** (not the generated types). At scale this meant:

- **Broken client methods.** `client.apply()`, `client.test_adapter()`, and `client.ai_sync()` (non-empty) raised on *any* real engine output.
- **Silently dropped fields.** Many wire fields never reached callers — the shadow models declared fewer fields than the wire carries and `extra="ignore"` swallowed the rest.
- **An engine keystone that forced the shadows to persist.** Several `*Output` fields used `#[serde(skip_serializing_if)]` **without** `#[serde(default)]`, so the *generated* Pydantic models marked them required and couldn't validate real output — leaving the hand-written shadows as the only thing that parsed.

## Fixes

**Engine keystone (unblocks everything).** Swept `output.rs` and added `default` to every `skip_serializing_if` field lacking it (`RunOutput`, `ExecutionSummary`, `QuarantineOutput`, `MetricsOutput`, `PartitionInfo`/`PartitionSummary`, the `Preview*` diffs). Serialization is unchanged — only deserialization/schema relax, so the schemas' `required` arrays shrink and the generated bindings become optional-with-default. Regenerated the full cascade (`schemas/`, `sdk/types_generated/`, vscode TS, `openapi.json`).

**`client.apply()` had never worked.** It parsed stdout into a hand-written `ApplyOutput` envelope (`{plan_id, plan_kind, success, result}`) the engine has **never** emitted. `rocky apply` prints the plan-kind's own output: run-shaped kinds print `RunOutput` (`command:"run"`), `gc` prints `GcApplyOutput` (`command:"apply"`), compact/archive/promote print their own. `apply()` now dispatches by the real `command`/shape and returns a documented union; an unrecognized shape raises a clear `RockyOutputParseError` naming the received command. The hand-made `apply.json` fixture (never live-captured) is **replaced with a live plan+apply capture** against the playground POC.

**Always-raising shadows.** `ConformanceResult` (required `version`/`command` the `test-adapter` payload lacks) → aliased to the generated `TestAdapterOutput`, unreachable dispatch entry removed. `AiSyncProposal` (required a phantom `current_source` never on the wire) → aliased to the generated AiSync types. Both were masked by empty-collection happy paths; new tests use **populated** payloads.

**Backfilled dropped fields.** `RunResult`, `MaterializationInfo`, `CheckResult`, `ExecutionSummary`, `PlanResult`, `StateResult`, `CompileResult`, `ModelDetail`, `DiscoverResult`, `ModelLineageResult`, `ColumnLineageResult`, `AiResult`, `ValidateMigrationResult`, `MetricsResult`, `OptimizeResult`, `HealthCheck` — each gained the wire fields it was dropping, with sensible defaults. Dropped the phantom `RunResult.contracts` field and its dead dagster consumer.

**Dead code.** Removed the `DriftDetectResult` shadow + its dispatch entry — there is no `rocky drift` subcommand (the binary rejects it; drift runs inside `run`/`plan`). Fixed the stale `rocky drift` row in `engine/AGENTS.md`.

**Barrel completeness.** `types_generated/__init__.py` was missing 18 command modules — the whole governor surface (`audit`/`policy`/`review`) plus `seed`/`load`/`estimate`/`profile`/`trace`/`validate`/`dag_run`/`compact_dedup`/`preview_rows`/`state_retention_sweep` — and 3 `__all__` entries. Added them all.

## New drift guards (the enforcement points the pipeline lacked)

- **`test_schema_parity.py`** — walks every runtime dispatch target, loads its `schemas/<command>.schema.json`, and asserts every top-level property has a model field (recursing one level into materializations / check results / execution summary). Adding a dispatch command without a parity entry fails the test.
- **`test_barrel_completeness.py`** — AST-walks every generated module and asserts each command-output type is exported by the barrel. `just codegen` restores the barrel from git, so this pytest is the only thing that can catch a missing module.

## Verification

- Engine: `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, `cargo test --workspace` — all green (goldens hold; serialization untouched).
- SDK: `ruff check` + `ruff format --check` + `pytest` (174) — green.
- Dagster: `ruff check` + `ruff format --check` + `pytest` (686) — green.
- `just codegen` and `just regen-fixtures` both produce zero drift.