### PR TITLE
test(engine): WP-01 PR-1 — remote-state test rig (fault store, cross-pod harness, live-S3 rung)

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4139,6 +4139,7 @@ dependencies = [
  "redis",
  "regex",
  "reqwest 0.12.28",
+ "rocky-core",
  "rocky-duckdb",
  "rocky-ir",
  "rocky-sql",

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -59,6 +59,10 @@ async-trait = { workspace = true }
 
 [dev-dependencies]
 async-trait = { workspace = true }
+# Turns on rocky-core's remote-state test rig (fault store, cross-pod
+# harness, provider-override seam) for THIS crate's test targets only — the
+# `rocky` binary build never sees the feature.
+rocky-core = { path = "../rocky-core", features = ["test-support"] }
 criterion = { version = "0.8", features = ["html_reports"] }
 tempfile = "3"
 # Holds the advisory write lock directly (no redb handle) in the policy-ledger

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -40,9 +40,23 @@ blake3 = { workspace = true }
 # implements it today). The default impl just errors, but the symbol is
 # referenced in the trait signature so the dep stays unconditional.
 arrow = { workspace = true }
+# Only compiled under the `test-support` feature (used by the cross-pod state
+# test harness). Release builds of the `rocky` binary never enable it.
+tempfile = { version = "3", optional = true }
+
+[features]
+# Deterministic remote-state test rig: the fault-injecting object store
+# (`fault_store`), the cross-pod harness (`test_harness`), and the public
+# provider-override seam (`state_sync::remote_testing`). Test-target-only —
+# the `rocky` binary never enables it, so release artifacts are unchanged.
+test-support = ["dep:tempfile"]
 
 [dev-dependencies]
 tempfile = "3"
+# Self-referential dev-dependency: turns `test-support` on for this crate's
+# own test targets, so `cargo test -p rocky-core` compiles the feature-gated
+# integration tests without extra flags.
+rocky-core = { path = ".", features = ["test-support"] }
 rocky-duckdb = { path = "../rocky-duckdb" }
 tokio = { workspace = true }
 # JSON Schema validator used in `tests/adapter_schema.rs` to assert every
@@ -52,6 +66,21 @@ jsonschema = { version = "0.46", default-features = false }
 criterion = { version = "0.8", features = ["html_reports"] }
 # Used by `tests/state_sync_timeout_test.rs` to front-end a hung S3 endpoint.
 wiremock = { workspace = true }
+
+# The remote-state rig tests need the `test-support` seams. The feature is
+# already on for all test targets via the self-referential dev-dependency;
+# `required-features` makes the dependency explicit per target.
+[[test]]
+name = "state_sync_cross_pod"
+required-features = ["test-support"]
+
+[[test]]
+name = "state_sync_live_store"
+required-features = ["test-support"]
+
+[[test]]
+name = "state_sync_s3_live"
+required-features = ["test-support"]
 
 [[bench]]
 name = "dag_execute"

--- a/engine/crates/rocky-core/src/fault_store.rs
+++ b/engine/crates/rocky-core/src/fault_store.rs
@@ -1,0 +1,345 @@
+//! Fault-injecting [`ObjectStore`] decorator for remote-state tests.
+//!
+//! Compiled only for the crate's own tests or under the `test-support`
+//! feature — the `rocky` binary never enables either, so nothing here can
+//! reach a production build.
+//!
+//! [`FaultingStore::wrap`] decorates any store (typically
+//! `object_store::memory::InMemory`) and returns a cloneable [`FaultHandle`]
+//! that arms deterministic failures per operation and reads unconditional
+//! per-operation call counters. Because the shared state lives behind an
+//! `Arc<Mutex<..>>`, arming and counting work across OS threads — a handle
+//! held by a test observes calls made from a spawned runtime thread.
+//!
+//! Injected failures surface as [`object_store::Error::Generic`] with
+//! `store: "FaultingStore"`, which the state-sync error taxonomy classifies
+//! like any other backend failure.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::{Arc, Mutex, PoisonError};
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use futures::stream::BoxStream;
+use object_store::path::Path as ObjectPath;
+use object_store::{
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    ObjectStoreExt, PutMultipartOptions, PutOptions, PutPayload, PutResult,
+};
+
+/// Logical object-store operation a fault can target.
+///
+/// The pinned `object_store` 0.14 trait routes several public operations
+/// through one entry point, so the mapping is by *intent*, not method name:
+/// `Head` is a `get_opts` call with `GetOptions::head` set (it backs
+/// `ObjectStoreProvider::exists`), `Put` covers both `put_opts` and
+/// `put_multipart_opts`, `List` covers `list` and `list_with_delimiter`,
+/// `Delete` fires per path inside `delete_stream`, and `Copy` covers
+/// `copy_opts` (so the `copy` / `copy_if_not_exists` extension methods too).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FaultOp {
+    Get,
+    Put,
+    Head,
+    List,
+    Delete,
+    Copy,
+}
+
+/// How an armed fault fires across successive calls of its [`FaultOp`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FaultMode {
+    /// Fail the next `n` calls, then recover (the arm disarms itself).
+    FailNext(u32),
+    /// Fail exactly the `n`-th call (1-based, counted from the store's
+    /// creation — not from arming), letting every other call through.
+    FailNth(u64),
+    /// Fail every call until [`FaultHandle::clear`] or a re-arm.
+    FailAll,
+}
+
+/// Shared fault/counter state between a [`FaultingStore`] and its
+/// [`FaultHandle`]s.
+#[derive(Debug, Default)]
+struct FaultState {
+    /// Unconditional per-op call counters (every call counts, faulted or not).
+    counts: HashMap<FaultOp, u64>,
+    /// Currently-armed fault per op.
+    armed: HashMap<FaultOp, FaultMode>,
+}
+
+fn lock(state: &Mutex<FaultState>) -> std::sync::MutexGuard<'_, FaultState> {
+    state.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+/// Count the call and decide whether the armed fault (if any) fires for it.
+/// An exhausted [`FaultMode::FailNext`] disarms itself so later calls recover.
+fn record_and_check(state: &Mutex<FaultState>, op: FaultOp) -> Result<(), object_store::Error> {
+    let mut guard = lock(state);
+    let count = guard.counts.entry(op).or_insert(0);
+    *count += 1;
+    let call_number = *count;
+    let fire = match guard.armed.get_mut(&op) {
+        None => false,
+        Some(FaultMode::FailAll) => true,
+        Some(FaultMode::FailNth(n)) => call_number == *n,
+        Some(FaultMode::FailNext(remaining)) => {
+            if *remaining == 0 {
+                false
+            } else {
+                *remaining -= 1;
+                true
+            }
+        }
+    };
+    if guard.armed.get(&op) == Some(&FaultMode::FailNext(0)) {
+        guard.armed.remove(&op);
+    }
+    drop(guard);
+    if fire {
+        Err(object_store::Error::Generic {
+            store: "FaultingStore",
+            source: format!("injected fault: {op:?} call #{call_number}").into(),
+        })
+    } else {
+        Ok(())
+    }
+}
+
+/// Cloneable control handle for a [`FaultingStore`].
+///
+/// Arms faults and reads counters through the same `Arc`-backed state the
+/// store consults, so it works from any thread and stays live for as long as
+/// any clone of the wrapped store does.
+#[derive(Debug, Clone)]
+pub struct FaultHandle(Arc<Mutex<FaultState>>);
+
+impl FaultHandle {
+    /// Arm `mode` for `op`, replacing any fault previously armed for it.
+    pub fn arm(&self, op: FaultOp, mode: FaultMode) {
+        lock(&self.0).armed.insert(op, mode);
+    }
+
+    /// Disarm every fault. Counters are intentionally NOT reset — counting is
+    /// unconditional for the store's lifetime.
+    pub fn clear(&self) {
+        lock(&self.0).armed.clear();
+    }
+
+    /// Total calls observed for `op` (faulted calls included).
+    pub fn count(&self, op: FaultOp) -> u64 {
+        lock(&self.0).counts.get(&op).copied().unwrap_or(0)
+    }
+}
+
+/// Fault-injecting decorator over an inner [`ObjectStore`].
+///
+/// Construct via [`FaultingStore::wrap`]; drive it through the returned
+/// [`FaultHandle`]. Un-faulted calls delegate verbatim to the inner store.
+#[derive(Debug)]
+pub struct FaultingStore {
+    inner: Arc<dyn ObjectStore>,
+    state: Arc<Mutex<FaultState>>,
+}
+
+impl FaultingStore {
+    /// Wrap `inner`, returning the decorated store and its control handle.
+    pub fn wrap(inner: Arc<dyn ObjectStore>) -> (Arc<dyn ObjectStore>, FaultHandle) {
+        let state = Arc::new(Mutex::new(FaultState::default()));
+        let handle = FaultHandle(Arc::clone(&state));
+        let store: Arc<dyn ObjectStore> = Arc::new(Self { inner, state });
+        (store, handle)
+    }
+
+    fn check(&self, op: FaultOp) -> Result<(), object_store::Error> {
+        record_and_check(&self.state, op)
+    }
+}
+
+impl fmt::Display for FaultingStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "FaultingStore({})", self.inner)
+    }
+}
+
+#[async_trait]
+impl ObjectStore for FaultingStore {
+    async fn put_opts(
+        &self,
+        location: &ObjectPath,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> object_store::Result<PutResult> {
+        self.check(FaultOp::Put)?;
+        self.inner.put_opts(location, payload, opts).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &ObjectPath,
+        opts: PutMultipartOptions,
+    ) -> object_store::Result<Box<dyn MultipartUpload>> {
+        self.check(FaultOp::Put)?;
+        self.inner.put_multipart_opts(location, opts).await
+    }
+
+    async fn get_opts(
+        &self,
+        location: &ObjectPath,
+        options: GetOptions,
+    ) -> object_store::Result<GetResult> {
+        // `ObjectStoreExt::head` (which backs `ObjectStoreProvider::exists`)
+        // is a `get_opts` with the `head` flag — count and fault it as `Head`.
+        let op = if options.head {
+            FaultOp::Head
+        } else {
+            FaultOp::Get
+        };
+        self.check(op)?;
+        self.inner.get_opts(location, options).await
+    }
+
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, object_store::Result<ObjectPath>>,
+    ) -> BoxStream<'static, object_store::Result<ObjectPath>> {
+        // Per-path injection: each location is counted/faulted individually,
+        // matching how `ObjectStoreExt::delete` drives this with a one-item
+        // stream. Delegation is per path (not a forwarded batch), which is
+        // indistinguishable for the in-memory backends this decorator wraps.
+        let inner = Arc::clone(&self.inner);
+        let state = Arc::clone(&self.state);
+        locations
+            .then(move |location| {
+                let inner = Arc::clone(&inner);
+                let state = Arc::clone(&state);
+                async move {
+                    let location = location?;
+                    record_and_check(&state, FaultOp::Delete)?;
+                    inner.delete(&location).await?;
+                    Ok(location)
+                }
+            })
+            .boxed()
+    }
+
+    fn list(
+        &self,
+        prefix: Option<&ObjectPath>,
+    ) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+        if let Err(e) = self.check(FaultOp::List) {
+            return futures::stream::once(async move { Err(e) }).boxed();
+        }
+        self.inner.list(prefix)
+    }
+
+    async fn list_with_delimiter(
+        &self,
+        prefix: Option<&ObjectPath>,
+    ) -> object_store::Result<ListResult> {
+        self.check(FaultOp::List)?;
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy_opts(
+        &self,
+        from: &ObjectPath,
+        to: &ObjectPath,
+        options: CopyOptions,
+    ) -> object_store::Result<()> {
+        self.check(FaultOp::Copy)?;
+        self.inner.copy_opts(from, to, options).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use object_store::memory::InMemory;
+
+    fn wrapped() -> (Arc<dyn ObjectStore>, FaultHandle) {
+        FaultingStore::wrap(Arc::new(InMemory::new()))
+    }
+
+    fn payload() -> PutPayload {
+        PutPayload::from(Bytes::from_static(b"bytes"))
+    }
+
+    #[tokio::test]
+    async fn fail_next_put_then_recover() {
+        let (store, faults) = wrapped();
+        let key = ObjectPath::from("k");
+        faults.arm(FaultOp::Put, FaultMode::FailNext(1));
+
+        let err = store.put(&key, payload()).await.unwrap_err();
+        assert!(
+            err.to_string().contains("injected fault"),
+            "the armed put must fail with the injected error, got: {err}"
+        );
+
+        // The one-shot has disarmed itself: the retry lands and the bytes
+        // are readable through the inner store.
+        store
+            .put(&key, payload())
+            .await
+            .expect("second put recovers");
+        let got = store.get(&key).await.unwrap().bytes().await.unwrap();
+        assert_eq!(got.as_ref(), b"bytes");
+    }
+
+    #[tokio::test]
+    async fn fail_all_get() {
+        let (store, faults) = wrapped();
+        let key = ObjectPath::from("k");
+        store.put(&key, payload()).await.unwrap();
+
+        faults.arm(FaultOp::Get, FaultMode::FailAll);
+        assert!(store.get(&key).await.is_err(), "first get faults");
+        assert!(store.get(&key).await.is_err(), "FailAll keeps faulting");
+
+        // A FailAll on Get must not bleed into Head (the `exists` probe).
+        store.head(&key).await.expect("head is a distinct op");
+
+        faults.clear();
+        store.get(&key).await.expect("get recovers after clear");
+    }
+
+    #[tokio::test]
+    async fn counts_every_op() {
+        let (store, faults) = wrapped();
+        let from = ObjectPath::from("a");
+        let to = ObjectPath::from("b");
+
+        store.put(&from, payload()).await.unwrap();
+        store.get(&from).await.unwrap();
+        store.head(&from).await.unwrap();
+        let listed: Vec<_> = store.list(None).collect().await;
+        assert_eq!(listed.len(), 1);
+        store.copy(&from, &to).await.unwrap();
+        store.delete(&to).await.unwrap();
+
+        // Counting is unconditional — no fault was armed at any point.
+        assert_eq!(faults.count(FaultOp::Put), 1);
+        assert_eq!(faults.count(FaultOp::Get), 1);
+        assert_eq!(faults.count(FaultOp::Head), 1);
+        assert_eq!(faults.count(FaultOp::List), 1);
+        assert_eq!(faults.count(FaultOp::Copy), 1);
+        assert_eq!(faults.count(FaultOp::Delete), 1);
+    }
+
+    /// `FailNth` targets one absolute call number and lets every other call
+    /// through — the shape a "the 3rd upload of the run dies" test needs.
+    #[tokio::test]
+    async fn fail_nth_targets_exact_call() {
+        let (store, faults) = wrapped();
+        let key = ObjectPath::from("k");
+        faults.arm(FaultOp::Put, FaultMode::FailNth(2));
+
+        store.put(&key, payload()).await.expect("call #1 passes");
+        assert!(store.put(&key, payload()).await.is_err(), "call #2 faults");
+        store.put(&key, payload()).await.expect("call #3 passes");
+        assert_eq!(faults.count(FaultOp::Put), 3);
+    }
+}

--- a/engine/crates/rocky-core/src/lib.rs
+++ b/engine/crates/rocky-core/src/lib.rs
@@ -20,6 +20,8 @@ pub mod dedup_analysis;
 pub mod docs;
 pub mod drift;
 pub mod failure_class;
+#[cfg(any(test, feature = "test-support"))]
+pub mod fault_store;
 pub mod hooks;
 pub mod idempotency;
 pub mod imports;
@@ -52,6 +54,8 @@ pub mod source;
 pub mod sql_gen;
 pub mod state;
 pub mod state_sync;
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_harness;
 pub mod tests;
 pub mod traits;
 pub mod unified_dag;

--- a/engine/crates/rocky-core/src/object_store.rs
+++ b/engine/crates/rocky-core/src/object_store.rs
@@ -192,6 +192,29 @@ impl ObjectStoreProvider {
         }
     }
 
+    /// Construct a provider around an existing [`ObjectStore`] instance.
+    ///
+    /// Lets callers wrap or derive a store — e.g. layer a decorator (caching,
+    /// metrics, fault injection) over a backend built elsewhere — while
+    /// keeping the provider's key handling identical to a
+    /// [`from_uri`](Self::from_uri)-built provider. `scheme` and `bucket`
+    /// label the provider in logs and error messages only; the store itself
+    /// decides where bytes actually go. `prefix` is joined ahead of every
+    /// relative key exactly as in [`from_uri`](Self::from_uri).
+    pub fn from_store(
+        store: Arc<dyn ObjectStore>,
+        scheme: impl Into<String>,
+        bucket: impl Into<String>,
+        prefix: impl Into<String>,
+    ) -> Self {
+        Self {
+            store,
+            scheme: scheme.into(),
+            bucket: bucket.into(),
+            prefix: prefix.into(),
+        }
+    }
+
     /// The URI scheme (`"s3"`, `"gs"`, `"file"`, etc.).
     pub fn scheme(&self) -> &str {
         &self.scheme
@@ -483,6 +506,30 @@ mod tests {
             leftover.is_empty(),
             "no .tmp file should remain after an atomic download"
         );
+    }
+
+    /// `from_store` must behave exactly like a `from_uri`-built provider for
+    /// the wrapped backend: keys resolve under the given prefix and the full
+    /// get/put/exists surface round-trips.
+    #[tokio::test]
+    async fn from_store_round_trip() {
+        let inner: Arc<dyn ObjectStore> = Arc::new(object_store::memory::InMemory::new());
+        let provider = ObjectStoreProvider::from_store(Arc::clone(&inner), "s3", "test", "pfx");
+        assert_eq!(provider.scheme(), "s3");
+        assert_eq!(provider.bucket(), "test");
+
+        assert!(!provider.exists("k").await.unwrap());
+        provider
+            .put("k", Bytes::from_static(b"payload"))
+            .await
+            .unwrap();
+        assert!(provider.exists("k").await.unwrap());
+        assert_eq!(provider.get("k").await.unwrap().as_ref(), b"payload");
+
+        // The provider wraps the SAME store it was given (no copy): the raw
+        // backend sees the object at the prefix-qualified path.
+        let raw = inner.get(&ObjectPath::from("pfx/k")).await.unwrap();
+        assert_eq!(raw.bytes().await.unwrap().as_ref(), b"payload");
     }
 
     #[test]

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -135,9 +135,20 @@ fn cloud_provider(
     // `test_support::install`, route every object-store construction to it so
     // the real `upload_state → strip → dispatch → upload_to_object_store` path
     // can be exercised end-to-end without a live cloud client. Production
-    // builds never compile this branch.
-    #[cfg(test)]
+    // builds never compile this branch — the `test-support` feature exists for
+    // test targets only and the `rocky` binary never enables it.
+    #[cfg(any(test, feature = "test-support"))]
     if let Some(provider) = test_support::current_override() {
+        return Ok(provider);
+    }
+
+    // The process-global override (installed by the cross-pod test harness) is
+    // consulted AFTER the thread-local one, so a test that needs a
+    // this-thread-only provider can still shadow a harness-installed global.
+    // Unlike the thread-local seam, this one survives OS-thread hops (e.g.
+    // rocky-cli's `block_on_state_sync` dedicated runtime thread).
+    #[cfg(any(test, feature = "test-support"))]
+    if let Some(provider) = test_support::current_global_override() {
         return Ok(provider);
     }
 
@@ -151,16 +162,24 @@ fn cloud_provider(
 }
 
 /// Test-only support for injecting an in-memory object store into the upload
-/// dispatch path. Lets a `#[cfg(test)]` test drive the real
+/// dispatch path. Lets a test drive the real
 /// `upload_state → strip → dispatch → upload_to_object_store → cloud_provider`
 /// chain against [`ObjectStoreProvider::in_memory`] instead of a live cloud
 /// client, so it observes the *actual* remote key the upload path computes
 /// (the round-trip-via-`provider.upload_file` test cannot, because it
 /// precomputes the key and skips dispatch entirely).
-#[cfg(test)]
+///
+/// Two override seams coexist:
+/// - the **thread-local** [`install`] used by this file's unit tests, and
+/// - the **process-global** [`install_global`] used by integration tests
+///   (re-exported via [`super::remote_testing`] under the `test-support`
+///   feature), which is visible from every OS thread and is consulted only
+///   when no thread-local override is installed.
+#[cfg(any(test, feature = "test-support"))]
 mod test_support {
     use super::ObjectStoreProvider;
     use std::cell::{Cell, RefCell};
+    use std::sync::{Mutex, MutexGuard, PoisonError};
 
     thread_local! {
         static PROVIDER_OVERRIDE: RefCell<Option<ObjectStoreProvider>> =
@@ -173,6 +192,7 @@ mod test_support {
 
     /// Arm a one-shot fault so the next `probe_exists` returns `Err`. Consumed
     /// (cleared) on read so it can't leak into a later leg/test on this thread.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(super) fn arm_object_store_exists_fault() {
         OBJECT_STORE_EXISTS_FAULT.with(|c| c.set(true));
     }
@@ -184,6 +204,7 @@ mod test_support {
 
     /// Arm a one-shot fault so the next `download_from_valkey` reports a MISS
     /// (`Absent`) without touching a live Valkey peer.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(super) fn arm_valkey_miss_fault() {
         VALKEY_MISS_FAULT.with(|c| c.set(true));
     }
@@ -197,6 +218,7 @@ mod test_support {
     /// out on this thread. Returns a clone so the caller retains a handle to
     /// assert on after the upload (the in-memory store is `Arc`-backed, so the
     /// clone shares storage with the installed copy).
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(super) fn install(provider: ObjectStoreProvider) -> ObjectStoreProvider {
         let handle = provider.clone();
         PROVIDER_OVERRIDE.with(|cell| *cell.borrow_mut() = Some(provider));
@@ -213,11 +235,105 @@ mod test_support {
 
     /// Clear any installed override and armed faults so nothing leaks into a
     /// later test on the same worker thread.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(super) fn clear() {
         PROVIDER_OVERRIDE.with(|cell| *cell.borrow_mut() = None);
         OBJECT_STORE_EXISTS_FAULT.with(|c| c.set(false));
         VALKEY_MISS_FAULT.with(|c| c.set(false));
     }
+
+    /// Process-global provider override, consulted by
+    /// [`super::cloud_provider`] AFTER the thread-local one.
+    static GLOBAL_PROVIDER_OVERRIDE: Mutex<Option<ObjectStoreProvider>> = Mutex::new(None);
+
+    /// Serializes tests that install the global override (see
+    /// [`serial_guard`]).
+    static GLOBAL_OVERRIDE_SERIAL: Mutex<()> = Mutex::new(());
+
+    fn lock_global() -> MutexGuard<'static, Option<ObjectStoreProvider>> {
+        GLOBAL_PROVIDER_OVERRIDE
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// Install `provider` as the PROCESS-GLOBAL provider every
+    /// [`super::cloud_provider`] call resolves to (unless a thread-local
+    /// override shadows it). Returns a guard that clears the override on drop.
+    ///
+    /// Unlike the thread-local [`install`], the global override is visible
+    /// from every OS thread — including the dedicated runtime threads
+    /// rocky-cli's `block_on_state_sync` hops to — so integration tests can
+    /// drive the real download/upload paths end to end.
+    ///
+    /// The override is process-wide shared state: tests that use it must hold
+    /// [`serial_guard`] for their whole duration or they will clobber each
+    /// other's provider.
+    pub fn install_global(provider: ObjectStoreProvider) -> GlobalOverrideGuard {
+        *lock_global() = Some(provider);
+        GlobalOverrideGuard { _priv: () }
+    }
+
+    /// RAII guard returned by [`install_global`]; clears the process-global
+    /// override on drop so nothing leaks into a later test.
+    #[derive(Debug)]
+    pub struct GlobalOverrideGuard {
+        _priv: (),
+    }
+
+    impl Drop for GlobalOverrideGuard {
+        fn drop(&mut self) {
+            *lock_global() = None;
+        }
+    }
+
+    /// Serialize tests that use [`install_global`]: the override is
+    /// process-global, so two concurrently-running tests in one test binary
+    /// would clobber each other's provider. Hold the returned guard for the
+    /// duration of the test. Lock poisoning (a panicking test) is deliberately
+    /// ignored — the next test proceeds with a clean override either way,
+    /// because the panicking test's [`GlobalOverrideGuard`] already cleared it.
+    pub fn serial_guard() -> SerialGuard {
+        SerialGuard(
+            GLOBAL_OVERRIDE_SERIAL
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner),
+        )
+    }
+
+    /// Guard returned by [`serial_guard`].
+    ///
+    /// Deliberately a newtype (not a bare `MutexGuard`) because tests hold it
+    /// across `.await` points for their WHOLE duration — that is the entire
+    /// point of the serialization — and that is sound here: contenders are
+    /// other tests' dedicated OS threads blocking in `lock()`, never tasks on
+    /// this test's runtime, so no async task is starved and no deadlock is
+    /// possible. A bare `MutexGuard` would trip `clippy::await_holding_lock`
+    /// in every consuming test file for a pattern that is intentional.
+    #[derive(Debug)]
+    pub struct SerialGuard(#[allow(dead_code)] MutexGuard<'static, ()>);
+
+    /// Clone the process-global override, if any. Like [`current_override`],
+    /// cloning (rather than taking) keeps every object-store construction —
+    /// e.g. both legs of a tiered transfer — on the same `Arc`-backed store.
+    pub(super) fn current_global_override() -> Option<ObjectStoreProvider> {
+        lock_global().clone()
+    }
+}
+
+/// Public remote-state testing seams, compiled only with the `test-support`
+/// cargo feature (or for the crate's own tests). The `rocky` binary never
+/// enables the feature, so none of this exists in a release build.
+///
+/// Integration tests (`rocky-core/tests/`, `rocky-cli/tests/`) cannot reach
+/// the crate-private `test_support` seam, and its thread-local override is
+/// invisible to code that hops OS threads. This module re-exports the
+/// process-global override so out-of-crate tests can inject a shared
+/// in-memory (or fault-decorated — see [`crate::fault_store`]) store into the
+/// real state-sync decision paths. See [`crate::test_harness`] for the
+/// ready-made cross-pod harness built on top of it.
+#[cfg(any(test, feature = "test-support"))]
+pub mod remote_testing {
+    pub use super::test_support::{GlobalOverrideGuard, SerialGuard, install_global, serial_guard};
 }
 
 /// Resolve the per-transfer wall-clock budget from `StateConfig`.
@@ -959,7 +1075,7 @@ fn apply_upload_failure_policy(
 /// provider never errors on `exists`, so this is the only in-crate way to prove
 /// the fail-closed propagation is RED before the fix and GREEN after it.
 async fn probe_exists(provider: &ObjectStoreProvider, key: &str) -> Result<bool, StateSyncError> {
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-support"))]
     if test_support::take_object_store_exists_fault() {
         return Err(StateSyncError::S3Download(
             "injected existence-check failure (test seam)".into(),
@@ -1131,7 +1247,7 @@ async fn download_from_valkey(
     // Test seam: force a Valkey MISS without a live Valkey peer, so the tiered
     // fall-through-to-S3 path (and the "stale local file is not a hit" fix) can
     // be exercised deterministically. See [`test_support::arm_valkey_miss_fault`].
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-support"))]
     if test_support::take_valkey_miss_fault() {
         return Ok(DownloadOutcome::Absent);
     }

--- a/engine/crates/rocky-core/src/test_harness.rs
+++ b/engine/crates/rocky-core/src/test_harness.rs
@@ -1,0 +1,131 @@
+//! Deterministic cross-pod remote-state test harness.
+//!
+//! Compiled only for the crate's own tests or under the `test-support`
+//! feature — the `rocky` binary never enables either, so nothing here can
+//! reach a production build.
+//!
+//! [`CrossPodHarness`] simulates two ephemeral pods (isolated temp dirs, each
+//! with its own local state file and `StateConfig`) sharing ONE remote store:
+//! a [`FaultingStore`]-decorated in-memory backend masquerading as S3,
+//! installed as the process-global provider override so the REAL
+//! [`state_sync::download_state`] / [`state_sync::upload_state`] decision
+//! paths run against it — from any thread, without credentials, byte-for-byte
+//! deterministic.
+//!
+//! The override is process-global, so tests that build a harness MUST hold
+//! [`crate::state_sync::remote_testing::serial_guard`] for their whole
+//! duration.
+
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use crate::config::{StateBackend, StateConfig, StateUploadFailureMode};
+use crate::fault_store::{FaultHandle, FaultingStore};
+use crate::object_store::ObjectStoreProvider;
+use crate::state::StateStore;
+use crate::state_sync::remote_testing::{GlobalOverrideGuard, install_global};
+use crate::state_sync::{self, StateSyncError};
+
+/// One simulated ephemeral pod: an isolated temp dir, a pod-local state file
+/// path inside it, and a `StateConfig` pointing at the harness's shared
+/// remote.
+#[derive(Debug)]
+pub struct Pod {
+    /// Backing temp dir — owned so it lives (and is cleaned up) with the pod.
+    pub dir: tempfile::TempDir,
+    /// The pod-local state file path (`<dir>/.rocky-state.redb`).
+    pub state_path: PathBuf,
+    /// The pod's state config (remote backend resolving to the shared store).
+    pub cfg: StateConfig,
+}
+
+impl Pod {
+    fn s3_like() -> Self {
+        let dir = tempfile::tempdir().expect("create pod temp dir");
+        let state_path = dir.path().join(".rocky-state.redb");
+        let cfg = StateConfig {
+            backend: StateBackend::S3,
+            s3_bucket: Some("test".into()),
+            // A test rig must fail loudly: the production default (`Skip`)
+            // swallows exhausted-retry upload failures into `Ok`.
+            on_upload_failure: StateUploadFailureMode::Fail,
+            ..StateConfig::default()
+        };
+        Self {
+            dir,
+            state_path,
+            cfg,
+        }
+    }
+}
+
+/// Two pods sharing one fault-injectable in-memory "S3".
+///
+/// Dropping the harness drops the held [`GlobalOverrideGuard`], clearing the
+/// process-global provider override.
+#[derive(Debug)]
+pub struct CrossPodHarness {
+    /// The shared provider both pods' state sync resolves to. Handy for
+    /// direct object-level assertions (`exists` / `get` / `list`).
+    pub provider: ObjectStoreProvider,
+    /// Fault/counter control for the shared store (see [`FaultingStore`]).
+    pub faults: FaultHandle,
+    pub pod_a: Pod,
+    pub pod_b: Pod,
+    _guard: GlobalOverrideGuard,
+}
+
+impl CrossPodHarness {
+    /// Build a two-pod harness over a shared fault-injecting in-memory store
+    /// masquerading as S3 (`backend = "s3"`, bucket `"test"`), and install it
+    /// as the process-global provider override.
+    ///
+    /// Callers sharing a test binary must hold
+    /// [`crate::state_sync::remote_testing::serial_guard`] for the duration
+    /// of the test — the override is process-global.
+    pub fn new_s3_like() -> Self {
+        let (store, faults) = FaultingStore::wrap(Arc::new(object_store::memory::InMemory::new()));
+        let provider = ObjectStoreProvider::from_store(store, "s3", "test", "");
+        let guard = install_global(provider.clone());
+        Self {
+            provider,
+            faults,
+            pod_a: Pod::s3_like(),
+            pod_b: Pod::s3_like(),
+            _guard: guard,
+        }
+    }
+
+    /// Run the real [`state_sync::download_state`] for `pod` (staging file,
+    /// writer-lock publish serialization, local-only merge — the whole path).
+    pub async fn download(&self, pod: &Pod) -> Result<(), StateSyncError> {
+        state_sync::download_state(&pod.cfg, &pod.state_path).await
+    }
+
+    /// Run the real [`state_sync::upload_state`] for `pod` (local-only strip,
+    /// dispatch, schema-qualified remote key derivation — the whole path).
+    pub async fn upload(&self, pod: &Pod) -> Result<(), StateSyncError> {
+        state_sync::upload_state(&pod.cfg, &pod.state_path).await
+    }
+
+    /// Open `pod`'s local state store — acquiring the advisory writer lock,
+    /// exactly like a live `rocky run` does. Drop the store to release it.
+    pub fn open_store(&self, pod: &Pod) -> StateStore {
+        StateStore::open(&pod.state_path).expect("open pod state store")
+    }
+}
+
+/// Run `f` while a [`StateStore`] is held open on `state_path` — holding the
+/// same advisory writer lock a live `rocky run` holds during execution — then
+/// release the lock and return `f`'s output.
+///
+/// The store is opened (and the lock acquired) BEFORE `f` is polled, so a
+/// concurrent download/publish driven from inside `f` is guaranteed to
+/// contend with the held writer.
+pub async fn with_held_writer<T>(state_path: &Path, f: impl Future<Output = T>) -> T {
+    let held = StateStore::open(state_path).expect("open held-writer state store");
+    let out = f.await;
+    drop(held);
+    out
+}

--- a/engine/crates/rocky-core/tests/state_sync_cross_pod.rs
+++ b/engine/crates/rocky-core/tests/state_sync_cross_pod.rs
@@ -1,0 +1,153 @@
+//! Cross-pod remote-state integration tests (WP-01 rig).
+//!
+//! These drive the REAL `download_state` / `upload_state` paths from outside
+//! the crate, against a shared fault-injectable in-memory "S3" installed via
+//! the process-global provider override
+//! (`state_sync::remote_testing::install_global`). Each test holds
+//! `remote_testing::serial_guard()` because the override is process-global.
+//!
+//! Requires the `test-support` feature (on by default for test targets via
+//! rocky-core's self-referential dev-dependency).
+
+use chrono::Utc;
+use rocky_core::fault_store::FaultOp;
+use rocky_core::state_sync::{self, remote_testing};
+use rocky_core::test_harness::CrossPodHarness;
+use rocky_ir::WatermarkState;
+
+fn wm_now() -> WatermarkState {
+    let now = Utc::now();
+    WatermarkState {
+        last_value: now,
+        updated_at: now,
+    }
+}
+
+/// The rig's core promise: state written by pod A round-trips to pod B
+/// through the real upload → shared remote → download chain.
+#[tokio::test]
+async fn pod_b_sees_pod_a_watermark() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+
+    // Pod A: open the store (writer lock, like a run), record a watermark,
+    // release, and push state to the shared remote.
+    {
+        let store = harness.open_store(&harness.pod_a);
+        store.set_watermark("cat.sch.orders", &wm_now()).unwrap();
+    }
+    harness.upload(&harness.pod_a).await.expect("pod A upload");
+
+    // Pod B: pull the remote and read pod A's watermark.
+    harness
+        .download(&harness.pod_b)
+        .await
+        .expect("pod B download");
+    let store = harness.open_store(&harness.pod_b);
+    assert!(
+        store.get_watermark("cat.sch.orders").unwrap().is_some(),
+        "pod B must see the watermark pod A uploaded"
+    );
+}
+
+/// PINS CURRENT BEHAVIOR (RD-002): interleaved writers on a shared remote
+/// state object are last-writer-wins — the second upload wholesale-replaces
+/// the first, silently dropping pod A's watermark.
+///
+/// This test is deliberately GREEN against today's engine: it documents the
+/// lost-update window, it does not endorse it. When compare-and-swap /
+/// conditional-put publication lands (a later WP-01 PR; see also #1120), this
+/// test MUST flip to a RED baseline: pod B's blind upload gets REFUSED
+/// (its ETag/generation is stale), and the assertions below invert —
+/// `from_a` survives and pod B is told to re-sync.
+#[tokio::test]
+async fn interleaved_writers_last_writer_wins_documented() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+
+    // Both pods sync from the same (empty) remote — neither sees the other.
+    harness.download(&harness.pod_a).await.unwrap();
+    harness.download(&harness.pod_b).await.unwrap();
+
+    // Pod A writes and uploads first...
+    {
+        let store = harness.open_store(&harness.pod_a);
+        store.set_watermark("cat.sch.from_a", &wm_now()).unwrap();
+    }
+    harness.upload(&harness.pod_a).await.expect("pod A upload");
+
+    // ...then pod B — which never saw A's upload — writes and uploads.
+    {
+        let store = harness.open_store(&harness.pod_b);
+        store.set_watermark("cat.sch.from_b", &wm_now()).unwrap();
+    }
+    harness.upload(&harness.pod_b).await.expect("pod B upload");
+
+    // A fresh download now serves pod B's file wholesale: pod A's watermark
+    // is gone from the shared remote.
+    harness.download(&harness.pod_a).await.unwrap();
+    let store = harness.open_store(&harness.pod_a);
+    assert!(
+        store.get_watermark("cat.sch.from_b").unwrap().is_some(),
+        "the last writer's row is served"
+    );
+    assert!(
+        store.get_watermark("cat.sch.from_a").unwrap().is_none(),
+        "RD-002 (documented, not endorsed): the interleaved writer's row is \
+         silently lost under last-writer-wins"
+    );
+}
+
+/// The reason the global override exists: the shared provider must be
+/// reachable from a `std::thread::spawn`ed OS thread — the shape of
+/// rocky-cli's `block_on_state_sync`, which runs state futures on a dedicated
+/// runtime thread. The crate-private thread-local seam alone can never
+/// satisfy this (the override would be unset on the new thread, so the
+/// upload would try to build a real S3 client).
+#[tokio::test]
+async fn global_override_visible_across_threads() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+
+    {
+        let store = harness.open_store(&harness.pod_a);
+        store
+            .set_watermark("cat.sch.cross_thread", &wm_now())
+            .unwrap();
+    }
+
+    // Upload from a spawned OS thread with its own runtime.
+    let cfg = harness.pod_a.cfg.clone();
+    let path = harness.pod_a.state_path.clone();
+    let uploaded = std::thread::spawn(move || {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build upload runtime")
+            .block_on(state_sync::upload_state(&cfg, &path))
+    })
+    .join()
+    .expect("upload thread panicked");
+    uploaded.expect("upload from a spawned thread must resolve the shared provider");
+
+    // The spawned thread hit the SAME shared store this thread's handle
+    // wraps: its Put registered on the shared fault counters...
+    assert!(
+        harness.faults.count(FaultOp::Put) >= 1,
+        "the cross-thread upload must land on the shared FaultingStore"
+    );
+
+    // ...and this thread can download what that thread uploaded.
+    harness
+        .download(&harness.pod_b)
+        .await
+        .expect("pod B download");
+    let store = harness.open_store(&harness.pod_b);
+    assert!(
+        store
+            .get_watermark("cat.sch.cross_thread")
+            .unwrap()
+            .is_some(),
+        "state uploaded from a foreign thread round-trips to pod B"
+    );
+}

--- a/engine/crates/rocky-core/tests/state_sync_live_store.rs
+++ b/engine/crates/rocky-core/tests/state_sync_live_store.rs
@@ -1,0 +1,146 @@
+//! Writer-lock contention integration tests for remote-state downloads
+//! (WP-01 rig).
+//!
+//! Out-of-crate mirror of the in-crate finding-B unit coverage
+//! (`state_sync.rs::download_publish_fails_closed_when_writer_lock_held`),
+//! driven through the cross-pod harness: a download must serialize its atomic
+//! publish behind the SAME advisory writer lock a live `rocky run` holds —
+//! waiting (bounded retries) for a short-lived writer, failing closed on one
+//! that never releases, and never leaking its staging file.
+//!
+//! Requires the `test-support` feature (on by default for test targets via
+//! rocky-core's self-referential dev-dependency).
+
+use std::time::Duration;
+
+use chrono::Utc;
+use rocky_core::fault_store::FaultOp;
+use rocky_core::state_sync::{self, remote_testing};
+use rocky_core::test_harness::{CrossPodHarness, with_held_writer};
+use rocky_ir::WatermarkState;
+
+fn wm_now() -> WatermarkState {
+    let now = Utc::now();
+    WatermarkState {
+        last_value: now,
+        updated_at: now,
+    }
+}
+
+/// Seed the shared remote with a pod-A watermark so pod-B downloads have
+/// something to publish.
+async fn seed_remote(harness: &CrossPodHarness, key: &str) {
+    {
+        let store = harness.open_store(&harness.pod_a);
+        store.set_watermark(key, &wm_now()).unwrap();
+    }
+    harness.upload(&harness.pod_a).await.expect("seed upload");
+}
+
+/// Any leftover download artifacts (staging redb scratch or atomic-download
+/// temp files) in `dir`, beyond the state file itself.
+fn leaked_download_artifacts(dir: &std::path::Path) -> Vec<String> {
+    std::fs::read_dir(dir)
+        .expect("read pod dir")
+        .filter_map(Result::ok)
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|name| name.starts_with(".rocky-state-download-") || name.ends_with(".tmp"))
+        .collect()
+}
+
+/// A download racing a SHORT-LIVED writer must not fail: it retries the
+/// publish lock and completes once the writer releases within the retry
+/// budget.
+#[tokio::test]
+async fn download_publish_waits_for_writer_release() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+    seed_remote(&harness, "cat.sch.seeded").await;
+
+    // Hold pod B's writer lock (as a live run would), start a concurrent
+    // download, and only release once the download has provably fetched the
+    // remote object — so its publish-lock attempts genuinely contend.
+    let cfg = harness.pod_b.cfg.clone();
+    let path = harness.pod_b.state_path.clone();
+    let faults = harness.faults.clone();
+    let gets_before = faults.count(FaultOp::Get);
+    // Deliberately yields the still-running download's `JoinHandle` out of the
+    // held-writer scope: the download must OUTLIVE the lock to prove it waits.
+    #[allow(clippy::async_yields_async)]
+    let download = with_held_writer(&harness.pod_b.state_path, async move {
+        let download = tokio::spawn(async move { state_sync::download_state(&cfg, &path).await });
+        // Handshake: wait for the download's remote GET to land on the shared
+        // store, then keep the lock a beat longer so at least one publish-lock
+        // attempt fails while we hold it.
+        while faults.count(FaultOp::Get) == gets_before {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        download
+    })
+    .await;
+
+    // Writer released — the download's remaining lock retries can publish.
+    download
+        .await
+        .expect("download task join")
+        .expect("download must succeed once the writer releases within the retry budget");
+
+    let store = harness.open_store(&harness.pod_b);
+    assert!(
+        store.get_watermark("cat.sch.seeded").unwrap().is_some(),
+        "the published download must carry the seeded remote watermark"
+    );
+    assert!(
+        leaked_download_artifacts(harness.pod_b.dir.path()).is_empty(),
+        "a successful download must clean up its staging artifacts"
+    );
+}
+
+/// A writer that NEVER releases must fail the download closed (finding B):
+/// the publish-lock retries exhaust, the download returns `Err`, the live
+/// writer's file is untouched, and no staging file is left behind.
+#[tokio::test]
+async fn download_fails_closed_when_writer_never_releases() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+    seed_remote(&harness, "cat.sch.seeded").await;
+
+    // Give pod B live local state so we can prove the held writer's file
+    // survives the failed publish.
+    {
+        let store = harness.open_store(&harness.pod_b);
+        store.set_watermark("cat.sch.local_b", &wm_now()).unwrap();
+    }
+
+    // Run the WHOLE download while the writer lock is held: every publish
+    // attempt inside the retry budget fails, so the download fails closed.
+    let cfg = harness.pod_b.cfg.clone();
+    let path = harness.pod_b.state_path.clone();
+    let result = with_held_writer(&harness.pod_b.state_path, async move {
+        state_sync::download_state(&cfg, &path).await
+    })
+    .await;
+    assert!(
+        result.is_err(),
+        "the download must fail closed while the writer lock never releases"
+    );
+
+    // Fail-closed means fail-clean: no staging redb / temp file leaked...
+    assert!(
+        leaked_download_artifacts(harness.pod_b.dir.path()).is_empty(),
+        "a failed download must remove its staging file, found: {:?}",
+        leaked_download_artifacts(harness.pod_b.dir.path())
+    );
+
+    // ...and the live writer's state was never clobbered by the remote.
+    let store = harness.open_store(&harness.pod_b);
+    assert!(
+        store.get_watermark("cat.sch.local_b").unwrap().is_some(),
+        "the held writer's local state must survive the failed publish"
+    );
+    assert!(
+        store.get_watermark("cat.sch.seeded").unwrap().is_none(),
+        "the remote content must NOT have been published over the live writer"
+    );
+}

--- a/engine/crates/rocky-core/tests/state_sync_s3_live.rs
+++ b/engine/crates/rocky-core/tests/state_sync_s3_live.rs
@@ -1,0 +1,191 @@
+//! Live-S3 rung for the remote-state rig (WP-01).
+//!
+//! `#[ignore]`-gated probes against a REAL S3 bucket — the honest top rung
+//! above the in-memory harness. They validate the two assumptions the
+//! deterministic rig takes on faith: that `upload_state`/`download_state`
+//! round-trip through a real AWS endpoint, and that the bucket honors the
+//! atomic create-if-absent precondition (`If-None-Match: *`) that
+//! conditional-put publication will build on.
+//!
+//! Reads connection params from env so no bucket name or credential is ever
+//! committed:
+//!   ROCKY_TEST_S3_BUCKET — bucket name (no scheme)
+//!   ROCKY_TEST_S3_PREFIX — key prefix to sandbox test objects under
+//!   ROCKY_TEST_S3_REGION — bucket region (exported to AWS_REGION if unset)
+//! plus the standard AWS credential chain (env vars / profile / SSO / IMDS).
+//!
+//! Run with:
+//!   ROCKY_TEST_S3_BUCKET=<bucket> ROCKY_TEST_S3_PREFIX=<prefix> \
+//!   ROCKY_TEST_S3_REGION=<region> \
+//!     cargo test -p rocky-core --features test-support \
+//!     --test state_sync_s3_live -- --ignored --nocapture
+
+use std::sync::{Mutex, MutexGuard, Once, PoisonError};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use bytes::Bytes;
+use chrono::Utc;
+use rocky_core::config::{StateBackend, StateConfig, StateUploadFailureMode};
+use rocky_core::object_store::{ObjectStoreProvider, PutIfNotExistsOutcome};
+use rocky_core::state::StateStore;
+use rocky_core::state_sync::{download_state, upload_state};
+use rocky_ir::WatermarkState;
+
+/// Serializes the live tests within this binary: they mutate the process
+/// environment (AWS_REGION) once and share one bucket prefix.
+static LIVE_SERIAL: Mutex<()> = Mutex::new(());
+
+/// Newtype so the guard can be held across the tests' `.await` points (the
+/// whole point of the serialization) without tripping
+/// `clippy::await_holding_lock` — contenders are other tests' OS threads
+/// blocking in `lock()`, never tasks on this test's runtime.
+struct LiveSerial(#[allow(dead_code)] MutexGuard<'static, ()>);
+
+fn live_serial() -> LiveSerial {
+    LiveSerial(LIVE_SERIAL.lock().unwrap_or_else(PoisonError::into_inner))
+}
+
+struct LiveS3 {
+    bucket: String,
+    prefix: String,
+}
+
+/// Read the live-S3 params, exporting `ROCKY_TEST_S3_REGION` to `AWS_REGION`
+/// (once, only if no region is already set) so the standard builder env chain
+/// resolves. Returns `None` when the env gate is not configured.
+fn live_s3_from_env() -> Option<LiveS3> {
+    let bucket = std::env::var("ROCKY_TEST_S3_BUCKET").ok()?;
+    let prefix = std::env::var("ROCKY_TEST_S3_PREFIX").ok()?;
+    let region = std::env::var("ROCKY_TEST_S3_REGION").ok()?;
+
+    static REGION_INIT: Once = Once::new();
+    REGION_INIT.call_once(|| {
+        if std::env::var("AWS_REGION").is_err() && std::env::var("AWS_DEFAULT_REGION").is_err() {
+            // SAFETY: test-only env mutation, serialized by `Once` and by the
+            // callers all holding `live_serial()` for their whole duration —
+            // no other thread reads the environment while this write runs.
+            unsafe { std::env::set_var("AWS_REGION", &region) };
+        }
+    });
+
+    Some(LiveS3 {
+        bucket,
+        prefix: prefix.trim_matches('/').to_string(),
+    })
+}
+
+/// Process-unique suffix so parallel/aborted runs never collide on a key.
+fn unique_suffix() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("{}-{}", std::process::id(), nanos)
+}
+
+fn wm_now() -> WatermarkState {
+    let now = Utc::now();
+    WatermarkState {
+        last_value: now,
+        updated_at: now,
+    }
+}
+
+/// `upload_state` → real bucket → `download_state` round-trip: a watermark
+/// written on one "pod" is readable after a download into a fresh dir.
+#[tokio::test]
+#[ignore]
+async fn live_round_trip() {
+    let _serial = live_serial();
+    let Some(live) = live_s3_from_env() else {
+        eprintln!("SKIP live_round_trip: ROCKY_TEST_S3_* env not set");
+        return;
+    };
+    // A per-run prefix sandbox so cleanup can sweep everything it wrote.
+    let run_prefix = format!("{}/round-trip-{}", live.prefix, unique_suffix());
+    let cfg = StateConfig {
+        backend: StateBackend::S3,
+        s3_bucket: Some(live.bucket.clone()),
+        s3_prefix: Some(run_prefix.clone()),
+        on_upload_failure: StateUploadFailureMode::Fail,
+        ..StateConfig::default()
+    };
+
+    // "Pod A": write a watermark and upload.
+    let up_dir = tempfile::tempdir().unwrap();
+    let up_path = up_dir.path().join(".rocky-state.redb");
+    {
+        let store = StateStore::open(&up_path).unwrap();
+        store.set_watermark("cat.sch.live", &wm_now()).unwrap();
+    }
+    upload_state(&cfg, &up_path).await.expect("live upload");
+
+    // "Pod B": download into a fresh dir and read it back.
+    let down_dir = tempfile::tempdir().unwrap();
+    let down_path = down_dir.path().join(".rocky-state.redb");
+    download_state(&cfg, &down_path)
+        .await
+        .expect("live download");
+    {
+        let store = StateStore::open(&down_path).unwrap();
+        assert!(
+            store.get_watermark("cat.sch.live").unwrap().is_some(),
+            "the watermark must round-trip through the real bucket"
+        );
+    }
+
+    // Best-effort cleanup: sweep the per-run prefix.
+    let provider = ObjectStoreProvider::from_uri(&format!("s3://{}/{run_prefix}", live.bucket))
+        .expect("cleanup provider");
+    match provider.list("").await {
+        Ok(keys) => {
+            for key in keys {
+                if let Err(e) = provider.delete(&key).await {
+                    eprintln!("cleanup: failed to delete {key}: {e}");
+                }
+            }
+        }
+        Err(e) => eprintln!("cleanup: failed to list {run_prefix}: {e}"),
+    }
+}
+
+/// The atomic create-if-absent primitive against a real bucket: the first
+/// `put_if_not_exists` claims the key, the second reports the conflict, and
+/// the loser's bytes never land.
+#[tokio::test]
+#[ignore]
+async fn live_put_if_not_exists_conflict() {
+    let _serial = live_serial();
+    let Some(live) = live_s3_from_env() else {
+        eprintln!("SKIP live_put_if_not_exists_conflict: ROCKY_TEST_S3_* env not set");
+        return;
+    };
+    let provider = ObjectStoreProvider::from_uri(&format!("s3://{}/{}", live.bucket, live.prefix))
+        .expect("live provider");
+    let key = format!("conflict-probe-{}", unique_suffix());
+
+    let first = provider
+        .put_if_not_exists(&key, Bytes::from_static(b"first"))
+        .await
+        .expect("first conditional put");
+    assert_eq!(first, PutIfNotExistsOutcome::Created, "first writer claims");
+
+    let second = provider
+        .put_if_not_exists(&key, Bytes::from_static(b"second"))
+        .await
+        .expect("second conditional put must resolve to an outcome, not an error");
+    assert_eq!(
+        second,
+        PutIfNotExistsOutcome::AlreadyExists,
+        "second writer must see the conflict"
+    );
+
+    let stored = provider.get(&key).await.expect("read back");
+    assert_eq!(
+        stored.as_ref(),
+        b"first",
+        "the losing writer's bytes must never land"
+    );
+
+    provider.delete(&key).await.expect("cleanup delete");
+}


### PR DESCRIPTION
## Summary

First implementation PR of **WP-01** (remote-state protocol redesign; ADRs: #1133). A deterministic, integration-test-reachable remote-state test rig — the enabler for the upcoming authority/session/CAS PRs. **Zero production behavior change**: everything new is either an always-compiled additive constructor or gated behind a new rocky-core `test-support` cargo feature that the `rocky` binary never enables (verified: `cargo tree -p rocky -e features` shows no `test-support`).

- **`fault_store.rs`** — a fault-injecting `ObjectStore` decorator (`FaultingStore::wrap`): per-op armable faults (`FailNext`/`FailNth`/`FailAll` over Get/Put/Head/List/Delete/Copy) + unconditional call counters via a cloneable, cross-thread `FaultHandle`; plus the always-compiled `ObjectStoreProvider::from_store`.
- **Provider-override seam promotion** — `state_sync::test_support` from `cfg(test)` to `cfg(any(test, feature))`; new **process-global** override (`install_global` + Drop-guard + `serial_guard`) consulted after the thread-local one — reachable from integration tests and across OS-thread hops (`block_on_state_sync`).
- **`test_harness.rs`** — `CrossPodHarness` (two pods sharing one faultable in-memory store through the real dispatch path) + `with_held_writer` (live-`StateStore` lock harness).
- **Three integration suites** — cross-pod replication (incl. `interleaved_writers_last_writer_wins_documented`, a GREEN pin of the current RD-002 last-writer-wins behavior that the CAS PR will flip to a refusal baseline); writer-lock/publish contention; and a live-S3 `#[ignore]` rung establishing the `ROCKY_TEST_S3_*` env convention.

## Verification

`cargo nextest run -p rocky-core --all-features` 1641 passed · `-p rocky-cli --all-features` 1137 passed · `cargo clippy --all-targets --all-features -- -D warnings` clean · `cargo fmt --check` clean · no changes under `schemas/`, `sdk/`, or generated bindings (no codegen cascade) · wiremock transport tests untouched.