### PR TITLE
fix: UI staleness/desync bugs + stampede token uniqueness + doc corrections

### DIFF
--- a/editors/vscode/src/__tests__/foldingProvider.test.ts
+++ b/editors/vscode/src/__tests__/foldingProvider.test.ts
@@ -138,4 +138,26 @@ describe("RockyFoldingRangeProvider", () => {
     const braceRanges = ranges.filter((r: { kind: number }) => r.kind === 3);
     expect(braceRanges).toHaveLength(0);
   });
+
+  it("an unbalanced brace inside a string does not desync later folds", () => {
+    // The `"a{b"` literal carries a lone `{`. If it were counted, the
+    // real `derive { ... }` block below would mispair (its `}` would
+    // close the string's phantom `{`), so the block wouldn't fold.
+    const doc = fakeDoc(
+      [
+        "from raw",
+        "derive {",
+        "  label = \"a{b\"",
+        "  n = 1",
+        "}",
+        "take 5",
+      ].join("\n"),
+    );
+    const ranges = provider.provideFoldingRanges(doc);
+    const braceRanges = ranges.filter((r: { kind: number }) => r.kind === 3);
+    expect(braceRanges).toHaveLength(1);
+    expect(braceRanges).toContainEqual(
+      expect.objectContaining({ start: 1, end: 4 }),
+    );
+  });
 });

--- a/editors/vscode/src/compiledSqlProvider.ts
+++ b/editors/vscode/src/compiledSqlProvider.ts
@@ -54,6 +54,19 @@ export class CompiledSqlProvider implements vscode.TextDocumentContentProvider {
   refresh(model: string): void {
     this.emitter.fire(compiledUri(model));
   }
+
+  /**
+   * Refresh every open compiled doc. Compiled SQL is macro-expanded across
+   * the whole project, so editing one model can change a *downstream*
+   * model's output — a per-model refresh would leave those panels stale.
+   */
+  refreshAllOpen(): void {
+    for (const doc of vscode.workspace.textDocuments) {
+      if (doc.uri.scheme === COMPILED_SCHEME) {
+        this.emitter.fire(doc.uri);
+      }
+    }
+  }
 }
 
 /** Resolve a model name from a command arg or the active editor. */
@@ -78,10 +91,8 @@ export function registerCompiledSqlProvider(context: vscode.ExtensionContext): v
   context.subscriptions.push(
     vscode.workspace.registerTextDocumentContentProvider(COMPILED_SCHEME, provider),
     vscode.workspace.onDidSaveTextDocument((doc) => {
-      // Refresh the compiled view for the saved model (no-op if not open).
       if (!/\.(rocky|sql)$/.test(doc.fileName)) return;
-      const model = path.basename(doc.fileName).replace(/\.(rocky|sql)$/, "");
-      provider.refresh(model);
+      provider.refreshAllOpen();
     }),
     vscode.commands.registerCommand("rocky.showCompiledSql", showCompiledSql),
   );

--- a/editors/vscode/src/foldingProvider.ts
+++ b/editors/vscode/src/foldingProvider.ts
@@ -42,8 +42,19 @@ export class RockyFoldingRangeProvider implements vscode.FoldingRangeProvider {
       // Strip trailing comment (naive: first `--` outside a string)
       const code = stripTrailingComment(text);
 
+      // Track string state so a brace inside a literal (e.g.
+      // `derive { label = "a{b" }`) doesn't desync the stack and mispair
+      // every fold region below it — mirrors the formatter's countBraces.
+      let inSingle = false;
+      let inDouble = false;
       for (const ch of code) {
-        if (ch === "{") {
+        if (ch === "'" && !inDouble) {
+          inSingle = !inSingle;
+        } else if (ch === '"' && !inSingle) {
+          inDouble = !inDouble;
+        } else if (inSingle || inDouble) {
+          continue;
+        } else if (ch === "{") {
           openStack.push(i);
         } else if (ch === "}") {
           const start = openStack.pop();

--- a/editors/vscode/src/webviews/host/registerPanel.ts
+++ b/editors/vscode/src/webviews/host/registerPanel.ts
@@ -42,16 +42,22 @@ export function createWebviewPanelApp(
  * Handle to a registered webview-view app. Lets a command push data into the
  * view, buffering until the view is first resolved (the {@link WebviewHost}
  * then buffers further until the React app posts `ready`).
+ *
+ * The latest payload of every message type is remembered across the view's
+ * lifetime, not just until first resolve: dragging the panel to another dock
+ * (or hiding it in a way that disposes the webview) destroys the host, and
+ * the re-resolved view must be re-seeded with the state the old one showed —
+ * otherwise it renders blank until the next push.
  */
 export class WebviewViewController {
   private host: WebviewHost | undefined;
-  private readonly preResolve: Array<{ type: string; payload: unknown }> = [];
+  private readonly lastByType = new Map<string, unknown>();
   private isVisible = false;
 
-  /** @internal Bind the live host once the view resolves; flushes buffered pushes. */
+  /** @internal Bind the live host once the view resolves; replays remembered state. */
   attach(host: WebviewHost): void {
     this.host = host;
-    for (const { type, payload } of this.preResolve.splice(0)) {
+    for (const [type, payload] of this.lastByType) {
       host.push(type, payload);
     }
   }
@@ -75,10 +81,10 @@ export class WebviewViewController {
     return this.host !== undefined && this.isVisible;
   }
 
-  /** Push to the view, buffering until it is resolved and ready. */
+  /** Push to the view, buffering (latest per type) until it is resolved and ready. */
   push<P>(type: string, payload: P): void {
+    this.lastByType.set(type, payload);
     if (this.host) this.host.push(type, payload);
-    else this.preResolve.push({ type, payload });
   }
 }
 
@@ -98,9 +104,9 @@ export function registerWebviewViewApp(
       const host = new WebviewHost(view.webview, context.extensionUri);
       const extra = opts.setup?.(host);
       // Render first: it resets the host's ready flag and push buffer. Only
-      // then attach the controller, whose flush of pre-resolve pushes (e.g. a
-      // `focus` queued before the view existed) must land in the fresh buffer
-      // rather than being wiped by render().
+      // then attach the controller, whose replay of remembered pushes (e.g. a
+      // `target` queued before the view existed, or shown by a previous host)
+      // must land in the fresh buffer rather than being wiped by render().
       host.render({ entry: opts.entry, title: opts.title });
       controller.attach(host);
       controller.setVisible(view.visible);

--- a/engine/crates/rocky-core/src/drift.rs
+++ b/engine/crates/rocky-core/src/drift.rs
@@ -9,7 +9,8 @@ use rocky_ir::{ColumnInfo, DriftAction, DriftResult, DriftedColumn, GracePeriodC
 
 /// Compares source and target column types to detect schema drift.
 ///
-/// Three categories surface from a single pass over the source columns:
+/// Two categories surface from a single pass over the source columns
+/// (column drops are detected separately by [`detect_column_drops`]):
 ///
 /// - **Type mismatches** on an existing column populate `drifted_columns`
 ///   and drive the [`DriftAction`] (`AlterColumnTypes` when every change

--- a/engine/crates/rocky-fivetran/src/stampede.rs
+++ b/engine/crates/rocky-fivetran/src/stampede.rs
@@ -26,8 +26,8 @@
 //!
 //! ## Lock fencing
 //!
-//! Each acquisition generates a unique 128-bit token persisted in the
-//! Valkey value. `LockGuard::Drop` issues an EVAL Lua script that
+//! Each acquisition generates a process-unique token (`{pid}-{ns}-{seq}`)
+//! persisted in the Valkey value. `LockGuard::Drop` issues an EVAL Lua script that
 //! check-and-DELs only if the value still matches our token; this
 //! prevents a leader that overran the TTL from deleting a fresh
 //! lock acquired by a different holder after expiry. The mechanism is
@@ -353,16 +353,23 @@ pub mod valkey {
         }
 
         /// Generate a fresh unique token for a lock acquisition.
-        /// Combines the process id, a high-resolution clock read, and
-        /// a hash of both so that two `rocky` processes that race to
-        /// acquire at the same nanosecond still get distinct tokens.
+        /// Combines the process id (distinct across processes), a
+        /// high-resolution clock read, and a per-process sequence
+        /// counter — so two acquisitions in the same process that race
+        /// to the same clock reading still get distinct tokens. The
+        /// release script's check-and-DEL fencing compares tokens by
+        /// exact equality, so a reused token would let one holder
+        /// delete another's lock.
         fn generate_token() -> String {
+            use std::sync::atomic::{AtomicU64, Ordering};
             use std::time::{SystemTime, UNIX_EPOCH};
+            static SEQ: AtomicU64 = AtomicU64::new(0);
             let ns = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .map(|d| d.as_nanos())
                 .unwrap_or(0);
-            format!("{}-{}", std::process::id(), ns)
+            let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+            format!("{}-{}-{}", std::process::id(), ns, seq)
         }
     }
 
@@ -468,6 +475,20 @@ pub mod valkey {
         fn from_url_is_sync_and_doesnt_connect() {
             let lock = ValkeyLock::from_url("redis://127.0.0.1:1/");
             assert!(lock.is_ok());
+        }
+
+        #[test]
+        fn tokens_are_unique_even_at_the_same_clock_reading() {
+            // Back-to-back generation can observe the same coarse clock
+            // value; the sequence counter must still keep tokens distinct
+            // (the fencing check-and-DEL compares by exact equality).
+            let tokens: Vec<String> = (0..100).map(|_| ValkeyLock::generate_token()).collect();
+            let unique: std::collections::HashSet<&String> = tokens.iter().collect();
+            assert_eq!(
+                unique.len(),
+                tokens.len(),
+                "duplicate lock tokens generated"
+            );
         }
 
         /// Live Valkey integration — gated on `ROCKY_TEST_VALKEY_URL`.


### PR DESCRIPTION
## Summary

First batch from a cross-subproject correctness sweep — the located leads and the one real uniqueness bug the docs-vs-code sweep turned up. Each verified against the source.

- **vscode**: the compiled-SQL panel refreshed only the saved model, but compiled SQL is macro-expanded project-wide, so editing an upstream model left a downstream panel stale — now refreshes every open compiled doc on any model save.
- **vscode**: the Inspector went blank after being dragged to another dock. `WebviewViewController` buffered pushes only until first resolve then cleared them; re-resolving the disposed webview flushed an empty buffer. It now remembers the latest payload per message type and replays it on every attach.
- **vscode**: the folding provider counted braces inside string literals, so an unbalanced brace like `"a{b"` desynced the open-stack and mispaired every fold below it — now tracks string state like the formatter's `countBraces`.
- **engine/rocky-fivetran**: the stampede lock's `generate_token` doc claimed a "hash of both" pid and clock that the code never computed, so two acquisitions in one process at the same coarse clock reading could collide — and the release script fences by exact token equality, so a reused token lets one holder delete another's lock. Added a per-process atomic sequence counter (genuinely unique now) and corrected the doc.
- **engine/rocky-core**: `detect_drift`'s doc said "Three categories" but the pass produces two (drops are a separate function) — corrected.

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [x] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Changes

- `editors/vscode/src/compiledSqlProvider.ts`: `refreshAllOpen()` refreshes every open compiled doc on save
- `editors/vscode/src/webviews/host/registerPanel.ts`: `WebviewViewController` keeps latest-per-type payloads and replays on attach
- `editors/vscode/src/foldingProvider.ts`: brace scan skips string-literal contents
- `engine/crates/rocky-fivetran/src/stampede.rs`: per-process sequence counter in `generate_token`; doc corrections
- `engine/crates/rocky-core/src/drift.rs`: doc count corrected

## Test Plan

- New tests: folding no longer desyncs on an unbalanced in-string brace; stampede tokens are unique across 100 back-to-back generations at the same clock reading
- `editors/vscode`: `npm run compile`, vitest unit tests, eslint clean
- `engine`: `cargo test -p rocky-fivetran --features valkey` (103 pass incl. new token test), `cargo clippy --all-targets --all-features -- -D warnings` clean on rocky-fivetran + rocky-core, `cargo fmt --check` clean

## Checklist

- [x] Commit messages follow conventional commits, scoped by subproject
- [x] No `Co-Authored-By` trailers
- [x] No CLI JSON schema or DSL syntax change

### Engine (`engine/`)
- [x] `cargo test` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo fmt --check` passes

### VS Code (`editors/vscode/`)
- [x] `npm run compile` succeeds
- [x] `npm run test:unit` passes
- [x] `npm run lint` is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CaCKoZS32ZivMZLVbVJaXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaCKoZS32ZivMZLVbVJaXS)_