### PR TITLE
docs(engine): WP-01 remote-state ADRs — authority, state-session, concurrency (PR-0 design gate)

### DIFF
--- a/docs/adr/ADR-AUTHORITY.md
+++ b/docs/adr/ADR-AUTHORITY.md
@@ -1,0 +1,287 @@
+# ADR-AUTHORITY — Typed remote-state authority (RD-001)
+
+**ADR:** WP-01 / PR-A
+**Status:** **Proposed** — PR-0 design gate. This ADR blocks implementation; no code lands until it is signed off. It is the keystone of the WP-01 remote-state redesign and is engineered to land **standalone** ahead of the `RemoteStateSession` spine (PR-B).
+
+---
+
+## Context
+
+### The problem (audit finding RD-001)
+
+Rocky's remote `[state]` backend downloads a redb ledger at run start and uploads it at run end so ephemeral pods (EKS, CI) resume watermarks, freeze markers, and autonomy-budget history. That ledger is also the enforcement substrate for governed apply: an active `rocky policy freeze` or an exhausted budget recorded by *another pod* is only visible if this pod's download actually reflects remote truth.
+
+Today `download_state` collapses three distinct outcomes into `Result<(), StateSyncError>` (`rocky-core/src/state_sync.rs:297`):
+
+- the remote object **existed and was restored** (`DownloadOutcome::Restored`, `state_sync.rs:238-243`),
+- **no remote object existed** — a genuine fresh start (`DownloadOutcome::Absent`),
+- the download or existence-check **failed** — a `#1089` fix propagates this as `Err` (`state_sync.rs:1029`).
+
+The internal `DownloadOutcome{Restored, Absent}` enum already carries the first two (`state_sync.rs:237-243`), but it is **flattened to `()` at the `download_state` boundary** (`state_sync.rs:303`, `335`). Every caller therefore reconstructs "is my ledger trustworthy?" from side facts (a `state_download_ok` bool, `was_recreated_for_forward_incompat()`), and nothing at the type level forces a caller to make that decision at all. RD-001 is that lost authority: the boundary throws away the one distinction — *authoritative vs. genuinely-empty vs. don't-know* — that every downstream governance gate needs.
+
+**Deployment reality (settled):** remote `[state]` is in **live, concurrent multi-pod** use. RD-001 is an **active** defect, not latent.
+
+### What #1089 already closed — do not re-do (verified in-tree)
+
+- Download **failure** is already fail-closed `Err`, not a swallowed `Ok` (`state_sync.rs:1011-1033`; the `Err(e) => { warn!; Err(e) }` arm at `1029`).
+- No unfiltered fallback on the upload strip path (`state_sync.rs:742-759`).
+- The governed **run** already fail-closes when a configured-`[policy]` run's download fails (`run.rs:1662-1668`).
+- The pre-gate seams already `?`-propagate a failed download and bail (apply.rs, gc.rs, policy.rs, mcp — enumerated in the matrix).
+- Local-only-table preservation is sound once refresh occurs after the store is dropped (`state_sync.rs:285`).
+
+### The residual (what PR-A closes)
+
+1. **Untyped authority.** The `Restored/Absent` distinction never crosses the `download_state` boundary; callers re-derive trust from a bool. A future caller can `download_state(...)?` and silently proceed on non-authoritative state with no compiler signal.
+2. **The run's own end-upload error is swallowed.** At `run.rs:4250-4258` a terminal `upload_state_unless_recreated` failure is `warn!`-and-continue. Worse, because that helper applies `on_upload_failure` **internally** (`state_sync.rs:932-951`), a **governed** apply left on the default `on_upload_failure = "skip"` never even produces an `Err` at `4250` — the failure is swallowed to `Ok` one level down. The governed ledger mutation is not durable, yet the run exits 0.
+
+Everything else in WP-01 (CAS/RD-002, bypass/RD-003, config-swap/#1120, governance-snapshot/#1093) is **out of PR-A scope** and lands in PR-B/PR-C/PR-D.
+
+---
+
+## Decision
+
+### 1. Introduce a typed authority, widening the success enum only
+
+Add a public, `#[must_use]` three-state authority in `rocky-core::state_sync`:
+
+```rust
+/// Whether a run may trust its local state ledger to back a governed decision.
+#[must_use]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StateAuthority {
+    /// The remote object existed and was restored (or the backend is Local, whose
+    /// on-disk file IS the authority). The ledger reflects durable truth.
+    Authoritative,
+    /// No remote object existed for this key — a genuine fresh start. The ledger
+    /// is trustworthy AND may bootstrap an empty ledger.
+    FreshStart,
+    /// A download / existence-check failure was elected-past by a caller. The
+    /// ledger is NON-authoritative: an active freeze / exhausted budget recorded
+    /// elsewhere may be invisible. Fail-closed.
+    Indeterminate,
+}
+
+impl StateAuthority {
+    /// The ledger may back a governed decision: the download restored the
+    /// authoritative remote or proved a genuine fresh start. `Indeterminate` is
+    /// NOT usable.
+    #[must_use]
+    pub fn is_usable(self) -> bool {
+        matches!(self, Self::Authoritative | Self::FreshStart)
+    }
+}
+```
+
+Change `download_state`'s return from `Result<(), StateSyncError>` to `Result<StateAuthority, StateSyncError>`, mapping the existing internal `DownloadOutcome` on the **success** path only:
+
+- `DownloadOutcome::Restored` ⇒ `Authoritative`
+- `DownloadOutcome::Absent` ⇒ `FreshStart`
+- **Local backend** ⇒ `Authoritative` (explicit arm). Local currently short-circuits to `DownloadOutcome::Absent` (`state_sync.rs:301-304` in `download_state`; `state_sync.rs:570-573` in `download_state_inner`); the naive map would label it `FreshStart`. That is wrong: there is no remote to be "fresh" against, and the on-disk redb file is the single source of truth — it must never be treated as an empty ledger to bootstrap. Mapping Local ⇒ `Authoritative` is both semantically correct and behavior-preserving (see Consequences).
+- **Download failure stays `Err(StateSyncError)`** — it is NOT mapped to `Ok(Indeterminate)`. This is the load-bearing F7 property (below).
+
+### 2. `Indeterminate` is caller-synthesized, never callee-returned (Codex F7)
+
+`download_state` never *returns* `Indeterminate`. The variant exists from PR-A but is produced only by a caller that **elects to continue past a download `Err`**. In PR-A that is **exactly one site** (`download_state` is called from six other places — all fail-closed `?`-bails, see the matrix) — the non-governed / no-`[policy]` continue arm of the replication-run authority at `run.rs:1650-1672`:
+
+```rust
+let authority = match rocky_core::state_sync::download_state(&rocky_cfg.state, state_path).await {
+    Ok(a) => a,                                   // Authoritative | FreshStart
+    Err(e) => {
+        // #1089 governed fail-closed (unchanged): a governed run with a [policy]
+        // plane cannot see a cross-pod freeze/budget from stale local state.
+        if exec_fp_gate.is_some() && rocky_cfg.policy.is_some() {
+            anyhow::bail!(
+                "refusing a governed run: remote state download failed ({e}), so a \
+                 cross-pod freeze/budget in the durable state ledger cannot be seen \
+                 (fail-closed). Retry once the `[state]` backend is reachable."
+            );
+        }
+        // Non-governed / no-policy: continue in degraded mode, but the ledger is
+        // now explicitly non-authoritative.
+        warn!(error = %e, "state download failed, continuing with local state");
+        StateAuthority::Indeterminate
+    }
+};
+```
+
+The `state_download_ok` bool (assigned at `run.rs:1650`, read at `run.rs:1720`) **disappears**; the derivation at `run.rs:1719-1720` becomes:
+
+```rust
+// was: !state_store.was_recreated_for_forward_incompat() && state_download_ok
+let ledger_authoritative =
+    authority.is_usable() && !state_store.was_recreated_for_forward_incompat();
+```
+
+This is **behavior-identical** to today for `ledger_authoritative` (on the `Ok` path `is_usable()` is trivially true; on the elected-past `Err` path `Indeterminate.is_usable()` is `false`, exactly as `state_download_ok = false` was), while making the authority a first-class value that `run.rs` folds into the existing `ledger_authoritative` fact. That fact is passed at `run.rs:2328` to `DriftGovernor::build` (call at `run.rs:2324`; `drift_governance.rs:111`) and consumed by `DriftGovernor::govern` (`drift_governance.rs:189`).
+
+**Why the callee keeps `Err` (F7):** if `download_state` returned `Ok(Indeterminate)` on failure, every seam that does `download_state(...)?` (apply.rs, gc.rs, policy.rs, mcp — all fail-closed today) would have its `?` **succeed** on a failed download and proceed on stale local state — *silently*, because those seams discard the value. Keeping failure as `Err` means a caller must make an *explicit* choice to continue (and only `run.rs:1650`'s non-governed arm does, yielding `Indeterminate`); every other caller's existing `?`-bail is untouched. This is what makes PR-A a **safe standalone keystone**: it cannot regress any seam's fail-closed behavior in the window before PR-B migrates them.
+
+### 3. `#[must_use]` turns PR-B's migration into a compiler-enforced sweep
+
+`StateAuthority` is `#[must_use]`, so a discarding `download_state(...)?;` / `.with_context(...)?;` in statement position raises `unused_must_use` (a `-D warnings` CI failure). The seam callers therefore take a **mechanical, behavior-preserving** edit in PR-A — bind the value they are (for now) entitled to ignore, because a successful download of either usable variant means "local now mirrors remote truth," and failure still `?`-bails:
+
+```rust
+let _authority = rocky_core::state_sync::download_state(&state_cfg, state_path)
+    .await
+    .with_context(|| "...")?;            // fail-closed Err handling unchanged
+```
+
+Two of the six seams do not call `download_state` directly — they route it through `policy::block_on_state_sync` (`policy.rs:471`, `apply.rs:854`), whose signature is hard-typed `fn block_on_state_sync<F>(fut: F) -> Result<(), StateSyncError> where F::Output = Result<(), StateSyncError>` (`policy.rs:354-357`). Widening `download_state` to `Result<StateAuthority, _>` makes those two call sites fail to compile until `block_on_state_sync` is **generalized to `Result<T, StateSyncError>`** (a one-signature change; all three of its callers then propagate the value). This is a small extra edit, not a pure one-line bind — called out here so the sign-off accounts for it.
+
+This is **not** "zero diff" — it is **zero behavior change**. The value is deliberately surfaced at every call site so PR-B's atomic migration (each `_authority` becomes a real Authoritative/FreshStart/Indeterminate decision, and download failure becomes an `Indeterminate` *value* the callers branch on inside `RemoteStateSession`) is a compiler-guided checklist rather than a grep-and-hope.
+
+### 4. Fail-closed upload on `Indeterminate`
+
+Extend the end-of-run upload suppression so a run that proceeded on `Indeterminate` does **not** push its local ledger back over a remote it could not read (a blind last-writer-wins over unseen state):
+
+```rust
+// was (run.rs:1711): state_store.was_recreated_for_forward_incompat()
+let suppress_state_upload =
+    state_store.was_recreated_for_forward_incompat() || !authority.is_usable();
+```
+
+`suppress_state_upload` already gates **both** upload paths: the mid-run **periodic** uploader spawn (`run.rs:2620` — `if estimated_run_secs < 60 || suppress_state_upload { None }`) and the **end-of-run** upload (`run.rs:4251`). So on `Indeterminate` both are suppressed — the run neither periodically nor terminally pushes local state over an unread remote. That is the intended fail-closed posture (this change extends the *spawn gate* only; it does not alter the periodic uploader's internals — its **abort/join lands in PR-B** with the `RemoteStateSession` lifecycle, and its **CAS-base correctness** — stop-and-don't-refresh-on-conflict — is PR-D). `FreshStart` remains usable, so a genuine bootstrap still uploads (the first write). Only `Indeterminate` newly suppresses.
+
+### 5. Propagate the run's own end-upload error for governed / Fail
+
+> **⚠ DECIDED — §5 is deferred to PR-B** (with a rationale corrected by the second review). Making the end-upload fatal at `run.rs:4250` would `return Err` *before* `persist_run_record` (`run.rs:4312`) and `finalize_drift_verify_after` (`:4334`) — skipping the run-history record and the verify-after custody row. It would **not** strand the `InFlight` idempotency claim, as an earlier revision of this note stated: the run body is wrapped in a `run_result` guard (`run.rs:1249`→`4522`) whose error path calls `finalize_idempotency_on_error` (`:4547`), releasing the claim on any `Err`. The fatality therefore lands in PR-B's fail-closed `finalize`, **repositioned past those terminal writes** (it *is* this same end-upload seam — see ADR-STATE-SESSION, `finalize`), leaving PR-A to §1–4 + §6. The framing below is the original PR-A proposal, retained for design context.
+
+At `run.rs:4250-4258`, stop swallowing a terminal upload failure when durability is required. The subtlety: `upload_state_unless_recreated` applies `on_upload_failure` **internally** (`state_sync.rs:932-951`), so under the default `Skip` a failure is already converted to `Ok` before it reaches `4250` — a bare `if let Err` there would never fire for a governed run on the default config. So the governed / `Fail` leg must **force** `on_upload_failure = Fail` on the config it hands the uploader (mirroring `apply.rs::upload_remote_ledger_fail_closed`, `apply.rs:902`), then propagate:
+
+```rust
+use rocky_core::config::{StateConfig, StateUploadFailureMode};
+
+// A governed apply (or any run explicitly configured `on_upload_failure = "fail"`)
+// must treat the terminal ledger upload as durable.
+let durable_required = governed_ctx.is_some()
+    || matches!(rocky_cfg.state.on_upload_failure, StateUploadFailureMode::Fail);
+
+// Force `Fail` for the durable leg so the error actually surfaces here
+// (the default `Skip` would otherwise swallow it inside the uploader).
+let upload_state_cfg = if durable_required {
+    StateConfig { on_upload_failure: StateUploadFailureMode::Fail, ..rocky_cfg.state.clone() }
+} else {
+    rocky_cfg.state.clone()
+};
+
+if let Err(e) = rocky_core::state_sync::upload_state_unless_recreated(
+    suppress_state_upload, &upload_state_cfg, state_path,
+).await {
+    if durable_required {
+        return Err(e).context(
+            "refusing to exit 0: the governed/durable state ledger mutation could not be \
+             persisted to the remote [state] backend",
+        );
+    }
+    warn!(error = %e, "state upload failed");   // ungoverned default (Skip): unchanged
+}
+```
+
+`governed_ctx` is the run's `Option<&GovernedRunContext>` parameter (`run.rs:1168`), in scope at `4250`; it is `Some` exactly when `exec_fp_gate` is (`run.rs:1276`). Note the deliberate asymmetry with the `#1089` download bail at `run.rs:1662`, which additionally requires `rocky_cfg.policy.is_some()`: §5 drops that conjunct, so a governed apply with **no `[policy]` block** still fails-closed on a non-durable terminal upload. That is intentional, not an oversight — ledger durability is orthogonal to policy enforcement: a governed apply that recorded *any* state mutation must persist it, whether or not a `[policy]` plane is present.
+
+The mid-run periodic uploader's own error handling (`run.rs:2635` — `warn!` on failure) is **out of PR-A scope**; its abort/join and CAS-base correctness belong to PR-C/PR-D. PR-A only changes whether that uploader *spawns* (via §4's suppression), not what it does once running.
+
+### 6. Audited operator bootstrap/recovery flag
+
+Add an audited operator flag (e.g. `--assume-fresh-state`, gated to remote backends) that lets a genuine disaster-recovery run treat a download failure as an *intentional* fresh start: at the `run.rs:1650` elect-past arm, when the flag is set, synthesize `FreshStart` instead of `Indeterminate` and emit a structured audit record (principal, reason, prefix). This keeps `Indeterminate` fail-closed by default while giving operators a deliberate, logged escape hatch when the remote is known-gone and the estate is being rebuilt.
+
+---
+
+## Per-entry authority matrix
+
+For every state-consuming entry point, what it does on each authority. Anchors verified in-tree (line numbers approximate; anchor on the named symbols).
+
+| Entry point (verified anchor) | `Authoritative` | `FreshStart` | `Indeterminate` |
+|---|---|---|---|
+| **Replication run authority** — `download_state` @ `run.rs:1650`; `ledger_authoritative` @ `run.rs:1719-1720`; passed @ `run.rs:2328` to `DriftGovernor::build` (call @ `run.rs:2324`, def @ `drift_governance.rs:111`) → `DriftGovernor::govern` @ `drift_governance.rs:189` | Restore & proceed. `is_usable()=true` ⇒ `ledger_authoritative = !was_recreated`. Auto-apply governor evaluates the real freeze/budget ledger. | Bootstrap an **empty** ledger & proceed. `is_usable()=true` ⇒ same derivation; governor evaluates against a genuinely-empty history (correct). | Only reachable via caller-synthesis on the non-governed/no-`[policy]` `Err` arm. `is_usable()=false` ⇒ `ledger_authoritative=false`. `govern`'s `if !self.ledger_authoritative` branch (`drift_governance.rs:198`) degrades the effect via `tighten_to_require_review` (`drift_governance.rs:207`, helper @ `409`), so every auto-apply is **refused** (`GovernDecision::Refuse`, fail-closed). **Periodic + end-upload suppressed** (§4). |
+| **Governed run bail** — `run.rs:1662-1668` | n/a (`Ok`) | n/a (`Ok`) | **Never synthesized.** A governed run (`exec_fp_gate.is_some() && policy.is_some()`) bails on download `Err` *before* any `Indeterminate` exists (nonzero exit). |
+| **Pre-gate ledger sync (apply)** — `sync_remote_ledger_before_gate` (`apply.rs:821`; `download_state` @ `829`) / `sync_remote_ledger_before_gate_blocking` (`apply.rs:846`; via `block_on_state_sync` @ `854`); **unconditional** replicated-ledger sync `download_remote_ledger_unconditional` (`apply.rs:873`; `download_state` @ `884`; used by `restore.rs:948` + backfill) | Download succeeded ⇒ gate reads the fresh remote ledger. Bind `_authority`, proceed (unchanged). | Download succeeded, no remote ledger yet ⇒ gate reads a genuinely-empty ledger, proceed. | **Never a value here** — failure is `Err`; each seam already `?`-bails fail-closed. Unchanged in PR-A. |
+| **MCP propose gate** — `download_state` @ `mcp/tools.rs:2403` (`.map_err(...)?`; guarded by remote + `[policy]` + non-empty touched @ `2398-2402`) | Fresh remote ledger; propose proceeds. Bind `_authority`. | Empty remote ledger; propose proceeds. | `Err` ⇒ `?`-returns `ToolError::internal` (fail-closed). Unchanged. *(Caller beyond the plan's original enumeration — scoped in here explicitly, not silently.)* |
+| **Policy freeze record** — `download_state` @ `policy.rs:471` (via `block_on_state_sync`; remote-only guard @ `policy.rs:465-470`) | Remote ledger pulled; freeze recorded **on top of** other pods' decisions. | No remote ledger; freeze recorded on an empty local (correct). | `Err` ⇒ `?`-bail; freeze **refused** (fail-closed) — never a local-only freeze a later download would overwrite. |
+| **gc apply** — `download_state` @ `gc.rs:1530` (remote-only guard @ `gc.rs:1528-1529`) | Remote tombstone ledger pulled; gc gates on the fresh ledger. | No remote ledger; gc gates on empty. | `Err` ⇒ `?`-bail (fail-closed). |
+| **restore** — download via `download_remote_ledger_unconditional` @ `restore.rs:948`; upload via `upload_remote_ledger_fail_closed` @ `restore.rs:991` | Pulled `TOMBSTONES`; restore reads the authoritative ledger. | No remote ledger; restore reads empty. | `Err` ⇒ `?`-bail (fail-closed). |
+| **End-of-run upload** — `upload_state_unless_recreated` @ `run.rs:4250-4258` | Upload (durable). Governed / `Fail` failures now **propagate** via the forced-`Fail` leg (§5). | Upload — this is the bootstrap write (durable). Same propagation. | **Suppressed** (§4): neither the periodic nor the terminal upload runs — no push over an unread remote. |
+
+Note: `Authoritative` **restores**, it does **not** bootstrap; **only `FreshStart`** may bootstrap an empty ledger; **only `Indeterminate`** is fail-closed.
+
+### Why forward-incompat stays a caller-side AND
+
+The derivation is `authority.is_usable() && !state_store.was_recreated_for_forward_incompat()` — an AND of two facts from two independent sources:
+
+- **`authority`** comes from `download_state` (network / existence probe), known *before* the store opens.
+- **`was_recreated_for_forward_incompat()`** is a property of the `StateStore` (method @ `state.rs:627-628`; the flag is set `true` at `state.rs:694`), which `run.rs` opens **separately and later** via `StateStore::open_with_policy` at `run.rs:1700` — *after* the `run.rs:1650` download. It reports a different failure mode: the on-disk local schema is *newer* than this binary and was recreated as a downgrade, so the local ledger must not be written back.
+
+The forthcoming `RemoteStateSession` (PR-B) surfaces download authority but, by design, **does not own the `StateStore`** (lock ordering — the store acquires the shared advisory writer lock in `open_inner` (`state.rs:631`, via `try_acquire_writer_lock` @ `state.rs:437`) and holds it for its lifetime in the `_lock` field (`state.rs:466`); `download_state`'s publish path takes the *same* lock briefly). The session cannot fold in forward-incompat because it does not hold the store handle and the store is not open at download time. So `ledger_authoritative` must remain a **caller-side** AND of (download authority is usable) AND (the local store was not recreated as a downgrade). PR-A keeps that AND exactly where it is (`run.rs:1719-1720`), only swapping the `state_download_ok` bool for `authority.is_usable()`.
+
+---
+
+## Consequences
+
+### What changes
+
+- `rocky-core::state_sync` gains a public `#[must_use] StateAuthority` and `download_state` returns `Result<StateAuthority, StateSyncError>`.
+- **Six seam call sites** — `download_state` @ `apply.rs:829`, `apply.rs:854` (via `block_on_state_sync`), `apply.rs:884`, `gc.rs:1530`, `policy.rs:471` (via `block_on_state_sync`), `mcp/tools.rs:2403` — take a mechanical `let _authority = …?` bind (must_use). The two download `block_on_state_sync` sites additionally require that helper generalized from `Result<(), _>` to `Result<T, _>` (`policy.rs:354`); its **third** caller — the freeze *upload* at `policy.rs:547` — compiles unchanged at `T = ()`. **Five test call sites** in `state_sync.rs` (`:2381`, `:2427`, `:2616`, `:2710`, `:2844`) discard the widened value in statement position and take the same `let _ =` bind (the `:2844` site upgrades to asserting `Ok(Authoritative)`). **No behavior change**; every seam's fail-closed `?`-bail on download failure is untouched.
+- **`run.rs:1650`** replaces the `state_download_ok` bool with an `authority` value and folds it into `ledger_authoritative` (`run.rs:1719-1720`). Behavior-identical for that derivation.
+- **Two deliberate, safer behavior deltas** (call these out for sign-off):
+  1. §5 — a **governed** run (or any run with `on_upload_failure = "fail"`) now **exits nonzero** when its terminal ledger upload fails, instead of `warn`-and-exit-0. For governed runs this holds **even under the default `on_upload_failure = "skip"`**, because §5 forces `Fail` for the durable leg.
+  2. §4 — a run that proceeded on `Indeterminate` (non-governed, no `[policy]`, download failed) now **suppresses both** its periodic and end-of-run uploads instead of blindly pushing local state over the unread remote.
+- New audited operator flag (§6) to treat `Indeterminate` as an intentional fresh start.
+
+### Migration / compatibility
+
+- **Wire format unchanged.** No redb schema bump, no object-key change, no config change. `download_state`'s network behavior is identical (the internal `DownloadOutcome` already computed all three outcomes; PR-A only stops discarding two of them).
+- **API break is internal.** `download_state` and `block_on_state_sync` are `rocky-core`/`rocky-cli` in-crate items; the return-type widening is source-visible to in-workspace callers only (all migrated in this PR). No `rocky-cli` JSON output struct changes ⇒ **no `just codegen` / `just regen-fixtures` cascade**.
+- **Rollback:** revert PR-A; the seam callers' `let _authority` binds, the `block_on_state_sync` signature, and the `run.rs` fold are self-contained.
+
+### What PR-A does — and does NOT — close
+
+- **Closes:** RD-001's authority-typing residual (the `Restored/Absent/failure` distinction now crosses the boundary and is `#[must_use]`), and the swallowed governed/`Fail` end-upload error (including the default-`Skip`-swallow path).
+- **Does NOT close (explicitly out of scope — later WP-01 PRs):**
+  - **RD-002 / CAS** — remote writes are still unconditional whole-file `put`/`SET`, last-writer-wins (PR-D). The `gc.rs:1519-1523` KNOWN LIMITATION comment already documents this.
+  - **RD-003 / bypass** — `run --model`, `run_local` transformation, standalone backfill, and `rocky load` (`PipelineConfig::Load`, `run.rs:1596`) still open state without a uniform sync (PR-B).
+  - **#1120 / config-swap TOCTOU** and **#1093 / governance-from-gated-snapshot** (PR-B).
+  - **Freeze kill-switch** add-wins marker (PR-F).
+  - The `RemoteStateSession` spine and the atomic caller migration to `Indeterminate`-as-a-value (PR-B). PR-A deliberately leaves `Indeterminate` synthesizable at exactly one site so the keystone stays minimal and safe alone.
+
+---
+
+## Alternatives considered
+
+| Alternative | Why rejected / escalation trigger |
+|---|---|
+| **Keep the `bool` + re-derive per caller** (status quo: `state_download_ok`, `ledger_authoritative`) | Loses the type: `download_state(...)?` compiles with no signal that authority was dropped, and each caller re-invents trust from side facts. This *is* RD-001. Rejected. |
+| **Return `Ok(Indeterminate)` on download failure in PR-A** (make `Indeterminate` a callee value now) | Breaks the safe-standalone property (Codex **F7**). The six fail-closed seams do `download_state(...)?` and discard the value; an `Ok(Indeterminate)` makes `?` succeed on a *failed* download, so they proceed on stale local state **silently** in the window before PR-B migrates them. Rejected for PR-A; this shape is the *target* — it lands in PR-B where `RemoteStateSession` migrates every caller to branch on the value atomically. |
+| **Fold forward-incompat into the authority / session** | The `StateStore` (which owns `was_recreated_for_forward_incompat`) is opened after the download and is not owned by the session (lock ordering, `state.rs:437`/`466`/`631`). The two facts have independent sources; keep them a caller-side AND. Rejected. |
+| **Propagate end-upload failure for *all* runs (default Skip too)** | Regresses availability for ungoverned best-effort runs, contradicting the documented `on_upload_failure = "skip"` default (degraded mode, next run re-derives — `state_sync.rs:939-947`). Scope propagation to governed / `Fail` only. |
+
+---
+
+## Validation
+
+Rung-1 unit / in-memory **fault-injection matrix**, using the existing test seams (`arm_object_store_exists_fault` @ `state_sync.rs:176`; `arm_valkey_miss_fault` @ `state_sync.rs:187`) plus the PR-1 fault store. Every assertion is provable **RED before / GREEN after** PR-A.
+
+**`download_state` return mapping**
+- Object exists ⇒ `Ok(Authoritative)`.
+- Object absent (genuine `Ok(false)`) ⇒ `Ok(FreshStart)` — and a run bootstraps an empty ledger.
+- Injected `exists` / `get` failure ⇒ `Err` (never `Ok(Indeterminate)`).
+- Local backend ⇒ `Ok(Authoritative)` (not `FreshStart`).
+- `#[must_use]`: a discarding `download_state(...)?;` fails to compile under `-D warnings` — proven by a **trybuild compile-fail guard, a required RED→GREEN deliverable of PR-A** (the `#[must_use]`-through-`?` lint behavior is reasoned but unexecuted until this test pins it; it is the proof of the §3 mechanism, not a nice-to-have).
+
+**Authority derivation (`run.rs`)**
+- Governed (`exec_fp_gate.is_some() && policy.is_some()`) + injected download failure ⇒ **nonzero exit**, no incremental mutation, no auto-apply, no upload (unchanged #1089 bail).
+- Non-governed / no-`[policy]` + injected download failure ⇒ run continues; `authority = Indeterminate`; `ledger_authoritative = false`; `DriftGovernor` refuses every auto-apply (`GovernDecision::Refuse` via `tighten_to_require_review`); **periodic + end-upload suppressed** (assert no `put`/`SET`). Extends the existing `non_authoritative_ledger_refuses_auto_apply` guard (`drift_governance.rs:1136`) to the download-failure origin.
+- Success (Authoritative or FreshStart) + `!was_recreated` ⇒ `ledger_authoritative = true`; parity with the pre-PR-A `state_download_ok` derivation on the same fixtures.
+- `was_recreated_for_forward_incompat` + any authority ⇒ `ledger_authoritative = false` (the AND still bites).
+
+**End-upload propagation**
+- Governed run (default `Skip`) + injected terminal `put` failure ⇒ **nonzero exit** (was exit 0 + `warn`) — proves the §5 forced-`Fail` leg, not just the explicit-`Fail` config.
+- `on_upload_failure = "fail"` + terminal `put` failure ⇒ propagates.
+- Ungoverned default (`Skip`) + terminal `put` failure ⇒ `warn` + exit 0 (unchanged).
+
+**Seam callers (regression / must-use)**
+- apply/gc/policy/mcp seams: injected download failure ⇒ each still `?`-bails fail-closed with its existing context message; the `let _authority` bind is behavior-inert. `block_on_state_sync` propagates the authority through the two indirect sites (`policy.rs:471`, `apply.rs:854`).
+
+**Operator flag**
+- `--assume-fresh-state` + injected download failure ⇒ `authority = FreshStart`, run proceeds, upload allowed, and a structured audit record is emitted.
+
+**Every PR:** `cargo nextest run -p rocky-core -p rocky-cli`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`. The wire format is unchanged, so the release is byte-identical on the object-store path; there is no codegen or fixture cascade.

--- a/docs/adr/ADR-CONCURRENCY.md
+++ b/docs/adr/ADR-CONCURRENCY.md
@@ -1,0 +1,252 @@
+# ADR-CONCURRENCY — Cross-pod remote-state concurrency + freeze kill-switch
+
+**Status:** Proposed (PR-0 design gate — stops for maintainer sign-off before any implementation)
+
+**Scope:** WP-01 fast-follow (PR-C consistent snapshot → PR-D CAS) plus the spine-urgent PR-F freeze marker. Closes audit finding **RD-002** (Critical, active) and the **#1120** freeze-erasure residual. Companion docs: **ADR-AUTHORITY** (RD-001 — the `StateAuthority` type this ADR's writer-class refusal reports through) and **ADR-STATE-SESSION** (PR-B — the `RemoteStateSession` spine whose `finalize` write choke-point and `base` `Generation` field this ADR's CAS hooks into). Read both first.
+
+---
+
+## Context
+
+### The problem (RD-002 — active, not latent)
+
+Remote `[state]` is in **live, concurrent multi-pod use today.** Every remote state write is an **unconditional whole-file overwrite:**
+
+- The S3/GCS/Azure tier uploads the entire `state.redb` via `state_sync::upload_state → upload_state_with_excluded_tables → upload_to_object_store` (`state_sync.rs:1047`), which calls `ObjectStoreProvider::upload_file` (`object_store.rs:272`) — it `tokio::fs::read`s the local file and hands it to `put` (`object_store.rs:225`), an unconditional `self.store.put`. There is no precondition on the write.
+- The Valkey tier writes the whole blob unconditionally: `upload_to_valkey` (`state_sync.rs:1213`) reads the local file and issues a plain `redis::cmd("SET")` — no compare token.
+
+Cross-writer safety today is **only a LOCAL, single-host advisory `flock`** on `<path>.redb.lock` (`state.rs::try_acquire_writer_lock`, `state.rs:437`). That lock is process-local to one pod's filesystem; it does nothing across pods sharing an S3 prefix. The result is **silent last-writer-wins:** two pods each download the ledger, mutate it, and upload; the second upload erases the first pod's committed state (watermarks, run records, budget rows, tombstones, idempotency claims) with no error and no signal.
+
+The freeze kill-switch inherits the same defect. A `rocky policy freeze` recorded by one pod lands in `POLICY_DECISIONS` (`state.rs:171`, redb table `policy_decisions`) inside the shared `state.redb`; a concurrent run whose start-of-run download **preceded** the freeze will, at its end-of-run upload, overwrite the freeze away — the kill-switch silently fails to engage while the racing run proceeds unfrozen. This is issue **#1120**'s freeze-erasure residual.
+
+Because deployment is live multi-pod, RD-002 lost-update **and** freeze-erasure are **active production exposure**, not hardening. The interim mitigation (until PR-D lands) is orchestrator-level serialization of writers per `[state]` prefix — one governed writer per namespace at a time.
+
+### What #1089 already closed — do NOT re-do
+
+`#1089` hardened the *decision* and *download* paths, not the *write* path:
+
+- Download fail-closed: `download_state` returns `Err` on transfer failure, and a governed run whose download failed refuses when a `[policy]` plane is configured (`run.rs:1662` — `exec_fp_gate.is_some() && rocky_cfg.policy.is_some()` → `anyhow::bail!`).
+- No unfiltered-fallback on the tiered read; single config snapshot threaded through the governed *decision* path; cross-pod freeze *enforcement* on the already-governed `apply` paths; fail-closed budget-pair writes and refused replication `verify_after`.
+
+None of that adds a precondition to the upload. `#1089` guarantees a governed run **sees** a durable freeze if its download succeeded; it does **not** stop that run's own later upload from **erasing** a freeze that landed after its download. That erasure is this ADR's job.
+
+### The residual this ADR closes
+
+1. **RD-002:** no compare-and-swap on the bulk `state.redb` upload → silent lost-update across pods.
+2. **#1120 freeze residual:** the kill-switch lives inside the erasable blob, so it is only as reliable as CAS coverage — exposed during the `off→cas` bake, on CAS-less backends, and across schema-version rolling upgrades.
+3. **Tiered coherence:** a Valkey HIT can shadow a durable freeze (read-side short-circuit, `state_sync.rs:608-616`), and a Valkey upload error is warn-swallowed even under `on_upload_failure = Fail` (tiered-upload branch, `state_sync.rs:918-921`) — both are documented KNOWN-LIMITATION comments in-tree, folded into the CAS work here.
+
+### The primitive we build on
+
+The S3 client is **already configured** for conditional puts: `AmazonS3Builder … .with_conditional_put(S3ConditionalPut::ETagMatch)` is pinned explicitly (`object_store.rs:155`), and `put_if_not_exists` already exercises that path via `PutMode::Create` (`If-None-Match: *`), with passing tests (`object_store.rs:410-437`). **CAS is not yet wired** — no code issues `PutMode::Update(UpdateVersion { e_tag, version })` (`If-Match`; a tuple variant — GCS matches on `version`, S3/Azure on `e_tag`) today. But the same client configuration that backs `Create` also backs `Update`, so enabling compare-and-swap is **new provider methods, no client re-config, and no redb schema bump** (the compare token is the object's external ETag, not a field in the database). InMemory supports the conditional-put path (used for tests); `put_if_not_exists`'s Create semantics prove the pattern end-to-end.
+
+---
+
+## Decision
+
+**One line:** CAS on every remote state write, split by writer class — cheap single-record **ledger seams RETRY**, full **runs REFUSE** (fail-closed) — plus a separate, rollout-independent **add-wins freeze marker** for the kill-switch.
+
+### D1 — CAS by writer class
+
+Every remote `state.redb` write becomes a compare-and-swap against the generation the writer downloaded (its **base**). The reconciliation on conflict is chosen by writer class:
+
+| Writer class | Members | On CAS conflict | Why |
+|---|---|---|---|
+| **Ledger seam** (single-record) | gc tombstone stamps, budget-pair writes, restore custody, verify-after custody, **and the `rocky policy freeze` audit row** | **RETRY:** each attempt is a **typed transition** — `validate_external_preconditions().await`, then the full atomic state operation, then re-CAS; bounded retries → fail-closed | Pure-ledger rows (freeze row, budget-pair, verify-after custody) have trivial preconditions ⇒ verbatim replay onto the winner's blob is correct. **gc tombstones and restore custody are NOT plain replays** (round-3 correction): their writes are authorized by *external proofs* — gc re-runs the Delta-log liveness proof then the atomic `evict_artifact` (the remove+tombstone pair, never split); restore re-hashes the restored object then re-runs the atomic `restore_artifact`. A proof that cannot be safely repeated ⇒ that seam is REFUSE-on-conflict. The `policy freeze` ledger row **must** retry — a freeze that *refused* under contention would silently fail to engage while the racing run proceeds unfrozen. (The enforcement *marker* in D3 is a separate, conflict-free `Create`.) |
+| **Full run** (whole-blob) | `run`, replication, backfill, `load` | **REFUSE:** fail-closed, nonzero exit; no merge, no replay | A losing run cannot overwrite the winner. No merge algebra is attempted (see Alternatives — auto-merge). |
+
+Refuse-for-runs closes the RD-002 Critical: **no silent last-writer-wins.** What it does and does *not* close is stated honestly in Consequences (RD-006).
+
+### D2 — CAS seam correctness (adopts Codex F1)
+
+The current end-of-run upload seam is **in the wrong place** and would corrupt state if naively made conditional:
+
+- The final upload is `state_sync::upload_state_unless_recreated` at `run.rs:4250`. It runs **before** the run's terminal state writes: `persist_run_record` (`run.rs:4312`), the verify-after custody gate (`super::drift_governance::finalize_drift_verify_after`, `run.rs:4334`), and `finalize_idempotency` (`run.rs:4379`).
+- The live `StateStore` holds the advisory writer lock for its **entire lifetime** — `open_inner` acquires `try_acquire_writer_lock` before opening the database and keeps it in the `_lock` field until drop (`state.rs:631`). A CAS upload cannot snapshot a consistent blob while that handle is still open and still writing.
+
+The corrected protocol:
+
+1. Complete **all** terminal and error-path state writes (RunRecord, verify-after custody, idempotency finalize) into the local `state.redb`.
+2. **Drop the `StateStore` handle** (release the advisory lock).
+3. Capture a **consistent snapshot** of the file (PR-C). *Mechanism corrected by the second review:* redb 2.6.3 has **no backup API**, and redb itself flocks the file — a second `Database` handle on the live path fails `DatabaseAlreadyOpen` — so the mid-run snapshot is a **logical export under a `begin_read` MVCC transaction** on the existing `StateStore` handle (a new method; `list_tables` + typed opens via a closed two-type registry), excluding the local-only tables. End-of-run needs no export: the store handle is already dropped (step 2), so a plain copy is race-free.
+4. `upload_file_if_match(base_generation)`.
+5. On conflict → **fail-closed** (the run refuses at state-commit).
+
+The **periodic mid-run uploader** (`tokio::spawn` at `run.rs:2632`, uploading via `upload_state` at `run.rs:2635`) has a hard invariant: **on CAS conflict it STOPS and must NOT refresh its base to the winner's generation.** Refreshing the base would let this pod's stale local blob later pass a CAS check and erase the winner. The periodic task's handle is `.abort()`ed at the finalize/error sites (`run.rs:3116`, `run.rs:3259`); **PR-B**'s `RemoteStateSession` owns that `JoinHandle` — `Drop` aborts it unconditionally (a warn is insufficient) and `finalize` aborts **and joins** it, so no overlapping upload survives finalize. This ADR's only added rule is the CAS-conflict behavior above: on conflict the periodic uploader stops and does not refresh its base.
+
+### D3 — Freeze = rollout-independent ADD-WINS MARKER (adopts Codex F4)
+
+The kill-switch does **not** ride the CAS rollout. It is a separate object-store marker set, reachable and enforceable the moment PR-F's reader code is deployed — independent of whether CAS is on, of the backend's CAS capability, and of schema version.
+
+- **Freeze** = a write-once object `<prefix>/freeze/<freeze_id>.json` with a **unique** `freeze_id` (UUID — no shared counter, no sequence allocator, so no Create-collision), carrying `{principal, scope, reason, created_at}`.
+- **Unfreeze** = a write-once object `<prefix>/unfreeze/<unfreeze_id>.json` that **explicitly references the `freeze_id`(s) it lifts.**
+- **Active set** = `{all freeze_ids}` − `{freeze_ids referenced by any unfreeze}`. This is an **order-independent OR-set projection:** no total sequence, no wall-clock comparison, no atomic allocator. It sidesteps *every* ordering hazard: unsorted LIST results, absence of a sequence allocator, and clock-skew misordering. **Re-freeze = a new `freeze_id`** (unfreezing one id never suppresses a later re-freeze).
+- **Writes use the existing `put_if_not_exists` (`Create`) on a unique id** — so a marker write **never conflicts** and is therefore **not part of the CAS retry/refuse state machine at all.** This is precisely why the kill-switch is rollout-independent of CAS.
+- **Schema-version-INDEPENDENT key layout** — the marker keys carry no redb schema version, so a mixed fleet (including an old binary mid-rolling-upgrade) that has the reader code reads the same active set.
+- **Gate read is FAIL-CLOSED and pinned to the DURABLE tier** (bypasses Valkey's stale shadow): LIST both prefixes, project the active set, OR it into enforcement. If the LIST fails while a `[policy]` plane is configured, **refuse** (mirrors the fail-closed download posture at `run.rs:1662`). Because the gate always reads the durable tier, the kill-switch is coherent on tiered backends **immediately** — with no dependency on the tiered-CAS coherence work in D5.
+- **Two-phase rollout is MANDATORY:** deploy marker **READERS to all pods first** (every pod reads + enforces markers), **then** enable freeze-marker **WRITES.** Otherwise a reader-less old pod ignores a freeze. ("Urgent — land PR-F now" and "two-phase — enable writes only after readers are everywhere" are not in tension: PR-F ships the reader code urgently; write-enablement is the second operational step.)
+- **Gate-to-mutation race — fence granularity (narrowed by the second review + round-3 red team):** a freeze landing after the gate's LIST must still fence, and the recheck points are: the exec-fingerprint choke-point (fresh LIST, governed paths), **each execution-layer boundary** (one LIST per layer), and **before the post-run governance reconcile**. On a fence hit, remaining layers/steps are withheld fail-closed and **already-committed layers' state is finalized (uploaded), never abandoned** — partial failure, not state loss. **The fence revokes *remaining* work**: a freeze landing mid-final-layer or mid-layer (parallel dispatch) completes that layer and fences at the next boundary or the next run; replication fan-out (no layer boundaries) keeps a bounded gate-to-copy window. *Implementation reality:* the `evaluate_apply_policy*` gate stack is synchronous — the async durable-tier LIST hoists to each async command entry and the projected active set threads into `autonomy_degradation` (rocky-core policy.rs), which has **two** callers to wire: `evaluate_apply_policy_core` (shared by apply/promote/MCP-propose/gc/restore/the in-run replication gate) **and the separate drift/verify-after seam in `drift_governance.rs`**. The status surfaces (`rocky brief`, MCP `estate_brief`) also merge marker freezes so enforcement and reporting cannot disagree (a marker-only freeze must not deny silently while status shows "no active freeze").
+
+**Why the ledger freeze row cannot be the enforcement marker.** The existing `active_freezes` (`policy.rs:691`) projects freezes from `POLICY_DECISIONS` by keeping, per `(principal, scope)` key, the **latest `PolicyDecisionRecord` by wall-clock `timestamp`** (`d.timestamp >= cur.timestamp`, `policy.rs:704`). That projection (a) depends on wall-clock ordering — exactly the clock-skew hazard the OR-set removes; (b) consumes `PolicyDecisionRecord`, which lives *inside* the erasable `state.redb` blob — the surface RD-002 corrupts; and (c) is bound to the redb schema. It therefore cannot be reused verbatim as a rollout-independent, un-erasable enforcement marker. **Disposition:** the `POLICY_DECISIONS` freeze row **stays the audit trail** and, as a single-record ledger seam, is written CAS-RETRY per D1 — that retry is **not** redundant with the marker, because the row also feeds `#1089`'s existing apply-path freeze gate (`evaluate_apply_policy`, `apply.rs:945`, consults the `policy_decisions` ledger via `list_policy_decisions` at ~`apply.rs:1003`/`1160`), so losing it under contention would silently reopen that pre-existing enforcement surface. The object-store OR-set **is the new rollout-independent enforcement truth.** Both are written on `policy freeze`; the marker gate is the un-erasable one.
+
+### D4 — Provider API additions (`object_store.rs`)
+
+```
+struct Generation { e_tag: Option<String>, version: Option<String> }
+
+enum CasOutcome { Committed(Generation), Conflict }
+
+async fn get_with_generation(rel) -> (Bytes, Generation)
+async fn download_file_with_generation(rel, local) -> Generation
+async fn put_if_match(rel, data, expected: Option<&Generation>) -> CasOutcome
+async fn upload_file_if_match(local, rel, expected: Option<&Generation>) -> CasOutcome
+```
+
+**`expected` semantics are explicit (a real hole if left implicit):**
+
+- `expected = Some(gen)` → `PutMode::Update(gen.to_update_version())` (`If-Match`; `UpdateVersion` carries both `e_tag` and `version` — GCS keys on `version`, S3/Azure on `e_tag`): commit only if the object still carries `gen`; otherwise `Conflict`.
+- `expected = None` → `PutMode::Create` (`If-None-Match: *`): commit only if the object is **absent** (first-ever writer bootstraps); a concurrent first-writer **conflicts** rather than blindly overwriting. `None` must **never** fall through to an unconditional `put` — that would reintroduce RD-002 on the bootstrap path.
+
+`CasOutcome::Committed` carries the new `Generation` (so a seam retry threads it forward); `Conflict` drives the state machine's reconcile/refuse branch. Backend errors propagate as `Err` (they are not a `Conflict`).
+
+### D5 — Tiered coherence (adopts Codex F3)
+
+- CAS runs against **durable S3 FIRST.**
+- Populate Valkey **only with the committed generation on success**; **invalidate on conflict/failure.**
+- Tiered reads **validate the cached generation against S3** before trusting the cache.
+- **Tiered CAS is disabled** (`concurrency_control` forced `off` on tiered) until this coherence lands. (Freeze markers already read the durable tier per D3, so the kill-switch is coherent on tiered from PR-F.)
+
+### D6 — Rollout flag
+
+`[state] concurrency_control = "off" | "cas" | "lease"`, **default `"off"`.** `"off"` keeps the release byte-identical (unconditional `put`, current behavior) until the flip; general-population moves to `"cas"` after a bake; auto-downgrades to `"off"` + warns where CAS is unavailable (see the per-backend matrix). **Live multi-pod S3 deployments should opt into `"cas"` as soon as PR-D lands** — they carry active RD-002 exposure and should not wait for the general bake. **Closure framing (round-3 correction): PR-D delivers the RD-002 *capability*; the audit finding is CLOSED only by the operational rollout gate** — deploy ≥PR-D fleet-wide, set `concurrency_control = "cas"` on every live prefix, verify effective-CAS via `rocky doctor`, run the acceptance test on the real deployment configuration, and only then drop the interim one-writer-per-prefix serialization. `"lease"` is reserved for the distributed-lease escalation (Alternatives). **No redb schema bump** — the generation is the external ETag.
+
+---
+
+## Conflict state machine
+
+One machine; the conflict node branches by writer class.
+
+```
+             download base generation G
+                        │
+                        ▼
+        ┌─────────  put_if_match(expected = G)  ─────────┐
+        │                                                │
+   CasOutcome::Committed(G')                     CasOutcome::Conflict
+        │                                                │
+        ▼                                    ┌────────────┴────────────┐
+     DONE                                    │                         │
+  (commit; on success                   SEAM class                 RUN class
+   populate Valkey                          │                         │
+   with G')                     re-download → re-apply THE       fail-closed
+                                ONE record → re-CAS(expected=G_new)   (nonzero exit;
+                                     │                                 no merge,
+                          ┌──────────┴──────────┐                     no replay)
+                     Committed             retries exhausted
+                          │                      │
+                        DONE               fail-closed
+```
+
+Invariants:
+
+- **Periodic uploader on `Conflict`: STOP, do NOT refresh base to the winner.** A refreshed base lets the stale local blob later erase the winner. `Drop` aborts the periodic task; happy path aborts **and** joins it.
+- **Backend error ≠ Conflict.** A transport/backend error propagates as `Err` (retryable per the existing `state_sync` retry budget); only a genuine precondition failure is a `Conflict`.
+- **Bounded seam retries.** Exhaustion is fail-closed, never a silent unconditional overwrite.
+
+---
+
+## Per-backend capability matrix
+
+| Backend | CAS mechanism | First cut | Notes |
+|---|---|---|---|
+| **S3** (`s3`/`s3a`) | ETag CAS — `PutMode::Update { If-Match }`, client already pins `S3ConditionalPut::ETagMatch` (`object_store.rs:155`) | **Yes (primary)** | The active-exposure deployment; opt into `"cas"` as soon as PR-D lands. |
+| **InMemory** | Native conditional put | **Yes (tests)** | Backs Rung-2; does not by itself prove S3 (InMemory has masked S3-only CAS bugs before). |
+| **GCS** (`gs`/`gcs`) | Native `x-goog-if-generation-match` | Flag-gated after conformance | Enable post-conformance; `"cas"` opt-in per deployment. |
+| **Azure** (`az`/`abfs*`) | Native ETag / If-Match | Flag-gated after conformance | As GCS. |
+| **LocalFS** (`file`) | `PutMode::Update` = `NotImplemented` | **Advisory-flock-only (documented)** | Single-host; the existing `state.rs` `flock` is the guard. `concurrency_control` auto-`off` + warn. |
+| **Valkey** | Lua-CAS (compare-and-set script) | **Deferred** | First cut writes unconditionally; tiered coherence (D5) keeps durable S3 authoritative in the meantime. |
+| **Tiered** | CAS on the durable S3 leg | **CAS disabled until D5 coherence** | Freeze markers already read durable tier, so the kill-switch is coherent on tiered from PR-F. |
+
+---
+
+## Two-phase freeze-marker rollout (mandatory)
+
+| Phase | Action | Fleet invariant | Failure if skipped |
+|---|---|---|---|
+| **Phase 1 — READERS** | Deploy PR-F to **all** pods. Every pod LISTs both marker prefixes, projects the active OR-set, OR-s it into enforcement, and does the pre-mutation recheck. **No pod writes markers yet.** | 100% of pods enforce markers | — |
+| **Phase 2 — WRITES** | Enable freeze-marker **writes** (`policy freeze`/`unfreeze` emit markers in addition to the ledger row). | A written freeze is enforced by every pod | A reader-less (pre-Phase-1) pod would ignore a freeze → kill-switch not universal. |
+
+Distinct guarantees (do not conflate): **schema-version-independent keys** protect *future* schema bumps for pods that **already have reader code**; they do **not** bind a pre-PR-F pod with no reader — that gap is exactly what mandatory two-phase rollout closes.
+
+---
+
+## Consequences
+
+### What changes
+
+- Every remote `state.redb` write becomes a CAS against a downloaded generation; new provider methods (`get_with_generation`, `download_file_with_generation`, `put_if_match`, `upload_file_if_match`, `Generation`, `CasOutcome`).
+- The end-of-run upload seam's **reposition** — from `run.rs:4250` (before the terminal writes) to after RunRecord/verify-after/idempotency (`4312`/`4334`/`4379`) — lands in **PR-B** (a prerequisite of the session's fail-closed `finalize`: a fatal upload at `4250` would skip `finalize_idempotency`). **PR-C** then drops the `StateStore` handle and supplies the torn-read-safe consistent snapshot; **PR-D** makes the repositioned upload a CAS `upload_file_if_match`.
+- `policy freeze`/`unfreeze` gain an object-store marker write; enforcement paths gain a durable-tier marker LIST at the gate and a pre-mutation recheck.
+- New `[state] concurrency_control` flag; `"off"` default preserves byte-identical behavior.
+
+### Migration
+
+- **No redb schema bump** — generation is the external ETag; old and new binaries read the same blob.
+- **Two-phase rollout** for freeze markers (readers everywhere → then writes) is an operational sequence, not a data migration.
+- Interim orchestrator serialization (one writer per `[state]` prefix) bounds RD-002 until PR-D; drop it once `"cas"` is on.
+
+### What it does NOT close — RD-006 (state honestly, up front)
+
+Refuse-for-runs closes the **silent lost-update** Critical (RD-002): a losing run cannot overwrite the winner, and the loss is now a visible nonzero exit instead of silent corruption. It does **not**:
+
+1. **Auto-preserve two concurrent runs** — the loser re-runs. (Acceptable first cut; auto-merge is a documented escalation.)
+2. **Reconcile a warehouse that is already ahead of committed state.** A run that has already written the warehouse and then **refuses** at state-commit leaves the **warehouse ahead of committed state.** For **non-merge (append / incremental-append)** strategies, an operator re-run can **duplicate rows.** This divergence is **RD-006**, a **separate WP-02 finding.** It **pre-exists today** (via crash-between-write-and-commit); refuse-on-conflict **adds a trigger** for it. Given live multi-pod, **refuse-on-conflict *will* fire in production, so RD-006/WP-02 should follow WP-01 tightly.** This ADR does not attempt to solve RD-006; it names it and flags the coupling.
+
+### What it does close
+
+- **RD-002 (Critical, active):** no silent last-writer-wins on `state.redb` — **once `concurrency_control = "cas"` is active on every live writer** (the rollout gate above); until then the interim serialization bounds the exposure.
+- **#1120 freeze residual:** un-erasable, rollout-independent, schema-version-independent kill-switch with a fail-closed durable-tier gate and pre-mutation recheck.
+- **Tiered stale-shadow for enforcement:** the freeze gate reads the durable tier; tiered CAS is gated on D5 coherence.
+
+---
+
+## Alternatives considered
+
+| Alternative | Why rejected as first cut | Escalation trigger |
+|---|---|---|
+| **Auto-merge replay** (reconcile a losing run's blob onto the winner by replaying its per-table deltas) | Codex F2: the ledger holds **many heterogeneous tables** with **blind-overwrite**, **non-disjoint**, and **reset** semantics (e.g. watermark rewinds), plus **millisecond-entropy run IDs** that collide. A generic `max`/union merge is *wrong* — it would silently corrupt watermarks and idempotency. Correct replay needs per-table merge algebra, collision-resistant run IDs, and epoch-modeled watermark resets. Too much surface for the Critical-closing cut. | Concurrent same-namespace long-runs become common **and** per-run re-run cost is unacceptable. Requires the per-table algebra above first. |
+| **Distributed lease** (a durable lock so only one pod writes a namespace at a time) | Adds a lock-service dependency and a liveness/expiry protocol (fencing tokens, lease renewal) for a problem CAS already fail-closes. Not needed to close RD-002. | Sustained CAS thrash under high contention, **or** a CAS-less durable tier that nonetheless needs multi-pod governed writes. Reserved as `concurrency_control = "lease"`. |
+| **CAS-only freeze** (protect the freeze purely via the `state.redb` CAS, no separate marker) | Rollout-**dependent**: protected only when *every* writer has CAS on within *one* schema version. Exposed during the `off→cas` bake, on CAS-less backends, and across version-bump rolling upgrades — exactly when a kill-switch most needs to be reliable. | Not an escalation — rejected outright. The add-wins marker is the decision. |
+
+---
+
+## Validation
+
+Repo bar is live-verify: InMemory has masked S3-only CAS bugs before, so the ladder does not stop at InMemory. Rung 1 (unit / in-memory authority fault-injection) belongs to **ADR-AUTHORITY**; this ADR's concurrency ladder starts at Rung 2.
+
+### Rung 2 — cross-pod concurrent (two-local-file harness + live `StateStore` lock/rebase + InMemory CAS)
+
+- **Interleaved run uploads:** two runs from a shared base → **winner commits, loser REFUSES** (nonzero exit, no incremental mutation applied to committed state, no auto-apply, no overwrite).
+- **Interleaved seam writes:** two single-record seam writers from a shared base → loser **RETRIES** (re-download → re-apply the one record → re-CAS); **both records survive.**
+- **Periodic partial-upload then conflict:** the periodic uploader hits a conflict → it **STOPS and does not advance its base**; a subsequent stale-base upload cannot erase the winner.
+- **Bootstrap race:** two first-ever writers with `expected = None` → one Creates, the other **conflicts** (no blind overwrite on the empty-object path).
+- **Freeze OR-set order-independence:** `freeze → unfreeze → re-freeze` projects the same active set regardless of LIST order / arrival order (re-freeze uses a new `freeze_id`, so the earlier unfreeze does not suppress it).
+- **Reader-less pod fenced:** a pod without PR-F reader code (simulating pre-Phase-1) is shown to ignore a freeze → proves why two-phase rollout (readers first) is mandatory.
+- **Gate-to-mutation recheck:** a freeze landing **between** the gate's LIST and the irreversible mutation is caught by the **pre-mutation recheck** → fail-closed.
+- **Stale-base run cannot erase a freeze:** the marker is separate from `state.redb`, so a losing run's blob overwrite (even if it happened) leaves the freeze marker intact.
+- **Tiered cache-poison rejected:** loser `SET`s Valkey then loses the S3 CAS → the next tiered read **validates the cached generation against S3 and rejects the stale entry.**
+- Same-key collisions (watermark / run_id / tombstone / idempotency); interrupt/error finalization; the `load` lifecycle.
+
+### Rung 3 — live-S3 `#[ignore]` (`ROCKY_TEST_S3_*`)
+
+- Real-bucket **ETag CAS roundtrip:** `download_file_with_generation` → concurrent mutation → `upload_file_if_match(base)` returns `Conflict`; a matching-base upload returns `Committed`.
+- Real-bucket **freeze-marker LIST + Create** roundtrip (OR-set projection against real object listing) — **not** InMemory-only.
+- Mock-S3 (wiremock) stays in CI for the non-`#[ignore]` lane.
+
+### Kill-switch drill (doubles as the #1120 killer-demo)
+
+Two `rocky run` against one live S3 `[state]` prefix; `rocky policy freeze` between their download and upload → **the freeze survives** (marker un-erasable), and **both runs are denied at the documented fence granularity** (gate / exec-fingerprint fence / next layer boundary / pre-governance-reconcile — a freeze landing mid-final-layer or mid-fan-out fences at the next boundary or the next run, per D3's narrowed guarantee).
+
+### Every PR
+
+`cargo nextest run`, `cargo clippy --all-targets --all-features -D warnings`, `cargo fmt --check`. With `concurrency_control` unset the full suite is byte-identical to today. **PR-F's OR-set projection + two-phase rollout get their own red-team pass before merge.**

--- a/docs/adr/ADR-STATE-SESSION.md
+++ b/docs/adr/ADR-STATE-SESSION.md
@@ -1,0 +1,226 @@
+# ADR-STATE-SESSION — `RemoteStateSession`, config-snapshot threading, bypass closure, and governance-from-gated-snapshot (#1093)
+
+**Status:** Proposed (PR-0 design gate — stop for maintainer sign-off before implementation)
+
+**Work package:** WP-01 (remote-state protocol redesign) · **PR-B (Spine)**
+**Closes:** audit finding **RD-003** (state-sync bypass), issue **#1120** (config-swap TOCTOU), issue **#1093** (governance reconcile fresh-compiles from disk)
+**Depends on:** ADR-AUTHORITY (PR-A) — `acquire` returns the `StateAuthority` that PR-A defines
+**Depended on by:** ADR-CONCURRENCY (**PR-C** consistent snapshot, **PR-D** CAS) — both hook `finalize`'s write choke-point and the `base` `Generation` field. **PR-F** (freeze markers) relies on this session's download-before-gate discipline to read `POLICY_DECISIONS`, but writes **separate** object-store marker objects (via `Create`), *not* through `finalize`.
+
+> Sibling-doc boundary. This ADR owns **session lifecycle, config threading, bypass closure, and the #1093 governance-snapshot fold-in**. It *references* `StateAuthority` (as `acquire`'s return) and the CAS write (as `finalize`'s future hook + the base-`Generation` field CAS reads) but defers their semantics to ADR-AUTHORITY and ADR-CONCURRENCY. Nothing here specifies the authority enum's variants or the CAS protocol.
+
+---
+
+## Context
+
+### The problem
+
+Remote `[state]` (`s3`/`valkey`/`tiered` backends) is in **live, concurrent, multi-pod** production use. Every mutating run mode is supposed to: (1) download the durable ledger *before* it reads freeze/budget/watermark/provenance state, and (2) upload *after* it mutates, so the next pod's start-download sees the change. Today that discipline is implemented as **seven independently-written inline seams** (mapped in the Decision below) with divergent policies, and **three run modes skip it entirely**.
+
+Two active defects converge on the same missing abstraction:
+
+- **RD-003 (Critical, ACTIVE) — bypass.** Three entry points open a `StateStore` and mutate state-backed data with **no** remote download/upload:
+  - `run --model` — `StateStore::open_with_policy` at `run.rs:1333`, no preceding `download_state`.
+  - `run_local` transformation — `StateStore::open` at `run_local.rs:115` (inside the `if models_dir.exists()` guard at `run_local.rs:114`), no sync.
+  - `rocky load` / the pipeline `Load` arm — `run_load` opens `<config_dir>/.rocky_state` at `load.rs:104` and writes `loaded_files` (replicated incremental-skip state) with no sync. Reached both standalone and via `run.rs:1596` (`PipelineConfig::Load` → `run_load` call at `run.rs:1600`).
+
+  On a remote backend, each of these reads stale local state and its writes are silently reverted by the next pod's start-download. (Quality and snapshot pipelines, `run_local.rs:319`/`853`, open **no** state store — they are correctly *not* in scope.)
+
+- **#1120 (Critical) — config-swap TOCTOU.** `run()` (`run.rs:1111`) takes a `config_path: &Path` and **re-reads it from disk twice more** after the caller already gated on it (`run.rs:1202` idempotency load, `run.rs:1262` main load; `run_dag_exec.rs:130` for the DAG). A `rocky.toml` swap timed between the gate and these re-reads points execution at an unverified config. The governed apply path loads the same config **three** times (`apply.rs:238`, `execute_run_plan` re-load at `apply.rs:479`, then `run()` at `run.rs:1262`), and the promote-apply path reloads a *second* config (`branch.rs:781`, in `run_promote_apply`) that was never routing-verified. `config_fingerprint` (`output.rs:59`) independently re-`std::fs::read`s the path (`output.rs:60`) — a fingerprint of a file that may already differ from the executed snapshot (Codex F10).
+
+- **#1093 (Med) — governance from disk, not from the gated snapshot.** After a governed run executes the plan-verified compiled set, the classification/masking/tag **reconcile fresh-compiles the models from disk again** — at `run.rs:4041` (full-replication/DAG reconcile) and inside `apply_model_governance_tags` at `run.rs:7295`. A post-execution edit to a `.sql`/`.toml` file changes what governance is applied, out from under the fingerprint that gated execution.
+
+### What #1089 already closed — do NOT re-do
+
+Verified in-tree, out of scope for this ADR:
+- Download failure is fail-closed `Err` (`download_state`, `state_sync.rs:297`; the object-store leg propagates via `download_from_object_store`, `state_sync.rs:984`); no unfiltered fallback.
+- A single config snapshot threads the *governed decision* on the apply paths (commit `8dd55d6c`); cross-pod freeze **enforcement** on governed paths (the governed download-fail bail at `run.rs:1662`); fail-closed budget-pair writes; refuse-replication `verify_after`.
+- Local-only-table preservation (`LOCAL_ONLY_TABLE_NAMES = ["schema_cache", "jobs"]`, `state.rs:219`) is sound once refresh occurs after the store is dropped.
+
+### The residual this ADR closes
+
+The three defects above share one root cause: there is **no object that owns a run's remote-state lifecycle**. The seams are copy-pasted, the config is a path re-read at each layer, and governance re-derives itself from disk. The spine introduces that object.
+
+---
+
+## Decision
+
+### 1. `RemoteStateSession` — the lifecycle owner
+
+A new type in `rocky-core::state_sync`, constructed from an **owned `StateConfig` snapshot** (`from(&StateConfig)`), **never** a `config_path`. Execute-from-owned by construction: a session cannot re-read a config off disk, so no seam can be redirected by a timed swap.
+
+**Owns:**
+
+| Field | Purpose |
+|---|---|
+| `StateConfig` (owned snapshot) | The backend/auth the whole lifecycle executes against |
+| `state_path: PathBuf` | The local ledger path this session syncs |
+| `StateAuthority` | Resolved at `acquire`; surfaced via `authority()` (defined by ADR-AUTHORITY) |
+| `base: Mutex<Option<Generation>>` | The download's observed generation. Interior-mutable so the periodic uploader can advance it. **The field the CAS PR (PR-D) reads/CAS-writes** — inert until then |
+| `finalize_policy` | Whether `finalize` uploads fail-closed vs `suppress` (forward-incompat) |
+| `finalized: bool` (one-shot) | Guards double-finalize; arms the Drop tripwire |
+| `periodic: Option<JoinHandle<()>>` | The mid-run uploader. Owned by the session, spawned during the run under **today's estimated-duration gating** (`run.rs:2620`, `estimated_run_secs` threshold; `None` on short runs and seam paths), **aborted _and joined_ at `finalize`** (fixes the abort-without-await leg of RD-004, `run.rs:3116`/`3259`) |
+
+**Does NOT own the `StateStore`.** This is a hard lock-ordering constraint, not a convenience. `download_state` (`state_sync.rs:297`) internally takes the *same* advisory writer lock `StateStore::open` takes (`acquire_publish_lock`, called at `state_sync.rs:321`; the function's own doc comment at `state_sync.rs:338`–`341` states it is "the same lock `StateStore::open` takes"). It holds that lock only around the local-only-table merge + atomic publish (`publish_merged`, `state_sync.rs:331`) and **releases it before returning** (`drop(lock)`, `state_sync.rs:333`). If the session held a `StateStore` open across `acquire`, that download-publish lock would contend with the session-held writer lock. Additionally, the seams open the store with *different* policies (`open_with_policy` vs `open`). Keeping the store out of the session preserves both invariants.
+
+**API:**
+
+| Method | Role |
+|---|---|
+| `acquire(&mut self) -> Result<StateAuthority>` | Download-before-read. Records + returns the `StateAuthority`, owns/spawns the periodic uploader (gated as above). **`StateBackend::Local` is a zero-I/O `Authoritative` no-op handled inside `acquire`** — mirrors `download_state`'s Local early-return (`state_sync.rs:301`–`304`) — the only skip |
+| `authority(&self) -> StateAuthority` | The recorded authority, for the governor. `Indeterminate` is the download-level non-authoritative signal (maps today's `state_download_ok == false`, `run.rs:1650`–`1672`) |
+| `require_synced(&self) -> Result<()>` | Fail-closed guard: bails **only on `Indeterminate`**. Replaces the governed bail at `run.rs:1662` (which currently inlines `exec_fp_gate.is_some() && rocky_cfg.policy.is_some()`), so an **ungoverned** run whose download failed still warns-and-continues on local state (preserves #1089's no-policy no-abort) |
+| `finalize(self) -> Result<()>` | Upload-after, **fail-closed**, one-shot. **The single write choke-point CAS (PR-D) hooks** via the base `Generation`. Aborts+joins the periodic task first. **PR-B repositions this call to run *after* the run's terminal state writes** (`persist_run_record`/verify-after/`finalize_idempotency`, `run.rs:4312`/`4334`/`4379`) — making it fatal at today's `run.rs:4250` position would `return Err` *before* `persist_run_record` and the verify-after custody row (the `InFlight` idempotency claim itself is safe either way: `finalize_idempotency_on_error`, invoked at `run.rs:4547` by the `run_result` error-path guard, releases it on any `Err` — the skipped writes are the history record and custody row). Store-drop + consistent-snapshot copy is PR-C; CAS is PR-D. See the behaviour-change note in Consequences — for the full-run paths this is stricter than today's best-effort end-of-run upload |
+| `suppress(self)` | Forward-incompat recreate path: consume the session **without** uploading a downgraded blob (mirrors `was_recreated_for_forward_incompat`, `run.rs:1711`, and today's `suppress_state_upload`). This — not `require_synced` — handles the recreated-store case, so a governed run on a forward-incompat-recreated store does **not** newly hard-bail |
+
+**Half-seam associated functions** — a *lifecycle shape* (download-XOR-upload; no `acquire`/`finalize` pairing; no Drop tripwire) for the ledger seams that touch remote state only one way:
+- `download_only(cfg, state_path)` — replaces `apply::sync_remote_ledger_before_gate` (`apply.rs:821`), its **blocking sibling** `sync_remote_ledger_before_gate_blocking` (`apply.rs:846`, used by the synchronous promote gate at `:2027` — served via the PR-A-generalized `block_on_state_sync`), and `apply::download_remote_ledger_unconditional` (`apply.rs:873`).
+- `upload_only_fail_closed(cfg, state_path, reason)` — replaces `apply::upload_remote_ledger_fail_closed` (`apply.rs:902`). This seam is **already** fail-closed today; the session does not change its semantics.
+
+> **Orthogonal to the CAS class.** The half-seam-vs-full-lifecycle split is *lifecycle shape*, not reconciliation policy. ADR-CONCURRENCY's **retry-vs-refuse** class is set by writer kind: full runs — **including backfill** (`acquire`/`finalize`) — are **REFUSE**; only genuine single-record ledger writes (gc tombstone, budget-pair, restore/verify-after custody, the `policy freeze` row) **RETRY**. Which helper a path uses does not set its CAS class.
+
+**Session lifecycle state machine** (the full-run paths — `acquire`/`finalize`):
+
+```mermaid
+stateDiagram-v2
+    [*] --> Constructed: from(&StateConfig)
+    Constructed --> Acquired: acquire() Ok(Authoritative|FreshStart|Indeterminate)
+    Constructed --> [*]: acquire() Err (download hard-fail on a fail-closed caller)
+    Acquired --> Finalized: finalize() -> upload (fail-closed) + abort&join periodic
+    Acquired --> Suppressed: suppress() (forward-incompat downgrade: no upload)
+    Acquired --> Tripwire: dropped un-finalized (debug_assert! + warn! + abort periodic)
+    Finalized --> [*]
+    Suppressed --> [*]
+    Tripwire --> [*]
+```
+
+Legend: `Indeterminate` gates the governor and (under a `[policy]` plane) `require_synced`; it does not by itself stop an ungoverned run. `Tripwire` is a diagnostic + resource-cleanup net, **not** a durability guarantee (see below).
+
+**`Drop` is a tripwire *and* a resource net:** `debug_assert!` + `warn!` if dropped un-finalized, **and** it aborts the periodic task so a leaked handle can't outlive the run. It is **not** a durability guarantee — a panic between mutation and `finalize` still skips the upload. The two paths that mutate the warehouse *and* must persist on failure keep their **explicit** upload-on-failure (`let r = mutate().await; drop(store); upload_only_fail_closed(…); r?`): `restore.rs` (already `let exec_result = …; drop(store); upload_remote_ledger_fail_closed(…); let output = exec_result?;`, `restore.rs:984`–`998`) and the backfill apply (`apply.rs:2656`/`2671`).
+
+**Seam → session-method map** (replaces seven divergent inline copies with one policy):
+
+| Current inline seam | Location | Replaced by |
+|---|---|---|
+| replication download | `run.rs:1650` (+ governed bail `1662`) | `acquire` (+ `require_synced`) |
+| periodic uploader | `run.rs:2632`/`2635` (abort `3116`/`3259`) | owned `JoinHandle`, abort+join in `finalize` |
+| end-of-run upload | `run.rs:4250` (`upload_state_unless_recreated`, best-effort today) | `finalize` (or `suppress`) |
+| policy freeze download / upload | `policy.rs:471` / `policy.rs:547` | `download_only` / `upload_only_fail_closed` |
+| restore download / upload | `restore.rs:948` / `restore.rs:991` | `download_only` / explicit `upload_only_fail_closed` |
+| gc download / upload | `gc.rs:1530` / `gc.rs:1611` | `download_only` / `upload_only_fail_closed` |
+| apply ledger sync-before-gate / upload | `apply.rs:821` (also `873`) / `apply.rs:902` | `download_only` / `upload_only_fail_closed` |
+
+### 2. Config-snapshot threading (#1120)
+
+**One owned config instance per invocation, threaded — never re-read.**
+
+- `run()` (`run.rs:1111`) and `run_dag_exec::default_sub_runner`/`run_with_dag` (`run_dag_exec.rs:51`/`111`) take **`Arc<RockyConfig>`** (`Arc` so DAG sub-runs share one instance). **Delete** the internal re-reads at `run.rs:1202` and `run.rs:1262`; **delete** `run_dag_exec.rs:130`. These are the only production re-reads on the run path.
+- Collapse the three governed loads to one: hard-load once at `apply.rs:238`, thread through `governed_run_context` (`apply.rs:334`) → `execute_run_plan` (**delete its re-load at `apply.rs:479`**) → `run()`. `verify_routing_identity` (`apply.rs:1907`, called at `run.rs:1805`) then checks the **one** instance that executes.
+- Callers to update to pass the `Arc` — **five** production sites (second-review correction; the fifth calls `run(` unqualified via `use super::run::{…, run}` and escapes a naive grep): `apply.rs:627`, `apply.rs:2809`, `apply.rs:3227` (`run_apply_inline_for_run`, `apply.rs:3205` — the plain `rocky run` entry loads **nothing** today, so threading **adds** the single load here rather than collapsing one), `run_dag_exec.rs:64` (`default_sub_runner`), and **`run_watch.rs:265`**. Watch semantics require a **fresh config load per watch iteration** — today each iteration live-reloads via `run()`'s internal `:1262` load; the new load moves *inside* `iter_once`, never hoisted above the loop (a broken config fails that iteration and the watcher continues — parity).
+- **Promote (Codex F5, in scope):** the promote gate `gate_promote_plan` (`apply.rs:2008`) hard-loads at `apply.rs:2018` and **returns the owned `Arc`**; thread it into `run_promote_apply` (`branch.rs:775`) and resolve the adapter from that instance instead of the **second** reload at `branch.rs:781`. Scope note: only the promote-apply config load is closed by this pass. `branch.rs` has other, unrelated config loads (`656`, `964`, `1212`, `1507`) that are out of scope.
+- **Load:** `run_load` (`load.rs:34`) currently self-loads config at `load.rs:46`. Fold it into the same threading so the loaded-files session executes from the caller's owned snapshot.
+
+**Two deliberate non-changes (honesty guards):**
+- **Do NOT bind `[policy]`/`[state]` into `config_policy_identity`** (`apply.rs:1630`). That identity is compared **raw** (`config_policy_identity(cfg)` at `apply.rs:1911`, `expected == actual` at `apply.rs:1913`) and those sections are `${VAR}`-templated — binding them would false-refuse on an env-var-only difference. `config_policy_identity` stays adapters+pipelines (routing) only.
+- **`config_fingerprint` (Codex F10, corrected by the second review):** hash the **raw bytes captured at the single load site** — `parse_rocky_config` already reads the file once via `read_to_string` (`config.rs:5468`); the fingerprinted loader hashes those bytes (same SipHash as today ⇒ values byte-identical for unswapped files) and returns the fingerprint alongside the config. Do **NOT** hash a serde serialization of the parsed config: `FreshnessConfig.overrides` is a `std::collections::HashMap` (`config.rs:1386`) reachable from `RockyConfig`, so serialization order — and therefore the hash — would be nondeterministic across processes, causing sporadic false config-mismatch refusals. The gate-path callers (`run.rs:1266`, `run.rs:5057`) switch to the captured fingerprint; the two output-only callers (`branch.rs:336`, `catalog.rs:370`) stay path-based.
+
+### 3. Bypass closure (RD-003, Codex F6)
+
+`acquire()` runs **unconditionally** at each mutating entry; the only skip is `StateBackend::Local`, absorbed inside `acquire` as a zero-I/O `Authoritative` no-op (so callers stay uniform).
+
+| Entry point | Opens store at | Sync today | Action |
+|---|---|---|---|
+| `run --model` | `run.rs:1333` | **none (live bypass)** | wrap in `acquire`/`finalize` |
+| `run_local` transformation | `run_local.rs:115` | **none (live bypass)** | wrap in `acquire`/`finalize` |
+| `rocky load` / `Load` arm (`run_load`) | `load.rs:104` | **none (live bypass)** | insert `acquire`/`finalize` **inside `run_load`** |
+| standalone backfill (`execute_backfill_set`) | `run.rs:5087` | **synced by caller** (`apply.rs:2545`/`2671`) | **consolidate** sync inward; delete the wrapper |
+| quality / snapshot (`run_local.rs:319`/`853`) | — (no store) | n/a | **EXCLUDED** — do not claim coverage |
+
+- **Load insertion point (precise):** `run_load` is the single funnel for both the `rocky load` command and the `rocky run --pipeline <load>` arm (`run.rs:1596`). Insert `acquire`/`finalize` **inside `run_load`** around its store open (`load.rs:104`). One insertion covers both callers. **Remote-key collision — load MUST be unified onto the canonical state path (second-review correction):** `remote_state_key` (`state_sync.rs:83-93`) keys on the parent *directory name* (`.rocky-state` = `STATE_NAMESPACE_DIR`), so load's `<config_dir>/.rocky_state` (`load.rs:103`) and the canonical `models/.rocky-state.redb` both map to the **same** remote object `state.redb` — syncing load's legacy path as-is would clobber the pipeline's canonical remote ledger on `finalize` (and overwrite load's local state on `acquire`). Fix: `run_load` uses the canonical threaded `state_path`; migration is a **logical import, not a rename** (a rename is erased by the next remote download replacing replicated `LOADED_FILES` wholesale, and a shared legacy DB can hold multiple pipelines keyed `pipeline|file_path`): acquire canonical first, then import only the selected pipeline's legacy `loaded_files` rows; idempotent; legacy left in place with a one-time warn. Load opens via `open_with_policy(state.on_schema_mismatch)` and propagates `was_recreated_for_forward_incompat()` into upload suppression (parity with the run path). Because `run_load` records successes per-file and errors only after all files (`load.rs:226-269`/`:330`), the session **captures the result → always finalizes → propagates** — `abandon` on a partial failure would drop successful files' state.
+- **Backfill (honest framing + one-session rule):** `execute_backfill_set` (`run.rs:5033`) opens its store at `run.rs:5087` with no *own* sync, but its **only** production caller — `run_apply_backfill_plan` (`apply.rs:2480`), which invokes `execute_backfill_set` at `apply.rs:2656` — already wraps it with `download_remote_ledger_unconditional` (`apply.rs:2545`) and `upload_remote_ledger_fail_closed` (`apply.rs:2671`). Backfill is therefore **synced today** — the consolidation is a defense against a future direct caller, not the closure of a live hole, and must not be listed among the active RD-003 bypasses. **Shape (red-team-corrected): ONE session, acquired in `run_apply_backfill_plan` *before* the gate and threaded into `execute_backfill_set`.** A second in-executor download after the gate would wholesale-replace the replicated `POLICY_DECISIONS` table (downloads replace replicated tables) and **erase the decision row the policy gate writes between the two downloads** — the decision must survive to the final upload. The executor captures the execution result and **always finalizes** (parity with today's `apply.rs:2671` upload-even-on-failure), then propagates.
+- **Optional structural guard:** an `open_synced_state_store(session, …)` proof-token so a store can only be opened through a session — makes "no future bypass" enforceable at the type level rather than by review.
+
+### 4. #1093 fold-in — capture a `GovernanceSnapshot`, don't recompile (Codex F8)
+
+`ModelIr.governance` (`ir.rs:537`) is a `GovernanceConfig` (`ir.rs:208`) carrying **only** `permissions_file` (`ir.rs:209`) / `auto_create_catalogs` (`ir.rs:210`) / `auto_create_schemas` (`ir.rs:211`) — it does **not** carry `[governance.tags]`, per-column classifications, or retention. Those live on `model.config` (TOML-sourced), which is why the reconcile re-compiles from disk rather than reusing the IR. So a purpose-built snapshot is needed, not `ProjectIr`.
+
+- Define an immutable `GovernanceSnapshot`: the required config fields + the executed-model selection (each model's target ref, `governance.tags`, `classification`, retention).
+- **Capture it inside `execute_models`** (`run.rs:5211`), **position-keyed**: immediately after the `if let Some(gate) { … gate.verify(…) }` block (`run.rs:5412-5437` — the verify runs only on *governed* paths, so the capture keys off the code position, which is unconditional) and **before the `--defer` in-place SQL rewrite block** (`if defer_opts.enabled { apply_defer_rewrite(&mut compile_result, …) }`, `run.rs:5489`), from `compile_result.project.models` — i.e. from the exact set the fingerprint gated (when governed), before defer mutates any SQL.
+- Change `execute_models`'s return from `Result<()>` (signature at `run.rs:5297`) to `Result<GovernanceSnapshot>`, thread the snapshot out, and use it to **replace both fresh compiles**:
+  - the full-replication/DAG reconcile compile at `run.rs:4041` (downstream of the `execute_models` call at `run.rs:3955`), and
+  - `apply_model_governance_tags` (`run.rs:7287`), whose recompile is at `run.rs:7295`.
+- **Blast radius:** `apply_model_governance_tags` has **three** production callers — `run.rs:1415` (model-only), `run.rs:5156` (backfill), `run_local.rs:164` (transformation). Replacing its recompile with a `&GovernanceSnapshot` parameter means changing its signature and updating all three sites plus each site's `execute_models` capture. This is more than "delete the compile."
+- **Behavior-preserving (verified, not inherited):** the load-bearing fact is that **both reconcile sites discard the compile's diagnostics** — `run.rs:4041`–`4063` pattern-matches `Some(Ok(gov_compile))` and reads only `gov_compile.project.models`; `apply_model_governance_tags` reads only `project.models` in its `Ok` arm (`run.rs:7310`) and `warn`s-and-drops on the `Err` arm (`run.rs:7335`), and the function has **no `output` parameter** (`run.rs:7287`–`7293`), so it *cannot* push to `output.errors`. Reading tags/classification off a captured snapshot instead of a recompile therefore surfaces nothing that was previously surfaced. (Independently: the lighter gov-compile inputs — `contracts_dir: None`, empty `source_schemas` — feed only the W004 classification-completeness and W005 freshness-coverage diagnostics, `compile.rs:325`/`333`, which are exactly what both sites discard.)
+
+---
+
+## Consequences
+
+### What changes
+- One `RemoteStateSession` type replaces seven divergent inline seams; one owned `Arc<RockyConfig>` replaces six+ path re-reads across the run/apply/promote paths; one `GovernanceSnapshot` replaces two fresh governance recompiles.
+- `run()`, `run_with_dag`, `default_sub_runner` take `Arc<RockyConfig>`; `execute_models` returns `Result<GovernanceSnapshot>`; `apply_model_governance_tags` takes `&GovernanceSnapshot`.
+- `config_fingerprint` hashes the owned snapshot, not a re-read.
+
+### One deliberate behavior change (not behavior-preserving on remote backends)
+`finalize`'s durability is **split by governance class** (`FinalizeDurability::{Durable, ConfigDefault}`): **Durable** (forces `on_upload_failure = Fail`) for **governed** runs — incl. the default-`skip` config — and **backfill** (always review-gated); **ConfigDefault** for all **ungoverned** paths, including the newly-wrapped bypasses — `on_upload_failure = "skip"` is a documented liveness contract (`config.rs:532-549`), and an ungoverned run must not turn a successful warehouse run nonzero on a failed state PUT. `finalize` is also **lazy**: it skips the upload when no state mutation occurred (a no-op transformation without a models dir, an empty load). For governed runs this closes the **RD-001 residual** (today's `run.rs:4250` is `warn!`-and-exit-0 even for governed applies), landing here because the session owns the write choke-point. PR-B also **repositions** the upload to after the terminal state writes (`run.rs:4312`/`4334`/`4379`), so a fatal finalize cannot skip `finalize_idempotency`. The newly-wrapped bypass paths (`run --model`, transformation, `load`) likewise gain a fail-closed finalize — a remote-unreachable upload now fails these runs where before they had no remote interaction at all (that is the RD-003 closure). The single-record seam paths (`apply`/`restore`/`gc`/`policy`) are **already** fail-closed on upload — no change. Backfill's upload is also already fail-closed today (`upload_remote_ledger_fail_closed`); after consolidation it runs the full `acquire`/`finalize` lifecycle, and its CAS reconciliation class is **REFUSE** (per ADR-CONCURRENCY), not the single-record retry.
+
+### Migration
+- Internal refactor only — no `rocky.toml`, wire-format, or CLI-surface change. No redb schema bump.
+- `[state] backend = "local"` is **byte-identical**: `acquire` is a zero-I/O no-op, `finalize` does no remote I/O, and no seam does remote I/O.
+- Seam migration + config threading + `execute_models` signature + authority-caller migration land **atomically in PR-B** (per ADR-AUTHORITY's PR-A→PR-B contract), so callers never observe a half-migrated state.
+
+### This is the keystone
+PR-C (consistent snapshot) and PR-D (CAS) hook `finalize` and read the base-`Generation` field; PR-F (freeze markers) relies on the session's single-choke-point download/upload discipline. The spine must land first.
+
+### What it does and does NOT close
+**Closes:**
+- **RD-003** — the three live bypasses (`run --model`, transformation, `rocky load`) sync remote state; the future-caller gap in backfill is structurally sealed.
+- **#1120** — no config re-read window on run, apply, DAG, or promote; the fingerprint describes the executed snapshot.
+- **#1093** — governance reconcile applies the plan-gated set, not a post-execution disk state.
+
+**Does NOT close (honest boundary):**
+- **No CAS / no lost-update protection.** `finalize` is still a whole-file `put` (last-writer-wins). RD-002 is closed by **PR-D**; this ADR only provides the hook. The base-`Generation` field is inert until then.
+- **RD-004 only partially touched.** The periodic uploader's abort-without-await (`run.rs:3116`/`3259`) is fixed here by `finalize`'s abort+join. The consistent-snapshot copy under the writer lock, the streaming (non-whole-file-in-memory) upload, and watermark durability remain **PR-C**.
+- **No freeze marker.** `require_synced` fail-closes on `Indeterminate` and the ledger `POLICY_DECISIONS` freeze row is still the read source — the rollout-independent add-wins marker is **PR-F**. An erasable-kill-switch window remains until PR-F.
+- **`Drop` is a resource net, not durability.** A panic between mutation and `finalize` skips the upload; only `restore` and backfill carry explicit upload-on-failure.
+- **#1093 is scoped to the governance-reconcile compiles.** `execute_models` becomes a governance-capture, not the broader within-apply provenance rework — the deferred `#1093` "provenance within apply" residual stays open.
+- **The Load state-path divergence** (`.rocky_state` vs `models/.rocky-state.redb`) is flagged, not unified.
+
+---
+
+## Alternatives considered
+
+| Alternative | Why rejected / escalation trigger |
+|---|---|
+| **Keep the seven inline seams**, fix each in place | Rejected — seven divergent copies is the root cause; each drift is a fresh RD-003/#1120. A single lifecycle owner is the only structural fix. |
+| **Session owns the `StateStore`** | Rejected — `download_state` takes the same writer lock internally (`acquire_publish_lock` at `state_sync.rs:321`, released `state_sync.rs:333`; its doc comment names it "the same lock `StateStore::open` takes") and the seams need different open policies (`open_with_policy` vs `open`). A session-held store would contend and couldn't express both policies. Store stays out of the session. |
+| **Bind `[policy]`/`[state]` into `config_policy_identity`** | Rejected — compared raw (`apply.rs:1911`/`1913`) and `${VAR}`-templated → false-refuse on env-only differences. Snapshot threading gives the same TOCTOU protection without the false refuse. |
+| **Reuse `ProjectIr` for #1093** instead of a new `GovernanceSnapshot` | Rejected — `GovernanceConfig` (`ir.rs:208`) carries only `permissions_file`/`auto_create_catalogs`/`auto_create_schemas`; tags/classifications/retention are TOML-sourced on `model.config`. A `ProjectIr` thread wouldn't carry the governance metadata the reconcile needs. |
+| **Pass `config_path` and re-read once inside the session** | Rejected — any in-session re-read reopens the swap window. Execute-from-owned by construction (`from(&StateConfig)`) is the invariant. |
+| **Make `require_synced`/`acquire` fail-closed on *every* download failure** | Rejected — an ungoverned run (no `[policy]`) that hits a transient download blip warns-and-continues today (`run.rs:1669`); hard-failing it is an availability regression (#1089's no-policy no-abort). `Indeterminate` gates only governed runs via `require_synced`. |
+| **Distributed lease / auto-merge replay for concurrency** | Deferred to ADR-CONCURRENCY as named escalations (sustained CAS thrash; common same-namespace long-runs). Not part of the spine. |
+
+---
+
+## Validation
+
+**RD-003 parameterized lifecycle matrix** — one table-driven suite over `{replication, transformation, model-only, backfill, load}`, each asserting the full session contract:
+
+| Assertion | What it proves |
+|---|---|
+| download-before-read | `acquire` ran before the first state read (no stale-local mutation) |
+| final persistence | `finalize` uploaded (or `suppress` deliberately didn't) |
+| download-failure fail-closed **(governed)** | injected `exists`/`get` failure under a `[policy]` plane + `exec_fp_gate` → `Indeterminate` → `require_synced` bails, nonzero exit, no incremental mutation, no upload |
+| download-failure availability **(ungoverned)** | injected `exists`/`get` failure with no `[policy]` → `Indeterminate` → warns and continues on local state (exit follows the run, not the download); preserves #1089 |
+| finalize fail-closed | injected final-`put` failure → nonzero exit for every mode with a live-run `finalize` (the RD-001 end-upload propagation) |
+| bootstrap | a genuine not-found → `FreshStart` bootstraps (does not fail) |
+| cleanup | periodic task aborted **and joined**; no leaked handle, no overlapping upload after finalize; `Drop` on an un-finalized session warns + aborts the task |
+
+Plus:
+- **#1120:** two `run`/apply invocations against one config, a `rocky.toml` swap timed between gate and execution → both execute the gated snapshot (fingerprint matches the owned instance). Kill-switch drill doubles as the #1120 demo (specified in ADR-CONCURRENCY).
+- **Promote:** the swap can't redirect the adapter — one owned `Arc` reaches both promote executors.
+- **#1093:** a post-execution `[governance.tags]`/`classification` edit does **not** change what the reconcile applies (snapshot captured post-fingerprint/pre-defer, `run.rs:5437`–`5489`); a golden test asserts the snapshot-driven reconcile and the (removed) recompile-driven reconcile produce identical tag/classification calls on a clean project.
+- **Local backend byte-identical:** full suite green with `[state] backend = "local"` (`acquire`/`finalize` no-ops).
+- **Gates:** `cargo nextest run`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`.
+
+**Line-number note for reviewers:** anchors are symbol-anchored; treat line numbers as approximate. Several earlier-cited numbers had drifted and are corrected here — transformation store-open `run_local.rs:115` (guard at `114`; plan said `108`), quality/snapshot `run_local.rs:319`/`853` (plan said `315`/`849`), policy freeze seams `policy.rs:471`/`547` (plan said `467`/`543`), backfill store-open `run.rs:5087`, model-only store-open `run.rs:1333`, `execute_models` return-type signature `run.rs:5297`, the #1093 reconcile compiles `run.rs:4041`/`7295` (plan said `4040`/`7294`), `verify_routing_identity` at `apply.rs:1907`, and `download_remote_ledger_unconditional` at `apply.rs:873`. The symbols are exact.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,21 @@
+# Architecture Decision Records
+
+This directory holds **ADRs** — durable records of significant, hard-to-reverse engine design decisions. An ADR states the *context* (the problem + what's already true in-tree), the *decision* (the design, grounded in real symbols/paths), its *consequences* (including what it does **not** close), the *alternatives* considered, and how the decision is *validated*.
+
+Convention: one file per decision, `ADR-<TOPIC>.md`, status one of **Proposed** → **Accepted** → **Superseded**. Code claims are symbol-anchored; line numbers are approximate. A design gate ("stops for sign-off") is a Proposed ADR that blocks implementation until accepted.
+
+## WP-01 — Remote-state protocol redesign (PR-0 design gate)
+
+Closes the 3 open Critical audit findings (RD-001/002/003) plus #1120 (freeze kill-switch / config-swap TOCTOU) and #1093 (governance-from-gated-snapshot), on a **live, concurrent multi-pod** `[state]` deployment. Read in this order:
+
+| # | ADR | PR | Closes |
+|---|---|---|---|
+| 1 | [`ADR-AUTHORITY.md`](ADR-AUTHORITY.md) | PR-A | RD-001 — typed `StateAuthority` (Authoritative / FreshStart / Indeterminate); the safe-standalone keystone. |
+| 2 | [`ADR-STATE-SESSION.md`](ADR-STATE-SESSION.md) | PR-B | RD-003 (bypass), #1120 (config-swap TOCTOU incl. promote), #1093 (`GovernanceSnapshot`) — the `RemoteStateSession` spine. |
+| 3 | [`ADR-CONCURRENCY.md`](ADR-CONCURRENCY.md) | PR-C→PR-D (+ spine-urgent PR-F) | RD-002 (CAS: retry-seams / refuse-runs) + the rollout-independent add-wins freeze marker. |
+
+Staging: **spine-first** (PR-A → PR-B → PR-F) then the CAS **fast-follow** (PR-C consistent snapshot → PR-D CAS), closed by an operational **rollout gate** (fleet-wide deploy → `concurrency_control = "cas"` on every live prefix → doctor-verified effective-CAS). Until that gate completes, RD-002 exposure is bounded by orchestrator-level per-`[state]`-prefix writer serialization.
+
+These ADRs went through three adversarial review rounds (a strategic-plan red team, an independent per-ADR second review, and a red team over the implementation plan); the corrections from all three are folded in.
+
+These three ADRs were authored under adversarial review (Codex, 10 findings dispositioned) and a cross-consistency pass. **Status: Proposed — awaiting sign-off before implementation.**


### PR DESCRIPTION
## Summary

PR-0 design gate for **WP-01**, the remote-state protocol redesign. Three Architecture Decision Records (establishing `docs/adr/`) that specify how the engine closes the remaining remote-`[state]` integrity findings on live, concurrent multi-pod deployments:

| ADR | Delivers | Closes |
|---|---|---|
| `ADR-AUTHORITY` | typed `StateAuthority` (Authoritative / FreshStart / Indeterminate) across the `download_state` boundary; fail-closed `Indeterminate`; audited operator bootstrap flag | RD-001 residual |
| `ADR-STATE-SESSION` | one `RemoteStateSession` lifecycle owner replacing the inline download/upload seams; `Arc`-threaded config snapshot (no post-gate re-reads, incl. promote); bypass closure for `run --model` / transformation / `rocky load`; `GovernanceSnapshot` captured at the fingerprint-gated compile | RD-003, #1120 (config-swap), #1093 |
| `ADR-CONCURRENCY` | CAS on every remote state write (single-record ledger seams **retry**, full runs **refuse**); a rollout-independent add-wins **freeze marker** (kill-switch survives any concurrent whole-blob upload); tiered coherence; consistent-snapshot prerequisite | RD-002 (via an explicit rollout gate), #1120 (freeze erasure) |

## Status

**Proposed — this PR is the design sign-off gate.** Implementation (staged PRs: test infra → authority → session spine → freeze markers → consistent snapshot → CAS → rollout gate) is blocked until these are accepted.

## Review provenance

The designs went through three adversarial review rounds (strategic-plan red team; an independent per-ADR second review that re-verified every code anchor; a red team over the implementation plan). All corrections are folded in — including the load remote-key collision, the raw-bytes config fingerprint, typed-transition seam retries, fence-granularity narrowing, and the CAS rollout-gate closure framing.

## Notes

- Docs only — no code, no behavior change, no codegen surface.
- Line anchors are symbol-anchored; treat line numbers as approximate.