### PR TITLE
feat: add deploy/observability quickstart stack

### DIFF
--- a/deploy/observability/README.md
+++ b/deploy/observability/README.md
@@ -1,0 +1,189 @@
+# Rocky observability quickstart
+
+A single-node Grafana + Alloy + Tempo + Loki + Prometheus stack that receives
+Rocky's OpenTelemetry and shows your runs: traces, run metrics, and logs, all
+correlated by trace ID.
+
+Rocky exports OpenTelemetry when you set `OTEL_EXPORTER_OTLP_ENDPOINT` (from a
+build that includes the exporter — see Prerequisites).
+It emits distributed traces (a span tree per run), run metrics (tables
+processed/failed, error rate, table and query duration histograms, retries),
+and structured JSON logs on stderr. This stack is somewhere to send all of
+that so you can look at it.
+
+> This is a **dev / quickstart** stack, not a hardened production deployment.
+> Storage is local and ephemeral, there is no authentication in front of any
+> component, retention is short, and every service runs single-node with no
+> replication. Use it to try Rocky's telemetry on your laptop or in CI, then
+> point Rocky at your real collector for anything that matters.
+
+## What's in it
+
+| Component | Role | Host port |
+|---|---|---|
+| Alloy | OTLP collector — the endpoint Rocky exports to | 4317 (gRPC), 4318 (HTTP), 12345 (UI) |
+| Tempo | Trace store + TraceQL search | 3200 |
+| Prometheus | Metric store (remote-write receiver) | 9090 |
+| Loki | Log store (OTLP + a file-tail example) | 3100 |
+| Grafana | Dashboards, datasources, alerts (pre-provisioned) | 3000 |
+
+Data flow:
+
+```
+rocky --(OTLP/gRPC :4317)--> alloy --> tempo        (traces)
+                                   \-> prometheus   (metrics, remote-write)
+                                   \-> loki         (logs)
+grafana <-- tempo / prometheus / loki               (provisioned datasources)
+```
+
+## Prerequisites
+
+- Docker with Compose v2 (`docker compose version`).
+- The DuckDB CLI (`duckdb`) — step 2 seeds a local DuckDB file with it.
+- A `rocky` binary **built with the OpenTelemetry exporter**. If setting
+  `OTEL_EXPORTER_OTLP_ENDPOINT` appears to do nothing, your binary was built
+  without it; build one with:
+
+  ```bash
+  cargo build --release --features otel   # run from the engine/ directory
+  ```
+
+## Quickstart (3 commands)
+
+Run these from `deploy/observability/`.
+
+**1. Bring the stack up.**
+
+```bash
+docker compose up -d
+```
+
+Give it a few seconds, then check everything is healthy:
+
+```bash
+docker compose ps
+```
+
+**2. Run a Rocky pipeline with OTel pointed at the stack.** This seeds and
+runs the replication playground POC, which produces a trace, run metrics, and
+the table-duration histogram. `2>` also tees Rocky's stderr JSON into `./logs`
+so the log pipeline picks it up.
+
+```bash
+cd ../../examples/playground/pocs/00-foundations/01-replication-basics
+duckdb playground.duckdb < data/seed.sql
+OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317 OTEL_SERVICE_NAME=rocky \
+  rocky run --filter source=orders \
+  2> "$(git rev-parse --show-toplevel)/deploy/observability/logs/rocky.jsonl"
+```
+
+**3. Open Grafana and look at the run.**
+
+```bash
+open http://localhost:3000        # macOS; use xdg-open on Linux
+```
+
+Grafana is provisioned with anonymous admin access (no login). Open the
+**Rocky Runs** dashboard in the **Rocky** folder. You'll see the run's metrics
+and, in the trace panel at the bottom, the run's trace; click it to open the
+full span tree and pivot to its logs in Loki.
+
+Any `rocky run` (or `plan`, `apply`, …) with those two env vars set will land
+here — the replication POC is just a convenient one that exercises every
+panel. A DuckDB run leaves the "Query duration" panel empty because SQL
+statement timing is recorded by the warehouse adapter (Databricks today), not
+by the local DuckDB path.
+
+### Verify from the command line (optional)
+
+Confirm a trace landed in Tempo without opening a browser:
+
+```bash
+curl -s 'http://localhost:3200/api/search?q=%7B%20resource.service.name%20%3D%20%22rocky%22%20%7D' | jq '.traces[] | {traceID, rootServiceName, rootTraceName}'
+```
+
+Confirm metrics landed in Prometheus:
+
+```bash
+curl -s 'http://localhost:9090/api/v1/label/__name__/values' | jq -r '.data[] | select(startswith("rocky"))'
+```
+
+## Teardown
+
+```bash
+docker compose down -v
+```
+
+`down -v` removes the containers **and** the named volumes, so nothing is left
+behind. Runtime log files you tee'd into `./logs/` are gitignored; delete them
+by hand if you want a truly clean tree.
+
+## Log collection
+
+Rocky writes structured JSON logs to stderr, one object per line. The Alloy
+config ships two log paths:
+
+- **OTLP logs** — wired to Loki's native OTLP endpoint for any source that
+  exports OTLP logs. Rocky does not export OTLP logs today (it uses stderr
+  JSON), so this route is there for completeness and forward-compatibility.
+- **File-tail (the one Rocky uses today)** — redirect Rocky's stderr to a file
+  under `./logs/` (as the quickstart does) and Alloy tails `./logs/*.jsonl`,
+  parses each line, promotes `level` to a label, and attaches `trace_id` /
+  `span_id` as structured metadata. That trace_id is what lets Grafana jump
+  from a span in Tempo straight to its log lines in Loki.
+
+See `alloy/config.alloy` for both pipelines; the file-tail block is documented
+inline.
+
+## Metrics reference
+
+The dashboard reads the metrics Rocky emits (names as they appear in
+Prometheus after OTLP conversion):
+
+| Prometheus series | Rocky metric | Shape |
+|---|---|---|
+| `rocky_tables_processed` | `rocky.tables_processed` | per-run gauge |
+| `rocky_tables_failed` | `rocky.tables_failed` | per-run gauge |
+| `rocky_error_rate_pct` | `rocky.error_rate_pct` | per-run gauge |
+| `rocky_retries_attempted` | `rocky.retries_attempted` | per-run gauge |
+| `rocky_retries_succeeded` | `rocky.retries_succeeded` | per-run gauge |
+| `rocky_statements_executed` | `rocky.statements_executed` | per-run gauge |
+| `rocky_table_duration_ms_bucket` / `_sum` / `_count` | `rocky.table_duration_ms` | histogram |
+| `rocky_query_duration_ms_bucket` / `_sum` / `_count` | `rocky.query_duration_ms` | histogram (warehouse adapter) |
+
+The counters are exported as **last-value gauges** — each run pushes the totals
+for that run, so the series is a per-run snapshot over time rather than a
+monotonic counter. Read "runs over time" panels accordingly; do not wrap these
+in `increase()` or `rate()`, which assume a cumulative counter.
+
+## Configuration
+
+Everything is provisioned from files in this directory, so edits are picked up
+on the next `docker compose up`:
+
+```
+compose.yaml                          # the stack
+alloy/config.alloy                    # OTLP routing + the file-tail example
+tempo/tempo.yaml                      # trace store
+loki/loki-config.yaml                 # log store
+prometheus/prometheus.yml             # metric store
+grafana/provisioning/datasources.yaml # Tempo + Loki + Prometheus (fixed UIDs)
+grafana/provisioning/dashboards.yaml  # dashboard provider
+grafana/dashboards/rocky-runs.json    # the Rocky Runs dashboard
+grafana/alerting/rocky-alerts.yaml    # provisioned alert rules
+```
+
+All images are pinned to explicit version tags in `compose.yaml`.
+
+### Alerts
+
+Two provisioned rules live in `grafana/alerting/rocky-alerts.yaml`:
+
+- **Rocky run reported failed tables** — fires when any run in the last 15
+  minutes reported `rocky.tables_failed > 0`.
+- **Rocky error rate above 5 percent** — fires when `rocky.error_rate_pct`
+  stays above 5 for 15 minutes.
+
+They provision the rules only; wire a Grafana contact point to actually deliver
+notifications. A commented scheduler-alert stub is left in the same file for
+when Rocky's native scheduler telemetry lands.

--- a/deploy/observability/alloy/config.alloy
+++ b/deploy/observability/alloy/config.alloy
@@ -1,0 +1,137 @@
+// Alloy — OTLP collector for the Rocky quickstart stack.
+//
+// Receives Rocky's OpenTelemetry over OTLP (gRPC :4317 / HTTP :4318) and
+// fans it out:
+//   traces  -> Tempo       (OTLP gRPC, plaintext)
+//   metrics -> Prometheus  (converted to Prometheus, remote-written)
+//   logs    -> Loki        (native OTLP endpoint)
+//
+// A separate file-tail pipeline (bottom of this file) picks up Rocky's
+// stderr JSON logs when you redirect them to ./logs (see README).
+
+// ---------------------------------------------------------------------------
+// OTLP receiver — the endpoint Rocky exports to.
+// ---------------------------------------------------------------------------
+otelcol.receiver.otlp "default" {
+  grpc {
+    endpoint = "0.0.0.0:4317"
+  }
+  http {
+    endpoint = "0.0.0.0:4318"
+  }
+
+  output {
+    traces  = [otelcol.exporter.otlp.tempo.input]
+    metrics = [otelcol.exporter.prometheus.default.input]
+    logs    = [otelcol.exporter.otlphttp.loki.input]
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Traces -> Tempo (plaintext OTLP gRPC on the internal network).
+// ---------------------------------------------------------------------------
+otelcol.exporter.otlp "tempo" {
+  client {
+    endpoint = "tempo:4317"
+    tls {
+      insecure = true
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Metrics -> Prometheus. Convert OTLP metrics to Prometheus, then
+// remote-write. add_metric_suffixes = false keeps names clean and
+// predictable ("rocky.table_duration_ms" -> "rocky_table_duration_ms")
+// instead of appending unit/type suffixes, so dashboard queries match.
+// ---------------------------------------------------------------------------
+otelcol.exporter.prometheus "default" {
+  add_metric_suffixes = false
+  forward_to          = [prometheus.remote_write.default.receiver]
+}
+
+prometheus.remote_write "default" {
+  endpoint {
+    url = "http://prometheus:9090/api/v1/write"
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Logs -> Loki via its native OTLP endpoint. Rocky does not export OTLP
+// logs today (it writes structured JSON to stderr — see the file-tail
+// pipeline below), but this route is wired so any OTLP-logs source, or a
+// future Rocky OTLP-logs exporter, lands in Loki with no config change.
+// ---------------------------------------------------------------------------
+otelcol.exporter.otlphttp "loki" {
+  client {
+    endpoint = "http://loki:3100/otlp"
+  }
+}
+
+// ===========================================================================
+// File-tail example: Rocky's stderr JSON -> Loki.
+//
+// Rocky writes structured JSON log lines to stderr. Redirect them to a file
+// under ./logs (mounted read-only into this container at /rocky-logs) and
+// this pipeline parses each line, promotes `level` to a label, and attaches
+// `trace_id`/`span_id` as structured metadata so a trace in Tempo links to
+// its logs in Loki. Example (from the repo root):
+//
+//   OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317 OTEL_SERVICE_NAME=rocky \
+//     rocky run 2> deploy/observability/logs/rocky.jsonl
+// ===========================================================================
+local.file_match "rocky" {
+  path_targets = [{
+    __path__ = "/rocky-logs/*.jsonl",
+    service  = "rocky",
+  }]
+}
+
+loki.source.file "rocky" {
+  targets    = local.file_match.rocky.targets
+  forward_to = [loki.process.rocky.receiver]
+}
+
+loki.process "rocky" {
+  // Rocky's stderr lines are JSON objects with (at least) level/target/
+  // fields; runs with OTel enabled also carry span context.
+  stage.json {
+    expressions = {
+      level    = "level",
+      target   = "target",
+      trace_id = "trace_id",
+      span_id  = "span_id",
+    }
+  }
+
+  // Low-cardinality label only.
+  stage.labels {
+    values = {
+      level = "",
+    }
+  }
+
+  // Trace correlation without label-cardinality blow-up.
+  stage.structured_metadata {
+    values = {
+      trace_id = "",
+      span_id  = "",
+      target   = "",
+    }
+  }
+
+  stage.static_labels {
+    values = {
+      service = "rocky",
+      job     = "rocky-cli",
+    }
+  }
+
+  forward_to = [loki.write.default.receiver]
+}
+
+loki.write "default" {
+  endpoint {
+    url = "http://loki:3100/loki/api/v1/push"
+  }
+}

--- a/deploy/observability/compose.yaml
+++ b/deploy/observability/compose.yaml
@@ -1,0 +1,107 @@
+# Rocky observability quickstart — single-node LGTM stack (dev-grade).
+#
+# Receives Rocky's OpenTelemetry over OTLP (gRPC :4317 / HTTP :4318 on the
+# host) and renders runs in Grafana. See README.md for the 3-command
+# quickstart. This is NOT a hardened production deployment.
+#
+# Data flow:
+#   rocky (OTLP/gRPC) -> alloy -> tempo   (traces)
+#                             \-> prometheus (metrics, remote-write)
+#                             \-> loki     (logs: OTLP + a file-tail example)
+#   grafana <- tempo / prometheus / loki  (provisioned datasources)
+
+name: rocky-observability
+
+services:
+  # OpenTelemetry collector. The only container that publishes OTLP ports to
+  # the host, so Rocky on the host exports to 127.0.0.1:4317.
+  alloy:
+    image: grafana/alloy:v1.5.1
+    command:
+      - run
+      - --server.http.listen-addr=0.0.0.0:12345
+      - --storage.path=/var/lib/alloy/data
+      - /etc/alloy/config.alloy
+    ports:
+      - "4317:4317" # OTLP gRPC  (OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317)
+      - "4318:4318" # OTLP HTTP  (for a synthetic-span smoke test / non-gRPC clients)
+      - "12345:12345" # Alloy diagnostic UI (http://localhost:12345)
+    volumes:
+      - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
+      # Mount the host log directory so the file-tail example can pick up
+      # Rocky's stderr JSON when you redirect it here (see README).
+      - ./logs:/rocky-logs:ro
+      - alloy-data:/var/lib/alloy/data
+    depends_on:
+      - tempo
+      - loki
+      - prometheus
+    restart: unless-stopped
+
+  # Trace store + TraceQL search API on :3200.
+  tempo:
+    image: grafana/tempo:2.6.1
+    command: ["-config.file=/etc/tempo/tempo.yaml"]
+    ports:
+      - "3200:3200" # Tempo HTTP API (trace search / evidence curl)
+    volumes:
+      - ./tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro
+      - tempo-data:/var/tempo
+    restart: unless-stopped
+
+  # Log store on :3100 (native OTLP endpoint at /otlp/v1/logs).
+  loki:
+    image: grafana/loki:3.3.2
+    command: ["-config.file=/etc/loki/loki-config.yaml"]
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./loki/loki-config.yaml:/etc/loki/loki-config.yaml:ro
+      - loki-data:/loki
+    restart: unless-stopped
+
+  # Metric store on :9090. Remote-write receiver enabled so Alloy can push
+  # the OTLP metrics it converts.
+  prometheus:
+    image: prom/prometheus:v3.1.0
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --web.enable-remote-write-receiver
+      - --web.enable-lifecycle
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    restart: unless-stopped
+
+  # Grafana on :3000 (anonymous admin; datasources + dashboard + alerts
+  # provisioned from disk). Default login admin/admin if you disable anon.
+  grafana:
+    image: grafana/grafana:11.4.0
+    ports:
+      - "3000:3000"
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: "Admin"
+      GF_AUTH_DISABLE_LOGIN_FORM: "true"
+      GF_FEATURE_TOGGLES_ENABLE: "traceqlEditor"
+    volumes:
+      - ./grafana/provisioning/datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml:ro
+      - ./grafana/provisioning/dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml:ro
+      - ./grafana/alerting/rocky-alerts.yaml:/etc/grafana/provisioning/alerting/rocky-alerts.yaml:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana-data:/var/lib/grafana
+    depends_on:
+      - tempo
+      - loki
+      - prometheus
+    restart: unless-stopped
+
+volumes:
+  alloy-data:
+  tempo-data:
+  loki-data:
+  prometheus-data:
+  grafana-data:

--- a/deploy/observability/grafana/alerting/rocky-alerts.yaml
+++ b/deploy/observability/grafana/alerting/rocky-alerts.yaml
@@ -1,0 +1,133 @@
+# Provisioned Grafana alert rules for Rocky runs. Deliberately few — this is
+# a quickstart, not an SRE program. Wire a contact point in Grafana (or add
+# one under provisioning/alerting/) to actually deliver these.
+#
+# Note on the metric shape: rocky.tables_failed and rocky.error_rate_pct are
+# emitted as last-value gauges (one value per run), NOT cumulative counters —
+# so "increase over 15m" is expressed as "any run in the last 15m reported a
+# non-zero value" via max_over_time(...[15m]), which is the honest reading of
+# a per-run gauge. Do not switch these to increase()/rate(); those assume a
+# monotonic counter and would silently produce nothing.
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: rocky-runs
+    folder: Rocky
+    interval: 1m
+    rules:
+      # Any run in the last 15 minutes reported one or more failed tables.
+      - uid: rocky-tables-failed
+        title: Rocky run reported failed tables
+        condition: C
+        for: 0m
+        noDataState: OK
+        execErrState: Error
+        labels:
+          severity: warning
+        annotations:
+          summary: "A Rocky run reported failed tables in the last 15m."
+          description: "rocky.tables_failed was > 0 for at least one run in the last 15 minutes."
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: prometheus
+            model:
+              refId: A
+              editorMode: code
+              expr: max_over_time(rocky_tables_failed[15m])
+              instant: true
+              range: false
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: C
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: A
+              conditions:
+                - type: query
+                  evaluator:
+                    type: gt
+                    params: [0]
+
+      # Error rate above 5% sustained for 15 minutes.
+      - uid: rocky-error-rate
+        title: Rocky error rate above 5 percent
+        condition: C
+        for: 15m
+        noDataState: OK
+        execErrState: Error
+        labels:
+          severity: critical
+        annotations:
+          summary: "Rocky error rate has been above 5% for 15m."
+          description: "rocky.error_rate_pct has stayed above 5 for the last 15 minutes."
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: prometheus
+            model:
+              refId: A
+              editorMode: code
+              expr: max(rocky_error_rate_pct)
+              instant: true
+              range: false
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: C
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: A
+              conditions:
+                - type: query
+                  evaluator:
+                    type: gt
+                    params: [5]
+
+# ---------------------------------------------------------------------------
+# Scheduler alerts (stub — arrives with the native-scheduler work).
+#
+# Once `rocky serve --scheduler` / `rocky tick` ship their telemetry, a
+# consecutive-failures alert belongs here. Left commented until those metrics
+# exist so provisioning never references a metric that isn't emitted yet.
+#
+#      - uid: rocky-scheduler-consecutive-failures
+#        title: Rocky scheduled pipeline is failing repeatedly
+#        condition: C
+#        for: 0m
+#        labels:
+#          severity: critical
+#        annotations:
+#          summary: "A scheduled Rocky pipeline has failed repeatedly."
+#        data:
+#          - refId: A
+#            relativeTimeRange: { from: 900, to: 0 }
+#            datasourceUid: prometheus
+#            model:
+#              refId: A
+#              editorMode: code
+#              expr: max(rocky_scheduler_consecutive_failures) by (pipeline)
+#              instant: true
+#          - refId: C
+#            datasourceUid: __expr__
+#            model:
+#              refId: C
+#              type: threshold
+#              expression: A
+#              conditions:
+#                - type: query
+#                  evaluator: { type: gt, params: [3] }

--- a/deploy/observability/grafana/dashboards/rocky-runs.json
+++ b/deploy/observability/grafana/dashboards/rocky-runs.json
@@ -1,0 +1,159 @@
+{
+  "uid": "rocky-runs",
+  "title": "Rocky Runs",
+  "tags": ["rocky"],
+  "timezone": "",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "10s",
+  "time": { "from": "now-6h", "to": "now" },
+  "templating": { "list": [] },
+  "annotations": { "list": [] },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Tables processed / failed per run",
+      "description": "Rocky emits rocky.tables_processed and rocky.tables_failed as last-value gauges: each run pushes the counts for that run. This is a per-run snapshot over time, not a cumulative counter, so read it as \"how many tables did each run touch / fail\".",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "drawStyle": "line", "lineWidth": 2, "pointSize": 6, "showPoints": "always", "fillOpacity": 10, "spanNulls": false },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "failed" }, "properties": [ { "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } } ] },
+          { "matcher": { "id": "byName", "options": "processed" }, "properties": [ { "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } } ] }
+        ]
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(rocky_tables_processed)", "legendFormat": "processed", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(rocky_tables_failed)", "legendFormat": "failed", "refId": "B" }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Error rate (%)",
+      "description": "rocky.error_rate_pct — failed tables as a percentage of tables processed for each run.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "drawStyle": "line", "lineWidth": 2, "pointSize": 6, "showPoints": "always", "fillOpacity": 10 },
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 5 } ] }
+        },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "max(rocky_error_rate_pct)", "legendFormat": "error rate", "refId": "A" }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "heatmap",
+      "title": "Table materialization duration (ms)",
+      "description": "Distribution of per-table materialization durations from the rocky.table_duration_ms histogram. Populates on replication runs; the latest run's bucket distribution is shown.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": { "mode": "scheme", "scheme": "Spectral", "steps": 64 },
+        "yAxis": { "unit": "ms", "axisPlacement": "left" },
+        "legend": { "show": true },
+        "tooltip": { "show": true, "yHistogram": true }
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(rocky_table_duration_ms_bucket) by (le)", "format": "heatmap", "legendFormat": "{{le}}", "refId": "A" }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "heatmap",
+      "title": "Query duration (ms) — warehouse adapter",
+      "description": "Distribution of SQL statement durations from the rocky.query_duration_ms histogram. Recorded by the warehouse adapter (Databricks today); a DuckDB playground run leaves this empty.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": { "mode": "scheme", "scheme": "Spectral", "steps": 64 },
+        "yAxis": { "unit": "ms", "axisPlacement": "left" },
+        "legend": { "show": true },
+        "tooltip": { "show": true, "yHistogram": true }
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(rocky_query_duration_ms_bucket) by (le)", "format": "heatmap", "legendFormat": "{{le}}", "refId": "A" }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Retries (attempted vs succeeded)",
+      "description": "rocky.retries_attempted and rocky.retries_succeeded — per-run self-healing activity (last-value gauges).",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "drawStyle": "line", "lineWidth": 2, "pointSize": 6, "showPoints": "always", "fillOpacity": 10 },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(rocky_retries_attempted)", "legendFormat": "attempted", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(rocky_retries_succeeded)", "legendFormat": "succeeded", "refId": "B" }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "SQL statements executed per run",
+      "description": "rocky.statements_executed — statements executed during each run (last-value gauge).",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "drawStyle": "bars", "lineWidth": 1, "fillOpacity": 60 },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(rocky_statements_executed)", "legendFormat": "statements", "refId": "A" }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "table",
+      "title": "Recent Rocky traces (service.name = rocky)",
+      "description": "Trace search against Tempo, filtered to Rocky's spans. Click a trace to open the full span tree and pivot to its logs in Loki.",
+      "datasource": { "type": "tempo", "uid": "tempo" },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 24 },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "options": { "showHeader": true },
+      "targets": [
+        {
+          "datasource": { "type": "tempo", "uid": "tempo" },
+          "queryType": "traceql",
+          "query": "{ resource.service.name = \"rocky\" }",
+          "tableType": "traces",
+          "limit": 20,
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/deploy/observability/grafana/provisioning/dashboards.yaml
+++ b/deploy/observability/grafana/provisioning/dashboards.yaml
@@ -1,0 +1,14 @@
+# Load committed dashboard JSON from disk into a "Rocky" folder.
+apiVersion: 1
+
+providers:
+  - name: rocky
+    orgId: 1
+    folder: Rocky
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/deploy/observability/grafana/provisioning/datasources.yaml
+++ b/deploy/observability/grafana/provisioning/datasources.yaml
@@ -1,0 +1,49 @@
+# Grafana datasources for the Rocky quickstart stack. UIDs are fixed
+# (prometheus / tempo / loki) so the committed dashboard and alert rules
+# can reference them by a stable identifier.
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    jsonData:
+      httpMethod: POST
+
+  - name: Tempo
+    uid: tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    jsonData:
+      # Trace -> logs: jump from a span to its Loki logs by trace_id.
+      tracesToLogsV2:
+        datasourceUid: loki
+        spanStartTimeShift: "-5m"
+        spanEndTimeShift: "5m"
+        filterByTraceID: true
+        filterBySpanID: false
+      # Trace -> metrics: pivot to Rocky's run metrics.
+      tracesToMetrics:
+        datasourceUid: prometheus
+      serviceMap:
+        datasourceUid: prometheus
+      nodeGraph:
+        enabled: true
+
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    jsonData:
+      # Turn the extracted trace_id into a link back to Tempo.
+      derivedFields:
+        - name: trace_id
+          matcherType: label
+          matcherRegex: trace_id
+          datasourceUid: tempo
+          url: "$${__value.raw}"

--- a/deploy/observability/logs/.gitignore
+++ b/deploy/observability/logs/.gitignore
@@ -1,0 +1,4 @@
+# Runtime log files land here (see alloy/config.alloy file-tail example).
+# Keep the directory, ignore its contents.
+*
+!.gitignore

--- a/deploy/observability/loki/loki-config.yaml
+++ b/deploy/observability/loki/loki-config.yaml
@@ -1,0 +1,47 @@
+# Loki — single-binary, filesystem storage, TSDB schema v13 (dev-grade).
+# Accepts logs on the native Loki push API (/loki/api/v1/push) and the
+# native OTLP endpoint (/otlp/v1/logs). Structured metadata is enabled so
+# the trace_id extracted from Rocky's stderr JSON can be attached without
+# exploding label cardinality.
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: info
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  allow_structured_metadata: true
+  volume_enabled: true
+  retention_period: 24h
+
+compactor:
+  working_directory: /loki/compactor
+  delete_request_store: filesystem
+  retention_enabled: true
+
+analytics:
+  reporting_enabled: false

--- a/deploy/observability/prometheus/prometheus.yml
+++ b/deploy/observability/prometheus/prometheus.yml
@@ -1,0 +1,13 @@
+# Prometheus — dev-grade. Metrics arrive via the remote-write receiver
+# (enabled with --web.enable-remote-write-receiver in compose.yaml); Alloy
+# converts Rocky's OTLP metrics and pushes them to /api/v1/write. Prometheus
+# also scrapes itself so the stack is self-observable.
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]

--- a/deploy/observability/tempo/tempo.yaml
+++ b/deploy/observability/tempo/tempo.yaml
@@ -1,0 +1,35 @@
+# Tempo — single-binary, local-filesystem storage (dev-grade).
+# Receives traces over OTLP gRPC on :4317 (in-container) and serves the
+# search/query API on :3200. Short flush windows keep freshly-received
+# traces searchable within a few seconds for the quickstart.
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+
+ingester:
+  # Flush live traces quickly so `rocky` spans are searchable moments after
+  # a run finishes (defaults are minutes; fine for prod, slow for a demo).
+  trace_idle_period: 5s
+  max_block_duration: 10s
+
+compactor:
+  compaction:
+    block_retention: 24h
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /var/tempo/wal
+    local:
+      path: /var/tempo/blocks
+
+usage_report:
+  reporting_enabled: false


### PR DESCRIPTION
## What

A repo-root `deploy/observability/` quickstart: a single-node LGTM stack
(Grafana, Alloy, Tempo, Loki, Prometheus) that receives Rocky's OpenTelemetry
over OTLP and renders runs — traces, run metrics, and structured logs,
correlated by trace ID.

- **Alloy** is the OTLP endpoint Rocky exports to (gRPC `:4317` / HTTP `:4318`).
  It fans traces to Tempo, metrics to Prometheus via remote-write, and logs to
  Loki (native OTLP plus a documented stderr-JSON file-tail example).
- **Grafana** ships provisioned Tempo/Loki/Prometheus datasources (fixed UIDs),
  a hand-authored **Rocky Runs** dashboard, and two provisioned alert rules.
- Every image is pinned to an explicit version tag (no `:latest`).
- The README carries a copy-paste 3-command quickstart against the playground,
  teardown, and an honest "dev/quickstart, not a hardened production
  deployment" note.

Dashboard panels use the real metric names as they land in Prometheus after
OTLP conversion: tables processed/failed, error rate, `table_duration_ms` and
`query_duration_ms` histograms, retries, statements, and a Tempo trace-search
panel filtered to `service.name = "rocky"`.

## Validation

Validated end-to-end on a live stack. Because a pre-existing standalone
`otel/opentelemetry-collector` already held `4317` on the shared Docker daemon,
the live run remapped Alloy's **host** ports to `24317/24318` (container config
byte-identical); the committed `compose.yaml` uses the canonical `4317/4318`,
which a clean checkout has free. Rocky was exercised with a locally-built
`--features otel` binary (the released binary does not yet include the exporter).

### `docker compose config` — clean (exit 0), canonical ports

```
CONFIG_EXIT=0            # no stderr
alloy        image=grafana/alloy:v1.5.1     ports=4317:4317,4318:4318,12345:12345
grafana      image=grafana/grafana:11.4.0   ports=3000:3000
loki         image=grafana/loki:3.3.2       ports=3100:3100
prometheus   image=prom/prometheus:v3.1.0   ports=9090:9090
tempo        image=grafana/tempo:2.6.1      ports=3200:3200
```

### Traces reached Tempo

A real `rocky run` (replication playground POC) exported to the stack. Tempo
TraceQL search `{ resource.service.name = "rocky" }`:

```
traces found: 2
 traceID= a28a63c76e30b26c6009b48ac2e0b4ae root= rocky / run          spans= 3   <- real rocky run
 traceID= 393364e45956a397ea48786169583956 root= rocky / pipeline.run spans= 2   <- synthetic OTLP smoke span
```

Real run's span names (from `GET /api/traces/<id>`): `run`, `run_transformation`,
`execute_models`.

### Metrics reached Prometheus

Alloy's receiver accepted the run's metric points; `GET /api/v1/label/__name__/values`:

```
rocky_tables_processed          rocky_tables_failed
rocky_error_rate_pct            rocky_statements_executed
rocky_retries_attempted         rocky_retries_succeeded
rocky_anomalies_detected
rocky_table_duration_ms_bucket  rocky_table_duration_ms_count  rocky_table_duration_ms_sum
```

(all labeled `job="rocky"`; `add_metric_suffixes=false` keeps names clean.
`rocky_query_duration_ms_*` is empty on a DuckDB run by design — statement
timing is recorded by the warehouse adapter, and the panel says so.)

### Logs reached Loki

The stderr-JSON file-tail pipeline parsed Rocky's logs into Loki — stream
`{service="rocky", job="rocky-cli", level="INFO", ...}` with `trace_id`/`target`
attached as structured metadata for trace-to-log correlation.

### Grafana provisioning

Provisioning logs clean (`finished to provision` for datasources, dashboards,
alerting). Dashboard loaded (`uid=rocky-runs`, 7 panels,
`provisionedExternalId=rocky-runs.json`). Both alert rules evaluate healthy:

```
[('Rocky run reported failed tables', health='ok', state='inactive'),
 ('Rocky error rate above 5 percent', health='ok', state='inactive')]
```

Prometheus datasource health `OK`, Loki `OK`, Tempo returns Grafana's standard
"Method not implemented" for its health probe (no health endpoint; trace search
verified directly above).

### Teardown — nothing left

`docker compose down -v`:

```
no containers (clean)
no volumes (clean)
no network (clean)
```

The pre-existing standalone collector on `4317` was left untouched.

## Notes

- Deploy-only PR; no engine/CI-gated code. The real rocky-span path also gets
  its own reachability run in the default-feature-flip PR that makes the
  released binary export by default.
- Alert rules are provisioned as rules only; wire a Grafana contact point to
  deliver notifications. A commented scheduler-alert stub is left inline for
  when Rocky's native scheduler telemetry lands.
