### PR TITLE
perf(engine): move blocking file I/O off tokio workers in adapter/LSP paths

### DIFF
--- a/engine/crates/rocky-bigquery/src/loader.rs
+++ b/engine/crates/rocky-bigquery/src/loader.rs
@@ -301,8 +301,6 @@ impl LoaderAdapter for BigQueryLoaderAdapter {
                 }
 
                 let delim = options.csv_delimiter as u8;
-                let reader = CsvBatchReader::with_delimiter(local_path, options.batch_size, delim)
-                    .map_err(|e| AdapterError::msg(format!("failed to open CSV: {e}")))?;
 
                 // Read all batches up front with the caller's delimiter
                 // (re-reading via the comma-only `read_csv_batches` would
@@ -310,11 +308,24 @@ impl LoaderAdapter for BigQueryLoaderAdapter {
                 // this INSERT path is dev-scale by design (see module docs),
                 // and type inference needs the rows anyway. The same batches
                 // then drive the INSERT loop, so the file is read exactly
-                // once.
-                let column_names = reader.column_names().to_vec();
-                let batches: Vec<RowBatch> = reader
-                    .collect::<Result<_, _>>()
-                    .map_err(|e| AdapterError::msg(format!("failed to read CSV batch: {e}")))?;
+                // once. Both the file read and the CSV parse are synchronous
+                // and CPU-bound, so run them on the blocking pool rather than
+                // stalling the tokio worker across the whole file.
+                let read_path = local_path.to_path_buf();
+                let batch_size = options.batch_size;
+                let (column_names, batches): (Vec<String>, Vec<RowBatch>) =
+                    tokio::task::spawn_blocking(move || {
+                        let reader = CsvBatchReader::with_delimiter(&read_path, batch_size, delim)
+                            .map_err(|e| AdapterError::msg(format!("failed to open CSV: {e}")))?;
+                        let column_names = reader.column_names().to_vec();
+                        let batches: Vec<RowBatch> =
+                            reader.collect::<Result<_, _>>().map_err(|e| {
+                                AdapterError::msg(format!("failed to read CSV batch: {e}"))
+                            })?;
+                        Ok::<_, AdapterError>((column_names, batches))
+                    })
+                    .await
+                    .map_err(|e| AdapterError::msg(format!("CSV read task failed: {e}")))??;
 
                 // If create_table is requested, infer column TYPES from the
                 // sampled rows and create the table with those types (mapped

--- a/engine/crates/rocky-databricks/src/loader.rs
+++ b/engine/crates/rocky-databricks/src/loader.rs
@@ -504,8 +504,10 @@ impl DatabricksLoaderAdapter {
             .map_err(|e| AdapterError::msg(e.to_string()))?;
 
         // Read the local file before uploading so a read error fails fast,
-        // before we've created anything to clean up on the volume.
-        let contents = std::fs::read(local_path).map_err(|e| {
+        // before we've created anything to clean up on the volume. Use the
+        // async fs API so a large staging file (or a slow/networked disk)
+        // doesn't block the tokio worker while it's read into memory.
+        let contents = tokio::fs::read(local_path).await.map_err(|e| {
             AdapterError::msg(format!(
                 "failed to read local file '{}': {e}",
                 local_path.display()

--- a/engine/crates/rocky-server/src/lsp.rs
+++ b/engine/crates/rocky-server/src/lsp.rs
@@ -568,7 +568,7 @@ impl RockyLsp {
         let models_dir = self.models_dir.read().await;
         let dir = models_dir.as_ref()?;
         let toml_path = std::path::PathBuf::from(dir).parent()?.join("rocky.toml");
-        let text = std::fs::read_to_string(&toml_path).ok()?;
+        let text = tokio::fs::read_to_string(&toml_path).await.ok()?;
         let uri = Url::from_file_path(&toml_path).ok()?;
         Some((uri, text))
     }
@@ -584,7 +584,9 @@ impl RockyLsp {
         model_file_path: &str,
     ) -> Option<(tower_lsp::lsp_types::Url, String)> {
         let sidecar_path = std::path::Path::new(model_file_path).with_extension("toml");
-        let text = std::fs::read_to_string(&sidecar_path).unwrap_or_default();
+        let text = tokio::fs::read_to_string(&sidecar_path)
+            .await
+            .unwrap_or_default();
         let uri = Url::from_file_path(&sidecar_path).ok()?;
         Some((uri, text))
     }

--- a/engine/crates/rocky-snowflake/src/auth.rs
+++ b/engine/crates/rocky-snowflake/src/auth.rs
@@ -310,8 +310,10 @@ impl Auth {
                 use rsa::pkcs8::{DecodePrivateKey, EncodePublicKey};
                 use sha2::{Digest, Sha256};
 
-                // Read PEM private key
-                let pem_str = std::fs::read_to_string(private_key_path)
+                // Read PEM private key (async so the read doesn't block the
+                // tokio worker on a slow/networked key path during a refresh).
+                let pem_str = tokio::fs::read_to_string(private_key_path)
+                    .await
                     .map_err(|e| AuthError::KeyPairIo(e.to_string()))?;
 
                 // Parse RSA private key from PKCS#8 PEM


### PR DESCRIPTION
## Summary

A blocking-in-async sweep found synchronous `std::fs` calls on async paths — the same class as the fivetran ratelimit budget fix already merged. Each stalls the tokio worker for the duration of the read; a slow or networked filesystem parks every other future scheduled on that worker.

- **rocky-databricks loader**: the local staging-file read before a volume upload used `std::fs::read` on a potentially-large file → `tokio::fs::read`.
- **rocky-bigquery loader**: the local-file INSERT fallback opened and fully parsed the CSV (file I/O + CPU-bound parse) inline on the async worker → now runs on `spawn_blocking`. Dev-scale path by design, but unbounded per file.
- **rocky-snowflake auth**: the RS256 key-pair private-key read on the async token-refresh path used `std::fs::read_to_string` → `tokio::fs`.
- **rocky-server LSP**: `load_rocky_toml` / `load_model_sidecar` read config files with `std::fs::read_to_string` inside async handlers → `tokio::fs`.

All behavior-preserving.

### Deliberately deferred (flagged, not fixed here)

The sweep's highest-impact finding — the redb `StateStore` driven synchronously (including fsync-ing write commits) on tokio workers throughout the concurrent `rocky run` loop — needs a blocking-actor or restructure (the `Arc<Mutex<StateStore>>` guard can't cross a `spawn_blocking` boundary as-is), so it deserves its own change with load testing rather than being lumped in here. The precedent for the fix already exists in `lsp.rs::load_cached_source_schemas`. Two lower-impact items (the LSP cold-start DSL-diagnostics directory walk, the MCP draft snapshot) are also left as follow-ups.

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Changes

- `engine/crates/rocky-databricks/src/loader.rs`: `tokio::fs::read`
- `engine/crates/rocky-bigquery/src/loader.rs`: CSV open + parse on `spawn_blocking`
- `engine/crates/rocky-snowflake/src/auth.rs`: `tokio::fs::read_to_string`
- `engine/crates/rocky-server/src/lsp.rs`: `tokio::fs::read_to_string` in two handlers

## Test Plan

- `engine`: `cargo test` on rocky-databricks (106), rocky-snowflake (219), rocky-bigquery (167) all pass; `cargo clippy --all-targets --all-features -- -D warnings` clean on all four crates (incl. rocky-server); `cargo fmt --check` clean

## Checklist

- [x] Commit messages follow conventional commits
- [x] No `Co-Authored-By` trailers
- [x] No CLI JSON schema or DSL syntax change

### Engine (`engine/`)
- [x] `cargo test` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CaCKoZS32ZivMZLVbVJaXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaCKoZS32ZivMZLVbVJaXS)_