### PR TITLE
fix(sdk): pass models directory to compliance

### DIFF
--- a/docs/src/content/docs/dagster/resource.md
+++ b/docs/src/content/docs/dagster/resource.md
@@ -15,7 +15,7 @@ sidebar:
 | `config_path` | `str` | `"rocky.toml"` | Path to the pipeline config file. |
 | `state_path` | `str` | `".rocky-state.redb"` | Path to the state store file. |
 | `state_namespace` | `str \| None` | `None` | Optional per-namespace state file (engine `--state-namespace`). Mutually exclusive with `state_path`: when set, `--state-namespace` is sent and `--state-path` is omitted, so independent fan-out runs don't serialize on a single writer lock. |
-| `models_dir` | `str` | `"models"` | Path to the directory containing `.rocky` model files. Used by `compile`, `lineage`, `test`, `ci`, `ai_sync`, `ai_explain`, and `ai_test`. |
+| `models_dir` | `str` | `"models"` | Path to the directory containing `.rocky` model files. Used by `compile`, `lineage`, `test`, `ci`, `compliance`, `ai_sync`, `ai_explain`, and `ai_test`. |
 | `contracts_dir` | `str \| None` | `None` | Optional directory containing contract files. Passed to `compile`, `test`, and `ci` when set. |
 | `server_url` | `str \| None` | `None` | Optional URL for a running `rocky serve` instance. When set, `compile()`, `lineage()`, and `metrics()` use the HTTP API instead of spawning a subprocess. |
 | `timeout_seconds` | `int` | `3600` | Subprocess timeout for any single CLI invocation (in seconds). |
@@ -282,6 +282,12 @@ Analyze materialization strategies and return cost optimization recommendations.
 Run health checks on the Rocky installation and configuration.
 
 **Wraps**: `rocky doctor --output json`
+
+### `compliance(*, env=None) -> ComplianceOutput`
+
+Runs the governance compliance rollup against the resource's configured `models_dir`.
+
+**Wraps**: `rocky compliance --models <models_dir> --output json [--env <env>]`
 
 ### `validate_migration(dbt_project, rocky_project=None, *, sample_size=None) -> ValidateMigrationResult`
 

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -483,7 +483,8 @@ class RockyResource(dg.ConfigurableResource):
         binary_path: Path to the ``rocky`` binary. Defaults to ``"rocky"`` (on PATH).
         config_path: Path to the ``rocky.toml`` config file.
         state_path: Path to the state store file.
-        models_dir: Directory containing model files (compile/lineage/test/ci).
+        models_dir: Directory containing model files for model-aware commands,
+            including compile, lineage, test, CI, AI, and compliance.
         contracts_dir: Optional directory containing contract files.
         server_url: Optional URL for a running ``rocky serve`` instance. When set,
             ``compile()``, ``lineage()`` and ``metrics()`` use the HTTP API.

--- a/integrations/dagster/tests/test_resource.py
+++ b/integrations/dagster/tests/test_resource.py
@@ -2313,7 +2313,7 @@ def test_doctor_with_check_kwarg_forwards_arbitrary_id():
 
 
 def test_compliance_builds_argv_without_env(compliance_json: str):
-    """Default ``compliance()`` call emits ``compliance --output json``."""
+    """Default ``compliance()`` call forwards the default models directory."""
     rocky = RockyResource()
     captured: list[list[str]] = []
 
@@ -2324,7 +2324,7 @@ def test_compliance_builds_argv_without_env(compliance_json: str):
     with patch.object(RockyClient, "run_cli", autospec=True, side_effect=fake_run):
         result = rocky.compliance()
 
-    assert captured[0] == ["compliance", "--output", "json"]
+    assert captured[0] == ["compliance", "--output", "json", "--models", "models"]
     assert result.command == "compliance"
     assert len(result.exceptions) == 2
 
@@ -2340,7 +2340,15 @@ def test_compliance_forwards_env_flag(compliance_json: str):
     with patch.object(RockyClient, "run_cli", autospec=True, side_effect=fake_run):
         rocky.compliance(env="prod")
 
-    assert captured[0] == ["compliance", "--output", "json", "--env", "prod"]
+    assert captured[0] == [
+        "compliance",
+        "--output",
+        "json",
+        "--models",
+        "models",
+        "--env",
+        "prod",
+    ]
 
 
 def test_retention_status_builds_argv_without_env(retention_status_json: str):

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`RockyClient.compliance()` now honors the configured `models_dir`.** The SDK forwards
+  `--models <models_dir>` instead of allowing the engine to silently scan its default `models/`
+  directory, preventing false empty compliance reports in custom-layout projects. (#1128)
+
 ## [0.8.1] — 2026-07-16
 
 ### Fixed

--- a/sdk/python/src/rocky_sdk/client.py
+++ b/sdk/python/src/rocky_sdk/client.py
@@ -311,7 +311,8 @@ class RockyClient:
             ``state_namespace``.
         state_namespace: Optional per-namespace state key (engine
             ``--state-namespace``). When set, ``--state-path`` is omitted.
-        models_dir: Directory containing model files (compile/lineage/test/ci).
+        models_dir: Directory containing model files for model-aware commands,
+            including compile, lineage, test, CI, AI, and compliance.
         contracts_dir: Optional directory containing contract files.
         server_url: Optional ``rocky serve`` URL. When set, ``compile``,
             ``lineage`` and ``metrics`` use the HTTP API instead of a subprocess.
@@ -1306,7 +1307,7 @@ class RockyClient:
         )
 
     def compliance(self, *, env: str | None = None) -> ComplianceOutput:
-        """Run ``rocky compliance`` and return the governance rollup."""
+        """Run ``rocky compliance`` against ``models_dir`` and return the governance rollup."""
         args = ["compliance", "--output", "json", "--models", self.models_dir]
         if env is not None:
             args.extend(["--env", env])

--- a/sdk/python/src/rocky_sdk/client.py
+++ b/sdk/python/src/rocky_sdk/client.py
@@ -1307,7 +1307,7 @@ class RockyClient:
 
     def compliance(self, *, env: str | None = None) -> ComplianceOutput:
         """Run ``rocky compliance`` and return the governance rollup."""
-        args = ["compliance", "--output", "json"]
+        args = ["compliance", "--output", "json", "--models", self.models_dir]
         if env is not None:
             args.extend(["--env", env])
         return _parse_rocky_json(self.run_cli(args), ComplianceOutput, command="compliance")

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -141,6 +141,24 @@ def test_build_plan_args_mirrors_run_with_plan_verb():
     assert run[1:] == plan[1:]
 
 
+def test_compliance_threads_models_dir():
+    client = _client(models_dir="custom-models")
+    output = json.dumps(
+        {
+            "version": "1.64.0",
+            "command": "compliance",
+            "summary": {"total_classified": 0, "total_exceptions": 0, "total_masked": 0},
+            "per_column": [],
+            "exceptions": [],
+        }
+    )
+    with patch.object(client, "run_cli", return_value=output) as run_cli:
+        client.compliance(env="prod")
+    run_cli.assert_called_once_with(
+        ["compliance", "--output", "json", "--models", "custom-models", "--env", "prod"]
+    )
+
+
 # --------------------------------------------------------------------------- #
 # version gate
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Fix `RockyClient.compliance()` so it forwards the client's configured `models_dir` to the Rocky CLI. This prevents valid custom-layout projects from silently receiving an empty or incomplete compliance report.

Closes #1128.

## Subproject(s) touched

- [ ] `engine/` (Rust CLI / crates)
- [x] `sdk/python/` (Python SDK)
- [x] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [x] Cross-project (root docs)

## Changes

- Pass `--models <models_dir>` from `RockyClient.compliance()` to the engine.
- Add an SDK regression test covering a non-default models directory and `--env`.
- Update the Dagster wrapper assertion to cover the forwarded default models directory.
- Document compliance as a `models_dir`-aware command in the SDK and Dagster surfaces.
- Add an SDK changelog entry for the corrected behavior.

## User impact

Users who configure `RockyClient(models_dir=...)` or `RockyResource(models_dir=...)` now get compliance results for that directory instead of the engine's default `models/` directory.

## Root cause

The engine's `compliance` command accepts `--models`, but the Python SDK wrapper omitted it and therefore silently used the engine default.

## Test Plan

- `cargo test` from `engine/` — full workspace and doctests passed; credential-gated live tests remained ignored as annotated.
- `uv run pytest` from `sdk/python/` — 194 passed.
- `uv run ruff check .` and `uv run ruff format --check .` from `sdk/python/` — passed.
- `uv build` from `sdk/python/` — passed.
- `uv run pytest` from `integrations/dagster/` — 696 passed.
- `uv run ruff check .` and `uv run ruff format --check .` from `integrations/dagster/` — passed.
- `uv build` from `integrations/dagster/` — passed.
- `npm run test:unit` from `editors/vscode/` — 208 passed.
- `npm run build` from `docs/` under Node 22 — passed.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/), scoped by subproject when relevant.
- [x] No `Co-Authored-By` trailers.
- [x] This does not change CLI JSON schemas or DSL syntax.

### Engine (`engine/`)

- [ ] `cargo test --all-targets` passes (engine code is unchanged; full-workspace `cargo test` passes)
- [ ] `cargo clippy --all-targets -- -D warnings` is clean (engine code is unchanged)
- [ ] `cargo fmt --check` passes (engine code is unchanged)

### SDK (`sdk/python/`)

- [x] `uv run pytest` passes
- [x] `uv run ruff check .` is clean
- [x] `uv run ruff format --check .` passes
- [x] `uv build` succeeds

### Dagster (`integrations/dagster/`)

- [x] `uv run pytest` passes
- [x] `uv run ruff check .` is clean
- [x] `uv run ruff format --check .` passes

### VS Code (`editors/vscode/`)

- [ ] `npm run compile` succeeds (VS Code code is unchanged)
- [x] `npm run test:unit` passes (electron tests run in CI)
- [ ] `npm run lint` is clean (VS Code code is unchanged)
