### PR TITLE
fix(engine): scope DAG transformation nodes to models

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1303,26 +1303,46 @@ pub async fn run(
         );
 
         let adapter_registry = AdapterRegistry::from_config(&rocky_cfg)?;
-        // Use the first transformation pipeline's target adapter, or fall back
-        // to the first replication pipeline's target adapter.
-        let target_adapter_name = rocky_cfg
-            .pipelines
-            .values()
-            .find_map(|p| match p {
+        let (target_adapter_name, auto_create_schemas) = if let Some(pipeline_name) =
+            pipeline_name_arg
+        {
+            match registry::resolve_pipeline(&rocky_cfg, Some(pipeline_name))?.1 {
                 rocky_core::config::PipelineConfig::Transformation(t) => {
-                    Some(t.target.adapter.clone())
+                    (
+                        t.target.adapter.clone(),
+                        t.target.governance.auto_create_schemas,
+                    )
                 }
-                _ => None,
-            })
-            .or_else(|| {
-                rocky_cfg.pipelines.values().find_map(|p| match p {
-                    rocky_core::config::PipelineConfig::Replication(r) => {
-                        Some(r.target.adapter.clone())
-                    }
-                    _ => None,
-                })
-            })
-            .unwrap_or_else(|| "default".to_string());
+                pipeline => anyhow::bail!(
+                    "pipeline '{pipeline_name}' is {}, not transformation (required for --model)",
+                    pipeline.pipeline_type_str()
+                ),
+            }
+        } else {
+            // Without an explicit pipeline, preserve the model-only fallback:
+            // first transformation adapter, then first replication adapter.
+            (
+                rocky_cfg
+                    .pipelines
+                    .values()
+                    .find_map(|p| match p {
+                        rocky_core::config::PipelineConfig::Transformation(t) => {
+                            Some(t.target.adapter.clone())
+                        }
+                        _ => None,
+                    })
+                    .or_else(|| {
+                        rocky_cfg.pipelines.values().find_map(|p| match p {
+                            rocky_core::config::PipelineConfig::Replication(r) => {
+                                Some(r.target.adapter.clone())
+                            }
+                            _ => None,
+                        })
+                    })
+                    .unwrap_or_else(|| "default".to_string()),
+                false,
+            )
+        };
 
         let warehouse = adapter_registry.warehouse_adapter(&target_adapter_name)?;
         // Propagate state-store open errors with context, matching the
@@ -1366,7 +1386,7 @@ pub async fn run(
             None, // model-only run has no pipeline hooks
             None,
             &schema_cache_cfg,
-            false, // model-only entry point has no pipeline governance context
+            auto_create_schemas,
             defer_opts,
             skip_gate,
             // Reuse is active iff `[reuse]` is enabled AND `--no-reuse` was

--- a/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
+++ b/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
@@ -57,10 +57,7 @@ fn default_sub_runner() -> SubRunner {
          model_name: Option<String>,
          skip_opts| {
             Box::pin(async move {
-                let models_dir = config_path
-                    .parent()
-                    .unwrap_or(Path::new("."))
-                    .join("models");
+                let models_dir = models_dir_for_model_scope(&config_path, model_name.as_deref());
                 let partition_opts = super::PartitionRunOptions {
                     partition: None,
                     from: None,
@@ -77,7 +74,7 @@ fn default_sub_runner() -> SubRunner {
                     &state_path,
                     None,
                     false, // json — sub-runs print to stdout if not silenced
-                    Some(&models_dir),
+                    models_dir.as_deref(),
                     false,
                     None,
                     false,
@@ -106,6 +103,18 @@ fn default_sub_runner() -> SubRunner {
             })
         },
     )
+}
+
+/// Returns the conventional models directory only for a model-scoped
+/// transformation sub-run. Supplying it to replication/load sub-runs makes
+/// `run()` execute every transformation model after the pipeline itself.
+fn models_dir_for_model_scope(config_path: &Path, model_name: Option<&str>) -> Option<PathBuf> {
+    model_name.map(|_| {
+        config_path
+            .parent()
+            .unwrap_or(Path::new("."))
+            .join("models")
+    })
 }
 
 /// Execute `rocky run --dag`: run every pipeline in dependency order.
@@ -357,15 +366,27 @@ impl NodeDispatcher for CliDispatcher {
 #[cfg(test)]
 mod skip_opts_threading_tests {
     use std::collections::HashMap;
+    use std::path::{Path, PathBuf};
     use std::sync::{Arc, Mutex};
 
     use rocky_core::dag_executor::NodeDispatcher;
     use rocky_core::unified_dag::{NodeId, NodeKind};
 
     use super::super::run::SkipRunOptions;
-    use super::{CliDispatcher, SubRunner};
+    use super::{CliDispatcher, SubRunner, models_dir_for_model_scope};
 
     type RecordedSubRun = (Option<String>, SkipRunOptions);
+
+    #[test]
+    fn models_dir_is_only_set_for_model_scoped_sub_runs() {
+        let config_path = Path::new("project/rocky.toml");
+
+        assert_eq!(
+            models_dir_for_model_scope(config_path, Some("dim_orders")),
+            Some(PathBuf::from("project/models"))
+        );
+        assert_eq!(models_dir_for_model_scope(config_path, None), None);
+    }
 
     /// 🔴 DEFECT 3 regression: `rocky run --dag --force-rebuild` / `--no-reuse`
     /// must reach each sub-run. Pre-fix, `run_with_dag` passed

--- a/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
+++ b/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
@@ -26,7 +26,7 @@ use crate::output::{DagRunNodeOutput, DagRunOutput, print_json};
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Runs one pipeline sub-run: `(config_path, state_path, pipeline_name,
-/// skip_opts) -> Result<(), String>`.
+/// model_name, skip_opts) -> Result<(), String>`.
 ///
 /// Injected into [`CliDispatcher`] so the escape-hatch flags flow to a single,
 /// observable seam. Production wraps [`super::run::run`] with the DAG sub-run's
@@ -38,6 +38,7 @@ type SubRunner = Arc<
             PathBuf,
             PathBuf,
             String,
+            Option<String>,
             SkipRunOptions,
         ) -> Pin<Box<dyn Future<Output = std::result::Result<(), String>> + Send>>
         + Send
@@ -45,13 +46,21 @@ type SubRunner = Arc<
 >;
 
 /// The production [`SubRunner`]: drives one pipeline through [`super::run::run`]
-/// with the DAG sub-run's fixed arguments (no `--model`/`--defer`/`--var`,
-/// config-derived TTL, no idempotency key). Only `config`, `state`, `pipeline`,
-/// and `skip_opts` vary per node.
+/// with the DAG sub-run's fixed arguments (no `--defer`/`--var`, config-derived
+/// TTL, no idempotency key). Transformation nodes supply their model name so
+/// each node materializes only itself; other pipeline nodes pass `None`.
 fn default_sub_runner() -> SubRunner {
     Arc::new(
-        |config_path: PathBuf, state_path: PathBuf, pipeline_name: String, skip_opts| {
+        |config_path: PathBuf,
+         state_path: PathBuf,
+         pipeline_name: String,
+         model_name: Option<String>,
+         skip_opts| {
             Box::pin(async move {
+                let models_dir = config_path
+                    .parent()
+                    .unwrap_or(Path::new("."))
+                    .join("models");
                 let partition_opts = super::PartitionRunOptions {
                     partition: None,
                     from: None,
@@ -68,20 +77,19 @@ fn default_sub_runner() -> SubRunner {
                     &state_path,
                     None,
                     false, // json — sub-runs print to stdout if not silenced
-                    None,
+                    Some(&models_dir),
                     false,
                     None,
                     false,
                     None,
                     &partition_opts,
-                    None,
+                    model_name.as_deref(),
                     // DAG sub-runs inherit config-derived TTL.
                     None,
                     // DAG sub-runs do not accept `--idempotency-key`.
                     None,
                     // DAG sub-runs inherit no `--env`.
                     None,
-                    // DAG sub-runs build full pipelines (no `--model` selection).
                     &super::run::DeferOptions::default(),
                     // The build-escape-hatch overlay (`--force-rebuild` /
                     // `--no-reuse`) threaded from the outer `rocky run --dag`.
@@ -246,14 +254,11 @@ fn status_str(s: &NodeStatus) -> &'static str {
 /// Dispatcher that turns each `NodeKind` into a future calling the matching
 /// CLI command function.
 ///
-/// Each pipeline-bound node (transformation / load / quality / snapshot, plus
-/// the replication sugar's load node) is dispatched via `super::run::run()`
-/// against its owning pipeline — looked up in `node_pipelines`, since a
-/// per-model node's *label* is the model name, not the pipeline. `Seed` nodes
-/// load their CSV (and fire pre/post hooks) via `super::seed::run_seed()`
-/// rather than `run()`, because a seed is not a pipeline. `Test` nodes are
-/// no-ops (tests run implicitly inside their parent transformation); `Source`
-/// nodes are markers for the replication extract side.
+/// Each pipeline-bound node is dispatched via `super::run::run()` against its
+/// owning pipeline. Transformation nodes also pass their model label so each
+/// per-model node materializes only itself; load / quality / snapshot nodes
+/// continue to run their whole pipeline. `Seed` nodes load their CSV directly,
+/// `Test` nodes are no-ops, and `Source` nodes are markers.
 struct CliDispatcher {
     config_path: std::path::PathBuf,
     /// Canonical state path threaded from the caller. Every sub-run drives
@@ -326,6 +331,7 @@ impl NodeDispatcher for CliDispatcher {
                         }));
                     }
                 };
+                let model_name = matches!(kind, NodeKind::Transformation).then_some(label.clone());
                 // Drive the sub-run through the injected [`SubRunner`] against
                 // the canonical state path the caller resolved, threading the
                 // build-escape-hatch `skip_opts` (`--force-rebuild` /
@@ -334,7 +340,14 @@ impl NodeDispatcher for CliDispatcher {
                 // `skip_opts` here reintroduces the silent-drop bug, which the
                 // `sub_runner` recorder test catches.
                 Some(Box::pin(async move {
-                    (sub_runner)(config_path, state_path, pipeline_name, skip_opts).await
+                    (sub_runner)(
+                        config_path,
+                        state_path,
+                        pipeline_name,
+                        model_name,
+                        skip_opts,
+                    )
+                    .await
                 }))
             }
         }
@@ -352,6 +365,8 @@ mod skip_opts_threading_tests {
     use super::super::run::SkipRunOptions;
     use super::{CliDispatcher, SubRunner};
 
+    type RecordedSubRun = (Option<String>, SkipRunOptions);
+
     /// 🔴 DEFECT 3 regression: `rocky run --dag --force-rebuild` / `--no-reuse`
     /// must reach each sub-run. Pre-fix, `run_with_dag` passed
     /// `SkipRunOptions::default()` to every sub-run, silently dropping the
@@ -366,17 +381,18 @@ mod skip_opts_threading_tests {
     /// live sandbox.)
     #[tokio::test]
     async fn dispatch_passes_the_threaded_skip_opts_to_each_sub_run() {
-        let recorded: Arc<Mutex<Vec<SkipRunOptions>>> = Arc::new(Mutex::new(Vec::new()));
+        let recorded: Arc<Mutex<Vec<RecordedSubRun>>> = Arc::new(Mutex::new(Vec::new()));
         let sink = recorded.clone();
         // A recorder sub-runner: capture the skip_opts and return Ok without
         // running a real pipeline.
-        let recorder: SubRunner = Arc::new(move |_config, _state, _pipeline, skip_opts| {
-            let sink = sink.clone();
-            Box::pin(async move {
-                sink.lock().unwrap().push(skip_opts);
-                Ok(())
-            })
-        });
+        let recorder: SubRunner =
+            Arc::new(move |_config, _state, _pipeline, model_name, skip_opts| {
+                let sink = sink.clone();
+                Box::pin(async move {
+                    sink.lock().unwrap().push((model_name, skip_opts));
+                    Ok(())
+                })
+            });
 
         let skip_opts = SkipRunOptions {
             skip_unchanged: false,
@@ -404,12 +420,13 @@ mod skip_opts_threading_tests {
 
         let got = recorded.lock().unwrap();
         assert_eq!(got.len(), 1, "exactly one sub-run was dispatched");
+        assert_eq!(got[0].0.as_deref(), Some("dim_orders"));
         assert!(
-            got[0].force_rebuild,
+            got[0].1.force_rebuild,
             "--force-rebuild must reach the sub-run, not be dropped to default()"
         );
         assert!(
-            got[0].no_reuse,
+            got[0].1.no_reuse,
             "--no-reuse must reach the sub-run, not be dropped to default()"
         );
     }
@@ -533,5 +550,88 @@ mod tests {
             .execute_sql("SELECT COUNT(*) FROM proj.silver.dim_country")
             .unwrap();
         assert_eq!(cell_i64(&model_rows.rows[0][0]), 2, "model rows");
+    }
+
+    #[tokio::test]
+    async fn transformation_nodes_execute_only_their_model() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let models = root.join("models");
+        std::fs::create_dir(&models).unwrap();
+
+        let db_path = root.join("proj.duckdb");
+        std::fs::write(
+            root.join("rocky.toml"),
+            format!(
+                "[adapter.local]\n\
+                 type = \"duckdb\"\n\
+                 path = \"{}\"\n\n\
+                 [pipeline.silver]\n\
+                 type = \"transformation\"\n\n\
+                 [pipeline.silver.target]\n\
+                 adapter = \"local\"\n\n\
+                 [pipeline.silver.target.governance]\n\
+                 auto_create_catalogs = true\n\
+                 auto_create_schemas = true\n",
+                db_path.display()
+            ),
+        )
+        .unwrap();
+
+        std::fs::write(
+            models.join("a.sql"),
+            "SELECT 1 AS id, TIMESTAMP '2026-01-01 00:00:00' AS ts\n",
+        )
+        .unwrap();
+        std::fs::write(
+            models.join("a.toml"),
+            "name = \"a\"\n\n\
+             [strategy]\n\
+             type = \"incremental\"\n\
+             timestamp_column = \"ts\"\n\n\
+             [target]\n\
+             catalog = \"proj\"\n\
+             schema = \"silver\"\n\
+             table = \"a\"\n",
+        )
+        .unwrap();
+
+        std::fs::write(models.join("b.sql"), "SELECT id, ts FROM proj.silver.a\n").unwrap();
+        std::fs::write(
+            models.join("b.toml"),
+            "name = \"b\"\n\
+             depends_on = [\"a\"]\n\n\
+             [strategy]\n\
+             type = \"incremental\"\n\
+             timestamp_column = \"ts\"\n\n\
+             [target]\n\
+             catalog = \"proj\"\n\
+             schema = \"silver\"\n\
+             table = \"b\"\n",
+        )
+        .unwrap();
+
+        run_with_dag(
+            &root.join("rocky.toml"),
+            &root.join(".rocky-state.redb"),
+            false,
+            &crate::commands::run::SkipRunOptions::default(),
+        )
+        .await
+        .expect("run --dag should succeed");
+
+        let adapter = DuckDbWarehouseAdapter::open(&db_path).unwrap();
+        let conn = adapter.shared_connector();
+        let guard = conn.lock().unwrap();
+        for table in ["a", "b"] {
+            let rows = guard
+                .execute_sql(&format!("SELECT COUNT(*) FROM proj.silver.{table}"))
+                .unwrap();
+            assert_eq!(
+                cell_i64(&rows.rows[0][0]),
+                1,
+                "{table} must materialize exactly once"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- dispatch each transformation DAG node with its model label instead of rerunning the owning transformation pipeline
- resolve the selected model through the owning pipeline's adapter and schema-creation policy
- keep the models directory model-scoped so replication/load DAG nodes cannot trigger transformation execution
- add DuckDB exact-once coverage plus a focused regression for the transformation-only scope boundary

## Root cause

The unified DAG correctly creates one node per transformation model, but every node called `run()` with the owning pipeline and no model filter. A two-model pipeline therefore ran all models twice, producing row counts `(2, 3)` for the dependent incremental targets instead of `(1, 1)`.

The dispatcher now supplies `Some(model_name)` only for transformation nodes and resolves that model through its owning transformation pipeline. The final review also tightened the shared sub-run seam: only those model-scoped calls receive `models_dir`; replication, load, quality, and snapshot nodes retain their existing pipeline-only behavior.

## Validation

- `cargo nextest run --all-features` — 5,238 passed, 102 skipped
- `cargo test -p rocky-cli --features duckdb run_dag_exec` — 4 passed
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #1140

Prior art: #1101, #986
