### PR TITLE
fix(sdk): dispatch restore apply outputs

### DIFF
--- a/sdk/python/src/rocky_sdk/client.py
+++ b/sdk/python/src/rocky_sdk/client.py
@@ -75,6 +75,7 @@ from rocky_sdk.types import (
     OptimizeResult,
     PlanResult,
     PromotePlan,
+    RestoreApplyOutput,
     RetentionStatusOutput,
     RunResult,
     StateResult,
@@ -86,7 +87,12 @@ from rocky_sdk.types import (
 # emit a wrapping envelope — each plan kind prints its own output, so the parsed
 # result is a discriminated union over those shapes. See :func:`_parse_apply`.
 ApplyResult = (
-    RunResult | GcApplyOutput | CompactApplyOutput | ArchiveApplyOutput | BranchPromoteOutput
+    RunResult
+    | GcApplyOutput
+    | RestoreApplyOutput
+    | CompactApplyOutput
+    | ArchiveApplyOutput
+    | BranchPromoteOutput
 )
 
 # Default subprocess timeout for any single Rocky CLI invocation. One hour is
@@ -207,7 +213,9 @@ def _parse_apply(output: str) -> ApplyResult:
     * ``"compact apply"`` → :class:`CompactApplyOutput`.
     * ``"archive apply"`` → :class:`ArchiveApplyOutput`.
     * ``"branch promote"`` → :class:`BranchPromoteOutput`.
-    * ``"apply"`` with gc markers (``evicted`` / ``refused``) →
+    * ``"apply"`` with restore markers (``restored``) →
+      :class:`RestoreApplyOutput`.
+    * ``"apply"`` with gc markers (``evicted``) →
       :class:`GcApplyOutput`.
 
     Anything else raises :class:`RockyOutputParseError` naming the received
@@ -240,7 +248,9 @@ def _parse_apply(output: str) -> ApplyResult:
         return _validate_payload(payload, ArchiveApplyOutput, command="apply", raw=output)
     if command == "branch promote":
         return _validate_payload(payload, BranchPromoteOutput, command="apply", raw=output)
-    if command == "apply" and ("evicted" in payload or "refused" in payload):
+    if command == "apply" and "restored" in payload:
+        return _validate_payload(payload, RestoreApplyOutput, command="apply", raw=output)
+    if command == "apply" and "evicted" in payload:
         return _validate_payload(payload, GcApplyOutput, command="apply", raw=output)
 
     raise RockyOutputParseError(
@@ -248,7 +258,8 @@ def _parse_apply(output: str) -> ApplyResult:
         stdout=output or "",
         parse_error=(
             f"unrecognized apply output (command={command!r}); expected one of "
-            "'run' / 'compact apply' / 'archive apply' / 'branch promote' / gc apply"
+            "'run' / 'compact apply' / 'archive apply' / 'branch promote' / "
+            "restore apply / gc apply"
         ),
         kind="validation",
     )
@@ -856,9 +867,10 @@ class RockyClient:
         Reads ``.rocky/plans/<plan_id>.json`` and dispatches by kind. Each plan
         kind's apply path prints its OWN output (there is no wrapping envelope),
         so the return type is a discriminated union: run / replication /
-        ai_authored / backfill plans yield a :class:`RunResult`; a ``gc`` plan
-        yields a :class:`GcApplyOutput`; compact / archive / promote plans yield
-        their respective outputs. See :func:`_parse_apply`.
+        ai_authored / backfill plans yield a :class:`RunResult`; ``restore`` and
+        ``gc`` plans yield :class:`RestoreApplyOutput` and :class:`GcApplyOutput`,
+        respectively; compact / archive / promote plans yield their respective
+        outputs. See :func:`_parse_apply`.
         """
         return _parse_apply(self.run_cli(["apply", plan_id], allow_partial=True))
 

--- a/sdk/python/src/rocky_sdk/types.py
+++ b/sdk/python/src/rocky_sdk/types.py
@@ -1297,6 +1297,7 @@ from .types_generated import (  # noqa: E402, F401
     RejectedApproval,
     ReplayModelOutput,
     ReplayOutput,
+    RestoreApplyOutput,
     RetentionStatusOutput,
     RunHistoryRecord,
     RunOutput,
@@ -1422,6 +1423,7 @@ RockyOutput = (
     | DoctorResult
     | DagResult
     | GcApplyOutput
+    | RestoreApplyOutput
     | ComplianceOutput
     | RetentionStatusOutput
     | CatalogOutput
@@ -1434,7 +1436,7 @@ RockyOutput = (
 
 
 # Maps the ``command`` field of a Rocky JSON payload to the model that should
-# parse it. Commands that need shape-based discrimination (lineage, history)
+# parse it. Commands that need shape-based discrimination (lineage, history, apply)
 # are handled separately below.
 _SIMPLE_DISPATCH: dict[str, type[BaseModel]] = {
     "discover": DiscoverResult,
@@ -1459,12 +1461,6 @@ _SIMPLE_DISPATCH: dict[str, type[BaseModel]] = {
     "validate-migration": ValidateMigrationResult,
     "doctor": DoctorResult,
     "dag": DagResult,
-    # ``rocky apply`` on a gc plan prints ``{command:"apply", ...}`` with gc
-    # markers (``evicted`` / ``refused``). Run-shaped apply prints
-    # ``command:"run"`` (→ ``RunResult``); compact / archive / promote apply
-    # print their own commands, already routed above. ``RockyClient.apply()``
-    # additionally disambiguates by shape.
-    "apply": GcApplyOutput,
     "compliance": ComplianceOutput,
     "retention-status": RetentionStatusOutput,
     "catalog": CatalogOutput,
@@ -1500,6 +1496,12 @@ def parse_rocky_output(json_str: str) -> RockyOutput:
         if "model" in data:
             return ModelHistoryResult.model_validate(data)
         return HistoryResult.model_validate(data)
+    if command == "apply":
+        if "restored" in data:
+            return RestoreApplyOutput.model_validate(data)
+        if "evicted" in data:
+            return GcApplyOutput.model_validate(data)
+        raise ValueError("Unknown Rocky apply output shape")
 
     if command in _SIMPLE_DISPATCH:
         return _SIMPLE_DISPATCH[command].model_validate(data)

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -537,6 +537,34 @@ _GC_APPLY_JSON = json.dumps(
     }
 )
 
+# A ``restore`` plan's apply output — also ``command == "apply"``, but with
+# restore-specific markers. The shared ``refused`` field must not route it to gc.
+_RESTORE_APPLY_JSON = json.dumps(
+    {
+        "version": "1.64.0",
+        "command": "apply",
+        "plan_id": "b" * 64,
+        "restored": [
+            {
+                "model_name": "orders",
+                "run_id": "run-1",
+                "blake3_hash": "deadbeef",
+                "size_bytes": 2048,
+                "file_path": "s3://warehouse/orders.parquet",
+                "status": "restored",
+                "bytes_written": True,
+                "hash_verified": True,
+            }
+        ],
+        "refused": [],
+        "already_restored": [],
+        "restored_count": 1,
+        "refused_count": 0,
+        "bytes_restored": 2048,
+        "notes": ["rebuilt bytes verified before publication"],
+    }
+)
+
 
 def _run_apply(client: RockyClient, stdout: str):
     proc = _fake_popen(stdout=stdout, returncode=0)
@@ -569,6 +597,16 @@ def test_apply_gc_plan_returns_gc_apply_output():
     assert result.evicted_count == 1
     assert result.evicted[0].model_name == "stale_model"
     assert result.bytes_evicted == 2048
+
+
+def test_apply_restore_plan_returns_restore_apply_output():
+    from rocky_sdk.types import RestoreApplyOutput
+
+    result = _run_apply(_client(), _RESTORE_APPLY_JSON)
+    assert isinstance(result, RestoreApplyOutput)
+    assert result.restored_count == 1
+    assert result.restored[0].model_name == "orders"
+    assert result.bytes_restored == 2048
 
 
 def test_apply_unknown_shape_raises_named_parse_error():

--- a/sdk/python/tests/test_schema_parity.py
+++ b/sdk/python/tests/test_schema_parity.py
@@ -100,7 +100,6 @@ _COMMAND_SCHEMA: dict[str, str] = {
     "validate-migration": "validate_migration.schema.json",
     "doctor": "doctor.schema.json",
     "dag": "dag.schema.json",
-    "apply": "gc_apply.schema.json",
     "compliance": "compliance.schema.json",
     "retention-status": "retention_status.schema.json",
     "catalog": "catalog.schema.json",
@@ -114,6 +113,8 @@ _COMMAND_SCHEMA: dict[str, str] = {
 # Client-only parse targets not routed by ``parse_rocky_output`` (their payloads
 # either carry no ``command`` key, or are shape-discriminated).
 _CLIENT_ONLY: dict[str, tuple[str, type]] = {
+    "apply-gc": ("gc_apply.schema.json", sdk_types.GcApplyOutput),
+    "apply-restore": ("restore_apply.schema.json", sdk_types.RestoreApplyOutput),
     "test-adapter": ("test_adapter.schema.json", sdk_types.ConformanceResult),
     "lineage-model": ("lineage.schema.json", sdk_types.ModelLineageResult),
     "lineage-column": ("column_lineage.schema.json", sdk_types.ColumnLineageResult),

--- a/sdk/python/tests/test_types.py
+++ b/sdk/python/tests/test_types.py
@@ -11,7 +11,7 @@ import pytest
 from rocky_sdk import CiResult, CompileResult, DiscoverResult, TestResult, parse_rocky_output
 from rocky_sdk.client import _parse_rocky_json, _parse_run_or_apply
 from rocky_sdk.exceptions import RockyOutputParseError
-from rocky_sdk.types import CheckResult, RunResult
+from rocky_sdk.types import CheckResult, GcApplyOutput, RestoreApplyOutput, RunResult
 
 DISCOVER_JSON = '{"version": "1.0.0", "command": "discover", "sources": []}'
 
@@ -20,6 +20,35 @@ def test_parse_rocky_output_dispatches_discover():
     result = parse_rocky_output(DISCOVER_JSON)
     assert isinstance(result, DiscoverResult)
     assert result.sources == []
+
+
+@pytest.mark.parametrize(
+    ("marker", "counter", "extra", "model"),
+    [
+        ("restored", "restored_count", {}, RestoreApplyOutput),
+        ("evicted", "evicted_count", {"bytes_refused": 0}, GcApplyOutput),
+    ],
+)
+def test_parse_rocky_output_dispatches_apply_by_shape(marker, counter, extra, model):
+    payload = {
+        "version": "1.64.0",
+        "command": "apply",
+        "plan_id": "a" * 64,
+        marker: [],
+        "refused": [],
+        f"already_{marker}": [],
+        counter: 0,
+        "refused_count": 0,
+        f"bytes_{marker}": 0,
+        "notes": [],
+        **extra,
+    }
+    assert isinstance(parse_rocky_output(json.dumps(payload)), model)
+
+
+def test_parse_rocky_output_rejects_unknown_apply_shape():
+    with pytest.raises(ValueError, match="Unknown Rocky apply output shape"):
+        parse_rocky_output('{"command": "apply", "refused": []}')
 
 
 def test_parse_compile_surfaces_model_governance_tags():


### PR DESCRIPTION
## Summary

Teach `rocky-sdk` to distinguish restore and GC apply output, which share `command: "apply"`, by their unique top-level markers. The generated `RestoreApplyOutput` already exists; this PR wires it into both SDK parsing paths and the public result unions.

Fixes #1110

## Subproject(s) touched

- [x] `sdk/python/` (Python SDK)
- [ ] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Changes

- Dispatch restore apply payloads by `restored` and GC payloads by `evicted`, instead of treating the shared `refused` field as a GC marker.
- Add `RestoreApplyOutput` to `ApplyResult` and `RockyOutput`, while rejecting unknown apply shapes explicitly.
- Cover both parser entry points, preserve GC behavior, and extend schema-parity coverage to both apply variants.

## Test Plan

- `cd sdk/python && uv run pytest -v` — 187 passed
- `cd sdk/python && uv run ruff check src/ tests/`
- `cd sdk/python && uv run ruff format --check src/ tests/`
- `cd sdk/python && uv build`
- `cd integrations/dagster && uv run pytest -v` — 696 passed

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/), scoped by subproject when relevant (e.g. `feat(engine/rocky-databricks): ...`, `fix(dagster): ...`)
- [x] No `Co-Authored-By` trailers
- [x] If this is a CLI JSON schema or DSL syntax change, all consumers (`integrations/dagster/`, `editors/vscode/`) are updated in this same PR (not applicable; no schema or DSL change)

### SDK (`sdk/python/`)

- [x] `uv run pytest` passes
- [x] `uv run ruff check` is clean
- [x] `uv run ruff format --check` passes
- [x] `uv build` succeeds

### Engine (`engine/`)

- [ ] `cargo test --all-targets` passes
- [ ] `cargo clippy --all-targets -- -D warnings` is clean
- [ ] `cargo fmt --check` passes

### Dagster (`integrations/dagster/`)

- [x] `uv run pytest` passes
- [x] `uv run ruff check` is clean
- [x] `uv run ruff format --check` passes

### VS Code (`editors/vscode/`)

- [ ] `npm run compile` succeeds
- [ ] `npm run test:unit` passes (electron tests run in CI)
- [ ] `npm run lint` is clean
