### PR TITLE
docs: add observability guide

### DIFF
--- a/docs/src/content/docs/guides/observability.mdx
+++ b/docs/src/content/docs/guides/observability.mdx
@@ -1,0 +1,161 @@
+---
+title: Observability
+description: Export Rocky's traces and metrics over OTLP, read its structured logs, and stand up a local Grafana stack to watch runs
+sidebar:
+  order: 8.5
+---
+
+Rocky is instrumented from the inside. A run emits OpenTelemetry spans and metrics, writes structured JSON logs to stderr, and keeps a local JSONL copy of every span on disk. You point the exporter at a collector, or you read the local files, and you can see exactly what a run did without adding a single line of code to your models.
+
+This guide covers what Rocky emits, how to turn on OTLP export, and how to stand up a local Grafana stack that renders it.
+
+## What Rocky emits
+
+Four signals come out of every run:
+
+- **Traces** — OpenTelemetry spans for the phases of a run, exported over OTLP gRPC.
+- **Metrics** — run counters and duration histograms, also exported over OTLP.
+- **Structured logs** — one JSON object per log line on stderr.
+- **Local trace files** — the same spans persisted as JSONL under `.rocky/traces/`.
+
+The OTLP signals are opt-in (set one environment variable). The structured logs and local trace files are always on.
+
+### Spans
+
+Spans are created where the work happens, so a trace reads as the shape of the run:
+
+| Span | Emitted by | What it covers |
+|---|---|---|
+| `discover_sources` | source discovery | resolving configured sources before planning |
+| `governance_setup` | governance phase | preparing permission and policy reconciliation |
+| `batched_checks` | quality phase | running data-quality checks |
+| `materialize.table` | model execution | building one model; one span per model, carrying `rocky.model.fqn` and `rocky.model.kind` |
+| `statement.execute` | warehouse adapter | one SQL statement sent to the warehouse, carrying `rocky.adapter.name`, `rocky.statement.kind`, and `rocky.warehouse.name` |
+| `state.download` / `state.upload` / `state.probe` | object-store state sync | reading and writing remote state, carrying the `backend` and `bucket` |
+
+When Rocky drives a warehouse, the `statement.execute` spans nest under the `materialize.table` span for the model being built, so a single model's SQL is grouped under it.
+
+Two honest limits worth knowing:
+
+- **`statement.execute` spans come from the warehouse adapters.** The Databricks, Snowflake, BigQuery, and Trino adapters emit them. The embedded DuckDB engine runs statements in-process and does not, so local DuckDB runs show model-level spans but no per-statement spans.
+- **`rocky.query_duration_ms` is populated by the Databricks adapter today.** Other adapters record their statement spans without feeding that metric yet.
+
+### Metrics
+
+Metrics are recorded in-process and pushed to the collector on a 30-second interval, with a final flush when the run exits. Counters are exported as gauges (the last value wins over the run) and durations as histograms so the backend computes its own percentiles.
+
+| Metric | Type | Meaning |
+|---|---|---|
+| `rocky.tables_processed` | gauge | tables materialized in the run |
+| `rocky.tables_failed` | gauge | tables that failed |
+| `rocky.statements_executed` | gauge | SQL statements executed |
+| `rocky.retries_attempted` | gauge | retries attempted |
+| `rocky.retries_succeeded` | gauge | retries that recovered |
+| `rocky.anomalies_detected` | gauge | anomalies flagged by checks |
+| `rocky.error_rate_pct` | gauge | failed tables as a percentage |
+| `rocky.table_duration_ms` | histogram | per-table materialization time, in milliseconds |
+| `rocky.query_duration_ms` | histogram | per-statement warehouse time, in milliseconds |
+
+### Structured logs
+
+Rocky writes logs to stderr as JSON (stdout stays reserved for the `--output json` result of `discover`, `plan`, and `run`). Run-scoped events carry a `run_id` field, which is the same id you see in `rocky history` and `rocky trace`, so a log line ties back to a specific run.
+
+```json
+{"timestamp":"2026-07-17T09:14:22.481Z","level":"INFO","fields":{"message":"idempotency key claimed — proceeding","run_id":"20260717-091422-481-a1b2c3","backend":"redb"},"target":"rocky::run"}
+```
+
+Log verbosity is controlled by `RUST_LOG`. The default keeps Rocky's own spans at `info` while quieting the query-cache trace:
+
+```bash
+RUST_LOG=info rocky run -c rocky.toml
+```
+
+### Local trace files
+
+Independently of any collector, Rocky writes one JSONL file per process under `.rocky/traces/`, named `{timestamp}-{pid}.jsonl`. Each line is a span record with its timestamp, level, target, fields, and the active span chain. This is on by default and needs no configuration.
+
+- The last 20 files are kept; set `ROCKY_TRACE_RETAIN_RUNS` to change the count.
+- Set `ROCKY_TRACE_DISABLE=1` to turn the files off entirely (useful on a shared filesystem or under tight disk quota).
+
+These files are raw span data you can inspect directly or ship to any log tool. They are separate from `rocky trace` and `rocky replay`, which render a run's timeline from the persisted run record in Rocky's state store rather than from these files.
+
+## Turning on OTLP export
+
+Export activates when `OTEL_EXPORTER_OTLP_ENDPOINT` is set. That single variable switches on both traces and metrics; when it is unset, the exporter is never constructed and there is no runtime cost.
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+export OTEL_SERVICE_NAME=rocky   # optional; defaults to "rocky"
+rocky run -c rocky.toml
+```
+
+- `OTEL_EXPORTER_OTLP_ENDPOINT` is the gRPC endpoint of your OTLP collector.
+- `OTEL_SERVICE_NAME` sets the `service.name` resource attribute, which is how you filter Rocky's data in the backend. It defaults to `rocky`.
+
+If the endpoint is unreachable, Rocky logs a warning and keeps running; export is best-effort and never fails a run.
+
+OTLP export requires the current Rocky release. Earlier release binaries were built without the exporter compiled in, so setting these variables had no effect on them. Upgrade to the current release before relying on export.
+
+## A local Grafana stack
+
+The repository ships a single-node Grafana, Alloy, Tempo, Loki, and Prometheus stack under [`deploy/observability/`](https://github.com/rocky-data/rocky/tree/main/deploy/observability) for watching runs locally. It is a development-grade quickstart, not a hardened production deployment.
+
+From that directory:
+
+```bash
+# 1. Start the stack (Grafana, Alloy, Tempo, Loki, Prometheus).
+docker compose up -d
+
+# 2. Run a pipeline with export pointed at Alloy's OTLP receiver.
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
+OTEL_SERVICE_NAME=rocky \
+  rocky run -c rocky.toml
+
+# 3. Open Grafana at http://localhost:3000.
+```
+
+In Grafana, open the Tempo data source and search for traces where `service.name` is `rocky`. Pick a recent trace to see the run laid out span by span: the model-level `materialize.table` spans, and the `statement.execute` spans nested under them when the run drives a warehouse. The provisioned dashboard renders the run metrics (tables processed and failed, error rate, and the duration histograms) from Prometheus.
+
+Tear the stack down when you are done. The exact commands, ports, and dashboard details live in the `deploy/observability/` README.
+
+## Collecting the structured logs
+
+Traces and metrics reach the backend over OTLP. To get Rocky's structured JSON logs into the same place, tail them with Alloy and lift the `run_id` into a label so log lines line up with run records.
+
+Capture Rocky's stderr to a file, for example when cron or a systemd unit runs it:
+
+```bash
+rocky run -c rocky.toml 2>> /var/log/rocky/run.jsonl
+```
+
+Then have Alloy tail that file, parse each JSON line, and label it by `run_id`:
+
+```
+local.file_match "rocky_logs" {
+  path_targets = [{ __path__ = "/var/log/rocky/*.jsonl" }]
+}
+
+loki.source.file "rocky_logs" {
+  targets    = local.file_match.rocky_logs.targets
+  forward_to = [loki.process.rocky.receiver]
+}
+
+loki.process "rocky" {
+  // Pull run_id out of each log line's fields.
+  stage.json {
+    expressions = { run_id = "fields.run_id" }
+  }
+  stage.labels {
+    values = { run_id = "" }
+  }
+  forward_to = [loki.write.default.receiver]
+}
+
+loki.write "default" {
+  endpoint {
+    url = "http://loki:3100/loki/api/v1/push"
+  }
+}
+```
+
+Because `run_id` is the same id `rocky history` and `rocky trace` report, filtering Loki by a `run_id` gives you every log line for a run, and you can cross-reference it against the run's record in Rocky's own state.

--- a/docs/src/content/docs/guides/observability.mdx
+++ b/docs/src/content/docs/guides/observability.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 8.5
 ---
 
-Rocky is instrumented from the inside. A run emits OpenTelemetry spans and metrics, writes structured JSON logs to stderr, and keeps a local JSONL copy of every span on disk. You point the exporter at a collector, or you read the local files, and you can see exactly what a run did without adding a single line of code to your models.
+Rocky is instrumented from the inside. A run emits OpenTelemetry spans and metrics, writes structured logs to stderr, and keeps a local JSONL record of each log event with its span context on disk. You point the exporter at a collector, or you read the local files, and you can see exactly what a run did without adding a single line of code to your models.
 
 This guide covers what Rocky emits, how to turn on OTLP export, and how to stand up a local Grafana stack that renders it.
 
@@ -15,34 +15,33 @@ Four signals come out of every run:
 
 - **Traces** — OpenTelemetry spans for the phases of a run, exported over OTLP gRPC.
 - **Metrics** — run counters and duration histograms, also exported over OTLP.
-- **Structured logs** — one JSON object per log line on stderr.
-- **Local trace files** — the same spans persisted as JSONL under `.rocky/traces/`.
+- **Structured logs** — log events on stderr, emitted as JSON (one object per line) when Rocky is producing JSON output, and in a compact human-readable form otherwise.
+- **Local trace files** — each log event, with its active span chain, persisted as JSONL under `.rocky/traces/`.
 
 The OTLP signals are opt-in (set one environment variable). The structured logs and local trace files are always on.
 
 ### Spans
 
-Spans are created where the work happens, so a trace reads as the shape of the run:
+Spans are created around the phases of a run, so a trace reads as the shape of the run:
 
 | Span | Emitted by | What it covers |
 |---|---|---|
-| `discover_sources` | source discovery | resolving configured sources before planning |
-| `governance_setup` | governance phase | preparing permission and policy reconciliation |
-| `batched_checks` | quality phase | running data-quality checks |
+| `discover_sources` | source discovery | resolving configured sources before planning (an entered span — it parents the discovery work) |
 | `materialize.table` | model execution | building one model; one span per model, carrying `rocky.model.fqn` and `rocky.model.kind` |
-| `statement.execute` | warehouse adapter | one SQL statement sent to the warehouse, carrying `rocky.adapter.name`, `rocky.statement.kind`, and `rocky.warehouse.name` |
+| `statement.execute` | warehouse adapter | one SQL statement sent to the warehouse |
 | `state.download` / `state.upload` / `state.probe` | object-store state sync | reading and writing remote state, carrying the `backend` and `bucket` |
 
 When Rocky drives a warehouse, the `statement.execute` spans nest under the `materialize.table` span for the model being built, so a single model's SQL is grouped under it.
 
-Two honest limits worth knowing:
+A few honest limits worth knowing:
 
-- **`statement.execute` spans come from the warehouse adapters.** The Databricks, Snowflake, BigQuery, and Trino adapters emit them. The embedded DuckDB engine runs statements in-process and does not, so local DuckDB runs show model-level spans but no per-statement spans.
+- **`statement.execute` spans come from the warehouse adapters.** The Databricks, Snowflake, BigQuery, and Trino adapters emit them. The embedded DuckDB engine runs statements in-process and does not, so local DuckDB runs show model-level spans but no per-statement spans. The `rocky.adapter.name`, `rocky.statement.kind`, and `rocky.warehouse.name` attributes are carried by the Databricks, Snowflake, and BigQuery spans; Trino emits a simpler `statement.execute` span (and a separate `statement.execute_arrow` span on its Arrow path).
 - **`rocky.query_duration_ms` is populated by the Databricks adapter today.** Other adapters record their statement spans without feeding that metric yet.
+- **`governance_setup` and `batched_checks` are marker spans.** They are declared to delimit the governance and quality-check phases, but they do not currently parent the events emitted during those phases (those events stay at the root of the trace). Treat them as phase markers, not as subtrees.
 
 ### Metrics
 
-Metrics are recorded in-process and pushed to the collector on a 30-second interval, with a final flush when the run exits. Counters are exported as gauges (the last value wins over the run) and durations as histograms so the backend computes its own percentiles.
+Metrics are recorded in-process and exported when the run finishes (the recorded values are flushed as the run exits). Counters are exported as gauges (the last value over the run) and durations as histograms, so the backend computes its own percentiles.
 
 | Metric | Type | Meaning |
 |---|---|---|
@@ -56,12 +55,14 @@ Metrics are recorded in-process and pushed to the collector on a 30-second inter
 | `rocky.table_duration_ms` | histogram | per-table materialization time, in milliseconds |
 | `rocky.query_duration_ms` | histogram | per-statement warehouse time, in milliseconds |
 
+Not every metric is populated on every run — instrumentation is adapter- and pipeline-specific today. `rocky.statements_executed` is emitted by the Databricks adapter; the retry counters by the Databricks and BigQuery adapters; and the table counters and durations (`rocky.tables_processed`, `rocky.tables_failed`, `rocky.table_duration_ms`) by replication runs. Other adapters and pipeline types still emit spans and logs, but do not feed these particular counters yet, so a metric you don't see means that path isn't instrumented, not that nothing happened.
+
 ### Structured logs
 
-Rocky writes logs to stderr as JSON (stdout stays reserved for the `--output json` result of `discover`, `plan`, and `run`). Run-scoped events carry a `run_id` field, which is the same id you see in `rocky history` and `rocky trace`, so a log line ties back to a specific run.
+When Rocky is producing JSON output, it writes logs to stderr as JSON, one object per line (stdout stays reserved for the `--output json` result of `discover`, `plan`, and `run`); interactive runs use a compact human-readable form instead. The active `run` span carries a `run_id` field — the same id you see in `rocky history` and `rocky trace` — so events emitted within a run tie back to it.
 
 ```json
-{"timestamp":"2026-07-17T09:14:22.481Z","level":"INFO","fields":{"message":"idempotency key claimed — proceeding","run_id":"20260717-091422-481-a1b2c3","backend":"redb"},"target":"rocky::run"}
+{"timestamp":"2026-07-17T09:14:22.481Z","level":"INFO","fields":{"message":"idempotency key claimed — proceeding","backend":"local"},"span":{"run_id":"run-20260717-091422-481","name":"run"},"target":"rocky::run"}
 ```
 
 Log verbosity is controlled by `RUST_LOG`. The default keeps Rocky's own spans at `info` while quieting the query-cache trace:
@@ -72,12 +73,12 @@ RUST_LOG=info rocky run -c rocky.toml
 
 ### Local trace files
 
-Independently of any collector, Rocky writes one JSONL file per process under `.rocky/traces/`, named `{timestamp}-{pid}.jsonl`. Each line is a span record with its timestamp, level, target, fields, and the active span chain. This is on by default and needs no configuration.
+Independently of any collector, Rocky writes one JSONL file per process under `.rocky/traces/`, named `{timestamp}-{pid}.jsonl`. Each line is a JSON log event with its timestamp, level, target, fields, and active span chain. This is on by default and needs no configuration.
 
 - The last 20 files are kept; set `ROCKY_TRACE_RETAIN_RUNS` to change the count.
 - Set `ROCKY_TRACE_DISABLE=1` to turn the files off entirely (useful on a shared filesystem or under tight disk quota).
 
-These files are raw span data you can inspect directly or ship to any log tool. They are separate from `rocky trace` and `rocky replay`, which render a run's timeline from the persisted run record in Rocky's state store rather than from these files.
+These files are structured event records with span context that you can inspect directly or ship to any log tool. They are separate from `rocky trace` and `rocky replay`, which render a run's timeline from the persisted run record in Rocky's state store rather than from these files.
 
 ## Turning on OTLP export
 
@@ -94,7 +95,7 @@ rocky run -c rocky.toml
 
 If the endpoint is unreachable, Rocky logs a warning and keeps running; export is best-effort and never fails a run.
 
-OTLP export requires the current Rocky release. Earlier release binaries were built without the exporter compiled in, so setting these variables had no effect on them. Upgrade to the current release before relying on export.
+OTLP export requires a Rocky release built with the OpenTelemetry exporter. Earlier release binaries were compiled without it, so setting these variables had no effect on them — see the CHANGELOG for the release that adds it.
 
 ## A local Grafana stack
 
@@ -120,7 +121,7 @@ Tear the stack down when you are done. The exact commands, ports, and dashboard 
 
 ## Collecting the structured logs
 
-Traces and metrics reach the backend over OTLP. To get Rocky's structured JSON logs into the same place, tail them with Alloy and lift the `run_id` into a label so log lines line up with run records.
+Traces and metrics reach the backend over OTLP. To get Rocky's structured JSON logs into the same place, tail them with Alloy and lift the run's `run_id` into a label so log lines line up with run records.
 
 Capture Rocky's stderr to a file, for example when cron or a systemd unit runs it:
 
@@ -128,7 +129,7 @@ Capture Rocky's stderr to a file, for example when cron or a systemd unit runs i
 rocky run -c rocky.toml 2>> /var/log/rocky/run.jsonl
 ```
 
-Then have Alloy tail that file, parse each JSON line, and label it by `run_id`:
+Then have Alloy tail that file, parse each JSON line, and label it by `run_id` (which the `run` span carries in the span context):
 
 ```
 local.file_match "rocky_logs" {
@@ -141,9 +142,9 @@ loki.source.file "rocky_logs" {
 }
 
 loki.process "rocky" {
-  // Pull run_id out of each log line's fields.
+  // Pull run_id out of the run span context on each log line.
   stage.json {
-    expressions = { run_id = "fields.run_id" }
+    expressions = { run_id = "span.run_id" }
   }
   stage.labels {
     values = { run_id = "" }
@@ -158,4 +159,4 @@ loki.write "default" {
 }
 ```
 
-Because `run_id` is the same id `rocky history` and `rocky trace` report, filtering Loki by a `run_id` gives you every log line for a run, and you can cross-reference it against the run's record in Rocky's own state.
+Because the `run` span carries the same `run_id` that `rocky history` and `rocky trace` report, events emitted during a run are labeled with it in Loki, and you can filter by a `run_id` to pull those lines and cross-reference them against the run's record in Rocky's own state. Events emitted outside the run span (early startup lines, for instance) won't carry the label.


### PR DESCRIPTION
Adds `docs/src/content/docs/guides/observability.mdx`, a guide covering what Rocky emits (spans, metrics, structured logs, local trace files), how to turn on OTLP export, the local Grafana quickstart stack, and log collection with Alloy. The page auto-registers under the **Guides** sidebar (Starlight `autogenerate` from the `guides/` directory).

## Docs build

`cd docs && npm install && npm run build` completes green (97 pages, `/guides/observability/` built). No new warnings introduced by this page.

## Every claim written from the code, not the plan

Each fact was verified against source; where the plan wording and the code disagreed, the code won:

- **Span names** — `discover_sources`, `governance_setup`, `batched_checks` (`crates/rocky-cli/src/commands/run.rs`); per-model `materialize.table` with `rocky.model.fqn` / `rocky.model.kind` (`crates/rocky-core/src/dag_executor.rs:234`, `crates/rocky-observe/src/events.rs`); per-statement `statement.execute` (`crates/rocky-databricks/src/connector.rs:533`, `crates/rocky-snowflake/src/connector.rs:305`, `crates/rocky-bigquery/src/connector.rs:298`, `crates/rocky-trino/src/connector.rs:336`); state sync `state.download` / `state.upload` / `state.probe` (`crates/rocky-core/src/state_sync.rs`).
- **Statement-span scope** — the guide states these come from the warehouse adapters and that embedded DuckDB emits none (`crates/rocky-duckdb/src` has no `info_span!`). The `rocky.query_duration_ms` metric is noted as Databricks-only, since `record_query_duration_ms` is called only in `crates/rocky-databricks/src/connector.rs`.
- **Metric list** — exactly the instruments built in `crates/rocky-observe/src/otel.rs:104-185` (`tables_processed`, `tables_failed`, `statements_executed`, `retries_attempted`, `retries_succeeded`, `anomalies_detected`, `error_rate_pct`, `table_duration_ms`, `query_duration_ms`), plus the 30s periodic reader.
- **Enable switch** — both traces and metrics activate on `OTEL_EXPORTER_OTLP_ENDPOINT`; `OTEL_SERVICE_NAME` defaults to `rocky`; no-op when unset (`crates/rocky-cli/src/otel_guard.rs:29-32`, `crates/rocky-observe/src/tracing_setup.rs:132`, `otel.rs:58-63`). Version floor phrased as "requires the current release".
- **Local trace files** — `.rocky/traces/{ts}-{pid}.jsonl`, retention 20 (`ROCKY_TRACE_RETAIN_RUNS`), opt out with `ROCKY_TRACE_DISABLE=1` (`crates/rocky-observe/src/traces.rs:33-45`, `tracing_setup.rs:113-128,185-190`). The guide keeps these distinct from `rocky trace` / `rocky replay`, which render from the state-store run record, not the JSONL (`crates/rocky-cli/src/commands/trace.rs:1-14`; `read_trace` has no CLI consumer).
- **Structured logs** — JSON on stderr with a `run_id` field on run-scoped events (`crates/rocky-cli/src/commands/run.rs`, e.g. lines 661-666). The Alloy example correlates on `run_id`.

## Scope note

The guide intentionally does not claim that orchestrator-launched runs join the caller's trace. The W3C propagator is installed and the extraction helper is unit-tested in `crates/rocky-observe/src/tracing_setup.rs`, but it has no call site in the run path (no `extract_remote_context` / `set_parent` / context attach outside that file's tests), so cross-process trace context does not propagate end-to-end today. The log-collection section correlates on `run_id` instead.

The `deploy/observability/` stack referenced here is created by a sibling PR; hold merge until that path exists and the OTLP-in-release-builds change has shipped in a release.
