### PR TITLE
chore(deps): bump rmcp to 2.2 and migrate rocky-mcp to the 2.x model API

### DIFF
--- a/docs/src/content/docs/concepts/mcp-authoring.md
+++ b/docs/src/content/docs/concepts/mcp-authoring.md
@@ -116,7 +116,9 @@ This is the same evaluator that gates `apply`, `promote`, and `propose`, so an a
 
 ## Structured errors
 
-Every failing tool call comes back as a tool-result error whose content is a stable envelope — `{ code, message, remediation_hint, policy_rule? }` — not a prose blob. `code` is a machine-matchable class (`invalid_argument`, `model_not_found`, `compile_failed`, `policy_denied`, `policy_review_required`, …); `remediation_hint` is a concrete next action; `policy_rule` names the deciding rule on a policy verdict. It is the tool-layer analog of Rocky's diagnostic codes: an agent branches on the `code` and acts on the `remediation_hint` without scraping text. A clean compile that reports error *diagnostics* is **not** an error envelope — it is a successful result with `has_errors: true`, so "the tool failed" and "the code has a problem" stay distinguishable.
+When a tool rejects a request it has parsed — an unknown model, a denied policy, a compile that can't run — the failure comes back as a tool-result error whose content is a stable envelope — `{ code, message, remediation_hint, policy_rule? }` — not a prose blob. `code` is a machine-matchable class (`invalid_argument`, `model_not_found`, `compile_failed`, `policy_denied`, `policy_review_required`, …); `remediation_hint` is a concrete next action; `policy_rule` names the deciding rule on a policy verdict. It is the tool-layer analog of Rocky's diagnostic codes: an agent branches on the `code` and acts on the `remediation_hint` without scraping text. A clean compile that reports error *diagnostics* is **not** an error envelope — it is a successful result with `has_errors: true`, so "the tool failed" and "the code has a problem" stay distinguishable.
+
+One boundary sits below the envelope: a request whose arguments fail to parse before the tool runs — a missing or mistyped field — also comes back as a tool-result error (never a transport-level failure), but its content is a plain message rather than the envelope. The input schema each tool publishes in `tools/list` is what keeps a well-behaved client from sending one.
 
 ## Egress discipline
 

--- a/engine/.claude/skills/rust-dep-hygiene/SKILL.md
+++ b/engine/.claude/skills/rust-dep-hygiene/SKILL.md
@@ -55,7 +55,7 @@ edition = "2024"
 rust-version = "1.88"
 ```
 
-> Bumped 1.85.1 → 1.88 on 2026-05-24: the `rocky-mcp` crate's `rmcp 1.7` tree (`rmcp-macros` → `darling 0.23`, plus `time 0.3.47`) requires rustc 1.88, so the effective workspace MSRV was already 1.88.
+> Bumped 1.85.1 → 1.88 on 2026-05-24: the `rocky-mcp` crate's `rmcp` tree (`rmcp-macros` → `darling 0.23`, edition 2024) requires rustc 1.88, so the effective workspace MSRV was already 1.88. (The tree was `rmcp 1.7` at the bump; it is `rmcp 2.2` now — still `darling 0.23` / edition 2024, so the 1.88 floor is unchanged.)
 
 **Rules:**
 

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bumped `rmcp` (the MCP SDK) 1.7 → 2.2, a breaking major that realigns MCP model types to spec 2025-11-25. The JSON wire format is unchanged — MCP clients see identical bytes — so the migration is Rust-API-only (`PromptMessageRole` → `Role`, `PromptMessageContent::Text` → `ContentBlock::Text`). `rocky mcp` behavior is unchanged: `initialize` still advertises protocol version 2024-11-05 with the same 28 tools and 5 prompts. (#1109)
+- Bumped `rmcp` (the MCP SDK) 1.7 → 2.2, a breaking major that realigns MCP model types to spec 2025-11-25. The JSON wire format is unchanged — MCP clients see identical bytes — so the migration is Rust-API-only (`PromptMessageRole` → `Role`, `PromptMessageContent::Text` → `ContentBlock::Text`). The `rocky mcp` tool/prompt surface (28 tools, 5 prompts) is identical. Two inherited rmcp-2.x behaviors are wire-compatible and worth noting: `initialize` now negotiates the MCP protocol version (a client is echoed the version it requests when rmcp recognizes it, falling back to the configured `2024-11-05` otherwise), and a tool call whose arguments fail to deserialize returns an `isError` result rather than a JSON-RPC error — Rocky's structured tool-error envelope (body-level validation) is unchanged. (#1109)
 
 ## [1.64.0] - 2026-07-12
 

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped `rmcp` (the MCP SDK) 1.7 → 2.2, a breaking major that realigns MCP model types to spec 2025-11-25. The JSON wire format is unchanged — MCP clients see identical bytes — so the migration is Rust-API-only (`PromptMessageRole` → `Role`, `PromptMessageContent::Text` → `ContentBlock::Text`). `rocky mcp` behavior is unchanged: `initialize` still advertises protocol version 2024-11-05 with the same 28 tools and 5 prompts. (#1109)
+
 ## [1.64.0] - 2026-07-12
 
 ### Added

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3871,9 +3871,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.7.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
 dependencies = [
  "async-trait",
  "base64",
@@ -3894,9 +3894,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.7.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -5210,7 +5210,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -92,7 +92,7 @@ tokio = { version = "1", features = ["full"] }
 # Transitively pulls schemars 1.x; the rest of the workspace uses schemars
 # 0.8. The dual-major is disjoint (rmcp's `#[tool]` param structs derive
 # schemars 1.x; Rocky's `*Output` structs derive 0.8) and compiles cleanly.
-rmcp = { version = "1.7", features = ["server", "macros", "transport-io"] }
+rmcp = { version = "2.2", features = ["server", "macros", "transport-io"] }
 
 # HTTP
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "gzip", "http2"] }

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -53,4 +53,4 @@ tempfile = "3"
 serde_json = { workspace = true }
 # The scripted round-trip test drives the stdio server in-process with an rmcp
 # client over a duplex pipe, so it needs the client side of rmcp too.
-rmcp = { version = "1.7", features = ["server", "macros", "transport-io", "client"] }
+rmcp = { version = "2.2", features = ["server", "macros", "transport-io", "client"] }

--- a/engine/crates/rocky-mcp/src/lib.rs
+++ b/engine/crates/rocky-mcp/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! ## schemars dual-major note
 //!
-//! rmcp 1.7 pulls schemars 1.x; the rest of the Rocky workspace uses
+//! rmcp 2.2 pulls schemars 1.x; the rest of the Rocky workspace uses
 //! schemars 0.8. The two `JsonSchema` traits are disjoint. Every result
 //! struct returned inside `Json<T>` therefore derives schemars **1.x** and is
 //! built from "pure" types only (`String`, `usize`, `bool`, `Vec<_>`, local

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -9,12 +9,8 @@ use rmcp::RoleServer;
 use rmcp::handler::server::router::prompt::PromptRouter;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
-// `GetPromptRequestParams`, `PaginatedRequestParams`, and `ListPromptsResult`
-// are referenced unqualified in the code the `#[prompt_handler]` macro emits,
-// so they must be in scope here even though this module names none of them.
 use rmcp::model::{
-    GetPromptRequestParams, GetPromptResult, Implementation, ListPromptsResult,
-    PaginatedRequestParams, PromptMessage, PromptMessageRole, ProtocolVersion, ServerCapabilities,
+    GetPromptResult, Implementation, PromptMessage, ProtocolVersion, Role, ServerCapabilities,
     ServerInfo,
 };
 use rmcp::service::RequestContext;
@@ -2830,14 +2826,14 @@ impl RockyMcpServer {
         let intent = args.intent.trim();
         let messages = vec![
             PromptMessage::new_text(
-                PromptMessageRole::Assistant,
+                Role::Assistant,
                 "I'll author this Rocky model SQL-first, grounding every decision in the \
                  real data, and stop at a proposed plan for you to review and apply. \
                  The substrate trusts my edits because the compiler checked them and you \
                  sign off the invariants — never because they merely compiled.",
             ),
             PromptMessage::new_text(
-                PromptMessageRole::User,
+                Role::User,
                 format!(
                     "Build a Rocky model for this intent:\n\n  {intent}\n\n\
                      Follow Rocky's authoring loop, using the MCP tools at each step:\n\n\
@@ -2897,14 +2893,14 @@ impl RockyMcpServer {
     ) -> Result<GetPromptResult, McpError> {
         let messages = vec![
             PromptMessage::new_text(
-                PromptMessageRole::Assistant,
+                Role::Assistant,
                 "I'll find the models that carry no declarative tests, draft tests grounded in \
                  their real data, and stop at a proposed plan for you to review and apply. A model \
                  that compiles is not the same as a model that is checked — tests are what make \
                  the substrate trust a future run.",
             ),
             PromptMessage::new_text(
-                PromptMessageRole::User,
+                Role::User,
                 "Find the untested models in this Rocky project and draft tests for them, using \
                  the MCP tools at each step:\n\n\
                  1. catalog — enumerate every model with its declared tests, checks, and \
@@ -2963,13 +2959,13 @@ impl RockyMcpServer {
         };
         let messages = vec![
             PromptMessage::new_text(
-                PromptMessageRole::Assistant,
+                Role::Assistant,
                 "I'll identify the primary-key and unique columns, draft uniqueness and not-null \
                  tests grounded in the real data, and stop at a proposed plan for you to review \
                  and apply. A declared key is a claim; the data is what proves it.",
             ),
             PromptMessage::new_text(
-                PromptMessageRole::User,
+                Role::User,
                 format!(
                     "Add uniqueness + not-null tests to the key columns of {scope} in this Rocky \
                      project, using the MCP tools at each step:\n\n\
@@ -3019,12 +3015,12 @@ impl RockyMcpServer {
     ) -> Result<GetPromptResult, McpError> {
         let messages = vec![
             PromptMessage::new_text(
-                PromptMessageRole::Assistant,
+                Role::Assistant,
                 "I'll summarize this Rocky project from the catalog and lineage. This is a \
                  read-only orientation — I will not edit, propose, or apply anything.",
             ),
             PromptMessage::new_text(
-                PromptMessageRole::User,
+                Role::User,
                 "Summarize this Rocky project, using only the read-only MCP tools:\n\n\
                  1. catalog — enumerate every model with its target table, materialization \
                  strategy, declared tests/checks, contract, and governance (classification / mask \
@@ -3067,14 +3063,14 @@ impl RockyMcpServer {
         };
         let messages = vec![
             PromptMessage::new_text(
-                PromptMessageRole::Assistant,
+                Role::Assistant,
                 "I'll run the tests, ground each failure in the real data before changing \
                  anything, and stop at a proposed fix for you to review and apply. A failing test \
                  is a signal — I will find out whether the test is wrong or the data is wrong \
                  before I touch either.",
             ),
             PromptMessage::new_text(
-                PromptMessageRole::User,
+                Role::User,
                 format!(
                     "Diagnose and fix the failing tests in {scope}, using the MCP tools at each \
                      step:\n\n\

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -112,6 +112,43 @@ async fn tools_list_returns_expected_set() {
     client.cancel().await.unwrap();
 }
 
+/// Malformed tool arguments (wrong-typed or missing required fields) fail
+/// *inside rmcp's parameter extraction*, before the tool body runs. rmcp 2.x
+/// surfaces that as an `isError` tool result carrying a plain-text message —
+/// deliberately NOT Rocky's structured `{code, message, remediation_hint}`
+/// envelope, which is the tool layer's own validation of *well-typed* arguments
+/// (see the error-contract eval). This pins that boundary so a future rmcp bump
+/// can't silently turn a bad-argument call into a transport error or reshape it.
+#[tokio::test]
+async fn malformed_arguments_are_a_plain_is_error_not_the_structured_envelope() {
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+
+    // `lineage` requires `model: String`; pass a number so deserialization into
+    // the parameter struct fails before the tool ever runs.
+    let bad_type = serde_json::json!({ "model": 12345 })
+        .as_object()
+        .unwrap()
+        .clone();
+    let res = client
+        .call_tool(CallToolRequestParams::new("lineage").with_arguments(bad_type))
+        .await
+        .expect("a malformed call still returns a tool result, not a transport error");
+    assert_eq!(
+        res.is_error,
+        Some(true),
+        "malformed arguments surface as an isError tool result"
+    );
+    assert!(
+        res.structured_content.is_none(),
+        "a deserialization failure is a plain rmcp error, not Rocky's structured envelope"
+    );
+
+    client.cancel().await.unwrap();
+}
+
 #[tokio::test]
 async fn compile_returns_trimmed_shape() {
     let dir = TempDir::new().unwrap();

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -1328,12 +1328,12 @@ async fn prompt_get_build_model_returns_authoring_loop() {
     // Flatten every text message into one haystack and assert on the key
     // workflow steps + the reconcile discipline + the user's intent — wording
     // is free to drift, but these anchors must survive copy edits.
-    use rmcp::model::PromptMessageContent;
+    use rmcp::model::ContentBlock;
     let haystack: String = result
         .messages
         .iter()
         .filter_map(|m| match &m.content {
-            PromptMessageContent::Text { text } => Some(text.as_str()),
+            ContentBlock::Text(t) => Some(t.text.as_str()),
             _ => None,
         })
         .collect::<Vec<_>>()
@@ -1366,12 +1366,12 @@ async fn prompt_get_build_model_returns_authoring_loop() {
 
 /// Flatten a prompt result's text messages into one searchable haystack.
 fn prompt_text(result: &rmcp::model::GetPromptResult) -> String {
-    use rmcp::model::PromptMessageContent;
+    use rmcp::model::ContentBlock;
     result
         .messages
         .iter()
         .filter_map(|m| match &m.content {
-            PromptMessageContent::Text { text } => Some(text.as_str()),
+            ContentBlock::Text(t) => Some(t.text.as_str()),
             _ => None,
         })
         .collect::<Vec<_>>()


### PR DESCRIPTION
## What

Bumps `rmcp` (the Rust MCP SDK) **1.7 → 2.2** and migrates `rocky-mcp` to the 2.x model API. Supersedes #1020 (the dependabot bump), which correctly bumped the pins but left the source uncompiled.

rmcp 2.0 is a breaking major that realigns model types to MCP spec 2025-11-25. **The JSON wire format is unchanged**, so MCP clients see identical bytes — the breaking changes are at the Rust-API level only.

## Changes

- `rmcp` / `rmcp-macros` 1.7 → 2.2 (workspace dep + `rocky-mcp` client dev-dep + lockfile)
- `PromptMessageRole` → `Role`
- `PromptMessageContent::Text { text }` → `ContentBlock::Text(t)` (roundtrip-test flatteners; the `_ => None` arm already absorbs the new `Audio` variant)
- Drop the `GetPromptRequestParams` / `ListPromptsResult` / `PaginatedRequestParams` imports — the 2.x `#[prompt_handler]` macro now fully-qualifies them

The schemars dual-major split (rmcp param structs on 1.x, Rocky `*Output` structs on 0.8) is undisturbed — rmcp 2.2 still requires `schemars ^1.0`.

## Validation

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- 64 credential-free tests pass (incl. the in-process client↔server `roundtrip` protocol suite)
- Real `initialize` handshake: `protocolVersion 2024-11-05` negotiated, 28 tools + 5 prompts enumerate
- Compiles at MSRV 1.88

Closes #1020.