### PR TITLE
docs: note server-mode option constraints for the SDK read methods

### DIFF
--- a/docs/src/content/docs/dagster/resource.md
+++ b/docs/src/content/docs/dagster/resource.md
@@ -346,6 +346,8 @@ When `server_url` is configured, the following methods use the `rocky serve` HTT
 - `lineage()` -- `GET /api/v1/models/<target>/lineage[/<column>]`
 - `metrics()` -- `GET /api/v1/models/<model>/metrics`
 
+These endpoints serve each command's default output. `lineage`'s `column` is supported (it has a dedicated route), but `compile`'s `model_filter` and `metrics`'s `trend`, `column`, or `alerts` raise `ValueError` rather than being silently ignored.
+
 This is useful when a Rocky server is already running (e.g., in a development environment or alongside the LSP).
 
 ## Example

--- a/docs/src/content/docs/python-sdk/introduction.md
+++ b/docs/src/content/docs/python-sdk/introduction.md
@@ -92,7 +92,7 @@ except RockyCommandError as exc:
 - **Governance and branches:** `compliance`, `retention_status`, `branch_approve`, `branch_promote`, `plan_promote`
 - **Diagnostics:** `doctor`, `validate_migration`, `test_adapter`, `hooks_list`, `hooks_test`
 
-`run()` accepts a `log_callback` that receives the engine's stderr line by line, so you can stream progress wherever you want. Setting `server_url` routes `compile`, `lineage`, and `metrics` through a running `rocky serve` instead of a subprocess.
+`run()` accepts a `log_callback` that receives the engine's stderr line by line, so you can stream progress wherever you want. Setting `server_url` routes `compile`, `lineage`, and `metrics` through a running `rocky serve` instead of a subprocess. Those endpoints serve each command's default output, so `compile`'s `model_filter` and `metrics`'s `trend`, `column`, or `alerts` raise `ValueError` in server mode, while `lineage`'s `column` is supported.
 
 Each method's full signature, parameters, and return type are in the [`RockyResource` reference](/dagster/resource/) — `RockyClient` exposes the same methods and configuration, since the Dagster resource delegates to it. Output model shapes are in the [JSON output reference](/reference/json-output/), and the `filter=` syntax in [Filters](/reference/filters/).
 

--- a/docs/src/content/docs/python-sdk/recipes.md
+++ b/docs/src/content/docs/python-sdk/recipes.md
@@ -64,7 +64,10 @@ lower-level `run_cli(args, allow_partial=False)`, which raises
 
 For repeated read-only calls, point the client at a running `rocky serve` instead
 of spawning a subprocess per call. Only `compile`, `lineage`, and `metrics` honor
-`server_url`; `run()` and the write paths always use a subprocess.
+`server_url`; `run()` and the write paths always use a subprocess. These endpoints
+serve each command's default output: `lineage`'s `column` is supported, but
+`compile`'s `model_filter` and `metrics`'s `trend`, `column`, or `alerts` raise
+`ValueError` rather than being silently ignored.
 
 ```python
 client = RockyClient(config_path="rocky.toml", server_url="http://localhost:8080")


### PR DESCRIPTION
## Summary

Follow-up to the 0.8.1 SDK fixes (#1122 metrics, #1124 compile). The per-method reference sections already document that `compile`'s `model_filter` and `metrics`'s `trend`/`column`/`alerts` raise `ValueError` in server mode, but three **overview** spots still described `server_url` routing without the constraint. This makes them consistent.

## Changes

- `python-sdk/introduction.md` — the SDK's server-mode one-liner.
- `python-sdk/recipes.md` — the "Use a long-lived server" recipe.
- `dagster/resource.md` — the "HTTP fallback" method→endpoint list.

Each now notes that the HTTP endpoints serve each command's **default** output, so `compile`'s `model_filter` and `metrics`'s `trend`/`column`/`alerts` raise `ValueError`, **while `lineage`'s `column` stays supported** (it has a dedicated `/lineage/<column>` route). The constraint is not uniform, so the wording is deliberately precise.

## Test Plan

- [x] `npm run build` in `docs/` — 96 pages built, no errors/broken links.
- [x] Verified against the client: `lineage()` forwards `column` in server mode (`client.py`); `compile()`/`metrics()` reject their extra options.

## Subproject(s) touched

- [x] Cross-project (public docs)