### PR TITLE
fix(dagster): floor rocky-sdk>=0.8.3 to guarantee the models_dir fixes

### DIFF
--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -22,8 +22,11 @@ dependencies = [
     # The typed result models + RockyClient now live in the standalone rocky-sdk
     # package; RockyResource is a thin Dagster adapter over RockyClient. In-repo
     # dev/CI resolves this from the local path (see [tool.uv.sources]); the
-    # published wheel floors on the released SDK.
-    "rocky-sdk>=0.7.0",
+    # published wheel floors on the released SDK. Floored at 0.8.3: the
+    # model-aware resource methods (optimize / branch_promote / plan_promote / ai
+    # / retention_status) inherit their `--models` forwarding + retention `env`
+    # guard from the SDK, so an older SDK would silently reintroduce those bugs.
+    "rocky-sdk>=0.8.3",
     # Floor matches the version CI actually resolves and tests (uv.lock). The
     # RockyComponent path uses dagster.components.* APIs from preview namespaces,
     # so we advertise a tested floor rather than an older, never-exercised one.


### PR DESCRIPTION
Follow-up to #1131 (rocky-sdk 0.8.3). The model-aware `RockyResource` methods (`optimize`, `branch_promote`, `plan_promote`, `ai`, `retention_status`) inherit their `--models` forwarding and the `retention_status` `env` guard from `rocky-sdk` — the fixes live in `RockyClient`, and `RockyResource` delegates.

The dagster floor was still `rocky-sdk>=0.7.0`, so a published `dagster-rocky` wheel could resolve an SDK in `0.7.0`–`0.8.2` that **lacks** those fixes and silently reintroduce the bugs (e.g. `retention_status(env=…)` hard-erroring at the CLI, `optimize` dropping `models_dir`). `rocky-sdk 0.8.3` is now on PyPI, so this raises the floor to match — and backs the `[Unreleased]` CHANGELOG note already added in #1131.

Dev/CI is unaffected (resolves the SDK via the editable path source); `uv lock --check` is clean; dagster tests green.