### PR TITLE
fix: fail closed on doctor exit-3, unparseable checks, skipped runs, and unknown severities

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -545,23 +545,46 @@ pub(crate) async fn run_custom_checks(
         let severity = custom.severity;
         match warehouse.execute_query(&sql).await {
             Ok(result) => {
-                let result_value =
-                    cell_as_u64(result.rows.first().and_then(|r| r.first())).unwrap_or(0);
-                // Delegate to the single canonical custom-check evaluator so the
-                // wired path and `checks::check_custom` can't drift on the pass
-                // condition again. `threshold` is the MAX allowed failing-row
-                // count, so the check passes iff `result_value <= threshold`
-                // (with the default `threshold = 0`, a violation-counting check
-                // passes only when it finds zero rows). `check_custom` defaults
-                // severity to Error; restore the check's configured severity.
-                let mut check = rocky_core::checks::check_custom(
-                    &custom.name,
-                    &sql,
-                    result_value,
-                    custom.threshold,
-                );
-                check.severity = severity;
-                results.push(check);
+                // `cell_as_u64` returns `None` on an absent/unparseable cell
+                // *specifically* so a parse failure isn't read as a real 0.
+                // With the default `threshold = 0` a violation-counting check
+                // passes iff `result_value <= 0`, so defaulting `None` to 0
+                // would report a never-evaluated check as green. Treat an
+                // unparseable count as a check failure instead.
+                match cell_as_u64(result.rows.first().and_then(|r| r.first())) {
+                    Some(result_value) => {
+                        // Delegate to the single canonical custom-check evaluator so
+                        // the wired path and `checks::check_custom` can't drift on the
+                        // pass condition again. `threshold` is the MAX allowed
+                        // failing-row count, so the check passes iff
+                        // `result_value <= threshold`. `check_custom` defaults
+                        // severity to Error; restore the check's configured severity.
+                        let mut check = rocky_core::checks::check_custom(
+                            &custom.name,
+                            &sql,
+                            result_value,
+                            custom.threshold,
+                        );
+                        check.severity = severity;
+                        results.push(check);
+                    }
+                    None => {
+                        warn!(
+                            check = custom.name.as_str(),
+                            "custom check returned no parseable count; failing the check"
+                        );
+                        results.push(CheckResult {
+                            name: custom.name.clone(),
+                            passed: false,
+                            severity,
+                            details: CheckDetails::Custom {
+                                query: sql,
+                                result_value: 0,
+                                threshold: custom.threshold,
+                            },
+                        });
+                    }
+                }
             }
             Err(e) => {
                 warn!(error = %e, check = custom.name.as_str(), "custom check query failed");
@@ -1484,5 +1507,47 @@ auto_create_schemas = true
             "the persisted run status must be Failure, got {:?}",
             runs[0].status
         );
+    }
+
+    #[tokio::test]
+    async fn custom_check_with_unparseable_count_fails_closed() {
+        // A custom check whose query succeeds but returns a non-numeric cell
+        // must FAIL, not silently pass. Previously the count defaulted to 0
+        // and `0 <= threshold(0)` reported the never-evaluated check green.
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("checks.duckdb");
+        {
+            let a = DuckDbWarehouseAdapter::open(&db).expect("open");
+            a.execute_statement("CREATE SCHEMA IF NOT EXISTS main")
+                .await
+                .unwrap();
+            a.execute_statement("CREATE TABLE main.t AS SELECT 1 AS id")
+                .await
+                .unwrap();
+        }
+        let warehouse = DuckDbWarehouseAdapter::open(&db).expect("reopen");
+
+        let unparseable = rocky_core::config::CustomCheckConfig {
+            name: "bad_count".to_string(),
+            // Succeeds, but the single cell is a string cell_as_u64 can't parse.
+            sql: "SELECT 'not-a-number'".to_string(),
+            threshold: 0,
+            severity: rocky_core::tests::TestSeverity::Error,
+        };
+        let good = rocky_core::config::CustomCheckConfig {
+            name: "zero_violations".to_string(),
+            sql: "SELECT 0".to_string(),
+            threshold: 0,
+            severity: rocky_core::tests::TestSeverity::Error,
+        };
+
+        let results = super::run_custom_checks(&warehouse, "main.t", &[unparseable, good]).await;
+
+        assert_eq!(results.len(), 2);
+        assert!(
+            !results[0].passed,
+            "an unparseable count must fail the check, not pass on a defaulted 0"
+        );
+        assert!(results[1].passed, "a genuine 0 <= threshold still passes");
     }
 }

--- a/integrations/dagster/src/dagster_rocky/health.py
+++ b/integrations/dagster/src/dagster_rocky/health.py
@@ -310,16 +310,21 @@ def _last_run_from_history(rocky: RockyResource) -> tuple[str | None, datetime |
     if not runs:
         return None, None
 
-    # The CLI returns runs newest-first; take the first entry.
-    first = runs[0]
-    wire_status = str(getattr(first, "status", "") or "")
-    normalised = _RUN_STATUS_NORMALISE.get(wire_status.strip().lower(), "failure")
-    started_at = getattr(first, "started_at", None)
-    # Guard against the rare case where a (legacy) shape lacks ``runs``
-    # or ``started_at`` — treat as "unknown" rather than synthesising.
-    if started_at is None:
-        return normalised, None
-    return normalised, started_at
+    # The CLI returns runs newest-first. Skip idempotency-deflected runs
+    # (``SkippedIdempotent`` / ``SkippedInFlight``): those never executed, so
+    # they carry no real outcome — reporting one as the "last run status"
+    # would flag a healthy pipeline (a run short-circuited because a prior run
+    # already succeeded) as ``failure``. Report the most recent run that
+    # actually ran; if every recent run was skipped, treat it as "unknown".
+    for run in runs:
+        wire_status = str(getattr(run, "status", "") or "").strip().lower()
+        if wire_status.startswith("skipped"):
+            continue
+        normalised = _RUN_STATUS_NORMALISE.get(wire_status, "failure")
+        started_at = getattr(run, "started_at", None)
+        return normalised, started_at
+
+    return None, None
 
 
 def _run_state_rw_probe(rocky: RockyResource) -> tuple[ProbeOutcome, int | None, str | None]:

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -676,16 +676,21 @@ class RockyResource(dg.ConfigurableResource):
         warn_failures: list[str] = []
         for check in report.checks:
             status = check.status.value if hasattr(check.status, "value") else str(check.status)
-            if status.lower() != "critical":
-                if status.lower() == "warning":
-                    log.warning(f"rocky doctor [{check.name}]: {check.message}")
+            status_l = status.lower()
+            if status_l == "healthy":
+                continue
+            if status_l == "warning":
+                log.warning(f"rocky doctor [{check.name}]: {check.message}")
                 continue
 
+            # `critical` and any status we don't recognise (a future severity
+            # above `warning`) are treated as gate-worthy — a strict-doctor gate
+            # must fail closed on an unknown-but-severe status, not skip it.
             if self._is_strict_check(check.name):
                 strict_failures.append(f"{check.name}: {check.message}")
             else:
                 warn_failures.append(f"{check.name}: {check.message}")
-                log.warning(f"rocky doctor [{check.name}] critical (non-strict): {check.message}")
+                log.warning(f"rocky doctor [{check.name}] {status_l} (non-strict): {check.message}")
 
         if strict_failures:
             raise dg.Failure(

--- a/sdk/python/src/rocky_sdk/client.py
+++ b/sdk/python/src/rocky_sdk/client.py
@@ -362,6 +362,14 @@ class RockyClient:
         # ``rocky --version`` outputs "rocky X.Y.Z" or just "X.Y.Z".
         version_str = result.stdout.strip().removeprefix("rocky ").strip()
         if not version_str:
+            # Fail open (don't block the real command) but make it visible —
+            # a silently-skipped gate is how an incompatible binary slips
+            # through and surfaces later as a confusing parse error.
+            self._logger.warning(
+                "rocky --version produced no parseable version; skipping the "
+                "minimum-version (%s) check",
+                MIN_ROCKY_VERSION,
+            )
             self._version_checked = True
             return
 
@@ -374,6 +382,11 @@ class RockyClient:
             detected = tuple(int(p) for p in core_version.split(".")[:3])
             required = tuple(int(p) for p in MIN_ROCKY_VERSION.split(".")[:3])
         except ValueError:
+            self._logger.warning(
+                "could not parse rocky version %r; skipping the minimum-version (%s) check",
+                version_str,
+                MIN_ROCKY_VERSION,
+            )
             self._version_checked = True
             return
 
@@ -1218,11 +1231,20 @@ class RockyClient:
         return _parse_rocky_json(self.run_cli(args), ConformanceResult, command="conformance")
 
     def doctor(self, *, check: str | None = None) -> DoctorResult:
-        """Run ``rocky doctor`` and return the parsed health-check results."""
+        """Run ``rocky doctor`` and return the parsed health-check results.
+
+        ``rocky doctor`` exits 3 when any check is critical, but still prints
+        the full JSON report. ``allow_partial=True`` returns that JSON instead
+        of raising, so a critical check surfaces as a parsed ``DoctorResult``
+        (with the critical check inside it) rather than a ``RockyPartialFailure``
+        — callers triage severity from the result, not from the exit code.
+        """
         args = ["doctor"]
         if check is not None:
             args.extend(["--check", check])
-        return _parse_rocky_json(self.run_cli(args), DoctorResult, command="doctor")
+        return _parse_rocky_json(
+            self.run_cli(args, allow_partial=True), DoctorResult, command="doctor"
+        )
 
     def compliance(self, *, env: str | None = None) -> ComplianceOutput:
         """Run ``rocky compliance`` and return the governance rollup."""


### PR DESCRIPTION
## Summary

A fail-open / swallowed-error audit plus a producer↔consumer contract sweep found five places where an error or edge path silently reported success.

- **SDK `doctor()` raised on a critical check instead of returning it.** `rocky doctor` exits 3 (with the full JSON report) when any check is critical, but `doctor()` ran with the default `allow_partial=False`, so `run_cli` raised `RockyPartialFailure` rather than returning the report. That made dagster's `strict_doctor` per-check triage and `rocky_healthcheck`'s documented "critical" branch unreachable — the first critical check aborted before triage. Now passes `allow_partial=True` and parses the emitted JSON.
- **SDK version gate silently disabled itself** on an empty/unparseable version string. It now logs a warning so a skipped gate is visible (still fail-open, but no longer invisible).
- **dagster `state_health` reported idempotency-deflected runs as `failure`.** `SkippedIdempotent` / `SkippedInFlight` fell through the status map's unknown-default to `"failure"`, so a healthy pipeline whose newest run was short-circuited (a prior run already succeeded) showed `last_run_status="failure"`. `_last_run_from_history` now skips deflected runs and reports the most recent run that actually executed.
- **dagster `strict_doctor` keyed on the exact string `"critical"`**, so any future severity above `warning` would pass the startup gate silently. It now fails closed on any unrecognised (non-healthy, non-warning) status.
- **engine `run_custom_checks` defaulted an unparseable count to 0** via `unwrap_or(0)`; with the default `threshold = 0` that reported a never-evaluated check as green. It now fails the check on an unparseable count, matching the `null_rate` path and `cell_as_u64`'s documented contract.

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [x] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Changes

- `sdk/python/src/rocky_sdk/client.py`: `doctor()` uses `allow_partial=True`; version gate warns on unparseable/empty version
- `integrations/dagster/src/dagster_rocky/health.py`: `_last_run_from_history` skips deflected runs
- `integrations/dagster/src/dagster_rocky/resource.py`: `strict_doctor` fails closed on unrecognised severities
- `engine/crates/rocky-cli/src/commands/run_local.rs`: custom-check unparseable count → check failure

## Test Plan

- New test: `run_custom_checks` fails the check when the query returns a non-numeric cell (previously passed on a defaulted 0)
- `sdk/python`: 36/36 pytest, ruff check + format clean
- `integrations/dagster`: health / state_health / strict_doctor suites pass (43 tests), ruff clean
- `engine`: `cargo test -p rocky-cli` new test passes; `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo fmt --check` clean

## Checklist

- [x] Commit messages follow conventional commits
- [x] No `Co-Authored-By` trailers
- [x] No CLI JSON schema or DSL syntax change (behavior only)

### Engine (`engine/`)
- [x] `cargo test` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo fmt --check` passes

### Dagster (`integrations/dagster/`)
- [x] `uv run pytest` passes
- [x] `uv run ruff check` is clean
- [x] `uv run ruff format --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CaCKoZS32ZivMZLVbVJaXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaCKoZS32ZivMZLVbVJaXS)_