### PR TITLE
perf(engine): move remaining blocking I/O off async workers in LSP + MCP

### DIFF
--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -1919,7 +1919,9 @@ impl RockyMcpServer {
         // artifact — a draft the policy plane refuses must not linger on disk
         // (mirrors the propose gate's deny → no plan written). A drop-guard,
         // not a manual closure: unwinding restores too.
-        let rollback = DraftRollback::snapshot([&paths.sql_path, &paths.sidecar_path]);
+        let rollback =
+            DraftRollback::snapshot_async(vec![paths.sql_path.clone(), paths.sidecar_path.clone()])
+                .await;
 
         // Write the draft: the SQL body verbatim + a minimal sidecar that carries
         // the intent. Target/strategy resolve from the project's conventions
@@ -2093,7 +2095,7 @@ impl RockyMcpServer {
         // Snapshot so a policy DENY (or a write/compile failure, or a panic
         // before the verdict) rolls back to leave NO new artifact — mirrors
         // `draft_model` and the propose gate. Drop-guard: unwinding restores.
-        let rollback = DraftRollback::snapshot([&paths.contract_path]);
+        let rollback = DraftRollback::snapshot_async(vec![paths.contract_path.clone()]).await;
 
         if let Err(e) = std::fs::write(&paths.contract_path, ensure_trailing_newline(&spec)) {
             return Err(ToolError::internal(
@@ -2215,7 +2217,7 @@ impl RockyMcpServer {
         // verdict) restores the model's PRIOR sidecar (the name/intent
         // draft_model wrote), never deletes it — the check is what rolls back,
         // not the model. A model with no sidecar yet snapshots None.
-        let rollback = DraftRollback::snapshot([&paths.sidecar_path]);
+        let rollback = DraftRollback::snapshot_async(vec![paths.sidecar_path.clone()]).await;
 
         // Merge: append the `[[tests]]` block(s) to the existing sidecar, or seed
         // a minimal sidecar (`name = "<stem>"`) when the model is a bare `.sql`.
@@ -3632,6 +3634,18 @@ impl DraftRollback {
             entries,
             defused: false,
         }
+    }
+
+    /// Async wrapper over [`snapshot`](Self::snapshot) that runs the prior-bytes
+    /// reads on the blocking pool. The async draft handlers use this so the
+    /// snapshot reads don't block the tokio worker; the sync `snapshot` stays
+    /// for the `catch_unwind`-based restore-on-panic unit test.
+    async fn snapshot_async(paths: Vec<PathBuf>) -> Self {
+        // `snapshot` only ever reads with `.ok()`, so the closure can't panic
+        // and the `JoinError` arm is unreachable in practice.
+        tokio::task::spawn_blocking(move || Self::snapshot(paths))
+            .await
+            .expect("DraftRollback::snapshot does not panic")
     }
 
     /// The snapshotted prior bytes for `path` (`None` = the file did not

--- a/engine/crates/rocky-server/src/lsp.rs
+++ b/engine/crates/rocky-server/src/lsp.rs
@@ -486,14 +486,27 @@ impl RockyLsp {
     /// `didOpen`) still surface E028 for syntactically-broken `.rocky`
     /// files.
     async fn publish_dsl_parse_diagnostics(&self, models_dir: &std::path::Path) {
-        let Ok(entries) = std::fs::read_dir(models_dir) else {
+        // Collect the `.rocky` paths off the async worker: the directory scan
+        // is blocking I/O and this runs on LSP cold start (and after every
+        // compile), so a large or slow models dir would otherwise stall the
+        // tower-lsp task. Nested `Ok(Ok(..))`: outer is the `JoinError`, inner
+        // is the `read_dir` result.
+        let dir = models_dir.to_path_buf();
+        let scan = tokio::task::spawn_blocking(move || {
+            let mut paths = Vec::new();
+            for entry in std::fs::read_dir(&dir)?.flatten() {
+                let path = entry.path();
+                if path.extension().and_then(|s| s.to_str()) == Some("rocky") {
+                    paths.push(path);
+                }
+            }
+            Ok::<Vec<std::path::PathBuf>, std::io::Error>(paths)
+        })
+        .await;
+        let Ok(Ok(rocky_paths)) = scan else {
             return;
         };
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().and_then(|s| s.to_str()) != Some("rocky") {
-                continue;
-            }
+        for path in rocky_paths {
             let Ok(uri) = Url::from_file_path(&path) else {
                 continue;
             };
@@ -516,10 +529,10 @@ impl RockyLsp {
             } else {
                 // Cold-start fallback: file not in salsa db yet (no
                 // `didOpen` seen). Match the legacy behaviour and re-read
-                // from disk; the parse runs through the original
-                // `rocky_lang::parse` because we don't have a salsa
-                // input to hang the memoization off.
-                let Ok(content) = std::fs::read_to_string(&path) else {
+                // from disk (async so the read doesn't block the worker); the
+                // parse runs through the original `rocky_lang::parse` because
+                // we don't have a salsa input to hang the memoization off.
+                let Ok(content) = tokio::fs::read_to_string(&path).await else {
                     continue;
                 };
                 let outcome = match rocky_lang::parse(&content) {


### PR DESCRIPTION
## Summary

Follow-up to #1097 — the two lower-impact blocking-I/O spots flagged there as deferred.

- **rocky-server LSP** (`publish_dsl_parse_diagnostics`): a synchronous `std::fs::read_dir` scan of the models directory (runs on LSP cold start and after every compile) plus a synchronous `std::fs::read_to_string` on the cold-start fallback, both on the tower-lsp task. The directory scan now runs on `spawn_blocking`; the cold-start read uses `tokio::fs`. The salsa fast path (in-memory, behind async locks) is unchanged.
- **rocky-mcp** (`DraftRollback::snapshot`): read prior file bytes with `std::fs::read` from three async draft handlers. Added `snapshot_async`, which runs the reads on the blocking pool, and pointed the three handlers at it. The sync `snapshot` stays for the `catch_unwind` restore-on-panic unit test (a sync context) and is still called by the async wrapper, so it isn't dead code.

Both behavior-preserving. The remaining higher-effort item — the redb `StateStore` driven synchronously on tokio workers throughout the concurrent `rocky run` loop — is a separate PR (a real refactor: drop the `Arc<Mutex<StateStore>>` to `Arc<StateStore>` and move the fsync-bearing commits to `spawn_blocking`).

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Changes

- `engine/crates/rocky-server/src/lsp.rs`: directory scan on `spawn_blocking`; cold-start read via `tokio::fs`
- `engine/crates/rocky-mcp/src/tools.rs`: `DraftRollback::snapshot_async` on the blocking pool; three draft handlers use it

## Test Plan

- `engine`: `cargo test` on rocky-server (22) and rocky-mcp (79) pass; `cargo clippy --all-targets --all-features -- -D warnings` clean on both; `cargo fmt --check` clean

## Checklist

- [x] Commit messages follow conventional commits
- [x] No `Co-Authored-By` trailers
- [x] No CLI JSON schema or DSL syntax change

### Engine (`engine/`)
- [x] `cargo test` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CaCKoZS32ZivMZLVbVJaXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaCKoZS32ZivMZLVbVJaXS)_