### PR TITLE
fix: review pass over the 11-wave program — replay, retry/containment, backfill, governor, verifier, dagster

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -1741,7 +1741,7 @@
         "type": "object"
       },
       "AuditSubjectKind": {
-        "description": "What `rocky audit --for <selector>` resolved its selector to.\n\nThe selector is resolved in priority order: a 64-char hex string with a plan file on disk is a [`AuditSubjectKind::Plan`]; a string matching a `run_id` in the run ledger is a [`AuditSubjectKind::Run`]; anything else is treated as a [`AuditSubjectKind::Model`] name.",
+        "description": "What `rocky audit --for <selector>` resolved its selector to.\n\nThe selector is resolved in priority order: a 64-char hex string with a plan file on disk is a [`AuditSubjectKind::Plan`]; a string matching a `run_id` in the run ledger is a [`AuditSubjectKind::Run`]; a string the decision ledger keys rows by is likewise a [`AuditSubjectKind::Plan`] (the plan file may be gone, or the id may be a decision-only custody key that never had one); anything else is treated as a [`AuditSubjectKind::Model`] name.",
         "oneOf": [
           {
             "description": "A model / table name — the primary custody-chain entry point.",
@@ -1758,7 +1758,7 @@
             "type": "string"
           },
           {
-            "description": "A `plan_id` (64-char blake3 hex) with a plan file on disk.",
+            "description": "A `plan_id` — a 64-char blake3 hex with a plan file on disk, or any id the decision ledger keys rows by (including decision-only custody ids like `freeze:…` / `draft:…` / `autoapply:…`, which never had a plan file).",
             "enum": [
               "plan"
             ],
@@ -1971,6 +1971,13 @@
           "version": {
             "description": "Rocky version that composed the plan.",
             "type": "string"
+          },
+          "warnings": {
+            "description": "Composition warnings the reviewer must weigh before approving. Today: `incremental` / `microbatch` closure members, whose transformation re-run is a bare `INSERT INTO … <model SQL>` — depending on the model's own filtering it appends duplicate rows or loads nothing, rather than rebuilding a window. Empty (and omitted from JSON) when the closure carries no such member.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           }
         },
         "required": [
@@ -6724,7 +6731,7 @@
             ]
           },
           "tables_failed": {
-            "description": "Tables that failed during the **execution phase** — copy or runtime failures while materializing. This does **not** include models excluded before execution started (for example, a model that failed to compile); those are counted only in the top-level `RunOutput.tables_failed`. For overall run pass/fail, read the top-level `tables_failed` / `status`, not this `execution.tables_failed`.",
+            "description": "Source tables whose **copy failed** on the replication path (the `table_errors` count). Transformation-model runtime failures — including contained-cause failures — are reported in `errors` and the top-level `RunOutput.tables_failed`, not here; transformation-only runs leave the whole `execution` block unpopulated. For overall run pass/fail, read the top-level `tables_failed` / `status`, never this field.",
             "format": "uint",
             "minimum": 0.0,
             "type": "integer"

--- a/editors/vscode/src/types/generated/audit_for.ts
+++ b/editors/vscode/src/types/generated/audit_for.ts
@@ -43,7 +43,7 @@ export type PolicyPrincipal = "human" | "agent";
 /**
  * What `rocky audit --for <selector>` resolved its selector to.
  *
- * The selector is resolved in priority order: a 64-char hex string with a plan file on disk is a [`AuditSubjectKind::Plan`]; a string matching a `run_id` in the run ledger is a [`AuditSubjectKind::Run`]; anything else is treated as a [`AuditSubjectKind::Model`] name.
+ * The selector is resolved in priority order: a 64-char hex string with a plan file on disk is a [`AuditSubjectKind::Plan`]; a string matching a `run_id` in the run ledger is a [`AuditSubjectKind::Run`]; a string the decision ledger keys rows by is likewise a [`AuditSubjectKind::Plan`] (the plan file may be gone, or the id may be a decision-only custody key that never had one); anything else is treated as a [`AuditSubjectKind::Model`] name.
  */
 export type AuditSubjectKind = "model" | "run" | "plan";
 

--- a/editors/vscode/src/types/generated/backfill.ts
+++ b/editors/vscode/src/types/generated/backfill.ts
@@ -63,6 +63,10 @@ export interface BackfillOutput {
    * Rocky version that composed the plan.
    */
   version: string;
+  /**
+   * Composition warnings the reviewer must weigh before approving. Today: `incremental` / `microbatch` closure members, whose transformation re-run is a bare `INSERT INTO … <model SQL>` — depending on the model's own filtering it appends duplicate rows or loads nothing, rather than rebuilding a window. Empty (and omitted from JSON) when the closure carries no such member.
+   */
+  warnings?: string[];
   [k: string]: unknown;
 }
 /**

--- a/editors/vscode/src/types/generated/run.ts
+++ b/editors/vscode/src/types/generated/run.ts
@@ -348,7 +348,7 @@ export interface ExecutionSummary {
    */
   rate_limits_detected?: number | null;
   /**
-   * Tables that failed during the **execution phase** — copy or runtime failures while materializing. This does **not** include models excluded before execution started (for example, a model that failed to compile); those are counted only in the top-level `RunOutput.tables_failed`. For overall run pass/fail, read the top-level `tables_failed` / `status`, not this `execution.tables_failed`.
+   * Source tables whose **copy failed** on the replication path (the `table_errors` count). Transformation-model runtime failures — including contained-cause failures — are reported in `errors` and the top-level `RunOutput.tables_failed`, not here; transformation-only runs leave the whole `execution` block unpopulated. For overall run pass/fail, read the top-level `tables_failed` / `status`, never this field.
    */
   tables_failed: number;
   tables_processed: number;

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -1054,6 +1054,23 @@ async fn run_apply_backfill_plan(
         bail!("backfill plan '{plan_id}' names no models to rebuild");
     }
 
+    // A half-open window must never execute: `to_selection` only yields a
+    // Range when BOTH bounds are present, so a lone bound would silently fall
+    // through to `PartitionSelection::Latest` — rebuilding one partition of a
+    // scope the reviewer approved as "from January". The CLI now rejects lone
+    // bounds at parse time; this guards plans persisted before that (or
+    // hand-authored plan files).
+    if run_plan.partition_from.is_some() != run_plan.partition_to.is_some() {
+        bail!(
+            "backfill plan '{plan_id}' carries a half-open partition window \
+             (from: {:?}, to: {:?}) — executing it would rebuild only the \
+             latest partition, not the approved range. Re-compose the backfill \
+             with both --from and --to (or neither).",
+            run_plan.partition_from,
+            run_plan.partition_to,
+        );
+    }
+
     // Only the partition window carries over — a backfill never resumes,
     // shadows, or runs `--latest`/`--missing`.
     let partition_opts = crate::commands::run::PartitionRunOptions {

--- a/engine/crates/rocky-cli/src/commands/audit.rs
+++ b/engine/crates/rocky-cli/src/commands/audit.rs
@@ -165,14 +165,26 @@ pub fn compute_audit_for(
         (Vec::new(), Vec::new())
     };
 
-    // Resolve the subject kind (plan file > run id > model name).
+    // Resolve the subject kind (plan file > run id > ledger plan id > model
+    // name). The ledger fallback matters twice: a plan whose .rocky/plans
+    // file was housekept away (or queried from a clone sharing only the state
+    // store) still has decision rows keyed by its plan_id, and decision-only
+    // custody ids (`freeze:…`, `draft:…`, `autoapply:…` — the rows the review
+    // queue's footnote sends here) are plan-keyed but never 64-hex and never
+    // on disk. Without it, both fall through to the Model join
+    // (`d.model == selector`), match nothing, and the drill-down reports
+    // "nothing in the ledger references this subject" while the ledger holds
+    // exactly those rows.
     let is_hex64 = selector.len() == 64 && selector.chars().all(|c| c.is_ascii_hexdigit());
     let plan_on_disk = is_hex64 && plan_file_path(root, selector).exists();
     let run_match = runs.iter().any(|r| r.run_id == selector);
+    let plan_in_ledger = decisions.iter().any(|d| d.plan_id == selector);
     let kind = if plan_on_disk {
         AuditSubjectKind::Plan
     } else if run_match {
         AuditSubjectKind::Run
+    } else if plan_in_ledger {
+        AuditSubjectKind::Plan
     } else {
         AuditSubjectKind::Model
     };
@@ -1260,6 +1272,41 @@ mod tests {
         assert!(ld.is_empty() && lt.is_empty());
         // An unknown model is absent from the graph.
         assert!(blast_radius_of(&result, "nope").is_none());
+    }
+
+    /// FIX: a selector that matches ledger plan_ids must resolve as a Plan
+    /// subject even when the plan file is gone (housekeeping, shared state
+    /// store) or the id is a decision-only custody key (`freeze:…`,
+    /// `draft:…`, `autoapply:…` — never 64-hex, never on disk). Pre-fix these
+    /// fell through to the Model join, matched nothing, and the drill-down
+    /// claimed nothing in the ledger referenced the subject.
+    #[test]
+    fn audit_for_resolves_ledger_plan_ids_without_a_plan_file() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        let models_dir = root.join("models");
+        fs::create_dir_all(&models_dir).unwrap();
+        let state_path = root.join("state.redb");
+        {
+            let store = rocky_core::state::StateStore::open(&state_path).unwrap();
+            store
+                .record_policy_decision(&decision(1, "freeze:global", "*", PolicyEffect::Deny))
+                .unwrap();
+        }
+
+        let out = compute_audit_for(
+            root,
+            &root.join("rocky.toml"),
+            &state_path,
+            &models_dir,
+            "freeze:global",
+        )
+        .unwrap();
+
+        assert_eq!(out.subject_kind, AuditSubjectKind::Plan);
+        assert!(out.resolved, "a ledger-only plan id must resolve: {out:?}");
+        assert_eq!(out.decisions.total, 1);
+        assert_eq!(out.decisions.entries[0].plan_id, "freeze:global");
     }
 
     #[test]

--- a/engine/crates/rocky-cli/src/commands/backfill.rs
+++ b/engine/crates/rocky-cli/src/commands/backfill.rs
@@ -155,7 +155,7 @@ pub(crate) fn run_backfill_in(
         .iter()
         .map(|n| (n.name.as_str(), n.depends_on.as_slice()))
         .collect();
-    let layers = order_closure(&closure, &dep_by_model)?;
+    let layers = order_closure(&closure, &dep_by_model, &physical_reader_edges(&compiled))?;
     let ordered: Vec<String> = layers.iter().flatten().cloned().collect();
 
     // 5. Partition scope: which closure models are partitioned, and the window.
@@ -178,6 +178,30 @@ pub(crate) fn run_backfill_in(
     } else {
         None
     };
+
+    // Reviewer-facing composition warnings. An `incremental` / `microbatch`
+    // closure member cannot actually be rebuilt by re-running it: its
+    // transformation SQL-gen is a bare `INSERT INTO … <model SQL>` (no
+    // watermark or window literal threaded in), so a re-run either appends
+    // every selected row again or — if the model self-filters against its own
+    // target — inserts nothing. The reviewer must know the approved "rebuild"
+    // does not repair those members' historical rows.
+    let warnings: Vec<String> = ordered
+        .iter()
+        .filter_map(|name| {
+            let strategy = &compiled.project.model(name)?.config.strategy;
+            let label = match strategy {
+                StrategyConfig::Incremental { .. } => "incremental",
+                StrategyConfig::Microbatch { .. } => "microbatch",
+                _ => return None,
+            };
+            Some(format!(
+                "'{name}' is {label}: its re-run is an unguarded INSERT of the model's SELECT \
+                 (append/no-op, not a windowed rebuild) — repair its history via a full-refresh \
+                 variant or a manual window, then re-run"
+            ))
+        })
+        .collect();
 
     // 6. Cost estimate from historical observations (offline).
     let cost_estimate = estimate_cost(&ordered, store.as_ref(), config_path);
@@ -237,6 +261,7 @@ pub(crate) fn run_backfill_in(
         cost_estimate,
         review_command: format!("rocky review {plan_id} --approve"),
         apply_command: format!("rocky apply {plan_id}"),
+        warnings,
         message: message.clone(),
     };
 
@@ -313,8 +338,88 @@ fn compute_closure(
                 closure.extend(transitive);
             }
         }
+        extend_with_physical_readers(&mut closure, compiled);
     }
     closure
+}
+
+/// `(reader, producers-it-physically-reads)` for every model whose read set
+/// is provably enumerable — the `physical ∪ bare` half of the containment
+/// plane's edge set, resolved against the produced-target index. Ref-declared
+/// dependencies are NOT included (the semantic graph already carries them).
+fn physical_reader_edges(compiled: &CompileResult) -> Vec<(String, Vec<String>)> {
+    use crate::commands::containment::{ProducerIndex, ReadResolution};
+
+    let producers = ProducerIndex::build(compiled.project.models.iter().map(|m| {
+        (
+            m.config.name.as_str(),
+            m.config.target.catalog.as_str(),
+            m.config.target.schema.as_str(),
+            m.config.target.table.as_str(),
+        )
+    }));
+
+    compiled
+        .project
+        .models
+        .iter()
+        .filter_map(|m| {
+            if !rocky_sql::lineage_complete::lineage_is_provably_complete(&m.sql) {
+                return None;
+            }
+            let lineage = rocky_sql::lineage::extract_lineage(&m.sql).ok()?;
+            let mut read_producers: Vec<String> = Vec::new();
+            for read in lineage.source_tables {
+                let read = read.name.to_lowercase();
+                if let ReadResolution::Edges(edge_producers) = producers.resolve(&read) {
+                    for producer in edge_producers {
+                        if producer != m.config.name {
+                            read_producers.push(producer);
+                        }
+                    }
+                }
+            }
+            (!read_producers.is_empty()).then(|| (m.config.name.clone(), read_producers))
+        })
+        .collect()
+}
+
+/// Fold **physical-name consumers** into the closure, to a fixpoint.
+///
+/// The semantic graph carries only `ref()` edges — a raw-SQL model reading a
+/// closure member's *target table by physical name* (`marts.orders_current`)
+/// has no graph edge, yet it consumed exactly the stale output this recovery
+/// exists to repair, and the runtime containment plane models that edge
+/// (`ref ∪ physical ∪ bare`). Resolve every model's enumerable reads against
+/// the produced-target index ([`ProducerIndex`], the same machinery
+/// containment uses) and pull matching readers — plus THEIR `ref()`
+/// downstream — into the closure until nothing new is added.
+///
+/// Scope mirrors containment's documented guarantee: readers whose read sets
+/// cannot be fully enumerated (CTEs, sub-queries — `lineage_is_provably_
+/// complete` rejects them) are best-effort out; declare the dependency with
+/// `ref()` for the hard guarantee.
+fn extend_with_physical_readers(closure: &mut BTreeSet<String>, compiled: &CompileResult) {
+    let physical_edges = physical_reader_edges(compiled);
+
+    loop {
+        let mut grew = false;
+        for (reader, read_producers) in &physical_edges {
+            if closure.contains(reader) {
+                continue;
+            }
+            if read_producers.iter().any(|p| closure.contains(p)) {
+                closure.insert(reader.clone());
+                if let Some((_, transitive)) = blast_radius_of(compiled, reader) {
+                    closure.extend(transitive);
+                }
+                grew = true;
+            }
+        }
+        if !grew {
+            break;
+        }
+    }
 }
 
 /// Topologically order a closure using only its intra-closure dependencies.
@@ -326,11 +431,19 @@ fn compute_closure(
 fn order_closure(
     closure: &BTreeSet<String>,
     dep_by_model: &HashMap<&str, &[String]>,
+    physical_edges: &[(String, Vec<String>)],
 ) -> Result<Vec<Vec<String>>> {
+    // Physical/bare reads impose the same ordering constraint as `ref()`
+    // edges within the closure: a reader rebuilt before its producer would
+    // consume the exact stale rows this recovery repairs.
+    let phys_by_reader: HashMap<&str, &Vec<String>> = physical_edges
+        .iter()
+        .map(|(reader, producers)| (reader.as_str(), producers))
+        .collect();
     let nodes: Vec<DagNode> = closure
         .iter()
         .map(|m| {
-            let depends_on = dep_by_model
+            let mut depends_on: Vec<String> = dep_by_model
                 .get(m.as_str())
                 .copied()
                 .unwrap_or(&[])
@@ -338,6 +451,13 @@ fn order_closure(
                 .filter(|d| closure.contains(*d))
                 .cloned()
                 .collect();
+            if let Some(producers) = phys_by_reader.get(m.as_str()) {
+                for producer in producers.iter() {
+                    if closure.contains(producer) && !depends_on.contains(producer) {
+                        depends_on.push(producer.clone());
+                    }
+                }
+            }
             DagNode {
                 name: m.clone(),
                 depends_on,
@@ -499,6 +619,9 @@ fn print_table(out: &BackfillOutput) {
             scope.models.join(", ")
         );
     }
+    for w in &out.warnings {
+        println!("  ⚠ {w}");
+    }
     match out.cost_estimate.total_cost_usd {
         Some(c) => println!(
             "  est. cost: ${c:.6} (estimate, {})",
@@ -527,6 +650,73 @@ mod tests {
             .collect()
     }
 
+    /// FIX: the recovery closure folds PHYSICAL-name consumers in. A raw-SQL
+    /// reader of a seed's target table has no `ref()` edge — the semantic
+    /// graph alone leaves it out and the approved recovery leaves it stale —
+    /// but the runtime containment plane models exactly that edge, so the
+    /// closure must too. Its own `ref()` downstream rides along, and the plan
+    /// layers order the reader strictly after its producer.
+    #[test]
+    fn closure_includes_physical_readers_of_seed_targets() {
+        use rocky_compiler::compile::{self, CompilerConfig};
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let write = |name: &str, sql: &str, table: &str| {
+            std::fs::write(dir.path().join(format!("{name}.sql")), sql).unwrap();
+            std::fs::write(
+                dir.path().join(format!("{name}.toml")),
+                format!(
+                    "name = \"{name}\"\n\n[strategy]\ntype = \"full_refresh\"\n\n\
+                     [target]\ncatalog = \"c\"\nschema = \"s\"\ntable = \"{table}\"\n"
+                ),
+            )
+            .unwrap();
+        };
+        write("a", "SELECT 1 AS id", "a_tbl");
+        // Physical 2-part read of a's target — no ref edge to `a`.
+        write("d", "SELECT id FROM s.a_tbl", "d_tbl");
+        // Ref-declared downstream of the physical reader.
+        write("e", "SELECT id FROM d", "e_tbl");
+
+        let config = CompilerConfig {
+            models_dir: dir.path().to_path_buf(),
+            ..Default::default()
+        };
+        let compiled = compile::compile(&config).unwrap();
+
+        let closure = compute_closure(&["a".to_string()], &compiled, true);
+        assert!(closure.contains("a"));
+        assert!(
+            closure.contains("d"),
+            "the physical reader of a's target must join the closure: {closure:?}"
+        );
+        assert!(
+            closure.contains("e"),
+            "the physical reader's ref() downstream rides along: {closure:?}"
+        );
+
+        // And the plan layers order the reader strictly after its producer.
+        let dep_by_model: HashMap<&str, &[String]> = compiled
+            .project
+            .dag_nodes
+            .iter()
+            .map(|n| (n.name.as_str(), n.depends_on.as_slice()))
+            .collect();
+        let layers =
+            order_closure(&closure, &dep_by_model, &physical_reader_edges(&compiled)).unwrap();
+        let layer_of = |name: &str| {
+            layers
+                .iter()
+                .position(|l| l.iter().any(|m| m == name))
+                .unwrap_or_else(|| panic!("{name} missing from layers {layers:?}"))
+        };
+        assert!(
+            layer_of("a") < layer_of("d"),
+            "physical reader must be layered after its producer: {layers:?}"
+        );
+        assert!(layer_of("d") < layer_of("e"));
+    }
+
     /// Ordering is dependency-first and drops out-of-closure upstreams.
     #[test]
     fn order_closure_is_dependency_first_within_the_set() {
@@ -540,7 +730,7 @@ mod tests {
             .collect();
         let closure: BTreeSet<String> = ["b", "c", "d"].iter().map(ToString::to_string).collect();
 
-        let layers = order_closure(&closure, &dep_by_model).unwrap();
+        let layers = order_closure(&closure, &dep_by_model, &[]).unwrap();
         let flat: Vec<String> = layers.iter().flatten().cloned().collect();
         assert_eq!(flat, vec!["b", "c", "d"]);
         // `a` is never scheduled — it is a healthy upstream, not part of the
@@ -559,7 +749,7 @@ mod tests {
             .collect();
         let closure: BTreeSet<String> = ["x", "y", "z"].iter().map(ToString::to_string).collect();
 
-        let layers = order_closure(&closure, &dep_by_model).unwrap();
+        let layers = order_closure(&closure, &dep_by_model, &[]).unwrap();
         assert_eq!(layers.len(), 2, "two topological layers");
         assert!(layers[0].contains(&"x".to_string()));
         assert!(layers[0].contains(&"y".to_string()));

--- a/engine/crates/rocky-cli/src/commands/brief.rs
+++ b/engine/crates/rocky-cli/src/commands/brief.rs
@@ -187,7 +187,16 @@ pub fn compute_brief(
     windowed_decisions.sort_by_key(|d| Reverse(d.timestamp));
 
     let agent_activity = build_agent_activity(&windowed_decisions);
-    let escalations = build_escalations(root, &windowed_decisions);
+    // Escalations are a *current-state* projection, like `autonomy` below: an
+    // escalation raised BEFORE the window that is still pending is precisely
+    // what "Needs you" exists to surface — the review queue ranks staleness
+    // up, so yesterday's unactioned item must not vanish from today's
+    // `--since last` brief. Selection runs over the full ledger, newest
+    // first; approved/withdrawn items drop out via the same
+    // outstanding-selection core the review queue uses.
+    let mut all_decisions_newest_first: Vec<&PolicyDecisionRecord> = decisions.iter().collect();
+    all_decisions_newest_first.sort_by_key(|d| Reverse(d.timestamp));
+    let escalations = build_escalations(root, &all_decisions_newest_first);
     let runs_section = build_runs(&windowed_runs);
     let drift = build_drift(&store, since_ts);
     let (freshness, quality) = build_freshness_and_quality(&store, &windowed_runs, since_ts);
@@ -307,8 +316,10 @@ fn build_agent_activity(decisions: &[&PolicyDecisionRecord]) -> BriefAgentActivi
 /// The "Needs you" section: decisions **still** awaiting review.
 ///
 /// Reuses the review queue's outstanding-selection core
-/// ([`select_outstanding`]) rather than re-listing every windowed
-/// `require_review` row, so the digest and `rocky review --queue` agree: one
+/// ([`select_outstanding`]) over the FULL ledger (current-state, not the
+/// `--since` slice — a still-pending escalation raised before the window is
+/// exactly what "Needs you" must surface), so the digest and
+/// `rocky review --queue` agree: one
 /// entry per `(plan_id, model)` (the newest row), already-approved plans
 /// dropped (their sign-off marker exists), and decision-only custody rows
 /// with no persisted plan dropped (nothing to approve). The raw per-effect
@@ -329,7 +340,7 @@ fn build_escalations(root: &Path, decisions: &[&PolicyDecisionRecord]) -> BriefE
     if pending.is_empty() {
         return BriefEscalationsSection {
             availability: SectionAvailability::NoData,
-            note: Some("no decisions awaiting review in the window".to_string()),
+            note: Some("no decisions awaiting review".to_string()),
             total: 0,
             ranking: "recency".to_string(),
             pending,
@@ -1539,5 +1550,49 @@ mod tests {
         assert!(md.contains("rule 3"));
         // Drift fails closed, not silently.
         assert!(md.contains("unavailable: not wired"));
+    }
+
+    /// FIX: escalations are a current-state projection — a still-pending
+    /// escalation raised BEFORE the `--since` window must not vanish from
+    /// the digest ("Needs you" and `rocky review --queue` must agree; the
+    /// queue ranks staleness UP). History sections stay windowed.
+    #[test]
+    fn escalations_survive_the_since_window() {
+        let root = tempfile::tempdir().unwrap();
+        let state_path = root.path().join("state.redb");
+        let stale = decision(
+            1,
+            PolicyPrincipal::Agent,
+            PolicyEffect::RequireReview,
+            "fct_orders",
+            None,
+        );
+        {
+            let store = rocky_core::state::StateStore::open(&state_path).unwrap();
+            store.record_policy_decision(&stale).unwrap();
+        }
+        seed_plan_file(root.path(), &stale.plan_id);
+
+        // `now` is days after the decision, so the 24h window excludes it.
+        let now = ts(1) + Duration::days(3);
+        let out = compute_brief(
+            root.path(),
+            &state_path,
+            &root.path().join("rocky.toml"),
+            BriefSince::Hours24,
+            now,
+        )
+        .unwrap();
+
+        assert_eq!(
+            out.escalations.total, 1,
+            "a pending escalation older than the window must still surface"
+        );
+        assert_eq!(out.escalations.pending[0].model, "fct_orders");
+        // The windowed history sections do NOT admit the old row.
+        assert_eq!(
+            out.agent_activity.total, 0,
+            "agent activity reports the window, not all history"
+        );
     }
 }

--- a/engine/crates/rocky-cli/src/commands/containment.rs
+++ b/engine/crates/rocky-cli/src/commands/containment.rs
@@ -97,7 +97,7 @@ pub(crate) struct ProducerIndex {
 }
 
 /// How a single physical read resolves against the produced targets.
-enum ReadResolution {
+pub(crate) enum ReadResolution {
     /// Resolves to one or more candidate producers — each is added as a
     /// containment edge, so the reader is blocked iff at least one is poisoned.
     /// Exactly one candidate for an unambiguous 2/3-part read; possibly several
@@ -162,7 +162,7 @@ impl ProducerIndex {
     /// target table is a candidate edge to that producer. A qualified read
     /// (2/3-part) resolves uniquely or is [`ReadResolution::Ambiguous`]; a read
     /// with more than three parts is out of range → [`ReadResolution::External`].
-    fn resolve(&self, read: &str) -> ReadResolution {
+    pub(crate) fn resolve(&self, read: &str) -> ReadResolution {
         let Some(parts) = canonicalize_identifier(read) else {
             // Un-canonicalizable — cannot attribute the read; fail closed.
             return ReadResolution::Ambiguous;
@@ -322,7 +322,6 @@ impl ContainmentLedger {
         &mut self,
         name: &str,
         ref_deps: &[String],
-        model_names: &HashSet<String>,
         reads: &[String],
         reads_complete: bool,
         producers: &ProducerIndex,
@@ -332,8 +331,17 @@ impl ContainmentLedger {
         // A read set we cannot fully enumerate cannot prove disjointness.
         let mut uncertain = !reads_complete;
         for read in reads {
-            // A bare model-name read is already a `ref()` edge (in `ref_deps`).
-            if model_names.contains(read) {
+            // A bare read is "already covered" only when the resolver made the
+            // SAME call — ref-edge derivation is case-sensitive on the
+            // as-written identifier, so the test must be exact membership in
+            // `ref_deps`, not membership in the model-name set: a
+            // case-differing bare read (`FROM ORDERS` for model `orders`) has
+            // NO ref edge, and skipping it here dropped the dependency
+            // entirely (unquoted identifiers are case-insensitive in every
+            // supported warehouse, so it IS a real data dependency). Anything
+            // not exactly covered falls through to producer resolution, which
+            // is set-deduped and fail-closed.
+            if ref_deps.iter().any(|d| d == read) {
                 continue;
             }
             match producers.resolve(read) {
@@ -525,12 +533,11 @@ mod tests {
         producers: &[(&str, &str, &str, &str)],
     ) -> ContainmentLedger {
         let index = ProducerIndex::build(producers.iter().copied());
-        let names: HashSet<String> = models.iter().map(|(n, ..)| n.to_string()).collect();
         let mut led = ContainmentLedger::new();
         for (name, deps, reads, complete) in models {
             let deps: Vec<String> = deps.iter().copied().map(String::from).collect();
             let reads: Vec<String> = reads.iter().map(|s| s.to_lowercase()).collect();
-            led.add_model(name, &deps, &names, &reads, *complete, &index);
+            led.add_model(name, &deps, &reads, *complete, &index);
         }
         led
     }
@@ -552,6 +559,48 @@ mod tests {
         assert!(led.evaluate("B").is_some(), "B depends on failed A");
         assert!(led.evaluate("C").is_none(), "C is disjoint");
         assert!(led.evaluate("D").is_none(), "D is disjoint");
+    }
+
+    /// FIX: a case-differing bare read of a model (`FROM ORDERS` for model
+    /// `orders`) is a real data dependency — unquoted identifiers are
+    /// case-insensitive in every supported warehouse — but ref-edge
+    /// derivation is case-sensitive on the as-written identifier, so no
+    /// `ref()` edge exists. The old "bare model-name read is already a ref
+    /// edge" skip compared against the (lowercased) model-name set and
+    /// dropped the dependency entirely: `rollup` built on failed `orders`'
+    /// stale output. The skip now requires exact `ref_deps` membership, so
+    /// the read falls through to producer resolution and yields the edge.
+    #[test]
+    fn case_differing_bare_read_of_failed_producer_is_contained() {
+        // As collected by the run loop: reads arrive lowercased, so
+        // `FROM ORDERS` in rollup's SQL is the read "orders"; model `orders`
+        // produces `c.main.orders`. No ref edge (case-sensitive derivation
+        // classified `ORDERS` as a raw ref).
+        let mut led = ledger(
+            &[
+                ("orders", &[], &[], true),
+                ("rollup", &[], &["orders"], true),
+            ],
+            &[("orders", "c", "main", "orders")],
+        );
+        led.poison("orders");
+        assert!(
+            led.evaluate("rollup").is_some(),
+            "a case-differing bare read of a failed producer must be contained"
+        );
+
+        // The exact-match skip still dedups a true ref-edge bare read: with
+        // the ref edge present the read is already covered, and the verdict
+        // is identical (edge via ref_deps).
+        let mut led2 = ledger(
+            &[
+                ("orders", &[], &[], true),
+                ("rollup", &["orders"], &["orders"], true),
+            ],
+            &[("orders", "c", "main", "orders")],
+        );
+        led2.poison("orders");
+        assert!(led2.evaluate("rollup").is_some());
     }
 
     /// (b) Physical-table read of a failed producer's TARGET is contained even

--- a/engine/crates/rocky-cli/src/commands/history.rs
+++ b/engine/crates/rocky-cli/src/commands/history.rs
@@ -89,13 +89,29 @@ fn record_to_history(run: &RunRecord, audit: bool) -> RunHistoryRecord {
     }
 }
 
+/// The longest prefix of `s` that is at most `max_bytes` long and ends on a
+/// char boundary. Raw byte slicing (`&s[..n]`) panics mid-codepoint, and none
+/// of the strings sliced for display here are guaranteed ASCII: `--recipe` is
+/// an arbitrary CLI argument and model names/hashes can arrive via state sync
+/// from another writer.
+fn prefix_on_char_boundary(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
 /// Truncate a text-table cell to `max` bytes, appending `…` when cut, so
 /// long model names don't break the fixed-column recipe-history layout.
 fn truncate_cell(s: &str, max: usize) -> String {
     if s.len() <= max {
         s.to_string()
     } else {
-        format!("{}…", &s[..max.saturating_sub(1)])
+        format!("{}…", prefix_on_char_boundary(s, max.saturating_sub(1)))
     }
 }
 
@@ -285,7 +301,7 @@ pub fn run_history(
         if output_json {
             print_json(&output)?;
         } else {
-            let short = &recipe_hash[..recipe_hash.len().min(16)];
+            let short = prefix_on_char_boundary(recipe_hash, 16);
             println!("Executions of recipe {short}…:");
             println!(
                 "{:<14} {:<24} {:<24} {:<10} {:<12} {:<10}",
@@ -333,7 +349,7 @@ pub fn run_history(
                         .map(|r| r.to_string())
                         .unwrap_or_else(|| "-".to_string()),
                     exec.status,
-                    &exec.sql_hash[..exec.sql_hash.len().min(8)],
+                    prefix_on_char_boundary(&exec.sql_hash, 8),
                 );
             }
             println!("\nTotal executions: {}", output.executions.len());
@@ -546,6 +562,18 @@ fn compute_rolling_stats(
 mod tests {
     use super::*;
     use rocky_core::state::{ModelExecution, RunStatus, RunTrigger};
+
+    #[test]
+    fn prefix_on_char_boundary_never_splits_a_codepoint() {
+        // 16 bytes would land mid-'€' (3 bytes each): floor to the boundary.
+        let s = "€€€€€€"; // 18 bytes, 6 chars
+        assert_eq!(prefix_on_char_boundary(s, 16), "€€€€€");
+        assert_eq!(prefix_on_char_boundary(s, 18), s);
+        assert_eq!(prefix_on_char_boundary(s, 2), "");
+        assert_eq!(prefix_on_char_boundary("abcdef", 4), "abcd");
+        // The pre-fix shape: `&arg[..16]` panicked on exactly this input.
+        assert_eq!(truncate_cell("é-model-name-that-is-long", 10), "é-model-…");
+    }
 
     fn sample_record() -> RunRecord {
         RunRecord {

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -214,6 +214,22 @@ pub async fn plan(
                 &conn.schema,
                 &table.name,
             );
+            // `enabled = false` → `rocky run` excludes the table (reason
+            // `table_override_disabled`), so the preview must not render copy
+            // SQL for it — a reviewer would approve a statement run never
+            // executes. Surface the exclusion instead.
+            if effective_override.enabled == Some(false) {
+                output.statements.push(PlannedStatement {
+                    purpose: "excluded".into(),
+                    target: target_label,
+                    sql: format!(
+                        "-- {}: excluded by [[table_overrides]] enabled = false \
+                         (rocky run skips this table)",
+                        table.name
+                    ),
+                });
+                continue;
+            }
             let strategy = match super::run::build_replication_strategy_with_override(
                 pipeline,
                 &effective_override,
@@ -2102,6 +2118,59 @@ schema_template = "s__{source}"
         assert!(
             matches!(s2, MaterializationStrategy::FullRefresh),
             "non-matching table must stay FullRefresh, got {s2:?}"
+        );
+    }
+
+    #[test]
+    fn table_override_disabled_resolves_for_exclusion() {
+        // Pins the resolution feeding the plan-loop exclusion arm: a
+        // `[[table_overrides]] enabled = false` table must resolve with
+        // `enabled == Some(false)` so the preview emits an "excluded"
+        // statement instead of copy SQL `rocky run` will never execute
+        // (run skips it with reason `table_override_disabled`).
+        let toml = r#"
+[adapter.duck]
+type = "duckdb"
+path = "x.duckdb"
+
+[pipeline.p]
+type = "replication"
+
+[[pipeline.p.table_overrides]]
+match.table = "legacy_dump"
+enabled = false
+
+[pipeline.p.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.p.target]
+catalog_template = "c"
+schema_template = "s__{source}"
+"#;
+        let cfg: rocky_core::config::RockyConfig = toml::from_str(toml).expect("parse config");
+        let (_name, pipeline) =
+            crate::registry::resolve_replication_pipeline(&cfg, None).expect("resolve pipeline");
+
+        let disabled = resolve_table_override(
+            &pipeline.table_overrides,
+            "conn",
+            "raw__orders",
+            "legacy_dump",
+        );
+        assert_eq!(
+            disabled.enabled,
+            Some(false),
+            "disabled table must resolve enabled = Some(false) → excluded from the preview"
+        );
+
+        let kept =
+            resolve_table_override(&pipeline.table_overrides, "conn", "raw__orders", "orders");
+        assert_ne!(
+            kept.enabled,
+            Some(false),
+            "non-matching table must stay in the preview"
         );
     }
 

--- a/engine/crates/rocky-cli/src/commands/replay.rs
+++ b/engine/crates/rocky-cli/src/commands/replay.rs
@@ -156,17 +156,28 @@ fn classify_input(store: &StateStore, upstream: &UpstreamIdentity) -> ReplayChec
             upstream_key,
             blake3_hash,
         } => {
-            let present = store
-                .list_artifacts_by_hash(blake3_hash)
-                .map(|rows| !rows.is_empty())
-                .unwrap_or(false);
-            let reason = if present {
-                None
-            } else {
-                Some(format!(
-                    "upstream '{upstream_key}' output (blake3 {}) is absent from the artifact ledger",
-                    short_hash(blake3_hash)
-                ))
+            // A ledger READ error is not absence: report it as itself
+            // (fail-closed on resolvability, honest in the reason) instead of
+            // letting a corrupt/failing store masquerade as "bytes were never
+            // recorded".
+            let (present, reason) = match store.list_artifacts_by_hash(blake3_hash) {
+                Ok(rows) if !rows.is_empty() => (true, None),
+                Ok(_) => (
+                    false,
+                    Some(format!(
+                        "upstream '{upstream_key}' output (blake3 {}) is absent from the artifact ledger",
+                        short_hash(blake3_hash)
+                    )),
+                ),
+                Err(e) => (
+                    false,
+                    Some(format!(
+                        "artifact-ledger read failed for upstream '{upstream_key}' (blake3 {}): {e} \
+                         — fail-closed (this is a state-store read error, not evidence the bytes \
+                         were never recorded)",
+                        short_hash(blake3_hash)
+                    )),
+                ),
             };
             ReplayCheckInputOutput {
                 upstream_key: upstream_key.clone(),
@@ -203,24 +214,35 @@ pub(crate) fn classify_model(
     run_id: &str,
     model_name: &str,
 ) -> ReplayCheckModelOutput {
-    let provenance: Option<ProvenanceRecord> =
-        store.get_provenance(run_id, model_name).ok().flatten();
+    let non_replayable = |reason: String| ReplayCheckModelOutput {
+        model_name: model_name.to_string(),
+        verdict: "non_replayable".to_string(),
+        reasons: vec![reason],
+        has_provenance: false,
+        ir_parseable: false,
+        nondeterministic: false,
+        proof_class: None,
+        inputs: Vec::new(),
+    };
+    // A provenance READ error is not "no provenance": say so (fail-closed
+    // verdict either way, but the reason must not claim reuse was disabled
+    // when the store failed to answer).
+    let provenance: Option<ProvenanceRecord> = match store.get_provenance(run_id, model_name) {
+        Ok(p) => p,
+        Err(e) => {
+            return non_replayable(format!(
+                "provenance read failed: {e} — fail-closed (state-store read error, not \
+                 evidence the run was un-indexed)"
+            ));
+        }
+    };
 
     let Some(prov) = provenance else {
-        return ReplayCheckModelOutput {
-            model_name: model_name.to_string(),
-            verdict: "non_replayable".to_string(),
-            reasons: vec![
-                "no provenance recorded for this model (the run was not content-addressed, \
-                 or auditable reuse was disabled)"
-                    .to_string(),
-            ],
-            has_provenance: false,
-            ir_parseable: false,
-            nondeterministic: false,
-            proof_class: None,
-            inputs: Vec::new(),
-        };
+        return non_replayable(
+            "no provenance recorded for this model (the run was not content-addressed, \
+             or auditable reuse was disabled)"
+                .to_string(),
+        );
     };
 
     let mut reasons: Vec<String> = Vec::new();
@@ -247,11 +269,51 @@ pub(crate) fn classify_model(
         .unwrap_or(false);
 
     // Resolve every declared input against the ledger.
-    let inputs: Vec<ReplayCheckInputOutput> = prov
+    let mut inputs: Vec<ReplayCheckInputOutput> = prov
         .upstreams
         .iter()
         .map(|u| classify_input(store, u))
         .collect();
+
+    // Check ↔ execute parity for the all-in-run case: `--execute` (DAG)
+    // rebuilds every in-run upstream from ITS provenance, so an upstream
+    // produced in this same run by a model that recorded none cannot be
+    // replayed — even though its artifact row makes it ledger-resolvable.
+    // Without this, `--check` (and `rocky gc`, which reuses this verdict as
+    // its derivability eligibility) reports `replayable` for a chain the
+    // executor always refuses. In-run producers are probed by the target
+    // FQN's table segment against the run's executed names (absent or
+    // unreadable run record ⇒ probe skipped, current semantics kept).
+    if let Ok(Some(run)) = store.get_run(run_id) {
+        for input in &mut inputs {
+            if !input.resolvable || input.kind != "content" {
+                continue;
+            }
+            let table = input
+                .upstream_key
+                .rsplit('.')
+                .next()
+                .unwrap_or(&input.upstream_key);
+            let in_run_producer = run
+                .models_executed
+                .iter()
+                .map(|e| e.model_name.as_str())
+                .filter(|n| *n != model_name)
+                .find(|n| n.eq_ignore_ascii_case(table));
+            if let Some(producer) = in_run_producer
+                && matches!(store.get_provenance(run_id, producer), Ok(None))
+            {
+                input.resolvable = false;
+                input.reason = Some(format!(
+                    "upstream '{}' is produced in this same run by '{producer}', which recorded \
+                     no provenance — the DAG replay rebuilds in-run upstreams from their \
+                     provenance and cannot; `--execute` refuses this model even though the \
+                     artifact row exists",
+                    input.upstream_key
+                ));
+            }
+        }
+    }
     for input in &inputs {
         if let Some(reason) = &input.reason {
             reasons.push(reason.clone());
@@ -597,6 +659,18 @@ async fn replay_execute_model(
             rows: Some(rows),
             reasons: Vec::new(),
         }
+    } else if let Some(undefined) = hash_comparison_undefined(store, run_id, &recorded) {
+        // The digests describe different encodings/engine versions — an
+        // honest non-verdict, not a claimed reproducibility gap.
+        ReplayExecuteModelOutput {
+            model_name: model_name.to_string(),
+            verdict: "non_replayable".to_string(),
+            nondeterministic: check.nondeterministic,
+            recorded_hash: Some(recorded),
+            computed_hash: Some(computed),
+            rows: Some(rows),
+            reasons: vec![undefined],
+        }
     } else {
         let mut reasons = vec![format!(
             "re-executed output blake3 {} != recorded {}",
@@ -626,6 +700,62 @@ async fn replay_execute_model(
 // `rocky replay --execute [--verify]` (whole run) — DAG-order multi-model
 // re-execution
 // ---------------------------------------------------------------------------
+
+/// A recorded output hash whose provenance makes offline byte-comparison
+/// undefined — the honest reason, or `None` when the comparison is
+/// meaningful. Two proven-incomparable shapes:
+///
+/// - **cross-version recording**: parquet byte-identity is only pinned for
+///   the SAME engine version over the same inputs (parquet-rs upgrades
+///   legitimately change file bytes), so a hash recorded under another
+///   `rocky_version` cannot adjudicate determinism;
+/// - **live-writer recording**: an artifact row pointing at object storage
+///   means the recorded parquet was encoded with the live table's physical
+///   column mapping (`col-<uuid>` names read from its `_delta_log`), which
+///   the offline replay's deterministic logical mapping never reproduces —
+///   the recorded and re-derived digests describe different encodings of
+///   the same rows.
+///
+/// A verify hitting either shape is reported `non_replayable` with the
+/// reason, never `diverged` — `diverged` is reserved for a meaningful
+/// comparison that failed (the schema tells consumers to read it as a real
+/// reproducibility gap). A matching hash is still `bit_exact`: byte
+/// equality is meaningful regardless.
+fn hash_comparison_undefined(
+    store: &StateStore,
+    run_id: &str,
+    recorded_hash: &str,
+) -> Option<String> {
+    let current = env!("CARGO_PKG_VERSION");
+    if let Ok(Some(run)) = store.get_run(run_id)
+        && !run.rocky_version.is_empty()
+        && run.rocky_version != "<pre-audit>"
+        && run.rocky_version != current
+    {
+        return Some(format!(
+            "recorded under rocky {}, replaying under rocky {current} — parquet byte-identity \
+             is only pinned within one engine version, so this mismatch does not evidence \
+             nondeterminism; re-record on the current version to re-baseline",
+            run.rocky_version
+        ));
+    }
+    let live_writer_artifact = store
+        .list_artifacts_by_hash(recorded_hash)
+        .ok()
+        .map(|rows| {
+            rows.iter()
+                .any(|r| r.file_path.starts_with("s3://") || r.file_path.starts_with("s3a://"))
+        })
+        .unwrap_or(false);
+    live_writer_artifact.then(|| {
+        "the recorded hash was written by the live UniForm writer (its artifact row points at \
+         object storage): that parquet is encoded with the table's physical column mapping, \
+         which the offline replay's deterministic logical mapping cannot reproduce — byte \
+         comparison is undefined for this recording (the warehouse-path replay is a later \
+         phase)"
+            .to_string()
+    })
+}
 
 /// Fully-qualified `catalog.schema.table` identity of a model's output.
 ///
@@ -833,12 +963,30 @@ async fn replay_execute_dag(
                     if produced.contains(&upstream_key) {
                         cand.in_run_upstreams.push(upstream_key);
                     } else {
-                        cand.blocked_reason = Some(format!(
-                            "upstream '{upstream_key}' is content-addressed but is not produced by \
-                             any model in this recorded run; its recorded bytes live on object \
-                             storage that the creds-free DAG replay never reads (a warehouse-path \
-                             replay is a later phase)"
-                        ));
+                        // Diagnose honestly: an in-run producer that simply
+                        // recorded no provenance (so it is not a candidate) is
+                        // a different failure from a genuinely cross-run
+                        // upstream — the old message sent operators hunting a
+                        // phantom external dependency.
+                        let table = upstream_key.rsplit('.').next().unwrap_or(&upstream_key);
+                        let unindexed_in_run = record
+                            .models_executed
+                            .iter()
+                            .any(|e| e.model_name.eq_ignore_ascii_case(table));
+                        cand.blocked_reason = Some(if unindexed_in_run {
+                            format!(
+                                "upstream '{upstream_key}' is produced in this run by a model \
+                                 that recorded no provenance, so the DAG replay cannot rebuild \
+                                 it (the run predates auditable reuse or `[reuse]` was disabled)"
+                            )
+                        } else {
+                            format!(
+                                "upstream '{upstream_key}' is content-addressed but is not produced by \
+                                 any model in this recorded run; its recorded bytes live on object \
+                                 storage that the creds-free DAG replay never reads (a warehouse-path \
+                                 replay is a later phase)"
+                            )
+                        });
                         break;
                     }
                 }
@@ -925,7 +1073,16 @@ async fn replay_execute_dag(
 
         finished.insert(
             cand.model_name.clone(),
-            replay_execute_dag_node(&adapter, cand, verify, &mut attached, &mut materialized).await,
+            replay_execute_dag_node(
+                store,
+                run_id,
+                &adapter,
+                cand,
+                verify,
+                &mut attached,
+                &mut materialized,
+            )
+            .await,
         );
     }
 
@@ -939,6 +1096,8 @@ async fn replay_execute_dag(
 /// fail-closed cascade denies its downstreams.
 #[cfg(feature = "duckdb")]
 async fn replay_execute_dag_node(
+    store: &StateStore,
+    run_id: &str,
     adapter: &rocky_duckdb::adapter::DuckDbWarehouseAdapter,
     cand: &DagCandidate,
     verify: bool,
@@ -1028,6 +1187,16 @@ async fn replay_execute_dag_node(
             computed_hash: Some(computed),
             rows: Some(rows),
             reasons: Vec::new(),
+        }
+    } else if let Some(undefined) = hash_comparison_undefined(store, run_id, &recorded) {
+        ReplayExecuteModelOutput {
+            model_name: cand.model_name.clone(),
+            verdict: "non_replayable".to_string(),
+            nondeterministic: cand.nondeterministic,
+            recorded_hash: Some(recorded),
+            computed_hash: Some(computed),
+            rows: Some(rows),
+            reasons: vec![undefined],
         }
     } else {
         let mut reasons = vec![format!(

--- a/engine/crates/rocky-cli/src/commands/replay.rs
+++ b/engine/crates/rocky-cli/src/commands/replay.rs
@@ -659,24 +659,18 @@ async fn replay_execute_model(
             rows: Some(rows),
             reasons: Vec::new(),
         }
-    } else if let Some(undefined) = hash_comparison_undefined(store, run_id, &recorded) {
-        // The digests describe different encodings/engine versions — an
-        // honest non-verdict, not a claimed reproducibility gap.
-        ReplayExecuteModelOutput {
-            model_name: model_name.to_string(),
-            verdict: "non_replayable".to_string(),
-            nondeterministic: check.nondeterministic,
-            recorded_hash: Some(recorded),
-            computed_hash: Some(computed),
-            rows: Some(rows),
-            reasons: vec![undefined],
-        }
     } else {
         let mut reasons = vec![format!(
             "re-executed output blake3 {} != recorded {}",
             short_hash(&computed),
             short_hash(&recorded)
         )];
+        if let Some(caveat) = encoding_skew_caveat(store, &recorded) {
+            reasons.push(caveat);
+        }
+        if let Some(caveat) = version_skew_caveat(store, run_id) {
+            reasons.push(caveat);
+        }
         if check.nondeterministic {
             reasons.push(
                 "expected: the recipe contains a nondeterministic construct \
@@ -701,44 +695,16 @@ async fn replay_execute_model(
 // re-execution
 // ---------------------------------------------------------------------------
 
-/// A recorded output hash whose provenance makes offline byte-comparison
-/// undefined — the honest reason, or `None` when the comparison is
-/// meaningful. Two proven-incomparable shapes:
-///
-/// - **cross-version recording**: parquet byte-identity is only pinned for
-///   the SAME engine version over the same inputs (parquet-rs upgrades
-///   legitimately change file bytes), so a hash recorded under another
-///   `rocky_version` cannot adjudicate determinism;
-/// - **live-writer recording**: an artifact row pointing at object storage
-///   means the recorded parquet was encoded with the live table's physical
-///   column mapping (`col-<uuid>` names read from its `_delta_log`), which
-///   the offline replay's deterministic logical mapping never reproduces —
-///   the recorded and re-derived digests describe different encodings of
-///   the same rows.
-///
-/// A verify hitting either shape is reported `non_replayable` with the
-/// reason, never `diverged` — `diverged` is reserved for a meaningful
-/// comparison that failed (the schema tells consumers to read it as a real
-/// reproducibility gap). A matching hash is still `bit_exact`: byte
-/// equality is meaningful regardless.
-fn hash_comparison_undefined(
-    store: &StateStore,
-    run_id: &str,
-    recorded_hash: &str,
-) -> Option<String> {
-    let current = env!("CARGO_PKG_VERSION");
-    if let Ok(Some(run)) = store.get_run(run_id)
-        && !run.rocky_version.is_empty()
-        && run.rocky_version != "<pre-audit>"
-        && run.rocky_version != current
-    {
-        return Some(format!(
-            "recorded under rocky {}, replaying under rocky {current} — parquet byte-identity \
-             is only pinned within one engine version, so this mismatch does not evidence \
-             nondeterminism; re-record on the current version to re-baseline",
-            run.rocky_version
-        ));
-    }
+/// A `diverged` caveat when the recorded hash's artifact row points at
+/// object storage: a live UniForm write encodes parquet with the table's
+/// physical column mapping (`col-<uuid>` names read from its `_delta_log`),
+/// which the offline replay's deterministic logical mapping does not
+/// reproduce — so the mismatch may be an encoding difference over identical
+/// rows rather than a reproducibility gap. The provenance does not record
+/// the encoding identity, so this is disclosed as ambiguity on `diverged`
+/// (a matching hash is still `bit_exact`: byte equality is meaningful
+/// regardless of how the recording was encoded).
+fn encoding_skew_caveat(store: &StateStore, recorded_hash: &str) -> Option<String> {
     let live_writer_artifact = store
         .list_artifacts_by_hash(recorded_hash)
         .ok()
@@ -748,13 +714,39 @@ fn hash_comparison_undefined(
         })
         .unwrap_or(false);
     live_writer_artifact.then(|| {
-        "the recorded hash was written by the live UniForm writer (its artifact row points at \
-         object storage): that parquet is encoded with the table's physical column mapping, \
-         which the offline replay's deterministic logical mapping cannot reproduce — byte \
-         comparison is undefined for this recording (the warehouse-path replay is a later \
-         phase)"
+        "caveat: the recorded hash's artifact lives on object storage, where the live UniForm \
+         writer encodes parquet with the table's physical column mapping — a mapping the \
+         offline replay's deterministic encoding does not reproduce — so this mismatch may be \
+         encoding skew over identical rows rather than a reproducibility gap (the \
+         warehouse-path replay is a later phase)"
             .to_string()
     })
+}
+
+/// A `diverged` caveat when the recording came from a DIFFERENT engine
+/// version: parquet byte-identity is only pinned for the same version over
+/// the same inputs (a parquet-rs upgrade legitimately changes file bytes),
+/// so a cross-version mismatch is ambiguous — it may be encoding drift, not
+/// nondeterminism. Ambiguity stays `diverged` (unlike the provably-undefined
+/// live-writer shape) but the reason must say so.
+fn version_skew_caveat(store: &StateStore, run_id: &str) -> Option<String> {
+    let current = env!("CARGO_PKG_VERSION");
+    match store.get_run(run_id) {
+        Ok(Some(run))
+            if !run.rocky_version.is_empty()
+                && run.rocky_version != "<pre-audit>"
+                && run.rocky_version != current =>
+        {
+            Some(format!(
+                "caveat: recorded under rocky {}, replayed under rocky {current} — parquet \
+                 byte-identity is only pinned within one engine version, so this mismatch may \
+                 be encoding drift rather than nondeterminism; re-record on the current version \
+                 to re-baseline",
+                run.rocky_version
+            ))
+        }
+        _ => None,
+    }
 }
 
 /// Fully-qualified `catalog.schema.table` identity of a model's output.
@@ -1188,22 +1180,18 @@ async fn replay_execute_dag_node(
             rows: Some(rows),
             reasons: Vec::new(),
         }
-    } else if let Some(undefined) = hash_comparison_undefined(store, run_id, &recorded) {
-        ReplayExecuteModelOutput {
-            model_name: cand.model_name.clone(),
-            verdict: "non_replayable".to_string(),
-            nondeterministic: cand.nondeterministic,
-            recorded_hash: Some(recorded),
-            computed_hash: Some(computed),
-            rows: Some(rows),
-            reasons: vec![undefined],
-        }
     } else {
         let mut reasons = vec![format!(
             "re-executed output blake3 {} != recorded {}",
             short_hash(&computed),
             short_hash(&recorded)
         )];
+        if let Some(caveat) = encoding_skew_caveat(store, &recorded) {
+            reasons.push(caveat);
+        }
+        if let Some(caveat) = version_skew_caveat(store, run_id) {
+            reasons.push(caveat);
+        }
         if cand.nondeterministic {
             reasons.push(
                 "expected: the recipe contains a nondeterministic construct \

--- a/engine/crates/rocky-cli/src/commands/resilience.rs
+++ b/engine/crates/rocky-cli/src/commands/resilience.rs
@@ -86,6 +86,26 @@ pub(crate) fn retry_policy_allows(config: &rocky_core::config::RockyConfig) -> b
     }
 }
 
+/// Whether re-running a model's WHOLE materialization after an ambiguous
+/// failure is idempotent for its strategy.
+///
+/// A transient transport failure (connection reset, gateway 5xx, poll
+/// timeout) can land AFTER the warehouse durably committed the statement.
+/// Replace-shaped strategies converge on re-run (CTAS full refresh, keyed
+/// MERGE, delete+insert of the same window, view/MV/dynamic-table DDL,
+/// ephemeral no-op) — but `incremental` and `microbatch` materialize as a
+/// bare `INSERT INTO … <model SQL>` with no watermark literal or dedup key
+/// threaded in, so a commit-then-error retry appends every row a second
+/// time. Those strategies must surface the transient failure instead of
+/// silently double-applying.
+pub(crate) fn rerun_is_idempotent(strategy: &rocky_core::models::StrategyConfig) -> bool {
+    !matches!(
+        strategy,
+        rocky_core::models::StrategyConfig::Incremental { .. }
+            | rocky_core::models::StrategyConfig::Microbatch { .. }
+    )
+}
+
 /// Run `attempt_fn` under the classified-retry policy, returning the eventual
 /// [`MaterializationOutput`] (with its attempt trail stamped when a retry
 /// occurred) or the terminal error.
@@ -93,11 +113,13 @@ pub(crate) fn retry_policy_allows(config: &rocky_core::config::RockyConfig) -> b
 /// `attempt_fn` is invoked once per attempt; it should re-run the whole model
 /// materialization each time (a fresh timing clock is taken internally). Only
 /// a [`FailureClass::Transient`] verdict — within the per-model budget, the
-/// run-level budget, the breaker, and the policy gate — triggers a retry.
+/// run-level budget, the breaker, the policy gate, AND `rerun_idempotent`
+/// (see [`rerun_is_idempotent`]) — triggers a retry.
 pub(crate) async fn run_model_with_retry<F, Fut>(
     plan: &ResiliencePlan<'_>,
     warehouse: &dyn WarehouseAdapter,
     model_name: &str,
+    rerun_idempotent: bool,
     mut attempt_fn: F,
 ) -> anyhow::Result<MaterializationOutput>
 where
@@ -137,10 +159,23 @@ where
             Err(err) => {
                 let duration_ms = started.elapsed().as_millis() as u64;
                 let class = classify_anyhow(&err, warehouse);
-                // Run-loop retryability: transient AND not auth. A survived
-                // auth/permission failure is terminal here (the connector owns
-                // credential recovery); see `FailureClass::is_run_retryable`.
-                let run_retryable = class.is_run_retryable();
+                // Run-loop retryability: transient AND not auth (a survived
+                // auth/permission failure is terminal here — the connector
+                // owns credential recovery; see
+                // `FailureClass::is_run_retryable`) AND idempotent to re-run:
+                // a commit-ambiguous transient on a bare-INSERT strategy must
+                // not be re-applied.
+                let class_retryable = class.is_run_retryable();
+                if class_retryable && !rerun_idempotent {
+                    warn!(
+                        model = model_name,
+                        class = class.label(),
+                        "transient model failure NOT retried: this strategy's \
+                         re-run is not idempotent (a bare INSERT may already \
+                         have committed); surfacing the error instead"
+                    );
+                }
+                let run_retryable = class_retryable && rerun_idempotent;
 
                 // Record this transient failure into the run-level breaker
                 // *before* the gate reads it, so the failure that crosses the
@@ -348,7 +383,7 @@ mod tests {
         let breaker = CircuitBreaker::new(cfg.circuit_breaker_threshold);
         let plan = plan_for(&cfg, &budget, Some(&breaker));
 
-        let mat = run_model_with_retry(&plan, &adapter, "orders", || {
+        let mat = run_model_with_retry(&plan, &adapter, "orders", true, || {
             let adapter = &adapter;
             async move {
                 adapter
@@ -381,7 +416,7 @@ mod tests {
         let budget = RetryBudget::from_config(cfg.max_retries_per_run);
         let plan = plan_for(&cfg, &budget, None);
 
-        let mat = run_model_with_retry(&plan, &adapter, "orders", || {
+        let mat = run_model_with_retry(&plan, &adapter, "orders", true, || {
             let adapter = &adapter;
             async move {
                 adapter
@@ -411,7 +446,7 @@ mod tests {
         let plan = plan_for(&cfg, &budget, None);
 
         let attempts = std::sync::atomic::AtomicU32::new(0);
-        let result = run_model_with_retry(&plan, &adapter, "orders", || {
+        let result = run_model_with_retry(&plan, &adapter, "orders", true, || {
             attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             let adapter = &adapter;
             async move {
@@ -426,6 +461,62 @@ mod tests {
         assert!(result.is_err());
         // 1 initial + 2 retries = 3 invocations, then it gives up.
         assert_eq!(attempts.load(std::sync::atomic::Ordering::SeqCst), 3);
+    }
+
+    /// FIX: a transient failure on a NON-idempotent strategy (incremental /
+    /// microbatch — bare `INSERT INTO … <model SQL>`) is never retried: a
+    /// commit-ambiguous transport error may land after the warehouse durably
+    /// applied the statement, and a re-run would append every row a second
+    /// time. One attempt, then the (transient) error surfaces.
+    #[tokio::test]
+    async fn transient_failure_on_non_idempotent_strategy_not_retried() {
+        let adapter = FlakyAdapter::new(1);
+        let cfg = ResilienceConfig {
+            transient_max_retries: 2,
+            initial_backoff_ms: 0,
+            jitter: false,
+            ..Default::default()
+        };
+        let budget = RetryBudget::unbounded();
+        let plan = plan_for(&cfg, &budget, None);
+
+        let attempts = std::sync::atomic::AtomicU32::new(0);
+        let result = run_model_with_retry(&plan, &adapter, "orders", false, || {
+            attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let adapter = &adapter;
+            async move {
+                adapter
+                    .execute_statement("x")
+                    .await
+                    .map(|()| sample_mat())
+                    .map_err(anyhow::Error::from)
+            }
+        })
+        .await;
+        assert!(
+            result.is_err(),
+            "the transient error must surface un-retried"
+        );
+        assert_eq!(
+            attempts.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "a non-idempotent re-run must not be attempted"
+        );
+    }
+
+    /// `rerun_is_idempotent` gates exactly the bare-INSERT strategies.
+    #[test]
+    fn rerun_idempotency_by_strategy() {
+        use rocky_core::models::StrategyConfig;
+        assert!(rerun_is_idempotent(&StrategyConfig::FullRefresh));
+        assert!(rerun_is_idempotent(&StrategyConfig::Merge {
+            unique_key: vec!["id".into()],
+            update_columns: None,
+        }));
+        assert!(rerun_is_idempotent(&StrategyConfig::View));
+        assert!(!rerun_is_idempotent(&StrategyConfig::Incremental {
+            timestamp_column: "ts".into(),
+        }));
     }
 
     /// A permanent failure is never retried — a single attempt, then the error.
@@ -466,7 +557,7 @@ mod tests {
         let plan = plan_for(&cfg, &budget, None);
 
         let attempts = std::sync::atomic::AtomicU32::new(0);
-        let result = run_model_with_retry(&plan, &adapter, "orders", || {
+        let result = run_model_with_retry(&plan, &adapter, "orders", true, || {
             attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             let adapter = &adapter;
             async move {
@@ -497,7 +588,7 @@ mod tests {
         };
         let budget = RetryBudget::unbounded();
         let plan = plan_for(&cfg, &budget, None);
-        let result = run_model_with_retry(&plan, &adapter, "orders", || {
+        let result = run_model_with_retry(&plan, &adapter, "orders", true, || {
             let adapter = &adapter;
             async move {
                 adapter
@@ -530,7 +621,7 @@ mod tests {
             budget: &budget,
             breaker: None,
         };
-        let result = run_model_with_retry(&plan, &adapter, "orders", || {
+        let result = run_model_with_retry(&plan, &adapter, "orders", true, || {
             let adapter = &adapter;
             async move {
                 adapter
@@ -548,7 +639,7 @@ mod tests {
     /// materialization was actually attempted.
     async fn count_attempts(plan: &ResiliencePlan<'_>, adapter: &FlakyAdapter, name: &str) -> u32 {
         let calls = std::sync::atomic::AtomicU32::new(0);
-        let _ = run_model_with_retry(plan, adapter, name, || {
+        let _ = run_model_with_retry(plan, adapter, name, true, || {
             calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             let adapter = &adapter;
             async move {
@@ -667,7 +758,7 @@ mod tests {
         let plan = plan_for(&cfg, &budget, None);
 
         let calls = std::sync::atomic::AtomicU32::new(0);
-        let result = run_model_with_retry(&plan, &adapter, "orders", || {
+        let result = run_model_with_retry(&plan, &adapter, "orders", true, || {
             calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             let adapter = &adapter;
             async move {

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -4799,9 +4799,23 @@ pub(crate) async fn execute_backfill_set(
     let mut output = RunOutput::new(String::new(), 0, 1);
 
     let schema_cache_cfg = rocky_cfg.cache.schemas.clone().with_ttl_override(None);
-    // A backfill never runs shadowed, so the skip gate resolves against the
-    // `[run]` config alone; it stays inert unless the operator enabled it.
-    let skip_gate = SkipGateConfig::resolve(&SkipRunOptions::default(), &rocky_cfg.run, false);
+    // A backfill is an explicit, reviewed rebuild order, so the plain skip
+    // gate must never adjudicate it — its signals (upstream `MAX(ts)` /
+    // rowcount) are blind to exactly the backdated corrections backfills
+    // exist to repair, and `[run] skip_unchanged = true` would otherwise
+    // silently no-op the whole approved recovery. `force_rebuild` makes the
+    // gate inert (`is_active()` = false) and pins the content-addressed
+    // column-skip off (belt over `backfill_reuse_gates`' suspenders), while
+    // point-to reuse stays governed by `backfill_reuse_gates` alone — a
+    // byte-identical reuse still satisfies a rebuild order.
+    let skip_gate = SkipGateConfig::resolve(
+        &SkipRunOptions {
+            force_rebuild: true,
+            ..Default::default()
+        },
+        &rocky_cfg.run,
+        false,
+    );
     let run_vars = rocky_core::run_vars::RunVars::new();
     // A backfill is an explicit rebuild order: point-to reuse may still
     // satisfy it byte-identically, but the column-level skip never may.
@@ -5257,12 +5271,6 @@ pub(crate) async fn execute_models(
                 )
             }),
         );
-        let model_names: std::collections::HashSet<String> = compile_result
-            .project
-            .models
-            .iter()
-            .map(|m| m.config.name.clone())
-            .collect();
         let dep_by_model: std::collections::HashMap<&str, &[String]> = compile_result
             .project
             .dag_nodes
@@ -5292,14 +5300,7 @@ pub(crate) async fn execute_models(
                 } else {
                     (Vec::new(), false)
                 };
-            containment.add_model(
-                name,
-                ref_deps,
-                &model_names,
-                &reads,
-                reads_complete,
-                &producers,
-            );
+            containment.add_model(name, ref_deps, &reads, reads_complete, &producers);
         }
         containment.seed_failed(compile_failed_models.iter().cloned());
     }
@@ -5341,6 +5342,29 @@ pub(crate) async fn execute_models(
             cooldown_seconds: None,
         });
     }
+    // A supervised backfill's planned set must survive contact with the
+    // compiled project intact: the per-layer filter below silently DROPS set
+    // members that no longer compile to a model (renamed/deleted since the
+    // plan was approved), and a zero-or-partial-model run then reports
+    // Success — the approved recovery quietly shrinks. Fail loud instead.
+    if let Some(set) = model_set {
+        let missing: Vec<&str> = set
+            .iter()
+            .map(String::as_str)
+            .filter(|name| compile_result.project.model(name).is_none())
+            .collect();
+        if !missing.is_empty() {
+            anyhow::bail!(
+                "backfill plan names {} model(s) that no longer exist in the compiled project: \
+                 {} — the approved scope cannot be executed as reviewed (models renamed or \
+                 deleted since the plan was composed). Re-compose the backfill against the \
+                 current project.",
+                missing.len(),
+                missing.join(", "),
+            );
+        }
+    }
+
     let execution_layers: &[Vec<String>] = match &augmented_plan {
         Some(plan) => &plan.layers,
         None => &compile_result.project.layers,
@@ -5551,6 +5575,7 @@ pub(crate) async fn execute_models(
                                 plan,
                                 warehouse,
                                 name,
+                                super::resilience::rerun_is_idempotent(&model.config.strategy),
                                 || {
                                     execute_one_plain_model(
                                         model,
@@ -5657,6 +5682,35 @@ pub(crate) async fn execute_models(
         for &(idx, model_name, model) in &matched {
             let model_name: &str = model_name.as_str();
 
+            // Re-adjudicate immediately before dispatch (serial path): the
+            // layer's verdicts were computed before any of this layer's models
+            // ran, but a mid-layer failure poisons the ledger, and a later
+            // same-layer model — an *uncertain* one, whose reads yield no
+            // ordering edge that augmented layering could separate on — must
+            // fail closed the moment any failure exists, not build on data it
+            // can't be proven disjoint from. Serial fail-fast aborts at that
+            // failure, so this never withholds anything fail-fast would build.
+            if resilience.contain_failures
+                && let Some(decision) = containment.evaluate(model_name)
+            {
+                containment.poison(model_name);
+                info!(
+                    model = model_name,
+                    blocked_by = decision.blocked_by.join(",").as_str(),
+                    fail_closed = decision.fail_closed,
+                    "containment: withholding model (mid-layer failure preceded it)"
+                );
+                output.contained.push(crate::output::ContainedModelOutput {
+                    model: model_name.to_string(),
+                    unblock_hint: super::containment::unblock_hint(
+                        &decision.blocked_by,
+                        decision.fail_closed,
+                    ),
+                    blocked_by: decision.blocked_by,
+                });
+                continue;
+            }
+
             // Content-addressed column-level skip, default-ON behind
             // `[reuse] column_level` (the caller has already folded the
             // `--no-reuse` escape hatch and the backfill rebuild-order into
@@ -5676,7 +5730,16 @@ pub(crate) async fn execute_models(
                     rocky_core::models::StrategyConfig::ContentAddressed { .. }
                 )
             {
-                let model_ir = model.to_model_ir();
+                // The fully-typed IR, not bare `to_model_ir()`: an empty
+                // `typed_columns` forces `skip_hash()` to the never-equal
+                // `None` sentinel, which made this gate silently inert on the
+                // real CLI path (every evaluation fell through to build).
+                let model_ir = typed_model_ir(
+                    model,
+                    exec_ctx.typed_models,
+                    exec_ctx.surrogate_keys,
+                    dialect,
+                );
                 if let ColumnSkipOutcome::Skip {
                     prior_output_column_hashes,
                     prior_blake3,
@@ -5760,7 +5823,19 @@ pub(crate) async fn execute_models(
                 model.config.strategy,
                 rocky_core::models::StrategyConfig::ContentAddressed { .. }
             ) {
-                let model_ir = model.to_model_ir();
+                // The fully-typed IR (typechecker columns + surrogate-key
+                // wrap), never bare `to_model_ir()`: the Arrow conversion in
+                // `execute_content_addressed_model` hard-errors when the
+                // declared column count (0 when unenriched) disagrees with the
+                // warehouse result, and an empty `typed_columns` also nulls
+                // `skip_hash()`, so the reuse spine / provenance ledger was
+                // never populated by a real `rocky run`.
+                let model_ir = typed_model_ir(
+                    model,
+                    exec_ctx.typed_models,
+                    exec_ctx.surrogate_keys,
+                    dialect,
+                );
                 let model_started_at = Utc::now();
                 let target_table_full_name = format!(
                     "{}.{}.{}",
@@ -5871,11 +5946,14 @@ pub(crate) async fn execute_models(
                         // downstream can record what it read from this upstream.
                         // Recorded only when the build produced hashes: a
                         // genuine unpartitioned build always does; a point-to
-                        // reuse carries the referenced run's recorded hashes
-                        // when present; a partitioned build produces none (the
-                        // per-file fold is deferred). An absent entry degrades a
-                        // downstream baseline to a safe rebuild. Keyed by target
-                        // full name as `reuse_outputs` is.
+                        // reuse never does (every pointer commit returns empty
+                        // `column_hashes` — see `WriteResult` — so a reused
+                        // upstream seeds no downstream baseline and the
+                        // consumer rebuilds, the safe direction); a partitioned
+                        // build produces none either (the per-file fold is
+                        // deferred). An absent entry degrades a downstream
+                        // baseline to a safe rebuild. Keyed by target full name
+                        // as `reuse_outputs` is.
                         if !summary.output_column_hashes.is_empty() {
                             built_output_hashes.insert(
                                 target_table_full_name.clone(),
@@ -6149,6 +6227,7 @@ pub(crate) async fn execute_models(
                 &resilience_plan,
                 warehouse,
                 model_name,
+                super::resilience::rerun_is_idempotent(&model.config.strategy),
                 || {
                     execute_one_plain_model(
                         model,
@@ -11848,6 +11927,54 @@ merge_keys = ["id"]
         );
     }
 
+    /// The content-addressed dispatch must hand the CA runner and the
+    /// column-skip gate the fully-typed IR — `typed_model_ir`, the same
+    /// helper the plain gate uses — never bare `to_model_ir()`. Bare IR
+    /// leaves `typed_columns` empty, which (a) hard-errors the Arrow
+    /// conversion ("model declares 0 typed columns") for any non-empty
+    /// SELECT and (b) nulls `skip_hash()`, silently disabling the reuse
+    /// spine and the default-ON column-level skip on the real CLI path.
+    #[test]
+    fn content_addressed_dispatch_ir_is_typed() {
+        let content = "---toml\nname = \"ca_events\"\n\n[strategy]\ntype = \"content_addressed\"\nstorage_prefix = \"s3://bucket/ca_events\"\n\n[target]\ncatalog = \"analytics\"\nschema = \"marts\"\ntable = \"ca_events\"\n---\n\nSELECT 1 AS id, 'a' AS name\n";
+        let model = rocky_core::models::parse_model_inline(content, "ca_events.sql", None)
+            .expect("parse content-addressed model");
+        assert!(
+            model.to_model_ir().skip_hash().is_none(),
+            "bare to_model_ir() has no typed columns — the regression shape"
+        );
+
+        let mut typed_models = indexmap::IndexMap::new();
+        typed_models.insert(
+            "ca_events".to_string(),
+            vec![
+                rocky_compiler::types::TypedColumn {
+                    name: "id".into(),
+                    data_type: rocky_ir::RockyType::Int64,
+                    nullable: false,
+                },
+                rocky_compiler::types::TypedColumn {
+                    name: "name".into(),
+                    data_type: rocky_ir::RockyType::String,
+                    nullable: false,
+                },
+            ],
+        );
+        let surrogate_keys = std::collections::HashMap::new();
+        let dialect = rocky_duckdb::dialect::DuckDbSqlDialect;
+
+        let ir = super::typed_model_ir(&model, &typed_models, &surrogate_keys, &dialect);
+        assert_eq!(
+            ir.typed_columns.len(),
+            2,
+            "dispatch IR must carry the typechecker's columns"
+        );
+        assert!(
+            ir.skip_hash().is_some(),
+            "a typed content-addressed IR canonicalises for the skip gate / reuse spine"
+        );
+    }
+
     /// Write a `full_refresh` model with an explicit `(schema, table)` target.
     fn write_model_with_target(
         dir: &std::path::Path,
@@ -12178,6 +12305,62 @@ merge_keys = ["id"]
     /// (CTE) project: `stage_orders` produces `main.orders_current` and fails;
     /// `rollup` reads it through a CTE, so its read set is unenumerable
     /// (`lineage_is_provably_complete` is false) and no ordering edge is derived.
+    /// FIX (serial fail-closed belt): once a mid-layer failure has poisoned
+    /// the ledger, a LATER same-layer *uncertain* (CTE — unenumerable reads)
+    /// model is re-adjudicated immediately before its serial dispatch and
+    /// withheld. Pre-fix, the layer's verdicts were computed only once,
+    /// before any model ran, so the uncertain model built on data it could
+    /// not be proven disjoint from — something serial fail-fast (which
+    /// aborts at the failure) would never have materialized, violating the
+    /// containment ⊆ fail-fast invariant. Kahn layering dispatches
+    /// alphabetically, so `a_fail` deterministically precedes `z_rollup`.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn containment_serial_withholds_uncertain_after_mid_layer_failure() {
+        use rocky_core::traits::WarehouseAdapter;
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).unwrap();
+        let db = tmp.path().join("t.duckdb");
+        {
+            let seed = DuckDbWarehouseAdapter::open(&db).expect("seed open");
+            seed.execute_statement("CREATE TABLE main.orders_current AS SELECT 999 AS id")
+                .await
+                .unwrap();
+        }
+        write_model_with_target(
+            &models_dir,
+            "a_fail",
+            "SELECT * FROM main.missing_source",
+            "main",
+            "a_fail_t",
+        );
+        write_model_with_target(
+            &models_dir,
+            "z_rollup",
+            "WITH x AS (SELECT id FROM main.orders_current) SELECT COUNT(*) AS n FROM x",
+            "main",
+            "z_rollup",
+        );
+
+        let (out, _) = run_models_with_containment(&models_dir, &db).await;
+
+        assert!(
+            out.contained.iter().any(|c| c.model == "z_rollup"),
+            "the uncertain model dispatched after a same-layer failure must be \
+             withheld, got contained = {:?}",
+            out.contained
+        );
+        assert!(
+            !out.materializations
+                .iter()
+                .any(|m| m.asset_key.last().map(String::as_str) == Some("z_rollup")),
+            "the withheld model must not materialize"
+        );
+    }
+
     async fn setup_same_layer_uncertain_project(
         models_dir: &std::path::Path,
         db: &std::path::Path,
@@ -15111,6 +15294,37 @@ merge_keys = ["id"]
         assert!(!backfill_reuse_gates(&default_cfg).1);
     }
 
+    /// FIX-cluster regression: the PLAIN skip gate is likewise inert for a
+    /// supervised backfill even when `[run] skip_unchanged = true`. The
+    /// gate's signals (upstream `MAX(ts)` / rowcount) are blind to backdated
+    /// corrections — exactly what a backfill repairs — so an operator-enabled
+    /// gate would silently no-op the whole approved rebuild while reporting
+    /// Success. `execute_backfill_set` resolves its gate with
+    /// `force_rebuild: true`; this pins that resolution shape.
+    #[test]
+    fn backfill_skip_gate_is_inert_even_when_run_config_opts_in() {
+        let cfg: rocky_core::config::RockyConfig =
+            toml::from_str("[run]\nskip_unchanged = true").unwrap();
+        assert!(cfg.run.skip_unchanged, "premise: operator opted in");
+        let gate = SkipGateConfig::resolve(
+            &SkipRunOptions {
+                force_rebuild: true,
+                ..Default::default()
+            },
+            &cfg.run,
+            false,
+        );
+        assert!(
+            !gate.is_active(),
+            "a reviewed backfill is an explicit rebuild order — the plain \
+             gate must never adjudicate it"
+        );
+        assert!(
+            gate.force_rebuild,
+            "force_rebuild also pins the content-addressed column-skip off"
+        );
+    }
+
     /// FIX-cluster regression: a column-skipped model publishes its PRIOR
     /// outputs to both in-run composition maps — the producer column hashes
     /// into `built_output_hashes` and (under `[reuse]`) the prior artifact's
@@ -16604,8 +16818,12 @@ table = "fct_events"
             inner: &inner,
             fail_next: AtomicU32::new(0),
         };
-        let mat_clean =
-            crate::commands::resilience::run_model_with_retry(&plan, &clean_adapter, "fct", || {
+        let mat_clean = crate::commands::resilience::run_model_with_retry(
+            &plan,
+            &clean_adapter,
+            "fct",
+            true,
+            || {
                 super::execute_one_plain_model(
                     &model,
                     &clean_adapter as &dyn WarehouseAdapter,
@@ -16614,9 +16832,10 @@ table = "fct_events"
                     Instant::now(),
                     exec_ctx,
                 )
-            })
-            .await
-            .expect("clean build succeeds");
+            },
+        )
+        .await
+        .expect("clean build succeeds");
         assert!(
             mat_clean.attempts.is_empty(),
             "a clean first-try success carries no attempt trail"
@@ -16631,8 +16850,12 @@ table = "fct_events"
             inner: &inner,
             fail_next: AtomicU32::new(1),
         };
-        let mat_flaky =
-            crate::commands::resilience::run_model_with_retry(&plan, &flaky_adapter, "fct", || {
+        let mat_flaky = crate::commands::resilience::run_model_with_retry(
+            &plan,
+            &flaky_adapter,
+            "fct",
+            true,
+            || {
                 super::execute_one_plain_model(
                     &model,
                     &flaky_adapter as &dyn WarehouseAdapter,
@@ -16641,9 +16864,10 @@ table = "fct_events"
                     Instant::now(),
                     exec_ctx,
                 )
-            })
-            .await
-            .expect("flaky build recovers after a transient failure");
+            },
+        )
+        .await
+        .expect("flaky build recovers after a transient failure");
 
         // (1) Reachability: recovered, with an honest attempt trail.
         assert_eq!(

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -448,12 +448,12 @@ fn is_zero(v: &usize) -> bool {
 pub struct ExecutionSummary {
     pub concurrency: usize,
     pub tables_processed: usize,
-    /// Tables that failed during the **execution phase** — copy or runtime
-    /// failures while materializing. This does **not** include models excluded
-    /// before execution started (for example, a model that failed to compile);
-    /// those are counted only in the top-level `RunOutput.tables_failed`. For
-    /// overall run pass/fail, read the top-level `tables_failed` / `status`,
-    /// not this `execution.tables_failed`.
+    /// Source tables whose **copy failed** on the replication path (the
+    /// `table_errors` count). Transformation-model runtime failures — including
+    /// contained-cause failures — are reported in `errors` and the top-level
+    /// `RunOutput.tables_failed`, not here; transformation-only runs leave the
+    /// whole `execution` block unpopulated. For overall run pass/fail, read
+    /// the top-level `tables_failed` / `status`, never this field.
     pub tables_failed: usize,
     /// Whether adaptive concurrency (AIMD throttle) was enabled for this run.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
@@ -3452,6 +3452,14 @@ pub struct BackfillOutput {
     pub review_command: String,
     /// The exact command that executes the plan once reviewed.
     pub apply_command: String,
+    /// Composition warnings the reviewer must weigh before approving. Today:
+    /// `incremental` / `microbatch` closure members, whose transformation
+    /// re-run is a bare `INSERT INTO … <model SQL>` — depending on the model's
+    /// own filtering it appends duplicate rows or loads nothing, rather than
+    /// rebuilding a window. Empty (and omitted from JSON) when the closure
+    /// carries no such member.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
     /// Human-readable one-line summary.
     pub message: String,
 }
@@ -6678,8 +6686,11 @@ pub struct AuditDecisionEntry {
 ///
 /// The selector is resolved in priority order: a 64-char hex string with a
 /// plan file on disk is a [`AuditSubjectKind::Plan`]; a string matching a
-/// `run_id` in the run ledger is a [`AuditSubjectKind::Run`]; anything else is
-/// treated as a [`AuditSubjectKind::Model`] name.
+/// `run_id` in the run ledger is a [`AuditSubjectKind::Run`]; a string the
+/// decision ledger keys rows by is likewise a [`AuditSubjectKind::Plan`]
+/// (the plan file may be gone, or the id may be a decision-only custody key
+/// that never had one); anything else is treated as a
+/// [`AuditSubjectKind::Model`] name.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum AuditSubjectKind {
@@ -6687,7 +6698,10 @@ pub enum AuditSubjectKind {
     Model,
     /// A `run_id` from the run ledger.
     Run,
-    /// A `plan_id` (64-char blake3 hex) with a plan file on disk.
+    /// A `plan_id` — a 64-char blake3 hex with a plan file on disk, or any
+    /// id the decision ledger keys rows by (including decision-only custody
+    /// ids like `freeze:…` / `draft:…` / `autoapply:…`, which never had a
+    /// plan file).
     Plan,
 }
 

--- a/engine/crates/rocky-core/src/circuit_breaker.rs
+++ b/engine/crates/rocky-core/src/circuit_breaker.rs
@@ -185,13 +185,24 @@ impl CircuitBreaker {
     /// failure counter; in `HalfOpen` it also closes the breaker.
     /// Returns [`TransitionOutcome::Recovered`] when a HalfOpen → Closed
     /// transition happened, otherwise [`TransitionOutcome::Unchanged`].
+    ///
+    /// In `Open` the breaker stays Open: recovery goes exclusively through
+    /// the timeout → HalfOpen → trial path. Closing from Open here would let
+    /// an in-flight success that raced the trip (or, for the run loop's
+    /// shared breaker, any later model's clean build) silently re-arm — the
+    /// `[resilience]` contract is "once tripped, no further model is retried
+    /// for the rest of the run", and event subscribers would see Open end
+    /// with no `Recovered` transition.
     pub fn record_success(&self) -> TransitionOutcome {
         self.consecutive_failures.store(0, Ordering::Release);
-        let prev = self.state.swap(STATE_CLOSED, Ordering::AcqRel);
-        if prev == STATE_HALF_OPEN {
-            TransitionOutcome::Recovered
-        } else {
-            TransitionOutcome::Unchanged
+        match self.state.compare_exchange(
+            STATE_HALF_OPEN,
+            STATE_CLOSED,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => TransitionOutcome::Recovered,
+            Err(_) => TransitionOutcome::Unchanged,
         }
     }
 
@@ -305,6 +316,20 @@ mod tests {
     }
 
     #[test]
+    fn test_success_while_open_does_not_close() {
+        // A straggler success racing the trip (it passed `check()` before the
+        // breaker opened) must not silently re-arm: Open recovers exclusively
+        // via timeout → HalfOpen → trial, and — for the run loop's shared
+        // breaker — "once tripped, no further model is retried this run".
+        let cb = CircuitBreaker::new(1);
+        cb.record_failure("boom");
+        assert!(cb.is_tripped());
+        assert_eq!(cb.record_success(), TransitionOutcome::Unchanged);
+        assert!(cb.is_tripped(), "Open must survive a raced success");
+        assert!(cb.check().is_err());
+    }
+
+    #[test]
     fn test_disabled_when_threshold_zero() {
         let cb = CircuitBreaker::new(0);
         for _ in 0..100 {
@@ -335,13 +360,25 @@ mod tests {
     }
 
     #[test]
-    fn test_half_open_after_timeout() {
-        // Threshold 2 so the counter-reset post-recovery is observable:
-        // one follow-up failure should NOT re-trip.
-        let cb = CircuitBreaker::with_recovery_timeout(2, Duration::from_millis(30));
+    fn test_open_before_recovery_timeout() {
+        // A window no loaded CI runner can plausibly cross between the trip
+        // and the check — asserting still-Open on a millisecond window races
+        // the wall clock and flakes when the scheduler stalls the thread.
+        let cb = CircuitBreaker::with_recovery_timeout(2, Duration::from_secs(300));
         cb.record_failure("boom 1");
         assert_eq!(cb.record_failure("boom 2"), TransitionOutcome::Tripped);
         assert!(cb.check().is_err(), "still Open before timeout");
+    }
+
+    #[test]
+    fn test_half_open_after_timeout() {
+        // Threshold 2 so the counter-reset post-recovery is observable:
+        // one follow-up failure should NOT re-trip. (The pre-timeout
+        // still-Open assertion lives in `test_open_before_recovery_timeout`
+        // on a generous window — on this 30ms window it would race.)
+        let cb = CircuitBreaker::with_recovery_timeout(2, Duration::from_millis(30));
+        cb.record_failure("boom 1");
+        assert_eq!(cb.record_failure("boom 2"), TransitionOutcome::Tripped);
 
         std::thread::sleep(Duration::from_millis(40));
         assert!(cb.check().is_ok(), "HalfOpen should let trial through");

--- a/engine/crates/rocky-verify/src/lib.rs
+++ b/engine/crates/rocky-verify/src/lib.rs
@@ -297,13 +297,17 @@ pub fn verify_artifacts(manifest: &Manifest, artifacts_dir: &Path) -> Vec<Artifa
 }
 
 fn check_one_artifact(output: &OutputHash, artifacts_dir: &Path) -> ArtifactCheck {
+    // Resolution is confined to `artifacts_dir`: the manifest's recorded
+    // `path` contributes only its basename. Honoring the recorded path
+    // verbatim (absolute, or relative to the verifier's cwd) would let a
+    // check pass against a file OUTSIDE the directory being verified — a
+    // manifest is untrusted input, and "the bytes under --artifacts-dir
+    // match" is the question being asked.
     let mut candidates: Vec<PathBuf> = Vec::new();
-    if let Some(path) = output.path.as_ref() {
-        // A bare/relative path may already point at the file.
-        candidates.push(PathBuf::from(path));
-        if let Some(name) = Path::new(path).file_name() {
-            candidates.push(artifacts_dir.join(name));
-        }
+    if let Some(path) = output.path.as_ref()
+        && let Some(name) = Path::new(path).file_name()
+    {
+        candidates.push(artifacts_dir.join(name));
     }
     candidates.push(artifacts_dir.join(&output.hash));
     candidates.push(artifacts_dir.join(format!("{}.parquet", output.hash)));
@@ -447,6 +451,64 @@ mod tests {
         m["manifest_version"] = serde_json::json!("0.2");
         let errs = validate_schema(&m).unwrap();
         assert!(!errs.is_empty(), "an unknown manifest_version must fail");
+    }
+
+    #[test]
+    fn artifact_check_never_resolves_outside_artifacts_dir() {
+        // A manifest's recorded `path` is untrusted: an absolute path to an
+        // intact copy elsewhere on the machine must NOT satisfy the check
+        // when the copy under --artifacts-dir was tampered with.
+        let outside = tempfile::TempDir::new().unwrap();
+        let intact = outside.path().join("orders.parquet");
+        std::fs::write(&intact, b"intact bytes").unwrap();
+        let hash = blake3::hash(b"intact bytes").to_hex().to_string();
+
+        let artifacts = tempfile::TempDir::new().unwrap();
+        std::fs::write(artifacts.path().join("orders.parquet"), b"TAMPERED").unwrap();
+
+        let output = OutputHash {
+            hash,
+            path: Some(intact.display().to_string()),
+        };
+        let check = check_one_artifact(&output, artifacts.path());
+        assert!(
+            !check.matched,
+            "a tampered in-dir artifact must fail even when the recorded \
+             absolute path points at an intact out-of-dir copy: {check:?}"
+        );
+        let resolved = check.file.expect("the in-dir candidate must resolve");
+        assert!(
+            resolved.starts_with(artifacts.path()),
+            "resolution must stay inside --artifacts-dir, got {}",
+            resolved.display()
+        );
+    }
+
+    #[test]
+    fn artifact_check_resolves_basename_and_hash_forms_in_dir() {
+        let artifacts = tempfile::TempDir::new().unwrap();
+        let bytes = b"the artifact bytes";
+        let hash = blake3::hash(bytes).to_hex().to_string();
+
+        // Basename of the recorded path, under artifacts_dir.
+        std::fs::write(artifacts.path().join("orders.parquet"), bytes).unwrap();
+        let by_name = check_one_artifact(
+            &OutputHash {
+                hash: hash.clone(),
+                path: Some("/produced/on/another/host/orders.parquet".into()),
+            },
+            artifacts.path(),
+        );
+        assert!(by_name.matched, "basename-in-dir must verify: {by_name:?}");
+
+        // Content-addressed <hash>.parquet naming, no recorded path at all.
+        std::fs::remove_file(artifacts.path().join("orders.parquet")).unwrap();
+        std::fs::write(artifacts.path().join(format!("{hash}.parquet")), bytes).unwrap();
+        let by_hash = check_one_artifact(&OutputHash { hash, path: None }, artifacts.path());
+        assert!(
+            by_hash.matched,
+            "hash-named artifact must verify: {by_hash:?}"
+        );
     }
 
     #[test]

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -471,11 +471,15 @@ enum Command {
         /// contained/quarantined window a partial failure left behind.
         #[arg(long, conflicts_with = "model")]
         from_last_run: bool,
-        /// Partition-window lower bound applied to partitioned models.
-        #[arg(long)]
+        /// Partition-window lower bound applied to partitioned models. Both
+        /// bounds are required together (mirroring `rocky run --from/--to`):
+        /// a lone bound would be recorded into the reviewed plan as a range
+        /// but execute as "latest partition only", silently shrinking the
+        /// approved scope.
+        #[arg(long, requires = "to")]
         from: Option<String>,
         /// Partition-window upper bound applied to partitioned models.
-        #[arg(long)]
+        #[arg(long, requires = "from")]
         to: Option<String>,
         /// Rebuild only the named/seed models, not their downstream closure.
         #[arg(long)]

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -36,6 +36,14 @@ from typing import TYPE_CHECKING, Annotated, Literal
 
 import dagster as dg
 from dagster._core.definitions.metadata.metadata_set import NamespacedMetadataSet
+
+# Status enum for the event-log query in ``_latest_completed_check_verdict``.
+# Not re-exported from the public ``dagster`` namespace in 1.13.x, but the
+# same storage surface ``DagsterInstance.get_latest_asset_check_evaluation_record``
+# is built on.
+from dagster._core.storage.asset_check_execution_record import (
+    AssetCheckExecutionRecordStatus,
+)
 from dagster._utils.env import using_dagster_dev
 from dagster.components.component.state_backed_component import StateBackedComponent
 from dagster.components.utils.defs_state import (
@@ -2289,15 +2297,68 @@ def _make_derived_model_asset(
         yield from _emit_derived_model_results(
             result=result,
             selected_keys=selected_keys,
+            key_by_model_name=_model_name_to_key(group.specs),
         )
 
     return _asset
+
+
+def _model_name_to_key(specs: list[dg.AssetSpec]) -> dict[str, dg.AssetKey]:
+    """Map each derived-model spec's Rocky model name to its Dagster asset key.
+
+    The authoritative name source is the ``rocky/model_name`` tag the stock
+    translator stamps on every derived-model spec (second pass, so it wins any
+    collision). The key's last path segment — the target table, which usually
+    equals the model name — is kept as a fallback so name-based lookups still
+    resolve under a custom translator that drops the tag.
+    """
+    key_by_name: dict[str, dg.AssetKey] = {}
+    for spec in specs:
+        key_by_name.setdefault(spec.key.path[-1], spec.key)
+    for spec in specs:
+        tag_name = (spec.tags or {}).get("rocky/model_name")
+        if tag_name:
+            key_by_name[tag_name] = spec.key
+    return key_by_name
+
+
+def _contained_models_failure(contained: list[ContainedModel]) -> dg.Failure:
+    """Build the loud failure for model(s) this op ran that containment withheld.
+
+    A contained model was **not built** — its upstream failed and
+    ``[resilience] contain_failures`` withheld it. Failing the op with the
+    blast-radius reason (``blocked_by`` / ``unblock_hint``) surfaces *why* in
+    the run viewer, instead of Dagster's generic "did not yield expected
+    outputs" error for the unyielded output.
+    """
+    lines: list[str] = []
+    blocked_by: list[str] = []
+    for entry in contained:
+        blocked = ", ".join(entry.blocked_by) or "an upstream failure"
+        line = (
+            f"Model '{entry.model}' was not built: withheld by failure "
+            f"containment (blocked by {blocked})."
+        )
+        if entry.unblock_hint:
+            line = f"{line} {entry.unblock_hint}"
+        lines.append(line)
+        for upstream in entry.blocked_by:
+            if upstream not in blocked_by:
+                blocked_by.append(upstream)
+    return dg.Failure(
+        description="\n".join(lines),
+        metadata={
+            "rocky/contained": dg.MetadataValue.bool(True),
+            "rocky/blocked_by": dg.MetadataValue.text(", ".join(blocked_by)),
+        },
+    )
 
 
 def _emit_derived_model_results(
     *,
     result: RunResult,
     selected_keys: set[dg.AssetKey],
+    key_by_model_name: Mapping[str, dg.AssetKey] | None = None,
 ) -> Iterator[dg.MaterializeResult]:
     """Yield ``MaterializeResult`` for the derived-model assets in ``selected_keys``.
 
@@ -2305,6 +2366,13 @@ def _emit_derived_model_results(
     materialization whose remapped asset key is in ``selected_keys``.
     Source-replication materializations (which Rocky also emits when the
     fallback filter matches a source) are dropped silently.
+
+    When the run withheld one of this op's models via failure containment
+    (``result.contained``, resolved through ``key_by_model_name``), a
+    :class:`dg.Failure` naming the model, its ``blocked_by`` upstream(s) and
+    the ``unblock_hint`` is raised **after** the loop — so sibling models'
+    materializations are recorded first and the containment reason reaches the
+    run viewer instead of the generic unyielded-output error.
     """
     for mat in result.materializations:
         # Derived-model materializations identify their key directly via
@@ -2338,6 +2406,14 @@ def _emit_derived_model_results(
             asset_key=asset_key,
             metadata=metadata,
         )
+
+    contained_here = [
+        entry
+        for entry in result.contained
+        if (key_by_model_name or {}).get(entry.model) in selected_keys
+    ]
+    if contained_here:
+        raise _contained_models_failure(contained_here)
 
 
 def _make_rocky_asset(
@@ -2485,6 +2561,7 @@ def _make_rocky_asset(
                 extra_yielded_checks=compliance_yielded,
                 collapsed_key_by_table=group.collapsed_key_by_table or None,
                 satisfy_empty_outputs=satisfy_empty_outputs,
+                instance=context.instance,
             )
 
             # If a filter surfaced the Fivetran-storm signal, raise the
@@ -2908,6 +2985,7 @@ def _emit_results(
     extra_yielded_checks: set[tuple[dg.AssetKey, str]] | None = None,
     collapsed_key_by_table: dict[str, dg.AssetKey] | None = None,
     satisfy_empty_outputs: bool = False,
+    instance: dg.DagsterInstance | None = None,
 ) -> Iterator[dg.MaterializeResult | dg.AssetCheckResult | dg.AssetObservation]:
     """Yield Dagster events for every materialization, check, drift event and anomaly.
 
@@ -3206,6 +3284,7 @@ def _emit_results(
         materialized_keys=materialized_keys,
         pruned_keys=pruned_keys,
         contained_by_key=contained_by_key,
+        instance=instance,
     )
 
 
@@ -3300,6 +3379,64 @@ def _build_table_resolver(
     return resolve
 
 
+def _latest_completed_check_verdict(
+    instance: dg.DagsterInstance | None,
+    check_key: dg.AssetCheckKey,
+) -> tuple[bool, dg.AssetCheckSeverity] | None:
+    """Return ``(passed, severity)`` from the last completed evaluation of ``check_key``.
+
+    Backs the pruned-table placeholder in :func:`_emit_placeholder_checks`: a
+    ``prune_unchanged`` skip must carry the prior verdict forward, not stamp an
+    unconditional pass — the engine records the prune marker when the *copy*
+    succeeds, before data checks run, so a failing check would otherwise be
+    flipped green for as long as the source stays unchanged.
+
+    Reads the event log via ``get_asset_check_execution_history`` with a
+    completed-status filter instead of
+    ``DagsterInstance.get_latest_asset_check_evaluation_record`` because the
+    *current* run records a PLANNED row for every declared check at run
+    creation — the unfiltered "latest" is therefore almost always this run's
+    own PLANNED record, never the last real verdict.
+
+    Returns ``None`` when there is no instance (direct ``_emit_results``
+    calls), no completed evaluation on record, or the storage query fails —
+    callers treat all three as "no prior verdict to carry forward".
+    """
+    if instance is None:
+        return None
+    try:
+        records = instance.event_log_storage.get_asset_check_execution_history(
+            check_key,
+            limit=1,
+            status={
+                AssetCheckExecutionRecordStatus.SUCCEEDED,
+                AssetCheckExecutionRecordStatus.FAILED,
+            },
+        )
+    except Exception:
+        # A placeholder must never crash the op — degrade to the no-prior
+        # path (an explicit "no recorded result" pass) and leave a trail.
+        _log.warning(
+            "Could not read the prior evaluation for check %r on %s from the "
+            "event log; emitting the pruned-table placeholder without a "
+            "carried-forward verdict.",
+            check_key.name,
+            check_key.asset_key.to_user_string(),
+            exc_info=True,
+        )
+        return None
+    if not records:
+        return None
+    record = records[0]
+    evaluation = record.evaluation
+    if evaluation is None:
+        # Completed records always carry an evaluation event per the storage
+        # invariant; fall back to the row status if that ever changes.
+        succeeded = record.status == AssetCheckExecutionRecordStatus.SUCCEEDED
+        return succeeded, dg.AssetCheckSeverity.ERROR
+    return evaluation.passed, evaluation.severity
+
+
 def _emit_placeholder_checks(
     *,
     check_specs: list[dg.AssetCheckSpec],
@@ -3308,6 +3445,7 @@ def _emit_placeholder_checks(
     materialized_keys: set[dg.AssetKey],
     pruned_keys: AbstractSet[dg.AssetKey] = frozenset(),
     contained_by_key: Mapping[dg.AssetKey, ContainedModel] = MappingProxyType({}),
+    instance: dg.DagsterInstance | None = None,
 ) -> Iterator[dg.AssetCheckResult]:
     """Emit placeholders for declared checks Rocky did not produce.
 
@@ -3315,10 +3453,16 @@ def _emit_placeholder_checks(
     for any pre-declared check that the actual run didn't cover.
 
     A check on a ``prune_unchanged``-pruned table is neither run nor a failure:
-    the source is unchanged, so the last real evaluation still holds. Those emit
-    ``passed=True`` with a "not re-checked" status rather than the WARN /
-    ``passed=False`` placeholder an unmaterialized table would otherwise get —
-    so pruning doesn't overwrite a passing check with a spurious failure.
+    the source is unchanged, so the last real evaluation still holds — and is
+    what the placeholder must report. The prune marker is recorded when the
+    *copy* succeeds, before data checks run, so the prior evaluation may well
+    be a failure; carrying it forward (verdict + severity, read from
+    ``instance`` via :func:`_latest_completed_check_verdict`) keeps a red check
+    red instead of silently flipping it green. When no completed evaluation is
+    on record (or no ``instance`` is available), the placeholder passes with an
+    explicit "pruned before this check ever ran" status. Both variants carry
+    ``rocky/pruned_unchanged=True`` so the UI can tell them from real
+    evaluations.
 
     A check on a model in ``contained_by_key`` was withheld by failure
     containment (its upstream failed). It is unmaterialized, so it would
@@ -3351,17 +3495,48 @@ def _emit_placeholder_checks(
             continue
 
         if cs.asset_key in pruned_keys:
-            yield dg.AssetCheckResult(
-                asset_key=cs.asset_key,
-                check_name=cs.name,
-                passed=True,
-                metadata={
-                    "status": dg.MetadataValue.text(
-                        "not re-checked: source unchanged since last copy "
-                        "(prune_unchanged) — prior result stands"
-                    )
-                },
+            prior = _latest_completed_check_verdict(
+                instance, dg.AssetCheckKey(cs.asset_key, cs.name)
             )
+            if prior is None:
+                yield dg.AssetCheckResult(
+                    asset_key=cs.asset_key,
+                    check_name=cs.name,
+                    passed=True,
+                    description=(
+                        "source unchanged since last copy (prune_unchanged) — "
+                        "table was pruned before this check ever ran; no "
+                        "recorded result to carry forward"
+                    ),
+                    metadata={
+                        "status": dg.MetadataValue.text(
+                            "not checked: source unchanged since last copy "
+                            "(prune_unchanged) — no prior evaluation on record"
+                        ),
+                        "rocky/pruned_unchanged": dg.MetadataValue.bool(True),
+                    },
+                )
+            else:
+                prior_passed, prior_severity = prior
+                yield dg.AssetCheckResult(
+                    asset_key=cs.asset_key,
+                    check_name=cs.name,
+                    passed=prior_passed,
+                    severity=prior_severity,
+                    description=(
+                        "source unchanged — not re-evaluated; carrying forward "
+                        "the last recorded result"
+                    ),
+                    metadata={
+                        "status": dg.MetadataValue.text(
+                            "not re-checked: source unchanged since last copy "
+                            "(prune_unchanged) — carrying forward the last "
+                            f"recorded result "
+                            f"({'passed' if prior_passed else 'failed'})"
+                        ),
+                        "rocky/pruned_unchanged": dg.MetadataValue.bool(True),
+                    },
+                )
             continue
 
         materialized = cs.asset_key in materialized_keys

--- a/integrations/dagster/src/dagster_rocky/dag_assets.py
+++ b/integrations/dagster/src/dagster_rocky/dag_assets.py
@@ -31,8 +31,6 @@ from . import partitions
 from .freshness import freshness_policy_from_model
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-
     from .contracts import ContractRules
     from .resource import RockyResource
     from .translator import RockyDagsterTranslator
@@ -41,6 +39,7 @@ if TYPE_CHECKING:
         DagResult,
         DiscoverResult,
         LineageEdgeRecord,
+        MaterializationInfo,
         OptimizeResult,
         RunResult,
     )
@@ -272,41 +271,113 @@ def _partition_kwargs_from_context(
     return {}
 
 
-def _emit_model_results(
-    result: RunResult,
-    selected_keys: set[dg.AssetKey],
-) -> Iterator[dg.MaterializeResult]:
-    """Yield MaterializeResult for model materializations in the run output."""
+def _model_materialization_metadata(mat: MaterializationInfo) -> dict[str, dg.MetadataValue]:
+    """Build the enriched Dagster metadata for one engine materialization."""
     from .component import RockyMetadataSet
 
-    for mat in result.materializations:
-        asset_key = dg.AssetKey(mat.asset_key)
-        if asset_key not in selected_keys:
-            continue
-        metadata: dict[str, dg.MetadataValue] = {
-            **RockyMetadataSet(
-                strategy=mat.metadata.strategy if mat.metadata else None,
-                duration_ms=mat.duration_ms,
-                rows_copied=mat.rows_copied,
-                watermark=(
-                    mat.metadata.watermark.isoformat()
-                    if mat.metadata is not None and mat.metadata.watermark is not None
-                    else None
-                ),
-                target_table_full_name=(
-                    mat.metadata.target_table_full_name if mat.metadata else None
-                ),
-                sql_hash=mat.metadata.sql_hash if mat.metadata else None,
-                column_count=mat.metadata.column_count if mat.metadata else None,
-                compile_time_ms=mat.metadata.compile_time_ms if mat.metadata else None,
+    metadata: dict[str, dg.MetadataValue] = {
+        **RockyMetadataSet(
+            strategy=mat.metadata.strategy if mat.metadata else None,
+            duration_ms=mat.duration_ms,
+            rows_copied=mat.rows_copied,
+            watermark=(
+                mat.metadata.watermark.isoformat()
+                if mat.metadata is not None and mat.metadata.watermark is not None
+                else None
             ),
-            "dagster/duration_ms": dg.MetadataValue.int(mat.duration_ms),
-        }
-        if mat.rows_copied is not None:
-            metadata["dagster/row_count"] = dg.MetadataValue.int(mat.rows_copied)
-        if mat.partition is not None:
-            metadata["rocky/partition_key"] = dg.MetadataValue.text(mat.partition.key)
-        yield dg.MaterializeResult(asset_key=asset_key, metadata=metadata)
+            target_table_full_name=(mat.metadata.target_table_full_name if mat.metadata else None),
+            sql_hash=mat.metadata.sql_hash if mat.metadata else None,
+            column_count=mat.metadata.column_count if mat.metadata else None,
+            compile_time_ms=mat.metadata.compile_time_ms if mat.metadata else None,
+        ),
+        "dagster/duration_ms": dg.MetadataValue.int(mat.duration_ms),
+    }
+    if mat.rows_copied is not None:
+        metadata["dagster/row_count"] = dg.MetadataValue.int(mat.rows_copied)
+    if mat.partition is not None:
+        metadata["rocky/partition_key"] = dg.MetadataValue.text(mat.partition.key)
+    return metadata
+
+
+def _resolve_transformation_outcome(
+    *,
+    result: RunResult,
+    node: DagNodeOutput,
+    spec_key: dg.AssetKey,
+) -> dg.MaterializeResult | dg.Failure:
+    """Decide the Dagster outcome for one transformation model's ``run_model`` result.
+
+    ``rocky run --model`` allows partial failure — a failed or contained model
+    comes back as a parsed :class:`RunResult`, not an exception — so the run
+    result itself must be read for the verdict instead of stamping a green
+    :class:`dg.MaterializeResult` whenever the call returned.
+
+    Matching is by the engine's *native* key: the engine stamps
+    materializations and errors with the model's target triple
+    ``[catalog, schema, table]`` regardless of how the translator shaped the
+    spec key, so the triple is derived from ``node.target`` exactly the way
+    ``RockyDagsterTranslator.get_dag_node_asset_key`` does. The spec key and
+    the bare model label are accepted too, so a custom translator (or an
+    engine emitting label-keyed entries) still matches instead of silently
+    falling through to a fake-green result.
+
+    Returns the :class:`dg.MaterializeResult` to yield when the model really
+    materialized (matched entry — enriched with its metadata — or an
+    engine-reported success with nothing to match), or the :class:`dg.Failure`
+    to raise when the model was contained (blast-radius reason) or failed
+    (the engine's own error).
+    """
+    model_keys = {spec_key, dg.AssetKey([node.label])}
+    if node.target is not None:
+        model_keys.add(dg.AssetKey([node.target.catalog, node.target.schema_, node.target.table]))
+
+    contained = [entry for entry in result.contained if entry.model == node.label]
+    if contained:
+        from .component import _contained_models_failure
+
+        return _contained_models_failure(contained)
+
+    matched = next(
+        (mat for mat in result.materializations if dg.AssetKey(mat.asset_key) in model_keys),
+        None,
+    )
+    if matched is not None:
+        return dg.MaterializeResult(
+            asset_key=spec_key,
+            metadata=_model_materialization_metadata(matched),
+        )
+
+    matched_errors = [err for err in result.errors if dg.AssetKey(err.asset_key) in model_keys]
+    # A single-model run's errors pertain to that model's execution even when
+    # the engine keys them differently — fall back to all itemised errors.
+    errors = matched_errors or result.errors
+    if errors:
+        detail = "; ".join(err.error for err in errors)
+        return dg.Failure(
+            description=f"Model '{node.label}' failed: {detail}",
+            metadata={
+                "rocky/model_name": dg.MetadataValue.text(node.label),
+                "rocky/failure_kind": dg.MetadataValue.text(errors[0].failure_kind),
+            },
+        )
+    if result.tables_failed > 0 or result.status in ("Failure", "PartialFailure"):
+        return dg.Failure(
+            description=(
+                f"Model '{node.label}' did not materialize: the engine reported "
+                f"status {result.status or 'unknown'} with "
+                f"{result.tables_failed} failed table(s) but itemised no "
+                f"matching error."
+            ),
+            metadata={"rocky/model_name": dg.MetadataValue.text(node.label)},
+        )
+    # Engine-reported success with no per-model entry to enrich from (e.g. a
+    # node without a target triple on an engine that keys entries another way).
+    return dg.MaterializeResult(
+        asset_key=spec_key,
+        metadata={
+            "dagster/duration_ms": dg.MetadataValue.int(result.duration_ms),
+        },
+    )
 
 
 def _build_source_filters(discover_result: DiscoverResult | None) -> list[str]:
@@ -405,6 +476,13 @@ def _make_dag_group_asset(
         selected_keys = set(context.selected_asset_keys)
         partition_kwargs = _partition_kwargs_from_context(context, group.partitions_def)
 
+        # Failed / contained models are collected and raised AFTER the loop so
+        # the remaining selected nodes still execute and their
+        # materializations are recorded — the op's retry then only re-runs
+        # what was lost (same partial-progress pattern as the component's
+        # quota-breach handling).
+        model_failures: list[dg.Failure] = []
+
         for spec_key in selected_keys:
             node_id = spec_key_to_node_id.get(spec_key)
             if node_id is None:
@@ -426,17 +504,18 @@ def _make_dag_group_asset(
                     f"Model {node.label}: {result.tables_copied} copied, "
                     f"{result.tables_failed} failed in {result.duration_ms}ms"
                 )
-                emitted = False
-                for mr in _emit_model_results(result, {spec_key}):
-                    emitted = True
-                    yield mr
-                if not emitted:
-                    yield dg.MaterializeResult(
-                        asset_key=spec_key,
-                        metadata={
-                            "dagster/duration_ms": dg.MetadataValue.int(result.duration_ms),
-                        },
+                outcome = _resolve_transformation_outcome(
+                    result=result,
+                    node=node,
+                    spec_key=spec_key,
+                )
+                if isinstance(outcome, dg.Failure):
+                    context.log.error(
+                        f"Model {node.label} did not materialize: {outcome.description}"
                     )
+                    model_failures.append(outcome)
+                else:
+                    yield outcome
 
             elif node.kind in ("source", "load"):
                 # Source/load nodes run the replication pipeline using
@@ -486,5 +565,15 @@ def _make_dag_group_asset(
                     f"Node {node.label} ({node.kind}): graph-only asset (marking as materialized)"
                 )
                 yield dg.MaterializeResult(asset_key=spec_key)
+
+        if model_failures:
+            if len(model_failures) == 1:
+                raise model_failures[0]
+            raise dg.Failure(
+                description="\n".join(failure.description or "" for failure in model_failures),
+                metadata={
+                    "rocky/failed_model_count": dg.MetadataValue.int(len(model_failures)),
+                },
+            )
 
     return _asset

--- a/integrations/dagster/tests/test_dag_assets.py
+++ b/integrations/dagster/tests/test_dag_assets.py
@@ -453,3 +453,189 @@ def test_build_dag_multi_assets_groups_by_kind():
     )
     # source, load, and transformation are different kinds → 3 groups.
     assert len(assets) == 3
+
+
+# ---------------------------------------------------------------------------
+# Transformation execution outcomes — a failed/contained model must fail the
+# op with the engine's reason, never be stamped fake-green; a materialized
+# model must match by the engine's target-triple key even under a custom
+# translator.
+# ---------------------------------------------------------------------------
+
+
+def _dag_run_result(
+    *,
+    status: str | None = "Success",
+    materializations: list[dict] | None = None,
+    errors: list[dict] | None = None,
+    contained: list[dict] | None = None,
+):
+    from dagster_rocky.types import RunResult
+
+    mats = materializations or []
+    errs = errors or []
+    payload = {
+        "version": "0.3.0",
+        "command": "run",
+        "filter": "",
+        "duration_ms": 100,
+        "tables_copied": len(mats),
+        "tables_failed": len(errs),
+        "materializations": mats,
+        "check_results": [],
+        "errors": errs,
+        "contained": contained or [],
+        "permissions": {
+            "grants_added": 0,
+            "grants_revoked": 0,
+            "catalogs_created": 0,
+            "schemas_created": 0,
+        },
+        "drift": {"tables_checked": 0, "tables_drifted": 0, "actions_taken": []},
+    }
+    if status is not None:
+        payload["status"] = status
+    return RunResult.model_validate(payload)
+
+
+def _single_transformation_dag() -> DagResult:
+    return _make_dag_result(
+        nodes=[
+            {
+                "id": "transformation:m1",
+                "kind": "transformation",
+                "label": "m1",
+                "target": {"catalog": "w", "schema": "s", "table": "m1"},
+            },
+        ]
+    )
+
+
+def _materialize_dag(dag: DagResult, run_result, translator=None):
+    from unittest.mock import MagicMock
+
+    mock_rocky = MagicMock()
+    mock_rocky.run_model.return_value = run_result
+    assets = build_dag_multi_assets(
+        dag,
+        rocky=mock_rocky,
+        translator=translator or RockyDagsterTranslator(),
+    )
+    return dg.materialize(assets, raise_on_error=False)
+
+
+def test_dag_transformation_failed_model_raises_failure_not_green():
+    """A model run that came back with itemised errors (run_model allows
+    partial failure) must FAIL the op with the engine's error — not yield the
+    bare fake-green MaterializeResult the old fallback stamped."""
+    run_result = _dag_run_result(
+        status="Failure",
+        errors=[
+            {
+                "asset_key": ["w", "s", "m1"],
+                "error": "SQL compilation error: column `amount` not found",
+                "failure_kind": "query-rejected",
+            }
+        ],
+    )
+
+    result = _materialize_dag(_single_transformation_dag(), run_result)
+
+    assert result.success is False
+    assert list(result.get_asset_materialization_events()) == []  # no green stamp
+
+    failures = [e for e in result.all_events if e.event_type_value == "STEP_FAILURE"]
+    assert len(failures) == 1
+    failure_data = failures[0].event_specific_data.user_failure_data
+    assert "m1" in failure_data.description
+    assert "SQL compilation error" in failure_data.description
+    assert failure_data.metadata["rocky/failure_kind"].value == "query-rejected"
+
+
+def test_dag_transformation_contained_model_fails_with_blocked_by():
+    """A model withheld by failure containment must fail the op with the
+    blast-radius reason (blocked_by / unblock_hint), same shape as the
+    derived-model path — not a green MaterializeResult."""
+    run_result = _dag_run_result(
+        status="PartialFailure",
+        errors=[{"asset_key": ["stg_upstream"], "error": "boom", "failure_kind": "query-rejected"}],
+        contained=[
+            {
+                "model": "m1",
+                "blocked_by": ["stg_upstream"],
+                "unblock_hint": "fix stg_upstream, then re-run",
+            }
+        ],
+    )
+
+    result = _materialize_dag(_single_transformation_dag(), run_result)
+
+    assert result.success is False
+    assert list(result.get_asset_materialization_events()) == []
+
+    failures = [e for e in result.all_events if e.event_type_value == "STEP_FAILURE"]
+    assert len(failures) == 1
+    failure_data = failures[0].event_specific_data.user_failure_data
+    assert "m1" in failure_data.description
+    assert "stg_upstream" in failure_data.description
+    assert "fix stg_upstream, then re-run" in failure_data.description
+    assert failure_data.metadata["rocky/contained"].value is True
+    assert failure_data.metadata["rocky/blocked_by"].value == "stg_upstream"
+
+
+def test_dag_transformation_success_matches_target_triple_and_yields_green():
+    """A materialization keyed by the engine's [catalog, schema, table] triple
+    matches the spec and yields green, enriched with the engine metadata
+    (row count proves the real entry was used, not the bare fallback)."""
+    run_result = _dag_run_result(
+        materializations=[
+            {
+                "asset_key": ["w", "s", "m1"],
+                "rows_copied": 42,
+                "duration_ms": 7,
+                "metadata": {"strategy": "incremental"},
+            }
+        ],
+    )
+
+    result = _materialize_dag(_single_transformation_dag(), run_result)
+
+    assert result.success
+    mats = list(result.get_asset_materialization_events())
+    assert [e.asset_key for e in mats] == [dg.AssetKey(["w", "s", "m1"])]
+    metadata = mats[0].materialization.metadata
+    assert metadata["dagster/row_count"].value == 42
+    assert metadata["dagster-rocky/strategy"].value == "incremental"
+
+
+def test_dag_transformation_custom_translator_key_still_matches_engine_triple():
+    """With a translator that reshapes spec keys, the engine's target-triple
+    materialization must still be matched (and remapped onto the spec key) —
+    previously naive key equality silently failed here and the fake-green
+    fallback became the common path."""
+
+    class PrefixedTranslator(RockyDagsterTranslator):
+        def get_dag_node_asset_key(self, node):
+            base = super().get_dag_node_asset_key(node)
+            return dg.AssetKey(["my_prefix", *base.path])
+
+    run_result = _dag_run_result(
+        materializations=[
+            {
+                "asset_key": ["w", "s", "m1"],
+                "rows_copied": 42,
+                "duration_ms": 7,
+                "metadata": {"strategy": "incremental"},
+            }
+        ],
+    )
+
+    result = _materialize_dag(
+        _single_transformation_dag(), run_result, translator=PrefixedTranslator()
+    )
+
+    assert result.success
+    mats = list(result.get_asset_materialization_events())
+    assert [e.asset_key for e in mats] == [dg.AssetKey(["my_prefix", "w", "s", "m1"])]
+    # Enriched from the matched engine entry — the fallback carries no row count.
+    assert mats[0].materialization.metadata["dagster/row_count"].value == 42

--- a/integrations/dagster/tests/test_derived_models.py
+++ b/integrations/dagster/tests/test_derived_models.py
@@ -521,3 +521,223 @@ def test_component_skips_derived_models_when_flag_disabled(tmp_path):
     assert dg.AssetKey(["fivetran", "acme", "us_west", "shopify", "orders"]) in all_keys
     # Derived-model asset is NOT present
     assert dg.AssetKey(["warehouse", "marts", "fct_orders"]) not in all_keys
+
+
+# ---------------------------------------------------------------------------
+# Failure containment — a contained model must fail the derived-model op
+# loudly with the blast-radius reason, not with the generic unyielded-output
+# error.
+# ---------------------------------------------------------------------------
+
+
+def _derived_run_result(
+    *,
+    materializations: list[dict] | None = None,
+    errors: list[dict] | None = None,
+    contained: list[dict] | None = None,
+):
+    from dagster_rocky.types import RunResult
+
+    mats = materializations or []
+    errs = errors or []
+    return RunResult.model_validate(
+        {
+            "version": "0.3.0",
+            "command": "run",
+            "filter": "client=acme",
+            "duration_ms": 100,
+            "tables_copied": len(mats),
+            "tables_failed": len(errs),
+            "materializations": mats,
+            "check_results": [],
+            "errors": errs,
+            "contained": contained or [],
+            "permissions": {
+                "grants_added": 0,
+                "grants_revoked": 0,
+                "catalogs_created": 0,
+                "schemas_created": 0,
+            },
+            "drift": {"tables_checked": 0, "tables_drifted": 0, "actions_taken": []},
+        }
+    )
+
+
+def test_emit_derived_model_results_raises_for_contained_model():
+    """Unit-level: a contained model in the group raises ``dg.Failure`` naming
+    the model, its blocked_by upstream and the unblock hint — after yielding
+    the sibling's real materialization. A contained model OUTSIDE the group is
+    ignored (the failure belongs to the op that ran it)."""
+    import pytest
+
+    from dagster_rocky.component import _emit_derived_model_results
+
+    dim_a = dg.AssetKey(["warehouse", "marts", "dim_a"])
+    dim_b = dg.AssetKey(["warehouse", "marts", "dim_b"])
+    key_by_model_name = {"dim_a": dim_a, "dim_b": dim_b}
+    result = _derived_run_result(
+        materializations=[
+            {
+                "asset_key": ["warehouse", "marts", "dim_a"],
+                "rows_copied": 10,
+                "duration_ms": 5,
+                "metadata": {"strategy": "full_refresh"},
+            }
+        ],
+        errors=[{"asset_key": ["stg_orders"], "error": "boom", "failure_kind": "query-rejected"}],
+        contained=[
+            {
+                "model": "dim_b",
+                "blocked_by": ["stg_orders"],
+                "unblock_hint": "fix stg_orders, then re-run",
+            }
+        ],
+    )
+
+    events = []
+    with pytest.raises(dg.Failure) as exc_info:
+        for event in _emit_derived_model_results(
+            result=result,
+            selected_keys={dim_a, dim_b},
+            key_by_model_name=key_by_model_name,
+        ):
+            events.append(event)
+
+    # The sibling's real materialization was yielded BEFORE the raise, so
+    # partial progress is preserved in the asset graph.
+    assert [e.asset_key for e in events] == [dim_a]
+
+    failure = exc_info.value
+    assert "dim_b" in failure.description
+    assert "stg_orders" in failure.description
+    assert "fix stg_orders, then re-run" in failure.description
+    assert failure.metadata["rocky/contained"].value is True
+    assert failure.metadata["rocky/blocked_by"].value == "stg_orders"
+
+    # A contained model that is NOT one of this group's models does not raise.
+    other = _derived_run_result(
+        contained=[{"model": "some_other_model", "blocked_by": ["root"], "unblock_hint": ""}]
+    )
+    assert (
+        list(
+            _emit_derived_model_results(
+                result=other,
+                selected_keys={dim_a, dim_b},
+                key_by_model_name=key_by_model_name,
+            )
+        )
+        == []
+    )
+
+
+def test_derived_model_contained_fails_op_with_blast_radius_reason(tmp_path):
+    """End-to-end through the real derived-model multi_asset: when the engine
+    contains a model, the op FAILS with the blocked_by / unblock_hint reason
+    (not the generic "did not yield expected outputs"), while the sibling
+    model's materialization is still recorded."""
+    import json
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from dagster_rocky.component import RockyComponent
+    from dagster_rocky.resource import RockyResource
+
+    state_file = Path(tmp_path) / "state.json"
+    state_file.write_text(
+        json.dumps(
+            {
+                "discover": {
+                    "version": "0.1.0",
+                    "command": "discover",
+                    "sources": [
+                        {
+                            "id": "src_001",
+                            "components": {"client": "acme", "source": "shopify"},
+                            "source_type": "fivetran",
+                            "tables": [{"name": "orders"}],
+                        }
+                    ],
+                },
+                "compile": {
+                    "version": "0.1.0",
+                    "command": "compile",
+                    "models": 2,
+                    "execution_layers": 1,
+                    "diagnostics": [],
+                    "has_errors": False,
+                    "models_detail": [
+                        {
+                            "name": "dim_a",
+                            "strategy": {"type": "full_refresh"},
+                            "target": {
+                                "catalog": "warehouse",
+                                "schema": "marts",
+                                "table": "dim_a",
+                            },
+                            "freshness": None,
+                        },
+                        {
+                            "name": "dim_b",
+                            "strategy": {"type": "full_refresh"},
+                            "target": {
+                                "catalog": "warehouse",
+                                "schema": "marts",
+                                "table": "dim_b",
+                            },
+                            "freshness": None,
+                        },
+                    ],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    component = RockyComponent(config_path="rocky.toml", surface_derived_models=True)
+    defs = component.build_defs_from_state(context=None, state_path=state_file)
+    asset_defs = [a for a in (defs.assets or []) if isinstance(a, dg.AssetsDefinition)]
+
+    dim_a = dg.AssetKey(["warehouse", "marts", "dim_a"])
+    dim_b = dg.AssetKey(["warehouse", "marts", "dim_b"])
+
+    run_result = _derived_run_result(
+        materializations=[
+            {
+                "asset_key": ["warehouse", "marts", "dim_a"],
+                "rows_copied": 10,
+                "duration_ms": 5,
+                "metadata": {"strategy": "full_refresh"},
+            }
+        ],
+        errors=[{"asset_key": ["stg_orders"], "error": "boom", "failure_kind": "query-rejected"}],
+        contained=[
+            {
+                "model": "dim_b",
+                "blocked_by": ["stg_orders"],
+                "unblock_hint": "fix stg_orders, then re-run",
+            }
+        ],
+    )
+
+    with patch.object(RockyResource, "run", return_value=run_result):
+        result = dg.materialize(
+            asset_defs,
+            resources={"rocky": RockyResource(config_path="rocky.toml")},
+            selection=[dim_a, dim_b],
+            raise_on_error=False,
+        )
+
+    assert result.success is False
+    # The sibling's materialization was recorded before the failure.
+    mat_keys = {e.asset_key for e in result.get_asset_materialization_events()}
+    assert dim_a in mat_keys
+    assert dim_b not in mat_keys
+
+    failures = [e for e in result.all_events if e.event_type_value == "STEP_FAILURE"]
+    assert len(failures) == 1
+    failure_data = failures[0].event_specific_data.user_failure_data
+    assert "dim_b" in failure_data.description
+    assert "stg_orders" in failure_data.description
+    assert "fix stg_orders, then re-run" in failure_data.description
+    assert failure_data.metadata["rocky/contained"].value is True
+    assert failure_data.metadata["rocky/blocked_by"].value == "stg_orders"

--- a/integrations/dagster/tests/test_empty_outputs.py
+++ b/integrations/dagster/tests/test_empty_outputs.py
@@ -42,6 +42,7 @@ def _run_result(
     tables_failed: int | None = None,
     excluded_tables: list[dict] | None = None,
     contained: list[dict] | None = None,
+    check_results: list[dict] | None = None,
 ) -> RunResult:
     mats = materializations or []
     errs = errors or []
@@ -57,7 +58,7 @@ def _run_result(
             "tables_copied": len(mats),
             "tables_failed": len(errs) if tables_failed is None else tables_failed,
             "materializations": mats,
-            "check_results": [],
+            "check_results": check_results or [],
             "errors": errs,
             "excluded_tables": excluded_tables or [],
             "contained": contained or [],
@@ -529,10 +530,13 @@ def test_pruned_table_gets_distinct_empty_stamp():
     assert "absent or empty" in by_key[c_raw].metadata["rocky/reason"].value
 
 
-def test_pruned_table_check_passes_not_warns():
-    """A declared check on a pruned table emits passed=True (prior result
-    stands), NOT the passed=False/WARN placeholder an unmaterialized table would
-    otherwise get — pruning must not overwrite a passing check with a failure."""
+def test_pruned_table_check_with_no_prior_evaluation_passes_not_warns():
+    """A declared check on a pruned table with NO recorded prior evaluation
+    emits passed=True with an explicit "pruned before this check ever ran"
+    status — NOT the passed=False/WARN placeholder an unmaterialized table
+    would otherwise get. Marked ``rocky/pruned_unchanged`` so the UI can tell
+    it from a real evaluation. (No instance is passed here, which is the same
+    "no prior verdict" degradation direct ``_emit_results`` callers get.)"""
     b_raw = dg.AssetKey(["b_raw"])
     mapping = {("b_raw",): b_raw}
     run_result = _run_result(excluded_tables=[_excluded("b_raw")])
@@ -552,6 +556,195 @@ def test_pruned_table_check_passes_not_warns():
     assert checks[0].check_name == "row_count"
     assert checks[0].passed is True
     assert "unchanged" in checks[0].metadata["status"].value
+    assert "no prior evaluation" in checks[0].metadata["status"].value
+    assert checks[0].metadata["rocky/pruned_unchanged"].value is True
+
+
+def _seed_check_evaluation(
+    instance: dg.DagsterInstance,
+    asset_key: dg.AssetKey,
+    check_name: str,
+    *,
+    passed: bool,
+    severity: dg.AssetCheckSeverity = dg.AssetCheckSeverity.ERROR,
+) -> None:
+    """Record a real check evaluation in ``instance``'s event log."""
+
+    @dg.multi_asset(
+        specs=[dg.AssetSpec(asset_key)],
+        check_specs=[dg.AssetCheckSpec(name=check_name, asset=asset_key)],
+        name="seed_prior_evaluation",
+    )
+    def seed(context):
+        yield dg.MaterializeResult(asset_key=asset_key)
+        yield dg.AssetCheckResult(
+            asset_key=asset_key, check_name=check_name, passed=passed, severity=severity
+        )
+
+    result = dg.materialize([seed], instance=instance, raise_on_error=False)
+    assert result.success
+
+
+def test_pruned_table_check_carries_forward_prior_failure():
+    """THE regression the prune placeholder existed to avoid inverting: the
+    engine records the prune marker when the COPY succeeds, before data checks
+    run — so Monday's copy can succeed while its check FAILS. Tuesday's prune
+    must carry that red verdict (and its severity) forward, not flip the check
+    green without re-evaluation."""
+    b_raw = dg.AssetKey(["b_raw"])
+    mapping = {("b_raw",): b_raw}
+    run_result = _run_result(excluded_tables=[_excluded("b_raw")])
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        _seed_check_evaluation(
+            instance, b_raw, "row_count", passed=False, severity=dg.AssetCheckSeverity.WARN
+        )
+        events = list(
+            _emit_results(
+                results=[run_result],
+                check_specs=[dg.AssetCheckSpec(name="row_count", asset=b_raw)],
+                selected_keys={b_raw},
+                rocky_key_to_dagster_key=mapping,
+                satisfy_empty_outputs=True,
+                instance=instance,
+            )
+        )
+
+    checks = [e for e in events if isinstance(e, dg.AssetCheckResult)]
+    assert len(checks) == 1
+    assert checks[0].passed is False  # the prior failure is carried, not reset
+    assert checks[0].severity == dg.AssetCheckSeverity.WARN  # severity carried too
+    assert "carrying forward" in checks[0].metadata["status"].value
+    assert "failed" in checks[0].metadata["status"].value
+    assert checks[0].metadata["rocky/pruned_unchanged"].value is True
+
+
+def test_pruned_table_check_carries_forward_prior_success():
+    """The healthy-pipeline counterpart: a prior passing verdict is carried
+    forward as passed=True with the carry-forward status."""
+    b_raw = dg.AssetKey(["b_raw"])
+    mapping = {("b_raw",): b_raw}
+    run_result = _run_result(excluded_tables=[_excluded("b_raw")])
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        _seed_check_evaluation(instance, b_raw, "row_count", passed=True)
+        events = list(
+            _emit_results(
+                results=[run_result],
+                check_specs=[dg.AssetCheckSpec(name="row_count", asset=b_raw)],
+                selected_keys={b_raw},
+                rocky_key_to_dagster_key=mapping,
+                satisfy_empty_outputs=True,
+                instance=instance,
+            )
+        )
+
+    checks = [e for e in events if isinstance(e, dg.AssetCheckResult)]
+    assert len(checks) == 1
+    assert checks[0].passed is True
+    assert "carrying forward" in checks[0].metadata["status"].value
+    assert checks[0].metadata["rocky/pruned_unchanged"].value is True
+
+
+def test_pruned_placeholder_carries_prior_failure_end_to_end(tmp_path):
+    """The full Monday/Tuesday story through the real component op — proving
+    both that ``_make_rocky_asset`` threads ``context.instance`` into the
+    placeholder pass and that the current run's own PLANNED check row (written
+    at run creation) is skipped in favour of the last *completed* verdict.
+
+    Run 1: the copy succeeds but ``row_count`` FAILS. Run 2: the source is
+    unchanged, the engine prunes the table — the placeholder must carry the
+    red verdict forward."""
+    discover = {
+        "version": "0.3.0",
+        "command": "discover",
+        "sources": [
+            {
+                "id": "src_sw",
+                "source_type": "fivetran",
+                "components": {"client": "sw", "source": "shopify"},
+                "tables": [{"name": "orders"}],
+            }
+        ],
+    }
+    state_file = tmp_path / "state.json"
+    state_file.write_text(json.dumps({"discover": discover}))
+    component = RockyComponent(config_path="rocky.toml")
+    defs = component.build_defs_from_state(context=None, state_path=state_file)
+    asset_defs = [a for a in (defs.assets or []) if isinstance(a, dg.AssetsDefinition)]
+
+    orders_key = dg.AssetKey(["fivetran", "sw", "shopify", "orders"])
+    engine_key = ["fivetran", "sw", "shopify", "orders"]
+
+    monday = _run_result(
+        materializations=[
+            {
+                "asset_key": engine_key,
+                "rows_copied": 100,
+                "duration_ms": 5,
+                "metadata": {"strategy": "full_refresh"},
+            }
+        ],
+        check_results=[
+            {
+                "asset_key": engine_key,
+                "checks": [
+                    {
+                        "name": "row_count",
+                        "passed": False,
+                        "source_count": 100,
+                        "target_count": 90,
+                    }
+                ],
+            }
+        ],
+    )
+    tuesday = _run_result(
+        excluded_tables=[
+            {
+                "asset_key": engine_key,
+                "source_schema": "raw__sw",
+                "table_name": "orders",
+                "reason": "unchanged_since_last_copy",
+            }
+        ],
+    )
+
+    def _materialize(run_result, instance):
+        with (
+            patch.object(RockyResource, "run", return_value=run_result),
+            patch.object(RockyResource, "run_streaming", return_value=run_result),
+        ):
+            return dg.materialize(
+                asset_defs,
+                resources={"rocky": RockyResource(config_path="rocky.toml")},
+                selection=[orders_key],
+                instance=instance,
+                raise_on_error=False,
+            )
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        result_1 = _materialize(monday, instance)
+        assert result_1.success  # a failed non-blocking check doesn't fail the run
+        result_2 = _materialize(tuesday, instance)
+        assert result_2.success
+
+    def _checks_by_name(result):
+        return {
+            e.event_specific_data.check_name: e.event_specific_data
+            for e in result.all_events
+            if e.event_type_value == "ASSET_CHECK_EVALUATION"
+        }
+
+    assert _checks_by_name(result_1)["row_count"].passed is False  # Monday: real failure
+
+    tuesday_checks = _checks_by_name(result_2)
+    # Tuesday's prune carries Monday's red verdict — the check stays red.
+    assert tuesday_checks["row_count"].passed is False
+    assert tuesday_checks["row_count"].metadata["rocky/pruned_unchanged"].value is True
+    # A sibling check whose Monday verdict passed carries forward green.
+    assert tuesday_checks["freshness"].passed is True
+    assert tuesday_checks["freshness"].metadata["rocky/pruned_unchanged"].value is True
 
 
 def test_prune_without_satisfy_empty_outputs_warns(caplog):

--- a/schemas/audit_for.schema.json
+++ b/schemas/audit_for.schema.json
@@ -319,7 +319,7 @@
       "type": "object"
     },
     "AuditSubjectKind": {
-      "description": "What `rocky audit --for <selector>` resolved its selector to.\n\nThe selector is resolved in priority order: a 64-char hex string with a plan file on disk is a [`AuditSubjectKind::Plan`]; a string matching a `run_id` in the run ledger is a [`AuditSubjectKind::Run`]; anything else is treated as a [`AuditSubjectKind::Model`] name.",
+      "description": "What `rocky audit --for <selector>` resolved its selector to.\n\nThe selector is resolved in priority order: a 64-char hex string with a plan file on disk is a [`AuditSubjectKind::Plan`]; a string matching a `run_id` in the run ledger is a [`AuditSubjectKind::Run`]; a string the decision ledger keys rows by is likewise a [`AuditSubjectKind::Plan`] (the plan file may be gone, or the id may be a decision-only custody key that never had one); anything else is treated as a [`AuditSubjectKind::Model`] name.",
       "oneOf": [
         {
           "description": "A model / table name — the primary custody-chain entry point.",
@@ -336,7 +336,7 @@
           "type": "string"
         },
         {
-          "description": "A `plan_id` (64-char blake3 hex) with a plan file on disk.",
+          "description": "A `plan_id` — a 64-char blake3 hex with a plan file on disk, or any id the decision ledger keys rows by (including decision-only custody ids like `freeze:…` / `draft:…` / `autoapply:…`, which never had a plan file).",
           "enum": [
             "plan"
           ],

--- a/schemas/backfill.schema.json
+++ b/schemas/backfill.schema.json
@@ -179,6 +179,13 @@
     "version": {
       "description": "Rocky version that composed the plan.",
       "type": "string"
+    },
+    "warnings": {
+      "description": "Composition warnings the reviewer must weigh before approving. Today: `incremental` / `microbatch` closure members, whose transformation re-run is a bare `INSERT INTO … <model SQL>` — depending on the model's own filtering it appends duplicate rows or loads nothing, rather than rebuilding a window. Empty (and omitted from JSON) when the closure carries no such member.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
     }
   },
   "required": [

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -439,7 +439,7 @@
           ]
         },
         "tables_failed": {
-          "description": "Tables that failed during the **execution phase** — copy or runtime failures while materializing. This does **not** include models excluded before execution started (for example, a model that failed to compile); those are counted only in the top-level `RunOutput.tables_failed`. For overall run pass/fail, read the top-level `tables_failed` / `status`, not this `execution.tables_failed`.",
+          "description": "Source tables whose **copy failed** on the replication path (the `table_errors` count). Transformation-model runtime failures — including contained-cause failures — are reported in `errors` and the top-level `RunOutput.tables_failed`, not here; transformation-only runs leave the whole `execution` block unpopulated. For overall run pass/fail, read the top-level `tables_failed` / `status`, never this field.",
           "format": "uint",
           "minimum": 0.0,
           "type": "integer"

--- a/sdk/python/src/rocky_sdk/types_generated/audit_for_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/audit_for_schema.py
@@ -41,7 +41,7 @@ class AuditSubjectKind2(StrEnum):
 
 class AuditSubjectKind3(StrEnum):
     """
-    A `plan_id` (64-char blake3 hex) with a plan file on disk.
+    A `plan_id` — a 64-char blake3 hex with a plan file on disk, or any id the decision ledger keys rows by (including decision-only custody ids like `freeze:…` / `draft:…` / `autoapply:…`, which never had a plan file).
     """
 
     plan = "plan"

--- a/sdk/python/src/rocky_sdk/types_generated/backfill_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/backfill_schema.py
@@ -132,3 +132,7 @@ class BackfillOutput(BaseModel):
     """
     Rocky version that composed the plan.
     """
+    warnings: list[str] | None = None
+    """
+    Composition warnings the reviewer must weigh before approving. Today: `incremental` / `microbatch` closure members, whose transformation re-run is a bare `INSERT INTO … <model SQL>` — depending on the model's own filtering it appends duplicate rows or loads nothing, rather than rebuilding a window. Empty (and omitted from JSON) when the closure carries no such member.
+    """

--- a/sdk/python/src/rocky_sdk/types_generated/run_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/run_schema.py
@@ -150,7 +150,7 @@ class ExecutionSummary(BaseModel):
     """
     tables_failed: conint(ge=0)
     """
-    Tables that failed during the **execution phase** — copy or runtime failures while materializing. This does **not** include models excluded before execution started (for example, a model that failed to compile); those are counted only in the top-level `RunOutput.tables_failed`. For overall run pass/fail, read the top-level `tables_failed` / `status`, not this `execution.tables_failed`.
+    Source tables whose **copy failed** on the replication path (the `table_errors` count). Transformation-model runtime failures — including contained-cause failures — are reported in `errors` and the top-level `RunOutput.tables_failed`, not here; transformation-only runs leave the whole `execution` block unpopulated. For overall run pass/fail, read the top-level `tables_failed` / `status`, never this field.
     """
     tables_processed: conint(ge=0)
 


### PR DESCRIPTION
## Summary

Cross-cutting review pass over the 11-wave feature program (#1023–#1079), covering the surfaces the earlier fix rounds (#1080–#1086) did not: replay, recipe-identity recording, classified retry + containment, backfill, the governor CLI, the offline verifier, and the Dagster integration. Every finding was verified against source before fixing; each fix carries a regression test pinning the failure shape.

**Correctness fixes (engine):**

- **Content-addressed dispatch built an untyped IR.** Both `execute_models` dispatch sites handed the CA runner and the column-skip gate a bare `to_model_ir()` whose empty `typed_columns` (a) hard-errored the Arrow conversion ("model declares 0 typed columns") for any non-empty SELECT and (b) nulled `skip_hash()` — so the reuse spine / provenance ledger was never populated and the default-ON column skip was inert on the real CLI path. Both sites now use `typed_model_ir` (the same helper the plain gate uses).
- **Classified retry could double-apply bare INSERTs.** A commit-ambiguous transient failure (connection reset after the warehouse durably committed) re-ran the whole materialization; for `incremental`/`microbatch` — bare `INSERT INTO … <model SQL>` — that appends every row a second time. Retry is now gated on `rerun_is_idempotent(strategy)`; non-idempotent strategies surface the transient error instead.
- **Containment dropped case-differing bare reads.** The "bare model-name read is already a ref edge" skip compared against the lowercased model-name set while ref-edge derivation is case-sensitive, so `FROM ORDERS` reading model `orders` produced no edge at all and the reader built on the failed producer's stale output. The skip now requires exact `ref_deps` membership; everything else falls through to producer resolution.
- **Serial containment missed mid-layer failures.** Layer verdicts were computed once before dispatch, so an *uncertain* (CTE-read) model serially dispatched after a same-layer failure still built — something serial fail-fast would never materialize. The serial path re-adjudicates immediately before each dispatch.
- **`CircuitBreaker::record_success` silently closed an Open breaker**, letting a success that raced the trip re-arm run-wide retries ("once tripped, no further model is retried this run") and skipping the `Recovered` event. Success now closes only from HalfOpen.
- **Backfill scope integrity.** (a) A lone `--from`/`--to` bound was recorded as a range but executed as "latest partition only" — the CLI now requires the pair and apply rejects persisted half-open windows; (b) `[run] skip_unchanged = true` could silently no-op an entire approved backfill (the gate's `MAX(ts)`/rowcount signals are blind to exactly the backdated corrections backfills repair) — the plain gate is now forced inert, mirroring #1083's column-skip rule; (c) the closure now folds in **physical-name consumers** (the `ProducerIndex` edge set containment already models) plus their downstream, and plan layers order readers after producers; (d) planned models missing from the compiled project now fail the apply loudly instead of silently shrinking the approved scope; (e) `incremental`/`microbatch` closure members surface a reviewer-facing warning (their re-run is append/no-op, not a windowed rebuild) — new optional `warnings` field on `BackfillOutput`.
- **Replay verdict honesty.** `--check` (and `rocky gc`'s derivability eligibility, which reuses the verdict) reported `replayable` for chains `--execute` always refuses — an in-run producer with no provenance; both now agree, and the executor's blocked reason no longer misdiagnoses that case as a cross-run dependency. A `--verify` mismatch presented every divergence as "a genuine reproducibility gap"; when the comparison is ambiguous — a recording from a different engine version (parquet byte-identity is per-version), or a live-UniForm-writer recording whose physical column-mapped encoding the offline replay does not reproduce — the `diverged` verdict now carries an explicit caveat saying the mismatch may be encoding/version skew (the causal replay tests pin that these shapes still compare meaningfully when the encoder matches, so reclassifying would overclaim). Store read errors during classification are reported as read errors, not as "no provenance recorded".
- **Governor surfaces.** `rocky brief` windowed the escalations section, so a still-pending escalation older than `--since` vanished from "Needs you" while the review queue still listed it — escalations are now a current-state projection (like `autonomy`). `rocky audit --for` silently dropped plan-keyed ledger rows when the plan file was housekept away or the id was a decision-only custody key (`freeze:…`/`draft:…`/`autoapply:…`) — the resolver now falls back to ledger plan-id matches.
- **`rocky history` panicked on non-ASCII input** (`--recipe "€€…"`, state-synced names) via byte-slicing at fixed offsets — all display truncation is now char-boundary-safe.
- **`rocky plan` rendered copy SQL for tables `rocky run` excludes** (`[[table_overrides]] enabled = false`) — the preview now emits an "excluded" statement, restoring plan↔run agreement.
- **Flaky test:** `circuit_breaker::test_half_open_after_timeout` asserted still-Open inside a 30ms window (raced the wall clock on loaded runners — it failed PR #1086's CI); the pre-timeout assertion now uses a generous window in its own test.

**rocky-verify:** artifact resolution honored the manifest's recorded `path` verbatim (absolute or CWD-relative) *ahead of* `--artifacts-dir`, so a tampered in-dir artifact verified green against an intact out-of-dir copy — and a hostile manifest could direct the tool to hash any readable file. Resolution is now confined to `--artifacts-dir` (basename + hash forms), matching the function's own documented contract.

**Dagster integration:**

- Pruned-table placeholder checks stamped `passed=True` unconditionally — a red check flipped green on the next prune without re-evaluation. The placeholder now carries forward the **prior recorded verdict** (event-log lookup with a completed-status filter; the naive "latest record" is the current run's PLANNED row) and tags `rocky/pruned_unchanged: true`.
- Contained models on the derived-model asset path died as Dagster's generic "did not yield expected outputs" — they now raise `dg.Failure` naming the model, `blocked_by`, and `unblock_hint` (after sibling results are recorded).
- Dag-mode stamped a fake-green `MaterializeResult` on failed/contained models, and its key-matching missed the engine's `[catalog, schema, table]` keys under custom translators. Outcomes are now resolved per model (contained → Failure with blast-radius reason; failed → Failure with the engine's error; matched → enriched green).

**Found, deliberately not fixed here** (each needs a design-owner call; flagged for follow-up):

- `ModelExecution` success rows are keyed by *target table* name while gates/history/audit/backfill-pricing look up by *model config* name (and failure rows use pipeline/sentinel names) — inert skip baselines and empty `history --model` for aliased models. Re-keying the ledger touches every consumer; needs a migration plan.
- Plain-path `recipe_hash` folds compiler-*inferred* `typed_columns` into program identity, so an engine upgrade forks recipe history without a `HASH_SCHEME` bump. Fixing forks history once more — needs a deliberate scheme bump.
- DAG replay hashes evaluation 1 while downstreams read a second CTAS evaluation — under row-order instability the wrong node gets blamed (never a false `bit_exact`).
- Governor MCP read tools have no pagination over unbounded ledgers (operational hazard, needs a paging design).
- `prune_unchanged` never probes the target, so an externally dropped target keeps pruning (documented; `--no-prune` is the escape hatch).

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [x] `integrations/dagster/` (Python package)
- [x] `editors/vscode/` (TypeScript extension — regenerated bindings only)
- [ ] `examples/playground/` (sample project / benchmarks)
- [x] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Changes

- `engine/crates/rocky-cli/src/commands/run.rs`: typed IR at both CA dispatch sites; serial containment re-adjudication; backfill plain-gate force-off; planned-set-shrink guard; retry idempotency threading
- `engine/crates/rocky-cli/src/commands/resilience.rs`: `rerun_is_idempotent` + retry gate
- `engine/crates/rocky-cli/src/commands/containment.rs`: exact-ref-membership skip (+ visibility for reuse)
- `engine/crates/rocky-core/src/circuit_breaker.rs`: HalfOpen-only close; de-flaked timeout test
- `engine/crates/rocky-cli/src/commands/backfill.rs`: physical-reader closure + ordering; reviewer warnings
- `engine/crates/rocky-cli/src/commands/apply.rs`: half-open window guard
- `engine/rocky/src/main.rs`: `--from`/`--to` pairing on backfill
- `engine/crates/rocky-cli/src/commands/replay.rs`: check↔execute parity; encoding/version-skew caveats on diverged; honest store-error reasons
- `engine/crates/rocky-cli/src/commands/{brief,audit,history,plan}.rs`: current-state escalations; ledger plan-id fallback; char-safe truncation; excluded-table preview
- `engine/crates/rocky-verify/src/lib.rs`: artifacts-dir-confined resolution
- `engine/crates/rocky-cli/src/output.rs`: `BackfillOutput.warnings` (additive, optional); doc corrections (`AuditSubjectKind`, `ExecutionSummary.tables_failed`)
- `integrations/dagster/src/dagster_rocky/{component,dag_assets}.py`: prior-verdict placeholders; contained-model failures; dag-mode outcome resolution
- `schemas/`, `sdk/python/src/rocky_sdk/types_generated/`, `editors/vscode/src/types/generated/`, `docs/public/openapi.json`: regenerated

**Also folded in:** the post-branch `main` (through #1084) is merged, including reconciling the independently-landed circuit-breaker de-flake with this branch's version.

## Test Plan

- New regression tests, one per finding (engine: typed CA dispatch, non-idempotent retry, case-differing bare read, serial mid-layer containment, Open-breaker success, backfill gates/closure/ordering, brief window survival, audit custody-id resolution, char-boundary truncation, disabled-override resolution, verifier out-of-dir confinement; dagster: prior-verdict carry-forward, contained-model Failure, dag-mode fake-green)
- `engine`: `cargo test --all-features`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`
- `integrations/dagster`: 695/695 pytest, ruff check + format clean
- `sdk/python`: full pytest
- `just codegen` clean against the committed bindings

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/), scoped by subproject when relevant (e.g. `feat(engine/rocky-databricks): ...`, `fix(dagster): ...`)
- [x] No `Co-Authored-By` trailers
- [x] If this is a CLI JSON schema or DSL syntax change, all consumers (`integrations/dagster/`, `editors/vscode/`) are updated in this same PR

### Engine (`engine/`)
- [x] `cargo test --all-targets` passes
- [x] `cargo clippy --all-targets -- -D warnings` is clean
- [x] `cargo fmt --check` passes

### Dagster (`integrations/dagster/`)
- [x] `uv run pytest` passes
- [x] `uv run ruff check` is clean
- [x] `uv run ruff format --check` passes

### VS Code (`editors/vscode/`)
- [x] `npm run compile` succeeds (regenerated types only)
- [x] `npm run test:unit` passes (electron tests run in CI)
- [x] `npm run lint` is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)