### PR TITLE
feat(engine): warehouse replay — re-execute content-addressed runs with bit-exact verification

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -14141,7 +14141,7 @@
         "type": "object"
       },
       "ReplayExecuteOutput": {
-        "description": "JSON output for `rocky replay --at <run_id> --execute [--verify]`.\n\nRe-execution surface (DuckDB). Each model's recipe is reconstructed from its recorded [`rocky_core::state::ProvenanceRecord`] — never the working tree — re-executed on an in-memory DuckDB engine, and its output artifact's blake3 re-derived. With `--verify` that digest is compared against the recorded output hash and a per-model verdict is emitted.\n\nTwo modes share this shape:\n\n- `--model <m>` re-executes a single, *self-contained* recipe on a throwaway engine. A recipe with recorded content upstreams is `non_replayable` in this mode — resolving those inputs is the DAG mode below. - no `--model` re-executes the *whole run* in topological order on one shared engine, materializing each upstream's **replayed** output so a downstream `SELECT` reads the replayed bytes (never the recorded object-store bytes, never production). A downstream whose in-run upstream could not be replayed is `non_replayable` (fail-closed cascade); an upstream not produced by any model in this run, or a mutable-source watermark, is likewise `non_replayable` rather than substituted.\n\nNothing is materialized to any warehouse schema: the entire in-memory engine is an ephemeral replay namespace, discarded after the run, so no production identity is ever touched.",
+        "description": "JSON output for `rocky replay --at <run_id> --execute [--verify]`.\n\nRe-execution surface. Each model's recipe is reconstructed from its recorded [`rocky_core::state::ProvenanceRecord`] — never the working tree — re-executed, and its output artifact's blake3 re-derived. With `--verify` that digest is compared against the recorded output hash and a per-model verdict is emitted. Execution runs on an in-memory DuckDB engine by default; with `--warehouse` it runs on the configured live warehouse instead, materializing replayed outputs into an isolated replay schema (see `replay_schema`) and encoding the recomputed artifact with the live table's physical column mapping so the digest is directly comparable to what the content-addressed writer recorded.\n\nTwo modes share this shape:\n\n- `--model <m>` re-executes a single, *self-contained* recipe on a throwaway engine. A recipe with recorded content upstreams is `non_replayable` in this mode — resolving those inputs is the DAG mode below. - no `--model` re-executes the *whole run* in topological order on one shared engine, materializing each upstream's **replayed** output so a downstream `SELECT` reads the replayed bytes (never the recorded object-store bytes, never production). A downstream whose in-run upstream could not be replayed is `non_replayable` (fail-closed cascade); an upstream not produced by any model in this run, or a mutable-source watermark, is likewise `non_replayable` rather than substituted.\n\nNo production identity is ever touched in either mode: the local path's entire in-memory engine is an ephemeral replay namespace discarded after the run, and the warehouse path writes only into the isolated `replay_schema`, dropped after the run unless `--keep` is passed.",
         "properties": {
           "bit_exact_count": {
             "description": "Number of models whose re-execution reproduced the recorded output byte-for-byte. Always `0` when `--verify` was not requested.",
@@ -14163,6 +14163,20 @@
               "$ref": "#/components/schemas/ReplayExecuteModelOutput"
             },
             "type": "array"
+          },
+          "replay_schema": {
+            "description": "Isolated warehouse schema the replayed outputs were materialized into (`--warehouse` only; absent on the local re-execution path). Replay never writes to the production location of any recorded target — every replayed table lands in this namespace, one schema per catalog touched.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "replay_schema_dropped": {
+            "description": "Whether the replay namespace was removed after the run (`--warehouse` only). `true` when no replay schema remains on the warehouse; `false` when `--keep` was passed or a drop failed.",
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "run_id": {
             "type": "string"

--- a/docs/src/content/docs/concepts/architecture-of-trust.md
+++ b/docs/src/content/docs/concepts/architecture-of-trust.md
@@ -101,11 +101,11 @@ The first is deterministic recording with ledger verification. Rocky records eac
 
 Alongside the run record, every materialization stamps a recipe-identity triple: `recipe_hash` (a fingerprint of the model's canonical typed IR, so the same program hashes the same no matter when it ran), `input_hash` (the inputs it read), and `env_hash` (the engine, adapter, and dialect it ran under). `rocky history --recipe <hash>` answers the audit question directly — "what produced this, and every other time this exact program ran." The triple is honest about strength: an `input_hash` proven by an observed freshness signature is tagged `heuristic` and is never presented as a byte-content claim, while a content-addressed input is `strong`. This is an identity and audit primitive, not a reproducibility claim.
 
-The second is re-execution from the pinned record: replaying a past run by feeding the recorded inputs back through the engine to reproduce its outputs from scratch. That is the follow-up. It arrives on top of the content-addressed write path, and it is not what `rocky replay` does now.
+The second is re-execution from the pinned record: replaying a past run by reconstructing each model's recipe from provenance (never the working tree) and re-running it to reproduce its output from scratch. `rocky replay --execute --verify` does this and compares the re-derived BLAKE3 against the recorded hash. It runs on a local DuckDB engine by default, or against the live warehouse with `--warehouse` — the latter materializes into an isolated `hcv2_replay_<run>` schema (never the recorded target's production location) and encodes the recomputed artifact with the target table's own physical column mapping, so a `bit_exact` verdict means the warehouse reproduced the recorded bytes exactly. Re-execution is scoped honestly: it covers deterministic, content-addressed models; a mutable-source read is `non_replayable` rather than re-run against current data, and a non-deterministic recipe is flagged so a `diverged` verdict there is expected rather than a failure.
 
-In short: deterministic recording and content-addressed verification today, re-execution from the record next.
+In short: deterministic recording and content-addressed verification, plus re-execution from the record for deterministic content-addressed models — locally or on the warehouse.
 
-**Partial.** Recording and ledger verification ship; re-execution from the record is the follow-up.
+**Shipped for deterministic content-addressed models.** Recording and ledger verification ship; re-execution ships for the deterministic content-addressed case (mutable-source models classified `non_replayable`, non-deterministic recipes flagged).
 
 Content-addressed materialization itself ships for single-writer Delta and UniForm: blake3-hashed Parquet files plus a Delta log commit, with Iceberg-compatible readers seeing the same snapshot. It is single-writer and does not yet cover multi-writer concurrency, broad schema evolution, or deletion vectors.
 
@@ -135,7 +135,7 @@ Every load-bearing claim, in one table. The partial and not-yet rows are where t
 | Dialect-divergence lint (`P001`) | Shipped | Opt-in via `--target-dialect`; error severity. |
 | VS Code trust overlays | Shipped | Exactly four: Drift, Breaking, Replay, Governance. |
 | Branches | Partial | Schema-prefix isolation with signed approval/promotion; no warehouse-native zero-copy clones yet. |
-| Replay | Partial | Deterministic recording + ledger verification today; re-execution from the pinned record is the follow-up. |
+| Replay | Partial | Deterministic recording + ledger verification, plus re-execution (`rocky replay --execute --verify`, local or `--warehouse`) for deterministic content-addressed models; mutable-source models are `non_replayable`, non-deterministic recipes flagged. |
 | Content-addressed writes | Partial | Single-writer Delta/UniForm; no multi-writer, broad schema evolution, or deletion vectors yet. |
 | Per-model cost | Partial | Billing-exact on BigQuery; a duration × DBU-rate estimate on Databricks and Snowflake; zero on DuckDB. Warehouse-reported-bytes plumbing on the non-BigQuery adapters is the follow-up. |
 | Declarative governance | Partial | Full on Databricks (Unity Catalog); `GRANT`/`REVOKE` only on Snowflake and BigQuery; no-op on DuckDB. |

--- a/docs/src/content/docs/getting-started/introduction.md
+++ b/docs/src/content/docs/getting-started/introduction.md
@@ -51,7 +51,7 @@ Quality is more than the inline runtime gate. Models can also declare fixture-dr
 
 1. **SQL as a typed, compiled language.** Column-level type inference across the full DAG. 35+ diagnostic codes (`E###` errors, `W###` warnings, `P###` portability lints) with actionable suggestions. Not text macros, but a real compiler with a real LSP.
 2. **Compile-time column-level lineage.** Every column traced through every transformation, before execution. `rocky lineage-diff main` lists per-column downstream blast radius for PR review. That CI gate is impossible without a compiled engine.
-3. **Branches + a content-addressed run record.** Named branches as isolated schemas. `rocky branch create` / `rocky run --branch` / `rocky replay <run_id>`. Each run records per-model SQL hashes, row counts, and bytes, and content-addresses the written artifacts; `rocky replay` inspects and verifies that record against the ledger. (Re-execution from the pinned record is on the roadmap.)
+3. **Branches + a content-addressed run record.** Named branches as isolated schemas. `rocky branch create` / `rocky run --branch` / `rocky replay <run_id>`. Each run records per-model SQL hashes, row counts, and bytes, and content-addresses the written artifacts; `rocky replay` inspects and verifies that record against the ledger, and `rocky replay --execute --verify` re-runs a deterministic content-addressed model to reproduce its output bit-for-bit — locally or, with `--warehouse`, on the live warehouse in an isolated replay schema.
 4. **Per-model cost attribution.** Cost is a column on every run record, not an afterthought dashboard. `[budget]` blocks fail the run on overspend; `budget_breach` fires the hook; `rocky preview cost` projects spend at PR time.
 5. **AI gated through the compiler.** Every AI suggestion type-checks before it lands. `rocky ai` generates, compiles, auto-fixes, and ships; the `Attempts: 2` retry loop is the signature feature. (The broader AI surface, like mass refactor or auto-migration on a column-type change, is on the [Roadmap](/getting-started/roadmap/).)
 6. **Dialect-divergence lint.** `P001` catches Snowflake-only constructs in a Databricks project, and the reverse. Useful the day you start a migration, essential the day you finish one.
@@ -86,7 +86,7 @@ See the [Roadmap](/getting-started/roadmap/) for the full breakdown.
 | Column-level lineage | Table-level (`dbt docs`); column-level needs Fusion or paid Catalog | Compile-time output, queryable per column |
 | Schema drift | Silent | Detected at run, rebuilt safely |
 | Cost attribution | — | Per-model, every run |
-| Replay | — | Content-addressed run record (re-execution on the roadmap) |
+| Replay | — | Content-addressed run record + re-execution (`replay --execute --verify`, local or `--warehouse`) for deterministic content-addressed models |
 
 **Evaluating SQLMesh?** SQLMesh is the tool Rocky most resembles: it also analyzes SQL statically (via SQLGlot, no Jinja), and its virtual environments, plan/apply, and column-level lineage are mature primitives Rocky shares rather than beats. Rocky keeps SQL as the default (SQLMesh leans Python-first) and differentiates on the enforcement plane: declarative OSS governance and `[budget]` blocks that fail the build (neither in SQLMesh OSS), plus source-schema-drift detection and a dialect-portability lint at PR time (where SQLMesh instead transpiles dialects via SQLGlot). SQLMesh is more mature in years, funding, and adoption, and ships native Python models and an OSS CI/CD bot.
 

--- a/docs/src/content/docs/getting-started/roadmap.md
+++ b/docs/src/content/docs/getting-started/roadmap.md
@@ -11,7 +11,7 @@ The trust primitives (compiler, branches, run records, lineage, contracts, cost 
 
 - **Databricks** is the production target for 2026: SQL Statement API, Unity Catalog, OAuth M2M, adaptive concurrency, and schema-prefix branches (warehouse-native `SHALLOW CLONE` is a follow-up).
 - **The compiler.** Typed column-level inference, the diagnostic codes, and the LSP all run the same in CI and in your editor.
-- **Branches and run records.** Named branches as isolated schemas, and a content-addressed record of each run that you inspect and verify against the ledger with `rocky replay`. (Re-execution from the pinned record is on the 2026 roadmap.)
+- **Branches and run records.** Named branches as isolated schemas, and a content-addressed record of each run that you inspect and verify against the ledger with `rocky replay`. For deterministic content-addressed models, `rocky replay --execute --verify` re-runs the recorded recipe to reproduce the output bit-for-bit — locally or, with `--warehouse`, on the live warehouse in an isolated replay schema.
 - **Cost attribution.** Per-model cost on every run record, with `[budget]` blocks that fail a run on overspend.
 - **The AI compile-validate loop.** `rocky ai` generates a model, compiles it, and auto-fixes parse errors before it lands.
 - **Deterministic surrogate keys.** A model declares a [`[[surrogate_key]]`](/reference/model-format/#surrogate_key) block, and `rocky run` injects a dialect-correct hash column at materialization on DuckDB, Databricks, Snowflake, and BigQuery. On a given warehouse the value matches what dbt Core's `dbt_utils.generate_surrogate_key` produces over the same columns, so a key joins across a Rocky/dbt Core boundary either way.

--- a/docs/src/content/docs/guides/verify-a-run.md
+++ b/docs/src/content/docs/guides/verify-a-run.md
@@ -262,10 +262,11 @@ Verifies, with the tools above and no `rocky` binary:
 - The output table's live schema and row count, checked against the warehouse directly.
 - On the content-addressed path, that the output bytes match the recorded hash exactly.
 - With `[reuse]` enabled, that an indexed build's declared inputs are internally consistent (recompute `skip_hash` from the embedded canonical IR, then recompute `input_hash` from the persisted `skip_hash` + target identity + `upstreams` and confirm it matches the recorded value), and that the recorded output bytes are exactly those bytes (`b3sum`, extendable one hop to each `strong` upstream's recorded bytes via its own record), each labelled `strong` or `heuristic`.
+- For a deterministic content-addressed model, that **re-executing** the recorded recipe reproduces the recorded output byte-for-byte. `rocky replay --execute --verify` reconstructs the recipe from provenance (never the working tree), re-runs it, and compares the re-derived BLAKE3 against the recorded hash; `--warehouse` runs that re-execution against the live warehouse in an isolated replay schema, encoding the recomputed artifact with the target table's own physical column mapping so the digest is directly comparable to what the writer recorded.
 
 Does **not** verify:
 
-- That re-running the SQL would reproduce the same output. Rocky's `replay` is an *inspection* of the recorded run, not a re-execution with pinned inputs; re-execution is a planned follow-up. The reuse provenance record makes the same input-logic + byte-identity attestation; it is likewise **not** a reproducibility claim.
+- That re-running an arbitrary model reproduces its output. Re-execution is scoped to deterministic, content-addressed models: a model that reads a mutable source is classified `non_replayable` rather than re-run against current data, a model with a non-deterministic recipe (`now()`, `random()`) is flagged and may legitimately `diverge`, and a plain DuckDB/Snowflake/BigQuery/Databricks target that is not content-addressed carries no whole-output hash to compare against. The verdict (`bit_exact` / `diverged` / `non_replayable`) is always a classification, never a fabricated success.
 - That the warehouse table was not mutated by something else after the run. The ledger records what Rocky wrote; a later out-of-band `UPDATE` is outside its scope (this is exactly why step 5 checks the live warehouse).
 
 ## Implementation honesty
@@ -275,8 +276,8 @@ Every load-bearing claim above, graded against what ships today:
 | Claim | Status |
 |---|---|
 | Ledger inspection: `run_history`, `sql_hash`, full audit trail | Shipped |
-| `rocky replay` surfaces the recorded run | Shipped (inspection only) |
-| Re-execution with pinned inputs reproduces the output | Not yet — planned follow-up |
+| `rocky replay` surfaces the recorded run | Shipped |
+| Re-execution reproduces the output (`rocky replay --execute --verify`) | Shipped for deterministic content-addressed models — local DuckDB engine or, with `--warehouse`, the live warehouse in an isolated replay schema; mutable-source models are `non_replayable`, non-deterministic recipes flagged |
 | Content-addressed Parquet named by BLAKE3 + recorded in `output_artifacts` | Shipped, but on the S3 content-addressed path only — not what a general DuckDB/Snowflake/BigQuery/Databricks run produces |
 | `[reuse]` input-match index + provenance record (offline-recomputable `skip_hash` *and* `input_hash` over persisted `upstreams` + `b3sum` + `proof_class`) | Shipped — opt-in (`[reuse] enabled`, default-off), recorded on the content-addressed (S3/UniForm) write path only |
 | Reuse *decision*: actually reusing a prior run's bytes instead of re-executing | Shipped — opt-in (`[reuse] enabled`, default-off), a fail-closed point-to decision on the content-addressed (S3/UniForm) write path, live-verified; any doubt builds |

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -34,7 +34,7 @@ Rocky exists because the most expensive failures in modern data platforms aren't
     Every column traced through every transformation, before execution. `rocky lineage-diff main` lists per-column downstream blast radius for PR review.
   </Card>
   <Card title="Branches + content-addressed run records" icon="random">
-    Named branches as isolated schemas. `rocky replay <run_id>` inspects and verifies a run against its content-addressed record: per-model SQL hashes, row counts, and bytes. (Re-execution from the pinned record is on the roadmap.)
+    Named branches as isolated schemas. `rocky replay <run_id>` inspects and verifies a run against its content-addressed record: per-model SQL hashes, row counts, and bytes. `--execute --verify` re-runs a deterministic content-addressed model to reproduce its output bit-for-bit, locally or on the live warehouse in an isolated replay schema.
   </Card>
   <Card title="Per-model cost attribution" icon="rocket">
     Cost is a column on every run, not a dashboard. `[budget]` blocks fail the run on overspend. `rocky preview cost` projects spend at PR time.

--- a/docs/src/content/docs/reference/commands/administration.md
+++ b/docs/src/content/docs/reference/commands/administration.md
@@ -633,7 +633,7 @@ The single-model envelope is byte-stable: `catalog`, `scope`, `tables`, and `tot
 
 ## `rocky replay`
 
-Inspect a recorded run from the state store. Surfaces the per-model SQL hashes, row counts, bytes, and timings captured by `RunRecord` at execution time: the concrete artefact behind the reproducibility claim. Inspection-only today; re-execution with pinned inputs is a follow-up.
+Inspect, audit, or re-execute a recorded run from the state store. The default view surfaces the per-model SQL hashes, row counts, bytes, and timings captured by `RunRecord` at execution time: the concrete artefact behind the reproducibility claim. `--check` runs a read-only replayability audit, and `--execute` re-runs the recorded recipes and re-derives each output hash — locally on DuckDB, or against the live warehouse with `--warehouse`.
 
 ```bash
 rocky replay <target> [flags]
@@ -650,6 +650,11 @@ rocky replay <target> [flags]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--model <NAME>` | `string` | | Filter to a single model within the run. Errors if the model wasn't executed. |
+| `--check` | `bool` | `false` | Read-only replayability audit instead of the inspection view. Classifies each model as `replayable` or `non_replayable` from the ledger alone and flags static non-determinism. Executes nothing. |
+| `--execute` | `bool` | `false` | Re-execute the recorded recipe (reconstructed from provenance, never the working tree) and re-derive the output hash. Runs on an ephemeral in-memory DuckDB engine by default. |
+| `--verify` | `bool` | `false` | With `--execute`, compare the re-derived blake3 against the recorded hash and emit a per-model verdict (`bit_exact` / `diverged` / `non_replayable`). Requires `--execute`. |
+| `--warehouse` | `bool` | `false` | With `--execute`, re-run against the live warehouse configured in `rocky.toml` instead of a local engine. Content-addressed models only. All replay writes land in an isolated `hcv2_replay_<run>` schema — never the production location of any recorded target — and it is dropped afterwards unless `--keep`. Requires `--execute`. |
+| `--keep` | `bool` | `false` | With `--warehouse`, keep the isolated replay schema (and the replayed tables) after the run for inspection. Requires `--warehouse`. |
 
 ### Examples
 
@@ -703,6 +708,38 @@ rocky replay run_20260420_143022 --model fct_revenue
 ```
 
 `sql_hash` is stable across runs where the compiled SQL is identical, so diffing two replays is a fast way to detect whether a re-run would execute the same statements.
+
+### Re-execution
+
+`--execute` reconstructs each model's recipe from its recorded provenance — the canonical `ModelIr` embedded at run time, never the current working tree — and re-runs it, re-deriving the output artifact's blake3. With `--verify`, that digest is compared against the recorded hash:
+
+```bash
+rocky replay latest --execute --verify
+```
+
+```json
+{
+  "command": "replay --execute --verify",
+  "run_id": "run_20260420_143022",
+  "verified": true,
+  "model_count": 2,
+  "bit_exact_count": 2,
+  "models": [
+    { "model_name": "stg_orders", "verdict": "bit_exact", "rows": 150000 },
+    { "model_name": "fct_revenue", "verdict": "bit_exact", "rows": 8900 }
+  ]
+}
+```
+
+Each per-model `verdict` is a classification, not a tool failure — `bit_exact`, `diverged`, `executed` (without `--verify`), or `non_replayable` — so the command exits `0` and you read the verdict. A model that reads a mutable source is classified `non_replayable` rather than silently re-run against current data; a model whose recipe contains a non-deterministic construct (`now()`, `random()`) is flagged and a `diverged` there is expected.
+
+By default re-execution runs on an ephemeral in-memory DuckDB engine. `--warehouse` re-runs against the live warehouse in `rocky.toml` instead, for content-addressed models whose artifacts live in the lakehouse:
+
+```bash
+rocky replay latest --execute --verify --warehouse
+```
+
+The warehouse path re-derives each output's blake3 encoded with the target table's own physical column mapping (read from its Delta log), so a `bit_exact` verdict means the warehouse reproduced exactly the bytes the content-addressed writer recorded. Execution is isolated: every replayed model is materialized into a fresh `hcv2_replay_<run>` schema, never the production location of any recorded target, and that schema is dropped after the run unless you pass `--keep`. No object-store objects are written — the recomputed artifact is hashed in memory, and existing content-addressed files are never touched. In-run upstream references are redirected into the replay schema, so a downstream model reads its upstream's replayed output rather than production; an upstream the run did not itself produce (or a mutable-source read) makes the model `non_replayable` rather than reading production data.
 
 ### Related Commands
 

--- a/docs/src/content/docs/reference/glossary.md
+++ b/docs/src/content/docs/reference/glossary.md
@@ -77,7 +77,7 @@ A deterministic, reviewable record of what a run will do: compiled SQL, drift ac
 
 ### Replay
 
-Inspecting and verifying a past run against its [content-addressed](#content-addressed) record: per-model SQL hashes, row counts, and bytes. `rocky replay <run_id>` checks the record against the ledger; re-executing a run bit-for-bit from the pinned record is on the roadmap. See [Roadmap](/getting-started/roadmap/).
+Inspecting, auditing, and re-executing a past run against its [content-addressed](#content-addressed) record. `rocky replay <run_id>` surfaces per-model SQL hashes, row counts, and bytes; `rocky replay <run_id> --execute --verify` reconstructs each recipe from its provenance and re-runs it to reproduce the recorded output bit-for-bit, on a local DuckDB engine or, with `--warehouse`, on the live warehouse in an isolated replay schema. Re-execution covers deterministic content-addressed models; mutable-source models are classified `non_replayable` and non-deterministic recipes are flagged. See [Roadmap](/getting-started/roadmap/).
 
 ### Shadow mode
 

--- a/editors/vscode/src/types/generated/replay_execute.ts
+++ b/editors/vscode/src/types/generated/replay_execute.ts
@@ -8,13 +8,13 @@
 /**
  * JSON output for `rocky replay --at <run_id> --execute [--verify]`.
  *
- * Re-execution surface (DuckDB). Each model's recipe is reconstructed from its recorded [`rocky_core::state::ProvenanceRecord`] — never the working tree — re-executed on an in-memory DuckDB engine, and its output artifact's blake3 re-derived. With `--verify` that digest is compared against the recorded output hash and a per-model verdict is emitted.
+ * Re-execution surface. Each model's recipe is reconstructed from its recorded [`rocky_core::state::ProvenanceRecord`] — never the working tree — re-executed, and its output artifact's blake3 re-derived. With `--verify` that digest is compared against the recorded output hash and a per-model verdict is emitted. Execution runs on an in-memory DuckDB engine by default; with `--warehouse` it runs on the configured live warehouse instead, materializing replayed outputs into an isolated replay schema (see `replay_schema`) and encoding the recomputed artifact with the live table's physical column mapping so the digest is directly comparable to what the content-addressed writer recorded.
  *
  * Two modes share this shape:
  *
  * - `--model <m>` re-executes a single, *self-contained* recipe on a throwaway engine. A recipe with recorded content upstreams is `non_replayable` in this mode — resolving those inputs is the DAG mode below. - no `--model` re-executes the *whole run* in topological order on one shared engine, materializing each upstream's **replayed** output so a downstream `SELECT` reads the replayed bytes (never the recorded object-store bytes, never production). A downstream whose in-run upstream could not be replayed is `non_replayable` (fail-closed cascade); an upstream not produced by any model in this run, or a mutable-source watermark, is likewise `non_replayable` rather than substituted.
  *
- * Nothing is materialized to any warehouse schema: the entire in-memory engine is an ephemeral replay namespace, discarded after the run, so no production identity is ever touched.
+ * No production identity is ever touched in either mode: the local path's entire in-memory engine is an ephemeral replay namespace discarded after the run, and the warehouse path writes only into the isolated `replay_schema`, dropped after the run unless `--keep` is passed.
  */
 export interface ReplayExecuteOutput {
   /**
@@ -27,6 +27,14 @@ export interface ReplayExecuteOutput {
    */
   model_count: number;
   models: ReplayExecuteModelOutput[];
+  /**
+   * Isolated warehouse schema the replayed outputs were materialized into (`--warehouse` only; absent on the local re-execution path). Replay never writes to the production location of any recorded target — every replayed table lands in this namespace, one schema per catalog touched.
+   */
+  replay_schema?: string | null;
+  /**
+   * Whether the replay namespace was removed after the run (`--warehouse` only). `true` when no replay schema remains on the warehouse; `false` when `--keep` was passed or a drop failed.
+   */
+  replay_schema_dropped?: boolean | null;
   run_id: string;
   /**
    * Recorded run status (`success`, `partial_failure`, ...).

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -151,7 +151,7 @@ pub use preview_rows::run_preview_rows;
 pub use profile::run_profile;
 pub use profile_storage::run_profile_storage;
 pub use publish_ir::run_publish_ir;
-pub use replay::{run_replay, run_replay_check, run_replay_execute};
+pub use replay::{run_replay, run_replay_check, run_replay_execute, run_replay_execute_warehouse};
 pub use retention_status::run_retention_status;
 pub use review::{compute_review, compute_review_queue, run_review, run_review_queue};
 // Re-exported so the `rocky` bin can build a clap ValueEnum for

--- a/engine/crates/rocky-cli/src/commands/replay.rs
+++ b/engine/crates/rocky-cli/src/commands/replay.rs
@@ -1,10 +1,15 @@
-//! `rocky replay <run_id|latest>` — inspect a recorded run.
+//! `rocky replay <run_id|latest>` — inspect, audit, or re-execute a recorded
+//! run.
 //!
-//! Surfaces the per-model SQL hashes, row counts, bytes, and timings captured
-//! by the state store's `RunRecord`. Re-execution with pinned inputs is an
-//! Arc-1 follow-up once the content-addressed write path arrives — the
-//! inspection surface exists today so the reproducibility claim has a
-//! concrete artefact to point at.
+//! Three surfaces share this module: the inspection view (per-model SQL
+//! hashes, row counts, bytes, and timings captured by the state store's
+//! `RunRecord`), the read-only replayability audit (`--check`), and
+//! re-execution (`--execute [--verify]`). Re-execution reconstructs each
+//! model's recipe from its recorded provenance — never the working tree —
+//! and runs it either on an ephemeral local DuckDB engine or, with
+//! `--warehouse`, against the live warehouse inside an isolated replay
+//! namespace, re-deriving the content-addressed output blake3 for comparison
+//! against the recorded artifact hash.
 
 use std::path::Path;
 
@@ -485,7 +490,6 @@ async fn execute_and_hash(
 
 /// A `non_replayable` per-model result — the fail-closed default for any
 /// re-execution the recording alone cannot support.
-#[cfg(feature = "duckdb")]
 fn non_replayable_exec(
     model_name: &str,
     nondeterministic: bool,
@@ -498,6 +502,92 @@ fn non_replayable_exec(
         recorded_hash: None,
         computed_hash: None,
         rows: None,
+        reasons,
+    }
+}
+
+/// Classify a completed re-execution into its per-model verdict.
+///
+/// Shared by the single-model, DAG, and warehouse re-execution paths so the
+/// verdict lattice is defined once: without `verify` the result is
+/// `executed`; with `verify`, a missing recorded hash is `non_replayable`, a
+/// matching digest is `bit_exact`, and a mismatch is `diverged` with the
+/// applicable caveats attached. `live_encoding` is `true` on the warehouse
+/// path, where the digest was re-derived with the live table's physical
+/// column mapping — making the offline encoding-skew caveat inapplicable.
+#[allow(clippy::too_many_arguments)]
+fn build_execute_verdict(
+    store: &StateStore,
+    run_id: &str,
+    model_name: &str,
+    nondeterministic: bool,
+    recorded_hash: Option<String>,
+    computed: String,
+    rows: u64,
+    verify: bool,
+    live_encoding: bool,
+) -> ReplayExecuteModelOutput {
+    if !verify {
+        return ReplayExecuteModelOutput {
+            model_name: model_name.to_string(),
+            verdict: "executed".to_string(),
+            nondeterministic,
+            recorded_hash,
+            computed_hash: Some(computed),
+            rows: Some(rows),
+            reasons: Vec::new(),
+        };
+    }
+
+    let Some(recorded) = recorded_hash else {
+        return ReplayExecuteModelOutput {
+            model_name: model_name.to_string(),
+            verdict: "non_replayable".to_string(),
+            nondeterministic,
+            recorded_hash: None,
+            computed_hash: Some(computed),
+            rows: Some(rows),
+            reasons: vec!["provenance record carried no output hash to verify against".to_string()],
+        };
+    };
+
+    if computed == recorded {
+        return ReplayExecuteModelOutput {
+            model_name: model_name.to_string(),
+            verdict: "bit_exact".to_string(),
+            nondeterministic,
+            recorded_hash: Some(recorded),
+            computed_hash: Some(computed),
+            rows: Some(rows),
+            reasons: Vec::new(),
+        };
+    }
+
+    let mut reasons = vec![format!(
+        "re-executed output blake3 {} != recorded {}",
+        short_hash(&computed),
+        short_hash(&recorded)
+    )];
+    if !live_encoding && let Some(caveat) = encoding_skew_caveat(store, &recorded) {
+        reasons.push(caveat);
+    }
+    if let Some(caveat) = version_skew_caveat(store, run_id) {
+        reasons.push(caveat);
+    }
+    if nondeterministic {
+        reasons.push(
+            "expected: the recipe contains a nondeterministic construct \
+             (now()/random()/…), so a byte-identical replay is not guaranteed"
+                .to_string(),
+        );
+    }
+    ReplayExecuteModelOutput {
+        model_name: model_name.to_string(),
+        verdict: "diverged".to_string(),
+        nondeterministic,
+        recorded_hash: Some(recorded),
+        computed_hash: Some(computed),
+        rows: Some(rows),
         reasons,
     }
 }
@@ -623,71 +713,17 @@ async fn replay_execute_model(
         }
     };
 
-    let recorded = prov.output_blake3.first().cloned();
-
-    if !verify {
-        return ReplayExecuteModelOutput {
-            model_name: model_name.to_string(),
-            verdict: "executed".to_string(),
-            nondeterministic: check.nondeterministic,
-            recorded_hash: recorded,
-            computed_hash: Some(computed),
-            rows: Some(rows),
-            reasons: Vec::new(),
-        };
-    }
-
-    let Some(recorded) = recorded else {
-        return ReplayExecuteModelOutput {
-            model_name: model_name.to_string(),
-            verdict: "non_replayable".to_string(),
-            nondeterministic: check.nondeterministic,
-            recorded_hash: None,
-            computed_hash: Some(computed),
-            rows: Some(rows),
-            reasons: vec!["provenance record carried no output hash to verify against".to_string()],
-        };
-    };
-
-    if computed == recorded {
-        ReplayExecuteModelOutput {
-            model_name: model_name.to_string(),
-            verdict: "bit_exact".to_string(),
-            nondeterministic: check.nondeterministic,
-            recorded_hash: Some(recorded),
-            computed_hash: Some(computed),
-            rows: Some(rows),
-            reasons: Vec::new(),
-        }
-    } else {
-        let mut reasons = vec![format!(
-            "re-executed output blake3 {} != recorded {}",
-            short_hash(&computed),
-            short_hash(&recorded)
-        )];
-        if let Some(caveat) = encoding_skew_caveat(store, &recorded) {
-            reasons.push(caveat);
-        }
-        if let Some(caveat) = version_skew_caveat(store, run_id) {
-            reasons.push(caveat);
-        }
-        if check.nondeterministic {
-            reasons.push(
-                "expected: the recipe contains a nondeterministic construct \
-                 (now()/random()/…), so a byte-identical replay is not guaranteed"
-                    .to_string(),
-            );
-        }
-        ReplayExecuteModelOutput {
-            model_name: model_name.to_string(),
-            verdict: "diverged".to_string(),
-            nondeterministic: check.nondeterministic,
-            recorded_hash: Some(recorded),
-            computed_hash: Some(computed),
-            rows: Some(rows),
-            reasons,
-        }
-    }
+    build_execute_verdict(
+        store,
+        run_id,
+        model_name,
+        check.nondeterministic,
+        prov.output_blake3.first().cloned(),
+        computed,
+        rows,
+        verify,
+        false,
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -717,8 +753,8 @@ fn encoding_skew_caveat(store: &StateStore, recorded_hash: &str) -> Option<Strin
         "caveat: the recorded hash's artifact lives on object storage, where the live UniForm \
          writer encodes parquet with the table's physical column mapping — a mapping the \
          offline replay's deterministic encoding does not reproduce — so this mismatch may be \
-         encoding skew over identical rows rather than a reproducibility gap (the \
-         warehouse-path replay is a later phase)"
+         encoding skew over identical rows rather than a reproducibility gap (re-run with \
+         `--warehouse` to compare against the live table's encoding)"
             .to_string()
     })
 }
@@ -765,7 +801,6 @@ fn target_fqn(ir: &ModelIr) -> String {
 /// record, its embedded IR parses, and it materialises a single whole-output
 /// blake3 (unpartitioned content-addressed). Models failing any of these get a
 /// direct `non_replayable` verdict and are never producers in the graph.
-#[cfg(feature = "duckdb")]
 struct DagCandidate {
     model_name: String,
     ir: ModelIr,
@@ -818,48 +853,33 @@ async fn ensure_namespace(
     Ok(())
 }
 
-/// Re-execute the *whole* recorded run in dependency order.
-///
-/// This is the DAG-order path taken when no `--model` filter is given. Each
-/// content-addressed model is reconstructed from its recording and executed on
-/// a **single shared** in-memory DuckDB engine in topological order, so a
-/// downstream model's `SELECT` reads its upstream's **replayed** output
-/// (materialised into the shared engine as `catalog.schema.table`) rather than
-/// the recorded object-store bytes or any production table. That is the real
-/// test of recipe sufficiency: a recipe that under-specifies its inputs
-/// diverges here because it consumed a freshly-replayed upstream.
-///
-/// Fail-closed cascade: a node whose in-run upstream did not materialise
-/// (blocked, errored, or itself `non_replayable`) is reported `non_replayable`
-/// and never runs against a missing/stale table — a divergent or errored
-/// upstream can never let a downstream fabricate a `bit_exact`. An upstream
-/// that *executed* but merely `diverged` still materialises (a diverged replay
-/// is still a replayed output), so its downstream reads those replayed bytes.
-///
-/// The `nondeterministic` flag is a static scan of a node's **own** SQL. A
-/// deterministic downstream of a nondeterministic upstream can therefore
-/// `diverge` without carrying the flag itself — the divergence is inherited
-/// through the replayed input, which is the honest, expected behaviour (the
-/// reason string still reports the byte mismatch). Propagating the flag
-/// transitively is a later refinement.
-///
-/// Isolation carries through from single-model replay: the entire engine is an
-/// ephemeral replay namespace, nothing is written to any warehouse or object
-/// store, and the working tree is never consulted.
-#[cfg(feature = "duckdb")]
-async fn replay_execute_dag(
+/// Which execution engine a DAG replay runs on. Decides the wording of the
+/// external-upstream block reason: the local path cannot reach object
+/// storage at all, while the warehouse path deliberately rebuilds only
+/// in-run upstreams (never substituting a table's current contents).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReplayEngineKind {
+    LocalDuckDb,
+    LiveWarehouse,
+}
+
+/// Pass A of DAG replay: reconstruct each recorded model from its provenance
+/// and split the run into executable [`DagCandidate`]s vs directly
+/// `non_replayable` verdicts. Reconstructs from the recording only — never
+/// the working tree.
+fn collect_dag_candidates(
     store: &StateStore,
     record: &RunRecord,
-    verify: bool,
-) -> Vec<ReplayExecuteModelOutput> {
-    use std::collections::{HashMap, HashSet};
+) -> (
+    std::collections::HashMap<String, ReplayExecuteModelOutput>,
+    Vec<DagCandidate>,
+) {
+    use std::collections::HashMap;
 
     let run_id = &record.run_id;
     let mut finished: HashMap<String, ReplayExecuteModelOutput> = HashMap::new();
     let mut candidates: Vec<DagCandidate> = Vec::new();
 
-    // --- Pass A: reconstruct each model; separate executable candidates from
-    // directly-non_replayable models. Reconstruct from the recording only. ---
     for exec in &record.models_executed {
         let name = exec.model_name.clone();
         let Some(prov) = store.get_provenance(run_id, &name).ok().flatten() else {
@@ -943,12 +963,23 @@ async fn replay_execute_dag(
         });
     }
 
+    (finished, candidates)
+}
+
+/// Pass B of DAG replay: classify each candidate's upstreams into in-run
+/// edges vs a blocking external/watermark read. `upstreams` is moved out so
+/// the loop can mutate the candidate's other fields without an aliasing
+/// borrow.
+fn classify_candidate_upstreams(
+    candidates: &mut [DagCandidate],
+    record: &RunRecord,
+    engine: ReplayEngineKind,
+) {
+    use std::collections::HashSet;
+
     let produced: HashSet<String> = candidates.iter().map(|c| c.output_fqn.clone()).collect();
 
-    // --- Pass B: classify each candidate's upstreams into in-run edges vs a
-    // blocking external/watermark read. `upstreams` is moved out so the loop
-    // can mutate the candidate's other fields without an aliasing borrow. ---
-    for cand in &mut candidates {
+    for cand in candidates.iter_mut() {
         for upstream in std::mem::take(&mut cand.upstreams) {
             match upstream {
                 UpstreamIdentity::Content { upstream_key, .. } => {
@@ -972,12 +1003,21 @@ async fn replay_execute_dag(
                                  it (the run predates auditable reuse or `[reuse]` was disabled)"
                             )
                         } else {
-                            format!(
-                                "upstream '{upstream_key}' is content-addressed but is not produced by \
-                                 any model in this recorded run; its recorded bytes live on object \
-                                 storage that the creds-free DAG replay never reads (a warehouse-path \
-                                 replay is a later phase)"
-                            )
+                            match engine {
+                                ReplayEngineKind::LocalDuckDb => format!(
+                                    "upstream '{upstream_key}' is content-addressed but is not \
+                                     produced by any model in this recorded run; its recorded \
+                                     bytes live on object storage that the creds-free DAG replay \
+                                     never reads"
+                                ),
+                                ReplayEngineKind::LiveWarehouse => format!(
+                                    "upstream '{upstream_key}' is content-addressed but is not \
+                                     produced by any model in this recorded run; the warehouse \
+                                     replay rebuilds only in-run upstreams from their recipes \
+                                     and never substitutes an upstream table's current contents \
+                                     (pinning a cross-run recorded upstream is a later phase)"
+                                ),
+                            }
                         });
                         break;
                     }
@@ -992,6 +1032,47 @@ async fn replay_execute_dag(
             }
         }
     }
+}
+
+/// Re-execute the *whole* recorded run in dependency order.
+///
+/// This is the DAG-order path taken when no `--model` filter is given. Each
+/// content-addressed model is reconstructed from its recording and executed on
+/// a **single shared** in-memory DuckDB engine in topological order, so a
+/// downstream model's `SELECT` reads its upstream's **replayed** output
+/// (materialised into the shared engine as `catalog.schema.table`) rather than
+/// the recorded object-store bytes or any production table. That is the real
+/// test of recipe sufficiency: a recipe that under-specifies its inputs
+/// diverges here because it consumed a freshly-replayed upstream.
+///
+/// Fail-closed cascade: a node whose in-run upstream did not materialise
+/// (blocked, errored, or itself `non_replayable`) is reported `non_replayable`
+/// and never runs against a missing/stale table — a divergent or errored
+/// upstream can never let a downstream fabricate a `bit_exact`. An upstream
+/// that *executed* but merely `diverged` still materialises (a diverged replay
+/// is still a replayed output), so its downstream reads those replayed bytes.
+///
+/// The `nondeterministic` flag is a static scan of a node's **own** SQL. A
+/// deterministic downstream of a nondeterministic upstream can therefore
+/// `diverge` without carrying the flag itself — the divergence is inherited
+/// through the replayed input, which is the honest, expected behaviour (the
+/// reason string still reports the byte mismatch). Propagating the flag
+/// transitively is a later refinement.
+///
+/// Isolation carries through from single-model replay: the entire engine is an
+/// ephemeral replay namespace, nothing is written to any warehouse or object
+/// store, and the working tree is never consulted.
+#[cfg(feature = "duckdb")]
+async fn replay_execute_dag(
+    store: &StateStore,
+    record: &RunRecord,
+    verify: bool,
+) -> Vec<ReplayExecuteModelOutput> {
+    use std::collections::{HashMap, HashSet};
+
+    let run_id = &record.run_id;
+    let (mut finished, mut candidates) = collect_dag_candidates(store, record);
+    classify_candidate_upstreams(&mut candidates, record, ReplayEngineKind::LocalDuckDb);
 
     // --- Topological order over the in-run edges (Kahn). A cycle (which the
     // real engine's acyclic DAG never produces) leaves its members unordered;
@@ -1146,76 +1227,23 @@ async fn replay_execute_dag_node(
     }
     materialized.insert(cand.output_fqn.clone());
 
-    if !verify {
-        return ReplayExecuteModelOutput {
-            model_name: cand.model_name.clone(),
-            verdict: "executed".to_string(),
-            nondeterministic: cand.nondeterministic,
-            recorded_hash: cand.recorded_hash.clone(),
-            computed_hash: Some(computed),
-            rows: Some(rows),
-            reasons: Vec::new(),
-        };
-    }
-
-    let Some(recorded) = cand.recorded_hash.clone() else {
-        return ReplayExecuteModelOutput {
-            model_name: cand.model_name.clone(),
-            verdict: "non_replayable".to_string(),
-            nondeterministic: cand.nondeterministic,
-            recorded_hash: None,
-            computed_hash: Some(computed),
-            rows: Some(rows),
-            reasons: vec!["provenance record carried no output hash to verify against".to_string()],
-        };
-    };
-
-    if computed == recorded {
-        ReplayExecuteModelOutput {
-            model_name: cand.model_name.clone(),
-            verdict: "bit_exact".to_string(),
-            nondeterministic: cand.nondeterministic,
-            recorded_hash: Some(recorded),
-            computed_hash: Some(computed),
-            rows: Some(rows),
-            reasons: Vec::new(),
-        }
-    } else {
-        let mut reasons = vec![format!(
-            "re-executed output blake3 {} != recorded {}",
-            short_hash(&computed),
-            short_hash(&recorded)
-        )];
-        if let Some(caveat) = encoding_skew_caveat(store, &recorded) {
-            reasons.push(caveat);
-        }
-        if let Some(caveat) = version_skew_caveat(store, run_id) {
-            reasons.push(caveat);
-        }
-        if cand.nondeterministic {
-            reasons.push(
-                "expected: the recipe contains a nondeterministic construct \
-                 (now()/random()/…), so a byte-identical replay is not guaranteed"
-                    .to_string(),
-            );
-        }
-        ReplayExecuteModelOutput {
-            model_name: cand.model_name.clone(),
-            verdict: "diverged".to_string(),
-            nondeterministic: cand.nondeterministic,
-            recorded_hash: Some(recorded),
-            computed_hash: Some(computed),
-            rows: Some(rows),
-            reasons,
-        }
-    }
+    build_execute_verdict(
+        store,
+        run_id,
+        &cand.model_name,
+        cand.nondeterministic,
+        cand.recorded_hash.clone(),
+        computed,
+        rows,
+        verify,
+        false,
+    )
 }
 
 /// Kahn topological sort of the candidates over their in-run edges. Any node
 /// left over after the queue drains (only possible under a cycle the real
 /// acyclic engine never emits) is appended so it still receives an
 /// unmaterialised-upstream cascade verdict.
-#[cfg(feature = "duckdb")]
 fn topo_order(candidates: &[DagCandidate]) -> Vec<String> {
     use std::collections::{HashMap, VecDeque};
 
@@ -1268,7 +1296,6 @@ fn topo_order(candidates: &[DagCandidate]) -> Vec<String> {
 }
 
 /// Assemble the per-model verdicts back into `record.models_executed` order.
-#[cfg(feature = "duckdb")]
 fn assemble(
     record: &RunRecord,
     mut finished: std::collections::HashMap<String, ReplayExecuteModelOutput>,
@@ -1347,6 +1374,8 @@ pub async fn run_replay_execute(
             verified: verify,
             model_count: models.len(),
             bit_exact_count,
+            replay_schema: None,
+            replay_schema_dropped: None,
             models,
         };
         println!("{}", serde_json::to_string_pretty(&output)?);
@@ -1359,6 +1388,530 @@ pub async fn run_replay_execute(
             println!("re-executed: {} models", models.len());
         }
         for m in &models {
+            print!("  {}  {}", m.model_name, m.verdict);
+            if m.nondeterministic {
+                print!("  [nondeterministic]");
+            }
+            if let Some(rows) = m.rows {
+                print!("  rows={rows}");
+            }
+            println!();
+            if let (Some(c), Some(r)) = (&m.computed_hash, &m.recorded_hash) {
+                println!(
+                    "      computed={}  recorded={}",
+                    short_hash(c),
+                    short_hash(r)
+                );
+            }
+            for reason in &m.reasons {
+                println!("      - {reason}");
+            }
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// `rocky replay --execute --warehouse [--verify] [--keep]` — content-addressed
+// re-execution on the live warehouse, isolated in a replay-scoped schema
+// ---------------------------------------------------------------------------
+
+/// Prefix of the isolated warehouse schema a replay materialises into.
+const REPLAY_SCHEMA_PREFIX: &str = "hcv2_replay_";
+
+/// Isolated schema name for a warehouse replay of `run_id`.
+///
+/// The run id is reduced to lowercase alphanumerics (bounded length) so the
+/// name is always a valid SQL identifier, and it is deterministic per run —
+/// re-replaying the same run reuses (and `CREATE OR REPLACE`s within) the
+/// same namespace instead of leaking one schema per attempt.
+fn replay_schema_name(run_id: &str) -> String {
+    let mut sanitized: String = run_id
+        .chars()
+        .filter(char::is_ascii_alphanumeric)
+        .map(|c| c.to_ascii_lowercase())
+        .take(24)
+        .collect();
+    if sanitized.is_empty() {
+        sanitized.push_str("unnamed");
+    }
+    format!("{REPLAY_SCHEMA_PREFIX}{sanitized}")
+}
+
+/// Result of a warehouse DAG replay: the per-model verdicts plus the
+/// isolation bookkeeping the output surface reports.
+struct WarehouseReplayOutcome {
+    models: Vec<ReplayExecuteModelOutput>,
+    replay_schema: String,
+    /// `true` iff no replay-namespace schema remains on the warehouse
+    /// (vacuously true when nothing was created).
+    schema_dropped: bool,
+}
+
+/// Re-execute a recorded run on the live warehouse, isolated in
+/// [`replay_schema_name`]'s namespace.
+///
+/// Same DAG semantics as [`replay_execute_dag`], with three warehouse
+/// specifics:
+///
+/// - **Isolation.** Nothing is ever written to the production location of a
+///   recorded target. Each node's replayed output is materialised as
+///   `catalog.<replay_schema>.<orig_schema>__<orig_table>`, and a downstream
+///   node's recorded SQL has its in-run upstream references rewritten to
+///   those replay tables before executing. Every rewrite is checked: an
+///   upstream whose reference cannot be located (or is ambiguous) makes the
+///   node `non_replayable` rather than letting the recipe silently read the
+///   production upstream.
+/// - **Live encoding identity.** The recomputed digest is encoded with the
+///   target table's *discovered* physical column mapping (via
+///   [`rederive_live_output_hash`]), so it is directly comparable to the
+///   hash the live content-addressed writer recorded. No object-store
+///   writes, no Delta commits: the S3 side is read-only.
+/// - **Teardown.** Every replay schema created is dropped (`CASCADE`) after
+///   the run unless `keep` — including after per-model failures, which are
+///   verdicts, not early exits.
+///
+/// [`rederive_live_output_hash`]: crate::commands::run_content_addressed::rederive_live_output_hash
+async fn replay_execute_warehouse(
+    store: &StateStore,
+    record: &RunRecord,
+    model_filter: Option<&str>,
+    verify: bool,
+    keep: bool,
+    warehouse: &dyn rocky_core::traits::WarehouseAdapter,
+) -> WarehouseReplayOutcome {
+    use std::collections::{HashMap, HashSet};
+
+    let run_id = &record.run_id;
+    let replay_schema = replay_schema_name(run_id);
+    let (mut finished, mut candidates) = collect_dag_candidates(store, record);
+
+    if let Some(name) = model_filter {
+        // Single-model mode mirrors the local path: only a self-contained
+        // recipe replays, because a filtered run rebuilds no upstreams.
+        candidates.retain(|c| c.model_name == name);
+        for cand in &mut candidates {
+            if !cand.upstreams.is_empty() {
+                cand.blocked_reason = Some(format!(
+                    "single-model re-execution requires a self-contained recipe, but this model \
+                     reads {} recorded upstream(s); omit --model to replay the whole run in DAG \
+                     order (upstream references are then redirected to their replayed outputs — \
+                     current warehouse data is never substituted)",
+                    cand.upstreams.len()
+                ));
+            }
+        }
+    } else {
+        classify_candidate_upstreams(&mut candidates, record, ReplayEngineKind::LiveWarehouse);
+    }
+
+    let order = topo_order(&candidates);
+    let by_name: HashMap<&str, &DagCandidate> = candidates
+        .iter()
+        .map(|c| (c.model_name.as_str(), c))
+        .collect();
+
+    // Catalogs in which `CREATE SCHEMA <catalog>.<replay_schema>` succeeded —
+    // the exact set torn down afterwards.
+    let mut created_catalogs: HashSet<String> = HashSet::new();
+    let mut materialized: HashSet<String> = HashSet::new();
+
+    for name in order {
+        let cand = by_name[name.as_str()];
+
+        if let Some(reason) = &cand.blocked_reason {
+            finished.insert(
+                cand.model_name.clone(),
+                non_replayable_exec(
+                    &cand.model_name,
+                    cand.nondeterministic,
+                    vec![reason.clone()],
+                ),
+            );
+            continue;
+        }
+
+        // Fail-closed cascade: every in-run upstream must have materialised.
+        if let Some(missing) = cand
+            .in_run_upstreams
+            .iter()
+            .find(|u| !materialized.contains(*u))
+        {
+            finished.insert(
+                cand.model_name.clone(),
+                non_replayable_exec(
+                    &cand.model_name,
+                    cand.nondeterministic,
+                    vec![format!(
+                        "upstream '{missing}' could not be replayed, so its replayed output is \
+                         unavailable to feed this model (cascade)"
+                    )],
+                ),
+            );
+            continue;
+        }
+
+        finished.insert(
+            cand.model_name.clone(),
+            replay_execute_warehouse_node(
+                store,
+                run_id,
+                warehouse,
+                cand,
+                verify,
+                &replay_schema,
+                &mut created_catalogs,
+                &mut materialized,
+            )
+            .await,
+        );
+    }
+
+    // Teardown: drop every replay schema this run created, even when every
+    // node failed — a per-model failure is a verdict, never an early return,
+    // so control always reaches here.
+    let mut schema_dropped = true;
+    if keep {
+        schema_dropped = created_catalogs.is_empty();
+    } else {
+        for catalog in &created_catalogs {
+            let drop_sql = format!("DROP SCHEMA IF EXISTS {catalog}.{replay_schema} CASCADE");
+            if let Err(e) = warehouse.execute_statement(&drop_sql).await {
+                tracing::warn!(
+                    catalog = catalog.as_str(),
+                    replay_schema = replay_schema.as_str(),
+                    error = %e,
+                    "replay: failed to drop the replay schema — manual cleanup needed"
+                );
+                schema_dropped = false;
+            }
+        }
+    }
+
+    let models: Vec<ReplayExecuteModelOutput> = match model_filter {
+        Some(name) => record
+            .models_executed
+            .iter()
+            .filter(|exec| exec.model_name == name)
+            .map(|exec| {
+                finished.remove(&exec.model_name).unwrap_or_else(|| {
+                    non_replayable_exec(
+                        &exec.model_name,
+                        false,
+                        vec!["model was not reached by the replay DAG".to_string()],
+                    )
+                })
+            })
+            .collect(),
+        None => assemble(record, finished),
+    };
+
+    WarehouseReplayOutcome {
+        models,
+        replay_schema,
+        schema_dropped,
+    }
+}
+
+/// Execute one topologically-ready node on the live warehouse.
+///
+/// Order of operations (each failure is a fail-closed `non_replayable`
+/// verdict): validate the recorded identifiers, redirect in-run upstream
+/// references into the replay namespace (checked — no reference may remain
+/// pointing at a production upstream), ensure the replay schema exists in
+/// the node's catalog, re-derive the output digest against the live table's
+/// encoding identity, then materialise the replayed output for downstream
+/// consumers and operator inspection. Only after all of that is the digest
+/// compared (`verify`) via [`build_execute_verdict`].
+#[allow(clippy::too_many_arguments)]
+async fn replay_execute_warehouse_node(
+    store: &StateStore,
+    run_id: &str,
+    warehouse: &dyn rocky_core::traits::WarehouseAdapter,
+    cand: &DagCandidate,
+    verify: bool,
+    replay_schema: &str,
+    created_catalogs: &mut std::collections::HashSet<String>,
+    materialized: &mut std::collections::HashSet<String>,
+) -> ReplayExecuteModelOutput {
+    use std::collections::HashMap;
+
+    use rocky_sql::defer::DeferTarget;
+    use rocky_sql::validation::validate_identifier;
+
+    let catalog = &cand.ir.target.catalog;
+
+    // Validate every identifier interpolated into DDL below. The recorded IR
+    // is trusted provenance, but fail closed on anything malformed rather
+    // than hand it to the warehouse.
+    for part in [catalog, &cand.ir.target.schema, &cand.ir.target.table] {
+        if validate_identifier(part).is_err() {
+            return non_replayable_exec(
+                &cand.model_name,
+                cand.nondeterministic,
+                vec![format!(
+                    "recorded target identifier {part:?} is not a valid SQL identifier — \
+                     fail-closed rather than interpolate it into replay DDL"
+                )],
+            );
+        }
+    }
+
+    // `<orig_schema>__<orig_table>` keeps two same-named tables from
+    // different production schemas collision-free inside the one replay
+    // schema per catalog.
+    let replay_table = format!("{}__{}", cand.ir.target.schema, cand.ir.target.table);
+
+    // Redirect in-run upstream references into the replay namespace. Checked
+    // rewrite: every recorded upstream must be located (unambiguously) among
+    // the recipe's table references, otherwise executing the SQL would read
+    // the production upstream's *current* contents — exactly what replay
+    // must never silently do.
+    let sql = if cand.in_run_upstreams.is_empty() {
+        cand.ir.sql.clone()
+    } else {
+        let mut renames: HashMap<String, DeferTarget> = HashMap::new();
+        for upstream in &cand.in_run_upstreams {
+            let parts: Vec<&str> = upstream.split('.').collect();
+            let [up_catalog, up_schema, up_table] = parts.as_slice() else {
+                return non_replayable_exec(
+                    &cand.model_name,
+                    cand.nondeterministic,
+                    vec![format!(
+                        "recorded upstream key {upstream:?} is not a catalog.schema.table \
+                         identity"
+                    )],
+                );
+            };
+            if [up_catalog, up_schema, up_table]
+                .iter()
+                .any(|p| validate_identifier(p).is_err())
+            {
+                return non_replayable_exec(
+                    &cand.model_name,
+                    cand.nondeterministic,
+                    vec![format!(
+                        "recorded upstream key {upstream:?} contains a part that is not a \
+                         valid SQL identifier"
+                    )],
+                );
+            }
+            renames.insert(
+                upstream.to_ascii_lowercase(),
+                DeferTarget {
+                    catalog: (*up_catalog).to_string(),
+                    schema: replay_schema.to_string(),
+                    table: format!("{up_schema}__{up_table}"),
+                    quote_style: None,
+                },
+            );
+        }
+        let outcome = match rocky_sql::defer::rewrite_upstream_refs(&cand.ir.sql, &renames) {
+            Ok(outcome) => outcome,
+            Err(e) => {
+                return non_replayable_exec(
+                    &cand.model_name,
+                    cand.nondeterministic,
+                    vec![format!(
+                        "recorded SQL could not be parsed to redirect upstream references into \
+                         the replay namespace: {e}"
+                    )],
+                );
+            }
+        };
+        if !outcome.ambiguous_refs.is_empty() {
+            return non_replayable_exec(
+                &cand.model_name,
+                cand.nondeterministic,
+                vec![format!(
+                    "table reference(s) {:?} match more than one recorded upstream, so the \
+                     redirection into the replay namespace is ambiguous — fail-closed rather \
+                     than guess which replayed upstream to read",
+                    outcome.ambiguous_refs
+                )],
+            );
+        }
+        if let Some(missing) = renames
+            .keys()
+            .find(|k| !outcome.rewritten_keys.contains(*k))
+        {
+            return non_replayable_exec(
+                &cand.model_name,
+                cand.nondeterministic,
+                vec![format!(
+                    "recorded upstream '{missing}' was not found among the recipe's table \
+                     references, so its reference cannot be redirected into the replay \
+                     namespace — fail-closed rather than let the recipe read the production \
+                     upstream's current contents"
+                )],
+            );
+        }
+        outcome.sql
+    };
+
+    // Ensure the isolated replay schema exists in this node's catalog.
+    if !created_catalogs.contains(catalog) {
+        let create_sql = format!("CREATE SCHEMA IF NOT EXISTS {catalog}.{replay_schema}");
+        if let Err(e) = warehouse.execute_statement(&create_sql).await {
+            return non_replayable_exec(
+                &cand.model_name,
+                cand.nondeterministic,
+                vec![format!(
+                    "could not create the isolated replay schema {catalog}.{replay_schema}: {e}"
+                )],
+            );
+        }
+        created_catalogs.insert(catalog.clone());
+    }
+
+    // Re-derive the output digest against the live table's encoding identity
+    // (a SELECT + Delta-log GETs; no writes anywhere).
+    let (rows, computed) = match crate::commands::run_content_addressed::rederive_live_output_hash(
+        &cand.ir, &sql, warehouse,
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            return non_replayable_exec(
+                &cand.model_name,
+                cand.nondeterministic,
+                vec![format!(
+                    "re-execution could not reproduce the artifact: {e:#}"
+                )],
+            );
+        }
+    };
+
+    // Materialise the replayed output for downstream consumers (and for
+    // operator inspection under `--keep`). A second evaluation of the same
+    // recipe, exactly like the local DAG path; a failure creates no table,
+    // so the fail-closed cascade denies dependents.
+    let ctas = format!("CREATE OR REPLACE TABLE {catalog}.{replay_schema}.{replay_table} AS {sql}");
+    if let Err(e) = warehouse.execute_statement(&ctas).await {
+        return non_replayable_exec(
+            &cand.model_name,
+            cand.nondeterministic,
+            vec![format!(
+                "re-executed but could not materialise the replayed output for downstream \
+                 consumers: {e}"
+            )],
+        );
+    }
+    materialized.insert(cand.output_fqn.clone());
+
+    build_execute_verdict(
+        store,
+        run_id,
+        &cand.model_name,
+        cand.nondeterministic,
+        cand.recorded_hash.clone(),
+        computed,
+        rows,
+        verify,
+        true,
+    )
+}
+
+/// Execute `rocky replay --execute --warehouse [--verify] [--keep]`.
+///
+/// Re-executes a recorded content-addressed run against the live warehouse
+/// configured in `rocky.toml`, inside an isolated replay schema (never the
+/// production location of any recorded target). Each model's recipe comes
+/// from its recorded provenance — never the working tree — and its
+/// recomputed blake3 is encoded with the live table's physical column
+/// mapping, so with `--verify` a `bit_exact` verdict means the warehouse
+/// re-derived the recorded artifact byte-for-byte.
+///
+/// Verdicts (`bit_exact` / `diverged` / `non_replayable`) are
+/// classifications, not tool failures: this returns `Ok` (exit 0) unless the
+/// run, config, or adapter cannot be resolved at all.
+pub async fn run_replay_execute_warehouse(
+    config_path: &Path,
+    state_path: &Path,
+    target: &str,
+    model_filter: Option<&str>,
+    verify: bool,
+    keep: bool,
+    json: bool,
+) -> Result<()> {
+    let store = StateStore::open_read_only(state_path)
+        .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
+
+    let record = resolve(&store, target)?;
+    if let Some(name) = model_filter
+        && !record.models_executed.iter().any(|m| m.model_name == name)
+    {
+        anyhow::bail!("run '{}' did not execute model '{name}'", record.run_id);
+    }
+
+    let cfg = rocky_core::config::load_rocky_config(config_path)
+        .with_context(|| format!("loading config from {}", config_path.display()))?;
+    let registry = crate::registry::AdapterRegistry::from_config(&cfg)
+        .context("building adapter registry from config")?;
+    let adapter_names = registry.warehouse_adapter_names();
+    let adapter_name = if adapter_names.iter().any(|n| n == "default") {
+        "default".to_string()
+    } else {
+        adapter_names
+            .into_iter()
+            .next()
+            .context("no warehouse adapters configured for warehouse replay")?
+    };
+    let warehouse = registry.warehouse_adapter(&adapter_name)?;
+
+    let outcome = replay_execute_warehouse(
+        &store,
+        &record,
+        model_filter,
+        verify,
+        keep,
+        warehouse.as_ref(),
+    )
+    .await;
+
+    let bit_exact_count = outcome
+        .models
+        .iter()
+        .filter(|m| m.verdict == "bit_exact")
+        .count();
+
+    if json {
+        let output = ReplayExecuteOutput {
+            version: VERSION.to_string(),
+            command: if verify {
+                "replay --execute --warehouse --verify".to_string()
+            } else {
+                "replay --execute --warehouse".to_string()
+            },
+            run_id: record.run_id.clone(),
+            status: status_str(&record.status).to_string(),
+            verified: verify,
+            model_count: outcome.models.len(),
+            bit_exact_count,
+            replay_schema: Some(outcome.replay_schema),
+            replay_schema_dropped: Some(outcome.schema_dropped),
+            models: outcome.models,
+        };
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        println!("run: {}", record.run_id);
+        println!("status: {}", status_str(&record.status));
+        println!("replay schema: {}", outcome.replay_schema);
+        println!(
+            "replay schema dropped: {}",
+            if outcome.schema_dropped { "yes" } else { "no" }
+        );
+        if verify {
+            println!(
+                "bit-exact: {}/{} models",
+                bit_exact_count,
+                outcome.models.len()
+            );
+        } else {
+            println!("re-executed: {} models", outcome.models.len());
+        }
+        for m in &outcome.models {
             print!("  {}  {}", m.model_name, m.verdict);
             if m.nondeterministic {
                 print!("  [nondeterministic]");
@@ -1823,5 +2376,357 @@ mod tests {
         assert!(v.computed_hash.is_some());
         assert_eq!(v.rows, Some(1));
         assert!(v.reasons.is_empty());
+    }
+
+    // -- warehouse replay: namespacing + isolation -------------------------
+
+    #[test]
+    fn replay_schema_name_is_a_valid_identifier() {
+        let name = replay_schema_name("run-20260712-101112-334");
+        assert!(name.starts_with(REPLAY_SCHEMA_PREFIX));
+        // Every character is a valid SQL identifier char (the prefix is too).
+        assert!(
+            name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'),
+            "replay schema name must be a bare SQL identifier: {name}"
+        );
+        // Deterministic per run id — re-replaying reuses the namespace.
+        assert_eq!(name, replay_schema_name("run-20260712-101112-334"));
+    }
+
+    #[test]
+    fn replay_schema_name_handles_degenerate_run_ids() {
+        // A run id with no alphanumerics still yields a usable identifier.
+        let name = replay_schema_name("///---");
+        assert_eq!(name, format!("{REPLAY_SCHEMA_PREFIX}unnamed"));
+        // Length is bounded so the schema name stays within warehouse limits.
+        let long = replay_schema_name(&"a".repeat(200));
+        assert_eq!(long.len(), REPLAY_SCHEMA_PREFIX.len() + 24);
+    }
+
+    // -- Databricks warehouse-replay live-verify (env-gated, #[ignore]) -----
+
+    /// Live end-to-end verification of the **content-addressed warehouse
+    /// replay** path against a real Databricks UniForm table. Written, not
+    /// run in CI — the `#[ignore]` is the real gate (CI runs `--all-features`
+    /// so a feature gate alone would still execute it).
+    ///
+    /// # What it certifies (and why only the live path can)
+    ///
+    /// Every offline `bit_exact` unit test seeds the recorded hash from the
+    /// same `build_parquet` the replay recomputes, so it can only prove
+    /// replay == replay. The load-bearing claim — that a warehouse replay
+    /// re-derives the digest the live `UniformWriter` recorded, encoded with
+    /// the table's *discovered* physical column mapping — is verifiable only
+    /// here: this test records a genuine content-addressed run (real S3 CAS
+    /// write + real artifact hash in the ledger), replays it through the
+    /// warehouse path, and asserts the verdict is `bit_exact`.
+    ///
+    /// # Isolation proof
+    ///
+    /// It also proves replay never writes the production target: the
+    /// production table's row count is captured after the recorded run and
+    /// again after replay and must be unchanged (replay materialises only
+    /// into the dropped-after `hcv2_replay_*` schema), and `schema_dropped`
+    /// must be `true`. The replay is run twice to confirm stability.
+    ///
+    /// # Reachability boundary (read before running)
+    ///
+    /// Mirrors `content_addressed_e2e_live_sandbox`: the target must be a
+    /// pre-provisioned external, unpartitioned, name-column-mapped UniForm
+    /// table with the canonical `(id BIGINT, name STRING, ts TIMESTAMP)`
+    /// shape, under an `hc_`/`hcv2_`-prefixed sandbox schema. Env vars:
+    /// `ROCKY_TEST_S3_BUCKET` / `ROCKY_TEST_S3_PREFIX` / `ROCKY_TEST_CATALOG`
+    /// / `ROCKY_TEST_SCHEMA` / `ROCKY_TEST_TABLE` + `DATABRICKS_*` + AWS env
+    /// creds. Teardown `DELETE`s the rows the recorded run appended (a `DROP
+    /// SCHEMA CASCADE` would destroy the externally provisioned fixture); the
+    /// content-addressed parquet objects are not deletable with these creds
+    /// and leak by design.
+    #[tokio::test]
+    #[ignore = "requires Databricks + s3 credentials; run manually — see doc comment"]
+    async fn warehouse_replay_bit_exact_live_sandbox() {
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        use rocky_core::reuse::{OutputArtifact, build_records};
+        use rocky_core::state::{
+            ArtifactRecord, ModelExecution, RunRecord, RunStatus, RunTrigger, SessionSource,
+        };
+        use rocky_core::traits::WarehouseAdapter;
+        use rocky_databricks::adapter::DatabricksWarehouseAdapter;
+        use rocky_databricks::auth::{Auth, AuthConfig};
+        use rocky_databricks::connector::{ConnectorConfig, DatabricksConnector};
+        use rocky_ir::{
+            GovernanceConfig, MaterializationStrategy, ModelIr, RockyType, TargetRef, TypedColumn,
+        };
+
+        let (Ok(bucket), Ok(prefix), Ok(catalog), Ok(schema), Ok(table)) = (
+            std::env::var("ROCKY_TEST_S3_BUCKET"),
+            std::env::var("ROCKY_TEST_S3_PREFIX"),
+            std::env::var("ROCKY_TEST_CATALOG"),
+            std::env::var("ROCKY_TEST_SCHEMA"),
+            std::env::var("ROCKY_TEST_TABLE"),
+        ) else {
+            eprintln!("skipping warehouse_replay_bit_exact_live_sandbox: ROCKY_TEST_* not set");
+            return;
+        };
+        let (Ok(host), Ok(http_path)) = (
+            std::env::var("DATABRICKS_HOST"),
+            std::env::var("DATABRICKS_HTTP_PATH"),
+        ) else {
+            eprintln!("skipping warehouse_replay_bit_exact_live_sandbox: DATABRICKS_* not set");
+            return;
+        };
+        let Some(warehouse_id) = ConnectorConfig::warehouse_id_from_http_path(&http_path) else {
+            eprintln!("skipping: DATABRICKS_HTTP_PATH has no warehouse id");
+            return;
+        };
+        let Ok(auth) = Auth::from_config(AuthConfig {
+            host: host.clone(),
+            token: std::env::var("DATABRICKS_TOKEN").ok(),
+            client_id: std::env::var("DATABRICKS_CLIENT_ID").ok(),
+            client_secret: std::env::var("DATABRICKS_CLIENT_SECRET").ok(),
+        }) else {
+            eprintln!("skipping: Databricks auth could not be constructed");
+            return;
+        };
+        let warehouse = DatabricksWarehouseAdapter::new(DatabricksConnector::new(
+            ConnectorConfig {
+                host,
+                warehouse_id,
+                timeout: Duration::from_secs(120),
+                retry: Default::default(),
+            },
+            auth,
+        ));
+        let warehouse_dyn: &dyn WarehouseAdapter = &warehouse;
+        let storage_prefix = format!("s3://{bucket}/{prefix}");
+        let fqtn = format!("{catalog}.{schema}.{table}");
+
+        let count_rows = async |w: &dyn WarehouseAdapter| -> i64 {
+            let r = w
+                .execute_query(&format!("SELECT COUNT(*) AS n FROM {fqtn}"))
+                .await
+                .expect("count query");
+            r.rows[0][0]
+                .as_i64()
+                .or_else(|| r.rows[0][0].as_str().and_then(|s| s.parse().ok()))
+                .expect("count i64")
+        };
+
+        // Distinct id range so re-runs are self-cleaning; pre-clean any leak.
+        let (id_a, id_b, id_c) = (960_001_i64, 960_002, 960_003);
+        warehouse_dyn
+            .execute_statement(&format!(
+                "DELETE FROM {fqtn} WHERE id IN ({id_a}, {id_b}, {id_c})"
+            ))
+            .await
+            .expect("pre-clean");
+
+        // --- Record a genuine content-addressed run: real S3 CAS write +
+        // real artifact hash. The SQL bakes in literal timestamps so the
+        // recorded recipe is self-contained and deterministic on replay. ---
+        let now_micros = chrono::Utc::now().timestamp_micros();
+        let ts = |off: i64| {
+            chrono::DateTime::from_timestamp_micros(now_micros + off)
+                .unwrap()
+                .format("%Y-%m-%dT%H:%M:%S%.6f")
+                .to_string()
+        };
+        let model_sql = format!(
+            "SELECT id, name, ts FROM (VALUES \
+             (CAST({id_a} AS BIGINT), CAST('replay-a' AS STRING), TIMESTAMP'{}'), \
+             (CAST({id_b} AS BIGINT), CAST('replay-b' AS STRING), TIMESTAMP'{}'), \
+             (CAST({id_c} AS BIGINT), CAST('replay-c' AS STRING), TIMESTAMP'{}')) \
+             AS t(id, name, ts)",
+            ts(0),
+            ts(1),
+            ts(2),
+        );
+        let mut model_ir = ModelIr::transformation(
+            TargetRef {
+                catalog: catalog.clone(),
+                schema: schema.clone(),
+                table: table.clone(),
+            },
+            MaterializationStrategy::ContentAddressed {
+                storage_prefix: storage_prefix.clone(),
+                partition_columns: vec![],
+            },
+            vec![],
+            model_sql.clone(),
+            GovernanceConfig {
+                permissions_file: None,
+                auto_create_catalogs: false,
+                auto_create_schemas: false,
+            },
+            None,
+            None,
+        );
+        model_ir.name = Arc::from("replay_live_model");
+        model_ir.typed_columns = vec![
+            TypedColumn {
+                name: "id".into(),
+                data_type: RockyType::Int64,
+                nullable: false,
+            },
+            TypedColumn {
+                name: "name".into(),
+                data_type: RockyType::String,
+                nullable: false,
+            },
+            TypedColumn {
+                name: "ts".into(),
+                data_type: RockyType::Timestamp,
+                nullable: false,
+            },
+        ];
+
+        let n_before_replay: i64;
+        {
+            let summary = crate::commands::run_content_addressed::execute_content_addressed_model(
+                &model_ir,
+                warehouse_dyn,
+                None,
+            )
+            .await
+            .expect("recorded content-addressed run must succeed");
+            assert_eq!(summary.num_rows, 3);
+            assert_eq!(summary.blake3_hash.len(), 64);
+            n_before_replay = count_rows(warehouse_dyn).await;
+
+            // --- Seed the ledger exactly as the runner would: provenance
+            // (with embedded canonical IR + real output hash) + artifact. ---
+            let tmp = TempDir::new().unwrap();
+            let store = StateStore::open(&tmp.path().join("state.redb")).unwrap();
+            let run_id = "run-warehouse-replay-live";
+            let outputs = vec![OutputArtifact {
+                blake3_hash: summary.blake3_hash.clone(),
+                file_path: summary.file_path.clone(),
+            }];
+            let (entry, prov) =
+                build_records(&model_ir, run_id, &[], &outputs, chrono::Utc::now()).unwrap();
+            store
+                .record_reuse_spine(std::slice::from_ref(&entry), std::slice::from_ref(&prov))
+                .unwrap();
+            store
+                .record_artifact(&ArtifactRecord {
+                    blake3_hash: summary.blake3_hash.clone(),
+                    run_id: run_id.to_string(),
+                    model_name: model_ir.name.to_string(),
+                    file_path: summary.file_path.clone(),
+                    commit_version: summary.commit_version,
+                    size_bytes: summary.size_bytes,
+                    written_at: chrono::Utc::now(),
+                })
+                .unwrap();
+            let now = chrono::Utc::now();
+            let record = RunRecord {
+                run_id: run_id.to_string(),
+                started_at: now,
+                finished_at: now,
+                status: RunStatus::Success,
+                models_executed: vec![ModelExecution {
+                    model_name: model_ir.name.to_string(),
+                    started_at: now,
+                    finished_at: now,
+                    duration_ms: 0,
+                    rows_affected: Some(3),
+                    status: "success".to_string(),
+                    sql_hash: String::new(),
+                    skip_hash: None,
+                    upstream_freshness: None,
+                    bytes_scanned: None,
+                    bytes_written: None,
+                    tenant: None,
+                    recipe_hash: None,
+                    input_hash: None,
+                    input_proof_class: None,
+                    env_hash: None,
+                    hash_scheme: None,
+                    output_column_hashes: None,
+                    attempts: Vec::new(),
+                }],
+                trigger: RunTrigger::Manual,
+                config_hash: "cfg".to_string(),
+                triggering_identity: None,
+                session_source: SessionSource::Cli,
+                git_commit: None,
+                git_branch: None,
+                idempotency_key: None,
+                target_catalog: None,
+                hostname: "replay-live".to_string(),
+                rocky_version: VERSION.to_string(),
+                check_outcomes: Vec::new(),
+            };
+            store.record_run(&record).unwrap();
+
+            // --- Replay through the warehouse path, twice, for stability. ---
+            for attempt in 1..=2 {
+                let outcome = replay_execute_warehouse(
+                    &store,
+                    &record,
+                    None,
+                    /* verify */ true,
+                    /* keep */ false,
+                    warehouse_dyn,
+                )
+                .await;
+                assert_eq!(outcome.models.len(), 1, "attempt {attempt}");
+                let m = &outcome.models[0];
+                assert_eq!(
+                    m.verdict, "bit_exact",
+                    "attempt {attempt}: warehouse replay must re-derive the recorded artifact \
+                     byte-for-byte; got {:?} reasons={:?}",
+                    m.verdict, m.reasons
+                );
+                assert_eq!(m.recorded_hash, m.computed_hash, "attempt {attempt}");
+                assert_eq!(m.rows, Some(3), "attempt {attempt}");
+                assert!(
+                    outcome.replay_schema.starts_with(REPLAY_SCHEMA_PREFIX),
+                    "attempt {attempt}: replayed into an isolated namespace"
+                );
+                assert!(
+                    outcome.schema_dropped,
+                    "attempt {attempt}: replay schema must be dropped after --verify"
+                );
+                // Isolation: production row count is untouched by replay.
+                let n_after = count_rows(warehouse_dyn).await;
+                assert_eq!(
+                    n_after, n_before_replay,
+                    "attempt {attempt}: replay must NOT write the production target \
+                     (before={n_before_replay}, after={n_after})"
+                );
+                // The replay schema must genuinely be gone.
+                let schema_gone = warehouse_dyn
+                    .execute_query(&format!(
+                        "SELECT COUNT(*) AS n FROM {catalog}.information_schema.schemata \
+                         WHERE schema_name = '{}'",
+                        outcome.replay_schema
+                    ))
+                    .await
+                    .ok()
+                    .and_then(|r| {
+                        r.rows[0][0]
+                            .as_i64()
+                            .or_else(|| r.rows[0][0].as_str().and_then(|s| s.parse().ok()))
+                    })
+                    .unwrap_or(0);
+                assert_eq!(
+                    schema_gone, 0,
+                    "attempt {attempt}: the replay schema {} must not remain",
+                    outcome.replay_schema
+                );
+            }
+        }
+
+        // Teardown: remove the rows the recorded run appended so re-runs are
+        // self-cleaning. The content-addressed parquet objects are not
+        // deletable with these creds and leak by design.
+        warehouse_dyn
+            .execute_statement(&format!(
+                "DELETE FROM {fqtn} WHERE id IN ({id_a}, {id_b}, {id_c})"
+            ))
+            .await
+            .expect("teardown DELETE");
     }
 }

--- a/engine/crates/rocky-cli/src/commands/run_content_addressed.rs
+++ b/engine/crates/rocky-cli/src/commands/run_content_addressed.rs
@@ -917,6 +917,89 @@ pub async fn execute_content_addressed_model(
     })
 }
 
+/// Re-derive a content-addressed model's output blake3 **against the live
+/// table's encoding identity**, without writing anything.
+///
+/// The warehouse replay path (`rocky replay --execute --warehouse`) uses this
+/// to make its recomputed digest directly comparable to the hash the live
+/// [`UniformWriter`] recorded: the recorded parquet was encoded with the
+/// table's physical column mapping (`col-<uuid>` names + field ids read from
+/// its `_delta_log`), so the replay must encode with the *same* discovered
+/// state — not the deterministic logical mapping the offline DuckDB replay
+/// pins.
+///
+/// Effects: one `discover()` (object-store GETs over the table's Delta log)
+/// and one `execute_query(sql)` on the warehouse. No object-store PUTs, no
+/// Delta commits, no DDL — this function never mutates the table, its log,
+/// or the CAS prefix.
+///
+/// `sql` is passed separately from `model_ir` because DAG replay may have
+/// redirected the recipe's in-run upstream references into the replay
+/// namespace; the typed columns and `storage_prefix` still come from the
+/// recorded IR.
+///
+/// # Errors
+///
+/// Fails when the strategy is not unpartitioned `ContentAddressed`, the
+/// table state cannot be discovered, the discovered table is partitioned,
+/// the query fails, or the rows cannot be encoded — callers map every error
+/// to a fail-closed `non_replayable` verdict.
+pub(crate) async fn rederive_live_output_hash(
+    model_ir: &ModelIr,
+    sql: &str,
+    warehouse: &dyn rocky_core::traits::WarehouseAdapter,
+) -> Result<(u64, String)> {
+    let MaterializationStrategy::ContentAddressed {
+        storage_prefix,
+        partition_columns,
+    } = &model_ir.materialization
+    else {
+        return Err(anyhow!(
+            "rederive_live_output_hash called on a non-ContentAddressed model"
+        ));
+    };
+    if !partition_columns.is_empty() {
+        return Err(anyhow!(
+            "partitioned models carry per-partition hashes, not a single whole-output digest"
+        ));
+    }
+
+    let store = build_object_store(storage_prefix)?;
+    let (_bucket, key_prefix) = parse_s3_url(storage_prefix)?;
+    let writer = UniformWriter::new(
+        UniformWriterConfig {
+            catalog: model_ir.target.catalog.clone(),
+            schema: model_ir.target.schema.clone(),
+            table: model_ir.target.table.clone(),
+            prefix: key_prefix,
+            engine_info: format!("rocky-cli/{}", env!("CARGO_PKG_VERSION")),
+        },
+        store,
+        Arc::new(NoOpSqlClient),
+    );
+    let state = writer
+        .discover()
+        .await
+        .with_context(|| format!("discover() failed for {:?}", model_ir.target))?;
+    if !state.partition_columns.is_empty() {
+        return Err(anyhow!(
+            "table at {storage_prefix:?} is partitioned ({:?}); the recorded whole-output hash \
+             is not reproducible from a single batch",
+            state.partition_columns
+        ));
+    }
+
+    let result = warehouse
+        .execute_query(sql)
+        .await
+        .map_err(|e| anyhow!("execute_query failed: {e}"))?;
+    let batch = query_result_to_record_batch(&model_ir.typed_columns, &result)?;
+    let rows = batch.num_rows() as u64;
+    let parquet = rocky_iceberg::uniform_writer::parquet_builder::build_parquet(&batch, &state)
+        .map_err(|e| anyhow!("replay parquet encode failed: {e}"))?;
+    Ok((rows, blake3::hash(&parquet).to_hex().to_string()))
+}
+
 /// Issue `MSCK REPAIR TABLE ... SYNC METADATA` directly via the warehouse
 /// adapter so DuckDB iceberg_scan + Iceberg-aware Trino + Photon see the
 /// commit(s) the writer just landed.

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -7502,11 +7502,16 @@ pub struct ReplayCheckInputOutput {
 
 /// JSON output for `rocky replay --at <run_id> --execute [--verify]`.
 ///
-/// Re-execution surface (DuckDB). Each model's recipe is reconstructed from its
+/// Re-execution surface. Each model's recipe is reconstructed from its
 /// recorded [`rocky_core::state::ProvenanceRecord`] — never the working tree —
-/// re-executed on an in-memory DuckDB engine, and its output artifact's blake3
-/// re-derived. With `--verify` that digest is compared against the recorded
-/// output hash and a per-model verdict is emitted.
+/// re-executed, and its output artifact's blake3 re-derived. With `--verify`
+/// that digest is compared against the recorded output hash and a per-model
+/// verdict is emitted. Execution runs on an in-memory DuckDB engine by
+/// default; with `--warehouse` it runs on the configured live warehouse
+/// instead, materializing replayed outputs into an isolated replay schema
+/// (see `replay_schema`) and encoding the recomputed artifact with the live
+/// table's physical column mapping so the digest is directly comparable to
+/// what the content-addressed writer recorded.
 ///
 /// Two modes share this shape:
 ///
@@ -7521,9 +7526,10 @@ pub struct ReplayCheckInputOutput {
 ///   upstream not produced by any model in this run, or a mutable-source
 ///   watermark, is likewise `non_replayable` rather than substituted.
 ///
-/// Nothing is materialized to any warehouse schema: the entire in-memory engine
-/// is an ephemeral replay namespace, discarded after the run, so no production
-/// identity is ever touched.
+/// No production identity is ever touched in either mode: the local path's
+/// entire in-memory engine is an ephemeral replay namespace discarded after
+/// the run, and the warehouse path writes only into the isolated
+/// `replay_schema`, dropped after the run unless `--keep` is passed.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct ReplayExecuteOutput {
     pub version: String,
@@ -7538,6 +7544,18 @@ pub struct ReplayExecuteOutput {
     /// Number of models whose re-execution reproduced the recorded output
     /// byte-for-byte. Always `0` when `--verify` was not requested.
     pub bit_exact_count: usize,
+    /// Isolated warehouse schema the replayed outputs were materialized
+    /// into (`--warehouse` only; absent on the local re-execution path).
+    /// Replay never writes to the production location of any recorded
+    /// target — every replayed table lands in this namespace, one schema
+    /// per catalog touched.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replay_schema: Option<String>,
+    /// Whether the replay namespace was removed after the run
+    /// (`--warehouse` only). `true` when no replay schema remains on the
+    /// warehouse; `false` when `--keep` was passed or a drop failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replay_schema_dropped: Option<bool>,
     pub models: Vec<ReplayExecuteModelOutput>,
 }
 

--- a/engine/crates/rocky-sql/src/defer.rs
+++ b/engine/crates/rocky-sql/src/defer.rs
@@ -124,6 +124,149 @@ pub fn qualify_deferred_refs(
     Ok(statement.to_string())
 }
 
+/// Outcome of [`rewrite_upstream_refs`].
+#[derive(Debug)]
+pub struct UpstreamRewriteOutcome {
+    /// The statement re-serialized after rewriting.
+    pub sql: String,
+    /// The rename keys (lowercase `catalog.schema.table`) that matched at
+    /// least one relation and were rewritten. Callers that require *every*
+    /// upstream reference to be redirected compare this against the rename
+    /// key set and fail closed on any miss.
+    pub rewritten_keys: HashSet<String>,
+    /// Display strings of relations that matched **more than one** rename
+    /// key (a partially-qualified reference whose tail is shared by several
+    /// upstreams). Ambiguous references are left untouched — callers must
+    /// fail closed rather than guess.
+    pub ambiguous_refs: Vec<String>,
+}
+
+/// Rewrite references to known upstream tables — bare, `schema.table`, or
+/// `catalog.schema.table` — to a replacement [`DeferTarget`].
+///
+/// `renames` is keyed by the upstream's lowercase fully-qualified
+/// `catalog.schema.table` identity. A relation matches a key when every part
+/// it *does* spell agrees case-insensitively with the key's tail: a three-part
+/// reference must match catalog, schema, and table; a two-part reference
+/// schema and table; a bare name just the table (subject to CTE shadowing,
+/// exactly as [`qualify_deferred_refs`] resolves it). A relation whose tail
+/// matches several keys is ambiguous: it is left as parsed and reported in
+/// [`UpstreamRewriteOutcome::ambiguous_refs`] so the caller can refuse the
+/// rewrite instead of redirecting a reference to the wrong upstream.
+///
+/// # Errors
+///
+/// Returns [`ParseError`] when `sql` is not a single parseable statement.
+pub fn rewrite_upstream_refs(
+    sql: &str,
+    renames: &HashMap<String, DeferTarget>,
+) -> Result<UpstreamRewriteOutcome, ParseError> {
+    let mut statement = parse_single_statement(sql)?;
+
+    // Pre-split each rename key into (catalog, schema, table) parts once.
+    let split: Vec<(Vec<String>, &String, &DeferTarget)> = renames
+        .iter()
+        .map(|(key, target)| {
+            let parts: Vec<String> = key.split('.').map(str::to_ascii_lowercase).collect();
+            (parts, key, target)
+        })
+        .collect();
+
+    let mut rewriter = UpstreamRewriter {
+        renames: &split,
+        scopes: Vec::new(),
+        rewritten_keys: HashSet::new(),
+        ambiguous_refs: Vec::new(),
+    };
+    let _: ControlFlow<()> = statement.visit(&mut rewriter);
+
+    let UpstreamRewriter {
+        rewritten_keys,
+        ambiguous_refs,
+        ..
+    } = rewriter;
+    Ok(UpstreamRewriteOutcome {
+        sql: statement.to_string(),
+        rewritten_keys,
+        ambiguous_refs,
+    })
+}
+
+/// Scope-aware visitor behind [`rewrite_upstream_refs`]. Shares the CTE
+/// shadowing discipline with [`DeferRewriter`]: a bare name shadowed by a CTE
+/// in scope is a reference to that CTE, never to the upstream.
+struct UpstreamRewriter<'a> {
+    /// `(key parts, original key, replacement)` triples, key parts lowercase.
+    renames: &'a [(Vec<String>, &'a String, &'a DeferTarget)],
+    scopes: Vec<HashSet<String>>,
+    rewritten_keys: HashSet<String>,
+    ambiguous_refs: Vec<String>,
+}
+
+impl UpstreamRewriter<'_> {
+    fn is_shadowed(&self, name: &str) -> bool {
+        self.scopes.iter().any(|frame| frame.contains(name))
+    }
+}
+
+impl VisitorMut for UpstreamRewriter<'_> {
+    type Break = ();
+
+    fn pre_visit_query(&mut self, query: &mut Query) -> ControlFlow<Self::Break> {
+        let mut frame: HashSet<String> = HashSet::new();
+        if let Some(with) = &query.with {
+            for cte in &with.cte_tables {
+                frame.insert(cte.alias.name.value.clone());
+            }
+        }
+        self.scopes.push(frame);
+        ControlFlow::Continue(())
+    }
+
+    fn post_visit_query(&mut self, _query: &mut Query) -> ControlFlow<Self::Break> {
+        self.scopes.pop();
+        ControlFlow::Continue(())
+    }
+
+    fn pre_visit_relation(&mut self, relation: &mut ObjectName) -> ControlFlow<Self::Break> {
+        // Extract the spelled parts — bail on anything that is not a plain
+        // identifier chain (e.g. a table function).
+        let mut original: Vec<&str> = Vec::with_capacity(relation.0.len());
+        for part in &relation.0 {
+            let Some(ident) = part.as_ident() else {
+                return ControlFlow::Continue(());
+            };
+            original.push(ident.value.as_str());
+        }
+        if original.is_empty() || original.len() > 3 {
+            return ControlFlow::Continue(());
+        }
+        // A bare name shadowed by a CTE in scope refers to the CTE.
+        if original.len() == 1 && self.is_shadowed(original[0]) {
+            return ControlFlow::Continue(());
+        }
+        let spelled: Vec<String> = original.iter().map(|p| p.to_ascii_lowercase()).collect();
+        // Tail-match the spelled parts against each rename key.
+        let matches: Vec<&(Vec<String>, &String, &DeferTarget)> = self
+            .renames
+            .iter()
+            .filter(|(key_parts, _, _)| {
+                key_parts.len() >= spelled.len()
+                    && key_parts[key_parts.len() - spelled.len()..] == spelled[..]
+            })
+            .collect();
+        match matches.as_slice() {
+            [] => {}
+            [(_, key, target)] => {
+                *relation = target.to_object_name();
+                self.rewritten_keys.insert((*key).clone());
+            }
+            _ => self.ambiguous_refs.push(relation.to_string()),
+        }
+        ControlFlow::Continue(())
+    }
+}
+
 /// Scope-aware visitor that qualifies bare deferred-model references while
 /// honouring lexical CTE shadowing.
 ///
@@ -452,5 +595,101 @@ mod tests {
         let deferred = deferred_map(&[("orders", target("", "prod", "orders"))]);
         let err = qualify_deferred_refs("NOT VALID SQL ;;;", &deferred);
         assert!(err.is_err());
+    }
+
+    // -- rewrite_upstream_refs ---------------------------------------------
+
+    fn renames_map(entries: &[(&str, DeferTarget)]) -> HashMap<String, DeferTarget> {
+        entries
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), v.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn rewrites_fully_qualified_ref() {
+        let renames = renames_map(&[("cat.raw.orders", target("cat", "replay_ns", "raw__orders"))]);
+        let out = rewrite_upstream_refs("SELECT * FROM cat.raw.orders", &renames).unwrap();
+        assert_eq!(out.sql, "SELECT * FROM cat.replay_ns.raw__orders");
+        assert!(out.rewritten_keys.contains("cat.raw.orders"));
+        assert!(out.ambiguous_refs.is_empty());
+    }
+
+    #[test]
+    fn rewrites_two_part_and_bare_tails() {
+        let renames = renames_map(&[("cat.raw.orders", target("cat", "replay_ns", "raw__orders"))]);
+        let two = rewrite_upstream_refs("SELECT * FROM raw.orders", &renames).unwrap();
+        assert_eq!(two.sql, "SELECT * FROM cat.replay_ns.raw__orders");
+        let bare = rewrite_upstream_refs("SELECT * FROM orders", &renames).unwrap();
+        assert_eq!(bare.sql, "SELECT * FROM cat.replay_ns.raw__orders");
+        assert!(bare.rewritten_keys.contains("cat.raw.orders"));
+    }
+
+    #[test]
+    fn matches_case_insensitively() {
+        let renames = renames_map(&[("cat.raw.orders", target("cat", "replay_ns", "raw__orders"))]);
+        let out = rewrite_upstream_refs("SELECT * FROM CAT.Raw.ORDERS", &renames).unwrap();
+        assert_eq!(out.sql, "SELECT * FROM cat.replay_ns.raw__orders");
+    }
+
+    #[test]
+    fn ambiguous_tail_is_reported_not_rewritten() {
+        // Two upstreams share the `orders` table segment: a bare reference
+        // cannot be attributed to either — it must be reported, not guessed.
+        let renames = renames_map(&[
+            ("cat.raw.orders", target("cat", "replay_ns", "raw__orders")),
+            (
+                "cat.staging.orders",
+                target("cat", "replay_ns", "staging__orders"),
+            ),
+        ]);
+        let out = rewrite_upstream_refs("SELECT * FROM orders", &renames).unwrap();
+        assert_eq!(out.sql, "SELECT * FROM orders", "ambiguous ref untouched");
+        assert!(out.rewritten_keys.is_empty());
+        assert_eq!(out.ambiguous_refs, vec!["orders".to_string()]);
+        // A fully qualified reference disambiguates.
+        let fq = rewrite_upstream_refs("SELECT * FROM cat.staging.orders", &renames).unwrap();
+        assert_eq!(fq.sql, "SELECT * FROM cat.replay_ns.staging__orders");
+        assert!(fq.ambiguous_refs.is_empty());
+    }
+
+    #[test]
+    fn cte_shadowing_protects_bare_names_only_in_scope() {
+        let renames = renames_map(&[("cat.raw.orders", target("cat", "replay_ns", "raw__orders"))]);
+        let out = rewrite_upstream_refs(
+            "WITH orders AS (SELECT 1 AS id) SELECT * FROM orders",
+            &renames,
+        )
+        .unwrap();
+        assert!(
+            out.sql.contains("SELECT * FROM orders"),
+            "CTE-shadowed bare name untouched: {}",
+            out.sql
+        );
+        assert!(out.rewritten_keys.is_empty());
+    }
+
+    #[test]
+    fn unmatched_key_reported_via_rewritten_keys_absence() {
+        let renames = renames_map(&[("cat.raw.orders", target("cat", "replay_ns", "raw__orders"))]);
+        let out = rewrite_upstream_refs("SELECT * FROM cat.raw.customers", &renames).unwrap();
+        assert!(out.rewritten_keys.is_empty());
+        assert_eq!(out.sql, "SELECT * FROM cat.raw.customers");
+    }
+
+    #[test]
+    fn non_matching_relations_are_left_alone() {
+        let renames = renames_map(&[("cat.raw.orders", target("cat", "replay_ns", "raw__orders"))]);
+        let out = rewrite_upstream_refs(
+            "SELECT o.id FROM cat.raw.orders o JOIN other.schema.customers c ON o.id = c.id",
+            &renames,
+        )
+        .unwrap();
+        assert!(
+            out.sql.contains("cat.replay_ns.raw__orders o"),
+            "{}",
+            out.sql
+        );
+        assert!(out.sql.contains("other.schema.customers c"), "{}", out.sql);
     }
 }

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -1785,14 +1785,17 @@ enum Command {
     /// Shows every model that ran with SQL hash, row counts, bytes, and
     /// timings captured at the time. Useful for "what exactly ran at
     /// 03:15 UTC?" and as the reproducibility artefact for branch +
-    /// replay. Re-execution with pinned inputs is a follow-up once the
-    /// content-addressed write path arrives.
+    /// replay.
     ///
     /// With `--check`, runs a read-only replayability audit instead of the
     /// inspection view: for each model it classifies whether the recording
     /// alone is sufficient to re-execute it (provenance present, embedded IR
     /// parses under the current engine, inputs resolvable from the ledger)
     /// and flags static non-determinism. Nothing is executed.
+    ///
+    /// With `--execute`, re-executes the recorded recipes (see the flag docs
+    /// below) either on a local DuckDB engine or, with `--warehouse`, against
+    /// the configured live warehouse in an isolated replay schema.
     Replay {
         /// Run id or the literal `latest`. May also be given via `--at`.
         target: Option<String>,
@@ -1806,10 +1809,11 @@ enum Command {
         /// Run a read-only replayability audit instead of the inspection view.
         #[arg(long)]
         check: bool,
-        /// Re-execute the recorded recipe on a local DuckDB engine instead of
-        /// inspecting: reconstructs the recipe from the recording (never the
-        /// working tree), runs its `SELECT` in an ephemeral in-memory engine,
-        /// and re-derives the output hash. Single, self-contained models only.
+        /// Re-execute the recorded recipe instead of inspecting: reconstructs
+        /// the recipe from the recording (never the working tree), runs its
+        /// `SELECT`, and re-derives the output hash. Runs on an ephemeral
+        /// in-memory DuckDB engine by default; see `--warehouse` for live
+        /// warehouse re-execution.
         #[arg(long)]
         execute: bool,
         /// With `--execute`, compare the re-derived output blake3 against the
@@ -1817,6 +1821,21 @@ enum Command {
         /// `diverged` / `non_replayable`).
         #[arg(long)]
         verify: bool,
+        /// With `--execute`, re-execute on the live warehouse configured in
+        /// rocky.toml instead of a local engine. Content-addressed models
+        /// only: the recomputed artifact is encoded with the live table's
+        /// physical column mapping, so `--verify` compares against exactly
+        /// what the content-addressed writer recorded. All replay writes go
+        /// into an isolated replay schema — never the production location of
+        /// any recorded target — and that schema is dropped afterwards
+        /// unless `--keep` is passed.
+        #[arg(long)]
+        warehouse: bool,
+        /// With `--warehouse`, keep the isolated replay schema (and the
+        /// replayed tables in it) after the run for inspection instead of
+        /// dropping it.
+        #[arg(long)]
+        keep: bool,
     },
 
     /// Render a completed run as a timeline.
@@ -3862,6 +3881,8 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             check,
             execute,
             verify,
+            warehouse,
+            keep,
         } => {
             let run_ref = at.or(target).ok_or_else(|| {
                 anyhow::anyhow!(
@@ -3871,7 +3892,24 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             if verify && !execute {
                 anyhow::bail!("`--verify` requires `--execute`");
             }
-            if execute {
+            if warehouse && !execute {
+                anyhow::bail!("`--warehouse` requires `--execute`");
+            }
+            if keep && !warehouse {
+                anyhow::bail!("`--keep` requires `--warehouse`");
+            }
+            if execute && warehouse {
+                rocky_cli::commands::run_replay_execute_warehouse(
+                    &cli.config,
+                    &state_path,
+                    &run_ref,
+                    model.as_deref(),
+                    verify,
+                    keep,
+                    json,
+                )
+                .await
+            } else if execute {
                 rocky_cli::commands::run_replay_execute(
                     &state_path,
                     &run_ref,

--- a/schemas/replay_execute.schema.json
+++ b/schemas/replay_execute.schema.json
@@ -55,7 +55,7 @@
       "type": "object"
     }
   },
-  "description": "JSON output for `rocky replay --at <run_id> --execute [--verify]`.\n\nRe-execution surface (DuckDB). Each model's recipe is reconstructed from its recorded [`rocky_core::state::ProvenanceRecord`] — never the working tree — re-executed on an in-memory DuckDB engine, and its output artifact's blake3 re-derived. With `--verify` that digest is compared against the recorded output hash and a per-model verdict is emitted.\n\nTwo modes share this shape:\n\n- `--model <m>` re-executes a single, *self-contained* recipe on a throwaway engine. A recipe with recorded content upstreams is `non_replayable` in this mode — resolving those inputs is the DAG mode below. - no `--model` re-executes the *whole run* in topological order on one shared engine, materializing each upstream's **replayed** output so a downstream `SELECT` reads the replayed bytes (never the recorded object-store bytes, never production). A downstream whose in-run upstream could not be replayed is `non_replayable` (fail-closed cascade); an upstream not produced by any model in this run, or a mutable-source watermark, is likewise `non_replayable` rather than substituted.\n\nNothing is materialized to any warehouse schema: the entire in-memory engine is an ephemeral replay namespace, discarded after the run, so no production identity is ever touched.",
+  "description": "JSON output for `rocky replay --at <run_id> --execute [--verify]`.\n\nRe-execution surface. Each model's recipe is reconstructed from its recorded [`rocky_core::state::ProvenanceRecord`] — never the working tree — re-executed, and its output artifact's blake3 re-derived. With `--verify` that digest is compared against the recorded output hash and a per-model verdict is emitted. Execution runs on an in-memory DuckDB engine by default; with `--warehouse` it runs on the configured live warehouse instead, materializing replayed outputs into an isolated replay schema (see `replay_schema`) and encoding the recomputed artifact with the live table's physical column mapping so the digest is directly comparable to what the content-addressed writer recorded.\n\nTwo modes share this shape:\n\n- `--model <m>` re-executes a single, *self-contained* recipe on a throwaway engine. A recipe with recorded content upstreams is `non_replayable` in this mode — resolving those inputs is the DAG mode below. - no `--model` re-executes the *whole run* in topological order on one shared engine, materializing each upstream's **replayed** output so a downstream `SELECT` reads the replayed bytes (never the recorded object-store bytes, never production). A downstream whose in-run upstream could not be replayed is `non_replayable` (fail-closed cascade); an upstream not produced by any model in this run, or a mutable-source watermark, is likewise `non_replayable` rather than substituted.\n\nNo production identity is ever touched in either mode: the local path's entire in-memory engine is an ephemeral replay namespace discarded after the run, and the warehouse path writes only into the isolated `replay_schema`, dropped after the run unless `--keep` is passed.",
   "properties": {
     "bit_exact_count": {
       "description": "Number of models whose re-execution reproduced the recorded output byte-for-byte. Always `0` when `--verify` was not requested.",
@@ -77,6 +77,20 @@
         "$ref": "#/definitions/ReplayExecuteModelOutput"
       },
       "type": "array"
+    },
+    "replay_schema": {
+      "description": "Isolated warehouse schema the replayed outputs were materialized into (`--warehouse` only; absent on the local re-execution path). Replay never writes to the production location of any recorded target — every replayed table lands in this namespace, one schema per catalog touched.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "replay_schema_dropped": {
+      "description": "Whether the replay namespace was removed after the run (`--warehouse` only). `true` when no replay schema remains on the warehouse; `false` when `--keep` was passed or a drop failed.",
+      "type": [
+        "boolean",
+        "null"
+      ]
     },
     "run_id": {
       "type": "string"

--- a/sdk/python/src/rocky_sdk/types_generated/replay_execute_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/replay_execute_schema.py
@@ -46,13 +46,13 @@ class ReplayExecuteOutput(BaseModel):
     """
     JSON output for `rocky replay --at <run_id> --execute [--verify]`.
 
-    Re-execution surface (DuckDB). Each model's recipe is reconstructed from its recorded [`rocky_core::state::ProvenanceRecord`] — never the working tree — re-executed on an in-memory DuckDB engine, and its output artifact's blake3 re-derived. With `--verify` that digest is compared against the recorded output hash and a per-model verdict is emitted.
+    Re-execution surface. Each model's recipe is reconstructed from its recorded [`rocky_core::state::ProvenanceRecord`] — never the working tree — re-executed, and its output artifact's blake3 re-derived. With `--verify` that digest is compared against the recorded output hash and a per-model verdict is emitted. Execution runs on an in-memory DuckDB engine by default; with `--warehouse` it runs on the configured live warehouse instead, materializing replayed outputs into an isolated replay schema (see `replay_schema`) and encoding the recomputed artifact with the live table's physical column mapping so the digest is directly comparable to what the content-addressed writer recorded.
 
     Two modes share this shape:
 
     - `--model <m>` re-executes a single, *self-contained* recipe on a throwaway engine. A recipe with recorded content upstreams is `non_replayable` in this mode — resolving those inputs is the DAG mode below. - no `--model` re-executes the *whole run* in topological order on one shared engine, materializing each upstream's **replayed** output so a downstream `SELECT` reads the replayed bytes (never the recorded object-store bytes, never production). A downstream whose in-run upstream could not be replayed is `non_replayable` (fail-closed cascade); an upstream not produced by any model in this run, or a mutable-source watermark, is likewise `non_replayable` rather than substituted.
 
-    Nothing is materialized to any warehouse schema: the entire in-memory engine is an ephemeral replay namespace, discarded after the run, so no production identity is ever touched.
+    No production identity is ever touched in either mode: the local path's entire in-memory engine is an ephemeral replay namespace discarded after the run, and the warehouse path writes only into the isolated `replay_schema`, dropped after the run unless `--keep` is passed.
     """
 
     bit_exact_count: conint(ge=0)
@@ -65,6 +65,14 @@ class ReplayExecuteOutput(BaseModel):
     Total number of models considered (after any `--model` filter).
     """
     models: list[ReplayExecuteModelOutput]
+    replay_schema: str | None = None
+    """
+    Isolated warehouse schema the replayed outputs were materialized into (`--warehouse` only; absent on the local re-execution path). Replay never writes to the production location of any recorded target — every replayed table lands in this namespace, one schema per catalog touched.
+    """
+    replay_schema_dropped: bool | None = None
+    """
+    Whether the replay namespace was removed after the run (`--warehouse` only). `true` when no replay schema remains on the warehouse; `false` when `--keep` was passed or a drop failed.
+    """
     run_id: str
     status: str
     """


### PR DESCRIPTION
Extends `rocky replay --execute` from the DuckDB-local path to the **content-addressed warehouse path**. A recorded content-addressed run can now be re-executed against the live warehouse and verified bit-exact: each model's recipe is re-derived on the recording engine, the recomputed blake3 is compared against the recorded artifact hash, and execution is isolated into a dropped-after `hcv2_replay_*` namespace — never the production target.

## What's here

- **Warehouse re-derivation + verify** — `replay --execute --verify` re-runs the recorded recipe on the configured warehouse adapter (the same engine that produced the artifact), re-encodes the parquet against the table's discovered physical column mapping, and compares hashes. Verdicts (`bit_exact` / `diverged` / `non_replayable`) are classifications, not failures; a mutable-source model stays `non_replayable` and is never silently substituted with current data.
- **DAG-order multi-model replay** — each downstream reads its upstream's *replayed* output. New `rewrite_upstream_refs` in `rocky-sql` redirects a model's upstream references (bare / `schema.table` / `catalog.schema.table`) to the replay namespace, failing closed on an ambiguous reference rather than redirecting to the wrong upstream.
- **Isolation** — replay materializes only into `hcv2_replay_<run>`, dropped after `--verify` (kept with `--keep`); the production table is never written.
- **Docs honesty flip** — the replay/auditor guides now state re-execution (including the warehouse path) with the honest caveats (deterministic + content-addressed only; mutable-source classified non-replayable; nondeterministic flagged), replacing the prior inspection-only claim.
- Codegen cascade for the new `replay_execute` output.

## Live verification (Databricks sandbox)

`warehouse_replay_bit_exact_live_sandbox` (`#[ignore]`, env-gated) records a genuine content-addressed run (real S3 CAS write + real artifact hash), replays it through the warehouse path, and asserts:
- verdict `bit_exact`, recomputed hash == recorded hash;
- the replay schema is created and dropped;
- the production table's row count is unchanged by replay.

Run against the live sandbox (name-column-mapped UniForm fixture): **passes bit-exact** (both replay attempts), replay schema dropped, production untouched. Confirmed the content-addressed write path is deterministic run-to-run on the warehouse, which is what makes same-engine re-derivation reproduce the recorded digest.

The `#[ignore]` is the real gate (CI runs `--all-features`); the creds-free suite covers the DuckDB path and the verdict lattice.