### PR TITLE
fix(engine): agent-policy tranche-4 — backfill execute-from-owned, effective-mask + roles relaxations, source-schema snapshot plumbing

### DIFF
--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -285,11 +285,40 @@ fn governed_run_context<'a>(
         expected_ir_fingerprint: embedded.models_fingerprint,
         expected_config_identity: embedded.config_identity,
         // A `fingerprint_version >= 1` plan is a NEW plan this binary wrote and
-        // MUST carry a fingerprint; version 0 is genuinely legacy (skip).
-        require_fingerprint: embedded.fingerprint_version
-            >= crate::plan_store::CURRENT_FINGERPRINT_VERSION,
+        // MUST carry the exec fingerprint + routing identity; version 0 is
+        // genuinely legacy (skip). This is DELIBERATELY `>= 1`, NOT
+        // `>= CURRENT_FINGERPRINT_VERSION`: gating on CURRENT (now 2) would make
+        // v1 plans stop requiring the fingerprint/routing identity — a regression
+        // (finding #2). The v2-only source-snapshot requirement is a SEPARATE
+        // preflight (`preflight_snapshot`), not folded into this flag.
+        require_fingerprint: embedded.fingerprint_version >= 1,
         reviewed_source_schemas: embedded.reviewed_source_schemas,
     })
+}
+
+/// Fail-closed preflight (finding #2) for a MODEL-EXECUTING governed apply: it
+/// must carry the v2 reviewed source-schema snapshot (`Some`, even empty), run
+/// **before any warehouse mutation** (before replication discovery/DDL). A v1
+/// model-executing plan's fingerprint hashes only config+SQL — not
+/// `typed_columns` — so typing from the live cache at apply is a TOCTOU; force a
+/// re-plan at v2 that captures the snapshot. A v2 plan whose snapshot could not
+/// be captured (`None`) is a production failure → refuse. Genuinely-legacy v0
+/// plans (`require_fingerprint == false`) and human applies (no context) are
+/// exempt. Pure-replication (no-model) plans never call this.
+fn preflight_snapshot(governed_ctx: Option<&GovernedRunContext<'_>>, plan_id: &str) -> Result<()> {
+    if let Some(ctx) = governed_ctx
+        && ctx.require_fingerprint
+        && ctx.reviewed_source_schemas.is_none()
+    {
+        bail!(
+            "refusing to apply governed plan '{plan_id}': it executes models but carries no \
+             reviewed source-schema snapshot (a v1 plan, or a v2 plan whose snapshot could not be \
+             captured), so `typed_columns` would be typed from the live cache at apply — a TOCTOU \
+             the fingerprint does not cover. Re-plan with `rocky plan` (which captures the snapshot \
+             at fingerprint v2) before applying."
+        );
+    }
+    Ok(())
 }
 
 /// Execute a deserialized [`RunPlan`] against the warehouse.
@@ -318,6 +347,12 @@ async fn execute_run_plan(
     // post-discovery replication gate. `None` for a human apply.
     governed_ctx: Option<&GovernedRunContext<'_>>,
 ) -> Result<()> {
+    // ‼️ Finding #2: preflight the reviewed source-schema snapshot BEFORE any
+    // warehouse mutation — this path executes models (and, for a replication
+    // pipeline, does replication discovery/DDL first), so a v1/missing-snapshot
+    // plan must be refused here rather than after the first statement runs.
+    preflight_snapshot(governed_ctx, plan_id)?;
+
     // Build partition options from the persisted flags.
     let partition_opts = crate::commands::run::PartitionRunOptions {
         partition: run_plan.partition.clone(),
@@ -1958,6 +1993,9 @@ async fn run_apply_backfill_plan(
         root,
         config_path,
     );
+    // ‼️ Finding #2: a backfill executes models — preflight the reviewed
+    // source-schema snapshot before any warehouse mutation.
+    preflight_snapshot(governed.as_ref(), plan_id)?;
     let exec_fp_gate = match (governed.as_ref(), backfill_cfg.as_ref()) {
         (Some(ctx), Some(cfg)) => {
             // Fail-closed (#4/#5): verify the routing identity before executing.

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -288,6 +288,7 @@ fn governed_run_context<'a>(
         // MUST carry a fingerprint; version 0 is genuinely legacy (skip).
         require_fingerprint: embedded.fingerprint_version
             >= crate::plan_store::CURRENT_FINGERPRINT_VERSION,
+        reviewed_source_schemas: embedded.reviewed_source_schemas,
     })
 }
 
@@ -1043,6 +1044,13 @@ pub(crate) fn execution_ir_fingerprint(
 ///   attribute) and its contents constrain the model's output. Keyed by model
 ///   name; the value is a content hash. An absent key means "no contract", so
 ///   adding or removing a contract moves the fingerprint.
+/// - **Effective masking plan (finding C).** The masking reconcile applies a
+///   strategy to a column only when the column's classification tag (in
+///   `ModelConfig`, already hashed) resolves under the active env. Binding the
+///   WHOLE `[mask]` map over-binds: an *unused* mask entry would move the
+///   fingerprint. Here we bind only the resolution for tags actually declared on
+///   the executed models — so an unused mask entry does NOT refuse, a used one
+///   does. Computed at the choke-point because it depends on the executed set.
 #[derive(Debug, Default, Clone, serde::Serialize)]
 pub(crate) struct ExecutionExtras {
     /// Per-model surrogate-key specs, name-sorted for stability.
@@ -1052,18 +1060,25 @@ pub(crate) struct ExecutionExtras {
     /// path is machine/tempdir-specific and would cause cross-machine
     /// false-refuse).
     contracts: BTreeMap<String, String>,
+    /// The EFFECTIVE masking resolution (finding C): `tag → strategy` restricted
+    /// to classification tags actually declared on the executed models. Only the
+    /// resolution is bound here — the model `(col → tag)` classification is
+    /// already in the config projection.
+    effective_masks: BTreeMap<String, rocky_ir::MaskStrategy>,
 }
 
 impl ExecutionExtras {
-    /// Assemble the extras from the already-loaded surrogate-key map plus the
-    /// compiled models (for their `contract_path`s). Called identically at plan
-    /// time and at the apply choke-point over the same `models_dir`.
+    /// Assemble the extras from the already-loaded surrogate-key map, the
+    /// compiled models (for `contract_path`s + classification tags), and the
+    /// env-resolved mask map. Called identically at plan time and at the apply
+    /// choke-point over the same `models_dir` / resolved mask.
     pub(crate) fn build(
         surrogate_keys: &std::collections::HashMap<
             String,
             Vec<rocky_core::models::SurrogateKeySpec>,
         >,
         models: &[rocky_core::models::Model],
+        resolved_mask: &BTreeMap<String, rocky_ir::MaskStrategy>,
     ) -> Self {
         let surrogate_keys: BTreeMap<String, Vec<rocky_core::models::SurrogateKeySpec>> =
             surrogate_keys
@@ -1071,6 +1086,7 @@ impl ExecutionExtras {
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect();
         let mut contracts = BTreeMap::new();
+        let mut effective_masks = BTreeMap::new();
         for m in models {
             if let Some(path) = &m.contract_path {
                 // Hash the CONTENTS. A read failure at apply that succeeded at
@@ -1084,10 +1100,17 @@ impl ExecutionExtras {
                 };
                 contracts.insert(m.config.name.clone(), hash);
             }
+            // Only the resolution for tags this model actually classifies with.
+            for tag in m.config.classification.values() {
+                if let Some(strategy) = resolved_mask.get(tag) {
+                    effective_masks.insert(tag.clone(), *strategy);
+                }
+            }
         }
         Self {
             surrogate_keys,
             contracts,
+            effective_masks,
         }
     }
 }
@@ -1143,44 +1166,49 @@ pub(crate) fn config_policy_identity(cfg: &rocky_core::config::RockyConfig) -> S
         .unwrap_or_default()
 }
 
-/// The env-resolved **governance** identity — the mutation-driving workspace
-/// governance the reviewed plan authorized. Hashed into the execution
-/// fingerprint **only** (never the routing gate), so a post-plan change to what
-/// the governance reconcile would apply is refused, while it cannot cause a
-/// routing false-refuse.
+/// The **model-independent governance** identity — the env-invariant,
+/// mutation-driving workspace governance the reviewed plan authorized. Hashed
+/// into the execution fingerprint **only** (never the routing gate), so a
+/// post-plan change to what the governance reconcile would apply is refused,
+/// while it cannot cause a routing false-refuse.
 ///
-/// Binds exactly the fields that **drive a warehouse mutation**:
-/// - `resolve_mask_for_env(env)` — the tag→strategy map the masking reconcile
-///   applies, resolved for the plan's persisted `--env` (so `[mask.<env>]`
-///   overlays are captured for the env that will actually run, and an unrelated
-///   env's mask does not over-bind);
-/// - the **flattened** role graph (`role_graph()`) — the resolved GRANT set the
-///   role reconcile applies (finding #2: a `SELECT → MANAGE` permission edit
-///   changes this); `None` when the graph is malformed (deterministic on both
-///   sides);
+/// Binds exactly the fields that **drive a warehouse mutation** and are
+/// model-independent:
+/// - the role graph's **effective GRANT set** — each role's *sorted flattened
+///   permissions* only (finding #2 + D). `inherits_from` is deliberately
+///   dropped: the adapter derives GRANTs solely from `flattened_permissions`
+///   (inherits is logging-only), so reordering semantically-equivalent
+///   `inherits` must NOT refuse. `None`/empty when the graph is malformed
+///   (deterministic on both sides).
 /// - the `[cache.schemas]` **selection toggle** (`enabled`) — an agent-controlled
 ///   on-disk switch that changes whether apply resolves concrete `typed_columns`
 ///   vs `Unknown` (finding #4a). Only the boolean toggle is bound, NOT the whole
 ///   struct: `ttl` can be env-var-templated, which would re-introduce the #5
 ///   cross-process false-refuse; `enabled` is a closed boolean.
 ///
+/// The **mask** is NOT bound here — it is model-DEPENDENT (only the resolution
+/// for tags declared on the executed models drives a mutation), so it lives in
+/// [`ExecutionExtras::effective_masks`], computed at the choke-point (finding C).
 /// Advisory `[classifications]` is **excluded by design** (finding #5): it drives
 /// no warehouse action (W004-only) and its env-var-templated `allow_unmasked`
-/// values would differ across processes → a false-refuse. Mask *values* are a
-/// closed vocabulary (`hash`/`redact`/`partial`/`none`), so the resolved map
-/// carries no cross-process templating variance.
-pub(crate) fn governance_policy_identity(
-    cfg: &rocky_core::config::RockyConfig,
-    env: Option<&str>,
-) -> String {
-    let mask = cfg.resolve_mask_for_env(env);
-    // Deterministic on both sides: a malformed graph serializes to `null` at
-    // plan and apply alike (same cfg), so it does not false-refuse; a valid→
-    // malformed edit moves the identity → refuse.
-    let roles = cfg.role_graph().ok();
+/// values would differ across processes → a false-refuse.
+pub(crate) fn governance_policy_identity(cfg: &rocky_core::config::RockyConfig) -> String {
+    // Project each role to its SORTED flattened permissions only (D): the GRANT
+    // set the adapter actually applies. `flattened_permissions` is Ord-sorted by
+    // construction; `role_graph()` is name-keyed (BTreeMap) → deterministic. A
+    // malformed graph → empty map on both sides (no false-refuse); an effective-
+    // permission change (SELECT→MANAGE) moves the identity → refuse.
+    let role_perms: BTreeMap<String, Vec<rocky_ir::Permission>> = cfg
+        .role_graph()
+        .map(|roles| {
+            roles
+                .into_iter()
+                .map(|(name, r)| (name, r.flattened_permissions))
+                .collect()
+        })
+        .unwrap_or_default();
     serde_json::to_value(serde_json::json!({
-        "mask": mask,
-        "roles": roles,
+        "roles": role_perms,
         "cache_schemas_enabled": cfg.cache.schemas.enabled,
     }))
     .map(|v| v.to_string())
@@ -1200,9 +1228,20 @@ pub struct ExecFingerprintGate {
     pub expected: Option<String>,
     /// The routing config identity computed from the execute-time config.
     pub config_identity: String,
-    /// The env-resolved governance identity computed from the execute-time
-    /// config + the plan's persisted `--env` (mask / roles / cache-selection).
+    /// The model-independent governance identity computed from the execute-time
+    /// config (roles / cache-selection).
     pub governance_identity: String,
+    /// The env-resolved mask map (`resolve_mask_for_env(plan-env)`). The
+    /// choke-point restricts it to the executed models' classification tags when
+    /// building [`ExecutionExtras`] (finding C — an unused mask entry must not
+    /// refuse). Carried here because `execute_models` has no `env`/`cfg`.
+    pub resolved_mask: BTreeMap<String, rocky_ir::MaskStrategy>,
+    /// The plan-authorized REVIEWED source-schema snapshot (finding #2b). When
+    /// non-empty, the choke-point seeds its compile's `source_schemas` from this
+    /// so `typed_columns` (→ the MERGE column list) replay the reviewed schema,
+    /// not a drifted live/cache read. Carried here because `execute_models` has
+    /// no plan handle.
+    pub reviewed_source_schemas: BTreeMap<String, Vec<rocky_ir::types::TypedColumn>>,
     /// The plan id, for the refusal message.
     pub plan_id: String,
     /// `true` when the plan is a NEW (`fingerprint_version >= 1`) governed plan
@@ -1292,6 +1331,13 @@ pub struct GovernedRunContext<'a> {
     /// that MUST carry a fingerprint/identity: a missing one is a production
     /// failure and REFUSES (finding #7), not a legacy skip.
     pub require_fingerprint: bool,
+    /// The plan-authorized REVIEWED source-schema snapshot (finding #2b). Apply
+    /// seeds its compile's `source_schemas` from this instead of a live/cache
+    /// read, so a post-plan source-schema drift cannot change `typed_columns` →
+    /// the executed MERGE column list stays what was reviewed. Empty ⇒ apply
+    /// uses its live cache load.
+    pub reviewed_source_schemas:
+        std::collections::BTreeMap<String, Vec<rocky_ir::types::TypedColumn>>,
 }
 
 impl GovernedRunContext<'_> {
@@ -1308,7 +1354,9 @@ impl GovernedRunContext<'_> {
         ExecFingerprintGate {
             expected: self.expected_ir_fingerprint.clone(),
             config_identity: config_policy_identity(cfg),
-            governance_identity: governance_policy_identity(cfg, env),
+            governance_identity: governance_policy_identity(cfg),
+            resolved_mask: cfg.resolve_mask_for_env(env),
+            reviewed_source_schemas: self.reviewed_source_schemas.clone(),
             plan_id: self.plan_id.to_string(),
             require: self.require_fingerprint,
         }
@@ -1929,8 +1977,22 @@ async fn run_apply_backfill_plan(
         _ => None,
     };
 
+    // Execute-from-owned (finding B): hand the SAME verified `backfill_cfg`
+    // instance `verify_routing_identity` checked to `execute_backfill_set`,
+    // rather than have it reload — a timed `rocky.toml` swap between the gate and
+    // a reload would otherwise pick a different, unverified destination. A config
+    // that will not load cannot be executed against; bail (mirrors the old
+    // internal load error).
+    let rocky_cfg = backfill_cfg.with_context(|| {
+        format!(
+            "failed to load config from {} (required for backfill)",
+            config_path.display()
+        )
+    })?;
+
     crate::commands::run::execute_backfill_set(
         config_path,
+        &rocky_cfg,
         state_path,
         models_dir,
         &set,
@@ -3023,6 +3085,7 @@ effect = "deny"
             models_fingerprint: None,
             config_identity: None,
             fingerprint_version: 0,
+            reviewed_source_schemas: std::collections::BTreeMap::new(),
         };
         let touched = caps.touched(&["m".to_string()]);
         assert!(!touched.is_empty(), "FIX 3 must synthesize a touched set");
@@ -3059,6 +3122,7 @@ effect = "deny"
             models_fingerprint: None,
             config_identity: None,
             fingerprint_version: 0,
+            reviewed_source_schemas: std::collections::BTreeMap::new(),
         };
         let touched = caps.touched(&["m".to_string()]);
         let gate = super::evaluate_apply_policy(
@@ -3088,6 +3152,7 @@ effect = "deny"
             models_fingerprint: None,
             config_identity: None,
             fingerprint_version: 0,
+            reviewed_source_schemas: std::collections::BTreeMap::new(),
         };
         let touched = caps.touched(&["m".to_string()]);
         let gate = super::evaluate_apply_policy(
@@ -3274,6 +3339,7 @@ effect = "allow"
             models_fingerprint: None,
             config_identity: None,
             fingerprint_version: 0,
+            reviewed_source_schemas: std::collections::BTreeMap::new(),
         };
         // Both models execute; only stg_x changed.
         let touched = caps.touched(&["stg_x".to_string(), "prod_critical".to_string()]);
@@ -3783,14 +3849,16 @@ auto_create_schemas = true
             std::fs::write(&p, body).unwrap();
             rocky_core::config::load_rocky_config(&p).unwrap()
         }
-        let gid = |c: &rocky_core::config::RockyConfig| super::governance_policy_identity(c, None);
+        let gid = |c: &rocky_core::config::RockyConfig| super::governance_policy_identity(c);
         let base = "[adapter]\ntype = \"duckdb\"\npath = \"a.duckdb\"\n\n[pipeline.p]\ntype = \"transformation\"\nmodels = \"models/**\"\n\n[pipeline.p.target]\nadapter = \"default\"\n";
 
-        // #6 mask strategy change → identity moves (drives a masking mutation).
-        assert_ne!(
+        // The mask is NOT in the governance identity anymore (it is model-
+        // dependent → `ExecutionExtras::effective_masks`, finding C). A `[mask]`
+        // change must NOT move the model-independent governance identity.
+        assert_eq!(
             gid(&cfg(&format!("{base}\n[mask]\npii = \"hash\"\n"))),
             gid(&cfg(&format!("{base}\n[mask]\npii = \"redact\"\n"))),
-            "a [mask] strategy change must move the governance identity (#6)"
+            "the mask must not be in the model-independent governance identity (C)"
         );
 
         // #2 role permission change (SELECT → MANAGE) → identity moves.
@@ -3799,6 +3867,23 @@ auto_create_schemas = true
             gid(&cfg(&role("SELECT"))),
             gid(&cfg(&role("MANAGE"))),
             "a role permission change must move the governance identity (#2)"
+        );
+
+        // 🔴 D (over-binding roles): reordering `inherits` that yields the SAME
+        // flattened permissions must NOT move the identity (GRANTs depend only on
+        // the flattened set; inherits is logging-only).
+        let two_parents = format!(
+            "{base}\n[role.a]\npermissions = [\"SELECT\"]\n\n[role.b]\npermissions = [\"MODIFY\"]\n\n[role.c]\ninherits = [{}]\n",
+            "\"a\", \"b\""
+        );
+        let reordered = format!(
+            "{base}\n[role.a]\npermissions = [\"SELECT\"]\n\n[role.b]\npermissions = [\"MODIFY\"]\n\n[role.c]\ninherits = [{}]\n",
+            "\"b\", \"a\""
+        );
+        assert_eq!(
+            gid(&cfg(&two_parents)),
+            gid(&cfg(&reordered)),
+            "reordering equivalent inherits must NOT move the governance identity (D)"
         );
 
         // #4a [cache.schemas] toggle → identity moves (changes whether apply
@@ -3843,6 +3928,8 @@ auto_create_schemas = true
             expected: None,
             config_identity: "c".to_string(),
             governance_identity: "g".to_string(),
+            resolved_mask: std::collections::BTreeMap::new(),
+            reviewed_source_schemas: std::collections::BTreeMap::new(),
             plan_id: "p".to_string(),
             require: false,
         }
@@ -3853,6 +3940,8 @@ auto_create_schemas = true
             expected: None,
             config_identity: "c".to_string(),
             governance_identity: "g".to_string(),
+            resolved_mask: std::collections::BTreeMap::new(),
+            reviewed_source_schemas: std::collections::BTreeMap::new(),
             plan_id: "p".to_string(),
             require: true,
         }
@@ -3864,6 +3953,8 @@ auto_create_schemas = true
             expected: Some(expected.clone()),
             config_identity: "c".to_string(),
             governance_identity: "g".to_string(),
+            resolved_mask: std::collections::BTreeMap::new(),
+            reviewed_source_schemas: std::collections::BTreeMap::new(),
             plan_id: "p".to_string(),
             require: true,
         }
@@ -3874,6 +3965,8 @@ auto_create_schemas = true
                 expected: Some(expected.clone()),
                 config_identity: "DIFFERENT".to_string(),
                 governance_identity: "g".to_string(),
+                resolved_mask: std::collections::BTreeMap::new(),
+                reviewed_source_schemas: std::collections::BTreeMap::new(),
                 plan_id: "p".to_string(),
                 require: true,
             }
@@ -3887,6 +3980,8 @@ auto_create_schemas = true
                 expected: Some(expected),
                 config_identity: "c".to_string(),
                 governance_identity: "DIFFERENT".to_string(),
+                resolved_mask: std::collections::BTreeMap::new(),
+                reviewed_source_schemas: std::collections::BTreeMap::new(),
                 plan_id: "p".to_string(),
                 require: true,
             }
@@ -3923,6 +4018,7 @@ auto_create_schemas = true
             expected_ir_fingerprint: None,
             expected_config_identity: expected,
             require_fingerprint: require,
+            reviewed_source_schemas: std::collections::BTreeMap::new(),
         };
         let authorized = super::config_policy_identity(&cfg_a);
         // Unchanged routing → proceeds.
@@ -3970,6 +4066,7 @@ effect = "deny"
             expected_ir_fingerprint: None,
             expected_config_identity: None,
             require_fingerprint: false,
+            reviewed_source_schemas: std::collections::BTreeMap::new(),
         };
         let targets: BTreeSet<String> = ["raw_orders".to_string()].into_iter().collect();
         let err = ctx
@@ -4015,6 +4112,7 @@ effect = "allow"
             expected_ir_fingerprint: None,
             expected_config_identity: None,
             require_fingerprint: false,
+            reviewed_source_schemas: std::collections::BTreeMap::new(),
         };
         let targets: BTreeSet<String> = ["raw_orders".to_string()].into_iter().collect();
 
@@ -4062,6 +4160,7 @@ effect = "allow"
             expected_ir_fingerprint: None,
             expected_config_identity: None,
             require_fingerprint: false,
+            reviewed_source_schemas: std::collections::BTreeMap::new(),
         };
         let targets: BTreeSet<String> = ["raw_orders".to_string()].into_iter().collect();
         ctx.gate_replication_targets(&targets, &ledger)

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -1236,12 +1236,14 @@ pub struct ExecFingerprintGate {
     /// building [`ExecutionExtras`] (finding C — an unused mask entry must not
     /// refuse). Carried here because `execute_models` has no `env`/`cfg`.
     pub resolved_mask: BTreeMap<String, rocky_ir::MaskStrategy>,
-    /// The plan-authorized REVIEWED source-schema snapshot (finding #2b). When
-    /// non-empty, the choke-point seeds its compile's `source_schemas` from this
-    /// so `typed_columns` (→ the MERGE column list) replay the reviewed schema,
-    /// not a drifted live/cache read. Carried here because `execute_models` has
-    /// no plan handle.
-    pub reviewed_source_schemas: BTreeMap<String, Vec<rocky_ir::types::TypedColumn>>,
+    /// The plan-authorized REVIEWED source-schema snapshot (finding #2). `Some`
+    /// (authoritative even if empty) ⇒ the choke-point seeds its compile's
+    /// `source_schemas` from EXACTLY this, never the live cache, so `typed_columns`
+    /// replay the reviewed schema. `None` on a genuinely-legacy plan; a required
+    /// (v2 governed) plan with `None` REFUSES. Carried here because
+    /// `execute_models` has no plan handle.
+    pub reviewed_source_schemas:
+        Option<BTreeMap<String, Vec<rocky_ir::types::TypedColumn>>>,
     /// The plan id, for the refusal message.
     pub plan_id: String,
     /// `true` when the plan is a NEW (`fingerprint_version >= 1`) governed plan
@@ -1331,13 +1333,12 @@ pub struct GovernedRunContext<'a> {
     /// that MUST carry a fingerprint/identity: a missing one is a production
     /// failure and REFUSES (finding #7), not a legacy skip.
     pub require_fingerprint: bool,
-    /// The plan-authorized REVIEWED source-schema snapshot (finding #2b). Apply
-    /// seeds its compile's `source_schemas` from this instead of a live/cache
-    /// read, so a post-plan source-schema drift cannot change `typed_columns` →
-    /// the executed MERGE column list stays what was reviewed. Empty ⇒ apply
-    /// uses its live cache load.
+    /// The plan-authorized REVIEWED source-schema snapshot (finding #2). `Some`
+    /// (authoritative even if empty) ⇒ apply seeds its compile from EXACTLY this,
+    /// never the live cache. `None` on a legacy plan; a required plan with `None`
+    /// REFUSES (fail-closed).
     pub reviewed_source_schemas:
-        std::collections::BTreeMap<String, Vec<rocky_ir::types::TypedColumn>>,
+        Option<std::collections::BTreeMap<String, Vec<rocky_ir::types::TypedColumn>>>,
 }
 
 impl GovernedRunContext<'_> {
@@ -3085,7 +3086,7 @@ effect = "deny"
             models_fingerprint: None,
             config_identity: None,
             fingerprint_version: 0,
-            reviewed_source_schemas: std::collections::BTreeMap::new(),
+            reviewed_source_schemas: None,
         };
         let touched = caps.touched(&["m".to_string()]);
         assert!(!touched.is_empty(), "FIX 3 must synthesize a touched set");
@@ -3122,7 +3123,7 @@ effect = "deny"
             models_fingerprint: None,
             config_identity: None,
             fingerprint_version: 0,
-            reviewed_source_schemas: std::collections::BTreeMap::new(),
+            reviewed_source_schemas: None,
         };
         let touched = caps.touched(&["m".to_string()]);
         let gate = super::evaluate_apply_policy(
@@ -3152,7 +3153,7 @@ effect = "deny"
             models_fingerprint: None,
             config_identity: None,
             fingerprint_version: 0,
-            reviewed_source_schemas: std::collections::BTreeMap::new(),
+            reviewed_source_schemas: None,
         };
         let touched = caps.touched(&["m".to_string()]);
         let gate = super::evaluate_apply_policy(
@@ -3339,7 +3340,7 @@ effect = "allow"
             models_fingerprint: None,
             config_identity: None,
             fingerprint_version: 0,
-            reviewed_source_schemas: std::collections::BTreeMap::new(),
+            reviewed_source_schemas: None,
         };
         // Both models execute; only stg_x changed.
         let touched = caps.touched(&["stg_x".to_string(), "prod_critical".to_string()]);
@@ -3929,7 +3930,7 @@ auto_create_schemas = true
             config_identity: "c".to_string(),
             governance_identity: "g".to_string(),
             resolved_mask: std::collections::BTreeMap::new(),
-            reviewed_source_schemas: std::collections::BTreeMap::new(),
+            reviewed_source_schemas: None,
             plan_id: "p".to_string(),
             require: false,
         }
@@ -3941,7 +3942,7 @@ auto_create_schemas = true
             config_identity: "c".to_string(),
             governance_identity: "g".to_string(),
             resolved_mask: std::collections::BTreeMap::new(),
-            reviewed_source_schemas: std::collections::BTreeMap::new(),
+            reviewed_source_schemas: None,
             plan_id: "p".to_string(),
             require: true,
         }
@@ -3954,7 +3955,7 @@ auto_create_schemas = true
             config_identity: "c".to_string(),
             governance_identity: "g".to_string(),
             resolved_mask: std::collections::BTreeMap::new(),
-            reviewed_source_schemas: std::collections::BTreeMap::new(),
+            reviewed_source_schemas: None,
             plan_id: "p".to_string(),
             require: true,
         }
@@ -3966,7 +3967,7 @@ auto_create_schemas = true
                 config_identity: "DIFFERENT".to_string(),
                 governance_identity: "g".to_string(),
                 resolved_mask: std::collections::BTreeMap::new(),
-                reviewed_source_schemas: std::collections::BTreeMap::new(),
+                reviewed_source_schemas: None,
                 plan_id: "p".to_string(),
                 require: true,
             }
@@ -3981,7 +3982,7 @@ auto_create_schemas = true
                 config_identity: "c".to_string(),
                 governance_identity: "DIFFERENT".to_string(),
                 resolved_mask: std::collections::BTreeMap::new(),
-                reviewed_source_schemas: std::collections::BTreeMap::new(),
+                reviewed_source_schemas: None,
                 plan_id: "p".to_string(),
                 require: true,
             }
@@ -4018,7 +4019,7 @@ auto_create_schemas = true
             expected_ir_fingerprint: None,
             expected_config_identity: expected,
             require_fingerprint: require,
-            reviewed_source_schemas: std::collections::BTreeMap::new(),
+            reviewed_source_schemas: None,
         };
         let authorized = super::config_policy_identity(&cfg_a);
         // Unchanged routing → proceeds.
@@ -4066,7 +4067,7 @@ effect = "deny"
             expected_ir_fingerprint: None,
             expected_config_identity: None,
             require_fingerprint: false,
-            reviewed_source_schemas: std::collections::BTreeMap::new(),
+            reviewed_source_schemas: None,
         };
         let targets: BTreeSet<String> = ["raw_orders".to_string()].into_iter().collect();
         let err = ctx
@@ -4112,7 +4113,7 @@ effect = "allow"
             expected_ir_fingerprint: None,
             expected_config_identity: None,
             require_fingerprint: false,
-            reviewed_source_schemas: std::collections::BTreeMap::new(),
+            reviewed_source_schemas: None,
         };
         let targets: BTreeSet<String> = ["raw_orders".to_string()].into_iter().collect();
 
@@ -4160,7 +4161,7 @@ effect = "allow"
             expected_ir_fingerprint: None,
             expected_config_identity: None,
             require_fingerprint: false,
-            reviewed_source_schemas: std::collections::BTreeMap::new(),
+            reviewed_source_schemas: None,
         };
         let targets: BTreeSet<String> = ["raw_orders".to_string()].into_iter().collect();
         ctx.gate_replication_targets(&targets, &ledger)

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -253,7 +253,14 @@ async fn run_apply_run_plan(
     // their apply behaviour stays byte-identical). Carries the plan-authorized
     // models fingerprint for the in-run TOCTOU reject and the identity for the
     // post-discovery replication gate.
-    let governed = governed_run_context(&plan, principal, plan_id, root, config_path);
+    let governed = governed_run_context(
+        &plan,
+        principal,
+        plan_id,
+        root,
+        config_path,
+        !run_plan.models.is_empty(),
+    );
     execute_run_plan(
         config_path,
         plan_id,
@@ -281,6 +288,9 @@ fn governed_run_context<'a>(
     plan_id: &'a str,
     root: &'a Path,
     config_path: &'a Path,
+    // `!run_plan.models.is_empty()` — the plan reviewed a non-empty model set
+    // (finding #2, threaded to the executor fail-closed legs).
+    expects_models: bool,
 ) -> Option<GovernedRunContext<'a>> {
     if principal != PolicyPrincipal::Agent {
         return None;
@@ -291,6 +301,7 @@ fn governed_run_context<'a>(
         plan_id,
         root,
         config_path,
+        expects_models,
         expected_ir_fingerprint: embedded.models_fingerprint,
         expected_config_identity: embedded.config_identity,
         // A `fingerprint_version >= 1` plan is a NEW plan this binary wrote and
@@ -416,8 +427,10 @@ async fn execute_run_plan(
     // plan must be refused here rather than after the first statement runs. A
     // replication-only plan (no `--all`/`--models`/`--model`) executes NO models
     // → exempt (fail-safe: a config that will not load stays strict).
-    let executes_models = rocky_core::config::load_rocky_config(config_path)
-        .map(|cfg| !is_replication_only(&cfg, &run_plan))
+    let resolved_cfg = rocky_core::config::load_rocky_config(config_path).ok();
+    let executes_models = resolved_cfg
+        .as_ref()
+        .map(|cfg| !is_replication_only(cfg, &run_plan))
         .unwrap_or(true);
     preflight_snapshot(governed_ctx, plan_id, executes_models)?;
 
@@ -503,22 +516,35 @@ async fn execute_run_plan(
         .with_context(|| format!("rocky apply run plan '{plan_id}' failed (dag path)"));
     }
 
-    // ‼️ Finding #2 (missing-dir): a governed non-dag apply whose plan REVIEWED a
-    // non-empty model set, but whose models directory no longer compiles to any
-    // model (deleted / renamed / broken since the plan), must FAIL CLOSED here —
-    // otherwise the executor's model leg silently skips (`if mdir.exists()`) or
-    // returns a successful no-op, the execution fingerprint is never recomputed,
-    // and apply reports SUCCESS without executing the planned models. Recompile the
-    // exact dir at the seam, BEFORE any warehouse statement (`run()` below is the
-    // first mutation; the `partition_opts`/`shadow_config` setup above is read-only).
-    // Placed AFTER the `--dag` guard so a governed dag apply keeps its categorical
-    // refusal (that path never reaches here).
+    // ‼️ Finding #2 (missing-dir), REPLICATION seam: a governed non-dag apply whose
+    // plan REVIEWED a non-empty silver-model set, but whose models directory no
+    // longer compiles to any model (deleted / renamed / broken since the plan),
+    // must FAIL CLOSED here — otherwise the replication path's model leg silently
+    // skips (`if mdir.exists()` at run.rs), the execution fingerprint is never
+    // recomputed, and apply reports SUCCESS without executing the planned models.
+    // Recompile the exact dir at the seam, BEFORE the replication DDL runs (the
+    // first warehouse mutation; the `partition_opts`/`shadow_config` setup above is
+    // read-only). Placed AFTER the `--dag` guard so a governed dag apply keeps its
+    // categorical refusal (that path never reaches here).
     //
-    // Scoped to `!run_plan.models.is_empty()` so a legitimate run of a replication
-    // pipeline with `--all` and NO silver `models/` (a valid pure-replication run
-    // whose reviewed model set is empty) is NOT failed. Human applies and
-    // replication-only plans are exempt (not governed / no model execution).
-    if governed_ctx.is_some() && executes_models && !run_plan.models.is_empty() {
+    // SCOPED to a Replication pipeline: replication resolves its silver-model leg
+    // cwd-relative (`run.rs`'s `models_dir.unwrap_or("models")`), which is exactly
+    // what we recompile here, so seam and executor agree on the path. The
+    // TRANSFORMATION path is NOT checked at this seam — `run_local` resolves
+    // `config_dir.join(models_base)` from the pipeline config (ignoring
+    // `run_plan.models_dir`), so a seam keyed on `run_plan.models_dir` would check a
+    // DIFFERENT directory and could false-refuse a valid apply; transformation is
+    // instead fail-closed at its OWN executor (`run_local`, which is its first
+    // mutation anyway). Scoped to a non-empty reviewed set so a valid pure-
+    // replication run with no silver `models/` is not failed; and the executor legs
+    // (guarded by `expects_models`) close the residual seam→execute race.
+    if governed_ctx.is_some()
+        && executes_models
+        && !run_plan.models.is_empty()
+        && resolved_cfg
+            .as_ref()
+            .is_some_and(|cfg| pipeline_is_replication(cfg, run_plan.pipeline.as_deref()))
+    {
         let mdir = models_dir_path
             .clone()
             .unwrap_or_else(|| std::path::PathBuf::from("models"));
@@ -1479,6 +1505,14 @@ pub struct GovernedRunContext<'a> {
     /// REFUSES (fail-closed).
     pub reviewed_source_schemas:
         Option<std::collections::BTreeMap<String, Vec<rocky_ir::types::TypedColumn>>>,
+    /// `true` when the plan REVIEWED a non-empty model set (`!run_plan.models
+    /// .is_empty()`). Finding #2 (missing-dir): threaded to the executor legs so a
+    /// governed model-executing apply whose reviewed models directory is deleted
+    /// AFTER the apply seam's compile (the seam→execute race) still fails CLOSED at
+    /// the executor rather than silently skipping. `false` (an empty reviewed set,
+    /// e.g. a pure-replication run with no silver models) preserves the executor's
+    /// legitimate silent-skip.
+    pub expects_models: bool,
 }
 
 impl GovernedRunContext<'_> {
@@ -1961,7 +1995,14 @@ async fn run_apply_ai_authored_plan(
     // One unique id for this apply's run, threaded into execution and into the
     // post-apply gate so the gate reads exactly this run, not "latest".
     let apply_run_id = new_apply_run_id();
-    let governed = governed_run_context(&plan, principal, plan_id, root, config_path);
+    let governed = governed_run_context(
+        &plan,
+        principal,
+        plan_id,
+        root,
+        config_path,
+        !run_plan.models.is_empty(),
+    );
     execute_run_plan(
         config_path,
         plan_id,
@@ -2107,6 +2148,10 @@ async fn run_apply_backfill_plan(
         plan_id,
         root,
         config_path,
+        // A backfill executes its `model_set`; carry the reviewed-set signal (it
+        // routes through `execute_backfill_set`, not the seam-guarded legs, but
+        // keep the derivation consistent).
+        !run_plan.models.is_empty(),
     );
     // ‼️ Finding #2: a backfill ALWAYS executes models (its `model_set`) —
     // preflight the reviewed source-schema snapshot before any warehouse mutation.
@@ -2284,6 +2329,10 @@ async fn run_apply_replication_plan(
         plan_id,
         root,
         config_path,
+        // A pure replication apply delegates to `run` with default model args
+        // (no --all/--models/--model) → it executes NO compiled models → an empty
+        // reviewed set, so the executor legs keep their legitimate silent-skip.
+        false,
     );
 
     crate::commands::run::run(
@@ -4172,6 +4221,7 @@ auto_create_schemas = true
             expected_config_identity: expected,
             require_fingerprint: require,
             reviewed_source_schemas: None,
+            expects_models: true,
         };
         let authorized = super::config_policy_identity(&cfg_a);
         // Unchanged routing → proceeds.
@@ -4275,6 +4325,7 @@ auto_create_schemas = true
             expected_config_identity: None,
             require_fingerprint: require,
             reviewed_source_schemas: snapshot,
+            expects_models: true,
         };
         // MODEL-EXECUTING (executes_models = true):
         // v1 / v2-capture-failure (require, None) → REFUSE.
@@ -4334,6 +4385,7 @@ effect = "deny"
             expected_config_identity: None,
             require_fingerprint: false,
             reviewed_source_schemas: None,
+            expects_models: true,
         };
         let targets: BTreeSet<String> = ["raw_orders".to_string()].into_iter().collect();
         let err = ctx
@@ -4380,6 +4432,7 @@ effect = "allow"
             expected_config_identity: None,
             require_fingerprint: false,
             reviewed_source_schemas: None,
+            expects_models: true,
         };
         let targets: BTreeSet<String> = ["raw_orders".to_string()].into_iter().collect();
 
@@ -4428,6 +4481,7 @@ effect = "allow"
             expected_config_identity: None,
             require_fingerprint: false,
             reviewed_source_schemas: None,
+            expects_models: true,
         };
         let targets: BTreeSet<String> = ["raw_orders".to_string()].into_iter().collect();
         ctx.gate_replication_targets(&targets, &ledger)
@@ -4470,31 +4524,52 @@ effect = "allow"
         Ok(())
     }
 
-    /// ‼️ Finding #2 (missing-dir): a governed (agent) apply whose plan reviewed a
-    /// NON-EMPTY model set, but whose models directory no longer compiles to any
-    /// model (deleted / renamed / broken since the plan), must FAIL CLOSED at the
-    /// apply seam — BEFORE any warehouse statement — rather than silently skipping
-    /// the planned models (the executor's `if mdir.exists()` leg / a transformation
-    /// no-op) and reporting SUCCESS without recomputing the execution fingerprint.
-    /// A v0 plan is used so the snapshot preflight is exempt and this isolates the
-    /// missing-dir seam. Neuter the seam (delete the `bail!` at execute_run_plan)
-    /// and this apply returns `Ok` — the silent-success the fix closes.
+    // A replication pipeline (duckdb, creds-free). Its silver-model leg resolves
+    // `run_plan.models_dir` cwd-relative — the path the apply seam recompiles.
+    const REPLICATION_TOML: &str = r#"
+[adapter]
+type = "duckdb"
+path = "x.duckdb"
+
+[pipeline.p]
+type = "replication"
+strategy = "full_refresh"
+
+[pipeline.p.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.p.target]
+adapter = "default"
+catalog_template = "c"
+schema_template = "s__{source}"
+"#;
+
+    /// ‼️ Finding #2 (missing-dir), REPLICATION apply seam: a governed (agent)
+    /// replication apply whose plan reviewed a NON-EMPTY silver-model set, but whose
+    /// reviewed models directory no longer compiles (deleted / renamed since the
+    /// plan), must FAIL CLOSED at the apply seam — BEFORE the replication DDL — not
+    /// silently skip and report SUCCESS. A v0 plan keeps the snapshot preflight
+    /// exempt so this isolates the seam. Neuter the seam `bail!` and this apply
+    /// still fails, now via the run.rs `else if governed…expects_models` executor
+    /// leg (the seam→execute race-closer) — the two layers are independent.
     #[tokio::test]
-    async fn governed_apply_refuses_a_deleted_reviewed_models_dir() -> anyhow::Result<()> {
+    async fn governed_replication_apply_seam_refuses_deleted_reviewed_dir() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
-        std::fs::write(dir.path().join("rocky.toml"), NO_POLICY_TOML)?;
-        // The plan reviewed a real, compilable models dir …
+        std::fs::write(dir.path().join("rocky.toml"), REPLICATION_TOML)?;
+        // The plan reviewed a real, compilable silver-models dir …
         let models_dir = dir.path().join("silver");
         write_min_model(&models_dir, "orders");
         let mut rp = minimal_run_plan();
         rp.pipeline = Some("p".to_string());
+        rp.run_all = true; // replication --all → enters the silver-model leg
         rp.models_dir = Some(models_dir.to_string_lossy().into_owned());
         rp.models = vec!["s.orders".to_string()]; // a non-empty reviewed set
         let plan_id = write_plan(dir.path(), PlanKind::Run, &rp)?;
         let state = dir.path().join("state.redb");
 
-        // … then the dir is DELETED after the plan was authorized (post-preflight
-        // drift). The seam recompiles the exact dir and finds nothing.
+        // … then the dir is DELETED after the plan was authorized.
         std::fs::remove_dir_all(&models_dir)?;
 
         let err = super::run_apply_run_plan(
@@ -4506,10 +4581,56 @@ effect = "allow"
             true,
         )
         .await
-        .expect_err("a governed apply of a deleted reviewed models dir must fail closed");
+        .expect_err("a governed replication apply of a deleted reviewed dir must fail closed");
         assert!(
             err.to_string().contains("no longer compiles to any model"),
-            "must refuse at the missing-dir seam, got: {err}"
+            "must refuse at the replication apply seam, got: {err}"
+        );
+        Ok(())
+    }
+
+    /// ‼️ Finding #2 (missing-dir), TRANSFORMATION executor leg: the apply seam does
+    /// NOT check the transformation path (it resolves `config_dir.join(models_base)`
+    /// from the pipeline config, which the seam's `run_plan.models_dir` does not
+    /// match), so `run_local` is the SOLE fail-closed guard here. A governed
+    /// transformation apply whose plan reviewed a non-empty model set but whose
+    /// config-resolved models directory is gone at execution must FAIL CLOSED at the
+    /// executor — before any warehouse mutation — not report SUCCESS with nothing
+    /// built. This is the real seam↔executor path-resolution gap the scoping fixes.
+    #[tokio::test]
+    async fn governed_transformation_apply_executor_refuses_deleted_reviewed_dir()
+    -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        // NO_POLICY_TOML is a transformation pipeline with `models = "models/**"`,
+        // so the reviewed dir `run_local` resolves is `<config_dir>/models`.
+        std::fs::write(dir.path().join("rocky.toml"), NO_POLICY_TOML)?;
+        let models_dir = dir.path().join("models");
+        write_min_model(&models_dir, "orders");
+        let mut rp = minimal_run_plan();
+        rp.pipeline = Some("p".to_string());
+        rp.models = vec!["s.orders".to_string()]; // a non-empty reviewed set
+        // rp.models_dir intentionally None — `run_local` ignores it and uses the
+        // config-resolved `<config_dir>/models`.
+        let plan_id = write_plan(dir.path(), PlanKind::Run, &rp)?;
+        let state = dir.path().join("state.redb");
+
+        std::fs::remove_dir_all(&models_dir)?;
+
+        let err = super::run_apply_run_plan(
+            dir.path(),
+            &dir.path().join("rocky.toml"),
+            &plan_id,
+            &state,
+            PolicyPrincipal::Agent,
+            true,
+        )
+        .await
+        .expect_err("a governed transformation apply of a deleted reviewed dir must fail closed");
+        // The executor `bail!` is wrapped by `run`'s apply context, so inspect the
+        // full cause chain (`{:#}`), not just the outermost message.
+        assert!(
+            format!("{err:#}").contains("does not exist at execution"),
+            "must fail closed at the transformation executor leg, got: {err:#}"
         );
         Ok(())
     }

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -1242,8 +1242,7 @@ pub struct ExecFingerprintGate {
     /// replay the reviewed schema. `None` on a genuinely-legacy plan; a required
     /// (v2 governed) plan with `None` REFUSES. Carried here because
     /// `execute_models` has no plan handle.
-    pub reviewed_source_schemas:
-        Option<BTreeMap<String, Vec<rocky_ir::types::TypedColumn>>>,
+    pub reviewed_source_schemas: Option<BTreeMap<String, Vec<rocky_ir::types::TypedColumn>>>,
     /// The plan id, for the refusal message.
     pub plan_id: String,
     /// `true` when the plan is a NEW (`fingerprint_version >= 1`) governed plan

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -4077,6 +4077,48 @@ auto_create_schemas = true
         Ok(())
     }
 
+    /// 🔴 #2 (snapshot preflight): a MODEL-EXECUTING governed plan must carry the
+    /// v2 reviewed source-schema snapshot BEFORE any mutation. A NEW
+    /// (`require_fingerprint`, i.e. version >= 1) plan with `None` snapshot — a v1
+    /// plan or a v2 capture failure — is REFUSED (re-plan at v2); a `Some`
+    /// (authoritative even empty) plan proceeds; a genuinely-legacy (v0) plan and
+    /// a human apply are exempt.
+    #[test]
+    fn preflight_snapshot_semantics() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let config_path = dir.path().join("rocky.toml");
+        let mk = |require: bool,
+                  snapshot: Option<
+            std::collections::BTreeMap<String, Vec<rocky_ir::types::TypedColumn>>,
+        >| super::GovernedRunContext {
+            principal: PolicyPrincipal::Agent,
+            plan_id: "p",
+            root: dir.path(),
+            config_path: &config_path,
+            expected_ir_fingerprint: None,
+            expected_config_identity: None,
+            require_fingerprint: require,
+            reviewed_source_schemas: snapshot,
+        };
+        // v1 / v2-capture-failure (require, None) → REFUSE.
+        let v1 = mk(true, None);
+        let err = super::preflight_snapshot(Some(&v1), "p")
+            .expect_err("a required plan with no snapshot must refuse (#2)");
+        assert!(
+            err.to_string()
+                .contains("no reviewed source-schema snapshot"),
+            "{err}"
+        );
+        // v2 (require, Some authoritative even empty) → OK.
+        let v2 = mk(true, Some(std::collections::BTreeMap::new()));
+        super::preflight_snapshot(Some(&v2), "p").expect("a v2 plan with a snapshot proceeds");
+        // Genuinely-legacy v0 (not required) → exempt.
+        super::preflight_snapshot(Some(&mk(false, None)), "p").expect("a legacy v0 plan is exempt");
+        // Human apply (no governed context) → exempt.
+        super::preflight_snapshot(None, "p").expect("a human apply is exempt");
+        Ok(())
+    }
+
     /// 🔴 D regression: the discovered replication target set is gated. An
     /// agent replication under `deny agent apply { any }` must be refused before
     /// any table materializes. Pre-fix the replication set was never

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -219,8 +219,17 @@ async fn run_apply_run_plan(
     // stored (tamperable) field. Absent `[policy]` this is a no-op.
     let models_dir = Path::new(run_plan.models_dir.as_deref().unwrap_or("models"));
     // Gate on the models this apply will ACTUALLY execute (fresh compile +
-    // `--model` selection), not the plan's informational `models` list.
-    let executable = run_executable_models(models_dir, &run_plan);
+    // `--model` selection), not the plan's informational `models` list. Finding
+    // #1: a replication-only plan runs NO models, so it gates none (fail-safe: a
+    // config that will not load is NOT treated as replication-only → strict).
+    let executable = if rocky_core::config::load_rocky_config(config_path)
+        .map(|cfg| is_replication_only(&cfg, &run_plan))
+        .unwrap_or(false)
+    {
+        Vec::new()
+    } else {
+        run_executable_models(models_dir, &run_plan)
+    };
     let touched = touched_models_for_run(&plan, &executable);
     let principal = plan.enforcement_principal(runtime_principal);
     let gate = evaluate_apply_policy(
@@ -296,6 +305,54 @@ fn governed_run_context<'a>(
     })
 }
 
+/// The resolved pipeline is a **Replication** pipeline. Any resolution failure ⇒
+/// `false` — the fail-safe for both consumers: the mask omits (harmless, apply
+/// never checks the gate on a non-reaching path), and the execution-shape
+/// carve-outs below default to STRICT (a non-replication plan is never
+/// replication-only, so it keeps full policy gating + the snapshot requirement).
+/// Uses the SAME `registry::resolve_pipeline` `commands::run::run` uses at apply.
+pub(crate) fn pipeline_is_replication(
+    cfg: &rocky_core::config::RockyConfig,
+    pipeline_name: Option<&str>,
+) -> bool {
+    crate::registry::resolve_pipeline(cfg, pipeline_name)
+        .map(|(_, p)| matches!(p, rocky_core::config::PipelineConfig::Replication(_)))
+        .unwrap_or(false)
+}
+
+/// A governed `Run` plan that, at apply, executes NO compiled models — a
+/// Replication pipeline with no `--all`, no `--models`, and no `--model` (its
+/// model leg at `run.rs`'s `run_all || models_dir.is_some()` is never entered,
+/// and it is not the `--model` path). Finding #1 (regression): such a plan must
+/// NOT preflight the snapshot and must NOT bind policy over models it never runs.
+///
+/// A **safe carve-out** (not a positive "executes models"): a resolution failure
+/// or any non-Replication pipeline (Transformation runs models via `run_local`
+/// unconditionally) is NOT replication-only ⇒ stays strict (snapshot required +
+/// full policy gating). So a wrong answer can only ever OVER-gate (fail-closed),
+/// never under-gate.
+///
+/// This carve-out **cannot become a policy bypass**, even against a config swapped
+/// to replication-only between plan and apply. Skipping the *model* policy gate is
+/// harmless because the models never execute on this path; and the replication
+/// mutation the plan *does* run is independently fail-closed at `run.rs`'s governed
+/// replication gate, which fires BEFORE any warehouse statement:
+/// [`verify_routing_identity`] refuses when the fresh config's routing identity ≠
+/// the plan's authorized `config_identity` (so a transformation→replication swap is
+/// caught), and [`gate_replication_targets`] re-evaluates the policy plane over the
+/// concrete discovered targets. Reading the pipeline type from a fresh
+/// `load_rocky_config` at apply is therefore safe in BOTH directions: a won't-load
+/// config → strict, and a swapped-to-replication config → caught by routing
+/// identity. The only inert case is a genuinely-legacy v0 plan (no identity,
+/// `!require_fingerprint`) — the pre-existing legacy exemption this carve-out does
+/// not widen.
+fn is_replication_only(cfg: &rocky_core::config::RockyConfig, run_plan: &RunPlan) -> bool {
+    pipeline_is_replication(cfg, run_plan.pipeline.as_deref())
+        && !run_plan.run_all
+        && run_plan.models_dir.is_none()
+        && run_plan.model.is_none()
+}
+
 /// Fail-closed preflight (finding #2) for a MODEL-EXECUTING governed apply: it
 /// must carry the v2 reviewed source-schema snapshot (`Some`, even empty), run
 /// **before any warehouse mutation** (before replication discovery/DDL). A v1
@@ -304,9 +361,15 @@ fn governed_run_context<'a>(
 /// re-plan at v2 that captures the snapshot. A v2 plan whose snapshot could not
 /// be captured (`None`) is a production failure → refuse. Genuinely-legacy v0
 /// plans (`require_fingerprint == false`) and human applies (no context) are
-/// exempt. Pure-replication (no-model) plans never call this.
-fn preflight_snapshot(governed_ctx: Option<&GovernedRunContext<'_>>, plan_id: &str) -> Result<()> {
-    if let Some(ctx) = governed_ctx
+/// exempt. `executes_models == false` (a replication-only plan) is exempt — it
+/// runs no models, so there is no typed-columns TOCTOU to close (finding #1).
+fn preflight_snapshot(
+    governed_ctx: Option<&GovernedRunContext<'_>>,
+    plan_id: &str,
+    executes_models: bool,
+) -> Result<()> {
+    if executes_models
+        && let Some(ctx) = governed_ctx
         && ctx.require_fingerprint
         && ctx.reviewed_source_schemas.is_none()
     {
@@ -347,11 +410,16 @@ async fn execute_run_plan(
     // post-discovery replication gate. `None` for a human apply.
     governed_ctx: Option<&GovernedRunContext<'_>>,
 ) -> Result<()> {
-    // ‼️ Finding #2: preflight the reviewed source-schema snapshot BEFORE any
+    // ‼️ Finding #2/#1: preflight the reviewed source-schema snapshot BEFORE any
     // warehouse mutation — this path executes models (and, for a replication
     // pipeline, does replication discovery/DDL first), so a v1/missing-snapshot
-    // plan must be refused here rather than after the first statement runs.
-    preflight_snapshot(governed_ctx, plan_id)?;
+    // plan must be refused here rather than after the first statement runs. A
+    // replication-only plan (no `--all`/`--models`/`--model`) executes NO models
+    // → exempt (fail-safe: a config that will not load stays strict).
+    let executes_models = rocky_core::config::load_rocky_config(config_path)
+        .map(|cfg| !is_replication_only(&cfg, &run_plan))
+        .unwrap_or(true);
+    preflight_snapshot(governed_ctx, plan_id, executes_models)?;
 
     // Build partition options from the persisted flags.
     let partition_opts = crate::commands::run::PartitionRunOptions {
@@ -433,6 +501,44 @@ async fn execute_run_plan(
         )
         .await
         .with_context(|| format!("rocky apply run plan '{plan_id}' failed (dag path)"));
+    }
+
+    // ‼️ Finding #2 (missing-dir): a governed non-dag apply whose plan REVIEWED a
+    // non-empty model set, but whose models directory no longer compiles to any
+    // model (deleted / renamed / broken since the plan), must FAIL CLOSED here —
+    // otherwise the executor's model leg silently skips (`if mdir.exists()`) or
+    // returns a successful no-op, the execution fingerprint is never recomputed,
+    // and apply reports SUCCESS without executing the planned models. Recompile the
+    // exact dir at the seam, BEFORE any warehouse statement (`run()` below is the
+    // first mutation; the `partition_opts`/`shadow_config` setup above is read-only).
+    // Placed AFTER the `--dag` guard so a governed dag apply keeps its categorical
+    // refusal (that path never reaches here).
+    //
+    // Scoped to `!run_plan.models.is_empty()` so a legitimate run of a replication
+    // pipeline with `--all` and NO silver `models/` (a valid pure-replication run
+    // whose reviewed model set is empty) is NOT failed. Human applies and
+    // replication-only plans are exempt (not governed / no model execution).
+    if governed_ctx.is_some() && executes_models && !run_plan.models.is_empty() {
+        let mdir = models_dir_path
+            .clone()
+            .unwrap_or_else(|| std::path::PathBuf::from("models"));
+        let compiles_to_models =
+            rocky_compiler::compile::compile(&rocky_compiler::compile::CompilerConfig {
+                models_dir: mdir.clone(),
+                ..Default::default()
+            })
+            .map(|r| !r.project.models.is_empty())
+            .unwrap_or(false);
+        if !compiles_to_models {
+            bail!(
+                "refusing to apply governed plan '{plan_id}': its reviewed models directory '{}' no \
+                 longer compiles to any model (deleted, renamed, or broken since the plan), so the \
+                 {} planned model(s) cannot be executed or re-fingerprinted — apply would otherwise \
+                 skip them and report success. Re-plan with `rocky plan` before applying.",
+                mdir.display(),
+                run_plan.models.len()
+            );
+        }
     }
 
     // Capture stdout from the run command — `run` writes JSON directly.
@@ -1814,8 +1920,17 @@ async fn run_apply_ai_authored_plan(
     // constructed and the pre-policy-plane marker gate remains — byte-identical to today.
     let models_dir = Path::new(run_plan.models_dir.as_deref().unwrap_or("models"));
     // Gate on the models this apply will ACTUALLY execute (fresh compile +
-    // `--model` selection), not the plan's informational `models` list.
-    let executable = run_executable_models(models_dir, &run_plan);
+    // `--model` selection), not the plan's informational `models` list. Finding
+    // #1: a replication-only plan runs NO models, so it gates none (fail-safe: a
+    // config that will not load is NOT treated as replication-only → strict).
+    let executable = if rocky_core::config::load_rocky_config(config_path)
+        .map(|cfg| is_replication_only(&cfg, &run_plan))
+        .unwrap_or(false)
+    {
+        Vec::new()
+    } else {
+        run_executable_models(models_dir, &run_plan)
+    };
     let touched = touched_models_for_run(&plan, &executable);
     let principal = plan.enforcement_principal(runtime_principal);
     let gate = evaluate_apply_policy(
@@ -1993,9 +2108,9 @@ async fn run_apply_backfill_plan(
         root,
         config_path,
     );
-    // ‼️ Finding #2: a backfill executes models — preflight the reviewed
-    // source-schema snapshot before any warehouse mutation.
-    preflight_snapshot(governed.as_ref(), plan_id)?;
+    // ‼️ Finding #2: a backfill ALWAYS executes models (its `model_set`) —
+    // preflight the reviewed source-schema snapshot before any warehouse mutation.
+    preflight_snapshot(governed.as_ref(), plan_id, true)?;
     let exec_fp_gate = match (governed.as_ref(), backfill_cfg.as_ref()) {
         (Some(ctx), Some(cfg)) => {
             // Fail-closed (#4/#5): verify the routing identity before executing.
@@ -4083,6 +4198,67 @@ auto_create_schemas = true
     /// plan or a v2 capture failure — is REFUSED (re-plan at v2); a `Some`
     /// (authoritative even empty) plan proceeds; a genuinely-legacy (v0) plan and
     /// a human apply are exempt.
+    /// 🔴 #1 (execution-shape carve-out): `is_replication_only` — the SAFE
+    /// negative that gates the snapshot preflight + policy selection — must be
+    /// `true` ONLY for a replication pipeline with no `--all`/`--models`/`--model`.
+    /// The **non-negotiable under-gate guard**: a TRANSFORMATION pipeline is NEVER
+    /// replication-only (it runs models via `run_local`), so it stays STRICT (full
+    /// policy gating + snapshot required) — the carve-out cannot become a policy
+    /// bypass. A resolution failure is also strict (`false`).
+    #[test]
+    fn is_replication_only_is_a_safe_carve_out() {
+        fn cfg(pipeline_type: &str) -> rocky_core::config::RockyConfig {
+            let dir = tempfile::tempdir().unwrap();
+            let p = dir.path().join("rocky.toml");
+            // A replication target carries `catalog_template`/`schema_template`; a
+            // transformation target does not — so the two pipeline kinds need
+            // structurally different TOML.
+            let body = if pipeline_type == "replication" {
+                "[pipeline.p]\ntype = \"replication\"\nstrategy = \"full_refresh\"\n\n[pipeline.p.source.schema_pattern]\nprefix = \"raw__\"\nseparator = \"__\"\ncomponents = [\"source\"]\n\n[pipeline.p.target]\nadapter = \"default\"\ncatalog_template = \"c\"\nschema_template = \"s__{source}\"\n"
+            } else {
+                "[pipeline.p]\ntype = \"transformation\"\nmodels = \"models/**\"\n\n[pipeline.p.target]\nadapter = \"default\"\n"
+            };
+            std::fs::write(
+                &p,
+                format!("[adapter]\ntype = \"duckdb\"\npath = \"a.duckdb\"\n\n{body}"),
+            )
+            .unwrap();
+            rocky_core::config::load_rocky_config(&p).unwrap()
+        }
+        let plan = |run_all: bool, models_dir: Option<&str>, model: Option<&str>| {
+            let mut rp = minimal_run_plan();
+            rp.pipeline = Some("p".to_string());
+            rp.run_all = run_all;
+            rp.models_dir = models_dir.map(str::to_string);
+            rp.model = model.map(str::to_string);
+            rp
+        };
+        // Replication + no flags → replication-only (carve out preflight + policy).
+        assert!(super::is_replication_only(
+            &cfg("replication"),
+            &plan(false, None, None)
+        ));
+        // TRANSFORMATION + no flags → NOT replication-only → STRICT (the under-gate
+        // guard: a transformation plan keeps full policy gating + snapshot).
+        assert!(!super::is_replication_only(
+            &cfg("transformation"),
+            &plan(false, None, None)
+        ));
+        // Replication + any execution flag → NOT replication-only (it runs models).
+        assert!(!super::is_replication_only(
+            &cfg("replication"),
+            &plan(true, None, None)
+        ));
+        assert!(!super::is_replication_only(
+            &cfg("replication"),
+            &plan(false, Some("m"), None)
+        ));
+        assert!(!super::is_replication_only(
+            &cfg("replication"),
+            &plan(false, None, Some("a"))
+        ));
+    }
+
     #[test]
     fn preflight_snapshot_semantics() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
@@ -4100,10 +4276,11 @@ auto_create_schemas = true
             require_fingerprint: require,
             reviewed_source_schemas: snapshot,
         };
+        // MODEL-EXECUTING (executes_models = true):
         // v1 / v2-capture-failure (require, None) → REFUSE.
         let v1 = mk(true, None);
-        let err = super::preflight_snapshot(Some(&v1), "p")
-            .expect_err("a required plan with no snapshot must refuse (#2)");
+        let err = super::preflight_snapshot(Some(&v1), "p", true)
+            .expect_err("a required model-executing plan with no snapshot must refuse (#2)");
         assert!(
             err.to_string()
                 .contains("no reviewed source-schema snapshot"),
@@ -4111,11 +4288,21 @@ auto_create_schemas = true
         );
         // v2 (require, Some authoritative even empty) → OK.
         let v2 = mk(true, Some(std::collections::BTreeMap::new()));
-        super::preflight_snapshot(Some(&v2), "p").expect("a v2 plan with a snapshot proceeds");
+        super::preflight_snapshot(Some(&v2), "p", true)
+            .expect("a v2 plan with a snapshot proceeds");
         // Genuinely-legacy v0 (not required) → exempt.
-        super::preflight_snapshot(Some(&mk(false, None)), "p").expect("a legacy v0 plan is exempt");
+        super::preflight_snapshot(Some(&mk(false, None)), "p", true)
+            .expect("a legacy v0 plan is exempt");
         // Human apply (no governed context) → exempt.
-        super::preflight_snapshot(None, "p").expect("a human apply is exempt");
+        super::preflight_snapshot(None, "p", true).expect("a human apply is exempt");
+        // 🔴 #1 regression: a REPLICATION-ONLY plan (executes_models = false)
+        // executes no models → NOT refused, for BOTH a v1/require plan with a
+        // missing snapshot AND a v2 plan carrying one. The snapshot requirement
+        // only ever applies to a model-executing plan.
+        super::preflight_snapshot(Some(&v1), "p", false)
+            .expect("a v1 replication-only (no-model) plan must NOT be refused (#1)");
+        super::preflight_snapshot(Some(&v2), "p", false)
+            .expect("a v2 replication-only (no-model) plan must NOT be refused (#1)");
         Ok(())
     }
 
@@ -4279,6 +4466,50 @@ effect = "allow"
         assert!(
             err.to_string().contains("not yet policy-gated"),
             "must refuse the governed dag apply, got: {err}"
+        );
+        Ok(())
+    }
+
+    /// ‼️ Finding #2 (missing-dir): a governed (agent) apply whose plan reviewed a
+    /// NON-EMPTY model set, but whose models directory no longer compiles to any
+    /// model (deleted / renamed / broken since the plan), must FAIL CLOSED at the
+    /// apply seam — BEFORE any warehouse statement — rather than silently skipping
+    /// the planned models (the executor's `if mdir.exists()` leg / a transformation
+    /// no-op) and reporting SUCCESS without recomputing the execution fingerprint.
+    /// A v0 plan is used so the snapshot preflight is exempt and this isolates the
+    /// missing-dir seam. Neuter the seam (delete the `bail!` at execute_run_plan)
+    /// and this apply returns `Ok` — the silent-success the fix closes.
+    #[tokio::test]
+    async fn governed_apply_refuses_a_deleted_reviewed_models_dir() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        std::fs::write(dir.path().join("rocky.toml"), NO_POLICY_TOML)?;
+        // The plan reviewed a real, compilable models dir …
+        let models_dir = dir.path().join("silver");
+        write_min_model(&models_dir, "orders");
+        let mut rp = minimal_run_plan();
+        rp.pipeline = Some("p".to_string());
+        rp.models_dir = Some(models_dir.to_string_lossy().into_owned());
+        rp.models = vec!["s.orders".to_string()]; // a non-empty reviewed set
+        let plan_id = write_plan(dir.path(), PlanKind::Run, &rp)?;
+        let state = dir.path().join("state.redb");
+
+        // … then the dir is DELETED after the plan was authorized (post-preflight
+        // drift). The seam recompiles the exact dir and finds nothing.
+        std::fs::remove_dir_all(&models_dir)?;
+
+        let err = super::run_apply_run_plan(
+            dir.path(),
+            &dir.path().join("rocky.toml"),
+            &plan_id,
+            &state,
+            PolicyPrincipal::Agent,
+            true,
+        )
+        .await
+        .expect_err("a governed apply of a deleted reviewed models dir must fail closed");
+        assert!(
+            err.to_string().contains("no longer compiles to any model"),
+            "must refuse at the missing-dir seam, got: {err}"
         );
         Ok(())
     }

--- a/engine/crates/rocky-cli/src/commands/backfill.rs
+++ b/engine/crates/rocky-cli/src/commands/backfill.rs
@@ -231,21 +231,23 @@ pub(crate) fn run_backfill_in(
     // skips the mask. An empty map ⇒ empty `effective_masks`.
     let resolved_mask: std::collections::BTreeMap<String, rocky_ir::MaskStrategy> =
         std::collections::BTreeMap::new();
-    // Capture the REVIEWED source-schema snapshot (finding #2b) the same way
-    // `compile_project` seeded the compile above (cache, `ttl_override(None)`),
-    // so apply replays these exact schemas → `typed_columns` cannot drift.
-    let reviewed_source_schemas: std::collections::BTreeMap<
-        String,
-        Vec<rocky_compiler::types::TypedColumn>,
-    > = backfill_cfg
-        .as_ref()
-        .map(|cfg| {
-            let schema_cfg = cfg.cache.schemas.clone().with_ttl_override(None);
-            crate::source_schemas::load_cached_source_schemas(&schema_cfg, state_path)
-        })
-        .unwrap_or_default()
-        .into_iter()
-        .collect();
+    // Capture the REVIEWED source-schema snapshot (finding #2) the same way
+    // `compile_project` seeded the compile above (cache, `ttl_override(None)`), so
+    // apply replays these exact schemas → `typed_columns` cannot drift. `Some` is
+    // authoritative even when empty (a cold cache → apply types from empty).
+    let reviewed_source_schemas: Option<
+        std::collections::BTreeMap<String, Vec<rocky_compiler::types::TypedColumn>>,
+    > = Some(
+        backfill_cfg
+            .as_ref()
+            .map(|cfg| {
+                let schema_cfg = cfg.cache.schemas.clone().with_ttl_override(None);
+                crate::source_schemas::load_cached_source_schemas(&schema_cfg, state_path)
+            })
+            .unwrap_or_default()
+            .into_iter()
+            .collect(),
+    );
     // Fold the seeding-independent extras (surrogate-key sidecars #1, contract
     // presence/contents #3, effective mask C) into the bound fingerprint so the
     // apply-time TOCTOU gate rejects a post-plan swap of any, built from the SAME

--- a/engine/crates/rocky-cli/src/commands/backfill.rs
+++ b/engine/crates/rocky-cli/src/commands/backfill.rs
@@ -214,25 +214,44 @@ pub(crate) fn run_backfill_in(
     // A backfill executes the same on-disk models it plans; bind their
     // compiled-IR fingerprint + routing identity so the apply-time TOCTOU gate
     // rejects a change.
-    let config_identity = rocky_core::config::load_rocky_config(config_path)
-        .ok()
+    let backfill_cfg = rocky_core::config::load_rocky_config(config_path).ok();
+    let config_identity = backfill_cfg
         .as_ref()
         .map(crate::commands::apply::config_policy_identity);
     let identity = config_identity.clone().unwrap_or_default();
-    // A backfill runs with no `--env`, so the governance identity resolves the
-    // env-default mask (+ roles + cache-selection).
-    let governance_identity = rocky_core::config::load_rocky_config(config_path)
-        .ok()
+    // A backfill runs with no `--env`, so the governance identity + mask resolve
+    // the env defaults (roles + cache-selection are env-invariant).
+    let governance_identity = backfill_cfg
         .as_ref()
-        .map(|cfg| crate::commands::apply::governance_policy_identity(cfg, None))
+        .map(crate::commands::apply::governance_policy_identity)
         .unwrap_or_default();
+    let resolved_mask = backfill_cfg
+        .as_ref()
+        .map(|cfg| cfg.resolve_mask_for_env(None))
+        .unwrap_or_default();
+    // Capture the REVIEWED source-schema snapshot (finding #2b) the same way
+    // `compile_project` seeded the compile above (cache, `ttl_override(None)`),
+    // so apply replays these exact schemas → `typed_columns` cannot drift.
+    let reviewed_source_schemas: std::collections::BTreeMap<
+        String,
+        Vec<rocky_compiler::types::TypedColumn>,
+    > = backfill_cfg
+        .as_ref()
+        .map(|cfg| {
+            let schema_cfg = cfg.cache.schemas.clone().with_ttl_override(None);
+            crate::source_schemas::load_cached_source_schemas(&schema_cfg, state_path)
+        })
+        .unwrap_or_default()
+        .into_iter()
+        .collect();
     // Fold the seeding-independent extras (surrogate-key sidecars #1, contract
-    // presence/contents #3) into the bound fingerprint so the apply-time TOCTOU
-    // gate rejects a post-plan swap of either, built from the SAME `models_dir`
-    // the apply choke-point re-reads.
+    // presence/contents #3, effective mask C) into the bound fingerprint so the
+    // apply-time TOCTOU gate rejects a post-plan swap of any, built from the SAME
+    // `models_dir` the apply choke-point re-reads.
     let extras = crate::commands::apply::ExecutionExtras::build(
         &rocky_core::models::load_surrogate_keys_from_dir(models_dir).unwrap_or_default(),
         &compiled.project.models,
+        &resolved_mask,
     );
     let capabilities = EmbeddedCapabilities {
         diff_available: true,
@@ -248,6 +267,7 @@ pub(crate) fn run_backfill_in(
         ),
         config_identity,
         fingerprint_version: crate::plan_store::CURRENT_FINGERPRINT_VERSION,
+        reviewed_source_schemas,
     };
     let plan_id = write_plan_governed(
         root,

--- a/engine/crates/rocky-cli/src/commands/backfill.rs
+++ b/engine/crates/rocky-cli/src/commands/backfill.rs
@@ -225,10 +225,12 @@ pub(crate) fn run_backfill_in(
         .as_ref()
         .map(crate::commands::apply::governance_policy_identity)
         .unwrap_or_default();
-    let resolved_mask = backfill_cfg
-        .as_ref()
-        .map(|cfg| cfg.resolve_mask_for_env(None))
-        .unwrap_or_default();
+    // Finding #4: a backfill is selection-scoped (`model_set`) and reconciles
+    // ONLY tags, never masks (run.rs `execute_backfill_set` → tags), so the mask
+    // is NOT bound — matching the apply choke-point, which sees `model_set` and
+    // skips the mask. An empty map ⇒ empty `effective_masks`.
+    let resolved_mask: std::collections::BTreeMap<String, rocky_ir::MaskStrategy> =
+        std::collections::BTreeMap::new();
     // Capture the REVIEWED source-schema snapshot (finding #2b) the same way
     // `compile_project` seeded the compile above (cache, `ttl_override(None)`),
     // so apply replays these exact schemas → `typed_columns` cannot drift.

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -951,14 +951,16 @@ fn build_and_persist_run_plan(
     // evaluates the plan against the identity that authored it and the exact
     // capabilities that were reviewed.
     let principal = run_options.principal.unwrap_or(PolicyPrincipal::Human);
-    // Bind masks only for a full run (finding #4): a `--model`-scoped plan runs
-    // no masking reconcile, so its fingerprint must omit the mask.
+    // Finding #4: `compute_embedded_capabilities` binds the mask only when the
+    // apply reaches the mask-reconciling path (a full run of a Replication
+    // pipeline), resolving the pipeline the same way `run()` does.
     let capabilities = compute_embedded_capabilities(
         config_path,
         models_dir,
         base_ref,
         Some(state_path),
         env,
+        pipeline,
         run_options.model.is_none(),
     );
     let plan_id = write_plan_governed(&cwd, PlanKind::Run, &run_plan, principal, capabilities)
@@ -987,12 +989,15 @@ pub fn compute_embedded_capabilities(
     base_ref: &str,
     state_path: Option<&Path>,
     env: Option<&str>,
-    // Finding #4: `true` only for a full `--all` run, which executes every model
-    // AND reconciles masks. A model-scoped plan (`--model`) runs no masking, so
-    // its fingerprint must NOT bind the mask (an unselected model's mask change
-    // would falsely refuse). The apply choke-point gates on the SAME predicate
-    // (no model filter / no model_set), keeping the fingerprint symmetric.
-    bind_masks: bool,
+    // Finding #4: the plan's pipeline name + whether it is a full (`--model`-less)
+    // run. The mask enters the fingerprint iff the apply will reach the
+    // mask-reconciling path — a full run of a REPLICATION pipeline. This is
+    // computed here with the SAME `registry::resolve_pipeline(cfg, pipeline_name)`
+    // that `commands::run::run` uses at apply, so `reconciles_masks` matches by
+    // construction; a Transformation / Quality / Snapshot pipeline (→ `run_local`,
+    // no masks) or a `--model` run omits the mask on both sides.
+    pipeline_name: Option<&str>,
+    model_is_none: bool,
 ) -> EmbeddedCapabilities {
     use crate::plan_store::CURRENT_FINGERPRINT_VERSION;
     use rocky_compiler::compile::{self, CompilerConfig};
@@ -1011,10 +1016,23 @@ pub fn compute_embedded_capabilities(
         .as_ref()
         .map(crate::commands::apply::governance_policy_identity)
         .unwrap_or_default();
+    // Finding #4: bind the mask iff the apply reaches the mask-reconciling path —
+    // a full run of a REPLICATION pipeline. Resolved with the same
+    // `resolve_pipeline` `run()` uses → symmetric with the apply-side
+    // `reconciles_masks`. Any resolution failure ⇒ do not bind (fail-safe: omit
+    // rather than risk an asymmetric refuse).
+    let bind_masks = model_is_none
+        && loaded_cfg
+            .as_ref()
+            .and_then(|cfg| {
+                crate::registry::resolve_pipeline(cfg, pipeline_name)
+                    .ok()
+                    .map(|(_, p)| matches!(p, rocky_core::config::PipelineConfig::Replication(_)))
+            })
+            .unwrap_or(false);
     // The env-resolved mask (finding C): the extras restrict it to the executed
     // models' classification tags. `env` is the plan's `--env`, so apply resolves
-    // the same masks the reviewed env will apply. Bound ONLY on a full run
-    // (finding #4) — empty on a model-scoped plan, matching the apply choke-point.
+    // the same masks the reviewed env will apply.
     let resolved_mask = if bind_masks {
         loaded_cfg
             .as_ref()

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -1032,8 +1032,8 @@ pub fn compute_embedded_capabilities(
         models_fingerprint: None,
         config_identity,
         fingerprint_version: CURRENT_FINGERPRINT_VERSION,
-        // No fingerprint ⇒ apply refuses regardless; the snapshot is moot.
-        reviewed_source_schemas: std::collections::BTreeMap::new(),
+        // No fingerprint ⇒ apply refuses regardless; the snapshot is moot (`None`).
+        reviewed_source_schemas: None,
     };
 
     if !models_dir.is_dir() {
@@ -1064,17 +1064,19 @@ pub fn compute_embedded_capabilities(
             Err(_) => return failed(config_identity),
         }
     };
-    // Capture the REVIEWED source-schema snapshot (finding #2b) — the exact
-    // schemas the head compile typed against. Apply seeds its compile from this
-    // (via the plan payload) so `typed_columns` replay the reviewed schema, not a
-    // drifted live read. Name-sorted (BTreeMap) for a stable `plan_id` digest.
-    let reviewed_source_schemas: std::collections::BTreeMap<
-        String,
-        Vec<rocky_compiler::types::TypedColumn>,
-    > = source_schemas
-        .iter()
-        .map(|(k, v)| (k.clone(), v.clone()))
-        .collect();
+    // Capture the REVIEWED source-schema snapshot (finding #2) — the exact
+    // schemas the head compile typed against. `Some` is AUTHORITATIVE even when
+    // empty (a cold-cache plan captures `Some(empty)`, and apply must type from
+    // that, never a later-warmed live cache). Apply seeds its compile from this
+    // via the plan payload. Name-sorted (BTreeMap) for a stable `plan_id` digest.
+    let reviewed_source_schemas: Option<
+        std::collections::BTreeMap<String, Vec<rocky_compiler::types::TypedColumn>>,
+    > = Some(
+        source_schemas
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect(),
+    );
     // Bind the compiled-IR fingerprint the gate authorizes so apply can refuse a
     // models/config change between planning and execution (TOCTOU), checked at
     // the single execution choke-point. Computed from the head compile that a

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -991,12 +991,18 @@ pub fn compute_embedded_capabilities(
     let config_identity = loaded_cfg
         .as_ref()
         .map(crate::commands::apply::config_policy_identity);
-    // The env-resolved governance identity (mask / roles / cache-selection),
-    // bound into the fingerprint so a post-plan governance change refuses. `env`
-    // is the plan's `--env`, so apply refuses if applied against a different env.
+    // The model-independent governance identity (roles / cache-selection), bound
+    // into the fingerprint so a post-plan governance change refuses.
     let governance_identity = loaded_cfg
         .as_ref()
-        .map(|cfg| crate::commands::apply::governance_policy_identity(cfg, env))
+        .map(crate::commands::apply::governance_policy_identity)
+        .unwrap_or_default();
+    // The env-resolved mask (finding C): the extras restrict it to the executed
+    // models' classification tags. `env` is the plan's `--env`, so apply resolves
+    // the same masks the reviewed env will apply.
+    let resolved_mask = loaded_cfg
+        .as_ref()
+        .map(|cfg| cfg.resolve_mask_for_env(env))
         .unwrap_or_default();
 
     // A plan whose fingerprint could not be produced (broken/absent models dir):
@@ -1007,6 +1013,8 @@ pub fn compute_embedded_capabilities(
         models_fingerprint: None,
         config_identity,
         fingerprint_version: CURRENT_FINGERPRINT_VERSION,
+        // No fingerprint ⇒ apply refuses regardless; the snapshot is moot.
+        reviewed_source_schemas: std::collections::BTreeMap::new(),
     };
 
     if !models_dir.is_dir() {
@@ -1037,6 +1045,17 @@ pub fn compute_embedded_capabilities(
             Err(_) => return failed(config_identity),
         }
     };
+    // Capture the REVIEWED source-schema snapshot (finding #2b) — the exact
+    // schemas the head compile typed against. Apply seeds its compile from this
+    // (via the plan payload) so `typed_columns` replay the reviewed schema, not a
+    // drifted live read. Name-sorted (BTreeMap) for a stable `plan_id` digest.
+    let reviewed_source_schemas: std::collections::BTreeMap<
+        String,
+        Vec<rocky_compiler::types::TypedColumn>,
+    > = source_schemas
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
     // Bind the compiled-IR fingerprint the gate authorizes so apply can refuse a
     // models/config change between planning and execution (TOCTOU), checked at
     // the single execution choke-point. Computed from the head compile that a
@@ -1047,6 +1066,7 @@ pub fn compute_embedded_capabilities(
     let extras = crate::commands::apply::ExecutionExtras::build(
         &rocky_core::models::load_surrogate_keys_from_dir(models_dir).unwrap_or_default(),
         &head.project.models,
+        &resolved_mask,
     );
     let models_fingerprint = crate::commands::apply::execution_ir_fingerprint(
         &head.project.models,
@@ -1067,6 +1087,7 @@ pub fn compute_embedded_capabilities(
                 models_fingerprint,
                 config_identity,
                 fingerprint_version: CURRENT_FINGERPRINT_VERSION,
+                reviewed_source_schemas,
             };
         }
     };
@@ -1098,6 +1119,7 @@ pub fn compute_embedded_capabilities(
         models_fingerprint,
         config_identity,
         fingerprint_version: CURRENT_FINGERPRINT_VERSION,
+        reviewed_source_schemas,
     }
 }
 

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -951,8 +951,16 @@ fn build_and_persist_run_plan(
     // evaluates the plan against the identity that authored it and the exact
     // capabilities that were reviewed.
     let principal = run_options.principal.unwrap_or(PolicyPrincipal::Human);
-    let capabilities =
-        compute_embedded_capabilities(config_path, models_dir, base_ref, Some(state_path), env);
+    // Bind masks only for a full run (finding #4): a `--model`-scoped plan runs
+    // no masking reconcile, so its fingerprint must omit the mask.
+    let capabilities = compute_embedded_capabilities(
+        config_path,
+        models_dir,
+        base_ref,
+        Some(state_path),
+        env,
+        run_options.model.is_none(),
+    );
     let plan_id = write_plan_governed(&cwd, PlanKind::Run, &run_plan, principal, capabilities)
         .context("failed to write run plan")?;
 
@@ -979,6 +987,12 @@ pub fn compute_embedded_capabilities(
     base_ref: &str,
     state_path: Option<&Path>,
     env: Option<&str>,
+    // Finding #4: `true` only for a full `--all` run, which executes every model
+    // AND reconciles masks. A model-scoped plan (`--model`) runs no masking, so
+    // its fingerprint must NOT bind the mask (an unselected model's mask change
+    // would falsely refuse). The apply choke-point gates on the SAME predicate
+    // (no model filter / no model_set), keeping the fingerprint symmetric.
+    bind_masks: bool,
 ) -> EmbeddedCapabilities {
     use crate::plan_store::CURRENT_FINGERPRINT_VERSION;
     use rocky_compiler::compile::{self, CompilerConfig};
@@ -999,11 +1013,16 @@ pub fn compute_embedded_capabilities(
         .unwrap_or_default();
     // The env-resolved mask (finding C): the extras restrict it to the executed
     // models' classification tags. `env` is the plan's `--env`, so apply resolves
-    // the same masks the reviewed env will apply.
-    let resolved_mask = loaded_cfg
-        .as_ref()
-        .map(|cfg| cfg.resolve_mask_for_env(env))
-        .unwrap_or_default();
+    // the same masks the reviewed env will apply. Bound ONLY on a full run
+    // (finding #4) — empty on a model-scoped plan, matching the apply choke-point.
+    let resolved_mask = if bind_masks {
+        loaded_cfg
+            .as_ref()
+            .map(|cfg| cfg.resolve_mask_for_env(env))
+            .unwrap_or_default()
+    } else {
+        std::collections::BTreeMap::new()
+    };
 
     // A plan whose fingerprint could not be produced (broken/absent models dir):
     // stamped as a NEW plan with NO fingerprint → the governed apply REFUSES.

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -951,17 +951,28 @@ fn build_and_persist_run_plan(
     // evaluates the plan against the identity that authored it and the exact
     // capabilities that were reviewed.
     let principal = run_options.principal.unwrap_or(PolicyPrincipal::Human);
-    // Finding #4: `compute_embedded_capabilities` binds the mask only when the
-    // apply reaches the mask-reconciling path (a full run of a Replication
-    // pipeline), resolving the pipeline the same way `run()` does.
+    // Finding #4: bind the mask iff the apply reaches the mask-reconciling path —
+    // a Replication pipeline whose model leg runs (`--all` / `--models`) on a full
+    // (`--model`-less) run. Resolved with the SAME `resolve_pipeline` `run()` uses,
+    // and the SAME `run_all || models_dir` predicate `run.rs` gates the model leg
+    // with, so it matches the apply-side literal `reconciles_masks`. A resolution
+    // failure ⇒ `false` (fail-safe: apply that doesn't reach the leg never checks
+    // the gate, so a wrong-`true` is harmless; a wrong-`false` would false-refuse).
+    let bind_masks = rocky_core::config::load_rocky_config(config_path)
+        .ok()
+        .map(|cfg| {
+            crate::commands::apply::pipeline_is_replication(&cfg, pipeline)
+                && (run_options.all || run_options.models_dir.is_some())
+                && run_options.model.is_none()
+        })
+        .unwrap_or(false);
     let capabilities = compute_embedded_capabilities(
         config_path,
         models_dir,
         base_ref,
         Some(state_path),
         env,
-        pipeline,
-        run_options.model.is_none(),
+        bind_masks,
     );
     let plan_id = write_plan_governed(&cwd, PlanKind::Run, &run_plan, principal, capabilities)
         .context("failed to write run plan")?;
@@ -989,15 +1000,15 @@ pub fn compute_embedded_capabilities(
     base_ref: &str,
     state_path: Option<&Path>,
     env: Option<&str>,
-    // Finding #4: the plan's pipeline name + whether it is a full (`--model`-less)
-    // run. The mask enters the fingerprint iff the apply will reach the
-    // mask-reconciling path — a full run of a REPLICATION pipeline. This is
-    // computed here with the SAME `registry::resolve_pipeline(cfg, pipeline_name)`
-    // that `commands::run::run` uses at apply, so `reconciles_masks` matches by
-    // construction; a Transformation / Quality / Snapshot pipeline (→ `run_local`,
-    // no masks) or a `--model` run omits the mask on both sides.
-    pipeline_name: Option<&str>,
-    model_is_none: bool,
+    // Finding #4: whether the mask enters the fingerprint — `true` iff the apply
+    // reaches the mask-reconciling path (a full run of a REPLICATION pipeline that
+    // hits the model leg). The CALLER computes this from the resolved pipeline +
+    // the persisted `run_all`/`models_dir`/`model` flags, with the SAME
+    // `resolve_pipeline` the apply uses, so it matches the apply-side literal
+    // `reconciles_masks` by construction. `false` is the fail-safe (apply that
+    // does not reach the mask leg never checks the gate, so a wrong-`true` is
+    // harmless; a wrong-`false` would false-refuse).
+    bind_masks: bool,
 ) -> EmbeddedCapabilities {
     use crate::plan_store::CURRENT_FINGERPRINT_VERSION;
     use rocky_compiler::compile::{self, CompilerConfig};
@@ -1016,20 +1027,6 @@ pub fn compute_embedded_capabilities(
         .as_ref()
         .map(crate::commands::apply::governance_policy_identity)
         .unwrap_or_default();
-    // Finding #4: bind the mask iff the apply reaches the mask-reconciling path —
-    // a full run of a REPLICATION pipeline. Resolved with the same
-    // `resolve_pipeline` `run()` uses → symmetric with the apply-side
-    // `reconciles_masks`. Any resolution failure ⇒ do not bind (fail-safe: omit
-    // rather than risk an asymmetric refuse).
-    let bind_masks = model_is_none
-        && loaded_cfg
-            .as_ref()
-            .and_then(|cfg| {
-                crate::registry::resolve_pipeline(cfg, pipeline_name)
-                    .ok()
-                    .map(|(_, p)| matches!(p, rocky_core::config::PipelineConfig::Replication(_)))
-            })
-            .unwrap_or(false);
     // The env-resolved mask (finding C): the extras restrict it to the executed
     // models' classification tags. `env` is the plan's `--env`, so apply resolves
     // the same masks the reviewed env will apply.

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -12475,6 +12475,79 @@ merge_keys = ["id"]
         );
     }
 
+    /// 🔴 #4 (the `bind_masks=true` path): for a REPLICATION pipeline (which
+    /// reaches the mask-reconciling `--all` route at apply), the plan-side
+    /// `compute_embedded_capabilities` must BIND the effective mask and AGREE with
+    /// the apply-side choke-point that also binds it (`reconciles_masks=true`).
+    /// This exercises the one production path where the plan side binds — the
+    /// exact cross-path the `scoped` proxy got wrong. Also asserts the mask is
+    /// actually bound (a mask change moves the plan fingerprint).
+    #[cfg(feature = "duckdb")]
+    #[test]
+    fn plan_and_apply_agree_replication_binds_mask() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("rocky.toml");
+        let cfg_toml = |mask: &str| {
+            format!(
+                "[adapter]\ntype = \"duckdb\"\npath = \"wh.duckdb\"\n\n[mask]\npii = \"{mask}\"\n\n\
+                 [pipeline.p]\ntype = \"replication\"\nstrategy = \"full_refresh\"\n\n\
+                 [pipeline.p.source.schema_pattern]\nprefix = \"raw__\"\nseparator = \"__\"\ncomponents = [\"source\"]\n\n\
+                 [pipeline.p.target]\nadapter = \"default\"\ncatalog_template = \"c\"\nschema_template = \"s__{{source}}\"\n"
+            )
+        };
+        std::fs::write(&config_path, cfg_toml("hash")).unwrap();
+        let models = dir.path().join("models");
+        std::fs::create_dir(&models).unwrap();
+        std::fs::write(models.join("orders.sql"), "SELECT 1 AS id\n").unwrap();
+        // The model classifies `id` as `pii`, so the `[mask] pii` resolves onto it
+        // → the effective mask is NON-empty when bound.
+        std::fs::write(
+            models.join("orders.toml"),
+            "[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"\"\nschema = \"main\"\ntable = \"orders\"\n\n[classification]\nid = \"pii\"\n",
+        )
+        .unwrap();
+
+        // Plan side: a full run (`model_is_none = true`) of the REPLICATION
+        // pipeline "p" → `bind_masks = true` → the mask is bound.
+        let caps = crate::commands::plan::compute_embedded_capabilities(
+            &config_path,
+            &models,
+            "main",
+            None,
+            None,
+            Some("p"),
+            true,
+        );
+        // Apply side: `reconciles_masks = true` binds `gate.resolved_mask`, which
+        // the choke-point restricts to the executed models' tags — mirror that.
+        let cfg = rocky_core::config::load_rocky_config(&config_path).unwrap();
+        let identity = crate::commands::apply::config_policy_identity(&cfg);
+        let gov = crate::commands::apply::governance_policy_identity(&cfg);
+        let resolved_mask = cfg.resolve_mask_for_env(None);
+        let apply_fp = exec_choke_fingerprint(&models, &identity, &gov, &resolved_mask);
+        assert_eq!(
+            caps.models_fingerprint.as_deref(),
+            Some(apply_fp.as_str()),
+            "replication plan↔apply must AGREE with the mask BOUND on both sides (#4)"
+        );
+
+        // The mask IS bound: changing `[mask] pii` moves the plan fingerprint.
+        std::fs::write(&config_path, cfg_toml("redact")).unwrap();
+        let caps_redact = crate::commands::plan::compute_embedded_capabilities(
+            &config_path,
+            &models,
+            "main",
+            None,
+            None,
+            Some("p"),
+            true,
+        );
+        assert_ne!(
+            caps.models_fingerprint, caps_redact.models_fingerprint,
+            "a used [mask] change must move the replication plan fingerprint (#4/C bound)"
+        );
+    }
+
     /// Drive `execute_models` serially (DuckDB) with `[resilience]
     /// contain_failures = true` — the failure-containment path under test.
     async fn run_models_with_containment(

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -12216,6 +12216,142 @@ merge_keys = ["id"]
         );
     }
 
+    /// 🔴 #4 KILL-CHECK (real DuckDB): on a model-SCOPED apply (`--model a`), a
+    /// change to a mask used ONLY by an unselected model (`b`) must NOT refuse —
+    /// masking is not reconciled on the scoped path, so binding `b`'s mask would
+    /// be a spurious refusal. Fails on producer revert (binding masks on scoped
+    /// paths): the gate would then fold `b`'s mask and the fingerprint would
+    /// mismatch the reviewed (mask-omitted) value.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn model_scoped_apply_omits_unselected_mask() {
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+        use rocky_ir::MaskStrategy;
+
+        let dir = tempfile::tempdir().unwrap();
+        let models = dir.path().join("models");
+        std::fs::create_dir(&models).unwrap();
+        // `a` classifies `id` as pii; `b` classifies `x` as confidential.
+        std::fs::write(models.join("a.sql"), "SELECT 1 AS id\n").unwrap();
+        std::fs::write(
+            models.join("a.toml"),
+            "[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"\"\nschema = \"main\"\ntable = \"a\"\n\n[classification]\nid = \"pii\"\n",
+        )
+        .unwrap();
+        std::fs::write(models.join("b.sql"), "SELECT 2 AS x\n").unwrap();
+        std::fs::write(
+            models.join("b.toml"),
+            "[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"\"\nschema = \"main\"\ntable = \"b\"\n\n[classification]\nx = \"confidential\"\n",
+        )
+        .unwrap();
+        let db = dir.path().join("wh.duckdb");
+
+        // A scoped apply omits the mask, so the reviewed fingerprint is computed
+        // with an EMPTY mask (over all compiled models).
+        let empty_mask = std::collections::BTreeMap::new();
+        let fp = exec_choke_fingerprint(&models, "cfg", "", &empty_mask);
+
+        // The gate still carries `b`'s (and `a`'s) resolved mask — but the scoped
+        // choke-point must ignore it. A confidential→redact change on `b` must not
+        // move the recomputed fingerprint for a `--model a` apply.
+        let with_b_mask = std::collections::BTreeMap::from([
+            ("pii".to_string(), MaskStrategy::Hash),
+            ("confidential".to_string(), MaskStrategy::Redact),
+        ]);
+        let gate = crate::commands::apply::ExecFingerprintGate {
+            expected: Some(fp),
+            config_identity: "cfg".to_string(),
+            governance_identity: String::new(),
+            resolved_mask: with_b_mask,
+            reviewed_source_schemas: Some(std::collections::BTreeMap::new()),
+            plan_id: "p".to_string(),
+            require: true,
+        };
+        let adapter = DuckDbWarehouseAdapter::open(&db).expect("open duckdb");
+        let mut output = RunOutput::new(String::new(), 0, 1);
+        super::execute_models(
+            &models,
+            &adapter as &dyn rocky_core::traits::WarehouseAdapter,
+            None,
+            &PartitionRunOptions::default(),
+            "scoped-run",
+            Some("a"), // model_name_filter → scoped path
+            None,
+            &mut output,
+            None,
+            None,
+            &rocky_core::config::SchemaCacheConfig::default(),
+            true,
+            &DeferOptions::default(),
+            super::SkipGateConfig::off(),
+            false,
+            false,
+            &rocky_core::run_vars::RunVars::new(),
+            rocky_core::config::ResilienceConfig::default(),
+            true,
+            Some(&gate),
+        )
+        .await
+        .expect(
+            "KILL-CHECK: a `--model a` apply must NOT refuse on an unselected model's mask (#4)",
+        );
+        assert_eq!(output.tables_failed, 0, "errors: {:?}", output.errors);
+    }
+
+    /// 🔴 #2 KILL-CHECK: a REQUIRED (v2 governed) plan whose reviewed source-schema
+    /// snapshot is `None` REFUSES — apply must never fall through to the live
+    /// (agent-swappable) cache. Fails on producer revert (falling back to cache):
+    /// the run would type from the live cache and execute.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn required_plan_without_snapshot_refuses() {
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+        let dir = tempfile::tempdir().unwrap();
+        let models = dir.path().join("models");
+        std::fs::create_dir(&models).unwrap();
+        write_model_with_target(&models, "orders", "SELECT 1 AS id", "main", "orders");
+        let db = dir.path().join("wh.duckdb");
+        let gate = crate::commands::apply::ExecFingerprintGate {
+            expected: None,
+            config_identity: "cfg".to_string(),
+            governance_identity: String::new(),
+            resolved_mask: std::collections::BTreeMap::new(),
+            reviewed_source_schemas: None, // v2 governed plan MUST carry Some
+            plan_id: "p".to_string(),
+            require: true,
+        };
+        let adapter = DuckDbWarehouseAdapter::open(&db).expect("open duckdb");
+        let mut output = RunOutput::new(String::new(), 0, 1);
+        let err = super::execute_models(
+            &models,
+            &adapter as &dyn rocky_core::traits::WarehouseAdapter,
+            None,
+            &PartitionRunOptions::default(),
+            "no-snapshot",
+            None,
+            None,
+            &mut output,
+            None,
+            None,
+            &rocky_core::config::SchemaCacheConfig::default(),
+            true,
+            &DeferOptions::default(),
+            super::SkipGateConfig::off(),
+            false,
+            false,
+            &rocky_core::run_vars::RunVars::new(),
+            rocky_core::config::ResilienceConfig::default(),
+            true,
+            Some(&gate),
+        )
+        .await
+        .expect_err("KILL-CHECK: a required plan with no reviewed snapshot must REFUSE (#2)");
+        assert!(
+            err.to_string().contains("no reviewed"),
+            "must refuse for the missing snapshot, got: {err}"
+        );
+    }
+
     /// 🔴 KILL-CHECK (unchanged plan→apply does NOT refuse, with the new
     /// inputs): the REAL plan-side `compute_embedded_capabilities` must produce
     /// the SAME fingerprint the apply-side choke-point recomputes, for a project

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1295,6 +1295,10 @@ pub async fn run(
             output.idempotency_key = Some(ctx.key.clone());
         }
 
+        // Finding #1: baseline the failure count so a SOFT model failure (compile
+        // error / contained runtime failure that still returns `Ok`) skips
+        // governance below, not just a hard `Err`.
+        let failures_before = output.tables_failed;
         let exec_result = execute_models(
             mdir,
             warehouse.as_ref(),
@@ -1325,6 +1329,8 @@ pub async fn run(
             rocky_cfg.resilience.clone(),
             super::resilience::retry_policy_allows(&rocky_cfg),
             exec_fp_gate.as_ref(),
+            // Finding #4: the `--model` path reconciles no masks.
+            false,
         )
         .await;
 
@@ -1341,7 +1347,10 @@ pub async fn run(
         // a runtime failure. The terminal-status exit contract is honoured by
         // `run_status_exit_result` below.
         match exec_result {
-            Ok(()) => {
+            // Finding #1: only when the model phase is CLEAN (no new failures) —
+            // a soft compile/runtime failure returns `Ok(())`, so `Ok` alone is
+            // not enough to authorize governance/manifest writes.
+            Ok(()) if output.tables_failed == failures_before => {
                 // Per-model `[governance.tags]` apply (scoped to the built
                 // model). The model-only path is one of the entry points the
                 // SDK / Dagster drive; without this its tags were silently
@@ -1362,6 +1371,10 @@ pub async fn run(
                 // recomputes it.
                 write_recipe_manifests(&output, governance_adapter.as_ref(), &run_id).await;
             }
+            // Finding #1: a SOFT model failure (`Ok(())` but a new failure was
+            // recorded) — skip governance/manifest, fall through to the failure
+            // payload.
+            Ok(()) => {}
             Err(e) => {
                 output.tables_failed += 1;
                 output.errors.push(crate::output::TableErrorOutput {
@@ -3839,10 +3852,19 @@ pub async fn run(
             ))
             .await;
     }
+    // Finding #1: whether the compiled-model phase completed cleanly, hoisted so
+    // the recipe-manifest write (outside the model block below) can also skip on
+    // a failed model phase. `true` when no models run (nothing to fail).
+    let mut model_phase_clean = true;
     // --- Compiled model execution (--all or --models) ---
     if run_all || models_dir.is_some() {
         let mdir = models_dir.unwrap_or_else(|| std::path::Path::new("models"));
         if mdir.exists() {
+            // Finding #1: capture the failure count BEFORE the model phase so the
+            // governance guard below can detect a SOFT failure (a compile error
+            // recorded into `output`, or a contained runtime failure) that still
+            // returns `Ok(())` — not just a hard `Err`.
+            let failures_before = output.tables_failed;
             // §P2.6 follow-up — execute_models + warehouse adapter
             // construction were the remaining `?`-propagation sites
             // where a pipeline error could surface without firing
@@ -3882,21 +3904,25 @@ pub async fn run(
                     rocky_cfg.resilience.clone(),
                     super::resilience::retry_policy_allows(&rocky_cfg),
                     exec_fp_gate.as_ref(),
+                    // Finding #4: THE mask-reconciling path — bind the mask.
+                    true,
                 )
                 .await?;
                 Ok(())
             }
             .await;
-            // ‼️ Governance runs ONLY when execution completed cleanly (finding
-            // #1 — critical). ANY `execute_models` error — a fingerprint mismatch
-            // (the reviewed set changed), a routing swap, or a model failure —
-            // means the gated set did not fully execute, so reconciling
-            // masks/classifications/retention/tags/role GRANTs now would push
-            // UNREVIEWED governance to the warehouse *despite the gate detecting
-            // the change*. On error we record the failure and SKIP all post-model
-            // governance below, falling through to the failure payload + non-zero
-            // exit.
-            let exec_ok = exec_result.is_ok();
+            // ‼️ Governance runs ONLY when the model phase completed cleanly
+            // (finding #1 — critical). "Clean" is `Ok(())` AND no NEW failures:
+            // a hard error (fingerprint mismatch, routing swap) OR a SOFT failure
+            // (a compile error recorded into `output`, or a contained runtime
+            // failure under `contain_failures`) means the gated set did not fully
+            // execute, so reconciling masks/classifications/retention/tags/role
+            // GRANTs — or writing the recipe manifest — would push UNREVIEWED
+            // governance to the warehouse *despite the gate detecting the change*.
+            // On any failure we record it and SKIP all post-model governance
+            // below, falling through to the failure payload + non-zero exit.
+            let exec_ok = exec_result.is_ok() && output.tables_failed == failures_before;
+            model_phase_clean = exec_ok;
             if let Err(e) = exec_result {
                 // Record the runtime model failure as a table error and fall
                 // through to the terminal emit instead of returning raw `Err`.
@@ -4176,7 +4202,13 @@ pub async fn run(
     // This single hook, keyed off `output.materializations`, covers every
     // replication / transformation / time-interval model built by this
     // pipeline path. Best-effort — never flips the run's exit code.
-    write_recipe_manifests(&output, governance_adapter.as_ref(), &run_id).await;
+    //
+    // Finding #1: the recipe manifest IS a governance attestation, so it is
+    // skipped on a failed model phase (a fingerprint mismatch or a soft failure)
+    // — the same halt the masking/role reconcile obeys above.
+    if model_phase_clean {
+        write_recipe_manifests(&output, governance_adapter.as_ref(), &run_id).await;
+    }
 
     // Persist the RunRecord so `rocky history`, `rocky replay`,
     // `rocky trace`, and `rocky cost` have real data to read.
@@ -4968,6 +5000,8 @@ pub(crate) async fn execute_backfill_set(
     // satisfy it byte-identically, but the column-level skip never may.
     let (reuse_enabled, column_level_enabled) = backfill_reuse_gates(rocky_cfg);
 
+    // Finding #1: baseline failures so a soft model failure skips governance.
+    let failures_before = output.tables_failed;
     let exec_result = execute_models(
         models_dir,
         warehouse.as_ref(),
@@ -4991,11 +5025,14 @@ pub(crate) async fn execute_backfill_set(
         rocky_cfg.resilience.clone(),
         super::resilience::retry_policy_allows(rocky_cfg),
         exec_fp_gate,
+        // Finding #4: a backfill reconciles only tags, not masks.
+        false,
     )
     .await;
 
     match exec_result {
-        Ok(()) => {
+        // Finding #1: only when the model phase is CLEAN (no new soft failures).
+        Ok(()) if output.tables_failed == failures_before => {
             // Re-apply each rebuilt model's `[governance.tags]`, scoped to the
             // closure so unrelated models are untouched.
             let governance_adapter = adapter_registry.governance_adapter(&target_adapter_name);
@@ -5011,6 +5048,8 @@ pub(crate) async fn execute_backfill_set(
             }
             write_recipe_manifests(&output, governance_adapter.as_ref(), &run_id).await;
         }
+        // Soft model failure — skip governance/manifest, fall through.
+        Ok(()) => {}
         Err(e) => {
             output.tables_failed += 1;
             output.errors.push(crate::output::TableErrorOutput {
@@ -5132,6 +5171,13 @@ pub(crate) async fn execute_models(
     // EXACT set about to execute and refuses (fail-closed) on mismatch —
     // checked == executed. `None` for bare `rocky run` and human applies.
     exec_fp_gate: Option<&crate::commands::apply::ExecFingerprintGate>,
+    // Finding #4: `true` ONLY at the full replication `--all` call site, the sole
+    // path that reconciles masks post-model. On every other path (model-only,
+    // backfill, the transformation route) masking is NOT reconciled, so the mask
+    // must NOT enter the TOCTOU fingerprint — otherwise a mask change on a model
+    // that path never masks would falsely refuse. The plan side computes the same
+    // value from the resolved pipeline type, keeping the fingerprint symmetric.
+    reconciles_masks: bool,
 ) -> Result<()> {
     info!(models_dir = %models_dir.display(), "compiling and executing transformation models");
 
@@ -5254,19 +5300,18 @@ pub(crate) async fn execute_models(
         // post-plan swap of any refuses here. `models_dir` is the SAME directory
         // the plan fingerprinted.
         //
-        // Finding #4: the mask is bound ONLY on the full `--all` path, where every
-        // model executes AND the post-model masking reconcile runs. On a
-        // selection-scoped path (`--model` / backfill `model_set`) masking is NOT
-        // reconciled (only tags), and only a subset executes — so binding a mask
-        // used by an *unselected* model would falsely refuse. Both plan and apply
-        // gate the mask on the SAME predicate (no model filter / no model_set),
-        // so the fingerprint stays symmetric.
-        let scoped = model_name_filter.is_some() || model_set.is_some();
+        // Finding #4: bind the mask into the fingerprint ONLY on the path that
+        // actually reconciles masks (the full replication `--all` route,
+        // `reconciles_masks == true`). Every other path — model-only, backfill,
+        // the transformation route (run_local) — reconciles no masks, so binding
+        // one would falsely refuse a mask change it never applies. The plan side
+        // computes `reconciles_masks` from the same resolved pipeline type, so the
+        // fingerprint is symmetric.
         let empty_mask = std::collections::BTreeMap::new();
-        let mask_for_extras = if scoped {
-            &empty_mask
-        } else {
+        let mask_for_extras = if reconciles_masks {
             &gate.resolved_mask
+        } else {
+            &empty_mask
         };
         let extras = crate::commands::apply::ExecutionExtras::build(
             &surrogate_keys,
@@ -11745,6 +11790,7 @@ merge_keys = ["id"]
             rocky_core::config::ResilienceConfig::default(),
             true,
             None, // exec_fp_gate (test)
+            false,
         )
         .await;
         (output, result)
@@ -11819,6 +11865,7 @@ merge_keys = ["id"]
             rocky_core::config::ResilienceConfig::default(),
             true,
             Some(&gate),
+            false,
         )
         .await;
         ok.expect("KILL-CHECK: an unchanged governed apply must NOT refuse");
@@ -11854,6 +11901,7 @@ merge_keys = ["id"]
             rocky_core::config::ResilienceConfig::default(),
             true,
             Some(&gate),
+            false,
         )
         .await
         .expect_err("KILL-CHECK: a changed model must be REFUSED at the choke-point");
@@ -11940,6 +11988,7 @@ merge_keys = ["id"]
         run_id: &str,
         expected_fp: &str,
         resolved_mask: &std::collections::BTreeMap<String, rocky_ir::MaskStrategy>,
+        reconciles_masks: bool,
     ) -> Result<()> {
         use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
         let gate = crate::commands::apply::ExecFingerprintGate {
@@ -11974,6 +12023,7 @@ merge_keys = ["id"]
             rocky_core::config::ResilienceConfig::default(),
             true,
             Some(&gate),
+            reconciles_masks,
         )
         .await
     }
@@ -12008,6 +12058,7 @@ merge_keys = ["id"]
             "sk-ok",
             &fp,
             &std::collections::BTreeMap::new(),
+            false,
         )
         .await
         .expect("KILL-CHECK: unchanged surrogate apply must NOT refuse");
@@ -12020,6 +12071,7 @@ merge_keys = ["id"]
             "sk-changed",
             &fp,
             &std::collections::BTreeMap::new(),
+            false,
         )
         .await
         .expect_err("KILL-CHECK: a surrogate-key change must be REFUSED (#1)");
@@ -12055,6 +12107,7 @@ merge_keys = ["id"]
             "contract-ok",
             &fp,
             &std::collections::BTreeMap::new(),
+            false,
         )
         .await
         .expect("KILL-CHECK: unchanged contract apply must NOT refuse");
@@ -12073,6 +12126,7 @@ merge_keys = ["id"]
             "contract-edited",
             &fp,
             &std::collections::BTreeMap::new(),
+            false,
         )
         .await
         .expect_err("KILL-CHECK: a same-presence contract CONTENT edit must be REFUSED (#3)");
@@ -12089,6 +12143,7 @@ merge_keys = ["id"]
             "contract-removed",
             &fp,
             &std::collections::BTreeMap::new(),
+            false,
         )
         .await
         .expect_err("KILL-CHECK: a removed contract must be REFUSED (#3)");
@@ -12122,7 +12177,7 @@ merge_keys = ["id"]
         let hash_mask = std::collections::BTreeMap::from([("pii".to_string(), MaskStrategy::Hash)]);
         // Baseline fp binds the EFFECTIVE mask {pii→hash}.
         let fp = exec_choke_fingerprint(&models, "cfg", "", &hash_mask);
-        governed_apply(&models, &db, "mask-ok", &fp, &hash_mask)
+        governed_apply(&models, &db, "mask-ok", &fp, &hash_mask, true)
             .await
             .expect("unchanged effective mask must NOT refuse");
 
@@ -12130,14 +12185,14 @@ merge_keys = ["id"]
         // mask unchanged → must NOT refuse.
         let mut with_unused = hash_mask.clone();
         with_unused.insert("other".to_string(), MaskStrategy::Redact);
-        governed_apply(&models, &db, "mask-unused", &fp, &with_unused)
+        governed_apply(&models, &db, "mask-unused", &fp, &with_unused, true)
             .await
             .expect("KILL-CHECK: an UNUSED mask entry must NOT refuse (C)");
 
         // A USED mask change (`pii` hash→redact) → effective mask changes → REFUSE.
         let redact_mask =
             std::collections::BTreeMap::from([("pii".to_string(), MaskStrategy::Redact)]);
-        let err = governed_apply(&models, &db, "mask-changed", &fp, &redact_mask)
+        let err = governed_apply(&models, &db, "mask-changed", &fp, &redact_mask, true)
             .await
             .expect_err("KILL-CHECK: a USED mask change must be REFUSED (C)");
         assert!(
@@ -12206,6 +12261,7 @@ merge_keys = ["id"]
             rocky_core::config::ResilienceConfig::default(),
             true,
             Some(&gate),
+            false,
         )
         .await
         .expect("the non-empty-snapshot seed branch must run, not panic");
@@ -12290,6 +12346,7 @@ merge_keys = ["id"]
             rocky_core::config::ResilienceConfig::default(),
             true,
             Some(&gate),
+            false,
         )
         .await
         .expect(
@@ -12343,6 +12400,7 @@ merge_keys = ["id"]
             rocky_core::config::ResilienceConfig::default(),
             true,
             Some(&gate),
+            false,
         )
         .await
         .expect_err("KILL-CHECK: a required plan with no reviewed snapshot must REFUSE (#2)");
@@ -12395,15 +12453,18 @@ merge_keys = ["id"]
             "main",
             None,
             None,
-            true, // full run — bind masks (finding #4)
+            None, // pipeline_name → default resolution (finding #4)
+            true, // full run (no `--model`)
         );
         // Apply side: the choke-point's routing + governance identity are the
-        // loaded config's, resolved for the same (None) env. A full run (no model
-        // filter) binds the mask, matching the plan side.
+        // loaded config's, resolved for the same (None) env. The POC pipeline is
+        // a TRANSFORMATION pipeline (→ `run_local`), which reconciles no masks, so
+        // the mask is omitted on BOTH sides (empty) — matching `bind_masks=false`.
         let cfg = rocky_core::config::load_rocky_config(&config_path).unwrap();
         let identity = crate::commands::apply::config_policy_identity(&cfg);
         let gov = crate::commands::apply::governance_policy_identity(&cfg);
-        let resolved_mask = cfg.resolve_mask_for_env(None);
+        let resolved_mask: std::collections::BTreeMap<String, rocky_ir::MaskStrategy> =
+            std::collections::BTreeMap::new();
         let apply_fp = exec_choke_fingerprint(&models, &identity, &gov, &resolved_mask);
 
         assert_eq!(
@@ -12450,6 +12511,7 @@ merge_keys = ["id"]
             resilience,
             true,
             None, // exec_fp_gate (test)
+            false,
         )
         .await;
         (output, result)
@@ -12492,6 +12554,7 @@ merge_keys = ["id"]
             resilience,
             true,
             None, // exec_fp_gate (test)
+            false,
         )
         .await;
         (output, result)
@@ -12540,6 +12603,7 @@ merge_keys = ["id"]
             resilience,
             true,
             None, // exec_fp_gate (test)
+            false,
         )
         .await;
         (output, result)
@@ -13561,6 +13625,7 @@ merge_keys = ["id"]
             rocky_core::config::ResilienceConfig::default(),
             true,
             None, // exec_fp_gate (test)
+            false,
         )
         .await
         .expect("run with --var should succeed");
@@ -13667,6 +13732,7 @@ merge_keys = ["id"]
             rocky_core::config::ResilienceConfig::default(),
             true,
             None, // exec_fp_gate (test)
+            false,
         )
         .await
         .expect("deferred run must succeed");
@@ -13788,6 +13854,7 @@ merge_keys = ["id"]
             rocky_core::config::ResilienceConfig::default(),
             true,
             None, // exec_fp_gate (test)
+            false,
         )
         .await;
 
@@ -14070,6 +14137,7 @@ merge_keys = ["id"]
                 rocky_core::config::ResilienceConfig::default(),
                 true,
                 None, // exec_fp_gate (test)
+                false,
             )
             .await
             .expect("backfill run must succeed on serial DuckDB under --parallel");
@@ -14195,6 +14263,7 @@ merge_keys = ["id"]
             rocky_core::config::ResilienceConfig::default(),
             true,
             None, // exec_fp_gate (test)
+            false,
         )
         .await
         .expect("gate run must succeed");
@@ -15168,6 +15237,7 @@ merge_keys = ["id"]
                 rocky_core::config::ResilienceConfig::default(),
                 true,
                 None, // exec_fp_gate (test)
+                false,
             )
             .await
             .unwrap();

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -5151,38 +5151,50 @@ pub(crate) async fn execute_models(
         breaker: retry_breaker.as_ref(),
     };
 
-    // Source schemas for the typecheck that resolves `typed_columns` (→ the
-    // MERGE column list). A governed apply whose plan carries a REVIEWED
-    // source-schema snapshot (finding #2b) SEEDS from that snapshot, so a
-    // post-plan source-schema drift, cache refresh, or `[cache.schemas]` toggle
-    // cannot change the executed columns — apply types against exactly what was
-    // reviewed. `execute-from-owned`, like surrogate keys (#1). Every other path
-    // (bare `rocky run`, human apply, a plan with no captured snapshot) falls
-    // through to the live cache load below — byte-identical to before.
-    let reviewed_snapshot = exec_fp_gate
-        .map(|g| &g.reviewed_source_schemas)
-        .filter(|s| !s.is_empty());
-    let source_schemas = if let Some(snapshot) = reviewed_snapshot {
-        snapshot
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect::<std::collections::HashMap<_, _>>()
-    } else if schema_cache_config.enabled {
-        // Load the persisted schema cache directly from the live `StateStore` —
-        // no round-trip through `crate::source_schemas::load_cached_source_schemas`,
-        // because that helper opens a read-only handle and we already hold a
-        // write-capable one here. Degrades silently when the cache is cold.
-        match state_store {
-            Some(store) => rocky_compiler::schema_cache::load_source_schemas_from_cache(
-                store,
-                chrono::Utc::now(),
-                schema_cache_config.ttl(),
-            )
-            .unwrap_or_default(),
-            None => std::collections::HashMap::new(),
+    // Source schemas for the typecheck that resolves `typed_columns`. A governed
+    // apply whose plan carries a REVIEWED source-schema snapshot (finding #2)
+    // types from EXACTLY that snapshot — `Some(map)` is authoritative even when
+    // empty, so a post-plan source drift, cache refresh, `[cache.schemas]` toggle,
+    // or a later-warmed cache cannot change `typed_columns` (which could silently
+    // clear a reviewed diagnostic). `execute-from-owned`, like surrogate keys.
+    //
+    // Fail-closed: a REQUIRED (v2 governed) plan whose snapshot is `None` is a
+    // production capture failure → refuse (do NOT fall through to the live cache).
+    // Only a genuinely-legacy plan (`None` + `!require`) and the non-gated paths
+    // (bare `rocky run`, human apply) load the live cache — byte-identical.
+    let cache_source_schemas = || {
+        if schema_cache_config.enabled {
+            match state_store {
+                Some(store) => rocky_compiler::schema_cache::load_source_schemas_from_cache(
+                    store,
+                    chrono::Utc::now(),
+                    schema_cache_config.ttl(),
+                )
+                .unwrap_or_default(),
+                None => std::collections::HashMap::new(),
+            }
+        } else {
+            std::collections::HashMap::new()
         }
-    } else {
-        std::collections::HashMap::new()
+    };
+    let source_schemas = match exec_fp_gate {
+        Some(gate) => match &gate.reviewed_source_schemas {
+            Some(snapshot) => snapshot
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect::<std::collections::HashMap<_, _>>(),
+            None if gate.require => {
+                anyhow::bail!(
+                    "refusing to execute plan '{}': it is a governed plan carrying no reviewed \
+                     source-schema snapshot, so `typed_columns` cannot be replayed against the \
+                     reviewed schema (a warmed/drifted cache could change them undetected). \
+                     Re-plan with `rocky plan` before applying.",
+                    gate.plan_id
+                );
+            }
+            None => cache_source_schemas(), // genuinely-legacy plan
+        },
+        None => cache_source_schemas(), // bare run / human apply
     };
 
     let compile_config = rocky_compiler::compile::CompilerConfig {
@@ -5943,7 +5955,9 @@ pub(crate) async fn execute_models(
                 // The fully-typed IR, not bare `to_model_ir()`: an empty
                 // `typed_columns` forces `skip_hash()` to the never-equal
                 // `None` sentinel, which made this gate silently inert on the
-                // real CLI path (every evaluation fell through to build).
+                // real CLI path (every evaluation fell through to build). The
+                // seeded typed IR (typed from the reviewed source-schema
+                // snapshot #2) is what the column-skip decision consumes (#3).
                 let model_ir = typed_model_ir(
                     model,
                     exec_ctx.typed_models,
@@ -6039,7 +6053,8 @@ pub(crate) async fn execute_models(
                 // declared column count (0 when unenriched) disagrees with the
                 // warehouse result, and an empty `typed_columns` also nulls
                 // `skip_hash()`, so the reuse spine / provenance ledger was
-                // never populated by a real `rocky run`.
+                // never populated by a real `rocky run`. Seeded from the
+                // reviewed source-schema snapshot (#2) so CAS consumes it (#3).
                 let model_ir = typed_model_ir(
                     model,
                     exec_ctx.typed_models,
@@ -11777,7 +11792,7 @@ merge_keys = ["id"]
             config_identity: "cfg".to_string(),
             governance_identity: String::new(),
             resolved_mask: std::collections::BTreeMap::new(),
-            reviewed_source_schemas: std::collections::BTreeMap::new(),
+            reviewed_source_schemas: Some(std::collections::BTreeMap::new()),
             plan_id: "p".to_string(),
             require: true,
         };
@@ -11932,7 +11947,7 @@ merge_keys = ["id"]
             config_identity: "cfg".to_string(),
             governance_identity: String::new(),
             resolved_mask: resolved_mask.clone(),
-            reviewed_source_schemas: std::collections::BTreeMap::new(),
+            reviewed_source_schemas: Some(std::collections::BTreeMap::new()),
             plan_id: "p".to_string(),
             require: true,
         };
@@ -12164,7 +12179,7 @@ merge_keys = ["id"]
             config_identity: "cfg".to_string(),
             governance_identity: String::new(),
             resolved_mask: std::collections::BTreeMap::new(),
-            reviewed_source_schemas: snapshot,
+            reviewed_source_schemas: Some(snapshot),
             plan_id: "p".to_string(),
             require: false,
         };

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -4862,8 +4862,16 @@ fn backfill_reuse_gates(cfg: &rocky_core::config::RockyConfig) -> (bool, bool) {
 ///
 /// It never rewrites SQL — a backfill re-runs existing recipes over a scoped
 /// window; the "what to fix" question is out of scope by construction.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_backfill_set(
     config_path: &Path,
+    // The VERIFIED, already-loaded config (execute-from-owned, finding B). The
+    // caller (`apply`) loaded this instance and ran `verify_routing_identity`
+    // against it BEFORE building the gate, so the adapter/destination selected
+    // below is the one authorization was checked against — no internal reload
+    // that a timed `rocky.toml` swap could point at a different, unverified
+    // destination while the gate held the old identity.
+    rocky_cfg: &rocky_core::config::RockyConfig,
     state_path: &Path,
     models_dir: &Path,
     model_set: &std::collections::BTreeSet<String>,
@@ -4881,16 +4889,13 @@ pub(crate) async fn execute_backfill_set(
     let run_id = format!("run-{}", started_at.format("%Y%m%d-%H%M%S-%3f"));
     let config_hash = crate::output::config_fingerprint(config_path);
 
-    let rocky_cfg = rocky_core::config::load_rocky_config(config_path)
-        .with_context(|| format!("failed to load config from {}", config_path.display()))?;
-
     anyhow::ensure!(
         models_dir.exists(),
         "models directory '{}' not found (required for backfill)",
         models_dir.display()
     );
 
-    let adapter_registry = AdapterRegistry::from_config(&rocky_cfg)?;
+    let adapter_registry = AdapterRegistry::from_config(rocky_cfg)?;
     // Mirror the `--model` path: the first transformation pipeline's target
     // adapter, falling back to the first replication pipeline's.
     let target_adapter_name = rocky_cfg
@@ -4942,7 +4947,7 @@ pub(crate) async fn execute_backfill_set(
     let run_vars = rocky_core::run_vars::RunVars::new();
     // A backfill is an explicit rebuild order: point-to reuse may still
     // satisfy it byte-identically, but the column-level skip never may.
-    let (reuse_enabled, column_level_enabled) = backfill_reuse_gates(&rocky_cfg);
+    let (reuse_enabled, column_level_enabled) = backfill_reuse_gates(rocky_cfg);
 
     let exec_result = execute_models(
         models_dir,
@@ -4965,7 +4970,7 @@ pub(crate) async fn execute_backfill_set(
         column_level_enabled,
         &run_vars,
         rocky_cfg.resilience.clone(),
-        super::resilience::retry_policy_allows(&rocky_cfg),
+        super::resilience::retry_policy_allows(rocky_cfg),
         exec_fp_gate,
     )
     .await;
@@ -4979,7 +4984,7 @@ pub(crate) async fn execute_backfill_set(
                 apply_model_governance_tags(
                     models_dir,
                     governance_adapter.as_ref(),
-                    &rocky_cfg,
+                    rocky_cfg,
                     &run_vars,
                     Some(model.as_str()),
                 )
@@ -5127,12 +5132,27 @@ pub(crate) async fn execute_models(
         breaker: retry_breaker.as_ref(),
     };
 
-    // Load the persisted schema cache directly from the live
-    // `StateStore` — no round-trip through
-    // `crate::source_schemas::load_cached_source_schemas`, because that
-    // helper opens a read-only handle and we already hold a write-capable
-    // one here. Degrades silently when the cache is cold or disabled.
-    let source_schemas = if schema_cache_config.enabled {
+    // Source schemas for the typecheck that resolves `typed_columns` (→ the
+    // MERGE column list). A governed apply whose plan carries a REVIEWED
+    // source-schema snapshot (finding #2b) SEEDS from that snapshot, so a
+    // post-plan source-schema drift, cache refresh, or `[cache.schemas]` toggle
+    // cannot change the executed columns — apply types against exactly what was
+    // reviewed. `execute-from-owned`, like surrogate keys (#1). Every other path
+    // (bare `rocky run`, human apply, a plan with no captured snapshot) falls
+    // through to the live cache load below — byte-identical to before.
+    let reviewed_snapshot = exec_fp_gate
+        .map(|g| &g.reviewed_source_schemas)
+        .filter(|s| !s.is_empty());
+    let source_schemas = if let Some(snapshot) = reviewed_snapshot {
+        snapshot
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect::<std::collections::HashMap<_, _>>()
+    } else if schema_cache_config.enabled {
+        // Load the persisted schema cache directly from the live `StateStore` —
+        // no round-trip through `crate::source_schemas::load_cached_source_schemas`,
+        // because that helper opens a read-only handle and we already hold a
+        // write-capable one here. Degrades silently when the cache is cold.
         match state_store {
             Some(store) => rocky_compiler::schema_cache::load_source_schemas_from_cache(
                 store,
@@ -5198,12 +5218,15 @@ pub(crate) async fn execute_models(
     // content. `None` (bare run / human apply / legacy plan) is a no-op.
     if let Some(gate) = exec_fp_gate {
         // Fold the seeding-independent on-disk extras the compiled IR omits —
-        // the OWNED surrogate map (#1) and contract presence/contents (#3) — into
-        // the recomputed fingerprint so a post-plan swap of either refuses here.
-        // `models_dir` is the SAME directory the plan fingerprinted.
+        // the OWNED surrogate map (#1), contract presence/contents (#3), and the
+        // EFFECTIVE mask for the executed set (finding C) — into the recomputed
+        // fingerprint so a post-plan swap of any refuses here. `models_dir` is the
+        // SAME directory the plan fingerprinted; `resolved_mask` is the plan-env
+        // mask the gate carries.
         let extras = crate::commands::apply::ExecutionExtras::build(
             &surrogate_keys,
             &compile_result.project.models,
+            &gate.resolved_mask,
         );
         gate.verify(&compile_result.project.models, &extras)?;
     }
@@ -11704,8 +11727,9 @@ merge_keys = ["id"]
         // (1) process-stability across two independent compiles — computed the
         // exact way `execute_models` recomputes at the choke-point (compile +
         // surrogate/contract extras), so the two must agree.
-        let fp1 = exec_choke_fingerprint(&models, "cfg", "");
-        let fp2 = exec_choke_fingerprint(&models, "cfg", "");
+        let no_mask = std::collections::BTreeMap::new();
+        let fp1 = exec_choke_fingerprint(&models, "cfg", "", &no_mask);
+        let fp2 = exec_choke_fingerprint(&models, "cfg", "", &no_mask);
         assert_eq!(
             fp1, fp2,
             "same bytes must fingerprint identically (stability)"
@@ -11719,6 +11743,8 @@ merge_keys = ["id"]
             expected: Some(fp1.clone()),
             config_identity: "cfg".to_string(),
             governance_identity: String::new(),
+            resolved_mask: std::collections::BTreeMap::new(),
+            reviewed_source_schemas: std::collections::BTreeMap::new(),
             plan_id: "p".to_string(),
             require: true,
         };
@@ -11834,6 +11860,7 @@ merge_keys = ["id"]
         models_dir: &std::path::Path,
         config_identity: &str,
         governance_identity: &str,
+        resolved_mask: &std::collections::BTreeMap<String, rocky_ir::MaskStrategy>,
     ) -> String {
         use rocky_compiler::compile::{self, CompilerConfig};
         let cc = CompilerConfig {
@@ -11842,7 +11869,11 @@ merge_keys = ["id"]
         };
         let result = compile::compile(&cc).unwrap();
         let sk = rocky_core::models::load_surrogate_keys_from_dir(models_dir).unwrap();
-        let extras = crate::commands::apply::ExecutionExtras::build(&sk, &result.project.models);
+        let extras = crate::commands::apply::ExecutionExtras::build(
+            &sk,
+            &result.project.models,
+            resolved_mask,
+        );
         crate::commands::apply::execution_ir_fingerprint(
             &result.project.models,
             config_identity,
@@ -11860,12 +11891,15 @@ merge_keys = ["id"]
         db: &std::path::Path,
         run_id: &str,
         expected_fp: &str,
+        resolved_mask: &std::collections::BTreeMap<String, rocky_ir::MaskStrategy>,
     ) -> Result<()> {
         use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
         let gate = crate::commands::apply::ExecFingerprintGate {
             expected: Some(expected_fp.to_string()),
             config_identity: "cfg".to_string(),
             governance_identity: String::new(),
+            resolved_mask: resolved_mask.clone(),
+            reviewed_source_schemas: std::collections::BTreeMap::new(),
             plan_id: "p".to_string(),
             require: true,
         };
@@ -11918,17 +11952,29 @@ merge_keys = ["id"]
 
         let db = dir.path().join("wh.duckdb");
         // Plan-time fingerprint binds the surrogate spec (columns = [id]).
-        let fp = exec_choke_fingerprint(&models, "cfg", "");
+        let fp = exec_choke_fingerprint(&models, "cfg", "", &std::collections::BTreeMap::new());
         // (2) unchanged apply → no refuse.
-        governed_apply(&models, &db, "sk-ok", &fp)
-            .await
-            .expect("KILL-CHECK: unchanged surrogate apply must NOT refuse");
+        governed_apply(
+            &models,
+            &db,
+            "sk-ok",
+            &fp,
+            &std::collections::BTreeMap::new(),
+        )
+        .await
+        .expect("KILL-CHECK: unchanged surrogate apply must NOT refuse");
 
         // (3) change ONLY the surrogate columns — ModelConfig + SQL unchanged.
         std::fs::write(models.join("orders.toml"), sidecar("\"id\", \"id\"")).unwrap();
-        let err = governed_apply(&models, &db, "sk-changed", &fp)
-            .await
-            .expect_err("KILL-CHECK: a surrogate-key change must be REFUSED (#1)");
+        let err = governed_apply(
+            &models,
+            &db,
+            "sk-changed",
+            &fp,
+            &std::collections::BTreeMap::new(),
+        )
+        .await
+        .expect_err("KILL-CHECK: a surrogate-key change must be REFUSED (#1)");
         assert!(
             err.to_string().contains("fingerprint mismatch"),
             "must refuse with a fingerprint mismatch, got: {err}"
@@ -11954,10 +12000,16 @@ merge_keys = ["id"]
         .unwrap();
 
         let db = dir.path().join("wh.duckdb");
-        let fp = exec_choke_fingerprint(&models, "cfg", "");
-        governed_apply(&models, &db, "contract-ok", &fp)
-            .await
-            .expect("KILL-CHECK: unchanged contract apply must NOT refuse");
+        let fp = exec_choke_fingerprint(&models, "cfg", "", &std::collections::BTreeMap::new());
+        governed_apply(
+            &models,
+            &db,
+            "contract-ok",
+            &fp,
+            &std::collections::BTreeMap::new(),
+        )
+        .await
+        .expect("KILL-CHECK: unchanged contract apply must NOT refuse");
 
         // SAME-PRESENCE CONTENT EDIT — the contract file still exists (presence
         // unchanged) but its CONTENTS change. This is the case a presence-only
@@ -11967,9 +12019,15 @@ merge_keys = ["id"]
             "[[columns]]\nname = \"id\"\ntype = \"Int64\"\n",
         )
         .unwrap();
-        let err = governed_apply(&models, &db, "contract-edited", &fp)
-            .await
-            .expect_err("KILL-CHECK: a same-presence contract CONTENT edit must be REFUSED (#3)");
+        let err = governed_apply(
+            &models,
+            &db,
+            "contract-edited",
+            &fp,
+            &std::collections::BTreeMap::new(),
+        )
+        .await
+        .expect_err("KILL-CHECK: a same-presence contract CONTENT edit must be REFUSED (#3)");
         assert!(
             err.to_string().contains("fingerprint mismatch"),
             "must refuse with a fingerprint mismatch, got: {err}"
@@ -11977,9 +12035,63 @@ merge_keys = ["id"]
 
         // Remove the contract — presence flips, ModelConfig + SQL unchanged.
         std::fs::remove_file(models.join("orders.contract.toml")).unwrap();
-        let err = governed_apply(&models, &db, "contract-removed", &fp)
+        let err = governed_apply(
+            &models,
+            &db,
+            "contract-removed",
+            &fp,
+            &std::collections::BTreeMap::new(),
+        )
+        .await
+        .expect_err("KILL-CHECK: a removed contract must be REFUSED (#3)");
+        assert!(
+            err.to_string().contains("fingerprint mismatch"),
+            "must refuse with a fingerprint mismatch, got: {err}"
+        );
+    }
+
+    /// 🔴 C KILL-CHECK (real DuckDB, effective mask): an UNUSED `[mask]` entry (a
+    /// tag no executed model classifies with) must NOT refuse; a change to a mask
+    /// that DOES resolve onto an executed model's classified column must refuse.
+    /// Fails on producer revert (binding the whole mask map): the unused-entry
+    /// case would then move the fingerprint and refuse.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn effective_mask_kill_check() {
+        use rocky_ir::MaskStrategy;
+        let dir = tempfile::tempdir().unwrap();
+        let models = dir.path().join("models");
+        std::fs::create_dir(&models).unwrap();
+        std::fs::write(models.join("orders.sql"), "SELECT 1 AS id\n").unwrap();
+        // The model classifies `id` as `pii`, so a `pii` mask resolves onto it.
+        std::fs::write(
+            models.join("orders.toml"),
+            "[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"\"\nschema = \"main\"\ntable = \"orders\"\n\n[classification]\nid = \"pii\"\n",
+        )
+        .unwrap();
+        let db = dir.path().join("wh.duckdb");
+
+        let hash_mask = std::collections::BTreeMap::from([("pii".to_string(), MaskStrategy::Hash)]);
+        // Baseline fp binds the EFFECTIVE mask {pii→hash}.
+        let fp = exec_choke_fingerprint(&models, "cfg", "", &hash_mask);
+        governed_apply(&models, &db, "mask-ok", &fp, &hash_mask)
             .await
-            .expect_err("KILL-CHECK: a removed contract must be REFUSED (#3)");
+            .expect("unchanged effective mask must NOT refuse");
+
+        // An UNUSED entry (`other`, which no model classifies with) → effective
+        // mask unchanged → must NOT refuse.
+        let mut with_unused = hash_mask.clone();
+        with_unused.insert("other".to_string(), MaskStrategy::Redact);
+        governed_apply(&models, &db, "mask-unused", &fp, &with_unused)
+            .await
+            .expect("KILL-CHECK: an UNUSED mask entry must NOT refuse (C)");
+
+        // A USED mask change (`pii` hash→redact) → effective mask changes → REFUSE.
+        let redact_mask =
+            std::collections::BTreeMap::from([("pii".to_string(), MaskStrategy::Redact)]);
+        let err = governed_apply(&models, &db, "mask-changed", &fp, &redact_mask)
+            .await
+            .expect_err("KILL-CHECK: a USED mask change must be REFUSED (C)");
         assert!(
             err.to_string().contains("fingerprint mismatch"),
             "must refuse with a fingerprint mismatch, got: {err}"
@@ -12034,8 +12146,9 @@ merge_keys = ["id"]
         // loaded config's, resolved for the same (None) env.
         let cfg = rocky_core::config::load_rocky_config(&config_path).unwrap();
         let identity = crate::commands::apply::config_policy_identity(&cfg);
-        let gov = crate::commands::apply::governance_policy_identity(&cfg, None);
-        let apply_fp = exec_choke_fingerprint(&models, &identity, &gov);
+        let gov = crate::commands::apply::governance_policy_identity(&cfg);
+        let resolved_mask = cfg.resolve_mask_for_env(None);
+        let apply_fp = exec_choke_fingerprint(&models, &identity, &gov, &resolved_mask);
 
         assert_eq!(
             caps.models_fingerprint.as_deref(),

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -12098,6 +12098,76 @@ merge_keys = ["id"]
         );
     }
 
+    /// A SMOKE TEST (real DuckDB): a governed apply whose gate carries a NON-EMPTY
+    /// `reviewed_source_schemas` snapshot (finding A) exercises the seed override
+    /// in `execute_models` — the branch that replays the reviewed source schema
+    /// into the typecheck instead of the live cache. Every other test uses an
+    /// empty snapshot, so this is the only runtime coverage of that
+    /// production-reachable branch: it must run, not panic, and materialize.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn nonempty_source_schema_snapshot_seed_runs() {
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+        use rocky_ir::RockyType;
+        use rocky_ir::types::TypedColumn;
+
+        let dir = tempfile::tempdir().unwrap();
+        let models = dir.path().join("models");
+        std::fs::create_dir(&models).unwrap();
+        // A source-free `full_refresh` model: the snapshot is loaded (exercising
+        // the seed branch) but the CTAS types itself, so it materializes cleanly.
+        write_model_with_target(&models, "orders", "SELECT 1 AS id", "main", "orders");
+        let db = dir.path().join("wh.duckdb");
+        let snapshot = std::collections::BTreeMap::from([(
+            "main.src".to_string(),
+            vec![TypedColumn {
+                name: "id".to_string(),
+                data_type: RockyType::Int64,
+                nullable: false,
+            }],
+        )]);
+        let gate = crate::commands::apply::ExecFingerprintGate {
+            expected: None,
+            config_identity: "cfg".to_string(),
+            governance_identity: String::new(),
+            resolved_mask: std::collections::BTreeMap::new(),
+            reviewed_source_schemas: snapshot,
+            plan_id: "p".to_string(),
+            require: false,
+        };
+        let adapter = DuckDbWarehouseAdapter::open(&db).expect("open duckdb");
+        let mut output = RunOutput::new(String::new(), 0, 1);
+        super::execute_models(
+            &models,
+            &adapter as &dyn rocky_core::traits::WarehouseAdapter,
+            None,
+            &PartitionRunOptions::default(),
+            "seed-run",
+            None,
+            None,
+            &mut output,
+            None,
+            None,
+            &rocky_core::config::SchemaCacheConfig::default(),
+            true,
+            &DeferOptions::default(),
+            super::SkipGateConfig::off(),
+            false,
+            false,
+            &rocky_core::run_vars::RunVars::new(),
+            rocky_core::config::ResilienceConfig::default(),
+            true,
+            Some(&gate),
+        )
+        .await
+        .expect("the non-empty-snapshot seed branch must run, not panic");
+        assert_eq!(
+            output.tables_failed, 0,
+            "the model materialized under a non-empty reviewed-schema seed (errors: {:?})",
+            output.errors
+        );
+    }
+
     /// 🔴 KILL-CHECK (unchanged plan→apply does NOT refuse, with the new
     /// inputs): the REAL plan-side `compute_embedded_capabilities` must produce
     /// the SAME fingerprint the apply-side choke-point recomputes, for a project

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -3887,6 +3887,16 @@ pub async fn run(
                 Ok(())
             }
             .await;
+            // ‼️ Governance runs ONLY when execution completed cleanly (finding
+            // #1 — critical). ANY `execute_models` error — a fingerprint mismatch
+            // (the reviewed set changed), a routing swap, or a model failure —
+            // means the gated set did not fully execute, so reconciling
+            // masks/classifications/retention/tags/role GRANTs now would push
+            // UNREVIEWED governance to the warehouse *despite the gate detecting
+            // the change*. On error we record the failure and SKIP all post-model
+            // governance below, falling through to the failure payload + non-zero
+            // exit.
+            let exec_ok = exec_result.is_ok();
             if let Err(e) = exec_result {
                 // Record the runtime model failure as a table error and fall
                 // through to the terminal emit instead of returning raw `Err`.
@@ -3920,8 +3930,11 @@ pub async fn run(
             // `resolve_mask_for_env` so `[mask.<env>]` overrides win over
             // the workspace `[mask]` defaults. `None` preserves the
             // pre-1.16 behavior of resolving defaults only.
-            let governance_compile = rocky_compiler::compile::compile(
-                &rocky_compiler::compile::CompilerConfig {
+            // `exec_ok.then(...)` (finding #1): a failed execution skips even the
+            // governance compile — no reconcile is attempted when the gated set
+            // did not fully execute.
+            let governance_compile = exec_ok.then(|| {
+                rocky_compiler::compile::compile(&rocky_compiler::compile::CompilerConfig {
                     models_dir: mdir.to_path_buf(),
                     contracts_dir: None,
                     source_schemas: std::collections::HashMap::new(),
@@ -3939,9 +3952,9 @@ pub async fn run(
                     // variable as missing (or leave placeholders in the SQL
                     // the masking/tag reconcile inspects).
                     run_vars: run_vars.clone(),
-                },
-            );
-            if let Ok(gov_compile) = governance_compile {
+                })
+            });
+            if let Some(Ok(gov_compile)) = governance_compile {
                 let tag_to_strategy = rocky_cfg.resolve_mask_for_env(env);
                 for model in &gov_compile.project.models {
                     let table_ref = TableRef {
@@ -4058,8 +4071,11 @@ pub async fn run(
             // vary per env because dev/prod sensitivity differs. The
             // caller's `--env` therefore does NOT flow into
             // `reconcile_role_graph`.
-            match rocky_cfg.role_graph() {
-                Ok(resolved) if !resolved.is_empty() => {
+            // `exec_ok.then(...)` (finding #1): skip role-graph reconciliation
+            // entirely on a failed execution — a fingerprint mismatch or model
+            // failure must not push an unreviewed GRANT set.
+            match exec_ok.then(|| rocky_cfg.role_graph()) {
+                Some(Ok(resolved)) if !resolved.is_empty() => {
                     // Borrow the `BTreeSet<String>` as `&[&str]` for the
                     // trait call — keeps `managed_catalogs` alive and
                     // lets the adapter iterate without cloning.
@@ -4077,11 +4093,14 @@ pub async fn run(
                         );
                     }
                 }
-                Ok(_) => {
+                Some(Ok(_)) => {
                     // No `[role.*]` block — nothing to reconcile.
                 }
-                Err(e) => {
+                Some(Err(e)) => {
                     warn!(error = %e, "role graph flatten failed; skipping role reconcile");
+                }
+                None => {
+                    // Execution did not complete cleanly — governance skipped.
                 }
             }
         }
@@ -5219,14 +5238,28 @@ pub(crate) async fn execute_models(
     if let Some(gate) = exec_fp_gate {
         // Fold the seeding-independent on-disk extras the compiled IR omits —
         // the OWNED surrogate map (#1), contract presence/contents (#3), and the
-        // EFFECTIVE mask for the executed set (finding C) — into the recomputed
-        // fingerprint so a post-plan swap of any refuses here. `models_dir` is the
-        // SAME directory the plan fingerprinted; `resolved_mask` is the plan-env
-        // mask the gate carries.
+        // EFFECTIVE mask (finding C) — into the recomputed fingerprint so a
+        // post-plan swap of any refuses here. `models_dir` is the SAME directory
+        // the plan fingerprinted.
+        //
+        // Finding #4: the mask is bound ONLY on the full `--all` path, where every
+        // model executes AND the post-model masking reconcile runs. On a
+        // selection-scoped path (`--model` / backfill `model_set`) masking is NOT
+        // reconciled (only tags), and only a subset executes — so binding a mask
+        // used by an *unselected* model would falsely refuse. Both plan and apply
+        // gate the mask on the SAME predicate (no model filter / no model_set),
+        // so the fingerprint stays symmetric.
+        let scoped = model_name_filter.is_some() || model_set.is_some();
+        let empty_mask = std::collections::BTreeMap::new();
+        let mask_for_extras = if scoped {
+            &empty_mask
+        } else {
+            &gate.resolved_mask
+        };
         let extras = crate::commands::apply::ExecutionExtras::build(
             &surrogate_keys,
             &compile_result.project.models,
-            &gate.resolved_mask,
+            mask_for_extras,
         );
         gate.verify(&compile_result.project.models, &extras)?;
     }
@@ -12211,9 +12244,11 @@ merge_keys = ["id"]
             "main",
             None,
             None,
+            true, // full run — bind masks (finding #4)
         );
         // Apply side: the choke-point's routing + governance identity are the
-        // loaded config's, resolved for the same (None) env.
+        // loaded config's, resolved for the same (None) env. A full run (no model
+        // filter) binds the mask, matching the plan side.
         let cfg = rocky_core::config::load_rocky_config(&config_path).unwrap();
         let identity = crate::commands::apply::config_policy_identity(&cfg);
         let gov = crate::commands::apply::governance_policy_identity(&cfg);

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -3921,7 +3921,7 @@ pub async fn run(
             // governance to the warehouse *despite the gate detecting the change*.
             // On any failure we record it and SKIP all post-model governance
             // below, falling through to the failure payload + non-zero exit.
-            let exec_ok = exec_result.is_ok() && output.tables_failed == failures_before;
+            let exec_ok = model_phase_ok(&exec_result, failures_before, output.tables_failed);
             model_phase_clean = exec_ok;
             if let Err(e) = exec_result {
                 // Record the runtime model failure as a table error and fall
@@ -4857,6 +4857,27 @@ fn apply_defer_rewrite(
     }
 
     Ok(())
+}
+
+/// The model phase completed cleanly: `execute_models` returned `Ok(())` AND it
+/// recorded NO new table failures (`failures_after == failures_before`).
+///
+/// Finding #1 (critical): post-model governance — masking/classification/retention
+/// reconcile, role-graph GRANT emission, and the recipe-manifest write — is gated
+/// on this. A hard error (fingerprint mismatch, routing swap) OR a SOFT failure (a
+/// compile error recorded into `output`, or a contained runtime failure under
+/// `[resilience] contain_failures`, both of which return `Ok(())` yet BUMP
+/// `tables_failed`) means the gated set did not fully execute, so reconciling
+/// governance would push an UNREVIEWED change to the warehouse despite the gate
+/// having detected it. This holds for BOTH a governed agent apply and a bare
+/// `rocky run` (governance is skipped on a partial failure either way). It is the
+/// exact condition the run-path evaluates at the replication `--all` site.
+pub(crate) fn model_phase_ok(
+    exec_result: &anyhow::Result<()>,
+    failures_before: usize,
+    failures_after: usize,
+) -> bool {
+    exec_result.is_ok() && failures_after == failures_before
 }
 
 /// Record a model's runtime failure as a *contained cause*: bump the failure
@@ -12453,8 +12474,7 @@ merge_keys = ["id"]
             "main",
             None,
             None,
-            None, // pipeline_name → default resolution (finding #4)
-            true, // full run (no `--model`)
+            false, // transformation pipeline → mask NOT bound (finding #4)
         );
         // Apply side: the choke-point's routing + governance identity are the
         // loaded config's, resolved for the same (None) env. The POC pipeline is
@@ -12515,8 +12535,7 @@ merge_keys = ["id"]
             "main",
             None,
             None,
-            Some("p"),
-            true,
+            true, // replication full run → mask BOUND (finding #4)
         );
         // Apply side: `reconciles_masks = true` binds `gate.resolved_mask`, which
         // the choke-point restricts to the executed models' tags — mirror that.
@@ -12539,8 +12558,7 @@ merge_keys = ["id"]
             "main",
             None,
             None,
-            Some("p"),
-            true,
+            true, // replication full run → mask BOUND (finding #4)
         );
         assert_ne!(
             caps.models_fingerprint, caps_redact.models_fingerprint,
@@ -12805,6 +12823,63 @@ merge_keys = ["id"]
         assert!(
             table_exists(&verify, "dep_of_good").await,
             "the healthy downstream must exist"
+        );
+    }
+
+    /// 🔴 Finding #1 regression (soft-failure governance/manifest skip): the
+    /// run-path gates ALL post-model governance — masking/classification/retention
+    /// reconcile, role-graph GRANT emission, and the recipe-manifest write — on
+    /// [`super::model_phase_ok`]. A CONTAINED runtime failure (`[resilience]
+    /// contain_failures = true`) returns `Ok(())` yet bumps `tables_failed`, so the
+    /// gate must read FALSE and skip governance for the partially-executed set —
+    /// otherwise an unreviewed change the gate detected is pushed to the warehouse
+    /// anyway. This holds for BOTH a governed agent apply and a bare `rocky run`
+    /// (the gate is not conditioned on the principal — the "bare-run partial-failure
+    /// governance-skip" case). Asserted at the predicate level over a REAL
+    /// contained-failure output because the DuckDB governance adapter is a Noop, so
+    /// there is no observable warehouse governance side effect to inspect creds-free.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn soft_failure_skips_post_model_governance() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+
+        // (soft-fail) A contained runtime failure: `Ok(())` + one recorded failure.
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        write_containment_dag(&models_dir);
+        let db = tmp.path().join("soft.duckdb");
+        let (out, result) = run_models_with_containment(&models_dir, &db).await;
+        assert!(
+            result.is_ok(),
+            "containment returns Ok — the failure is recorded, not thrown: {result:?}"
+        );
+        assert_eq!(
+            out.tables_failed, 1,
+            "the contained run recorded one failure"
+        );
+        assert!(
+            !super::model_phase_ok(&result, 0, out.tables_failed),
+            "a soft (contained) failure must gate post-model governance + manifest OFF"
+        );
+
+        // (clean, discriminating) An all-healthy run: `Ok(())` + zero failures →
+        // the SAME gate reads TRUE, so governance + manifest run as before. Without
+        // this the assertion above would also pass if the predicate were `false`
+        // unconditionally — this proves it discriminates on the failure.
+        let clean_dir = tmp.path().join("clean");
+        std::fs::create_dir(&clean_dir).expect("mkdir clean");
+        write_model_with_target(&clean_dir, "orders", "SELECT 1 AS id", "main", "orders");
+        let clean_db = tmp.path().join("clean.duckdb");
+        let (clean_out, clean_result) =
+            run_models_against_duckdb(&clean_dir, &clean_db, false, 1).await;
+        assert!(
+            clean_result.is_ok(),
+            "a clean run returns Ok: {clean_result:?}"
+        );
+        assert_eq!(clean_out.tables_failed, 0, "no failures on the clean run");
+        assert!(
+            super::model_phase_ok(&clean_result, 0, clean_out.tables_failed),
+            "a clean model phase must ENABLE governance + manifest (discriminator)"
         );
     }
 

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1518,6 +1518,10 @@ pub async fn run(
                 // values (or inline defaults) at compile time.
                 run_vars,
                 exec_fp_gate.as_ref(),
+                // Finding #2 (missing-dir): fail closed at the transformation
+                // executor when a governed plan reviewed a non-empty model set but
+                // its models directory is gone. `false` for a bare run.
+                governed_ctx.is_some_and(|c| c.expects_models),
             )
             .await?;
             finalize_idempotency_on_success(&mut idempotency_ctx, state_path, &run_id).await;
@@ -4129,6 +4133,23 @@ pub async fn run(
                     // Execution did not complete cleanly — governance skipped.
                 }
             }
+        } else if governed_ctx.is_some_and(|c| c.expects_models) {
+            // ‼️ Finding #2 (missing-dir), executor leg: a governed apply entered the
+            // replication silver-model leg (`--all` / `--models`) with a NON-EMPTY
+            // reviewed model set, but the models directory is gone at execution
+            // (deleted / renamed AFTER the apply seam's compile — the seam→execute
+            // race). Fail CLOSED rather than silently skip and report success for
+            // models that never ran. An empty reviewed set (`expects_models ==
+            // false`, e.g. a pure-replication run with no silver `models/`) keeps
+            // the legitimate silent-skip. Bare `rocky run` (governed_ctx None) is
+            // likewise unaffected.
+            anyhow::bail!(
+                "refusing to complete governed apply: the reviewed models directory '{}' does not \
+                 exist at execution (deleted or renamed since the plan was authorized), so its \
+                 planned models cannot run — refusing rather than reporting success for models that \
+                 never executed. Re-plan with `rocky plan` before applying.",
+                mdir.display()
+            );
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -75,6 +75,11 @@ pub async fn run_transformation(
     run_vars: &rocky_core::run_vars::RunVars,
     // Governed-apply TOCTOU gate (E) — `Some` for an agent transformation apply.
     exec_fp_gate: Option<&super::apply::ExecFingerprintGate>,
+    // Finding #2 (missing-dir): the governed plan reviewed a non-empty model set,
+    // so a missing models directory at execution is a fail-closed error rather than
+    // the legitimate no-op silent-skip. `false` for a bare `rocky run` and for a
+    // governed plan with an empty reviewed set — both keep the silent-skip.
+    expects_models: bool,
 ) -> Result<()> {
     let start = Instant::now();
 
@@ -190,6 +195,24 @@ pub async fn run_transformation(
         }
 
         state_store = Some(store);
+    } else if expects_models {
+        // ‼️ Finding #2 (missing-dir), transformation executor leg: this is the
+        // PRIMARY guard for the transformation path — the apply seam does not
+        // check here because `run_local` resolves `config_dir.join(models_base)`
+        // from the pipeline config (this `models_dir`), which the seam's
+        // `run_plan.models_dir` does not match. A governed apply whose plan
+        // reviewed a non-empty model set but whose (config-resolved) models
+        // directory is absent at execution must FAIL CLOSED rather than silently
+        // succeed with nothing built. Fires before the state store is opened —
+        // no warehouse mutation. A bare `rocky run` / an empty reviewed set has
+        // `expects_models == false` and keeps the silent no-op below.
+        anyhow::bail!(
+            "refusing to complete governed apply: the reviewed models directory '{}' does not \
+             exist at execution (deleted or renamed since the plan was authorized), so its \
+             planned models cannot run — refusing rather than reporting success for models that \
+             never executed. Re-plan with `rocky plan` before applying.",
+            models_dir.display()
+        );
     } else {
         warn!(
             models_dir = %models_dir.display(),

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -110,6 +110,8 @@ pub async fn run_transformation(
         let store = StateStore::open(state_path)
             .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
 
+        // Finding #1: baseline failures so a soft model failure skips governance.
+        let failures_before = output.tables_failed;
         let exec_result = super::run::execute_models(
             &models_dir,
             warehouse_adapter.as_ref(),
@@ -137,11 +139,15 @@ pub async fn run_transformation(
             rocky_cfg.resilience.clone(),
             super::resilience::retry_policy_allows(rocky_cfg),
             exec_fp_gate,
+            // Finding #4: the transformation route reconciles no masks.
+            false,
         )
         .await;
 
         match exec_result {
-            Ok(()) => {
+            // Finding #1: only when the model phase is CLEAN (no new soft
+            // failures) — a soft failure returns `Ok(())`.
+            Ok(()) if output.tables_failed == failures_before => {
                 // --- Governance: per-model `[governance.tags]` ---
                 //
                 // After every model materializes, apply each model's
@@ -159,6 +165,8 @@ pub async fn run_transformation(
                 )
                 .await;
             }
+            // Soft model failure — skip governance, fall through.
+            Ok(()) => {}
             Err(e) => {
                 // A runtime model failure (warehouse rejected the SQL, an
                 // unresolved upstream, ...) surfaces here as `Err`. Record it

--- a/engine/crates/rocky-cli/src/plan_store.rs
+++ b/engine/crates/rocky-cli/src/plan_store.rs
@@ -240,6 +240,17 @@ pub struct EmbeddedCapabilities {
     /// FAILURE and the governed apply REFUSES (finding #7 — legacy vs failure).
     #[serde(default)]
     pub fingerprint_version: u32,
+    /// The REVIEWED source-schema snapshot (finding #2b) — the per-source typed
+    /// columns the plan-time compile resolved. Apply seeds its compile's
+    /// `source_schemas` from THIS snapshot instead of a live/cache read, so a
+    /// post-plan source-schema drift (or a `[cache.schemas]` toggle / ttl change)
+    /// cannot change the executed `typed_columns` → the MERGE column list the
+    /// warehouse receives is exactly what was reviewed. Empty ⇒ apply falls back
+    /// to its live cache load (legacy plans, replication-only, or a creds-free
+    /// plan with no cached schemas). Bound into the `plan_id` (tamper-evident);
+    /// keyed by source table, name-sorted for a stable digest.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub reviewed_source_schemas: BTreeMap<String, Vec<rocky_ir::types::TypedColumn>>,
 }
 
 /// The fingerprint feature version this binary stamps onto every plan it writes.
@@ -650,6 +661,65 @@ mod tests {
         assert_eq!(plan.kind, PlanKind::Compact);
         assert_eq!(plan.payload["model"], json!("mydb.myschema.orders"));
         assert_eq!(plan.payload["statement_count"], json!(2));
+        Ok(())
+    }
+
+    /// 🔴 #2b round-trip: a governed plan whose embedded `reviewed_source_schemas`
+    /// is NON-EMPTY must survive `read_plan`'s integrity re-hash. The load path
+    /// recomputes the `plan_id` from the parsed payload and REFUSES a mismatch
+    /// (plan_store integrity check), so a non-canonical snapshot round-trip would
+    /// be a refuse-everything for every governed apply that captured schemas. The
+    /// snapshot is serde-canonical (name-sorted `BTreeMap`, `TypedColumn` has no
+    /// floats), so a successful read proves stability. The creds-free playground
+    /// POC captures an EMPTY snapshot (skip-serialized), so this synthesises a
+    /// non-empty one directly.
+    #[test]
+    fn governed_plan_with_source_schema_snapshot_round_trips() -> anyhow::Result<()> {
+        use rocky_ir::RockyType;
+        use rocky_ir::types::TypedColumn;
+
+        let dir = tempfile::tempdir()?;
+        let payload = DummyPayload {
+            model: "cat.sc.m",
+            statement_count: 1,
+        };
+        let caps = EmbeddedCapabilities {
+            diff_available: true,
+            changed: BTreeMap::new(),
+            models_fingerprint: Some("fp".to_string()),
+            config_identity: Some("cfg".to_string()),
+            fingerprint_version: CURRENT_FINGERPRINT_VERSION,
+            reviewed_source_schemas: BTreeMap::from([(
+                "main.src".to_string(),
+                vec![
+                    TypedColumn {
+                        name: "id".to_string(),
+                        data_type: RockyType::Int64,
+                        nullable: false,
+                    },
+                    TypedColumn {
+                        name: "amt".to_string(),
+                        data_type: RockyType::Decimal {
+                            precision: 10,
+                            scale: 2,
+                        },
+                        nullable: true,
+                    },
+                ],
+            )]),
+        };
+        let plan_id = write_plan_governed(
+            dir.path(),
+            PlanKind::Run,
+            &payload,
+            PolicyPrincipal::Agent,
+            caps.clone(),
+        )?;
+        // A successful read proves the non-empty snapshot re-hashes to the same
+        // `plan_id` (no refuse) and survives the round-trip intact.
+        let plan = read_plan(dir.path(), &plan_id)?;
+        assert_eq!(plan.plan_id, plan_id);
+        assert_eq!(plan.embedded_capabilities(), caps);
         Ok(())
     }
 
@@ -1147,6 +1217,7 @@ mod tests {
             models_fingerprint: None,
             config_identity: None,
             fingerprint_version: 0,
+            reviewed_source_schemas: std::collections::BTreeMap::new(),
         };
         let touched = caps.touched(&["stg_orders".to_string(), "fct_sales".to_string()]);
         assert_eq!(
@@ -1168,6 +1239,7 @@ mod tests {
             models_fingerprint: None,
             config_identity: None,
             fingerprint_version: 0,
+            reviewed_source_schemas: std::collections::BTreeMap::new(),
         };
         assert!(caps.touched(&[]).is_empty());
     }
@@ -1191,6 +1263,7 @@ mod tests {
             models_fingerprint: None,
             config_identity: None,
             fingerprint_version: 0,
+            reviewed_source_schemas: std::collections::BTreeMap::new(),
         };
         let touched = caps.touched(&["stg_orders".to_string(), "fct_sales".to_string()]);
         assert_eq!(
@@ -1219,6 +1292,7 @@ mod tests {
             models_fingerprint: None,
             config_identity: None,
             fingerprint_version: 0,
+            reviewed_source_schemas: std::collections::BTreeMap::new(),
         };
         // Only `orders` executes; the change to the non-executing `customers`
         // is absent from the touched set.

--- a/engine/crates/rocky-cli/src/plan_store.rs
+++ b/engine/crates/rocky-cli/src/plan_store.rs
@@ -256,8 +256,7 @@ pub struct EmbeddedCapabilities {
     /// no snapshot; a version-2 governed plan whose snapshot is `None` is a
     /// production capture failure and the governed apply REFUSES (fail-closed).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub reviewed_source_schemas:
-        Option<BTreeMap<String, Vec<rocky_ir::types::TypedColumn>>>,
+    pub reviewed_source_schemas: Option<BTreeMap<String, Vec<rocky_ir::types::TypedColumn>>>,
 }
 
 /// The fingerprint feature version this binary stamps onto every plan it writes.

--- a/engine/crates/rocky-cli/src/plan_store.rs
+++ b/engine/crates/rocky-cli/src/plan_store.rs
@@ -240,21 +240,31 @@ pub struct EmbeddedCapabilities {
     /// FAILURE and the governed apply REFUSES (finding #7 — legacy vs failure).
     #[serde(default)]
     pub fingerprint_version: u32,
-    /// The REVIEWED source-schema snapshot (finding #2b) — the per-source typed
-    /// columns the plan-time compile resolved. Apply seeds its compile's
+    /// The REVIEWED source-schema snapshot (finding #2b/#2) — the per-source
+    /// typed columns the plan-time compile resolved. Apply seeds its compile's
     /// `source_schemas` from THIS snapshot instead of a live/cache read, so a
     /// post-plan source-schema drift (or a `[cache.schemas]` toggle / ttl change)
-    /// cannot change the executed `typed_columns` → the MERGE column list the
-    /// warehouse receives is exactly what was reviewed. Empty ⇒ apply falls back
-    /// to its live cache load (legacy plans, replication-only, or a creds-free
-    /// plan with no cached schemas). Bound into the `plan_id` (tamper-evident);
-    /// keyed by source table, name-sorted for a stable digest.
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub reviewed_source_schemas: BTreeMap<String, Vec<rocky_ir::types::TypedColumn>>,
+    /// cannot change the resolved `typed_columns` — apply types from exactly what
+    /// was reviewed. Bound into the `plan_id` (tamper-evident); keyed by source
+    /// table, name-sorted for a stable digest.
+    ///
+    /// `Some(map)` is **authoritative even when empty** (finding #2): a plan built
+    /// against a cold/missing schema cache captures `Some(empty)`, and apply MUST
+    /// type from that empty set — NOT fall through to a (later-warmed, agent-
+    /// swappable) live cache that could silently clear a reviewed diagnostic.
+    /// `None` marks a genuinely-legacy plan (`fingerprint_version < 2`) that has
+    /// no snapshot; a version-2 governed plan whose snapshot is `None` is a
+    /// production capture failure and the governed apply REFUSES (fail-closed).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reviewed_source_schemas:
+        Option<BTreeMap<String, Vec<rocky_ir::types::TypedColumn>>>,
 }
 
 /// The fingerprint feature version this binary stamps onto every plan it writes.
-pub const CURRENT_FINGERPRINT_VERSION: u32 = 1;
+///
+/// v2 (finding #2): every plan now carries an authoritative `Some` reviewed
+/// source-schema snapshot; a v2 governed plan whose snapshot is absent refuses.
+pub const CURRENT_FINGERPRINT_VERSION: u32 = 2;
 
 /// The principal an absent stamp resolves to, **by kind** (never a blanket
 /// `human`): an `ai_authored` plan is agent-authored by construction
@@ -689,7 +699,7 @@ mod tests {
             models_fingerprint: Some("fp".to_string()),
             config_identity: Some("cfg".to_string()),
             fingerprint_version: CURRENT_FINGERPRINT_VERSION,
-            reviewed_source_schemas: BTreeMap::from([(
+            reviewed_source_schemas: Some(BTreeMap::from([(
                 "main.src".to_string(),
                 vec![
                     TypedColumn {
@@ -706,7 +716,7 @@ mod tests {
                         nullable: true,
                     },
                 ],
-            )]),
+            )])),
         };
         let plan_id = write_plan_governed(
             dir.path(),
@@ -1217,7 +1227,7 @@ mod tests {
             models_fingerprint: None,
             config_identity: None,
             fingerprint_version: 0,
-            reviewed_source_schemas: std::collections::BTreeMap::new(),
+            reviewed_source_schemas: None,
         };
         let touched = caps.touched(&["stg_orders".to_string(), "fct_sales".to_string()]);
         assert_eq!(
@@ -1239,7 +1249,7 @@ mod tests {
             models_fingerprint: None,
             config_identity: None,
             fingerprint_version: 0,
-            reviewed_source_schemas: std::collections::BTreeMap::new(),
+            reviewed_source_schemas: None,
         };
         assert!(caps.touched(&[]).is_empty());
     }
@@ -1263,7 +1273,7 @@ mod tests {
             models_fingerprint: None,
             config_identity: None,
             fingerprint_version: 0,
-            reviewed_source_schemas: std::collections::BTreeMap::new(),
+            reviewed_source_schemas: None,
         };
         let touched = caps.touched(&["stg_orders".to_string(), "fct_sales".to_string()]);
         assert_eq!(
@@ -1292,7 +1302,7 @@ mod tests {
             models_fingerprint: None,
             config_identity: None,
             fingerprint_version: 0,
-            reviewed_source_schemas: std::collections::BTreeMap::new(),
+            reviewed_source_schemas: None,
         };
         // Only `orders` executes; the change to the non-executing `customers`
         // is absent from the touched set.

--- a/engine/crates/rocky-ir/src/types.rs
+++ b/engine/crates/rocky-ir/src/types.rs
@@ -60,7 +60,7 @@ pub struct StructField {
 }
 
 /// A column with its inferred type and nullability.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TypedColumn {
     pub name: std::string::String,
     pub data_type: RockyType,

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -2342,12 +2342,11 @@ impl RockyMcpServer {
             "main",
             Some(&state_path),
             None, // MCP propose has no `--env`; governance identity binds defaults
-            // Finding #4: MCP propose persists no pipeline name (apply resolves the
-            // default), so pass `None` — `compute_embedded_capabilities` binds the
-            // mask only if that default pipeline is a Replication pipeline reached
-            // by a full run, matching the apply choke-point.
-            None,
-            params.0.model.is_none(),
+            // Finding #4: `build_ai_run_plan` persists `run_all=false, models_dir=
+            // None`, so the apply never reaches the mask-reconciling model leg
+            // (replication needs `run_all||models_dir`; transformation runs no
+            // masks). The mask is therefore never bound — `false` on both sides.
+            false,
         );
 
         // Consult the agent-policy plane before persisting — the same per-model

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -2342,6 +2342,9 @@ impl RockyMcpServer {
             "main",
             Some(&state_path),
             None, // MCP propose has no `--env`; governance identity binds defaults
+            // Bind masks only for a full-project propose (finding #4): a
+            // model-scoped propose runs no masking reconcile at apply.
+            params.0.model.is_none(),
         );
 
         // Consult the agent-policy plane before persisting — the same per-model

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -2342,8 +2342,11 @@ impl RockyMcpServer {
             "main",
             Some(&state_path),
             None, // MCP propose has no `--env`; governance identity binds defaults
-            // Bind masks only for a full-project propose (finding #4): a
-            // model-scoped propose runs no masking reconcile at apply.
+            // Finding #4: MCP propose persists no pipeline name (apply resolves the
+            // default), so pass `None` — `compute_embedded_capabilities` binds the
+            // mask only if that default pipeline is a Replication pipeline reached
+            // by a full run, matching the apply choke-point.
+            None,
             params.0.model.is_none(),
         );
 

--- a/integrations/dagster/tests/fixtures_generated/plan.json
+++ b/integrations/dagster/tests/fixtures_generated/plan.json
@@ -14,7 +14,7 @@
       "sql": "CREATE OR REPLACE TABLE staging__orders.orders AS\nSELECT *\nFROM raw__orders.orders"
     }
   ],
-  "plan_id": "3c528e8ebda61656ea2f5c61b1662935e32b190b9cf8259522789adaf783a1c3",
+  "plan_id": "eeb2e2bae1031d0e0f33eb01348c7c8deb1c4f7d8bb3fbe3d4d83644acbf7adc",
   "plan_kind": "run",
   "created_at": "2000-01-01T00:00:00Z",
   "models": [

--- a/integrations/dagster/tests/fixtures_generated/plan.json
+++ b/integrations/dagster/tests/fixtures_generated/plan.json
@@ -14,7 +14,7 @@
       "sql": "CREATE OR REPLACE TABLE staging__orders.orders AS\nSELECT *\nFROM raw__orders.orders"
     }
   ],
-  "plan_id": "eeb2e2bae1031d0e0f33eb01348c7c8deb1c4f7d8bb3fbe3d4d83644acbf7adc",
+  "plan_id": "c8f83a6cb71d02eb4344998703f7b912a8bccedfb9e30c44c4ec8adcfafd0822",
   "plan_kind": "run",
   "created_at": "2000-01-01T00:00:00Z",
   "models": [


### PR DESCRIPTION
Hardens Rocky's agent-policy enforcement plane against TOCTOU / authorization-bypass in the two-step `rocky plan` → `rocky apply` flow, across iterative red-team tranches. Rebased onto `origin/main` (past #1087).

## Tranche-7 (final merge-blockers)

**#1 — replication-only false-refuse (regression):** `preflight_snapshot` ran for every `RunPlan` and treated a default replication-only plan as model-executing, over-refusing it (and over-binding policy/mask selection). A replication pipeline with no `--all`/`--models`/`--model` executes NO compiled models. Introduced a SAFE carve-out `is_replication_only` (only a resolved `Replication` pipeline with no execution flags; a won't-load config or any other pipeline stays STRICT — a wrong answer can only over-gate) and threaded one shared execution shape into (a) the snapshot preflight, (b) both `run_executable_models` policy carve-outs, and (c) plan-side `bind_masks`. The carve-out cannot become a policy bypass: the replication mutation is independently fail-closed by `verify_routing_identity` (config-swap) + `gate_replication_targets`.

**#2 — deleted reviewed models dir (bounded hole):** a governed model-executing plan whose reviewed models dir is deleted/renamed post-preflight silently skipped execution and reported SUCCESS. Closed at two layers:
- **Apply seam** (before the replication DDL) recompiles the reviewed dir for a Replication pipeline with a non-empty reviewed set — fail closed if it no longer compiles.
- **Executor legs** (`run.rs` replication model leg + `run_local` transformation leg) fail closed on a missing dir when `expects_models` (the reviewed set was non-empty), closing the seam→execute race. The seam is scoped to replication because `run_local` resolves `config_dir.join(models_base)` from config (ignoring `run_plan.models_dir`); the transformation executor leg is the correct-path sole guard there.
- Empty reviewed sets (pure-replication with no silver models) and every bare `rocky run` keep `expects_models=false` → legitimate silent no-op preserved.

**#1 soft-failure gate:** extracted `model_phase_ok` — post-model governance + recipe-manifest writes are skipped on a soft/contained failure (`Ok(())` + bumped `tables_failed`), for both governed apply and bare run.

### Tests + kill-checks
- `is_replication_only_is_a_safe_carve_out`, `preflight_snapshot_semantics` (v1 AND v2 replication-only NOT refused; model-executing still refused).
- `governed_replication_apply_seam_refuses_deleted_reviewed_dir` (apply seam) + `governed_transformation_apply_executor_refuses_deleted_reviewed_dir` (executor leg — the real path gap).
- `soft_failure_skips_post_model_governance` (real contained failure via DuckDB; clean-vs-fail discriminator; covers governed + bare).
- Discriminating experiments (neuter → refusal stops / false-refuse returns → restore) run for #1 carve-out, #2 missing-dir (both layers), and the soft-failure gate.

## Full gate
`cargo nextest --workspace --all-features` (5172 passed), `clippy --all-targets --all-features -D warnings`, `fmt --check` all green. No `just codegen` schema drift and no `just regen-fixtures` fixture drift (the `bind_masks` change did not move the replication POC `plan_id`).

Prior tranches (2–6): execution-snapshot refactor closing post-gate disk re-reads; execute-from-owned snapshot; authoritative source-schema snapshot + fingerprint v2 + `preflight_snapshot`; CAS consumes seeded typed IR; DAG-apply refusal; applier-identity enforcement; governance-halt on execute failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
