### PR TITLE
test: deflake real-clock timing races in fivetran + drift-diagnostics tests

### DIFF
--- a/editors/vscode/src/__tests__/driftDiagnostics.test.ts
+++ b/editors/vscode/src/__tests__/driftDiagnostics.test.ts
@@ -292,9 +292,14 @@ describe("diagnostic mapping", () => {
     openCallback!(mockDoc);
 
     // Wait for the async refreshDiagnostics to complete.
-    await vi.waitFor(() => {
-      expect(mockDiagnosticCollection.set).toHaveBeenCalled();
-    });
+    // 2s timeout: the open/save path is debounced 500ms, so the default
+    // 1s poll deadline leaves only 2× headroom and races a CI stall.
+    await vi.waitFor(
+      () => {
+        expect(mockDiagnosticCollection.set).toHaveBeenCalled();
+      },
+      { timeout: 2000 },
+    );
 
     const [uri, diags] = mockDiagnosticCollection.set.mock.calls[0];
     expect(uri.fsPath).toBe("/project/models/my_model.sql");
@@ -373,9 +378,13 @@ describe("diagnostic mapping", () => {
 
     openCallback!(mockDoc);
 
-    await vi.waitFor(() => {
-      expect(mockDiagnosticCollection.delete).toHaveBeenCalledWith(mockDoc.uri);
-    });
+    // 2s timeout: the debounced 500ms refresh races the default 1s poll.
+    await vi.waitFor(
+      () => {
+        expect(mockDiagnosticCollection.delete).toHaveBeenCalledWith(mockDoc.uri);
+      },
+      { timeout: 2000 },
+    );
   });
 
   it("filters diagnostics to the current model only", async () => {
@@ -433,9 +442,14 @@ describe("diagnostic mapping", () => {
 
     openCallback!(mockDoc);
 
-    await vi.waitFor(() => {
-      expect(mockDiagnosticCollection.set).toHaveBeenCalled();
-    });
+    // 2s timeout: the open/save path is debounced 500ms, so the default
+    // 1s poll deadline leaves only 2× headroom and races a CI stall.
+    await vi.waitFor(
+      () => {
+        expect(mockDiagnosticCollection.set).toHaveBeenCalled();
+      },
+      { timeout: 2000 },
+    );
 
     const [, diags] = mockDiagnosticCollection.set.mock.calls[0];
     expect(diags).toHaveLength(1);

--- a/engine/crates/rocky-fivetran/src/ratelimit.rs
+++ b/engine/crates/rocky-fivetran/src/ratelimit.rs
@@ -512,13 +512,19 @@ mod tests {
         );
     }
 
+    // The "returns quickly" bounds below are 2s, not tens of ms: they only
+    // need to distinguish "returned without observing a wait" from "slept
+    // toward a future wake_at" (proven at 250ms granularity by
+    // `pre_request_wait_blocks_until_future_wake_at`). A tight bound races
+    // scheduling + filesystem stalls on a loaded CI runner.
+
     #[tokio::test]
     async fn pre_request_wait_returns_quickly_on_missing_file() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("missing.json");
         let start = std::time::Instant::now();
         pre_request_wait(&path).await;
-        assert!(start.elapsed() < Duration::from_millis(50));
+        assert!(start.elapsed() < Duration::from_secs(2));
     }
 
     #[tokio::test]
@@ -529,7 +535,7 @@ mod tests {
         write_wake_at(&path, past);
         let start = std::time::Instant::now();
         pre_request_wait(&path).await;
-        assert!(start.elapsed() < Duration::from_millis(50));
+        assert!(start.elapsed() < Duration::from_secs(2));
     }
 
     #[tokio::test]

--- a/engine/crates/rocky-fivetran/tests/resilience_tests.rs
+++ b/engine/crates/rocky-fivetran/tests/resilience_tests.rs
@@ -85,7 +85,9 @@ async fn circuit_cooldown_transitions_to_half_open() {
         .unwrap();
     assert_eq!(cb.state("acct").await.unwrap(), CircuitState::Open);
 
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    // Sleep 4× the cooldown (safe direction — extra slowness only makes the
+    // HalfOpen transition more certain), not the borderline 2× that flakes.
+    tokio::time::sleep(Duration::from_millis(200)).await;
     assert_eq!(cb.state("acct").await.unwrap(), CircuitState::HalfOpen);
 }
 
@@ -107,7 +109,13 @@ async fn circuit_half_open_success_closes_breaker() {
 }
 
 #[tokio::test]
-async fn circuit_half_open_failure_reopens_with_extended_cooldown() {
+async fn circuit_reopens_immediately_on_half_open_failure() {
+    // The "a HalfOpen failure returns to Open" invariant, tested without
+    // a wall-clock window: assert Open right after the re-trip (elapsed is
+    // microseconds, so no cooldown edge can be crossed by a slow runner).
+    // The paired "reopens with an EXTENDED cooldown" timing is verified by
+    // `circuit_half_open_failure_extends_cooldown` below with generous
+    // margins, and precisely by the breaker's own unit tests.
     let cb = InMemoryCircuit::new(CircuitConfig {
         failure_threshold: 1,
         cooldown: Duration::from_millis(40),
@@ -117,22 +125,46 @@ async fn circuit_half_open_failure_reopens_with_extended_cooldown() {
     cb.record_failure("acct", FailureKind::Remote)
         .await
         .unwrap();
-    tokio::time::sleep(Duration::from_millis(60)).await;
+    tokio::time::sleep(Duration::from_millis(120)).await; // 3× cooldown — safe direction
     assert_eq!(cb.state("acct").await.unwrap(), CircuitState::HalfOpen);
 
-    // A failure in HalfOpen pushes back to Open with extended
-    // cooldown (40ms → 80ms).
+    cb.record_failure("acct", FailureKind::Remote)
+        .await
+        .unwrap();
+    assert_eq!(cb.state("acct").await.unwrap(), CircuitState::Open);
+}
+
+#[tokio::test]
+async fn circuit_half_open_failure_extends_cooldown() {
+    // Prove the cooldown genuinely lengthens after a HalfOpen failure.
+    // Scaled to whole seconds so the one unavoidable two-sided assertion
+    // ("still Open past the ORIGINAL cooldown but before the EXTENDED one")
+    // carries ~1s of slack on both edges instead of tens of ms.
+    let cb = InMemoryCircuit::new(CircuitConfig {
+        failure_threshold: 1,
+        cooldown: Duration::from_secs(1),
+        cooldown_max: Duration::from_secs(10),
+        ..CircuitConfig::default()
+    });
+    cb.record_failure("acct", FailureKind::Remote)
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(1500)).await; // past 1s cooldown
+    assert_eq!(cb.state("acct").await.unwrap(), CircuitState::HalfOpen);
+
+    // Re-trip in HalfOpen → cooldown extends 1s → 2s.
     cb.record_failure("acct", FailureKind::Remote)
         .await
         .unwrap();
     assert_eq!(cb.state("acct").await.unwrap(), CircuitState::Open);
 
-    // After the original 40ms it must NOT yet be HalfOpen.
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    // At 1.5s (well past the original 1s, well before the extended 2s) it
+    // must still be Open — this is what proves the cooldown extended.
+    tokio::time::sleep(Duration::from_millis(1500)).await;
     assert_eq!(cb.state("acct").await.unwrap(), CircuitState::Open);
 
-    // After 80ms total it should be HalfOpen again.
-    tokio::time::sleep(Duration::from_millis(40)).await;
+    // Past the full 2s it returns to HalfOpen.
+    tokio::time::sleep(Duration::from_millis(1000)).await;
     assert_eq!(cb.state("acct").await.unwrap(), CircuitState::HalfOpen);
 }
 
@@ -144,13 +176,16 @@ async fn circuit_cooldown_caps_at_cooldown_max() {
         cooldown_max: Duration::from_millis(50),
         ..CircuitConfig::default()
     });
-    // Drive multiple half-open → open transitions; the cooldown
-    // doubles each time but must not exceed cooldown_max.
+    // Drive multiple half-open → open transitions; the cooldown doubles
+    // each time but must not exceed cooldown_max (50ms). Sleep 200ms each
+    // round — comfortably past the capped 50ms cooldown (safe direction) —
+    // and assert Open only immediately after each re-trip (microseconds
+    // elapsed, no window to race).
     cb.record_failure("acct", FailureKind::Remote)
         .await
         .unwrap();
     for _ in 0..6 {
-        tokio::time::sleep(Duration::from_millis(80)).await;
+        tokio::time::sleep(Duration::from_millis(200)).await;
         assert_eq!(cb.state("acct").await.unwrap(), CircuitState::HalfOpen);
         cb.record_failure("acct", FailureKind::Remote)
             .await


### PR DESCRIPTION
## Summary

A flaky-test sweep found the close cousins of the `circuit_breaker.rs` CI flake just fixed — same real-clock-race species. All are test-only changes; no production code moves.

- **rocky-fivetran ratelimit**: the two "returns quickly" tests bounded `start.elapsed() < 50ms` after an async filesystem stat + tokio scheduling hop — a loaded runner blows the bound from pure slowness. Raised to 2s; they only need to distinguish "returned without waiting" from a 250ms+ observed wait, which `pre_request_wait_blocks_until_future_wake_at` already pins at 250ms granularity.
- **rocky-fivetran resilience tests**: `circuit_half_open_failure_reopens_with_extended_cooldown` asserted "still Open" at 50ms of an 80ms window (30ms slack) — the exact circuit-breaker failure mode. Split into a fast no-sleep reopen assertion plus a seconds-scaled extension test whose one unavoidable two-sided assert now carries ~1s of slack on both edges. The cap test asserts Open only immediately after each re-trip (microseconds, no window), and the half-open transition sleeps 4× the cooldown instead of a borderline 2×.
- **vscode driftDiagnostics**: three `vi.waitFor` calls wrapping the provider's 500ms debounce used the default 1s poll deadline (2× headroom) — bumped to 2s to match the sibling death-sweep test that already uses `{ timeout: 2000 }`.

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [x] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Changes

- `engine/crates/rocky-fivetran/src/ratelimit.rs`: 50ms → 2s upper bounds on the "returns quickly" tests
- `engine/crates/rocky-fivetran/tests/resilience_tests.rs`: split the extended-cooldown test; safe-direction margins for the cap + transition tests
- `editors/vscode/src/__tests__/driftDiagnostics.test.ts`: `{ timeout: 2000 }` on three debounce-wrapping `waitFor` calls

## Test Plan

- `engine`: `cargo test -p rocky-fivetran --all-features` — resilience circuit tests (21 pass) and ratelimit tests (9 pass); `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo fmt --check` clean
- `editors/vscode`: driftDiagnostics vitest suite passes (8 tests)

## Checklist

- [x] Commit messages follow conventional commits
- [x] No `Co-Authored-By` trailers
- [x] No CLI JSON schema or DSL syntax change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CaCKoZS32ZivMZLVbVJaXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaCKoZS32ZivMZLVbVJaXS)_