### PR TITLE
fix(sdk): reject unsupported server metrics options

### DIFF
--- a/docs/src/content/docs/dagster/resource.md
+++ b/docs/src/content/docs/dagster/resource.md
@@ -248,7 +248,9 @@ Retrieve pipeline run history. Returns `ModelHistoryResult` when filtered to a s
 
 ### `metrics(model, *, trend=False, column=None, alerts=False) -> MetricsResult`
 
-Retrieve quality metrics for a model. When `server_url` is configured, fetches from the HTTP API instead.
+Retrieve quality metrics for a model. When `server_url` is configured, fetches from the HTTP API
+instead. The HTTP endpoint supports default metrics only; passing `trend`, `column`, or `alerts`
+raises `ValueError` rather than silently ignoring the option.
 
 **Wraps**: `rocky metrics <model> --output json` or `GET /api/v1/models/<model>/metrics`
 

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`RockyClient.metrics()` no longer silently ignores options in server mode.** Passing
+  CLI-only `trend`, `column`, or `alerts` options when `server_url` is set now raises a
+  clear `ValueError` before making an HTTP request. (#1122)
+
 ## [0.8.0] — 2026-07-14
 
 ### Fixed

--- a/sdk/python/src/rocky_sdk/client.py
+++ b/sdk/python/src/rocky_sdk/client.py
@@ -1151,7 +1151,13 @@ class RockyClient:
         column: str | None = None,
         alerts: bool = False,
     ) -> MetricsResult:
-        """Run ``rocky metrics`` (or the HTTP API when ``server_url`` is set)."""
+        """Run ``rocky metrics`` (or the HTTP API when ``server_url`` is set).
+
+        Raises:
+            ValueError: A CLI-only metrics option is used with ``server_url``.
+        """
+        if self.server_url is not None and (trend or column is not None or alerts):
+            raise ValueError("trend, column, and alerts are not supported when server_url is set")
         if self.server_url is not None:
             return _parse_rocky_json(
                 self._http_get(f"/api/v1/models/{model}/metrics"),

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -460,6 +460,26 @@ def test_http_error_raises_server_error():
         client.compile()
 
 
+def test_http_metrics_uses_default_endpoint():
+    client = _client(server_url="http://localhost:8080")
+    body = '{"version":"1","command":"metrics","model":"orders","snapshots":[],"count":0}'
+    with patch.object(client, "_http_get", return_value=body) as http_get:
+        result = client.metrics("orders")
+    http_get.assert_called_once_with("/api/v1/models/orders/metrics")
+    assert result.model == "orders"
+
+
+@pytest.mark.parametrize("kwargs", [{"trend": True}, {"column": "email"}, {"alerts": True}])
+def test_http_metrics_rejects_cli_only_options(kwargs):
+    client = _client(server_url="http://localhost:8080")
+    with (
+        patch.object(client, "_http_get") as http_get,
+        pytest.raises(ValueError, match="not supported when server_url is set"),
+    ):
+        client.metrics("orders", **kwargs)
+    http_get.assert_not_called()
+
+
 # --------------------------------------------------------------------------- #
 # apply() — dispatch by real wire shape (there is NO wrapping envelope)
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Prevent `RockyClient.metrics()` from silently discarding `trend`, `column`, and `alerts`
when `server_url` selects the default-only HTTP endpoint.

Closes #1122

## Subproject(s) touched

- [ ] `engine/` (Rust CLI / crates)
- [x] `sdk/python/` (Python SDK)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [x] Cross-project (public docs)

## Changes

- Reject CLI-only metrics options with `ValueError` before making an HTTP request.
- Preserve the existing default server-mode request to `GET /api/v1/models/<model>/metrics`.
- Cover the default path and each unsupported option with focused SDK tests.
- Document the constraint in the public method reference and SDK changelog.

## Test Plan

- [x] `uv run python -m pytest -q` — 191 passed
- [x] `uv run python -m ruff check src/ tests/ examples/`
- [x] `uv run python -m ruff format --check src/ tests/ examples/`
- [x] `npm run build` in `docs/`
- [x] All GitHub Actions checks pass

## Checklist

- [x] Commit message follows conventional commits and is scoped to the SDK.
- [x] No `Co-Authored-By` trailers.
- [x] This is not a CLI JSON schema or DSL syntax change; consumer regeneration is not required.
