### PR TITLE
fix(engine): ship OTel exporter in default builds

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped `rmcp` (the MCP SDK) 1.7 → 2.2, a breaking major that realigns MCP model types to spec 2025-11-25. The JSON wire format is unchanged — MCP clients see identical bytes — so the migration is Rust-API-only (`PromptMessageRole` → `Role`, `PromptMessageContent::Text` → `ContentBlock::Text`). The `rocky mcp` tool/prompt surface (28 tools, 5 prompts) is identical. Two inherited rmcp-2.x behaviors are wire-compatible and worth noting: `initialize` now negotiates the MCP protocol version (a client is echoed the version it requests when rmcp recognizes it, falling back to the configured `2024-11-05` otherwise), and a tool call whose arguments fail to deserialize returns an `isError` result rather than a JSON-RPC error — Rocky's structured tool-error envelope (body-level validation) is unchanged. (#1109)
 
+### Fixed
+
+- Released binaries now include the OpenTelemetry exporter; `OTEL_EXPORTER_OTLP_ENDPOINT` was previously a no-op on release builds.
+
 ## [1.64.0] - 2026-07-12
 
 ### Added

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -75,11 +75,11 @@ name = "compile"
 harness = false
 
 [features]
-default = ["duckdb"]
+default = ["duckdb", "otel"]
 duckdb = ["dep:rocky-duckdb", "rocky-engine/duckdb"]
-# Enable OTLP metrics export at end of `rocky run`. Off by default;
-# when enabled, the CLI auto-initialises `OtelExporter` when the
-# OTEL_EXPORTER_OTLP_ENDPOINT env var is set.
+# Enable OTLP metrics export at end of `rocky run`. In the default
+# feature set; at runtime the CLI auto-initialises `OtelExporter` only
+# when the OTEL_EXPORTER_OTLP_ENDPOINT env var is set.
 otel = ["rocky-observe/otel"]
 
 [lints]

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["duckdb"]
+default = ["duckdb", "otel"]
 duckdb = ["rocky-cli/duckdb"]
 # Forward the OTLP metrics exporter flag to rocky-cli.
 otel = ["rocky-cli/otel", "rocky-observe/otel"]


### PR DESCRIPTION
## What

Add `otel` to the `default` feature array of both the `rocky` binary package (`engine/rocky/Cargo.toml`) and `rocky-cli` (`engine/crates/rocky-cli/Cargo.toml`).

## Why

Release binaries are built with default features (`engine-release.yml` runs `cargo build --release --bin rocky --bin rocky-lsp`, no `--features` flags). The default was `["duckdb"]`, so the OpenTelemetry export path — the OTLP tracer layer in `rocky-observe::tracing_setup` and the metrics exporter behind `OtelGuard` — was compiled out of every shipped binary. Setting `OTEL_EXPORTER_OTLP_ENDPOINT` was a silent no-op on release builds.

The export code is gated on `rocky-observe/otel` (and `rocky-cli/otel`, which forwards to it). Neither was reachable from the default feature set, so the `#[cfg(feature = "otel")]` blocks that read `OTEL_EXPORTER_OTLP_ENDPOINT` and install the tracer/exporter never existed in the binary. Flipping the default wires them in.

## Binary size (before / after)

Measured on macOS ARM64, `--release`, same target dir:

| build | `target/release/rocky` |
|---|---|
| baseline (`--no-default-features --features duckdb`) | 71,508,896 bytes |
| otel default (`--features duckdb,otel`) | 71,508,944 bytes |
| **delta** | **+48 bytes** |

The growth is negligible: the OpenTelemetry / tonic / OTLP crates are already pulled into the build by other workspace crates, so activating the feature adds no measurable size. Well under the 20 MB stop-threshold.

## Reachability (real binary end-to-end)

Built the release binary with the new default, ran a one-off collector:

```
docker run -d -p 4317:4317 -v <config>:/etc/otelcol/config.yaml otel/opentelemetry-collector:0.114.0
```

(config: OTLP gRPC receiver on 4317 → `debug` exporter, `verbosity: detailed`.)

Then ran the `examples/playground` default transformation POC (3 models) with the release binary and `OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317`. The run succeeded (`status: Success`, exit 0, clean export — no connection errors) and the collector logged a connected trace with `service.name=rocky`:

```
     -> service.name: Str(rocky)
ResourceSpans #0
ScopeSpans #0
    Trace ID       : c65efd7e2a5df0793dfb569685897d53
    Name           : execute_models
    Trace ID       : c65efd7e2a5df0793dfb569685897d53
    Name           : run_transformation
    Trace ID       : c65efd7e2a5df0793dfb569685897d53
    Name           : run
```

`run` is the root pipeline-run span; `run_transformation` and `execute_models` are its children (single trace id). Per-model `materialize.table` spans are emitted by the concurrent DAG executor path, which this sequential transformation POC does not exercise.

The metrics exporter lands too — the same run flushed these to the collector under `service.name=rocky`:

```
     -> Name: rocky.tables_processed
     -> Name: rocky.tables_failed
     -> Name: rocky.statements_executed
     -> Name: rocky.retries_attempted
     -> Name: rocky.retries_succeeded
     -> Name: rocky.anomalies_detected
     -> Name: rocky.error_rate_pct
```

## Zero-cost when unset

Ran the same POC with the release binary and **no** `OTEL_EXPORTER_OTLP_ENDPOINT`: `status: Success`, exit 0, zero OTLP/exporter/connection lines on stderr, zero WARN/ERROR lines. `OtelGuard::init_if_enabled` and the tracing-setup otel block both short-circuit when the env var is absent, so there is no OTLP connection attempt and no new startup cost.

## CI impact

`rg "no-default-features"` finds no CI job that relies on the old default. `engine-ci.yml` already runs tests and clippy with `--all-features` (otel exercised), and the `release-build-smoke` job only guards the `valkey` dep-edge (unaffected — this change adds `otel`, it does not drop `duckdb`/`valkey`).

## Gates (from `engine/`, default features = duckdb,otel)

- `cargo build --release --bin rocky --bin rocky-lsp` — clean
- `cargo fmt --check` — clean
- `cargo clippy --all-targets` — clean (exit 0)
- `cargo test` — passed (exit 0); ~1128 tests. A single timing-sensitive redb write-lock test (`commands::apply::tests::snapshot_sees_freeze_while_write_lock_held_elsewhere`) flaked once under heavy concurrent machine load on a re-run; it passes 4/4 in isolation and is unrelated to this feature flip.

`engine-ci.yml` additionally runs clippy + tests with `--all-features`, which already exercises `otel`.

## Changelog

Added under `[Unreleased] / Fixed`.
