### PR TITLE
fix(engine): validate metadata data_type in SELECT; escape backslash in Snowflake tags

### DIFF
--- a/engine/crates/rocky-bigquery/src/dialect.rs
+++ b/engine/crates/rocky-bigquery/src/dialect.rs
@@ -103,10 +103,18 @@ impl SqlDialect for BigQueryDialect {
             return Ok(base);
         }
 
-        let meta_cols: Vec<String> = metadata
-            .iter()
-            .map(|m| format!("CAST({} AS {}) AS {}", m.value, m.data_type, m.name))
-            .collect();
+        // `name` and `data_type` are interpolated raw into the CAST — validate
+        // both (same guards used elsewhere) so a metadata block from a hostile
+        // config can't inject; the trusted `value` expression is left as-is.
+        let mut meta_cols: Vec<String> = Vec::with_capacity(metadata.len());
+        for m in metadata {
+            validation::validate_identifier(&m.name).map_err(AdapterError::new)?;
+            rocky_core::sql_gen::validate_sql_type(&m.data_type).map_err(AdapterError::new)?;
+            meta_cols.push(format!(
+                "CAST({} AS {}) AS {}",
+                m.value, m.data_type, m.name
+            ));
+        }
 
         Ok(format!("{base}, {}", meta_cols.join(", ")))
     }

--- a/engine/crates/rocky-databricks/src/dialect.rs
+++ b/engine/crates/rocky-databricks/src/dialect.rs
@@ -113,6 +113,10 @@ impl SqlDialect for DatabricksSqlDialect {
 
         for mc in metadata {
             validation::validate_identifier(&mc.name).map_err(AdapterError::new)?;
+            // `data_type` is interpolated raw into the CAST — validate it as a
+            // SQL type (the same guard the drift path uses) so a hostile
+            // `rocky.toml` metadata `type` can't break out of the cast.
+            rocky_core::sql_gen::validate_sql_type(&mc.data_type).map_err(AdapterError::new)?;
             write!(
                 sql,
                 ", CAST({} AS {}) AS {}",

--- a/engine/crates/rocky-duckdb/src/dialect.rs
+++ b/engine/crates/rocky-duckdb/src/dialect.rs
@@ -139,6 +139,10 @@ impl SqlDialect for DuckDbSqlDialect {
 
         for mc in metadata {
             validation::validate_identifier(&mc.name).map_err(AdapterError::new)?;
+            // Validate `data_type` before interpolating it raw into the CAST
+            // (same guard as the drift path) — a metadata `type` from a
+            // hostile config must not break out of the cast expression.
+            rocky_core::sql_gen::validate_sql_type(&mc.data_type).map_err(AdapterError::new)?;
             write!(
                 sql,
                 ", CAST({} AS {}) AS {}",

--- a/engine/crates/rocky-snowflake/src/dialect.rs
+++ b/engine/crates/rocky-snowflake/src/dialect.rs
@@ -153,6 +153,10 @@ impl SqlDialect for SnowflakeSqlDialect {
 
         for mc in metadata {
             validation::validate_identifier(&mc.name).map_err(AdapterError::new)?;
+            // Validate `data_type` before interpolating it raw into the CAST
+            // (same guard as `alter_column_type_sql`) — a metadata `type` from
+            // a hostile config must not break out of the cast expression.
+            rocky_core::sql_gen::validate_sql_type(&mc.data_type).map_err(AdapterError::new)?;
             // Snowflake uses :: for casting: value::TYPE. Quote the output
             // alias so the materialized metadata column is stored
             // lowercase-preserving, consistent with the quoted column path

--- a/engine/crates/rocky-snowflake/src/governance.rs
+++ b/engine/crates/rocky-snowflake/src/governance.rs
@@ -248,8 +248,12 @@ fn format_set_tags_sql(
         .iter()
         .map(|(k, v)| {
             validation::validate_identifier(k).map_err(AdapterError::new)?;
-            // Escape single quotes in tag values.
-            let escaped = v.replace('\'', "''");
+            // Snowflake string literals honor backslash escapes by default, so
+            // doubling quotes alone is bypassable: a leading `\` escapes the
+            // first quote of a `''` pair, letting the second close the literal.
+            // Escape backslashes FIRST (so we don't double-escape the ones we
+            // add), then single quotes — closing the quote-doubling bypass.
+            let escaped = v.replace('\\', "\\\\").replace('\'', "''");
             Ok(format!("{k} = '{escaped}'"))
         })
         .collect::<AdapterResult<Vec<_>>>()?;
@@ -462,6 +466,20 @@ mod tests {
         assert_eq!(
             sql,
             "ALTER DATABASE my_database SET TAG managed_by = 'rocky'"
+        );
+    }
+
+    #[test]
+    fn test_set_tags_escapes_backslash_before_quote() {
+        // Snowflake honors backslash escapes, so `\'` would otherwise let a
+        // doubled `''` be split and the literal terminated early. Escaping
+        // backslashes first neutralizes the bypass: `\` → `\\`, `'` → `''`.
+        let mut tags = BTreeMap::new();
+        tags.insert("note".into(), "\\'; DROP TABLE x; --".into());
+        let sql = format_set_tags_sql(&TagTarget::Catalog("db".into()), &tags).unwrap();
+        assert_eq!(
+            sql,
+            "ALTER DATABASE db SET TAG note = '\\\\''; DROP TABLE x; --'"
         );
     }
 

--- a/engine/crates/rocky-trino/src/dialect.rs
+++ b/engine/crates/rocky-trino/src/dialect.rs
@@ -99,10 +99,19 @@ impl SqlDialect for TrinoDialect {
         if metadata.is_empty() {
             return Ok(base);
         }
-        let meta_cols: Vec<String> = metadata
-            .iter()
-            .map(|m| format!("CAST({} AS {}) AS {}", m.value, m.data_type, m.name))
-            .collect();
+        // `name` and `data_type` are both interpolated raw into the CAST — the
+        // other dialects validate them and this one did not, so a metadata
+        // block from a hostile config could inject here. Validate both (the
+        // trusted `value` expression is intentionally left as-is).
+        let mut meta_cols: Vec<String> = Vec::with_capacity(metadata.len());
+        for m in metadata {
+            validation::validate_identifier(&m.name).map_err(AdapterError::new)?;
+            rocky_core::sql_gen::validate_sql_type(&m.data_type).map_err(AdapterError::new)?;
+            meta_cols.push(format!(
+                "CAST({} AS {}) AS {}",
+                m.value, m.data_type, m.name
+            ));
+        }
         Ok(format!("{base}, {}", meta_cols.join(", ")))
     }
 
@@ -284,6 +293,25 @@ mod tests {
         }];
         let sql = d.select_clause(&ColumnSelection::All, &meta).unwrap();
         assert!(sql.contains("CAST(NULL AS VARCHAR) AS _loaded_by"));
+    }
+
+    #[test]
+    fn select_clause_rejects_injection_in_metadata_type_and_name() {
+        let d = TrinoDialect::new();
+        // A hostile `data_type` that tries to break out of the CAST.
+        let bad_type = vec![MetadataColumn {
+            name: "_loaded_by".to_string(),
+            data_type: "VARCHAR) AS x, (SELECT secret FROM creds) AS leak --".to_string(),
+            value: "NULL".to_string(),
+        }];
+        assert!(d.select_clause(&ColumnSelection::All, &bad_type).is_err());
+        // A hostile alias `name`.
+        let bad_name = vec![MetadataColumn {
+            name: "x, (SELECT 1) AS y".to_string(),
+            data_type: "VARCHAR".to_string(),
+            value: "NULL".to_string(),
+        }];
+        assert!(d.select_clause(&ColumnSelection::All, &bad_name).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A SQL-injection call-site audit found two config-controlled paths that reach `format!`-built SQL without the validation the repo invariant requires.

- **Metadata `data_type` unvalidated in every dialect's `select_clause`.** The replication runner builds `CAST(<value> AS <data_type>) AS <name>` per configured metadata column. `value` is a trusted expression and `name` is validated on three of five dialects — but `data_type` is validated on **none**, and Trino + BigQuery didn't validate `name` either. `MetadataColumnConfig.data_type`/`name` are plain strings from `rocky.toml` with nothing between config parse and SQL-gen. A hostile `type` like `STRING) AS x, (SELECT secret FROM admin.creds) AS leak --` breaks out of the cast. Now validated via `validate_sql_type` (the same guard the drift path uses) plus `validate_identifier` on the alias, in all five dialects (databricks, duckdb, snowflake, trino, bigquery).
- **Snowflake `SET TAG` backslash-escaping bypass.** Tag values were escaped with `'` → `''` only, but Snowflake string literals honor backslash escapes by default, so a leading `\` escapes the first quote of a doubled pair and terminates the literal early (`\'; DROP TABLE x; --`). Now escapes backslashes first, then quotes.

Both require a hostile or compromised `rocky.toml`, but that config is exactly the kind of input the "validate identifiers before interpolation" invariant exists to defend.

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Changes

- `engine/crates/rocky-{databricks,duckdb,snowflake,trino,bigquery}/src/dialect.rs`: validate `data_type` (and, on Trino/BigQuery, the `name` alias) before interpolation in `select_clause`
- `engine/crates/rocky-snowflake/src/governance.rs`: escape backslashes before quotes in `format_set_tags_sql`

## Test Plan

- New tests: Trino `select_clause` rejects injection in both `data_type` and `name`; Snowflake `format_set_tags_sql` escapes `\` before `'`
- `engine`: `cargo test` on all five adapter crates passes (existing metadata tests with clean types like `STRING`/`VARCHAR` still pass); `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo fmt --check` clean

## Checklist

- [x] Commit messages follow conventional commits
- [x] No `Co-Authored-By` trailers
- [x] No CLI JSON schema or DSL syntax change

### Engine (`engine/`)
- [x] `cargo test` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CaCKoZS32ZivMZLVbVJaXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaCKoZS32ZivMZLVbVJaXS)_