### PR TITLE
test(engine): deflake api parity test against retryable 503 engine_busy

### DIFF
--- a/engine/crates/rocky-cli/src/api.rs
+++ b/engine/crates/rocky-cli/src/api.rs
@@ -1403,6 +1403,25 @@ mod tests {
         assert_eq!(api, reference, "GET /dag must match `rocky dag`");
     }
 
+    /// GET `url`, retrying while the endpoint returns a *documented-retryable*
+    /// `503 engine_busy`. The three state-backed read routes open the redb
+    /// store read-only, and redb takes an unconditional `flock` on open; the
+    /// store's open-retry budget is only ~250ms (tuned for the LSP-vs-CLI
+    /// keystroke race), which a loaded CI runner can exhaust — so the handler
+    /// correctly returns the retryable 503 rather than blocking forever. Real
+    /// embedders back off and retry on that 503; the parity assertion should
+    /// too, instead of demanding 200 on the first request.
+    async fn get_retrying_on_busy(url: &str) -> reqwest::Response {
+        for _ in 0..40 {
+            let resp = reqwest::get(url).await.unwrap();
+            if resp.status() != reqwest::StatusCode::SERVICE_UNAVAILABLE {
+                return resp;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        panic!("{url} still returning 503 engine_busy after ~2s of retries");
+    }
+
     #[tokio::test]
     async fn parity_runs_history_metrics_on_empty_state() {
         // A hermetic, empty state store. Both the API and the CLI core resolve
@@ -1418,7 +1437,7 @@ mod tests {
         let base = spawn_router(state).await;
 
         // /runs
-        let resp = reqwest::get(format!("{base}/api/v1/runs")).await.unwrap();
+        let resp = get_retrying_on_busy(&format!("{base}/api/v1/runs")).await;
         assert_eq!(resp.status(), 200);
         assert_eq!(
             resp.text().await.unwrap(),
@@ -1426,9 +1445,7 @@ mod tests {
         );
 
         // /models/{name}/history
-        let resp = reqwest::get(format!("{base}/api/v1/models/some_model/history"))
-            .await
-            .unwrap();
+        let resp = get_retrying_on_busy(&format!("{base}/api/v1/models/some_model/history")).await;
         assert_eq!(resp.status(), 200);
         assert_eq!(
             resp.text().await.unwrap(),
@@ -1438,9 +1455,7 @@ mod tests {
         );
 
         // /models/{name}/metrics
-        let resp = reqwest::get(format!("{base}/api/v1/models/some_model/metrics"))
-            .await
-            .unwrap();
+        let resp = get_retrying_on_busy(&format!("{base}/api/v1/models/some_model/metrics")).await;
         assert_eq!(resp.status(), 200);
         assert_eq!(
             resp.text().await.unwrap(),


### PR DESCRIPTION
## Summary

Follow-up to a flake observed in CI: `api::tests::parity_runs_history_metrics_on_empty_state` intermittently fails with `503 != 200`.

Root cause: the three state-backed read routes (`/runs`, `/models/{name}/history`, `/models/{name}/metrics`) open the redb store read-only, and redb takes an unconditional `flock` on open. The store's open-retry budget is only ~250ms (5×50ms, deliberately tuned for the LSP-vs-CLI keystroke race), which a loaded CI runner can exhaust — at which point the handler **correctly** returns the *documented-retryable* `503 engine_busy` (it even carries a "retry" hint). The test asserted a hard `200` on the first request, so it failed.

The endpoint is behaving exactly as designed; the test was too strict. Real embedders back off and retry on that 503, so the parity assertion now does too — via a small `get_retrying_on_busy` helper (retries for ~2s) — then asserts `200` + byte-for-byte parity as before. Test-only; no production behavior change.

This is the same real-runner-load flake species as the deflakes in #1092, surfaced separately because it lives in a different mechanism (redb flock contention, not a real-clock window).

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Changes

- `engine/crates/rocky-cli/src/api.rs`: `get_retrying_on_busy` test helper; the three parity GETs retry on 503 before asserting 200 + parity

## Test Plan

- `engine`: `cargo test -p rocky-cli api::tests::parity_runs_history_metrics_on_empty_state` passes; `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo fmt --check` clean

## Checklist

- [x] Commit messages follow conventional commits
- [x] No `Co-Authored-By` trailers
- [x] No CLI JSON schema or DSL syntax change (test-only)

### Engine (`engine/`)
- [x] `cargo test` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CaCKoZS32ZivMZLVbVJaXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaCKoZS32ZivMZLVbVJaXS)_