### PR TITLE
feat(engine): WP-01 PR-A — typed StateAuthority across the state download boundary

### DIFF
--- a/docs/adr/ADR-AUTHORITY.md
+++ b/docs/adr/ADR-AUTHORITY.md
@@ -1,7 +1,7 @@
 # ADR-AUTHORITY — Typed remote-state authority (RD-001)
 
 **ADR:** WP-01 / PR-A
-**Status:** **Proposed** — PR-0 design gate. This ADR blocks implementation; no code lands until it is signed off. It is the keystone of the WP-01 remote-state redesign and is engineered to land **standalone** ahead of the `RemoteStateSession` spine (PR-B).
+**Status:** **Accepted** — signed off; PR-A implements §1–§4 + §6 (§5 is deferred to PR-B). It is the keystone of the WP-01 remote-state redesign and is engineered to land **standalone** ahead of the `RemoteStateSession` spine (PR-B).
 
 ---
 

--- a/docs/adr/ADR-CONCURRENCY.md
+++ b/docs/adr/ADR-CONCURRENCY.md
@@ -1,6 +1,6 @@
 # ADR-CONCURRENCY — Cross-pod remote-state concurrency + freeze kill-switch
 
-**Status:** Proposed (PR-0 design gate — stops for maintainer sign-off before any implementation)
+**Status:** Accepted (signed off at the PR-0 design gate; implemented by the later WP-01 PRs)
 
 **Scope:** WP-01 fast-follow (PR-C consistent snapshot → PR-D CAS) plus the spine-urgent PR-F freeze marker. Closes audit finding **RD-002** (Critical, active) and the **#1120** freeze-erasure residual. Companion docs: **ADR-AUTHORITY** (RD-001 — the `StateAuthority` type this ADR's writer-class refusal reports through) and **ADR-STATE-SESSION** (PR-B — the `RemoteStateSession` spine whose `finalize` write choke-point and `base` `Generation` field this ADR's CAS hooks into). Read both first.
 

--- a/docs/adr/ADR-STATE-SESSION.md
+++ b/docs/adr/ADR-STATE-SESSION.md
@@ -1,6 +1,6 @@
 # ADR-STATE-SESSION — `RemoteStateSession`, config-snapshot threading, bypass closure, and governance-from-gated-snapshot (#1093)
 
-**Status:** Proposed (PR-0 design gate — stop for maintainer sign-off before implementation)
+**Status:** Accepted (signed off at the PR-0 design gate; implemented by PR-B)
 
 **Work package:** WP-01 (remote-state protocol redesign) · **PR-B (Spine)**
 **Closes:** audit finding **RD-003** (state-sync bypass), issue **#1120** (config-swap TOCTOU), issue **#1093** (governance reconcile fresh-compiles from disk)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,4 +18,4 @@ Staging: **spine-first** (PR-A → PR-B → PR-F) then the CAS **fast-follow** (
 
 These ADRs went through three adversarial review rounds (a strategic-plan red team, an independent per-ADR second review, and a red team over the implementation plan); the corrections from all three are folded in.
 
-These three ADRs were authored under adversarial review (Codex, 10 findings dispositioned) and a cross-consistency pass. **Status: Proposed — awaiting sign-off before implementation.**
+These three ADRs were authored under adversarial review (Codex, 10 findings dispositioned) and a cross-consistency pass. **Status: Accepted (2026-07-17) — implementation in progress.**

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1780,6 +1780,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "googleapis-tonic-google-api"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4152,6 +4158,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "trybuild",
  "url",
  "wiremock",
 ]
@@ -5205,6 +5212,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5215,6 +5228,15 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -5735,6 +5757,21 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06649c6f63d86604ba0c8950d5a1829fc9a17afd70fc6629f481d75b6a624c78"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
+]
 
 [[package]]
 name = "twox-hash"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -210,6 +210,9 @@ wasm-bindgen = "0.2"
 
 # Testing
 wiremock = "0.6"
+# Compile-fail guard: pins the `#[must_use]`-through-`?` lint mechanism the
+# remote-state authority seams rely on (rocky-core/tests/must_use_guard.rs).
+trybuild = "1"
 
 # UUID v4 — used by Snowflake stage-name generation to avoid collisions on
 # parallel loads. `SystemTime::now().subsec_nanos()` resolves to

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -655,6 +655,9 @@ async fn execute_run_plan(
         Some(apply_run_id),
         // Governance context: the in-run TOCTOU reject + replication gate.
         governed_ctx,
+        // `--assume-fresh-state` is a `rocky run` runtime flag, never part of
+        // a persisted plan — the two-step apply path always runs without it.
+        false,
     )
     .await
     .with_context(|| format!("rocky apply run plan '{plan_id}' failed"))?;
@@ -826,7 +829,10 @@ pub(crate) async fn sync_remote_ledger_before_gate(
     let Some(state_cfg) = remote_state_backend_for_gate(cfg, touched) else {
         return Ok(());
     };
-    rocky_core::state_sync::download_state(&state_cfg, state_path)
+    // PR-A (RD-001): bind the typed authority — a successful download of either
+    // usable variant means the local ledger now mirrors remote truth; failure
+    // still `?`-bails fail-closed (unchanged). PR-B branches on the value.
+    let _authority = rocky_core::state_sync::download_state(&state_cfg, state_path)
         .await
         .with_context(|| {
             "failed to download remote state before the agent-policy gate; a remote-backend \
@@ -851,9 +857,10 @@ fn sync_remote_ledger_before_gate_blocking(
     let Some(state_cfg) = remote_state_backend_for_gate(cfg, touched) else {
         return Ok(());
     };
-    crate::commands::policy::block_on_state_sync(rocky_core::state_sync::download_state(
-        &state_cfg, state_path,
-    ))
+    // PR-A (RD-001): bind the typed authority — see `sync_remote_ledger_before_gate`.
+    let _authority = crate::commands::policy::block_on_state_sync(
+        rocky_core::state_sync::download_state(&state_cfg, state_path),
+    )
     .with_context(|| {
         "failed to download remote state before the promote policy gate; a remote-backend \
          governed promote requires the state backend reachable so a cross-pod freeze/budget \
@@ -881,7 +888,8 @@ pub(crate) async fn download_remote_ledger_unconditional(
     if matches!(cfg.state.backend, StateBackend::Local) {
         return Ok(());
     }
-    rocky_core::state_sync::download_state(&cfg.state, state_path)
+    // PR-A (RD-001): bind the typed authority — see `sync_remote_ledger_before_gate`.
+    let _authority = rocky_core::state_sync::download_state(&cfg.state, state_path)
         .await
         .with_context(|| {
             format!(
@@ -2840,6 +2848,9 @@ async fn run_apply_replication_plan(
         // Replication apply has no `verify_after` gate; mint the usual id.
         None,
         governed.as_ref(),
+        // `--assume-fresh-state` is a `rocky run` runtime flag, never part of
+        // a persisted plan — the replication apply path always runs without it.
+        false,
     )
     .await
     .with_context(|| format!("rocky apply replication plan '{plan_id}' failed"))?;
@@ -3222,6 +3233,7 @@ pub async fn run_apply_inline_for_run(
     defer_opts: &crate::commands::run::DeferOptions,
     skip_opts: &crate::commands::run::SkipRunOptions,
     run_vars: &rocky_core::run_vars::RunVars,
+    assume_fresh_state: bool,
 ) -> Result<()> {
     // Thin passthrough — routes to the existing run implementation.
     crate::commands::run::run(
@@ -3249,6 +3261,9 @@ pub async fn run_apply_inline_for_run(
         None,
         // Inline `rocky run` is never a governed two-step apply — no gate.
         None,
+        // `--assume-fresh-state` threads through from the CLI (main.rs
+        // validated it against the configured `[state]` backend).
+        assume_fresh_state,
     )
     .await
 }

--- a/engine/crates/rocky-cli/src/commands/drift_governance.rs
+++ b/engine/crates/rocky-cli/src/commands/drift_governance.rs
@@ -1168,6 +1168,38 @@ mod tests {
             matches!(d2, GovernDecision::Apply),
             "the same grant on an authoritative ledger must apply"
         );
+
+        // Download-failure origin (PR-A / RD-001, derivation parity): derive
+        // `ledger_authoritative` exactly as `run()` does — an ungoverned run's
+        // failed download resolves to `Indeterminate`, whose `is_usable()` is
+        // false — and the governor must refuse just like the literal `false`
+        // above. This pins the elect-past `Err` path to the same fail-closed
+        // refusal as the forward-incompat origin.
+        let authority = crate::commands::run::resolve_replication_authority(
+            Err(rocky_core::state_sync::StateSyncError::S3Download(
+                "injected (test)".into(),
+            )),
+            /* governed_with_policy */ false,
+            /* assume_fresh_state */ false,
+        )
+        .expect("an ungoverned run continues past a failed download");
+        // The run.rs derivation with `was_recreated_for_forward_incompat()`
+        // false: authority alone decides.
+        let ledger_authoritative = authority.is_usable();
+        assert!(!ledger_authoritative);
+        let gov_dl = DriftGovernor::build(&cfg, "run-dl", "wh.raw.orders", ledger_authoritative)
+            .expect("governor");
+        let (store3, _d3) = temp_store();
+        let d3 = gov_dl
+            .govern(&additive_add_drift(), "wh.raw.orders", &Arc::new(store3))
+            .await;
+        let GovernDecision::Refuse(reason) = d3 else {
+            panic!("a download-failure (Indeterminate) ledger must refuse the auto-apply");
+        };
+        assert!(
+            reason.contains("non-authoritative"),
+            "refusal must cite the non-authoritative ledger: {reason}"
+        );
     }
 
     /// 🔴 D6 regression: freeze composition records the tightened policy

--- a/engine/crates/rocky-cli/src/commands/gc.rs
+++ b/engine/crates/rocky-cli/src/commands/gc.rs
@@ -1527,7 +1527,11 @@ pub(crate) async fn run_gc_apply_in_with(
         .unwrap_or_default();
     let remote_state = !matches!(state_cfg.backend, StateBackend::Local);
     if remote_state {
-        rocky_core::state_sync::download_state(&state_cfg, state_path)
+        // PR-A (RD-001): bind the typed authority — a successful download of
+        // either usable variant means the local ledger now mirrors remote
+        // truth; failure still `?`-bails fail-closed (unchanged). PR-B
+        // branches on the value.
+        let _authority = rocky_core::state_sync::download_state(&state_cfg, state_path)
             .await
             .with_context(|| {
                 "failed to download remote state before gc apply; a remote-backend gc apply \

--- a/engine/crates/rocky-cli/src/commands/policy.rs
+++ b/engine/crates/rocky-cli/src/commands/policy.rs
@@ -351,9 +351,10 @@ fn serde_plain<T: serde::Serialize>(value: &T) -> String {
 /// ([`crate::commands::apply::gate_promote_plan`]) — reached from two async
 /// entry points — can pull remote state before it reads the freeze ledger,
 /// without threading an async download through each caller.
-pub(crate) fn block_on_state_sync<F>(fut: F) -> Result<(), rocky_core::state_sync::StateSyncError>
+pub(crate) fn block_on_state_sync<T, F>(fut: F) -> Result<T, rocky_core::state_sync::StateSyncError>
 where
-    F: std::future::Future<Output = Result<(), rocky_core::state_sync::StateSyncError>> + Send,
+    T: Send,
+    F: std::future::Future<Output = Result<T, rocky_core::state_sync::StateSyncError>> + Send,
 {
     std::thread::scope(|scope| {
         scope
@@ -468,7 +469,11 @@ pub fn run_policy_freeze(
     // (overwriting the local file) BEFORE opening the store, so the freeze is
     // recorded on top of other pods' decisions rather than over an empty local.
     if remote_state {
-        block_on_state_sync(rocky_core::state_sync::download_state(
+        // PR-A (RD-001): bind the typed authority — a successful download of
+        // either usable variant means the local ledger now mirrors remote
+        // truth; failure still `?`-bails fail-closed (unchanged). PR-B
+        // branches on the value.
+        let _authority = block_on_state_sync(rocky_core::state_sync::download_state(
             &state_cfg, state_path,
         ))
         .with_context(|| {

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1105,6 +1105,67 @@ pub(crate) fn refuse_governed_side_effects(
     Ok(())
 }
 
+/// Fold the replication run's remote-state download result into a typed
+/// [`StateAuthority`] — the ONE site where `Indeterminate` may be synthesized.
+///
+/// `download_state` never returns `Indeterminate` (failure stays `Err`, the F7
+/// safe-standalone property); a caller that elects to continue past a download
+/// `Err` must do so explicitly, and this is that election:
+///
+/// - `Ok(authority)` passes through unchanged;
+/// - `Err` + `governed_with_policy` — the existing #1089 fail-closed bail: a
+///   governed run with a `[policy]` plane cannot see a cross-pod freeze/budget
+///   from stale local state;
+/// - `Err` + `assume_fresh_state` — the audited operator escape hatch (§6):
+///   treat the failure as an *intentional* fresh start (disaster recovery,
+///   the remote is known-gone) and emit a structured audit warn;
+/// - `Err` otherwise — continue in degraded mode with an explicitly
+///   non-authoritative ledger: auto-applies are refused and both state uploads
+///   are suppressed downstream.
+///
+/// The governed bail deliberately takes precedence over `assume_fresh_state`:
+/// an operator assertion must not un-gate a governed run's fail-closed check.
+pub(crate) fn resolve_replication_authority(
+    download: Result<
+        rocky_core::state_sync::StateAuthority,
+        rocky_core::state_sync::StateSyncError,
+    >,
+    governed_with_policy: bool,
+    assume_fresh_state: bool,
+) -> Result<rocky_core::state_sync::StateAuthority> {
+    use rocky_core::state_sync::StateAuthority;
+    match download {
+        Ok(authority) => Ok(authority),
+        Err(e) => {
+            // #2 (red-team): a GOVERNED run whose remote-state download failed
+            // cannot see a cross-pod freeze/budget recorded by another pod. If a
+            // `[policy]` plane is configured (the in-run gate WILL consult
+            // POLICY_DECISIONS), fail-closed rather than evaluate the freeze from
+            // stale local state and fail OPEN. With no `[policy]` there is nothing
+            // to enforce, so continue — same as an ungoverned run, no availability
+            // regression (red-team #8's no-policy false-abort avoided).
+            if governed_with_policy {
+                anyhow::bail!(
+                    "refusing a governed run: remote state download failed ({e}), so a \
+                     cross-pod freeze/budget in the durable state ledger cannot be seen \
+                     (fail-closed). Retry once the `[state]` backend is reachable."
+                );
+            }
+            if assume_fresh_state {
+                tracing::warn!(
+                    target: "rocky::state_authority",
+                    reason = %e,
+                    "operator asserted --assume-fresh-state: treating failed download as an \
+                     intentional fresh start"
+                );
+                return Ok(StateAuthority::FreshStart);
+            }
+            warn!(error = %e, "state download failed, continuing with local state");
+            Ok(StateAuthority::Indeterminate)
+        }
+    }
+}
+
 /// Execute `rocky run` — full pipeline.
 #[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip_all, name = "run", fields(run_id))]
@@ -1166,6 +1227,13 @@ pub async fn run(
     // (TOCTOU models-drift reject + post-discovery replication gate) are
     // skipped and behaviour is byte-identical. See [`GovernedRunContext`].
     governed_ctx: Option<&crate::commands::apply::GovernedRunContext<'_>>,
+    // `--assume-fresh-state`: audited disaster-recovery escape hatch. When a
+    // configured remote `[state]` download fails, treat it as an *intentional*
+    // fresh start (`StateAuthority::FreshStart`) instead of the fail-closed
+    // `Indeterminate`. Caller-validated remote-only (main.rs rejects it on the
+    // Local backend); it never overrides the governed fail-closed bail. See
+    // [`resolve_replication_authority`].
+    assume_fresh_state: bool,
 ) -> Result<()> {
     // With `-o json` stdout is reserved for the JSON payload — route any
     // human-readable summary/progress line (e.g. a `depends_on` upstream
@@ -1642,34 +1710,17 @@ pub async fn run(
     let pattern = pipeline.schema_pattern()?;
     let parsed_filter = filter.map(parse_filter).transpose()?;
 
-    // Download state from remote storage (S3/GCS/Valkey) if configured.
-    // A no-op `Ok(())` when no remote is configured; an `Err` when a configured
-    // remote download failed — in which case the local ledger may be missing
-    // freeze/budget history recorded by another pod, so it is not authoritative
-    // for the auto-apply governor below (fail-closed).
-    let state_download_ok = match rocky_core::state_sync::download_state(&rocky_cfg.state, state_path)
-        .await
-    {
-        Ok(()) => true,
-        Err(e) => {
-            // #2 (red-team): a GOVERNED run whose remote-state download failed
-            // cannot see a cross-pod freeze/budget recorded by another pod. If a
-            // `[policy]` plane is configured (the in-run gate WILL consult
-            // POLICY_DECISIONS), fail-closed rather than evaluate the freeze from
-            // stale local state and fail OPEN. With no `[policy]` there is nothing
-            // to enforce, so continue — same as an ungoverned run, no availability
-            // regression (red-team #8's no-policy false-abort avoided).
-            if exec_fp_gate.is_some() && rocky_cfg.policy.is_some() {
-                anyhow::bail!(
-                    "refusing a governed run: remote state download failed ({e}), so a \
-                     cross-pod freeze/budget in the durable state ledger cannot be seen \
-                     (fail-closed). Retry once the `[state]` backend is reachable."
-                );
-            }
-            warn!(error = %e, "state download failed, continuing with local state");
-            false
-        }
-    };
+    // Download state from remote storage (S3/GCS/Valkey) if configured. The
+    // typed [`StateAuthority`] answers "may the local ledger back a governed
+    // decision?": `Authoritative` (remote restored, or the Local backend's
+    // on-disk truth), `FreshStart` (no remote object — a genuine bootstrap), or
+    // the caller-synthesized `Indeterminate` when an ungoverned run elects to
+    // continue past a failed download (see [`resolve_replication_authority`]).
+    let authority = resolve_replication_authority(
+        rocky_core::state_sync::download_state(&rocky_cfg.state, state_path).await,
+        exec_fp_gate.is_some() && rocky_cfg.policy.is_some(),
+        assume_fresh_state,
+    )?;
 
     // Build adapter registry and resolve adapters
     let adapter_registry = AdapterRegistry::from_config(&rocky_cfg)?;
@@ -1703,21 +1754,30 @@ pub async fn run(
             state_path.display()
         ))?;
 
-    // When the on-disk state was forward-incompatible (newer schema than this
-    // binary) and `on_schema_mismatch = recreate`, the store was bootstrapped
-    // fresh locally. We must NOT write that downgraded state back to a shared
-    // remote tier — doing so would clobber the newer state that already-upgraded
-    // pods depend on. Suppress both the periodic and the end-of-run upload.
-    let suppress_state_upload = state_store.was_recreated_for_forward_incompat();
+    // Suppress both the periodic and the end-of-run upload when either:
+    // - the on-disk state was forward-incompatible (newer schema than this
+    //   binary) and `on_schema_mismatch = recreate` bootstrapped it fresh —
+    //   writing that downgraded state back would clobber the newer state
+    //   already-upgraded pods depend on; or
+    // - the download authority is `Indeterminate` (an ungoverned run elected
+    //   past a failed download) — pushing the local ledger over a remote this
+    //   run could not read would be a blind last-writer-wins over unseen state.
+    // Both upload paths key on this variable: the periodic uploader's spawn
+    // gate and the terminal `upload_state_unless_recreated` call.
+    let suppress_state_upload =
+        state_store.was_recreated_for_forward_incompat() || !authority.is_usable();
 
     // The decision ledger is authoritative for the auto-apply governor only
-    // when it carries the estate's real freeze/budget history: the store was
-    // NOT bootstrapped fresh for a forward-incompatible schema, AND any
-    // configured remote download succeeded. When it is non-authoritative an
-    // active freeze / exhausted budget recorded elsewhere would be invisible,
-    // so the governor refuses every auto-apply (fail-closed).
+    // when it carries the estate's real freeze/budget history: the download
+    // authority is usable (`Authoritative` or `FreshStart`), AND the store was
+    // NOT bootstrapped fresh for a forward-incompatible schema. When it is
+    // non-authoritative an active freeze / exhausted budget recorded elsewhere
+    // would be invisible, so the governor refuses every auto-apply
+    // (fail-closed). The forward-incompat fact stays a caller-side AND: it is
+    // a property of the `StateStore` opened above, known only after the
+    // download resolved its authority.
     let ledger_authoritative =
-        !state_store.was_recreated_for_forward_incompat() && state_download_ok;
+        authority.is_usable() && !state_store.was_recreated_for_forward_incompat();
 
     // Discover sources
     let discovery_result = async {
@@ -4242,11 +4302,13 @@ pub async fn run(
     )
     .await;
 
-    // Upload state to remote storage — unless this store was bootstrapped
-    // fresh from a forward-incompatible on-disk schema. In that case the local
+    // Upload state to remote storage — unless suppressed: the store was
+    // bootstrapped fresh from a forward-incompatible on-disk schema (the local
     // state is a downgrade; persisting it back would clobber the newer state
-    // that already-upgraded pods depend on, so the upload is deliberately
-    // skipped (the periodic mid-run uploader above is gated by the same flag).
+    // that already-upgraded pods depend on), or the download authority was
+    // `Indeterminate` (pushing local state over a remote this run could not
+    // read would be a blind last-writer-wins over unseen state). The periodic
+    // mid-run uploader above is gated by the same flag.
     if let Err(e) = rocky_core::state_sync::upload_state_unless_recreated(
         suppress_state_upload,
         &rocky_cfg.state,
@@ -9412,6 +9474,79 @@ mod tests {
     use super::*;
     use rocky_core::plan_partition::PartitionSelection;
 
+    // -------------------------------------------------------------------
+    // PR-A (RD-001) — `resolve_replication_authority`, the ONE site where
+    // `Indeterminate` may be synthesized.
+    // -------------------------------------------------------------------
+
+    use rocky_core::state_sync::{StateAuthority, StateSyncError};
+
+    fn injected_download_failure() -> Result<StateAuthority, StateSyncError> {
+        Err(StateSyncError::S3Download("injected (test)".into()))
+    }
+
+    /// Governed (`exec_fp_gate` + `[policy]`) + failed download ⇒ the existing
+    /// #1089 fail-closed bail, message text unchanged.
+    #[test]
+    fn resolve_authority_governed_failure_bails() {
+        let err = resolve_replication_authority(injected_download_failure(), true, false)
+            .expect_err("a governed run must fail closed on a failed download");
+        assert!(
+            err.to_string()
+                .contains("refusing a governed run: remote state download failed"),
+            "the #1089 bail text must be preserved; got: {err:#}"
+        );
+    }
+
+    /// Ungoverned + failed download ⇒ continue in degraded mode with an
+    /// explicitly non-authoritative (`Indeterminate`) ledger.
+    #[test]
+    fn resolve_authority_ungoverned_failure_is_indeterminate() {
+        let authority = resolve_replication_authority(injected_download_failure(), false, false)
+            .expect("an ungoverned run continues past a failed download");
+        assert_eq!(authority, StateAuthority::Indeterminate);
+        assert!(!authority.is_usable(), "Indeterminate is fail-closed");
+    }
+
+    /// A successful download passes its authority through untouched.
+    #[test]
+    fn resolve_authority_success_passthrough() {
+        for authority in [StateAuthority::Authoritative, StateAuthority::FreshStart] {
+            assert_eq!(
+                resolve_replication_authority(Ok(authority), false, false).unwrap(),
+                authority
+            );
+            // The governed flag is irrelevant on the Ok path.
+            assert_eq!(
+                resolve_replication_authority(Ok(authority), true, false).unwrap(),
+                authority
+            );
+        }
+    }
+
+    /// `--assume-fresh-state` + failed download ⇒ the audited operator escape
+    /// hatch synthesizes a trusted `FreshStart` instead of `Indeterminate`.
+    #[test]
+    fn resolve_authority_assume_fresh_synthesizes_fresh_start() {
+        let authority = resolve_replication_authority(injected_download_failure(), false, true)
+            .expect("--assume-fresh-state elects past the failed download");
+        assert_eq!(authority, StateAuthority::FreshStart);
+        assert!(authority.is_usable(), "an asserted fresh start is trusted");
+    }
+
+    /// The governed fail-closed bail takes precedence: an operator assertion
+    /// must not un-gate a governed run whose download failed.
+    #[test]
+    fn resolve_authority_assume_fresh_does_not_override_governed_bail() {
+        let err = resolve_replication_authority(injected_download_failure(), true, true)
+            .expect_err("--assume-fresh-state must not override the governed bail");
+        assert!(
+            err.to_string()
+                .contains("refusing a governed run: remote state download failed"),
+            "the #1089 bail text must be preserved; got: {err:#}"
+        );
+    }
+
     /// A recording [`GovernanceAdapter`] that captures every
     /// `write_recipe_manifest` call — the coverage-proof analogue of the
     /// `set_tags`-recording `CountingGovernance` mock below.
@@ -10312,8 +10447,9 @@ adapter = "default"
             &DeferOptions::default(),
             &SkipRunOptions::default(),
             &rocky_core::run_vars::RunVars::new(),
-            None, // no run_id override — mint the usual timestamp id
-            None, // no governance ctx (test)
+            None,  // no run_id override — mint the usual timestamp id
+            None,  // no governance ctx (test)
+            false, // assume_fresh_state (test)
         )
         .await
         .expect("transformation run should succeed");
@@ -10421,8 +10557,9 @@ schema = "mart"
             &DeferOptions::default(),
             &SkipRunOptions::default(),
             &rocky_core::run_vars::RunVars::new(),
-            None, // no run_id override — mint the usual timestamp id
-            None, // no governance ctx (test)
+            None,  // no run_id override — mint the usual timestamp id
+            None,  // no governance ctx (test)
+            false, // assume_fresh_state (test)
         )
         .await
         .expect(

--- a/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
+++ b/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
@@ -92,6 +92,8 @@ fn default_sub_runner() -> SubRunner {
                     None,
                     // DAG sub-runs are not governed two-step applies — no gate.
                     None,
+                    // `--assume-fresh-state` is not surfaced on the DAG path.
+                    false,
                 )
                 .await
                 .map_err(|e| e.to_string())

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -1091,8 +1091,9 @@ mod tests {
             &DeferOptions::default(),
             &skip_opts,
             &rocky_core::run_vars::RunVars::new(),
-            None, // no run_id override — mint the usual timestamp id
-            None, // no governance ctx (test)
+            None,  // no run_id override — mint the usual timestamp id
+            None,  // no governance ctx (test)
+            false, // assume_fresh_state (test)
         )
         .await
         .expect("full-DAG transformation run should succeed");
@@ -1278,8 +1279,9 @@ auto_create_schemas = true
             &DeferOptions::default(),
             &SkipRunOptions::default(),
             &rocky_core::run_vars::RunVars::new(),
-            None, // no run_id override — mint the usual timestamp id
-            None, // no governance ctx (test)
+            None,  // no run_id override — mint the usual timestamp id
+            None,  // no governance ctx (test)
+            false, // assume_fresh_state (test)
         )
         .await
         .expect("full-DAG transformation run with idempotency key should succeed");
@@ -1436,8 +1438,9 @@ auto_create_schemas = true
             &DeferOptions::default(),
             &SkipRunOptions::default(),
             &rocky_core::run_vars::RunVars::new(),
-            None, // no run_id override — mint the usual timestamp id
-            None, // no governance ctx (test)
+            None,  // no run_id override — mint the usual timestamp id
+            None,  // no governance ctx (test)
+            false, // assume_fresh_state (test)
         )
         .await
         .expect("model-only run must reach the governance.tags apply path and succeed");
@@ -1512,8 +1515,9 @@ auto_create_schemas = true
             &DeferOptions::default(),
             &SkipRunOptions::default(),
             &rocky_core::run_vars::RunVars::new(),
-            None, // no run_id override — mint the usual timestamp id
-            None, // no governance ctx (test)
+            None,  // no run_id override — mint the usual timestamp id
+            None,  // no governance ctx (test)
+            false, // assume_fresh_state (test)
         )
         .await;
 

--- a/engine/crates/rocky-cli/src/commands/run_watch.rs
+++ b/engine/crates/rocky-cli/src/commands/run_watch.rs
@@ -292,6 +292,9 @@ async fn iter_once(
         None,
         // `--watch` is a dev loop, never a governed two-step apply — no gate.
         None,
+        // `--assume-fresh-state` is not surfaced on the watch path (clap
+        // rejects the combination at parse time).
+        false,
     )
     .await;
     let elapsed_ms = started.elapsed().as_millis();

--- a/engine/crates/rocky-cli/tests/remote_state_authority.rs
+++ b/engine/crates/rocky-cli/tests/remote_state_authority.rs
@@ -1,0 +1,248 @@
+//! WP-01 PR-A integration tests: the replication run's typed remote-state
+//! authority (RD-001).
+//!
+//! Drives the REAL `commands::run` replication path end-to-end against a temp
+//! DuckDB project, with the PR-1 remote-state rig — a fault-injecting
+//! in-memory "S3" installed as the process-global provider override — standing
+//! in for the `[state] backend = "s3"` remote. Each test holds
+//! `remote_testing::serial_guard()` because the override is process-global.
+//!
+//! What is pinned here:
+//! - an UNGOVERNED run that elects past a failed download (`Indeterminate`)
+//!   suppresses BOTH state uploads (RED before PR-A: the end upload fired);
+//! - a genuine fresh start (`FreshStart`) still bootstraps — the first upload
+//!   is the bootstrap write;
+//! - `--assume-fresh-state` turns a failed download into a trusted fresh
+//!   start: the run proceeds AND uploads;
+//! - the fail-closed seams (policy freeze) keep their existing `?`-bail and
+//!   context message on a failed download.
+
+#![cfg(feature = "duckdb")]
+
+use std::path::{Path, PathBuf};
+
+use rocky_core::fault_store::{FaultMode, FaultOp};
+use rocky_core::state_sync::remote_testing;
+use rocky_core::test_harness::CrossPodHarness;
+use rocky_core::traits::WarehouseAdapter;
+use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+
+/// Seed `raw__acme.orders` in the persistent DuckDB file, dropping the
+/// connection before returning so `rocky run` can reopen the file.
+async fn seed_source(db: &Path) {
+    let a = DuckDbWarehouseAdapter::open(db).expect("seed open");
+    a.execute_statement("CREATE SCHEMA IF NOT EXISTS raw__acme")
+        .await
+        .unwrap();
+    a.execute_statement("DROP TABLE IF EXISTS raw__acme.orders")
+        .await
+        .unwrap();
+    a.execute_statement("CREATE TABLE raw__acme.orders AS SELECT 1 AS id, 'widget' AS name")
+        .await
+        .unwrap();
+}
+
+/// A minimal temp DuckDB replication project with a remote `[state]` backend
+/// (`s3`, resolved to the harness's fault-injecting in-memory store by the
+/// process-global provider override).
+struct TestProject {
+    /// Owned so the temp dir lives (and is cleaned up) with the project.
+    _dir: tempfile::TempDir,
+    config_path: PathBuf,
+    state_path: PathBuf,
+}
+
+impl TestProject {
+    async fn new() -> Self {
+        let dir = tempfile::tempdir().expect("create project temp dir");
+        let db = dir.path().join("wh.duckdb");
+        seed_source(&db).await;
+        let config_path = dir.path().join("rocky.toml");
+        // `catalog_template = "wh"` matches the DuckDB catalog of `wh.duckdb`.
+        std::fs::write(
+            &config_path,
+            format!(
+                r#"
+[adapter]
+type = "duckdb"
+path = "{db}"
+
+[pipeline.poc]
+strategy = "full_refresh"
+
+[pipeline.poc.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.poc.target]
+catalog_template = "wh"
+schema_template = "staging__{{source}}"
+
+[pipeline.poc.target.governance]
+auto_create_schemas = true
+
+[state]
+backend = "s3"
+s3_bucket = "test"
+"#,
+                db = db.display()
+            ),
+        )
+        .expect("write rocky.toml");
+        let state_path = dir.path().join(".rocky-state.redb");
+        Self {
+            _dir: dir,
+            config_path,
+            state_path,
+        }
+    }
+}
+
+/// Drive the real `commands::run` replication path (ungoverned: no plan, no
+/// `[policy]`, no governance context).
+async fn drive_run(
+    config_path: &Path,
+    state_path: &Path,
+    assume_fresh_state: bool,
+) -> anyhow::Result<()> {
+    rocky_cli::commands::run(
+        config_path,
+        None, // filter
+        None, // pipeline_name_arg — single pipeline resolves
+        state_path,
+        None,  // governance_override
+        false, // output_json
+        None,  // models_dir
+        false, // run_all
+        None,  // resume_run_id
+        false, // resume_latest
+        None,  // shadow_config
+        &rocky_cli::commands::PartitionRunOptions::default(),
+        None, // model_name_filter
+        None, // cache_ttl_override
+        None, // idempotency_key
+        None, // env
+        &rocky_cli::commands::DeferOptions::default(),
+        &rocky_cli::commands::SkipRunOptions::default(),
+        &rocky_core::run_vars::RunVars::new(),
+        None, // run_id_override
+        None, // governed_ctx
+        assume_fresh_state,
+    )
+    .await
+}
+
+/// (a) An UNGOVERNED run whose remote-state download fails continues in
+/// degraded mode (current semantics) but must suppress BOTH state uploads —
+/// the periodic spawn and the terminal upload. RED before PR-A: the run
+/// proceeded on the old `state_download_ok = false` bool and the end upload
+/// still fired, blindly pushing local state over a remote it could not read.
+///
+/// `FailAll` (not `FailNext`): the download probe must keep failing however
+/// many times any leg retries it.
+#[tokio::test]
+async fn ungoverned_download_failure_suppresses_all_uploads() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+    let project = TestProject::new().await;
+
+    harness.faults.arm(FaultOp::Head, FaultMode::FailAll);
+
+    drive_run(&project.config_path, &project.state_path, false)
+        .await
+        .expect("an ungoverned run continues past a failed download (degraded mode)");
+
+    harness.faults.clear();
+    assert_eq!(
+        harness.faults.count(FaultOp::Put),
+        0,
+        "an Indeterminate-authority run must suppress BOTH the periodic and the terminal \
+         state upload — never a blind last-writer-wins over an unread remote"
+    );
+}
+
+/// (b) A genuine fresh start (empty remote, download resolves `FreshStart`)
+/// keeps bootstrapping: the run succeeds and the end-of-run upload is the
+/// bootstrap write. Only `Indeterminate` suppresses.
+#[tokio::test]
+async fn fresh_start_bootstrap_still_uploads() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+    let project = TestProject::new().await;
+
+    drive_run(&project.config_path, &project.state_path, false)
+        .await
+        .expect("a fresh-start replication run must succeed");
+
+    assert!(
+        harness.faults.count(FaultOp::Put) >= 1,
+        "a FreshStart run must still perform its bootstrap upload"
+    );
+}
+
+/// (c) `--assume-fresh-state`: an armed download fault + the operator flag ⇒
+/// the run treats the failure as an intentional fresh start — it proceeds AND
+/// its uploads stay enabled (authority is the trusted `FreshStart`, not
+/// `Indeterminate`).
+#[tokio::test]
+async fn assume_fresh_state_proceeds_and_uploads() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+    let project = TestProject::new().await;
+
+    harness.faults.arm(FaultOp::Head, FaultMode::FailAll);
+
+    drive_run(&project.config_path, &project.state_path, true)
+        .await
+        .expect("--assume-fresh-state elects past the failed download");
+
+    harness.faults.clear();
+    assert!(
+        harness.faults.count(FaultOp::Put) >= 1,
+        "an asserted fresh start is trusted: the end-of-run upload must fire"
+    );
+}
+
+/// (d) Seam regression: the pre-gate download seams keep their fail-closed
+/// `?`-bail with the existing context on a failed download — the PR-A
+/// `let _authority` bind is behavior-inert. Pinned through `policy freeze`
+/// (the kill switch), whose download half must abort the command rather than
+/// record a freeze a later remote download would clobber.
+#[test]
+fn policy_freeze_download_failure_fails_closed() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+    let dir = tempfile::tempdir().expect("create freeze temp dir");
+    let config_path = dir.path().join("rocky.toml");
+    std::fs::write(
+        &config_path,
+        "[state]\nbackend = \"s3\"\ns3_bucket = \"test\"\n",
+    )
+    .expect("write rocky.toml");
+    let state_path = dir.path().join(".rocky-state.redb");
+
+    harness.faults.arm(FaultOp::Head, FaultMode::FailAll);
+
+    let err = rocky_cli::commands::run_policy_freeze(
+        &config_path,
+        &state_path,
+        None,  // principal — both
+        None,  // scope — any
+        false, // lift
+        false, // json
+    )
+    .expect_err("a remote-backend freeze must fail closed when the download fails");
+
+    harness.faults.clear();
+    assert!(
+        format!("{err:#}")
+            .contains("failed to download remote state before recording the policy freeze"),
+        "the freeze seam must keep its existing fail-closed context; got: {err:#}"
+    );
+    assert_eq!(
+        harness.faults.count(FaultOp::Put),
+        0,
+        "a refused freeze must not upload anything"
+    );
+}

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -66,6 +66,10 @@ jsonschema = { version = "0.46", default-features = false }
 criterion = { version = "0.8", features = ["html_reports"] }
 # Used by `tests/state_sync_timeout_test.rs` to front-end a hung S3 endpoint.
 wiremock = { workspace = true }
+# Compile-fail guard for the `#[must_use] StateAuthority`-through-`?` lint
+# (`tests/must_use_guard.rs`): proves a discarding `download_state(...)?;`
+# fails to compile under `deny(unused_must_use)`.
+trybuild = { workspace = true }
 
 # The remote-state rig tests need the `test-support` seams. The feature is
 # already on for all test targets via the self-referential dev-dependency;

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -358,11 +358,58 @@ enum DownloadOutcome {
     Absent,
 }
 
+/// Whether a run may trust its local state ledger to back a governed decision.
+///
+/// Returned by [`download_state`] on success. The variants carry the one
+/// distinction every downstream governance gate needs — *authoritative vs.
+/// genuinely-empty vs. don't-know*:
+///
+/// - a download **failure stays `Err(StateSyncError)`** — it is never mapped to
+///   `Ok(Indeterminate)`. [`Indeterminate`][StateAuthority::Indeterminate] is
+///   **caller-synthesized**: it exists only when a caller explicitly elects to
+///   continue past a download `Err`. Keeping failure as `Err` means every
+///   fail-closed `download_state(...)?` seam keeps bailing unchanged — a caller
+///   must make an *explicit* choice to proceed on non-authoritative state.
+#[must_use = "the download's authority decides whether the local ledger may back a governed decision"]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StateAuthority {
+    /// The remote object existed and was restored (or the backend is Local,
+    /// whose on-disk file IS the authority). The ledger reflects durable truth.
+    Authoritative,
+    /// No remote object existed for this key — a genuine fresh start. The
+    /// ledger is trustworthy AND may bootstrap an empty ledger.
+    FreshStart,
+    /// A download / existence-check failure was elected-past by a caller. The
+    /// ledger is NON-authoritative: an active freeze / exhausted budget
+    /// recorded elsewhere may be invisible. Fail-closed.
+    Indeterminate,
+}
+
+impl StateAuthority {
+    /// The ledger may back a governed decision: the download restored the
+    /// authoritative remote or proved a genuine fresh start.
+    /// [`Indeterminate`][StateAuthority::Indeterminate] is NOT usable.
+    #[must_use]
+    pub fn is_usable(self) -> bool {
+        matches!(self, Self::Authoritative | Self::FreshStart)
+    }
+}
+
 /// Downloads state from remote storage to a local file before a run.
 ///
-/// A missing remote object is **non-fatal** (`Ok(())`, a fresh start). A real
-/// download/existence-check *failure* is **propagated** as `Err` so the caller
-/// can fail closed — see [`download_from_object_store`].
+/// Returns the typed [`StateAuthority`] of the local ledger after the download:
+///
+/// - the remote object existed and was restored ⇒ [`StateAuthority::Authoritative`];
+/// - no remote object existed (a genuine fresh start) ⇒ [`StateAuthority::FreshStart`]
+///   — **non-fatal** by design;
+/// - the **Local** backend ⇒ [`StateAuthority::Authoritative`] (the on-disk
+///   file is the single source of truth — see the explicit arm below).
+///
+/// A real download/existence-check *failure* is **propagated** as `Err` so the
+/// caller can fail closed — see [`download_from_object_store`]. It is never
+/// mapped to `Ok(StateAuthority::Indeterminate)`: that variant is synthesized
+/// only by a caller that explicitly elects to continue past an `Err`, so every
+/// fail-closed `download_state(...)?` seam keeps bailing unchanged.
 ///
 /// # Local-only-preserving merge (findings 6 + 7)
 ///
@@ -410,13 +457,23 @@ enum DownloadOutcome {
 /// a live writer's file. Crucially, the local-only tables are re-read from the
 /// CURRENT local file *under the lock*, so a concurrent run's just-committed
 /// `jobs` are captured rather than lost.
-pub async fn download_state(config: &StateConfig, local_path: &Path) -> Result<(), StateSyncError> {
+pub async fn download_state(
+    config: &StateConfig,
+    local_path: &Path,
+) -> Result<StateAuthority, StateSyncError> {
     let remote_key = remote_state_key(local_path);
 
     // Local backend never replaces the file — nothing to stage, merge, or lock.
+    //
+    // Local is `Authoritative`, NOT `FreshStart`: the inner dispatch reports
+    // `Absent` for Local (there is no remote object to restore), but a naive
+    // outcome map would mislabel that as a bootstrappable fresh start. There is
+    // no remote to be "fresh" against — the on-disk redb file IS the single
+    // source of truth and must never be treated as an empty ledger to
+    // bootstrap over.
     if matches!(config.backend, StateBackend::Local) {
         download_state_inner(config, local_path, &remote_key).await?;
-        return Ok(());
+        return Ok(StateAuthority::Authoritative);
     }
 
     // 1. Download the remote into a STAGING file (no lock). `local_path` is left
@@ -448,7 +505,11 @@ pub async fn download_state(config: &StateConfig, local_path: &Path) -> Result<(
 
     drop(lock);
     let _ = std::fs::remove_file(&staged);
-    result
+    result?;
+    Ok(match outcome {
+        DownloadOutcome::Restored => StateAuthority::Authoritative,
+        DownloadOutcome::Absent => StateAuthority::FreshStart,
+    })
 }
 
 /// Acquire the StateStore writer lock for `local_path` (the same lock
@@ -2301,12 +2362,100 @@ mod tests {
         test_support::clear();
 
         assert!(
-            result.is_ok(),
-            "an absent remote object must be a fresh start (Ok); got {result:?}"
+            matches!(result, Ok(StateAuthority::FreshStart)),
+            "an absent remote object must be a fresh start (Ok(FreshStart)); got {result:?}"
         );
         assert!(
             !local.exists(),
             "nothing to restore, so no local file is written"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // PR-A (RD-001) — typed StateAuthority across the download boundary
+    // -----------------------------------------------------------------------
+
+    /// An existing remote object restores and maps to `Ok(Authoritative)`.
+    #[tokio::test]
+    async fn download_maps_restored_to_authoritative() {
+        test_support::clear();
+        let dir = TempDir::new().unwrap();
+        let local = dir.path().join(".rocky-state.redb");
+        let remote_bytes = build_remote_object_bytes(dir.path(), "remote.fresh");
+        let provider = test_support::install(ObjectStoreProvider::in_memory());
+        let key = object_store_state_key(&remote_state_key(&local));
+        provider.put(&key, Bytes::from(remote_bytes)).await.unwrap();
+
+        let config = StateConfig {
+            backend: StateBackend::S3,
+            s3_bucket: Some("bucket".into()),
+            ..Default::default()
+        };
+        let result = download_state(&config, &local).await;
+        test_support::clear();
+        assert!(
+            matches!(result, Ok(StateAuthority::Authoritative)),
+            "a restored remote object must map to Ok(Authoritative); got {result:?}"
+        );
+    }
+
+    /// A genuinely-absent remote object maps to `Ok(FreshStart)`.
+    #[tokio::test]
+    async fn download_maps_absent_to_fresh_start() {
+        test_support::clear();
+        let dir = TempDir::new().unwrap();
+        let local = dir.path().join(".rocky-state.redb");
+        let _provider = test_support::install(ObjectStoreProvider::in_memory());
+
+        let config = StateConfig {
+            backend: StateBackend::S3,
+            s3_bucket: Some("bucket".into()),
+            ..Default::default()
+        };
+        let result = download_state(&config, &local).await;
+        test_support::clear();
+        assert!(
+            matches!(result, Ok(StateAuthority::FreshStart)),
+            "an absent remote object must map to Ok(FreshStart); got {result:?}"
+        );
+    }
+
+    /// The F7 safe-standalone property: a download failure stays `Err` — it is
+    /// NEVER collapsed into `Ok(Indeterminate)`. If it were, every fail-closed
+    /// `download_state(...)?` seam would have its `?` succeed on a failed
+    /// download and silently proceed on stale local state.
+    #[tokio::test]
+    async fn download_failure_stays_err_never_indeterminate() {
+        test_support::clear();
+        let dir = TempDir::new().unwrap();
+        let local = dir.path().join(".rocky-state.redb");
+        let _provider = test_support::install(ObjectStoreProvider::in_memory());
+        test_support::arm_object_store_exists_fault();
+
+        let config = StateConfig {
+            backend: StateBackend::S3,
+            s3_bucket: Some("bucket".into()),
+            ..Default::default()
+        };
+        let result = download_state(&config, &local).await;
+        test_support::clear();
+        assert!(
+            matches!(result, Err(StateSyncError::S3Download(_))),
+            "a failed download must stay Err — never Ok(Indeterminate); got {result:?}"
+        );
+    }
+
+    /// The Local backend maps to `Authoritative`, NOT `FreshStart`: the on-disk
+    /// redb file IS the authority — there is no remote to be "fresh" against,
+    /// and it must never be treated as a bootstrappable empty ledger.
+    #[tokio::test]
+    async fn local_backend_is_authoritative_not_fresh_start() {
+        let config = StateConfig::default();
+        let dir = TempDir::new().unwrap();
+        let result = download_state(&config, &dir.path().join("state.redb")).await;
+        assert!(
+            matches!(result, Ok(StateAuthority::Authoritative)),
+            "the Local backend's on-disk file is the authority; got {result:?}"
         );
     }
 
@@ -2494,10 +2643,15 @@ mod tests {
             s3_bucket: Some("bucket".into()),
             ..Default::default()
         };
-        download_state(&config, &local)
+        let authority = download_state(&config, &local)
             .await
             .expect("restored download should succeed");
         test_support::clear();
+        assert_eq!(
+            authority,
+            StateAuthority::Authoritative,
+            "a restored remote object maps to Authoritative"
+        );
 
         let store = StateStore::open(&local).unwrap();
         assert!(
@@ -2540,10 +2694,15 @@ mod tests {
             s3_bucket: Some("bucket".into()),
             ..Default::default()
         };
-        download_state(&config, &local)
+        let authority = download_state(&config, &local)
             .await
             .expect("an absent remote is a fresh start");
         test_support::clear();
+        assert_eq!(
+            authority,
+            StateAuthority::FreshStart,
+            "an absent remote object maps to FreshStart"
+        );
 
         let store = StateStore::open(&local).unwrap();
         assert!(
@@ -2729,10 +2888,11 @@ mod tests {
             s3_bucket: Some("bucket".into()),
             ..Default::default()
         };
-        download_state(&config, &local)
+        let authority = download_state(&config, &local)
             .await
             .expect("restored download should succeed");
         test_support::clear();
+        assert_eq!(authority, StateAuthority::Authoritative);
 
         let store = StateStore::open(&local).unwrap();
         assert!(
@@ -2823,10 +2983,11 @@ mod tests {
         // Release the lock; a fresh download now applies the remote + preserves
         // the local-only `jobs`.
         drop(held);
-        download_state(&config, &local)
+        let authority = download_state(&config, &local)
             .await
             .expect("download should succeed once the writer lock is free");
         test_support::clear();
+        assert_eq!(authority, StateAuthority::Authoritative);
 
         let store = StateStore::open(&local).unwrap();
         assert!(
@@ -2957,7 +3118,10 @@ mod tests {
         // Pod B: a fresh pod downloads the remote state.
         let dir_b = TempDir::new().unwrap();
         let pod_b = dir_b.path().join(".rocky-state.redb");
-        download_state(&config, &pod_b).await.unwrap();
+        assert_eq!(
+            download_state(&config, &pod_b).await.unwrap(),
+            StateAuthority::Authoritative
+        );
         test_support::clear();
 
         let store = StateStore::open(&pod_b).unwrap();

--- a/engine/crates/rocky-core/src/test_harness.rs
+++ b/engine/crates/rocky-core/src/test_harness.rs
@@ -25,7 +25,7 @@ use crate::fault_store::{FaultHandle, FaultingStore};
 use crate::object_store::ObjectStoreProvider;
 use crate::state::StateStore;
 use crate::state_sync::remote_testing::{GlobalOverrideGuard, install_global};
-use crate::state_sync::{self, StateSyncError};
+use crate::state_sync::{self, StateAuthority, StateSyncError};
 
 /// One simulated ephemeral pod: an isolated temp dir, a pod-local state file
 /// path inside it, and a `StateConfig` pointing at the harness's shared
@@ -98,8 +98,9 @@ impl CrossPodHarness {
     }
 
     /// Run the real [`state_sync::download_state`] for `pod` (staging file,
-    /// writer-lock publish serialization, local-only merge — the whole path).
-    pub async fn download(&self, pod: &Pod) -> Result<(), StateSyncError> {
+    /// writer-lock publish serialization, local-only merge — the whole path),
+    /// propagating the typed [`StateAuthority`] the download resolved.
+    pub async fn download(&self, pod: &Pod) -> Result<StateAuthority, StateSyncError> {
         state_sync::download_state(&pod.cfg, &pod.state_path).await
     }
 

--- a/engine/crates/rocky-core/tests/compile_fail/discarded_authority.rs
+++ b/engine/crates/rocky-core/tests/compile_fail/discarded_authority.rs
@@ -1,0 +1,19 @@
+//! The exact seam shape the remote-state callers use: `download_state(...)?;`
+//! in statement position. The `?` returns a `#[must_use] StateAuthority`
+//! that this statement discards — `deny(unused_must_use)` (CI's
+//! `-D warnings`) must refuse to compile it, forcing every seam to bind the
+//! authority explicitly.
+#![deny(unused_must_use)]
+
+use std::path::Path;
+
+use rocky_core::config::StateConfig;
+use rocky_core::state_sync::StateSyncError;
+
+#[allow(dead_code)]
+async fn seam(cfg: &StateConfig, state_path: &Path) -> Result<(), StateSyncError> {
+    rocky_core::state_sync::download_state(cfg, state_path).await?;
+    Ok(())
+}
+
+fn main() {}

--- a/engine/crates/rocky-core/tests/compile_fail/discarded_authority.stderr
+++ b/engine/crates/rocky-core/tests/compile_fail/discarded_authority.stderr
@@ -1,0 +1,16 @@
+error: unused `StateAuthority` that must be used
+  --> tests/compile_fail/discarded_authority.rs:15:5
+   |
+15 |     rocky_core::state_sync::download_state(cfg, state_path).await?;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the download's authority decides whether the local ledger may back a governed decision
+note: the lint level is defined here
+  --> tests/compile_fail/discarded_authority.rs:6:9
+   |
+ 6 | #![deny(unused_must_use)]
+   |         ^^^^^^^^^^^^^^^
+help: use `let _ = ...` to ignore the resulting value
+   |
+15 |     let _ = rocky_core::state_sync::download_state(cfg, state_path).await?;
+   |     +++++++

--- a/engine/crates/rocky-core/tests/must_use_guard.rs
+++ b/engine/crates/rocky-core/tests/must_use_guard.rs
@@ -1,0 +1,15 @@
+//! Compile-fail guard for the `#[must_use] StateAuthority` boundary.
+//!
+//! The remote-state seam migration relies on one compiler mechanism: a
+//! discarding `download_state(...)?;` in statement position must raise
+//! `unused_must_use`, so under `-D warnings` a caller can never silently drop
+//! the download's authority. This pins that the lint actually fires *through
+//! the `?` operator* — the proof of the mechanism, not a nice-to-have.
+//!
+//! Regenerate the expected diagnostics after a rustc bump changes the wording:
+//! `TRYBUILD=overwrite cargo test -p rocky-core --test must_use_guard`.
+
+#[test]
+fn discarded_authority_fails_to_compile() {
+    trybuild::TestCases::new().compile_fail("tests/compile_fail/*.rs");
+}

--- a/engine/crates/rocky-core/tests/state_sync_cross_pod.rs
+++ b/engine/crates/rocky-core/tests/state_sync_cross_pod.rs
@@ -11,7 +11,7 @@
 
 use chrono::Utc;
 use rocky_core::fault_store::FaultOp;
-use rocky_core::state_sync::{self, remote_testing};
+use rocky_core::state_sync::{self, StateAuthority, remote_testing};
 use rocky_core::test_harness::CrossPodHarness;
 use rocky_ir::WatermarkState;
 
@@ -39,10 +39,15 @@ async fn pod_b_sees_pod_a_watermark() {
     harness.upload(&harness.pod_a).await.expect("pod A upload");
 
     // Pod B: pull the remote and read pod A's watermark.
-    harness
+    let authority = harness
         .download(&harness.pod_b)
         .await
         .expect("pod B download");
+    assert_eq!(
+        authority,
+        StateAuthority::Authoritative,
+        "a restored remote object is Authoritative"
+    );
     let store = harness.open_store(&harness.pod_b);
     assert!(
         store.get_watermark("cat.sch.orders").unwrap().is_some(),
@@ -66,8 +71,15 @@ async fn interleaved_writers_last_writer_wins_documented() {
     let harness = CrossPodHarness::new_s3_like();
 
     // Both pods sync from the same (empty) remote — neither sees the other.
-    harness.download(&harness.pod_a).await.unwrap();
-    harness.download(&harness.pod_b).await.unwrap();
+    assert_eq!(
+        harness.download(&harness.pod_a).await.unwrap(),
+        StateAuthority::FreshStart,
+        "an empty remote is a genuine fresh start"
+    );
+    assert_eq!(
+        harness.download(&harness.pod_b).await.unwrap(),
+        StateAuthority::FreshStart
+    );
 
     // Pod A writes and uploads first...
     {
@@ -85,7 +97,10 @@ async fn interleaved_writers_last_writer_wins_documented() {
 
     // A fresh download now serves pod B's file wholesale: pod A's watermark
     // is gone from the shared remote.
-    harness.download(&harness.pod_a).await.unwrap();
+    assert_eq!(
+        harness.download(&harness.pod_a).await.unwrap(),
+        StateAuthority::Authoritative
+    );
     let store = harness.open_store(&harness.pod_a);
     assert!(
         store.get_watermark("cat.sch.from_b").unwrap().is_some(),
@@ -138,10 +153,13 @@ async fn global_override_visible_across_threads() {
     );
 
     // ...and this thread can download what that thread uploaded.
-    harness
-        .download(&harness.pod_b)
-        .await
-        .expect("pod B download");
+    assert_eq!(
+        harness
+            .download(&harness.pod_b)
+            .await
+            .expect("pod B download"),
+        StateAuthority::Authoritative
+    );
     let store = harness.open_store(&harness.pod_b);
     assert!(
         store

--- a/engine/crates/rocky-core/tests/state_sync_live_store.rs
+++ b/engine/crates/rocky-core/tests/state_sync_live_store.rs
@@ -81,10 +81,14 @@ async fn download_publish_waits_for_writer_release() {
     .await;
 
     // Writer released — the download's remaining lock retries can publish.
-    download
-        .await
-        .expect("download task join")
-        .expect("download must succeed once the writer releases within the retry budget");
+    assert_eq!(
+        download
+            .await
+            .expect("download task join")
+            .expect("download must succeed once the writer releases within the retry budget"),
+        rocky_core::state_sync::StateAuthority::Authoritative,
+        "the seeded remote object restores as Authoritative"
+    );
 
     let store = harness.open_store(&harness.pod_b);
     assert!(

--- a/engine/crates/rocky-core/tests/state_sync_s3_live.rs
+++ b/engine/crates/rocky-core/tests/state_sync_s3_live.rs
@@ -123,9 +123,13 @@ async fn live_round_trip() {
     // "Pod B": download into a fresh dir and read it back.
     let down_dir = tempfile::tempdir().unwrap();
     let down_path = down_dir.path().join(".rocky-state.redb");
-    download_state(&cfg, &down_path)
-        .await
-        .expect("live download");
+    assert_eq!(
+        download_state(&cfg, &down_path)
+            .await
+            .expect("live download"),
+        rocky_core::state_sync::StateAuthority::Authoritative,
+        "the just-uploaded object must restore as Authoritative"
+    );
     {
         let store = StateStore::open(&down_path).unwrap();
         assert!(

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -2400,7 +2400,11 @@ impl RockyMcpServer {
             && !touched.is_empty()
             && !matches!(cfg.state.backend, rocky_core::config::StateBackend::Local)
         {
-            rocky_core::state_sync::download_state(&cfg.state, &state_path)
+            // PR-A (RD-001): bind the typed authority — a successful download
+            // of either usable variant means the local ledger now mirrors
+            // remote truth; failure still `?`-bails fail-closed (unchanged).
+            // PR-B branches on the value.
+            let _authority = rocky_core::state_sync::download_state(&cfg.state, &state_path)
                 .await
                 .map_err(|e| {
                     ToolError::internal(

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -1036,6 +1036,21 @@ enum Command {
         /// distinct from `${ENV}` config-time interpolation in `rocky.toml`.
         #[arg(long = "var", value_name = "NAME=VALUE")]
         var: Vec<String>,
+
+        /// Audited disaster-recovery escape hatch: treat a failed remote-state
+        /// download as an intentional fresh start. Requires a remote `[state]`
+        /// backend (s3, gcs, valkey, or tiered).
+        ///
+        /// By default a failed download leaves the local ledger explicitly
+        /// non-authoritative (fail-closed): auto-applies are refused and the
+        /// run's state uploads are suppressed so local state is never pushed
+        /// over a remote it could not read. When the remote is known-gone and
+        /// the estate is being rebuilt, this flag asserts the fresh start is
+        /// deliberate — the run proceeds with a trusted empty ledger, uploads
+        /// re-enabled, and a structured audit record is emitted. It never
+        /// overrides the governed-run fail-closed bail.
+        #[arg(long, conflicts_with_all = ["dag", "watch"])]
+        assume_fresh_state: bool,
     },
 
     /// Compare shadow tables against production tables
@@ -3094,6 +3109,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             no_reuse,
             no_prune,
             var,
+            assume_fresh_state,
         } => {
             // Parse `--var name=value` pairs into the run-variable map. A
             // malformed pair (no `=`, empty/invalid name) is a clear CLI error.
@@ -3118,6 +3134,34 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                     "--idempotency-key cannot be combined with --resume / --resume-latest \
                      (resume is an explicit override of idempotent skip)"
                 );
+            }
+            // --assume-fresh-state only makes sense against a remote `[state]`
+            // backend: it elects past a FAILED remote download. On the Local
+            // backend there is no remote download to elect past, so the flag
+            // can only mean operator confusion — reject it before any work. A
+            // genuinely-absent config resolves to the Local default; any other
+            // config error aborts (the run would refuse the same config).
+            if assume_fresh_state {
+                let backend = match rocky_core::config::load_rocky_config(&cli.config) {
+                    Ok(cfg) => cfg.state.backend,
+                    Err(rocky_core::config::ConfigError::FileNotFound { .. }) => {
+                        rocky_core::config::StateBackend::Local
+                    }
+                    Err(e) => {
+                        return Err(anyhow::Error::new(e).context(format!(
+                            "cannot validate --assume-fresh-state: {} failed to load, so the \
+                             [state] backend cannot be resolved",
+                            cli.config.display()
+                        )));
+                    }
+                };
+                if matches!(backend, rocky_core::config::StateBackend::Local) {
+                    anyhow::bail!(
+                        "--assume-fresh-state requires a remote `[state]` backend (s3, gcs, \
+                         valkey, or tiered): with the local backend there is no remote-state \
+                         download whose failure could be treated as a fresh start"
+                    );
+                }
             }
             // Parse governance override (JSON string or @file.json)
             let gov_override = parse_governance_override(governance_override.as_deref())?;
@@ -3240,6 +3284,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                     &defer_opts,
                     &skip_opts,
                     &run_vars,
+                    assume_fresh_state,
                 )
                 .await
             }


### PR DESCRIPTION
## Summary

Second implementation PR of **WP-01** (ADRs: #1133 — implements `ADR-AUTHORITY` §1–§4 + §6; §5 is deferred to the session PR per the ADR). Closes the RD-001 typing residual: the download's authority now crosses the `download_state` boundary as a `#[must_use]` value instead of being re-derived from a bool.

- **`StateAuthority { Authoritative, FreshStart, Indeterminate }`** — `download_state` returns it; `Restored ⇒ Authoritative`, `Absent ⇒ FreshStart`, and the **Local backend is explicitly `Authoritative`** (the on-disk redb is the authority — never a bootstrappable empty ledger). **Download failure stays `Err`** — never `Ok(Indeterminate)` — so every existing fail-closed seam keeps its `?`-bail untouched (the safe-standalone property).
- **`Indeterminate` is synthesized at exactly one site** (`resolve_replication_authority`, extracted and unit-pinned): the ungoverned continue-past arm. The governed #1089 bail and all warn/context texts are byte-identical (test-asserted).
- **Six seam binds** (`let _authority = …?`, each commented for the session PR's migration) + `block_on_state_sync` generalized to `Result<T, _>`.
- **Trybuild compile-fail guard** proving the `#[must_use]`-through-`?` mechanism actually fires under `-D warnings` — the migration-sweep assumption is proven, not assumed.
- **ADR status flips** Proposed → Accepted (merged via #1133).

## Two deliberate behavior deltas (both test-pinned, RED-verified)

1. **Fail-closed upload suppression on `Indeterminate`**: a run that elected past a failed download no longer pushes local state over the unread remote — both the periodic uploader spawn and the terminal upload are suppressed (`count(Put) == 0` proven via the #1134 fault-counter rig; reverting the one line flips the test RED).
2. **`--assume-fresh-state`**: an audited operator escape hatch for disaster recovery — synthesizes `FreshStart` with a structured audit event; requires a remote `[state]` backend; never overrides the governed bail.

## Verification

`cargo test -p rocky-core/-cli/-mcp --all-features` all green (incl. the new 4-test integration suite driving full in-process runs against the cross-pod rig) · `clippy --all-targets --all-features -D warnings` clean · `fmt --check` clean · no generated-binding changes (no codegen cascade).