### PR TITLE
fix(sdk): reject unsupported server compile model_filter

### DIFF
--- a/docs/src/content/docs/dagster/resource.md
+++ b/docs/src/content/docs/dagster/resource.md
@@ -141,13 +141,15 @@ Runs `rocky state` and returns the current watermark state for all tracked table
 
 ### `compile(model_filter=None) -> CompileResult`
 
-Runs `rocky compile` and returns compiler diagnostics (errors, warnings, info). When `server_url` is configured, fetches from the HTTP API instead of spawning a subprocess.
+Runs `rocky compile` and returns compiler diagnostics (errors, warnings, info). When `server_url` is
+configured, fetches from the HTTP API instead of spawning a subprocess. The HTTP endpoint compiles
+the whole project only; passing `model_filter` raises `ValueError` rather than silently ignoring it.
 
 **Wraps**: `rocky compile --models <models_dir> --output json` or `GET /api/v1/compile`
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `model_filter` | `str \| None` | `None` | Optional model name to filter diagnostics |
+| `model_filter` | `str \| None` | `None` | Optional model name to filter diagnostics (CLI mode only) |
 
 ### `lineage(target, column=None) -> ModelLineageResult | ColumnLineageResult`
 

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`RockyClient.metrics()` no longer silently ignores options in server mode.** Passing
   CLI-only `trend`, `column`, or `alerts` options when `server_url` is set now raises a
   clear `ValueError` before making an HTTP request. (#1122)
+- **`RockyClient.compile()` no longer silently ignores `model_filter` in server mode.** Passing
+  `model_filter` when `server_url` is set now raises a clear `ValueError` before making an HTTP
+  request, instead of returning unfiltered whole-project diagnostics. (#1124)
 
 ## [0.8.0] — 2026-07-14
 

--- a/sdk/python/src/rocky_sdk/client.py
+++ b/sdk/python/src/rocky_sdk/client.py
@@ -1056,7 +1056,14 @@ class RockyClient:
     # ------------------------------------------------------------------ #
 
     def compile(self, model_filter: str | None = None) -> CompileResult:
-        """Run ``rocky compile`` (or the HTTP API when ``server_url`` is set)."""
+        """Run ``rocky compile`` (or the HTTP API when ``server_url`` is set).
+
+        Raises:
+            ValueError: ``model_filter`` is used with ``server_url`` (the HTTP
+                compile endpoint compiles the whole project only).
+        """
+        if self.server_url is not None and model_filter is not None:
+            raise ValueError("model_filter is not supported when server_url is set")
         if self.server_url is not None:
             return _parse_rocky_json(
                 self._http_get("/api/v1/compile"), CompileResult, command="compile"

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -480,6 +480,28 @@ def test_http_metrics_rejects_cli_only_options(kwargs):
     http_get.assert_not_called()
 
 
+def test_http_compile_uses_default_endpoint():
+    client = _client(server_url="http://localhost:8080")
+    body = (
+        '{"version":"1","command":"compile","models":0,'
+        '"execution_layers":0,"diagnostics":[],"has_errors":false}'
+    )
+    with patch.object(client, "_http_get", return_value=body) as http_get:
+        result = client.compile()
+    http_get.assert_called_once_with("/api/v1/compile")
+    assert result.command == "compile"
+
+
+def test_http_compile_rejects_model_filter():
+    client = _client(server_url="http://localhost:8080")
+    with (
+        patch.object(client, "_http_get") as http_get,
+        pytest.raises(ValueError, match="not supported when server_url is set"),
+    ):
+        client.compile("orders")
+    http_get.assert_not_called()
+
+
 # --------------------------------------------------------------------------- #
 # apply() — dispatch by real wire shape (there is NO wrapping envelope)
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Prevent `RockyClient.compile()` from silently discarding `model_filter` when `server_url` selects the default-only HTTP endpoint. Direct parallel of #1123 (metrics), for the second and last instance of this silent-discard class.

Closes #1124.

## Subproject(s) touched

- [ ] `engine/`
- [x] `sdk/python/`
- [ ] `integrations/dagster/`
- [ ] `editors/vscode/`
- [ ] `examples/playground/`
- [ ] `schemas/`
- [x] Cross-project (public docs)

## Changes

- Reject `compile(model_filter=...)` with `ValueError` before the HTTP request when `server_url` is set (the `GET /api/v1/compile` handler compiles the whole project only — `model_filter = None`).
- Preserve the existing default server-mode request to `GET /api/v1/compile`.
- Add default-path and rejection SDK tests.
- Document the constraint in the method reference and SDK changelog.

## Why not pass the filter through?

The engine endpoint is intentionally default-only (`compile_status` hardcodes `None` for `model_filter`), same as the metrics endpoint. Rejecting is the minimal correctness fix; teaching the endpoint to honor a filter is separate engine work.

## Test Plan

- [x] `uv run python -m pytest -q` — 193 passed
- [x] `uv run python -m ruff check src/ tests/`
- [x] `uv run python -m ruff format --check src/ tests/`

## Checklist

- [x] Conventional commit, scoped to the SDK.
- [x] No `Co-Authored-By` trailers.
- [x] Not a CLI JSON schema or DSL change; no consumer regeneration required.