### PR TITLE
fix(sdk): forward models_dir to every model-aware command that dropped it; reject unsupported retention env (rocky-sdk 0.8.3)

### DIFF
--- a/docs/src/content/docs/dagster/resource.md
+++ b/docs/src/content/docs/dagster/resource.md
@@ -267,7 +267,11 @@ raises `ValueError` rather than silently ignoring the option.
 
 Analyze materialization strategies and return cost optimization recommendations.
 
-**Wraps**: `rocky optimize --output json`
+**Wraps**: `rocky optimize --models <models_dir> --output json`
+
+`--models` is forwarded so the engine computes each model's `downstream_references`
+against the configured layout; without it a custom `models_dir` silently yields
+`downstream_references: 0` for every model and skews the recommendation.
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
@@ -288,6 +292,16 @@ Run health checks on the Rocky installation and configuration.
 Runs the governance compliance rollup against the resource's configured `models_dir`.
 
 **Wraps**: `rocky compliance --models <models_dir> --output json [--env <env>]`
+
+### `retention_status(*, env=None) -> RetentionStatusOutput`
+
+Reports which models declare a `retention` sidecar value, scanned against the
+resource's configured `models_dir`.
+
+**Wraps**: `rocky retention-status --models <models_dir> --output json`
+
+Passing `env` raises `ValueError` — `rocky retention-status` has no `--env` flag
+(unlike `compliance`); retention is not environment-scoped.
 
 ### `validate_migration(dbt_project, rocky_project=None, *, sample_size=None) -> ValidateMigrationResult`
 

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`RockyResource.optimize()` / `retention_status()` now scan the configured
-  `models_dir`** (via `rocky-sdk` — forward `--models`). A custom-layout project
-  previously got silently-zeroed `downstream_references` from `optimize` and a
-  `NoModels` error from `retention_status`. `retention_status(env=...)` now raises
-  a clear `ValueError` (`rocky retention-status` has no `--env` flag). Requires
-  `rocky-sdk>=0.8.3`.
+- **Model-aware resource methods now scan the configured `models_dir`** (via
+  `rocky-sdk` — forward `--models`). Previously `optimize()`, `branch_promote()`,
+  `plan_promote()`, `ai()`, and `retention_status()` silently used the engine's
+  default `models/` on a custom layout — misclassified `optimize`
+  recommendations, a **silently-skipped breaking-change gate** on
+  promote, `ai` generating into the wrong directory, and a `NoModels` error from
+  `retention_status`. `retention_status(env=...)` now raises a clear `ValueError`
+  (`rocky retention-status` has no `--env` flag). Requires `rocky-sdk>=0.8.3`.
 
 ## [1.60.0] — 2026-07-12
 

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`RockyResource.optimize()` / `retention_status()` now scan the configured
+  `models_dir`** (via `rocky-sdk` — forward `--models`). A custom-layout project
+  previously got silently-zeroed `downstream_references` from `optimize` and a
+  `NoModels` error from `retention_status`. `retention_status(env=...)` now raises
+  a clear `ValueError` (`rocky retention-status` has no `--env` flag). Requires
+  `rocky-sdk>=0.8.3`.
+
 ## [1.60.0] — 2026-07-12
 
 ### Changed

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -1437,7 +1437,11 @@ class RockyResource(dg.ConfigurableResource):
             return self._get_client().compliance(env=env)
 
     def retention_status(self, *, env: str | None = None) -> RetentionStatusOutput:
-        """Run ``rocky retention-status`` and return per-model retention status."""
+        """Run ``rocky retention-status`` and return per-model retention status.
+
+        Raises ``ValueError`` if ``env`` is set — ``rocky retention-status`` has
+        no ``--env`` flag (retention is not environment-scoped).
+        """
         with _translating():
             return self._get_client().retention_status(env=env)
 

--- a/integrations/dagster/tests/test_resource.py
+++ b/integrations/dagster/tests/test_resource.py
@@ -2324,7 +2324,7 @@ def test_compliance_builds_argv_without_env(compliance_json: str):
     with patch.object(RockyClient, "run_cli", autospec=True, side_effect=fake_run):
         result = rocky.compliance()
 
-    assert captured[0] == ["compliance", "--output", "json", "--models", "models"]
+    assert captured[0] == ["compliance", "--models", "models"]
     assert result.command == "compliance"
     assert len(result.exceptions) == 2
 
@@ -2340,19 +2340,11 @@ def test_compliance_forwards_env_flag(compliance_json: str):
     with patch.object(RockyClient, "run_cli", autospec=True, side_effect=fake_run):
         rocky.compliance(env="prod")
 
-    assert captured[0] == [
-        "compliance",
-        "--output",
-        "json",
-        "--models",
-        "models",
-        "--env",
-        "prod",
-    ]
+    assert captured[0] == ["compliance", "--models", "models", "--env", "prod"]
 
 
-def test_retention_status_builds_argv_without_env(retention_status_json: str):
-    """Default ``retention_status()`` call emits ``retention-status --output json``."""
+def test_retention_status_builds_argv_with_models(retention_status_json: str):
+    """Default ``retention_status()`` forwards ``--models`` (compliance parity)."""
     rocky = RockyResource()
     captured: list[list[str]] = []
 
@@ -2363,23 +2355,23 @@ def test_retention_status_builds_argv_without_env(retention_status_json: str):
     with patch.object(RockyClient, "run_cli", autospec=True, side_effect=fake_run):
         result = rocky.retention_status()
 
-    assert captured[0] == ["retention-status", "--output", "json"]
+    assert captured[0] == ["retention-status", "--models", "models"]
     assert result.command == "retention-status"
     assert len(result.models) == 3
 
 
-def test_retention_status_forwards_env_flag(retention_status_json: str):
+def test_retention_status_rejects_env():
+    """``rocky retention-status`` has no ``--env`` flag, so passing env raises a
+    ``ValueError`` in-process instead of hard-erroring at the CLI."""
     rocky = RockyResource()
-    captured: list[list[str]] = []
 
-    def fake_run(self, args, *, allow_partial=False, log_callback=None):
-        captured.append(args)
-        return retention_status_json
-
-    with patch.object(RockyClient, "run_cli", autospec=True, side_effect=fake_run):
+    with (
+        patch.object(RockyClient, "run_cli", autospec=True) as run_cli,
+        pytest.raises(ValueError, match="env is not supported by retention-status"),
+    ):
         rocky.retention_status(env="prod")
 
-    assert captured[0] == ["retention-status", "--output", "json", "--env", "prod"]
+    run_cli.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -910,7 +910,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.7.0"
+version = "0.8.3"
 source = { editable = "../../sdk/python" }
 dependencies = [
     { name = "pydantic" },

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -11,18 +11,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`RockyClient.optimize()` now forwards the configured `models_dir`.** Without
-  `--models` the engine defaulted to `models/` and, for a custom layout, silently
-  reported `downstream_references: 0` for every model — misclassifying the
-  recommended materialization strategy (a model with 2+ consumers never routes to
-  the "materialize once (table)" branch). `optimize()` now passes
-  `--models <models_dir>`, matching the other model-aware methods.
-- **`RockyClient.retention_status()` now forwards `models_dir` and rejects the
-  unsupported `env` option.** It passes `--models <models_dir>` (compliance
-  parity — a custom layout previously failed with `NoModels`), and raises a clear
-  `ValueError` when `env` is set. `rocky retention-status` has no `--env` flag
-  (unlike `compliance`), so the option hard-errored at the CLI before; the guard
-  surfaces it in-process without a subprocess round-trip. (Latent since #874.)
+- **Model-aware commands now forward the configured `models_dir`.** An audit of
+  every `RockyClient` method's argv against the engine CLI found several methods
+  that accept `--models` but never received it, so a custom `models_dir` was
+  silently ignored (the engine fell back to its default `models/`):
+  - **`optimize()`** — a custom layout silently reported `downstream_references: 0`
+    for every model (the engine's model-DAG scan degrades to empty on a missing
+    dir), misclassifying the recommended materialization strategy: a model with
+    2+ consumers never routed to the "materialize once (table)" branch.
+  - **`branch_promote()` / `plan_promote()`** — the semantic breaking-change gate
+    silently **skipped** when the default `models/` was absent, promoting
+    potentially-breaking changes unchecked. It now runs against the real layout.
+  - **`ai()`** — the engine grounds the prompt on, and writes the generated model
+    into, `models_dir`; without `--models` a custom-layout client generated
+    against and wrote the new model into the wrong directory.
+  - **`retention_status()`** — a custom layout previously failed with `NoModels`;
+    it now scans the configured directory (compliance parity).
+- **`retention_status()` rejects the unsupported `env` option.** `rocky
+  retention-status` has no `--env` flag (unlike `compliance`), so passing `env`
+  hard-errored at the CLI. It now raises a clear `ValueError` before spawning a
+  subprocess. (Latent since #874.)
 
 ### Changed
 

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.3] — 2026-07-17
+
+### Fixed
+
+- **`RockyClient.optimize()` now forwards the configured `models_dir`.** Without
+  `--models` the engine defaulted to `models/` and, for a custom layout, silently
+  reported `downstream_references: 0` for every model — misclassifying the
+  recommended materialization strategy (a model with 2+ consumers never routes to
+  the "materialize once (table)" branch). `optimize()` now passes
+  `--models <models_dir>`, matching the other model-aware methods.
+- **`RockyClient.retention_status()` now forwards `models_dir` and rejects the
+  unsupported `env` option.** It passes `--models <models_dir>` (compliance
+  parity — a custom layout previously failed with `NoModels`), and raises a clear
+  `ValueError` when `env` is set. `rocky retention-status` has no `--env` flag
+  (unlike `compliance`), so the option hard-errored at the CLI before; the guard
+  surfaces it in-process without a subprocess round-trip. (Latent since #874.)
+
+### Changed
+
+- **`compliance()` / `retention_status()` no longer emit a redundant `--output
+  json`.** The shared argv builder already supplies the global `--output json`;
+  the duplicated per-method copy is removed. No behavior change.
+
 ## [0.8.2] — 2026-07-16
 
 ### Fixed

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rocky-sdk"
-version = "0.8.2"
+version = "0.8.3"
 description = "Typed Python client for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/python/src/rocky_sdk/client.py
+++ b/sdk/python/src/rocky_sdk/client.py
@@ -1182,8 +1182,15 @@ class RockyClient:
         return _parse_rocky_json(self.run_cli(args), MetricsResult, command="metrics")
 
     def optimize(self, model: str | None = None) -> OptimizeResult:
-        """Run ``rocky optimize`` and return materialization recommendations."""
-        args: list[str] = ["optimize"]
+        """Run ``rocky optimize`` and return materialization recommendations.
+
+        Forwards ``--models`` so the engine can build the model DAG and compute
+        each model's ``downstream_references`` accurately. Without it the engine
+        defaults to ``models/`` and, for a custom ``models_dir``, silently reports
+        ``downstream_references: 0`` for every model — skewing the recommended
+        materialization strategy (table vs view vs ephemeral).
+        """
+        args: list[str] = ["optimize", "--models", self.models_dir]
         if model is not None:
             args.extend(["--model", model])
         return _parse_rocky_json(self.run_cli(args), OptimizeResult, command="optimize")
@@ -1308,16 +1315,27 @@ class RockyClient:
 
     def compliance(self, *, env: str | None = None) -> ComplianceOutput:
         """Run ``rocky compliance`` against ``models_dir`` and return the governance rollup."""
-        args = ["compliance", "--output", "json", "--models", self.models_dir]
+        args = ["compliance", "--models", self.models_dir]
         if env is not None:
             args.extend(["--env", env])
         return _parse_rocky_json(self.run_cli(args), ComplianceOutput, command="compliance")
 
     def retention_status(self, *, env: str | None = None) -> RetentionStatusOutput:
-        """Run ``rocky retention-status`` and return per-model retention status."""
-        args = ["retention-status", "--output", "json"]
+        """Run ``rocky retention-status`` against ``models_dir`` and return per-model status.
+
+        Forwards ``--models`` (like :meth:`compliance`) so a custom ``models_dir``
+        is honored; without it the engine defaults to ``models/`` and a
+        custom-layout project errors with ``NoModels``.
+
+        Raises:
+            ValueError: ``env`` is set. ``rocky retention-status`` has no
+                ``--env`` flag (unlike ``compliance``) — retention is not
+                environment-scoped, so passing ``env`` would hard-error at the
+                CLI. Raised in-process instead of paying a subprocess round-trip.
+        """
         if env is not None:
-            args.extend(["--env", env])
+            raise ValueError("env is not supported by retention-status (the CLI has no --env flag)")
+        args = ["retention-status", "--models", self.models_dir]
         return _parse_rocky_json(
             self.run_cli(args), RetentionStatusOutput, command="retention-status"
         )

--- a/sdk/python/src/rocky_sdk/client.py
+++ b/sdk/python/src/rocky_sdk/client.py
@@ -1028,8 +1028,14 @@ class RockyClient:
     def branch_promote(
         self, name: str, *, filter: str | None = None, skip_approval: bool = False
     ) -> BranchPromoteOutput:
-        """Run ``rocky branch promote <name>`` and return the parsed result."""
-        args = ["branch", "promote", name]
+        """Run ``rocky branch promote <name>`` and return the parsed result.
+
+        Forwards ``--models`` so the semantic breaking-change gate runs against
+        the configured layout. Without it the engine defaults to ``models/`` and,
+        for a custom ``models_dir``, the gate silently skips (missing directory)
+        — promoting potentially-breaking changes unchecked.
+        """
+        args = ["branch", "promote", name, "--models", self.models_dir]
         if filter is not None:
             args.extend(["--filter", filter])
         if skip_approval:
@@ -1044,8 +1050,12 @@ class RockyClient:
         allow_breaking: bool = False,
         filter: str | None = None,
     ) -> PromotePlan:
-        """Run ``rocky plan promote <name>`` — gates at plan time, persists a plan."""
-        args = ["plan", "promote", name, "--base", base]
+        """Run ``rocky plan promote <name>`` — gates at plan time, persists a plan.
+
+        Forwards ``--models`` so the hard breaking-change gate runs against the
+        configured layout (see :meth:`branch_promote`).
+        """
+        args = ["plan", "promote", name, "--base", base, "--models", self.models_dir]
         if allow_breaking:
             args.append("--allow-breaking")
         if filter is not None:
@@ -1204,9 +1214,16 @@ class RockyClient:
     # ------------------------------------------------------------------ #
 
     def ai(self, intent: str, format: str = "rocky") -> AiResult:
-        """Generate a model from a natural-language intent."""
+        """Generate a model from a natural-language intent.
+
+        Forwards ``--models`` so the engine grounds the prompt on — and writes the
+        generated model into — the configured ``models_dir`` rather than the
+        default ``models/``.
+        """
         return _parse_rocky_json(
-            self.run_cli(["ai", intent, "--format", format]), AiResult, command="ai"
+            self.run_cli(["ai", intent, "--format", format, "--models", self.models_dir]),
+            AiResult,
+            command="ai",
         )
 
     def ai_sync(

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -199,6 +199,64 @@ def test_retention_status_rejects_env():
     run_cli.assert_not_called()
 
 
+def test_branch_promote_threads_models_dir():
+    # --models must reach the breaking-change gate; without it a custom layout
+    # silently skips the gate (missing default ``models/``).
+    client = _client(models_dir="custom-models")
+    with (
+        patch.object(client, "run_cli", return_value="{}") as run_cli,
+        patch("rocky_sdk.client._parse_rocky_json"),
+    ):
+        client.branch_promote("feature-x", filter="client=acme", skip_approval=True)
+    run_cli.assert_called_once_with(
+        [
+            "branch",
+            "promote",
+            "feature-x",
+            "--models",
+            "custom-models",
+            "--filter",
+            "client=acme",
+            "--skip-approval",
+        ]
+    )
+
+
+def test_plan_promote_threads_models_dir():
+    client = _client(models_dir="custom-models")
+    with (
+        patch.object(client, "run_cli", return_value="{}") as run_cli,
+        patch("rocky_sdk.client._parse_rocky_json"),
+    ):
+        client.plan_promote("feature-x", base="main", allow_breaking=True)
+    run_cli.assert_called_once_with(
+        [
+            "plan",
+            "promote",
+            "feature-x",
+            "--base",
+            "main",
+            "--models",
+            "custom-models",
+            "--allow-breaking",
+        ]
+    )
+
+
+def test_ai_threads_models_dir():
+    # ``rocky ai`` grounds on and *writes into* models_dir, so a custom layout
+    # must forward --models or the generated model lands in the wrong directory.
+    client = _client(models_dir="custom-models")
+    with (
+        patch.object(client, "run_cli", return_value="{}") as run_cli,
+        patch("rocky_sdk.client._parse_rocky_json"),
+    ):
+        client.ai("build a daily revenue model")
+    run_cli.assert_called_once_with(
+        ["ai", "build a daily revenue model", "--format", "rocky", "--models", "custom-models"]
+    )
+
+
 # --------------------------------------------------------------------------- #
 # version gate
 # --------------------------------------------------------------------------- #

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -154,9 +154,49 @@ def test_compliance_threads_models_dir():
     )
     with patch.object(client, "run_cli", return_value=output) as run_cli:
         client.compliance(env="prod")
-    run_cli.assert_called_once_with(
-        ["compliance", "--output", "json", "--models", "custom-models", "--env", "prod"]
+    # ``--output json`` is supplied globally by ``_build_cmd``; the method must
+    # not append a second redundant copy.
+    run_cli.assert_called_once_with(["compliance", "--models", "custom-models", "--env", "prod"])
+
+
+def test_optimize_threads_models_dir():
+    client = _client(models_dir="custom-models")
+    output = json.dumps(
+        {
+            "version": "1.64.0",
+            "command": "optimize",
+            "recommendations": [],
+            "total_models_analyzed": 0,
+        }
     )
+    with patch.object(client, "run_cli", return_value=output) as run_cli:
+        client.optimize(model="fct_orders")
+    # ``--models`` must be forwarded so downstream_references is computed against
+    # the configured layout, not the engine's default ``models/``.
+    run_cli.assert_called_once_with(
+        ["optimize", "--models", "custom-models", "--model", "fct_orders"]
+    )
+
+
+def test_retention_status_threads_models_dir():
+    client = _client(models_dir="custom-models")
+    output = json.dumps({"version": "1.64.0", "command": "retention-status", "models": []})
+    with patch.object(client, "run_cli", return_value=output) as run_cli:
+        client.retention_status()
+    # ``--models`` forwarded (compliance parity); no redundant ``--output json``.
+    run_cli.assert_called_once_with(["retention-status", "--models", "custom-models"])
+
+
+def test_retention_status_rejects_env():
+    # ``rocky retention-status`` has no ``--env`` flag (unlike ``compliance``);
+    # passing env must raise before any subprocess spawns, not hard-error at clap.
+    client = _client()
+    with (
+        patch.object(client, "run_cli") as run_cli,
+        pytest.raises(ValueError, match="env is not supported by retention-status"),
+    ):
+        client.retention_status(env="prod")
+    run_cli.assert_not_called()
 
 
 # --------------------------------------------------------------------------- #

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.8.2"
+version = "0.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

An audit of every `RockyClient` method's argv against the engine's clap definitions — following the `compile` / `metrics` / `compliance` fixes — found a cluster of model-aware methods that accept `--models` but never forwarded the configured `models_dir`, so a custom layout was silently ignored (the engine fell back to `models/`). Plus one inverse bug and one cleanup. Completeness was then proven deterministically (every `--models`-accepting subcommand ↔ its SDK method) and confirmed by two red-team rounds.

### Fixes — dropped `models_dir` (silent on custom layouts, invisible on the default layout)
- **`optimize()`** — the engine's model-DAG scan degrades to empty on a missing dir, so a custom layout silently reported `downstream_references: 0` for every model, misclassifying the recommended materialization strategy (a model with 2+ consumers never routed to the "materialize once / table" branch).
- **`branch_promote()` / `plan_promote()`** — the semantic breaking-change gate **silently skips** when the default `models/` is absent (`branch.rs` records `BreakingChangesGateSkipped` and returns `None`), so a custom-layout promotion proceeded **unchecked**. Now the gate runs against the real layout.
- **`ai()`** — the engine grounds the prompt on, and **unconditionally writes the generated model into**, `models_dir`; without `--models` a custom-layout client generated against and wrote the new model into the wrong directory.
- **`retention_status()`** — a custom layout previously failed with `NoModels`; now scans the configured directory (compliance parity).

### Fix — inverse omission
- **`retention_status(env=...)`** forwarded `--env`, but the engine's `retention-status` has no `--env` flag (unlike `compliance`), so it hard-errored at the CLI — latent since the SDK's first commit (#874). Now raises a clear `ValueError` before spawning.

### Cleanup
- Removed the redundant per-method `--output json` from `compliance()` / `retention_status()` — the shared argv builder already supplies the global one.

### Not changed (verified, out of scope)
- **`plan()`** (public) omits `--models` by design — a transformation-only custom layout hard-errors (not silent); a replication plan is the correct output.
- **`resume_run()`** is replication-resume by design (no `run_models` param); forwarding `--models` unconditionally would wrongly run the model leg on a replication-only resume. Resuming a model-inclusive run is a separate feature gap (needs a `run_models` param + checkpoint-aware models) — follow-up, not this PR.

### Tests / docs / release
- Added the previously-missing argv tests for all five methods (that untested-argv gap is the root cause), including a reject-`env` test.
- Mirrored into the dagster resource docstring, tests, and the resource reference docs.
- Bumps `rocky-sdk` to **0.8.3** (patch — bug fixes).

## Verification
- SDK: 200 passed; ruff check + format clean; wheel builds as `rocky_sdk-0.8.3`.
- dagster: 696 passed; ruff check + format clean.
- Engine facts confirmed by direct read: the `--models` defaults, the `branch.rs:1492` gate-skip, `ai.rs:223` unconditional write, `recommend_strategy`'s use of `downstream_references`, and the `resume_run` model-leg gating (`run.rs:3938`).