### PR TITLE
feat(engine/rocky-core): schedule config + tick reconciler core

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -9564,6 +9564,17 @@
             },
             "description": "Load options (batch size, create/truncate behavior, CSV settings)."
           },
+          "schedule": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ScheduleConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional native-schedule declaration. See [`ScheduleConfig`]."
+          },
           "source_dir": {
             "description": "Directory or glob pattern for source files, relative to the config file.",
             "type": "string"
@@ -13652,6 +13663,17 @@
             },
             "description": "Execution settings (concurrency, retries, etc.)."
           },
+          "schedule": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ScheduleConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional native-schedule declaration. See [`ScheduleConfig`]."
+          },
           "tables": {
             "default": [],
             "description": "Tables to check. Each entry specifies catalog + schema, and optionally a specific table (omit for all tables in the schema).",
@@ -14396,6 +14418,17 @@
             "default": false,
             "description": "When `true`, the replication runner skips (\"prunes\") any table whose source is provably unchanged since the last successful copy — detected via the adapter's `source_change_marker` (a `DESCRIBE DETAIL`-derived marker on Databricks; adapters without a cheap change signal always copy). A pruned table runs no copy and no data checks: the runner emits no materialization and records it under `excluded_tables` with reason `\"unchanged_since_last_copy\"`.\n\nDownstream continuity — and preserving the table's prior check results — is then the orchestrator's job. The Dagster integration treats a pruned, unmaterialized key as unchanged via `satisfy_empty_outputs`; enabling pruning without an orchestrator that handles unmaterialized keys drops the table from the run.\n\nDefaults to `false` — opt in per pipeline, since silently skipping copies is a behavior change. The marker is compared against the target's recorded last-copied value (never wall-clock), so a failed prior run cannot cause a false skip. Pass `--no-prune` to `rocky run` to force a full pass (e.g. after a manual target-side mutation).",
             "type": "boolean"
+          },
+          "schedule": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ScheduleConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional native-schedule declaration. See [`ScheduleConfig`]."
           },
           "source": {
             "allOf": [
@@ -15491,6 +15524,18 @@
             },
             "description": "Opt-in run-execution tuning for the `--skip-unchanged` model-skip gate. Default-OFF: an absent `[run]` block (or one that leaves every field at its default) keeps `rocky run`'s behavior byte-identical to before the gate existed. See [`RunConfig`]."
           },
+          "schedule": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ScheduleDefaultsConfig"
+              }
+            ],
+            "default": {
+              "poll_interval_seconds": 15,
+              "timezone": "UTC"
+            },
+            "description": "Project-level schedule defaults for native demand reconciliation. Supplies the fallback timezone for per-pipeline `[…schedule]` cron blocks and the resident-loop poll cadence. See [`ScheduleDefaultsConfig`]."
+          },
           "schema_evolution": {
             "allOf": [
               {
@@ -16130,6 +16175,100 @@
           }
         ]
       },
+      "ScheduleConfig": {
+        "additionalProperties": false,
+        "description": "Per-pipeline schedule declaration for native demand reconciliation.\n\nEvery field is optional; an absent `[pipeline.<name>.schedule]` block leaves the pipeline with today's behavior (it runs only when invoked directly). A pipeline may combine demand sources — `cron`, `after`, and `freshness` union, so any one of them makes the pipeline due.\n\nUnlike the five pipeline variant structs (which deliberately omit `deny_unknown_fields` so the IDE schema can inject the `type` discriminator), this struct **denies unknown fields**: a typo inside `[…schedule]` is a silent scheduling bug — a misspelled `corn` key would leave a pipeline unscheduled with no error — so the deserializer rejects it outright.",
+        "properties": {
+          "after": {
+            "description": "Upstream pipelines this one runs after. The pipeline is due once every listed pipeline has a successful run that completed after this pipeline's own latest success started (a partial-success run does not count as an upstream success).",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "catchup": {
+            "default": "latest",
+            "description": "Catch-up policy when more than one cron occurrence elapsed since the last fire: `\"latest\"` (default) fires one demand at the most recent missed occurrence; `\"skip\"` advances the anchor and runs nothing. `\"all\"` is rejected at validation — runs are watermark-driven, not windowed, so replaying every missed occurrence is pure cost.",
+            "type": "string"
+          },
+          "cron": {
+            "description": "Standard 5-field cron expression (minute hour day-of-month month day-of-week). When set, the pipeline is due at each occurrence.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "enabled": {
+            "default": true,
+            "description": "When `false`, demand is suppressed but the config is kept. Default `true`.",
+            "type": "boolean"
+          },
+          "freshness": {
+            "default": false,
+            "description": "When `true`, the pipeline is due once its own run-staleness exceeds its freshness budget (resolved from per-model `max_lag_seconds`, falling back to the project `[freshness].expected_lag_seconds`). This is run-staleness only — the reconciler never queries the warehouse.",
+            "type": "boolean"
+          },
+          "retry": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ScheduleRetryConfig"
+              }
+            ],
+            "default": {
+              "max": 0
+            },
+            "description": "In-tick immediate re-submissions on failure. The reconciler never sleeps between attempts; minutes-scale spacing is the always-on cross-tick throttle, not this knob. Default `0` (off)."
+          },
+          "timeout_minutes": {
+            "default": 0,
+            "description": "Scheduler-level timeout in minutes for a launched run. `0` (default) means no scheduler-level timeout — the run's own limits apply.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "timezone": {
+            "description": "IANA timezone name (e.g. `\"Europe/Lisbon\"`) the `cron` occurrences are evaluated in. Falls back to the project `[schedule].timezone`, which itself defaults to `\"UTC\"`.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "ScheduleDefaultsConfig": {
+        "additionalProperties": false,
+        "description": "Project-level schedule defaults (`[schedule]`).\n\nSupplies the fallback timezone for per-pipeline `cron` blocks that omit their own, plus the resident-loop poll cadence consumed by a later phase.",
+        "properties": {
+          "poll_interval_seconds": {
+            "default": 15,
+            "description": "Poll cadence in seconds for the resident scheduler loop. Not consumed by the one-shot tick; reserved for the resident-loop phase. Default `15`.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "timezone": {
+            "default": "UTC",
+            "description": "Default IANA timezone for per-pipeline cron evaluation. Default `\"UTC\"`.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ScheduleRetryConfig": {
+        "additionalProperties": false,
+        "description": "In-tick retry budget for a scheduled pipeline.",
+        "properties": {
+          "max": {
+            "default": 0,
+            "description": "Maximum number of *additional* immediate re-submissions after the first attempt fails. `0` means the first attempt is the only one.",
+            "format": "uint32",
+            "minimum": 0.0,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
       "SchemaCacheConfig": {
         "additionalProperties": false,
         "description": "`[cache.schemas]` — schema cache configuration.\n\nControls the DESCRIBE-result cache. Defaults are chosen so the feature is useful out of the box: the cache is on, entries live for 24 hours, and nothing replicates off-machine until the user opts in.",
@@ -16573,6 +16712,17 @@
             "default": false,
             "description": "When true, rows deleted from the source get their `valid_to` set to the current timestamp in the target. Default: false.",
             "type": "boolean"
+          },
+          "schedule": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ScheduleConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional native-schedule declaration. See [`ScheduleConfig`]."
           },
           "source": {
             "allOf": [
@@ -18037,6 +18187,17 @@
             "default": "models/**",
             "description": "Glob pattern for model files, relative to the config file directory. Default: `\"models/**\"`.",
             "type": "string"
+          },
+          "schedule": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ScheduleConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional native-schedule declaration. See [`ScheduleConfig`]."
           },
           "target": {
             "allOf": [

--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -1642,6 +1642,17 @@
           },
           "description": "Load options (batch size, create/truncate behavior, CSV settings)."
         },
+        "schedule": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ScheduleConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional native-schedule declaration. See [`ScheduleConfig`]."
+        },
         "source_dir": {
           "description": "Directory or glob pattern for source files, relative to the config file.",
           "type": "string"
@@ -2920,6 +2931,17 @@
           },
           "description": "Execution settings (concurrency, retries, etc.)."
         },
+        "schedule": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ScheduleConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional native-schedule declaration. See [`ScheduleConfig`]."
+        },
         "tables": {
           "default": [],
           "description": "Tables to check. Each entry specifies catalog + schema, and optionally a specific table (omit for all tables in the schema).",
@@ -3092,6 +3114,17 @@
           "default": false,
           "description": "When `true`, the replication runner skips (\"prunes\") any table whose source is provably unchanged since the last successful copy — detected via the adapter's `source_change_marker` (a `DESCRIBE DETAIL`-derived marker on Databricks; adapters without a cheap change signal always copy). A pruned table runs no copy and no data checks: the runner emits no materialization and records it under `excluded_tables` with reason `\"unchanged_since_last_copy\"`.\n\nDownstream continuity — and preserving the table's prior check results — is then the orchestrator's job. The Dagster integration treats a pruned, unmaterialized key as unchanged via `satisfy_empty_outputs`; enabling pruning without an orchestrator that handles unmaterialized keys drops the table from the run.\n\nDefaults to `false` — opt in per pipeline, since silently skipping copies is a behavior change. The marker is compared against the target's recorded last-copied value (never wall-clock), so a failed prior run cannot cause a false skip. Pass `--no-prune` to `rocky run` to force a full pass (e.g. after a manual target-side mutation).",
           "type": "boolean"
+        },
+        "schedule": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ScheduleConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional native-schedule declaration. See [`ScheduleConfig`]."
         },
         "source": {
           "allOf": [
@@ -3372,6 +3405,100 @@
       },
       "type": "object"
     },
+    "ScheduleConfig": {
+      "additionalProperties": false,
+      "description": "Per-pipeline schedule declaration for native demand reconciliation.\n\nEvery field is optional; an absent `[pipeline.<name>.schedule]` block leaves the pipeline with today's behavior (it runs only when invoked directly). A pipeline may combine demand sources — `cron`, `after`, and `freshness` union, so any one of them makes the pipeline due.\n\nUnlike the five pipeline variant structs (which deliberately omit `deny_unknown_fields` so the IDE schema can inject the `type` discriminator), this struct **denies unknown fields**: a typo inside `[…schedule]` is a silent scheduling bug — a misspelled `corn` key would leave a pipeline unscheduled with no error — so the deserializer rejects it outright.",
+      "properties": {
+        "after": {
+          "description": "Upstream pipelines this one runs after. The pipeline is due once every listed pipeline has a successful run that completed after this pipeline's own latest success started (a partial-success run does not count as an upstream success).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "catchup": {
+          "default": "latest",
+          "description": "Catch-up policy when more than one cron occurrence elapsed since the last fire: `\"latest\"` (default) fires one demand at the most recent missed occurrence; `\"skip\"` advances the anchor and runs nothing. `\"all\"` is rejected at validation — runs are watermark-driven, not windowed, so replaying every missed occurrence is pure cost.",
+          "type": "string"
+        },
+        "cron": {
+          "description": "Standard 5-field cron expression (minute hour day-of-month month day-of-week). When set, the pipeline is due at each occurrence.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enabled": {
+          "default": true,
+          "description": "When `false`, demand is suppressed but the config is kept. Default `true`.",
+          "type": "boolean"
+        },
+        "freshness": {
+          "default": false,
+          "description": "When `true`, the pipeline is due once its own run-staleness exceeds its freshness budget (resolved from per-model `max_lag_seconds`, falling back to the project `[freshness].expected_lag_seconds`). This is run-staleness only — the reconciler never queries the warehouse.",
+          "type": "boolean"
+        },
+        "retry": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ScheduleRetryConfig"
+            }
+          ],
+          "default": {
+            "max": 0
+          },
+          "description": "In-tick immediate re-submissions on failure. The reconciler never sleeps between attempts; minutes-scale spacing is the always-on cross-tick throttle, not this knob. Default `0` (off)."
+        },
+        "timeout_minutes": {
+          "default": 0,
+          "description": "Scheduler-level timeout in minutes for a launched run. `0` (default) means no scheduler-level timeout — the run's own limits apply.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "timezone": {
+          "description": "IANA timezone name (e.g. `\"Europe/Lisbon\"`) the `cron` occurrences are evaluated in. Falls back to the project `[schedule].timezone`, which itself defaults to `\"UTC\"`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "ScheduleDefaultsConfig": {
+      "additionalProperties": false,
+      "description": "Project-level schedule defaults (`[schedule]`).\n\nSupplies the fallback timezone for per-pipeline `cron` blocks that omit their own, plus the resident-loop poll cadence consumed by a later phase.",
+      "properties": {
+        "poll_interval_seconds": {
+          "default": 15,
+          "description": "Poll cadence in seconds for the resident scheduler loop. Not consumed by the one-shot tick; reserved for the resident-loop phase. Default `15`.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "timezone": {
+          "default": "UTC",
+          "description": "Default IANA timezone for per-pipeline cron evaluation. Default `\"UTC\"`.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ScheduleRetryConfig": {
+      "additionalProperties": false,
+      "description": "In-tick retry budget for a scheduled pipeline.",
+      "properties": {
+        "max": {
+          "default": 0,
+          "description": "Maximum number of *additional* immediate re-submissions after the first attempt fails. `0` means the first attempt is the only one.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
     "SchemaCacheConfig": {
       "additionalProperties": false,
       "description": "`[cache.schemas]` — schema cache configuration.\n\nControls the DESCRIBE-result cache. Defaults are chosen so the feature is useful out of the box: the cache is on, entries live for 24 hours, and nothing replicates off-machine until the user opts in.",
@@ -3502,6 +3629,17 @@
           "default": false,
           "description": "When true, rows deleted from the source get their `valid_to` set to the current timestamp in the target. Default: false.",
           "type": "boolean"
+        },
+        "schedule": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ScheduleConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional native-schedule declaration. See [`ScheduleConfig`]."
         },
         "source": {
           "allOf": [
@@ -4076,6 +4214,17 @@
           "description": "Glob pattern for model files, relative to the config file directory. Default: `\"models/**\"`.",
           "type": "string"
         },
+        "schedule": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ScheduleConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional native-schedule declaration. See [`ScheduleConfig`]."
+        },
         "target": {
           "allOf": [
             {
@@ -4479,6 +4628,18 @@
         "skip_unchanged": false
       },
       "description": "Opt-in run-execution tuning for the `--skip-unchanged` model-skip gate. Default-OFF: an absent `[run]` block (or one that leaves every field at its default) keeps `rocky run`'s behavior byte-identical to before the gate existed. See [`RunConfig`]."
+    },
+    "schedule": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/ScheduleDefaultsConfig"
+        }
+      ],
+      "default": {
+        "poll_interval_seconds": 15,
+        "timezone": "UTC"
+      },
+      "description": "Project-level schedule defaults for native demand reconciliation. Supplies the fallback timezone for per-pipeline `[…schedule]` cron blocks and the resident-loop poll cadence. See [`ScheduleDefaultsConfig`]."
     },
     "schema_evolution": {
       "allOf": [

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -492,6 +492,10 @@ export interface RockyConfig {
    */
   run?: RunConfig;
   /**
+   * Project-level schedule defaults for native demand reconciliation. Supplies the fallback timezone for per-pipeline `[…schedule]` cron blocks and the resident-loop poll cadence. See [`ScheduleDefaultsConfig`].
+   */
+  schedule?: ScheduleDefaultsConfig;
+  /**
    * Schema evolution configuration (grace-period column drops).
    */
   schema_evolution?: SchemaEvolutionConfig;
@@ -1103,6 +1107,10 @@ export interface ReplicationPipelineConfig {
    */
   prune_unchanged?: boolean;
   /**
+   * Optional native-schedule declaration. See [`ScheduleConfig`].
+   */
+  schedule?: ScheduleConfig | null;
+  /**
    * Source configuration.
    */
   source: PipelineSourceConfig;
@@ -1289,6 +1297,56 @@ export interface MetadataColumnConfig {
   name: string;
   type: string;
   value: string;
+}
+/**
+ * Per-pipeline schedule declaration for native demand reconciliation.
+ *
+ * Every field is optional; an absent `[pipeline.<name>.schedule]` block leaves the pipeline with today's behavior (it runs only when invoked directly). A pipeline may combine demand sources — `cron`, `after`, and `freshness` union, so any one of them makes the pipeline due.
+ *
+ * Unlike the five pipeline variant structs (which deliberately omit `deny_unknown_fields` so the IDE schema can inject the `type` discriminator), this struct **denies unknown fields**: a typo inside `[…schedule]` is a silent scheduling bug — a misspelled `corn` key would leave a pipeline unscheduled with no error — so the deserializer rejects it outright.
+ */
+export interface ScheduleConfig {
+  /**
+   * Upstream pipelines this one runs after. The pipeline is due once every listed pipeline has a successful run that completed after this pipeline's own latest success started (a partial-success run does not count as an upstream success).
+   */
+  after?: string[];
+  /**
+   * Catch-up policy when more than one cron occurrence elapsed since the last fire: `"latest"` (default) fires one demand at the most recent missed occurrence; `"skip"` advances the anchor and runs nothing. `"all"` is rejected at validation — runs are watermark-driven, not windowed, so replaying every missed occurrence is pure cost.
+   */
+  catchup?: string;
+  /**
+   * Standard 5-field cron expression (minute hour day-of-month month day-of-week). When set, the pipeline is due at each occurrence.
+   */
+  cron?: string | null;
+  /**
+   * When `false`, demand is suppressed but the config is kept. Default `true`.
+   */
+  enabled?: boolean;
+  /**
+   * When `true`, the pipeline is due once its own run-staleness exceeds its freshness budget (resolved from per-model `max_lag_seconds`, falling back to the project `[freshness].expected_lag_seconds`). This is run-staleness only — the reconciler never queries the warehouse.
+   */
+  freshness?: boolean;
+  /**
+   * In-tick immediate re-submissions on failure. The reconciler never sleeps between attempts; minutes-scale spacing is the always-on cross-tick throttle, not this knob. Default `0` (off).
+   */
+  retry?: ScheduleRetryConfig;
+  /**
+   * Scheduler-level timeout in minutes for a launched run. `0` (default) means no scheduler-level timeout — the run's own limits apply.
+   */
+  timeout_minutes?: number;
+  /**
+   * IANA timezone name (e.g. `"Europe/Lisbon"`) the `cron` occurrences are evaluated in. Falls back to the project `[schedule].timezone`, which itself defaults to `"UTC"`.
+   */
+  timezone?: string | null;
+}
+/**
+ * In-tick retry budget for a scheduled pipeline.
+ */
+export interface ScheduleRetryConfig {
+  /**
+   * Maximum number of *additional* immediate re-submissions after the first attempt fails. `0` means the first attempt is the only one.
+   */
+  max?: number;
 }
 /**
  * Pipeline source configuration.
@@ -1508,6 +1566,10 @@ export interface TransformationPipelineConfig {
    */
   models?: string;
   /**
+   * Optional native-schedule declaration. See [`ScheduleConfig`].
+   */
+  schedule?: ScheduleConfig | null;
+  /**
    * Target configuration (adapter + governance).
    */
   target: TransformationTargetConfig;
@@ -1554,6 +1616,10 @@ export interface QualityPipelineConfig {
    * Execution settings (concurrency, retries, etc.).
    */
   execution?: ExecutionConfig;
+  /**
+   * Optional native-schedule declaration. See [`ScheduleConfig`].
+   */
+  schedule?: ScheduleConfig | null;
   /**
    * Tables to check. Each entry specifies catalog + schema, and optionally a specific table (omit for all tables in the schema).
    */
@@ -1612,6 +1678,10 @@ export interface SnapshotPipelineConfig {
    * When true, rows deleted from the source get their `valid_to` set to the current timestamp in the target. Default: false.
    */
   invalidate_hard_deletes?: boolean;
+  /**
+   * Optional native-schedule declaration. See [`ScheduleConfig`].
+   */
+  schedule?: ScheduleConfig | null;
   /**
    * Source table reference (single table, not pattern-based discovery).
    */
@@ -1691,6 +1761,10 @@ export interface LoadPipelineConfig {
    * Load options (batch size, create/truncate behavior, CSV settings).
    */
   options?: LoadOptionsConfig;
+  /**
+   * Optional native-schedule declaration. See [`ScheduleConfig`].
+   */
+  schedule?: ScheduleConfig | null;
   /**
    * Directory or glob pattern for source files, relative to the config file.
    */
@@ -2095,6 +2169,21 @@ export interface RunConfig {
    * Master switch for the model-skip gate. `false` (default) ⇒ every selected model always builds, exactly as before. The `--skip-unchanged` CLI flag turns the gate on for a single invocation regardless of this value.
    */
   skip_unchanged?: boolean;
+}
+/**
+ * Project-level schedule defaults (`[schedule]`).
+ *
+ * Supplies the fallback timezone for per-pipeline `cron` blocks that omit their own, plus the resident-loop poll cadence consumed by a later phase.
+ */
+export interface ScheduleDefaultsConfig {
+  /**
+   * Poll cadence in seconds for the resident scheduler loop. Not consumed by the one-shot tick; reserved for the resident-loop phase. Default `15`.
+   */
+  poll_interval_seconds?: number;
+  /**
+   * Default IANA timezone for per-pipeline cron evaluation. Default `"UTC"`.
+   */
+  timezone?: string;
 }
 /**
  * Schema evolution configuration.

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -861,6 +861,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1143,6 +1153,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "croner"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa42bcd3d846ebf66e15bd528d1087f75d1c6c1c66ebff626178a106353c576"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "strum",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,12 +1276,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1278,11 +1323,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.118",
 ]
@@ -1363,6 +1419,37 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
  "syn 2.0.118",
 ]
 
@@ -3227,6 +3314,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3904,7 +4009,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -4130,7 +4235,9 @@ dependencies = [
  "blake3",
  "bytes",
  "chrono",
+ "chrono-tz",
  "criterion",
+ "croner",
  "csv",
  "fs4",
  "futures",
@@ -4138,6 +4245,7 @@ dependencies = [
  "indexmap",
  "jsonschema",
  "lasso",
+ "libc",
  "memmap2",
  "object_store",
  "rayon",
@@ -4160,6 +4268,7 @@ dependencies = [
  "tracing",
  "trybuild",
  "url",
+ "uuid",
  "wiremock",
 ]
 
@@ -5006,6 +5115,12 @@ dependencies = [
  "thiserror",
  "time",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -49,6 +49,9 @@ large_enum_variant = "warn"
 [workspace.dependencies]
 # Async traits
 async-trait = "0.1"
+# Unix signal delivery (SIGTERM to a scheduled child before SIGKILL). Only used
+# on unix; the schedule spawner falls back to the platform kill elsewhere.
+libc = "0.2"
 
 # Machine hostname detection for governance audit trail
 # (portable across Linux/macOS/Windows — std::env::var("HOSTNAME")
@@ -62,6 +65,12 @@ serde_yaml = "0.9"
 indexmap = { version = "2", features = ["serde"] }
 toml = "1"
 chrono = { version = "0.4", features = ["serde"] }
+# IANA timezone database for chrono (schedule cron evaluation in a named tz).
+chrono-tz = "0.10"
+# Cron occurrence math for the schedule reconciler. croner declares no MSRV,
+# so the version is pinned exactly — a patch bump could raise the required
+# toolchain past the workspace's 1.88 floor without warning.
+croner = "=3.0.1"
 
 # JSON Schema generation (Phase 2 — codegen source of truth for dagster + vscode types)
 schemars = { version = "0.8", features = ["chrono", "indexmap2"] }

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -6338,6 +6338,8 @@ schema_template = "s__{source}"
                     passed: *p,
                 })
                 .collect(),
+            pipeline: None,
+            submission_id: None,
         };
         store.record_run(&record).unwrap();
     }

--- a/engine/crates/rocky-cli/src/commands/brief.rs
+++ b/engine/crates/rocky-cli/src/commands/brief.rs
@@ -1290,6 +1290,8 @@ mod tests {
             hostname: "host".to_string(),
             rocky_version: "0.0.0-test".to_string(),
             check_outcomes: Vec::new(),
+            pipeline: None,
+            submission_id: None,
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/catalog.rs
+++ b/engine/crates/rocky-cli/src/commands/catalog.rs
@@ -1222,6 +1222,8 @@ mod tests {
                 hostname: "test-host".to_string(),
                 rocky_version: "test-version".to_string(),
                 check_outcomes: Vec::new(),
+                pipeline: None,
+                submission_id: None,
             }
         }
 

--- a/engine/crates/rocky-cli/src/commands/cost.rs
+++ b/engine/crates/rocky-cli/src/commands/cost.rs
@@ -538,6 +538,8 @@ mod tests {
             hostname: "cost-test-host".to_string(),
             rocky_version: "0.0.0-test".to_string(),
             check_outcomes: Vec::new(),
+            pipeline: None,
+            submission_id: None,
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/drift_governance.rs
+++ b/engine/crates/rocky-cli/src/commands/drift_governance.rs
@@ -648,6 +648,7 @@ mod tests {
                 auto_apply_additive_drift: true,
                 ..Default::default()
             },
+            schedule: Default::default(),
         }
     }
 
@@ -848,6 +849,8 @@ mod tests {
                     passed: *p,
                 })
                 .collect(),
+            pipeline: None,
+            submission_id: None,
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/gc.rs
+++ b/engine/crates/rocky-cli/src/commands/gc.rs
@@ -2033,6 +2033,8 @@ auto_create_schemas = true
                 hostname: "gc-test".to_string(),
                 rocky_version: "0.0.0-test".to_string(),
                 check_outcomes: Vec::new(),
+                pipeline: None,
+                submission_id: None,
             })
             .unwrap();
     }

--- a/engine/crates/rocky-cli/src/commands/history.rs
+++ b/engine/crates/rocky-cli/src/commands/history.rs
@@ -613,6 +613,8 @@ mod tests {
             hostname: "dev-laptop".to_string(),
             rocky_version: "1.16.0".to_string(),
             check_outcomes: Vec::new(),
+            pipeline: None,
+            submission_id: None,
         }
     }
 
@@ -700,6 +702,8 @@ mod tests {
             hostname: "host".to_string(),
             rocky_version: "0.0.0-test".to_string(),
             check_outcomes: Vec::new(),
+            pipeline: None,
+            submission_id: None,
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/preview.rs
+++ b/engine/crates/rocky-cli/src/commands/preview.rs
@@ -2299,6 +2299,8 @@ mod tests {
             hostname: "test".into(),
             rocky_version: "0.0.0-test".into(),
             check_outcomes: Vec::new(),
+            pipeline: None,
+            submission_id: None,
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/replay.rs
+++ b/engine/crates/rocky-cli/src/commands/replay.rs
@@ -2001,6 +2001,8 @@ mod tests {
             hostname: "replay-test-host".to_string(),
             rocky_version: "0.0.0-test".to_string(),
             check_outcomes: Vec::new(),
+            pipeline: None,
+            submission_id: None,
         }
     }
 
@@ -2657,6 +2659,8 @@ mod tests {
                 hostname: "replay-live".to_string(),
                 rocky_version: VERSION.to_string(),
                 check_outcomes: Vec::new(),
+                pipeline: None,
+                submission_id: None,
             };
             store.record_run(&record).unwrap();
 

--- a/engine/crates/rocky-cli/src/commands/restore.rs
+++ b/engine/crates/rocky-cli/src/commands/restore.rs
@@ -1386,6 +1386,8 @@ mod tests {
                     hostname: "restore-test".to_string(),
                     rocky_version: "0.0.0-test".to_string(),
                     check_outcomes: Vec::new(),
+                    pipeline: None,
+                    submission_id: None,
                 })
                 .unwrap();
         }
@@ -2205,6 +2207,8 @@ mod tests {
                         hostname: "restore-live".to_string(),
                         rocky_version: VERSION.to_string(),
                         check_outcomes: Vec::new(),
+                        pipeline: None,
+                        submission_id: None,
                     })
                     .unwrap();
 

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -553,6 +553,22 @@ pub(crate) fn audit_to_record(ctx: &AuditContext) -> RunRecordAudit {
     }
 }
 
+/// Resolve the run trigger from `ROCKY_RUN_TRIGGER`, defaulting to `Manual`.
+///
+/// The reconciler sets `ROCKY_RUN_TRIGGER=schedule` on the children it spawns;
+/// Dagster sets `sensor`/`schedule`; CI wrappers may set `ci`. An absent or
+/// unrecognized value is `Manual` — the pre-existing behavior, so nothing
+/// changes for a directly-invoked `rocky run`.
+fn run_trigger_from_env() -> rocky_core::state::RunTrigger {
+    use rocky_core::state::RunTrigger;
+    match std::env::var("ROCKY_RUN_TRIGGER").ok().as_deref() {
+        Some("schedule") => RunTrigger::Schedule,
+        Some("sensor") => RunTrigger::Sensor,
+        Some("ci") => RunTrigger::Ci,
+        _ => RunTrigger::Manual,
+    }
+}
+
 pub(crate) fn persist_run_record(
     state_store: Option<&StateStore>,
     output: &RunOutput,
@@ -560,21 +576,35 @@ pub(crate) fn persist_run_record(
     started_at: DateTime<Utc>,
     config_hash: &str,
     audit: &RunRecordAudit,
+    // The pipeline this run built, when it was a single-pipeline run. Stamped
+    // onto the record so the schedule reconciler can answer "did pipeline X
+    // succeed?" for `after`/`freshness` demands. `None` for a model-only run or
+    // a multi-pipeline set (a backfill), which the reconciler never matches.
+    pipeline: Option<&str>,
 ) {
     let Some(store) = state_store else {
         return;
     };
     let finished_at = Utc::now();
     let status = output.derive_run_status();
-    let record = output.to_run_record(
+    let mut record = output.to_run_record(
         run_id,
         started_at,
         finished_at,
         config_hash.to_string(),
-        rocky_core::state::RunTrigger::Manual,
+        run_trigger_from_env(),
         status,
         audit.clone(),
     );
+    // Advisory attribution threaded by the reconciler (or any wrapper): how the
+    // run was initiated, and the schedule submission it belongs to. Both mirror
+    // the env-derived `ROCKY_SESSION_SOURCE` precedent — any caller may set them;
+    // nothing gates on them (they exist so `rocky history` tells operators how a
+    // run was launched, and so recovery can join a demand to *its* run).
+    record.pipeline = pipeline.map(str::to_string);
+    record.submission_id = std::env::var("ROCKY_SUBMISSION_ID")
+        .ok()
+        .filter(|s| !s.is_empty());
     if let Err(e) = store.record_run(&record) {
         warn!(
             error = %e,
@@ -1539,6 +1569,8 @@ pub async fn run(
             started_at,
             &config_hash,
             &audit,
+            // Model-only run — no single pipeline to attribute.
+            None,
         );
         finalize_idempotency(
             &mut idempotency_ctx,
@@ -1632,6 +1664,10 @@ pub async fn run(
                 &run_id,
                 started_at,
                 &config_hash,
+                // The resolved pipeline name, stamped onto the persisted record
+                // so the schedule reconciler's `after`/`freshness` demands can
+                // observe this transformation pipeline's successes.
+                Some(pipeline_name),
                 // Raw `--idempotency-key` so the persisted audit records the
                 // claimed key, matching the model-only / replication paths.
                 // The claim is finalized under this same value just below.
@@ -3201,6 +3237,7 @@ pub async fn run(
                 started_at,
                 &config_hash,
                 &audit,
+                Some(pipeline_name),
             );
             finalize_idempotency(&mut idempotency_ctx, Some(state), &shared_run_id, &output).await;
         }
@@ -4378,6 +4415,7 @@ pub async fn run(
         started_at,
         &config_hash,
         &audit,
+        Some(pipeline_name),
     );
 
     // Post-apply `verify_after` gate for any additive drift this run
@@ -4415,6 +4453,7 @@ pub async fn run(
             started_at,
             &config_hash,
             &audit,
+            Some(pipeline_name),
         );
         finalize_idempotency(
             &mut idempotency_ctx,
@@ -5258,6 +5297,8 @@ pub(crate) async fn execute_backfill_set(
         started_at,
         &config_hash,
         &audit,
+        // A backfill spans a model set, not a single pipeline.
+        None,
     );
 
     output.status = output.derive_run_status();
@@ -9473,6 +9514,81 @@ fn is_rate_limit_error(error_msg: &str) -> bool {
 mod tests {
     use super::*;
     use rocky_core::plan_partition::PartitionSelection;
+
+    // Serializes the process-global env-var mutations in the trigger-threading
+    // tests below (env is shared across the test binary's threads).
+    static TRIGGER_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn run_trigger_from_env_maps_known_values() {
+        use rocky_core::state::RunTrigger;
+        let _g = TRIGGER_ENV_LOCK.lock().unwrap();
+        // SAFETY: serialized by TRIGGER_ENV_LOCK; no other thread reads the var
+        // concurrently while it is set here.
+        unsafe {
+            std::env::remove_var("ROCKY_RUN_TRIGGER");
+            assert!(matches!(run_trigger_from_env(), RunTrigger::Manual));
+            std::env::set_var("ROCKY_RUN_TRIGGER", "schedule");
+            assert!(matches!(run_trigger_from_env(), RunTrigger::Schedule));
+            std::env::set_var("ROCKY_RUN_TRIGGER", "sensor");
+            assert!(matches!(run_trigger_from_env(), RunTrigger::Sensor));
+            std::env::set_var("ROCKY_RUN_TRIGGER", "ci");
+            assert!(matches!(run_trigger_from_env(), RunTrigger::Ci));
+            std::env::set_var("ROCKY_RUN_TRIGGER", "manual");
+            assert!(matches!(run_trigger_from_env(), RunTrigger::Manual));
+            // An unrecognized value falls back to Manual (never guesses).
+            std::env::set_var("ROCKY_RUN_TRIGGER", "nonsense");
+            assert!(matches!(run_trigger_from_env(), RunTrigger::Manual));
+            std::env::remove_var("ROCKY_RUN_TRIGGER");
+        }
+    }
+
+    #[test]
+    fn persist_run_record_stamps_trigger_submission_and_pipeline() {
+        use rocky_core::state::{RunTrigger, StateStore};
+        let _g = TRIGGER_ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let store = StateStore::open(&dir.path().join("state.redb")).unwrap();
+        // SAFETY: serialized by TRIGGER_ENV_LOCK.
+        unsafe {
+            std::env::set_var("ROCKY_RUN_TRIGGER", "schedule");
+            std::env::set_var("ROCKY_SUBMISSION_ID", "sub-xyz");
+        }
+        let output = RunOutput::new(String::new(), 0, 1);
+        let audit = audit_to_record(&AuditContext::detect(None, None));
+        persist_run_record(
+            Some(&store),
+            &output,
+            "run-trigger-test",
+            Utc::now(),
+            "cfg",
+            &audit,
+            Some("raw"),
+        );
+        // SAFETY: serialized by TRIGGER_ENV_LOCK.
+        unsafe {
+            std::env::remove_var("ROCKY_RUN_TRIGGER");
+            std::env::remove_var("ROCKY_SUBMISSION_ID");
+        }
+        let rec = store
+            .get_run("run-trigger-test")
+            .unwrap()
+            .expect("record persisted");
+        assert!(
+            matches!(rec.trigger, RunTrigger::Schedule),
+            "ROCKY_RUN_TRIGGER stamps the trigger"
+        );
+        assert_eq!(
+            rec.submission_id.as_deref(),
+            Some("sub-xyz"),
+            "ROCKY_SUBMISSION_ID stamps the join key"
+        );
+        assert_eq!(
+            rec.pipeline.as_deref(),
+            Some("raw"),
+            "the resolved pipeline name is stamped"
+        );
+    }
 
     // -------------------------------------------------------------------
     // PR-A (RD-001) — `resolve_replication_authority`, the ONE site where
@@ -15290,6 +15406,8 @@ merge_keys = ["id"]
             hostname: "test".to_string(),
             rocky_version: "test".to_string(),
             check_outcomes: Vec::new(),
+            pipeline: None,
+            submission_id: None,
         };
         state.record_run(&failed).unwrap();
 
@@ -16496,6 +16614,8 @@ merge_keys = ["id"]
             hostname: "test".to_string(),
             rocky_version: "test".to_string(),
             check_outcomes: Vec::new(),
+            pipeline: None,
+            submission_id: None,
         };
         store.record_run(&run).unwrap();
         // The prior build's LIVE artifact — the ledger row the liveness gate
@@ -16680,6 +16800,8 @@ merge_keys = ["id"]
             hostname: "test".to_string(),
             rocky_version: "test".to_string(),
             check_outcomes: Vec::new(),
+            pipeline: None,
+            submission_id: None,
         };
         store.record_run(&run).unwrap();
 
@@ -17662,6 +17784,8 @@ merge_keys = ["id"]
                 hostname: "test".to_string(),
                 rocky_version: "test".to_string(),
                 check_outcomes: Vec::new(),
+                pipeline: None,
+                submission_id: None,
             };
             store.record_run(&run).unwrap();
             // The prior build's LIVE artifact row — the liveness gate resolves
@@ -17962,6 +18086,8 @@ merge_keys = ["id"]
                     hostname: "test".to_string(),
                     rocky_version: "test".to_string(),
                     check_outcomes: Vec::new(),
+                    pipeline: None,
+                    submission_id: None,
                 })
                 .unwrap();
             // The prior live_d build's LIVE artifact-ledger row — the liveness

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -61,6 +61,10 @@ pub async fn run_transformation(
     // Config fingerprint computed once in `run()` (mirrors every other
     // `persist_run_record` call site).
     config_hash: &str,
+    // The resolved `--pipeline` name, stamped onto the persisted `RunRecord`
+    // so the schedule reconciler can answer `after`/`freshness` demands on this
+    // transformation pipeline. `None` for a non-pipeline invocation.
+    pipeline_name: Option<&str>,
     // Caller-supplied `--idempotency-key` (verbatim, as `run()` received
     // it). Threaded so the persisted audit records the claimed key — the
     // model-only (`run.rs`) and replication paths pass the same value into
@@ -265,6 +269,7 @@ pub async fn run_transformation(
         started_at,
         config_hash,
         &audit,
+        pipeline_name,
     );
 
     // Stamp the terminal status onto the emitted payload so a JSON

--- a/engine/crates/rocky-cli/src/commands/trace.rs
+++ b/engine/crates/rocky-cli/src/commands/trace.rs
@@ -284,6 +284,8 @@ mod tests {
             hostname: "trace-test-host".to_string(),
             rocky_version: "0.0.0-test".to_string(),
             check_outcomes: Vec::new(),
+            pipeline: None,
+            submission_id: None,
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/validate.rs
+++ b/engine/crates/rocky-cli/src/commands/validate.rs
@@ -148,10 +148,20 @@ fn validate_inner(config_path: &Path) -> Result<ValidateOutput> {
             for msg in inert_config_messages(name, pc) {
                 out.push(msg);
             }
+
+            // Validate the optional `[schedule]` block (native demand
+            // reconciliation) — invalid cron/tz/catchup/freshness, unknown
+            // after targets, inert blocks, and the run-record persistence gap.
+            for msg in schedule_messages(name, pc, &cfg) {
+                out.push(msg);
+            }
         }
 
         // Validate pipeline dependency graph (depends_on)
         validate_pipeline_dag(&cfg, &mut out);
+
+        // Validate the schedule `after` graph is acyclic (mutual `after` hangs).
+        validate_schedule_dag(&cfg, &mut out);
     }
 
     // Validate models directory if it exists
@@ -532,6 +542,195 @@ fn inert_config_messages(
     }
 
     msgs
+}
+
+/// Whether a pipeline type persists a `RunRecord` on a successful run — the
+/// ground truth `after`/`freshness` demands read. Replication and transformation
+/// do; quality, snapshot, and load do not (yet), so a demand that reads one of
+/// their records would wait forever. Surfaced as an experimental limitation.
+fn schedule_persists_run_records(pc: &rocky_core::config::PipelineConfig) -> bool {
+    use rocky_core::config::PipelineConfig;
+    matches!(
+        pc,
+        PipelineConfig::Replication(_) | PipelineConfig::Transformation(_)
+    )
+}
+
+/// Validation for a pipeline's optional `[schedule]` block (native demand
+/// reconciliation). Core validity is driven by the reconciler's own
+/// [`resolve_schedule`](rocky_core::schedule::resolve_schedule) so `rocky
+/// validate` and `rocky tick` never disagree on what is invalid; the remaining
+/// checks catch unknown `after` targets, inert blocks, and the run-record
+/// persistence gap.
+fn schedule_messages(
+    name: &str,
+    pc: &rocky_core::config::PipelineConfig,
+    cfg: &rocky_core::config::RockyConfig,
+) -> Vec<ValidateMessage> {
+    use rocky_core::schedule::{ScheduleConfigError, resolve_schedule};
+
+    let Some(sched) = pc.schedule() else {
+        return Vec::new();
+    };
+    let mut msgs = Vec::new();
+    let field = format!("pipeline.{name}.schedule");
+
+    // Core validity — the same resolution the reconciler runs. Reports the first
+    // blocking error found.
+    if let Err(e) = resolve_schedule(
+        name,
+        sched,
+        &cfg.schedule.timezone,
+        &[],
+        cfg.freshness.expected_lag_seconds,
+    ) {
+        let (code, message) = match e {
+            ScheduleConfigError::BadCron(expr) => (
+                "V036",
+                format!(
+                    "pipeline.{name}: schedule.cron \"{expr}\" is not a valid cron expression."
+                ),
+            ),
+            ScheduleConfigError::BadTimezone(tz) => (
+                "V036",
+                format!(
+                    "pipeline.{name}: schedule.timezone \"{tz}\" is not a known IANA timezone name."
+                ),
+            ),
+            ScheduleConfigError::BadCatchup(v) if v == "all" => (
+                "V037",
+                format!(
+                    "pipeline.{name}: schedule.catchup = \"all\" is not supported — Rocky runs are watermark-driven, not windowed, so replaying every missed occurrence is pure cost. Use \"latest\" (default: one run at the most recent missed occurrence) or \"skip\"."
+                ),
+            ),
+            ScheduleConfigError::BadCatchup(v) => (
+                "V037",
+                format!(
+                    "pipeline.{name}: schedule.catchup \"{v}\" is invalid — expected \"latest\" or \"skip\"."
+                ),
+            ),
+            ScheduleConfigError::FreshnessNoBudget => (
+                "V038",
+                format!(
+                    "pipeline.{name}: schedule.freshness = true but no freshness budget resolves — set [freshness].expected_lag_seconds or a per-model max_lag_seconds."
+                ),
+            ),
+        };
+        msgs.push(ValidateMessage {
+            severity: "error".into(),
+            code: code.into(),
+            message,
+            file: None,
+            field: Some(field.clone()),
+        });
+    }
+
+    // Unknown `after` targets.
+    for up in &sched.after {
+        if !cfg.pipelines.contains_key(up) {
+            msgs.push(ValidateMessage {
+                severity: "error".into(),
+                code: "V039".into(),
+                message: format!(
+                    "pipeline.{name}: schedule.after references unknown pipeline \"{up}\"."
+                ),
+                file: None,
+                field: Some(format!("{field}.after")),
+            });
+        }
+    }
+
+    // An enabled schedule with no demand source is inert (never scheduled).
+    if sched.enabled && sched.cron.is_none() && sched.after.is_empty() && !sched.freshness {
+        msgs.push(ValidateMessage {
+            severity: "warn".into(),
+            code: "V040".into(),
+            message: format!(
+                "pipeline.{name}: [schedule] declares no cron, after, or freshness — the block is inert and the pipeline is never scheduled. Add a demand source or remove the block."
+            ),
+            file: None,
+            field: Some(field.clone()),
+        });
+    }
+
+    // Run-record persistence gap (experimental limitation): an `after` on, or
+    // `freshness = true` for, a pipeline type that persists no run record cannot
+    // observe the success it waits on, so the demand never fires.
+    for up in &sched.after {
+        if let Some(up_pc) = cfg.pipelines.get(up)
+            && !schedule_persists_run_records(up_pc)
+        {
+            msgs.push(ValidateMessage {
+                severity: "warn".into(),
+                code: "V041".into(),
+                message: format!(
+                    "pipeline.{name}: schedule.after references \"{up}\", a {} pipeline that does not persist a run record — this `after` demand cannot observe its success and will not fire (experimental limitation).",
+                    up_pc.pipeline_type_str()
+                ),
+                file: None,
+                field: Some(format!("{field}.after")),
+            });
+        }
+    }
+    if sched.freshness && !schedule_persists_run_records(pc) {
+        msgs.push(ValidateMessage {
+            severity: "warn".into(),
+            code: "V041".into(),
+            message: format!(
+                "pipeline.{name}: schedule.freshness = true on a {} pipeline that does not persist a run record — its run-staleness cannot be observed, so the demand will not fire (experimental limitation).",
+                pc.pipeline_type_str()
+            ),
+            file: None,
+            field: Some(format!("{field}.freshness")),
+        });
+    }
+
+    msgs
+}
+
+/// Validates the schedule `after` graph is acyclic — a mutual `after` would make
+/// the reconciler refuse to run rather than pick an ambiguous order. Only edges
+/// to existing pipelines are considered (unknown targets are the V039 error).
+fn validate_schedule_dag(cfg: &rocky_core::config::RockyConfig, out: &mut ValidateOutput) {
+    let names: std::collections::HashSet<&str> = cfg.pipelines.keys().map(String::as_str).collect();
+    let mut has_after = false;
+    let dag_nodes: Vec<rocky_ir::dag::DagNode> = cfg
+        .pipelines
+        .iter()
+        .map(|(name, pc)| {
+            let after: Vec<String> = pc
+                .schedule()
+                .map(|s| {
+                    s.after
+                        .iter()
+                        .filter(|u| names.contains(u.as_str()))
+                        .cloned()
+                        .collect()
+                })
+                .unwrap_or_default();
+            if !after.is_empty() {
+                has_after = true;
+            }
+            rocky_ir::dag::DagNode {
+                name: name.clone(),
+                depends_on: after,
+            }
+        })
+        .collect();
+    if !has_after {
+        return;
+    }
+    if let Err(e) = rocky_ir::dag::topological_sort(&dag_nodes) {
+        out.push(ValidateMessage {
+            severity: "error".into(),
+            code: "V042".into(),
+            message: format!(
+                "schedule.after graph has a cycle — a pipeline cannot run after itself, transitively ({e})."
+            ),
+            file: None,
+            field: None,
+        });
+    }
 }
 
 /// The `[checks]` sub-field name for a [`CheckKind`], used to point the
@@ -1122,6 +1321,194 @@ mod tests {
         let mut f = NamedTempFile::new().unwrap();
         f.write_all(toml_str.as_bytes()).unwrap();
         validate_inner(f.path()).unwrap()
+    }
+
+    #[test]
+    fn schedule_catchup_all_is_rejected_v037() {
+        let out = validate_toml(
+            r#"
+[adapter.db]
+type = "duckdb"
+[pipeline.raw]
+type = "transformation"
+[pipeline.raw.target]
+adapter = "db"
+[pipeline.raw.schedule]
+cron = "0 3 * * *"
+catchup = "all"
+"#,
+        );
+        let v037: Vec<_> = out
+            .messages
+            .iter()
+            .filter(|m| m.code == "V037" && m.severity == "error")
+            .collect();
+        assert_eq!(v037.len(), 1, "expected one V037: {:?}", out.messages);
+        assert!(v037[0].message.contains("watermark-driven"));
+        assert!(!out.valid);
+    }
+
+    #[test]
+    fn schedule_unknown_after_target_is_v039() {
+        let out = validate_toml(
+            r#"
+[adapter.db]
+type = "duckdb"
+[pipeline.staging]
+type = "transformation"
+[pipeline.staging.target]
+adapter = "db"
+[pipeline.staging.schedule]
+after = ["ghost"]
+"#,
+        );
+        assert!(
+            out.messages
+                .iter()
+                .any(|m| m.code == "V039" && m.severity == "error"),
+            "{:?}",
+            out.messages
+        );
+        assert!(!out.valid);
+    }
+
+    #[test]
+    fn schedule_after_cycle_is_v042() {
+        let out = validate_toml(
+            r#"
+[adapter.db]
+type = "duckdb"
+[pipeline.a]
+type = "transformation"
+[pipeline.a.target]
+adapter = "db"
+[pipeline.a.schedule]
+after = ["b"]
+[pipeline.b]
+type = "transformation"
+[pipeline.b.target]
+adapter = "db"
+[pipeline.b.schedule]
+after = ["a"]
+"#,
+        );
+        assert!(
+            out.messages
+                .iter()
+                .any(|m| m.code == "V042" && m.severity == "error"),
+            "{:?}",
+            out.messages
+        );
+        assert!(!out.valid);
+    }
+
+    #[test]
+    fn schedule_freshness_without_budget_is_v038() {
+        let out = validate_toml(
+            r#"
+[adapter.db]
+type = "duckdb"
+[pipeline.raw]
+type = "transformation"
+[pipeline.raw.target]
+adapter = "db"
+[pipeline.raw.schedule]
+freshness = true
+"#,
+        );
+        assert!(
+            out.messages
+                .iter()
+                .any(|m| m.code == "V038" && m.severity == "error"),
+            "{:?}",
+            out.messages
+        );
+        assert!(!out.valid);
+    }
+
+    #[test]
+    fn schedule_inert_block_is_v040_warning() {
+        let out = validate_toml(
+            r#"
+[adapter.db]
+type = "duckdb"
+[pipeline.raw]
+type = "transformation"
+[pipeline.raw.target]
+adapter = "db"
+[pipeline.raw.schedule]
+enabled = true
+"#,
+        );
+        assert!(
+            out.messages
+                .iter()
+                .any(|m| m.code == "V040" && m.severity == "warn"),
+            "{:?}",
+            out.messages
+        );
+        assert!(out.valid, "inert schedule is a warning, not an error");
+    }
+
+    #[test]
+    fn schedule_after_non_persisting_type_is_v041_warning() {
+        let out = validate_toml(
+            r#"
+[adapter.db]
+type = "duckdb"
+[pipeline.dq]
+type = "quality"
+[pipeline.dq.target]
+adapter = "db"
+[pipeline.dq.checks]
+enabled = true
+[pipeline.staging]
+type = "transformation"
+[pipeline.staging.target]
+adapter = "db"
+[pipeline.staging.schedule]
+after = ["dq"]
+"#,
+        );
+        let v041: Vec<_> = out.messages.iter().filter(|m| m.code == "V041").collect();
+        assert_eq!(v041.len(), 1, "expected one V041: {:?}", out.messages);
+        assert_eq!(v041[0].severity, "warn");
+        assert!(out.valid, "the persistence gap is a warning, not an error");
+    }
+
+    #[test]
+    fn schedule_valid_config_has_no_schedule_errors() {
+        let out = validate_toml(
+            r#"
+[adapter.db]
+type = "duckdb"
+[pipeline.raw]
+type = "transformation"
+[pipeline.raw.target]
+adapter = "db"
+[pipeline.raw.schedule]
+cron = "0 3 * * *"
+timezone = "Europe/Lisbon"
+[pipeline.staging]
+type = "transformation"
+[pipeline.staging.target]
+adapter = "db"
+[pipeline.staging.schedule]
+after = ["raw"]
+"#,
+        );
+        let sched_errs: Vec<_> = out
+            .messages
+            .iter()
+            .filter(|m| {
+                ["V036", "V037", "V038", "V039", "V040", "V041", "V042"].contains(&m.code.as_str())
+                    && m.severity == "error"
+            })
+            .collect();
+        assert!(
+            sched_errs.is_empty(),
+            "valid schedule should have no errors: {sched_errs:?}"
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-cli/src/commands/validate.rs
+++ b/engine/crates/rocky-cli/src/commands/validate.rs
@@ -685,6 +685,29 @@ fn schedule_messages(
         });
     }
 
+    // The reconciler resolves the freshness budget from the PROJECT
+    // [freshness].expected_lag_seconds in this version; per-model
+    // `max_lag_seconds` is not consulted (that resolution needs per-pipeline
+    // model loading, which lands with the `rocky tick` verb). A member model
+    // with a tighter budget would therefore under-fire silently — surface the
+    // limitation loudly whenever a project budget exists (the no-budget case is
+    // already the V038 error).
+    if sched.freshness
+        && schedule_persists_run_records(pc)
+        && cfg.freshness.expected_lag_seconds.is_some()
+    {
+        msgs.push(ValidateMessage {
+            severity: "warn".into(),
+            code: "V043".into(),
+            message: format!(
+                "pipeline.{name}: schedule.freshness resolves its budget from the project [freshness].expected_lag_seconds ({}s) in this version — per-model max_lag_seconds is NOT consulted, so a member model that declares a tighter budget will under-fire. Set the project budget to the tightest member value until per-model resolution lands (experimental limitation).",
+                cfg.freshness.expected_lag_seconds.unwrap_or_default()
+            ),
+            file: None,
+            field: Some(format!("{field}.freshness")),
+        });
+    }
+
     msgs
 }
 
@@ -1474,6 +1497,56 @@ after = ["dq"]
         assert_eq!(v041.len(), 1, "expected one V041: {:?}", out.messages);
         assert_eq!(v041[0].severity, "warn");
         assert!(out.valid, "the persistence gap is a warning, not an error");
+    }
+
+    #[test]
+    fn schedule_freshness_per_model_budget_gap_is_v043_warning() {
+        // freshness = true with a project budget → the reconciler resolves the
+        // project value only (per-model max_lag_seconds not consulted in v1), so
+        // the under-fire limitation is surfaced loudly as a warning.
+        let out = validate_toml(
+            r#"
+[freshness]
+expected_lag_seconds = 3600
+[adapter.db]
+type = "duckdb"
+[pipeline.raw]
+type = "transformation"
+[pipeline.raw.target]
+adapter = "db"
+[pipeline.raw.schedule]
+freshness = true
+"#,
+        );
+        let v043: Vec<_> = out.messages.iter().filter(|m| m.code == "V043").collect();
+        assert_eq!(v043.len(), 1, "expected one V043: {:?}", out.messages);
+        assert_eq!(v043[0].severity, "warn");
+        assert!(
+            out.valid,
+            "the per-model budget gap is a warning, not an error"
+        );
+        // No project budget → this is the V038 error instead, not V043.
+        let out2 = validate_toml(
+            r#"
+[adapter.db]
+type = "duckdb"
+[pipeline.raw]
+type = "transformation"
+[pipeline.raw.target]
+adapter = "db"
+[pipeline.raw.schedule]
+freshness = true
+"#,
+        );
+        assert!(
+            out2.messages.iter().all(|m| m.code != "V043"),
+            "no project budget → V038 error, not V043"
+        );
+        assert!(
+            out2.messages
+                .iter()
+                .any(|m| m.code == "V038" && m.severity == "error")
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -4965,6 +4965,8 @@ impl RunOutput {
             hostname: audit.hostname,
             rocky_version: audit.rocky_version,
             check_outcomes,
+            pipeline: None,
+            submission_id: None,
         }
     }
 

--- a/engine/crates/rocky-cli/src/scope.rs
+++ b/engine/crates/rocky-cli/src/scope.rs
@@ -443,6 +443,7 @@ table = "customers"
             checks: Default::default(),
             execution: Default::default(),
             depends_on: vec![],
+            schedule: None,
         };
 
         let config_path = dir.path().join("rocky.toml");
@@ -491,6 +492,7 @@ table = "secret"
             checks: Default::default(),
             execution: Default::default(),
             depends_on: vec![],
+            schedule: None,
         };
 
         let config_path = project_dir.join("rocky.toml");

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -16,6 +16,9 @@ schemars = { workspace = true }
 indexmap = { workspace = true }
 toml = { workspace = true }
 chrono = { workspace = true }
+chrono-tz = { workspace = true }
+croner = { workspace = true }
+uuid = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 redb = { workspace = true }
@@ -35,6 +38,9 @@ lasso = { version = "0.7", features = ["multi-threaded"] }
 memmap2 = "0.9"
 rayon = "1"
 blake3 = { workspace = true }
+# Unix SIGTERM delivery for the schedule spawner's graceful-then-forced child
+# termination. Usage is `#[cfg(unix)]`-gated; the crate is a no-op shim elsewhere.
+libc = { workspace = true }
 # Apache Arrow appears in the `WarehouseAdapter::fetch_arrow_batch` return
 # type (proof-of-concept inter-adapter wire format — only rocky-duckdb
 # implements it today). The default impl just errors, but the symbol is

--- a/engine/crates/rocky-core/src/bridge.rs
+++ b/engine/crates/rocky-core/src/bridge.rs
@@ -319,6 +319,7 @@ mod tests {
             gc: Default::default(),
             policy: None,
             resilience: Default::default(),
+            schedule: Default::default(),
         }
     }
 

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -2500,6 +2500,13 @@ pub struct RockyConfig {
     #[serde(default)]
     pub freshness: ProjectFreshnessConfig,
 
+    /// Project-level schedule defaults for native demand reconciliation.
+    /// Supplies the fallback timezone for per-pipeline `[…schedule]` cron
+    /// blocks and the resident-loop poll cadence. See
+    /// [`ScheduleDefaultsConfig`].
+    #[serde(default)]
+    pub schedule: ScheduleDefaultsConfig,
+
     /// Imported producer-project snapshots, keyed by import name.
     ///
     /// Each `[imports.<name>]` block points at a vendored snapshot of a
@@ -4186,6 +4193,18 @@ impl PipelineConfig {
         }
     }
 
+    /// Returns the optional `[schedule]` block for native demand
+    /// reconciliation, or `None` when the pipeline declares no schedule.
+    pub fn schedule(&self) -> Option<&ScheduleConfig> {
+        match self {
+            Self::Replication(r) => r.schedule.as_ref(),
+            Self::Transformation(t) => t.schedule.as_ref(),
+            Self::Quality(q) => q.schedule.as_ref(),
+            Self::Snapshot(s) => s.schedule.as_ref(),
+            Self::Load(l) => l.schedule.as_ref(),
+        }
+    }
+
     /// Unwraps the replication config, returning `None` for other types.
     pub fn as_replication(&self) -> Option<&ReplicationPipelineConfig> {
         match self {
@@ -4225,6 +4244,120 @@ impl PipelineConfig {
             _ => None,
         }
     }
+}
+
+/// Per-pipeline schedule declaration for native demand reconciliation.
+///
+/// Every field is optional; an absent `[pipeline.<name>.schedule]` block leaves
+/// the pipeline with today's behavior (it runs only when invoked directly). A
+/// pipeline may combine demand sources — `cron`, `after`, and `freshness` union,
+/// so any one of them makes the pipeline due.
+///
+/// Unlike the five pipeline variant structs (which deliberately omit
+/// `deny_unknown_fields` so the IDE schema can inject the `type` discriminator),
+/// this struct **denies unknown fields**: a typo inside `[…schedule]` is a
+/// silent scheduling bug — a misspelled `corn` key would leave a pipeline
+/// unscheduled with no error — so the deserializer rejects it outright.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ScheduleConfig {
+    /// Standard 5-field cron expression (minute hour day-of-month month
+    /// day-of-week). When set, the pipeline is due at each occurrence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cron: Option<String>,
+
+    /// IANA timezone name (e.g. `"Europe/Lisbon"`) the `cron` occurrences are
+    /// evaluated in. Falls back to the project `[schedule].timezone`, which
+    /// itself defaults to `"UTC"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timezone: Option<String>,
+
+    /// Upstream pipelines this one runs after. The pipeline is due once every
+    /// listed pipeline has a successful run that completed after this
+    /// pipeline's own latest success started (a partial-success run does not
+    /// count as an upstream success).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub after: Vec<String>,
+
+    /// When `true`, the pipeline is due once its own run-staleness exceeds its
+    /// freshness budget (resolved from per-model `max_lag_seconds`, falling
+    /// back to the project `[freshness].expected_lag_seconds`). This is
+    /// run-staleness only — the reconciler never queries the warehouse.
+    #[serde(default)]
+    pub freshness: bool,
+
+    /// Catch-up policy when more than one cron occurrence elapsed since the
+    /// last fire: `"latest"` (default) fires one demand at the most recent
+    /// missed occurrence; `"skip"` advances the anchor and runs nothing.
+    /// `"all"` is rejected at validation — runs are watermark-driven, not
+    /// windowed, so replaying every missed occurrence is pure cost.
+    #[serde(default = "default_catchup")]
+    pub catchup: String,
+
+    /// In-tick immediate re-submissions on failure. The reconciler never
+    /// sleeps between attempts; minutes-scale spacing is the always-on
+    /// cross-tick throttle, not this knob. Default `0` (off).
+    #[serde(default)]
+    pub retry: ScheduleRetryConfig,
+
+    /// Scheduler-level timeout in minutes for a launched run. `0` (default)
+    /// means no scheduler-level timeout — the run's own limits apply.
+    #[serde(default)]
+    pub timeout_minutes: u64,
+
+    /// When `false`, demand is suppressed but the config is kept. Default
+    /// `true`.
+    #[serde(default = "default_true_config")]
+    pub enabled: bool,
+}
+
+/// In-tick retry budget for a scheduled pipeline.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ScheduleRetryConfig {
+    /// Maximum number of *additional* immediate re-submissions after the first
+    /// attempt fails. `0` means the first attempt is the only one.
+    #[serde(default)]
+    pub max: u32,
+}
+
+/// Project-level schedule defaults (`[schedule]`).
+///
+/// Supplies the fallback timezone for per-pipeline `cron` blocks that omit
+/// their own, plus the resident-loop poll cadence consumed by a later phase.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ScheduleDefaultsConfig {
+    /// Default IANA timezone for per-pipeline cron evaluation. Default `"UTC"`.
+    #[serde(default = "default_schedule_timezone")]
+    pub timezone: String,
+
+    /// Poll cadence in seconds for the resident scheduler loop. Not consumed
+    /// by the one-shot tick; reserved for the resident-loop phase. Default
+    /// `15`.
+    #[serde(default = "default_poll_interval_seconds")]
+    pub poll_interval_seconds: u64,
+}
+
+impl Default for ScheduleDefaultsConfig {
+    fn default() -> Self {
+        Self {
+            timezone: default_schedule_timezone(),
+            poll_interval_seconds: default_poll_interval_seconds(),
+        }
+    }
+}
+
+fn default_catchup() -> String {
+    "latest".to_string()
+}
+
+fn default_schedule_timezone() -> String {
+    "UTC".to_string()
+}
+
+fn default_poll_interval_seconds() -> u64 {
+    15
 }
 
 /// Replication pipeline configuration.
@@ -4305,6 +4438,10 @@ pub struct ReplicationPipelineConfig {
     /// Pipeline dependencies for chaining.
     #[serde(default)]
     pub depends_on: Vec<String>,
+
+    /// Optional native-schedule declaration. See [`ScheduleConfig`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schedule: Option<ScheduleConfig>,
 
     /// Per-`(connector, table)` overrides applied on top of the pipeline
     /// defaults. Each rule matches against a discovered connector +
@@ -4727,6 +4864,10 @@ pub struct TransformationPipelineConfig {
     /// Pipeline dependencies for chaining.
     #[serde(default)]
     pub depends_on: Vec<String>,
+
+    /// Optional native-schedule declaration. See [`ScheduleConfig`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schedule: Option<ScheduleConfig>,
 }
 
 fn default_models_glob() -> String {
@@ -4794,6 +4935,10 @@ pub struct QualityPipelineConfig {
     /// Pipeline dependencies for chaining.
     #[serde(default)]
     pub depends_on: Vec<String>,
+
+    /// Optional native-schedule declaration. See [`ScheduleConfig`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schedule: Option<ScheduleConfig>,
 }
 
 /// Target configuration for quality pipelines (adapter reference only).
@@ -4873,6 +5018,10 @@ pub struct SnapshotPipelineConfig {
     /// Pipeline dependencies for chaining.
     #[serde(default)]
     pub depends_on: Vec<String>,
+
+    /// Optional native-schedule declaration. See [`ScheduleConfig`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schedule: Option<ScheduleConfig>,
 }
 
 /// Source table for a snapshot pipeline (explicit single-table reference).
@@ -4961,6 +5110,10 @@ pub struct LoadPipelineConfig {
     /// Pipeline dependencies for chaining.
     #[serde(default)]
     pub depends_on: Vec<String>,
+
+    /// Optional native-schedule declaration. See [`ScheduleConfig`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schedule: Option<ScheduleConfig>,
 }
 
 /// File format for load pipelines, parsed from TOML.

--- a/engine/crates/rocky-core/src/cross_engine.rs
+++ b/engine/crates/rocky-core/src/cross_engine.rs
@@ -547,6 +547,7 @@ mod tests {
             depends_on,
             table_overrides: vec![],
             prune_unchanged: false,
+            schedule: None,
         }))
     }
 
@@ -561,6 +562,7 @@ mod tests {
             checks: ChecksConfig::default(),
             execution: ExecutionConfig::default(),
             depends_on,
+            schedule: None,
         }))
     }
 
@@ -597,6 +599,7 @@ mod tests {
             gc: Default::default(),
             policy: None,
             resilience: Default::default(),
+            schedule: Default::default(),
         }
     }
 
@@ -709,6 +712,7 @@ mod tests {
                         checks: ChecksConfig::default(),
                         execution: ExecutionConfig::default(),
                         depends_on: vec!["transform".into()],
+                        schedule: None,
                     })),
                 ),
             ],
@@ -877,6 +881,7 @@ mod tests {
                     checks: ChecksConfig::default(),
                     execution: ExecutionConfig::default(),
                     depends_on: vec![],
+                    schedule: None,
                 })),
             )],
         );

--- a/engine/crates/rocky-core/src/docs.rs
+++ b/engine/crates/rocky-core/src/docs.rs
@@ -746,6 +746,7 @@ mod tests {
             gc: Default::default(),
             policy: None,
             resilience: Default::default(),
+            schedule: Default::default(),
         };
 
         let models = vec![
@@ -846,6 +847,7 @@ mod tests {
             gc: Default::default(),
             policy: None,
             resilience: Default::default(),
+            schedule: Default::default(),
         };
 
         let models = vec![Model {
@@ -948,6 +950,7 @@ mod tests {
             gc: Default::default(),
             policy: None,
             resilience: Default::default(),
+            schedule: Default::default(),
         };
 
         let index = build_doc_index(&[], &config, None, None);

--- a/engine/crates/rocky-core/src/lib.rs
+++ b/engine/crates/rocky-core/src/lib.rs
@@ -45,6 +45,7 @@ pub mod retry_budget;
 pub mod reuse;
 pub mod role_graph;
 pub mod run_vars;
+pub mod schedule;
 pub mod schema;
 pub mod schema_cache;
 pub mod seeds;

--- a/engine/crates/rocky-core/src/schedule/claim.rs
+++ b/engine/crates/rocky-core/src/schedule/claim.rs
@@ -1,0 +1,816 @@
+//! The per-demand claim state machine — the soundness heart of the reconciler.
+//!
+//! Every due demand takes a **claim** before its child is spawned. The claim is
+//! a small record in redb, transitioned by compare-and-swap inside a write
+//! transaction, so two reconcilers racing the same demand cannot both spawn:
+//! redb serializes writers, exactly one lands the `submitted` transition, and a
+//! reconciler whose CAS fails has *lost ownership* and stands down.
+//!
+//! This module holds only the **pure decisions**. The redb CAS that applies
+//! them lives on [`crate::state::StateStore`]; keeping the decision logic here,
+//! free of any transaction, is what makes the state machine exhaustively
+//! unit-testable — the regression matrix below is the executable spec.
+//!
+//! The three decision points:
+//!
+//! - [`decide_pre_spawn`] — before spawning: claim an absent or re-claimable
+//!   key (`released`), refuse to spawn over a live `submitted` (resolve it
+//!   first) or a terminal `completed`.
+//! - [`decide_post_attempt`] — after a child returns *in the same tick*: either
+//!   an in-tick retry transition (`submitted{id_n} -> submitted{id_n+1}`) while
+//!   budget remains, or a terminal transition on exhaustion.
+//! - [`decide_resolver`] — for a `submitted` claim re-encountered on a later
+//!   tick (its owner crashed): budget-aware, it continues the retry budget
+//!   across the crash rather than finalizing after one of N attempts.
+//!
+//! A claim is `submitted` (a run is in flight for this key), `released` (the
+//! attempt was voided or is retryable — the key may be re-claimed), or
+//! `completed` (a terminal run was observed — the key must NEVER run again).
+//! Conflating `released` and `completed` is the crash-duplicate bug: recovery
+//! re-promotes anything it reads as merely released.
+
+use chrono::{DateTime, Utc};
+
+/// The demand source a claim belongs to. Governs the terminal transition: a
+/// spent cron/webhook demand is `completed` (its next fire is a new key), while
+/// a standing `after`/`freshness` demand that failed goes back to `released`
+/// so its next backoff window can re-claim it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DemandKind {
+    /// A cron occurrence. The anchor advances on submission; the next
+    /// occurrence is a fresh key.
+    Cron,
+    /// An `after` dependency trigger. Standing until its own run succeeds.
+    After,
+    /// A freshness (run-staleness) trigger. Standing until a run succeeds.
+    Freshness,
+    /// A webhook delivery (reserved for the resident-loop phase). One-shot:
+    /// consumed by being attempted.
+    Webhook,
+}
+
+impl DemandKind {
+    /// The stable source token used in the claim storage key.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            DemandKind::Cron => "cron",
+            DemandKind::After => "after",
+            DemandKind::Freshness => "freshness",
+            DemandKind::Webhook => "webhook",
+        }
+    }
+
+    /// Whether this demand is *standing* — a source that keeps demanding until a
+    /// run actually succeeds (`after`, `freshness`). Cron and webhook are
+    /// one-shot per key.
+    pub fn is_standing(self) -> bool {
+        matches!(self, DemandKind::After | DemandKind::Freshness)
+    }
+}
+
+/// The terminal outcome of an attempt, from the child's exit code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TerminalOutcome {
+    /// Exit 0.
+    Success,
+    /// Exit 2 — a partial success. Does NOT satisfy downstream `after`; does
+    /// clear the emitter's own cron demand for that occurrence; is never
+    /// retried; neither increments nor resets `consecutive_failures`.
+    Partial,
+    /// Exit 1 / any other — an infrastructure failure. Retryable within budget;
+    /// increments `consecutive_failures` on exhaustion.
+    Failure,
+}
+
+impl TerminalOutcome {
+    /// Map a child process exit code to an outcome.
+    pub fn from_exit_code(code: i32) -> Self {
+        match code {
+            0 => TerminalOutcome::Success,
+            2 => TerminalOutcome::Partial,
+            _ => TerminalOutcome::Failure,
+        }
+    }
+
+    /// The string recorded in `ScheduleStateRecord.last_attempt_outcome`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TerminalOutcome::Success => "success",
+            TerminalOutcome::Partial => "partial",
+            TerminalOutcome::Failure => "failure",
+        }
+    }
+}
+
+/// The lifecycle state of a claim.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case", tag = "state")]
+pub enum ClaimState {
+    /// A run is (or was) in flight for this key under `submission_id`.
+    Submitted,
+    /// The attempt was voided or is retryable — this key may be re-claimed.
+    /// `budget_open` on the record decides whether the re-claim continues the
+    /// current retry cycle or starts a fresh one.
+    Released,
+    /// A terminal run was observed and this key is finished — it must NEVER run
+    /// again.
+    Completed {
+        /// The observed terminal outcome.
+        outcome: TerminalOutcome,
+    },
+}
+
+/// A claim record: the authoritative, per-key mutable state of the reconciler.
+///
+/// Every field beyond the first three is serde-defaulted so a record written by
+/// an older binary — or a future one that adds a field — round-trips cleanly.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ClaimRecord {
+    /// The lifecycle state (`submitted` / `released` / `completed`).
+    #[serde(flatten)]
+    pub state: ClaimState,
+    /// The current attempt's submission id (a fresh UUID per submission). The
+    /// precise join key between a demand and *its* run record.
+    pub submission_id: String,
+    /// Monotonic audit counter of total submissions on this key. Never consulted
+    /// by any budget guard.
+    #[serde(default)]
+    pub attempts: u32,
+    /// The authoritative retry-budget ordinal: submissions in the current retry
+    /// cycle INCLUDING the one in flight. Initialized to 1 on insert. The sole
+    /// input to every budget guard (`cycle_attempts < 1 + retry.max`).
+    #[serde(default)]
+    pub cycle_attempts: u32,
+    /// Set on every `released` transition: `true` = the retry cycle continues
+    /// (a re-claim does `cycle_attempts + 1`); `false` = the cycle is over
+    /// (exhaustion/backoff), so a re-claim resets `cycle_attempts` to 1.
+    #[serde(default)]
+    pub budget_open: bool,
+    /// The spawned child's PID, recorded for the recovery sweep's liveness
+    /// probe. `None` until a child is spawned (or on platforms without a probe).
+    #[serde(default)]
+    pub child_pid: Option<u32>,
+    /// The spawned child's process start time, paired with `child_pid` to make
+    /// a later liveness probe PID-reuse-proof. Populated by the recovery phase.
+    #[serde(default)]
+    pub child_start_time: Option<u64>,
+    /// When a stuck `submitted` claim was first re-encountered by a sweep, so a
+    /// bounded grace can elapse before it is force-resolved. RFC3339.
+    #[serde(default)]
+    pub first_swept_at: Option<String>,
+    /// The instant of the last transition. RFC3339. Drives the 7-day GC of
+    /// terminal claims.
+    #[serde(default)]
+    pub last_transition_at: Option<String>,
+}
+
+impl ClaimRecord {
+    /// A fresh `submitted` claim starting a new retry cycle (`cycle_attempts`
+    /// = 1, `attempts` = 1).
+    pub fn new_submitted(submission_id: String, now: DateTime<Utc>) -> Self {
+        Self {
+            state: ClaimState::Submitted,
+            submission_id,
+            attempts: 1,
+            cycle_attempts: 1,
+            budget_open: false,
+            child_pid: None,
+            child_start_time: None,
+            first_swept_at: None,
+            last_transition_at: Some(now.to_rfc3339()),
+        }
+    }
+
+    /// True when the claim is terminal (`completed`).
+    pub fn is_completed(&self) -> bool {
+        matches!(self.state, ClaimState::Completed { .. })
+    }
+}
+
+/// The outcome of a claim compare-and-swap against the store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClaimCas {
+    /// The CAS matched the observed prior and the new claim (plus any cursor
+    /// mutation) was committed. The caller owns the demand and may spawn.
+    Won,
+    /// The stored claim no longer equals what was observed — another reconciler
+    /// moved it. The caller has lost ownership: no spawn, no further writes for
+    /// this demand this pass. Carries the current stored claim, if any.
+    Lost(Option<ClaimRecord>),
+}
+
+/// Whether the retry budget has room for another attempt, given the count of
+/// submissions already made in this cycle (including the in-flight one) and the
+/// configured maximum number of *additional* re-submissions.
+///
+/// `cycle_attempts < 1 + retry_max`. With `retry_max = 0`, a freshly-inserted
+/// claim (`cycle_attempts = 1`) reads `1 < 1` = false — the first attempt is
+/// the only one.
+pub fn budget_remains(cycle_attempts: u32, retry_max: u32) -> bool {
+    cycle_attempts < 1 + retry_max
+}
+
+/// The pre-spawn decision for a due demand, given the claim currently stored
+/// (if any) and a freshly-minted submission id.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PreSpawn {
+    /// Claim the key: CAS-insert this `submitted` record, then spawn. The CAS
+    /// asserts the stored claim still equals what was observed; a lost CAS is a
+    /// stand-down (no spawn).
+    Claim(ClaimRecord),
+    /// The key is already `submitted` — do not spawn over it; run the resolver
+    /// against the identity table first.
+    ResolveStuck,
+    /// The key is `completed` — terminal, never spawn.
+    SkipCompleted,
+}
+
+/// Decide the pre-spawn transition. Pure — the CAS that applies it is on the
+/// state store.
+///
+/// - absent ⇒ insert `submitted` (`cycle_attempts = 1`).
+/// - `released{budget_open = true}` ⇒ re-claim continuing the cycle
+///   (`cycle_attempts + 1`).
+/// - `released{budget_open = false}` ⇒ re-claim resetting the cycle
+///   (`cycle_attempts = 1`).
+/// - `submitted` ⇒ [`PreSpawn::ResolveStuck`].
+/// - `completed` ⇒ [`PreSpawn::SkipCompleted`].
+pub fn decide_pre_spawn(
+    observed: Option<&ClaimRecord>,
+    fresh_submission_id: String,
+    now: DateTime<Utc>,
+) -> PreSpawn {
+    match observed {
+        None => PreSpawn::Claim(ClaimRecord::new_submitted(fresh_submission_id, now)),
+        Some(prior) => match &prior.state {
+            ClaimState::Completed { .. } => PreSpawn::SkipCompleted,
+            ClaimState::Submitted => PreSpawn::ResolveStuck,
+            ClaimState::Released => {
+                let cycle_attempts = if prior.budget_open {
+                    prior.cycle_attempts + 1
+                } else {
+                    1
+                };
+                PreSpawn::Claim(ClaimRecord {
+                    state: ClaimState::Submitted,
+                    submission_id: fresh_submission_id,
+                    attempts: prior.attempts + 1,
+                    cycle_attempts,
+                    budget_open: false,
+                    child_pid: None,
+                    child_start_time: None,
+                    first_swept_at: None,
+                    last_transition_at: Some(now.to_rfc3339()),
+                })
+            }
+        },
+    }
+}
+
+/// How a terminal transition should move `consecutive_failures`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CfDelta {
+    /// Failure on exhaustion — `consecutive_failures += 1`.
+    Increment,
+    /// Success — `consecutive_failures = 0`.
+    Reset,
+    /// Partial — neither increment nor reset.
+    Unchanged,
+}
+
+/// Bookkeeping to apply to the pipeline's `ScheduleStateRecord` alongside a
+/// terminal claim transition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Bookkeeping {
+    /// The outcome recorded in `last_attempt_outcome`.
+    pub outcome: TerminalOutcome,
+    /// How `consecutive_failures` moves.
+    pub cf_delta: CfDelta,
+}
+
+/// The decision after an in-tick attempt returns.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PostAttempt {
+    /// Budget remains after a failure — the in-tick retry transition
+    /// `submitted{id_n} -> submitted{id_n+1}`. Spawn again immediately; no
+    /// `consecutive_failures`/backoff bookkeeping yet.
+    Retry(ClaimRecord),
+    /// The demand is exhausted — apply the terminal claim transition together
+    /// with the bookkeeping, in one write.
+    Terminal {
+        /// The terminal claim record to store.
+        claim: ClaimRecord,
+        /// The `ScheduleStateRecord` bookkeeping to apply in the same write.
+        bookkeeping: Bookkeeping,
+    },
+}
+
+/// Compute the terminal claim state for a demand kind + outcome (frozen table).
+///
+/// - cron / webhook: any outcome ⇒ `completed` (the next fire is a new key).
+/// - after / freshness: success ⇒ `completed`; failure | partial ⇒ `released`
+///   with `budget_open = false` (the demand is still standing and must be
+///   re-claimable when its backoff elapses).
+fn terminal_state(kind: DemandKind, outcome: TerminalOutcome) -> ClaimState {
+    match kind {
+        DemandKind::Cron | DemandKind::Webhook => ClaimState::Completed { outcome },
+        DemandKind::After | DemandKind::Freshness => match outcome {
+            TerminalOutcome::Success => ClaimState::Completed { outcome },
+            TerminalOutcome::Failure | TerminalOutcome::Partial => ClaimState::Released,
+        },
+    }
+}
+
+fn bookkeeping_for(outcome: TerminalOutcome) -> Bookkeeping {
+    let cf_delta = match outcome {
+        TerminalOutcome::Success => CfDelta::Reset,
+        TerminalOutcome::Failure => CfDelta::Increment,
+        TerminalOutcome::Partial => CfDelta::Unchanged,
+    };
+    Bookkeeping { outcome, cf_delta }
+}
+
+fn terminal_claim(
+    current: &ClaimRecord,
+    kind: DemandKind,
+    outcome: TerminalOutcome,
+    now: DateTime<Utc>,
+) -> ClaimRecord {
+    let state = terminal_state(kind, outcome);
+    ClaimRecord {
+        state,
+        submission_id: current.submission_id.clone(),
+        attempts: current.attempts,
+        cycle_attempts: current.cycle_attempts,
+        // A terminal `released` (standing demand, failure/partial) closes the
+        // cycle so the next backoff-driven re-claim resets `cycle_attempts`.
+        budget_open: false,
+        child_pid: current.child_pid,
+        child_start_time: current.child_start_time,
+        first_swept_at: None,
+        last_transition_at: Some(now.to_rfc3339()),
+    }
+}
+
+/// Decide the transition after an in-tick attempt returns with `outcome`.
+///
+/// A `failure` with budget remaining is an in-tick [`PostAttempt::Retry`]; any
+/// other outcome — success, partial, or an exhausted failure — is terminal.
+pub fn decide_post_attempt(
+    current: &ClaimRecord,
+    outcome: TerminalOutcome,
+    kind: DemandKind,
+    retry_max: u32,
+    fresh_submission_id: String,
+    now: DateTime<Utc>,
+) -> PostAttempt {
+    let retryable =
+        outcome == TerminalOutcome::Failure && budget_remains(current.cycle_attempts, retry_max);
+    if retryable {
+        return PostAttempt::Retry(ClaimRecord {
+            state: ClaimState::Submitted,
+            submission_id: fresh_submission_id,
+            attempts: current.attempts + 1,
+            cycle_attempts: current.cycle_attempts + 1,
+            budget_open: false,
+            child_pid: None,
+            child_start_time: None,
+            first_swept_at: None,
+            last_transition_at: Some(now.to_rfc3339()),
+        });
+    }
+    PostAttempt::Terminal {
+        claim: terminal_claim(current, kind, outcome, now),
+        bookkeeping: bookkeeping_for(outcome),
+    }
+}
+
+/// The resolver decision for a stuck `submitted` claim re-encountered on a later
+/// tick (its owner crashed between spawn and the next transition).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Resolved {
+    /// A failure with budget remaining: the retry budget continues across the
+    /// crash. Store this `released{budget_open = true}` with NO
+    /// `consecutive_failures`/backoff — the next tick re-claims and continues
+    /// the cycle. This is what the plain terminal table would have wrongly
+    /// suppressed one state over.
+    ReleasedBudgetOpen(ClaimRecord),
+    /// The attempt is exhausted (or a success/partial). Apply the terminal
+    /// transition + bookkeeping, exactly as the in-tick exhaustion path would.
+    Terminal {
+        /// The terminal claim record to store.
+        claim: ClaimRecord,
+        /// The bookkeeping to apply in the same write.
+        bookkeeping: Bookkeeping,
+    },
+}
+
+/// Decide how to resolve a stuck `submitted` claim, given the outcome the
+/// resolver derived (from a terminal run record carrying the claim's
+/// `submission_id`, or a verified-dead child treated as `failure`).
+///
+/// Budget-aware: a `failure` with `cycle_attempts < 1 + retry_max` continues the
+/// budget cross-tick ([`Resolved::ReleasedBudgetOpen`], no `consecutive_failures`);
+/// an exhausted failure — or a partial/success — is terminal. Routing a
+/// budget-remaining failure straight to the terminal table would silently
+/// suppress configured retries across a crash.
+pub fn decide_resolver(
+    current: &ClaimRecord,
+    outcome: TerminalOutcome,
+    kind: DemandKind,
+    retry_max: u32,
+    now: DateTime<Utc>,
+) -> Resolved {
+    let budget_open_failure =
+        outcome == TerminalOutcome::Failure && budget_remains(current.cycle_attempts, retry_max);
+    if budget_open_failure {
+        return Resolved::ReleasedBudgetOpen(ClaimRecord {
+            state: ClaimState::Released,
+            submission_id: current.submission_id.clone(),
+            attempts: current.attempts,
+            // Preserve the cycle ordinal so the next re-claim (budget_open =
+            // true) continues it (`cycle_attempts + 1`).
+            cycle_attempts: current.cycle_attempts,
+            budget_open: true,
+            child_pid: current.child_pid,
+            child_start_time: current.child_start_time,
+            first_swept_at: None,
+            last_transition_at: Some(now.to_rfc3339()),
+        });
+    }
+    Resolved::Terminal {
+        claim: terminal_claim(current, kind, outcome, now),
+        bookkeeping: bookkeeping_for(outcome),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn now() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 5, 1, 0, 0, 0).unwrap()
+    }
+
+    fn submitted(id: &str, attempts: u32, cycle: u32) -> ClaimRecord {
+        ClaimRecord {
+            state: ClaimState::Submitted,
+            submission_id: id.to_string(),
+            attempts,
+            cycle_attempts: cycle,
+            budget_open: false,
+            child_pid: None,
+            child_start_time: None,
+            first_swept_at: None,
+            last_transition_at: Some(now().to_rfc3339()),
+        }
+    }
+
+    // --- budget guard (attempt-accounting matrix, regression viii) ---------
+
+    #[test]
+    fn budget_guard_off_by_one_seed() {
+        // retry.max = 0: a freshly-inserted claim (cycle_attempts = 1) has NO
+        // budget — the first failure is exhaustion. A 0-seeded counter would
+        // read 0 < 1 and fire a phantom second run.
+        assert!(!budget_remains(1, 0), "seed=1, max=0 must be exhausted");
+        // retry.max = 2: cycles 1 and 2 have budget, cycle 3 does not.
+        assert!(budget_remains(1, 2));
+        assert!(budget_remains(2, 2));
+        assert!(!budget_remains(3, 2));
+    }
+
+    // --- pre-spawn -----------------------------------------------------------
+
+    #[test]
+    fn pre_spawn_absent_inserts_submitted_seeded_at_one() {
+        let d = decide_pre_spawn(None, "s1".into(), now());
+        let PreSpawn::Claim(rec) = d else {
+            panic!("expected Claim")
+        };
+        assert_eq!(rec.state, ClaimState::Submitted);
+        assert_eq!(rec.attempts, 1);
+        assert_eq!(rec.cycle_attempts, 1);
+    }
+
+    #[test]
+    fn pre_spawn_completed_never_spawns() {
+        let prior = ClaimRecord {
+            state: ClaimState::Completed {
+                outcome: TerminalOutcome::Success,
+            },
+            ..submitted("s1", 1, 1)
+        };
+        assert_eq!(
+            decide_pre_spawn(Some(&prior), "s2".into(), now()),
+            PreSpawn::SkipCompleted
+        );
+    }
+
+    #[test]
+    fn pre_spawn_submitted_resolves_never_spawns_over() {
+        let prior = submitted("s1", 1, 1);
+        assert_eq!(
+            decide_pre_spawn(Some(&prior), "s2".into(), now()),
+            PreSpawn::ResolveStuck
+        );
+    }
+
+    #[test]
+    fn pre_spawn_released_budget_open_continues_cycle() {
+        // regression viii: crash-recovery re-claim CONTINUES the cycle ordinal.
+        let prior = ClaimRecord {
+            state: ClaimState::Released,
+            budget_open: true,
+            attempts: 1,
+            cycle_attempts: 1,
+            ..submitted("s1", 1, 1)
+        };
+        let PreSpawn::Claim(rec) = decide_pre_spawn(Some(&prior), "s2".into(), now()) else {
+            panic!("expected Claim")
+        };
+        assert_eq!(rec.cycle_attempts, 2, "continue the cycle");
+        assert_eq!(rec.attempts, 2);
+        assert_eq!(rec.submission_id, "s2", "fresh submission id");
+    }
+
+    #[test]
+    fn pre_spawn_released_budget_closed_resets_cycle() {
+        // regression viii: after an EXHAUSTED release + backoff, the next
+        // cycle's re-claim RESETS cycle_attempts = 1 (full retry budget again).
+        let prior = ClaimRecord {
+            state: ClaimState::Released,
+            budget_open: false,
+            attempts: 3,
+            cycle_attempts: 3,
+            ..submitted("s1", 3, 3)
+        };
+        let PreSpawn::Claim(rec) = decide_pre_spawn(Some(&prior), "s4".into(), now()) else {
+            panic!("expected Claim")
+        };
+        assert_eq!(rec.cycle_attempts, 1, "reset the cycle");
+        assert_eq!(rec.attempts, 4, "attempts stays monotonic");
+    }
+
+    // --- in-tick post-attempt (regression vi) --------------------------------
+
+    #[test]
+    fn post_attempt_failure_with_budget_retries_in_tick() {
+        // cron retry=2, attempt 1 fails -> RETRY transition, not terminal.
+        let cur = submitted("s1", 1, 1);
+        let d = decide_post_attempt(
+            &cur,
+            TerminalOutcome::Failure,
+            DemandKind::Cron,
+            2,
+            "s2".into(),
+            now(),
+        );
+        let PostAttempt::Retry(rec) = d else {
+            panic!("expected Retry")
+        };
+        assert_eq!(rec.submission_id, "s2");
+        assert_eq!(rec.cycle_attempts, 2);
+        assert_eq!(rec.state, ClaimState::Submitted);
+    }
+
+    #[test]
+    fn post_attempt_failure_exhausted_is_terminal_completed_for_cron() {
+        let cur = submitted("s3", 3, 3);
+        let d = decide_post_attempt(
+            &cur,
+            TerminalOutcome::Failure,
+            DemandKind::Cron,
+            2,
+            "s4".into(),
+            now(),
+        );
+        let PostAttempt::Terminal { claim, bookkeeping } = d else {
+            panic!("expected Terminal")
+        };
+        assert_eq!(
+            claim.state,
+            ClaimState::Completed {
+                outcome: TerminalOutcome::Failure
+            }
+        );
+        assert_eq!(bookkeeping.cf_delta, CfDelta::Increment);
+    }
+
+    #[test]
+    fn post_attempt_retry_max_zero_is_immediately_terminal() {
+        // regression viii: retry.max=0 -> first failure is exhaustion, exactly
+        // one run ever.
+        let cur = submitted("s1", 1, 1);
+        let d = decide_post_attempt(
+            &cur,
+            TerminalOutcome::Failure,
+            DemandKind::After,
+            0,
+            "s2".into(),
+            now(),
+        );
+        assert!(
+            matches!(d, PostAttempt::Terminal { .. }),
+            "no phantom retry at max=0"
+        );
+    }
+
+    #[test]
+    fn post_attempt_after_failure_releases_not_completes() {
+        // Routing an after-failure to `completed` would kill retries one state
+        // over — it must be `released{budget_open=false}`.
+        let cur = submitted("s1", 1, 1);
+        let d = decide_post_attempt(
+            &cur,
+            TerminalOutcome::Failure,
+            DemandKind::After,
+            0,
+            "s2".into(),
+            now(),
+        );
+        let PostAttempt::Terminal { claim, .. } = d else {
+            panic!("terminal")
+        };
+        assert_eq!(claim.state, ClaimState::Released);
+        assert!(!claim.budget_open, "exhausted release closes the cycle");
+    }
+
+    #[test]
+    fn post_attempt_after_success_completes() {
+        // regression v: after SUCCEEDS -> completed (terminal, never re-run).
+        let cur = submitted("s1", 1, 1);
+        let d = decide_post_attempt(
+            &cur,
+            TerminalOutcome::Success,
+            DemandKind::After,
+            0,
+            "s2".into(),
+            now(),
+        );
+        let PostAttempt::Terminal { claim, bookkeeping } = d else {
+            panic!("terminal")
+        };
+        assert_eq!(
+            claim.state,
+            ClaimState::Completed {
+                outcome: TerminalOutcome::Success
+            }
+        );
+        assert_eq!(bookkeeping.cf_delta, CfDelta::Reset);
+    }
+
+    #[test]
+    fn post_attempt_partial_is_terminal_never_retried_cf_unchanged() {
+        let cur = submitted("s1", 1, 1);
+        // Even with budget, partial is never retried.
+        let d = decide_post_attempt(
+            &cur,
+            TerminalOutcome::Partial,
+            DemandKind::After,
+            5,
+            "s2".into(),
+            now(),
+        );
+        let PostAttempt::Terminal { claim, bookkeeping } = d else {
+            panic!("terminal")
+        };
+        assert_eq!(
+            claim.state,
+            ClaimState::Released,
+            "standing demand stays claimable"
+        );
+        assert_eq!(
+            bookkeeping.cf_delta,
+            CfDelta::Unchanged,
+            "partial neither increments nor resets cf"
+        );
+    }
+
+    #[test]
+    fn post_attempt_cron_partial_completes() {
+        // Partial clears the emitter's own cron demand for that occurrence.
+        let cur = submitted("s1", 1, 1);
+        let d = decide_post_attempt(
+            &cur,
+            TerminalOutcome::Partial,
+            DemandKind::Cron,
+            0,
+            "s2".into(),
+            now(),
+        );
+        let PostAttempt::Terminal { claim, .. } = d else {
+            panic!("terminal")
+        };
+        assert_eq!(
+            claim.state,
+            ClaimState::Completed {
+                outcome: TerminalOutcome::Partial
+            }
+        );
+    }
+
+    // --- resolver (regression iii, vii) --------------------------------------
+
+    #[test]
+    fn resolver_failure_with_budget_releases_budget_open_no_cf() {
+        // regression vii: crash between attempt-1 failure and retry CAS.
+        // Resolver sees failure + budget remaining -> released{budget_open=true},
+        // NO consecutive_failures. The next tick re-claims and fires attempt 2.
+        let cur = submitted("s1", 1, 1);
+        let r = decide_resolver(&cur, TerminalOutcome::Failure, DemandKind::Cron, 2, now());
+        let Resolved::ReleasedBudgetOpen(rec) = r else {
+            panic!("expected ReleasedBudgetOpen")
+        };
+        assert_eq!(rec.state, ClaimState::Released);
+        assert!(rec.budget_open);
+        assert_eq!(rec.cycle_attempts, 1, "cycle preserved for the +1 re-claim");
+    }
+
+    #[test]
+    fn resolver_failure_exhausted_is_terminal_with_cf() {
+        let cur = submitted("s3", 3, 3);
+        let r = decide_resolver(&cur, TerminalOutcome::Failure, DemandKind::After, 2, now());
+        let Resolved::Terminal { claim, bookkeeping } = r else {
+            panic!("terminal")
+        };
+        assert_eq!(claim.state, ClaimState::Released);
+        assert!(!claim.budget_open);
+        assert_eq!(bookkeeping.cf_delta, CfDelta::Increment);
+    }
+
+    #[test]
+    fn resolver_success_is_terminal_completed() {
+        // regression iii: record exists (success) -> outcome applied, completed.
+        let cur = submitted("s1", 1, 1);
+        let r = decide_resolver(&cur, TerminalOutcome::Success, DemandKind::After, 2, now());
+        let Resolved::Terminal { claim, bookkeeping } = r else {
+            panic!("terminal")
+        };
+        assert_eq!(
+            claim.state,
+            ClaimState::Completed {
+                outcome: TerminalOutcome::Success
+            }
+        );
+        assert_eq!(bookkeeping.cf_delta, CfDelta::Reset);
+    }
+
+    #[test]
+    fn resolver_partial_never_continues_budget() {
+        let cur = submitted("s1", 1, 1);
+        let r = decide_resolver(&cur, TerminalOutcome::Partial, DemandKind::After, 5, now());
+        assert!(
+            matches!(r, Resolved::Terminal { .. }),
+            "partial is never budget-continued"
+        );
+    }
+
+    #[test]
+    fn full_retry_cycle_never_exceeds_configured_submissions() {
+        // regression viii: retry.max=2 -> at most 3 total submissions across the
+        // cycle. Walk the in-tick path: fail, fail, fail(exhausted).
+        let mut cur = ClaimRecord::new_submitted("s1".into(), now());
+        assert_eq!(cur.cycle_attempts, 1);
+        // attempt 1 fails
+        let PostAttempt::Retry(c2) = decide_post_attempt(
+            &cur,
+            TerminalOutcome::Failure,
+            DemandKind::Cron,
+            2,
+            "s2".into(),
+            now(),
+        ) else {
+            panic!()
+        };
+        cur = c2;
+        assert_eq!(cur.cycle_attempts, 2);
+        // attempt 2 fails
+        let PostAttempt::Retry(c3) = decide_post_attempt(
+            &cur,
+            TerminalOutcome::Failure,
+            DemandKind::Cron,
+            2,
+            "s3".into(),
+            now(),
+        ) else {
+            panic!()
+        };
+        cur = c3;
+        assert_eq!(cur.cycle_attempts, 3);
+        // attempt 3 fails -> exhausted (3 total submissions)
+        let PostAttempt::Terminal { .. } = decide_post_attempt(
+            &cur,
+            TerminalOutcome::Failure,
+            DemandKind::Cron,
+            2,
+            "s4".into(),
+            now(),
+        ) else {
+            panic!("attempt 3 must be terminal — never a 4th submission")
+        };
+    }
+}

--- a/engine/crates/rocky-core/src/schedule/demand.rs
+++ b/engine/crates/rocky-core/src/schedule/demand.rs
@@ -1,0 +1,955 @@
+//! Pure demand evaluation: given resolved schedules, the schedule cursors, and
+//! the run history, decide what is due — with no clock read and no side effect.
+//!
+//! The three demand sources, per the frozen semantics:
+//!
+//! - **cron** (§4.1): due at each occurrence after the catch-up anchor. First
+//!   sight records the anchor at `now` and does NOT fire. The anchor advances on
+//!   submission regardless of outcome, so a failed occurrence waits for the next
+//!   occurrence, not the next tick. Catch-up is `skip` or `latest` only.
+//! - **after** (§4.2): due once every upstream has a successful run that
+//!   completed *after this pipeline's own latest success started*. The
+//!   started-vs-completed asymmetry is load-bearing — it closes the
+//!   stale-forever overlap where an upstream succeeds while my unrelated run is
+//!   in flight. A partial (exit-2) upstream never counts.
+//! - **freshness** (§4.3): due once this pipeline's own run-staleness exceeds
+//!   its budget. Run-staleness only — the reconciler never queries the
+//!   warehouse.
+//!
+//! Standing demands (`after`, `freshness`) are additionally subject to the
+//! always-on cross-tick throttle ([`super::record::ScheduleStateRecord::standing_throttle`]);
+//! cron is throttled by its own occurrence granularity and is never
+//! backoff-suppressed.
+
+use chrono::{DateTime, Duration, Utc};
+use chrono_tz::Tz;
+
+use super::claim::DemandKind;
+use super::occurrence::{OccurrenceError, next_occurrence, previous_or_equal_occurrence};
+use super::record::{ScheduleStateRecord, Throttle};
+
+/// Catch-up policy for a cron schedule with more than one missed occurrence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Catchup {
+    /// Advance the anchor to the latest missed occurrence and run nothing.
+    Skip,
+    /// Fire one demand at the latest missed occurrence.
+    Latest,
+}
+
+/// A resolved, validated schedule for one pipeline — the input to evaluation.
+///
+/// Produced by [`resolve_schedule`], which parses the cron/timezone/catch-up
+/// and resolves the freshness budget. A resolution error is a config error the
+/// reconciler surfaces as a skip (fail closed), never a fire.
+#[derive(Debug, Clone)]
+pub struct ResolvedSchedule {
+    /// The pipeline name.
+    pub pipeline: String,
+    /// Whether the schedule is enabled (`enabled = true`).
+    pub enabled: bool,
+    /// The parsed cron expression and its timezone, when a cron is configured.
+    pub cron: Option<(String, Tz)>,
+    /// Upstream pipelines for the `after` trigger.
+    pub after: Vec<String>,
+    /// The resolved freshness budget, when `freshness = true` and a budget was
+    /// resolvable. `None` disables the freshness trigger.
+    pub freshness_budget: Option<Duration>,
+    /// Catch-up policy.
+    pub catchup: Catchup,
+    /// In-tick retry budget (`retry.max`).
+    pub retry_max: u32,
+    /// Scheduler-level timeout, when `timeout_minutes > 0`.
+    pub timeout: Option<Duration>,
+}
+
+/// A config error found while resolving a schedule. Mirrors the validation
+/// codes so the reconciler and `rocky validate` agree on what is invalid.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScheduleConfigError {
+    /// The cron expression did not parse.
+    BadCron(String),
+    /// The timezone name is not a known IANA zone.
+    BadTimezone(String),
+    /// `catchup` was neither `skip` nor `latest`. `"all"` is called out
+    /// specifically.
+    BadCatchup(String),
+    /// `freshness = true` but no budget was resolvable anywhere.
+    FreshnessNoBudget,
+}
+
+/// Resolve the freshness budget for a pipeline: the minimum of its member
+/// models' declared `max_lag_seconds`, falling back to the project
+/// `expected_lag_seconds`. `member_max_lags` holds only the members that
+/// declare a budget (empty for pipeline types with no such models, e.g.
+/// replication), so the project default is the honest budget there.
+pub fn resolve_freshness_budget(
+    member_max_lags: &[u64],
+    project_expected_lag_seconds: Option<u64>,
+) -> Option<u64> {
+    if let Some(min) = member_max_lags.iter().copied().min() {
+        Some(min)
+    } else {
+        project_expected_lag_seconds
+    }
+}
+
+/// Resolve a raw [`ScheduleConfig`](crate::config::ScheduleConfig) into a
+/// validated [`ResolvedSchedule`], or the first config error found.
+///
+/// `default_timezone` is the project `[schedule].timezone`; `member_max_lags`
+/// are the freshness budgets of the pipeline's member models (empty when the
+/// type has none); `project_expected_lag_seconds` is the project freshness
+/// default.
+///
+/// # Errors
+///
+/// Returns a [`ScheduleConfigError`] for a malformed cron, an unknown timezone,
+/// an invalid `catchup`, or `freshness = true` with no resolvable budget.
+pub fn resolve_schedule(
+    pipeline: &str,
+    schedule: &crate::config::ScheduleConfig,
+    default_timezone: &str,
+    member_max_lags: &[u64],
+    project_expected_lag_seconds: Option<u64>,
+) -> Result<ResolvedSchedule, ScheduleConfigError> {
+    let cron = match &schedule.cron {
+        None => None,
+        Some(expr) => {
+            // Validate the expression parses.
+            super::occurrence::parse_cron(expr)
+                .map_err(|_| ScheduleConfigError::BadCron(expr.clone()))?;
+            let tz_name = schedule.timezone.as_deref().unwrap_or(default_timezone);
+            let tz: Tz = tz_name
+                .parse()
+                .map_err(|_| ScheduleConfigError::BadTimezone(tz_name.to_string()))?;
+            Some((expr.clone(), tz))
+        }
+    };
+
+    let catchup = match schedule.catchup.as_str() {
+        "skip" => Catchup::Skip,
+        "latest" => Catchup::Latest,
+        other => return Err(ScheduleConfigError::BadCatchup(other.to_string())),
+    };
+
+    let freshness_budget = if schedule.freshness {
+        match resolve_freshness_budget(member_max_lags, project_expected_lag_seconds) {
+            Some(secs) => Some(Duration::seconds(secs as i64)),
+            None => return Err(ScheduleConfigError::FreshnessNoBudget),
+        }
+    } else {
+        None
+    };
+
+    let timeout = if schedule.timeout_minutes > 0 {
+        Some(Duration::minutes(schedule.timeout_minutes as i64))
+    } else {
+        None
+    };
+
+    let _ = pipeline;
+    Ok(ResolvedSchedule {
+        pipeline: pipeline.to_string(),
+        enabled: schedule.enabled,
+        cron,
+        after: schedule.after.clone(),
+        freshness_budget,
+        catchup,
+        retry_max: schedule.retry.max,
+        timeout,
+    })
+}
+
+/// A concrete due demand: a `(pipeline, source, logical_ts)` instance.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Demand {
+    /// The pipeline to run.
+    pub pipeline: String,
+    /// The source that made it due.
+    pub source: DemandKind,
+    /// The logical timestamp: the cron occurrence, the max upstream success
+    /// completion, or the staleness reference instant.
+    pub logical_ts: DateTime<Utc>,
+}
+
+/// Why a source did not produce a demand this tick. Every "do not run" path is
+/// an explicit, recorded reason.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkipReason {
+    /// No demand from this source right now.
+    NotDue,
+    /// The schedule is disabled (`enabled = false`).
+    Disabled,
+    /// More than one cron occurrence elapsed and `catchup = "skip"`: the anchor
+    /// advanced, nothing ran.
+    CatchupSkipped {
+        /// Number of missed occurrences (capped for reporting).
+        missed: u32,
+    },
+    /// A standing demand suppressed by the failure backoff ladder.
+    FailureBackoff {
+        /// When the demand becomes eligible again.
+        resume_at: DateTime<Utc>,
+    },
+    /// A standing demand suppressed by the fixed partial backoff.
+    PartialBackoff {
+        /// When the demand becomes eligible again.
+        resume_at: DateTime<Utc>,
+    },
+    /// A higher-priority source already produced the demand this tick.
+    Superseded,
+}
+
+/// A per-source skip record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceSkip {
+    /// The source that was skipped.
+    pub source: DemandKind,
+    /// Why.
+    pub reason: SkipReason,
+}
+
+/// The evaluation of one pipeline: the single demand chosen to run (by source
+/// priority cron > after > freshness), any anchor updates to persist without
+/// firing, and per-source skip reasons.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EvaluatedPipeline {
+    /// The pipeline name.
+    pub pipeline: String,
+    /// The demand to run this tick, if any.
+    pub due: Option<Demand>,
+    /// First-sight cron anchor to initialize (set without firing).
+    pub anchor_init: Option<DateTime<Utc>>,
+    /// Cron anchor to advance on a catch-up skip (set without firing).
+    pub catchup_advance: Option<DateTime<Utc>>,
+    /// Per-source skip reasons.
+    pub skips: Vec<SourceSkip>,
+}
+
+/// A pipeline's latest successful run, reduced to the two instants the
+/// reconciler needs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RunSuccess {
+    /// When the run started (the `after` comparison baseline).
+    pub started_at: DateTime<Utc>,
+    /// When the run finished (the upstream-satisfaction / staleness instant).
+    pub finished_at: DateTime<Utc>,
+}
+
+/// Read-only view of the schedule cursors.
+pub trait ScheduleStateView {
+    /// The cursor for a pipeline, or its default when never evaluated.
+    fn get(&self, pipeline: &str) -> ScheduleStateRecord;
+}
+
+/// Read-only view of the run history, per pipeline.
+pub trait RunHistoryView {
+    /// The most recent *successful* run for a pipeline, or `None`.
+    fn latest_successful_run(&self, pipeline: &str) -> Option<RunSuccess>;
+}
+
+/// A stable reference instant for a freshness claim when the pipeline has never
+/// succeeded — the Unix epoch, so the claim key does not rotate each tick.
+fn never_ran_reference() -> DateTime<Utc> {
+    DateTime::<Utc>::from_timestamp(0, 0).expect("epoch is a valid instant")
+}
+
+/// The outcome of evaluating a cron source.
+enum CronEval {
+    NotDue,
+    InitAnchor(DateTime<Utc>),
+    Due(DateTime<Utc>),
+    CatchupSkip {
+        anchor_to: DateTime<Utc>,
+        missed: u32,
+    },
+}
+
+fn evaluate_cron(
+    expr: &str,
+    tz: Tz,
+    catchup: Catchup,
+    state: &ScheduleStateRecord,
+    now: DateTime<Utc>,
+) -> Result<CronEval, OccurrenceError> {
+    let Some(anchor) = state.fire_anchor() else {
+        // First sight: record the anchor at `now`, do not fire.
+        return Ok(CronEval::InitAnchor(now));
+    };
+    let next1 = next_occurrence(expr, tz, anchor)?;
+    if next1 > now {
+        return Ok(CronEval::NotDue);
+    }
+    // At least one occurrence elapsed. Peek one more to detect catch-up.
+    let next2 = next_occurrence(expr, tz, next1)?;
+    if next2 > now {
+        // Exactly one occurrence is due.
+        return Ok(CronEval::Due(next1));
+    }
+    // More than one occurrence elapsed. The latest at-or-before `now`:
+    let latest = previous_or_equal_occurrence(expr, tz, now)?;
+    // A capped count for reporting.
+    let mut missed = 1u32;
+    let mut cursor = next1;
+    while missed < 1000 {
+        let n = next_occurrence(expr, tz, cursor)?;
+        if n > now {
+            break;
+        }
+        missed += 1;
+        cursor = n;
+    }
+    match catchup {
+        Catchup::Skip => Ok(CronEval::CatchupSkip {
+            anchor_to: latest,
+            missed,
+        }),
+        Catchup::Latest => Ok(CronEval::Due(latest)),
+    }
+}
+
+/// Whether `after` is due, and if so the logical timestamp
+/// (`max(upstream success completions)`).
+fn evaluate_after(
+    pipeline: &str,
+    upstreams: &[String],
+    history: &dyn RunHistoryView,
+) -> Option<DateTime<Utc>> {
+    if upstreams.is_empty() {
+        return None;
+    }
+    // My baseline: the start of my latest success. If I never succeeded, every
+    // upstream success counts (baseline = epoch).
+    let my_baseline = history
+        .latest_successful_run(pipeline)
+        .map(|r| r.started_at)
+        .unwrap_or_else(never_ran_reference);
+
+    let mut max_completion: Option<DateTime<Utc>> = None;
+    for upstream in upstreams {
+        let Some(u) = history.latest_successful_run(upstream) else {
+            // An upstream with no success at all — not due.
+            return None;
+        };
+        // The upstream must have completed AFTER my latest success started
+        // (completion-vs-start asymmetry closes the overlap stale-forever case).
+        if u.finished_at <= my_baseline {
+            return None;
+        }
+        max_completion = Some(match max_completion {
+            Some(m) if m >= u.finished_at => m,
+            _ => u.finished_at,
+        });
+    }
+    max_completion
+}
+
+/// Whether `freshness` is due, and if so the (stable) logical timestamp.
+fn evaluate_freshness(
+    pipeline: &str,
+    budget: Duration,
+    history: &dyn RunHistoryView,
+    now: DateTime<Utc>,
+) -> Option<DateTime<Utc>> {
+    match history.latest_successful_run(pipeline) {
+        None => Some(never_ran_reference()),
+        Some(r) => {
+            if now - r.finished_at > budget {
+                Some(r.finished_at)
+            } else {
+                None
+            }
+        }
+    }
+}
+
+/// Evaluate every scheduled pipeline against the cursors and run history at
+/// `now`. Pure — no clock read, no writes. The reconciler applies the results.
+///
+/// # Errors
+///
+/// Returns [`OccurrenceError`] only if a cron occurrence search fails on a
+/// schedule that already parsed (a pathological pattern). A per-pipeline cron
+/// evaluation error is surfaced by the caller as a fail-closed skip.
+pub fn evaluate_demands(
+    schedules: &[ResolvedSchedule],
+    state: &dyn ScheduleStateView,
+    history: &dyn RunHistoryView,
+    now: DateTime<Utc>,
+) -> Vec<EvaluatedPipeline> {
+    schedules
+        .iter()
+        .map(|s| evaluate_one(s, state, history, now))
+        .collect()
+}
+
+/// Evaluate a single pipeline. A cron search error becomes a fail-closed
+/// `NotDue` cron skip (never a fire).
+pub fn evaluate_one(
+    schedule: &ResolvedSchedule,
+    state: &dyn ScheduleStateView,
+    history: &dyn RunHistoryView,
+    now: DateTime<Utc>,
+) -> EvaluatedPipeline {
+    let mut out = EvaluatedPipeline {
+        pipeline: schedule.pipeline.clone(),
+        due: None,
+        anchor_init: None,
+        catchup_advance: None,
+        skips: Vec::new(),
+    };
+
+    if !schedule.enabled {
+        out.skips.push(SourceSkip {
+            source: DemandKind::Cron,
+            reason: SkipReason::Disabled,
+        });
+        return out;
+    }
+
+    let cursor = state.get(&schedule.pipeline);
+
+    // --- cron (highest priority) --------------------------------------------
+    if let Some((expr, tz)) = &schedule.cron {
+        match evaluate_cron(expr, *tz, schedule.catchup, &cursor, now) {
+            Ok(CronEval::InitAnchor(at)) => {
+                out.anchor_init = Some(at);
+                out.skips.push(SourceSkip {
+                    source: DemandKind::Cron,
+                    reason: SkipReason::NotDue,
+                });
+            }
+            Ok(CronEval::NotDue) => {
+                out.skips.push(SourceSkip {
+                    source: DemandKind::Cron,
+                    reason: SkipReason::NotDue,
+                });
+            }
+            Ok(CronEval::CatchupSkip { anchor_to, missed }) => {
+                out.catchup_advance = Some(anchor_to);
+                out.skips.push(SourceSkip {
+                    source: DemandKind::Cron,
+                    reason: SkipReason::CatchupSkipped { missed },
+                });
+            }
+            Ok(CronEval::Due(logical_ts)) => {
+                out.due = Some(Demand {
+                    pipeline: schedule.pipeline.clone(),
+                    source: DemandKind::Cron,
+                    logical_ts,
+                });
+            }
+            Err(_) => {
+                // Fail closed: a cron search error never fires.
+                out.skips.push(SourceSkip {
+                    source: DemandKind::Cron,
+                    reason: SkipReason::NotDue,
+                });
+            }
+        }
+    }
+
+    // --- after --------------------------------------------------------------
+    let after_due = evaluate_after(&schedule.pipeline, &schedule.after, history);
+    if !schedule.after.is_empty() {
+        match after_due {
+            Some(logical_ts) if out.due.is_none() => match apply_standing_throttle(&cursor, now) {
+                Ok(()) => {
+                    out.due = Some(Demand {
+                        pipeline: schedule.pipeline.clone(),
+                        source: DemandKind::After,
+                        logical_ts,
+                    });
+                }
+                Err(reason) => out.skips.push(SourceSkip {
+                    source: DemandKind::After,
+                    reason,
+                }),
+            },
+            Some(_) => out.skips.push(SourceSkip {
+                source: DemandKind::After,
+                reason: SkipReason::Superseded,
+            }),
+            None => out.skips.push(SourceSkip {
+                source: DemandKind::After,
+                reason: SkipReason::NotDue,
+            }),
+        }
+    }
+
+    // --- freshness ----------------------------------------------------------
+    if let Some(budget) = schedule.freshness_budget {
+        let fresh_due = evaluate_freshness(&schedule.pipeline, budget, history, now);
+        match fresh_due {
+            Some(logical_ts) if out.due.is_none() => match apply_standing_throttle(&cursor, now) {
+                Ok(()) => {
+                    out.due = Some(Demand {
+                        pipeline: schedule.pipeline.clone(),
+                        source: DemandKind::Freshness,
+                        logical_ts,
+                    });
+                }
+                Err(reason) => out.skips.push(SourceSkip {
+                    source: DemandKind::Freshness,
+                    reason,
+                }),
+            },
+            Some(_) => out.skips.push(SourceSkip {
+                source: DemandKind::Freshness,
+                reason: SkipReason::Superseded,
+            }),
+            None => out.skips.push(SourceSkip {
+                source: DemandKind::Freshness,
+                reason: SkipReason::NotDue,
+            }),
+        }
+    }
+
+    out
+}
+
+/// Map the standing throttle to `Ok` (clear) or a skip reason.
+fn apply_standing_throttle(
+    cursor: &ScheduleStateRecord,
+    now: DateTime<Utc>,
+) -> Result<(), SkipReason> {
+    match cursor.standing_throttle(now) {
+        Throttle::Clear => Ok(()),
+        Throttle::FailureBackoff { resume_at } => Err(SkipReason::FailureBackoff { resume_at }),
+        Throttle::PartialBackoff { resume_at } => Err(SkipReason::PartialBackoff { resume_at }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use std::collections::HashMap;
+
+    fn ts(y: i32, mo: u32, d: u32, h: u32, mi: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(y, mo, d, h, mi, 0).unwrap()
+    }
+
+    #[derive(Default)]
+    struct States(HashMap<String, ScheduleStateRecord>);
+    impl ScheduleStateView for States {
+        fn get(&self, pipeline: &str) -> ScheduleStateRecord {
+            self.0.get(pipeline).cloned().unwrap_or_default()
+        }
+    }
+
+    #[derive(Default)]
+    struct History(HashMap<String, RunSuccess>);
+    impl RunHistoryView for History {
+        fn latest_successful_run(&self, pipeline: &str) -> Option<RunSuccess> {
+            self.0.get(pipeline).copied()
+        }
+    }
+
+    fn cron_schedule(name: &str, catchup: Catchup) -> ResolvedSchedule {
+        ResolvedSchedule {
+            pipeline: name.to_string(),
+            enabled: true,
+            cron: Some(("0 3 * * *".to_string(), Tz::UTC)),
+            after: vec![],
+            freshness_budget: None,
+            catchup,
+            retry_max: 0,
+            timeout: None,
+        }
+    }
+
+    // --- cron ----------------------------------------------------------------
+
+    #[test]
+    fn cron_first_sight_records_anchor_and_does_not_fire() {
+        let s = cron_schedule("raw", Catchup::Latest);
+        let states = States::default();
+        let history = History::default();
+        let e = evaluate_one(&s, &states, &history, ts(2026, 5, 1, 12, 0));
+        assert!(e.due.is_none(), "first sight must not fire");
+        assert_eq!(e.anchor_init, Some(ts(2026, 5, 1, 12, 0)));
+    }
+
+    #[test]
+    fn cron_fires_once_after_anchor() {
+        let s = cron_schedule("raw", Catchup::Latest);
+        let mut states = States::default();
+        states.0.insert(
+            "raw".into(),
+            ScheduleStateRecord {
+                last_fire_logical_ts: Some(ts(2026, 5, 1, 3, 0).to_rfc3339()),
+                ..Default::default()
+            },
+        );
+        let history = History::default();
+        // Next day 03:00 has elapsed by 04:00.
+        let e = evaluate_one(&s, &states, &history, ts(2026, 5, 2, 4, 0));
+        assert_eq!(
+            e.due.map(|d| (d.source, d.logical_ts)),
+            Some((DemandKind::Cron, ts(2026, 5, 2, 3, 0)))
+        );
+    }
+
+    #[test]
+    fn cron_catchup_latest_fires_only_the_most_recent_missed() {
+        let s = cron_schedule("raw", Catchup::Latest);
+        let mut states = States::default();
+        states.0.insert(
+            "raw".into(),
+            ScheduleStateRecord {
+                last_fire_logical_ts: Some(ts(2026, 5, 1, 3, 0).to_rfc3339()),
+                ..Default::default()
+            },
+        );
+        let history = History::default();
+        // Three days later — 3 occurrences missed; latest is 05-04 03:00.
+        let e = evaluate_one(&s, &states, &history, ts(2026, 5, 4, 12, 0));
+        assert_eq!(e.due.unwrap().logical_ts, ts(2026, 5, 4, 3, 0));
+    }
+
+    #[test]
+    fn cron_catchup_skip_advances_anchor_and_runs_nothing() {
+        let s = cron_schedule("raw", Catchup::Skip);
+        let mut states = States::default();
+        states.0.insert(
+            "raw".into(),
+            ScheduleStateRecord {
+                last_fire_logical_ts: Some(ts(2026, 5, 1, 3, 0).to_rfc3339()),
+                ..Default::default()
+            },
+        );
+        let history = History::default();
+        let e = evaluate_one(&s, &states, &history, ts(2026, 5, 4, 12, 0));
+        assert!(e.due.is_none());
+        assert_eq!(e.catchup_advance, Some(ts(2026, 5, 4, 3, 0)));
+        assert!(matches!(
+            e.skips
+                .iter()
+                .find(|k| k.source == DemandKind::Cron)
+                .map(|k| &k.reason),
+            Some(SkipReason::CatchupSkipped { missed: 3 })
+        ));
+    }
+
+    #[test]
+    fn cron_now_earlier_than_anchor_does_not_fire() {
+        // Anchor monotonicity: a `now` before the anchor is a no-op.
+        let s = cron_schedule("raw", Catchup::Latest);
+        let mut states = States::default();
+        states.0.insert(
+            "raw".into(),
+            ScheduleStateRecord {
+                last_fire_logical_ts: Some(ts(2026, 5, 10, 3, 0).to_rfc3339()),
+                ..Default::default()
+            },
+        );
+        let history = History::default();
+        let e = evaluate_one(&s, &states, &history, ts(2026, 5, 2, 4, 0));
+        assert!(e.due.is_none(), "now before anchor must not fire");
+    }
+
+    // --- after ---------------------------------------------------------------
+
+    fn after_schedule(name: &str, upstream: &str) -> ResolvedSchedule {
+        ResolvedSchedule {
+            pipeline: name.to_string(),
+            enabled: true,
+            cron: None,
+            after: vec![upstream.to_string()],
+            freshness_budget: None,
+            catchup: Catchup::Latest,
+            retry_max: 0,
+            timeout: None,
+        }
+    }
+
+    #[test]
+    fn after_due_when_upstream_completed_after_my_start() {
+        let s = after_schedule("staging", "raw");
+        let states = States::default();
+        let mut history = History::default();
+        // My last success started at 10:00; upstream finished at 11:00 (after).
+        history.0.insert(
+            "staging".into(),
+            RunSuccess {
+                started_at: ts(2026, 5, 1, 10, 0),
+                finished_at: ts(2026, 5, 1, 10, 30),
+            },
+        );
+        history.0.insert(
+            "raw".into(),
+            RunSuccess {
+                started_at: ts(2026, 5, 1, 10, 45),
+                finished_at: ts(2026, 5, 1, 11, 0),
+            },
+        );
+        let e = evaluate_one(&s, &states, &history, ts(2026, 5, 1, 12, 0));
+        assert_eq!(
+            e.due.map(|d| (d.source, d.logical_ts)),
+            Some((DemandKind::After, ts(2026, 5, 1, 11, 0)))
+        );
+    }
+
+    #[test]
+    fn after_overlap_upstream_finished_before_my_start_not_due() {
+        // Upstream finished BEFORE my latest success started -> already consumed.
+        let s = after_schedule("staging", "raw");
+        let states = States::default();
+        let mut history = History::default();
+        history.0.insert(
+            "staging".into(),
+            RunSuccess {
+                started_at: ts(2026, 5, 1, 11, 0),
+                finished_at: ts(2026, 5, 1, 11, 30),
+            },
+        );
+        history.0.insert(
+            "raw".into(),
+            RunSuccess {
+                started_at: ts(2026, 5, 1, 10, 0),
+                finished_at: ts(2026, 5, 1, 10, 30),
+            },
+        );
+        let e = evaluate_one(&s, &states, &history, ts(2026, 5, 1, 12, 0));
+        assert!(e.due.is_none());
+    }
+
+    #[test]
+    fn after_overlap_upstream_finished_during_my_run_still_due_next_tick() {
+        // The started-vs-completed trap: my run started 10:00, finished 11:30;
+        // upstream finished 11:00 (during my run). My completion (11:30) is
+        // LATER than the upstream, but my START (10:00) is earlier, so the
+        // upstream data was NOT seen by my run -> still due.
+        let s = after_schedule("staging", "raw");
+        let states = States::default();
+        let mut history = History::default();
+        history.0.insert(
+            "staging".into(),
+            RunSuccess {
+                started_at: ts(2026, 5, 1, 10, 0),
+                finished_at: ts(2026, 5, 1, 11, 30),
+            },
+        );
+        history.0.insert(
+            "raw".into(),
+            RunSuccess {
+                started_at: ts(2026, 5, 1, 10, 45),
+                finished_at: ts(2026, 5, 1, 11, 0),
+            },
+        );
+        let e = evaluate_one(&s, &states, &history, ts(2026, 5, 1, 12, 0));
+        assert_eq!(
+            e.due.map(|d| d.source),
+            Some(DemandKind::After),
+            "must still be due — compares completion vs my START"
+        );
+    }
+
+    #[test]
+    fn after_not_due_when_an_upstream_never_succeeded() {
+        let s = after_schedule("staging", "raw");
+        let states = States::default();
+        let history = History::default(); // no runs at all
+        let e = evaluate_one(&s, &states, &history, ts(2026, 5, 1, 12, 0));
+        assert!(e.due.is_none());
+    }
+
+    #[test]
+    fn after_never_ran_downstream_fires_on_first_upstream_success() {
+        let s = after_schedule("staging", "raw");
+        let states = States::default();
+        let mut history = History::default();
+        // staging never succeeded; raw has a success.
+        history.0.insert(
+            "raw".into(),
+            RunSuccess {
+                started_at: ts(2026, 5, 1, 10, 0),
+                finished_at: ts(2026, 5, 1, 10, 30),
+            },
+        );
+        let e = evaluate_one(&s, &states, &history, ts(2026, 5, 1, 12, 0));
+        assert_eq!(e.due.map(|d| d.source), Some(DemandKind::After));
+    }
+
+    // --- throttle on standing demands ---------------------------------------
+
+    #[test]
+    fn after_due_but_failure_backoff_suppresses() {
+        let s = after_schedule("staging", "raw");
+        let mut states = States::default();
+        states.0.insert(
+            "staging".into(),
+            ScheduleStateRecord {
+                last_attempt_at: Some(ts(2026, 5, 1, 11, 30).to_rfc3339()),
+                last_attempt_outcome: Some("failure".into()),
+                consecutive_failures: 1, // 5 min backoff
+                ..Default::default()
+            },
+        );
+        let mut history = History::default();
+        history.0.insert(
+            "raw".into(),
+            RunSuccess {
+                started_at: ts(2026, 5, 1, 10, 0),
+                finished_at: ts(2026, 5, 1, 11, 0),
+            },
+        );
+        // now is 11:32 — within the 5-min window from 11:30.
+        let e = evaluate_one(&s, &states, &history, ts(2026, 5, 1, 11, 32));
+        assert!(
+            e.due.is_none(),
+            "failure backoff suppresses the standing demand"
+        );
+        assert!(matches!(
+            e.skips
+                .iter()
+                .find(|k| k.source == DemandKind::After)
+                .map(|k| &k.reason),
+            Some(SkipReason::FailureBackoff { .. })
+        ));
+        // After the window, it fires.
+        let e2 = evaluate_one(&s, &states, &history, ts(2026, 5, 1, 11, 36));
+        assert_eq!(e2.due.map(|d| d.source), Some(DemandKind::After));
+    }
+
+    #[test]
+    fn perma_partial_throttles_at_sixty_minutes() {
+        // A reliably-partial standing pipeline must NOT re-run every tick.
+        let s = after_schedule("staging", "raw");
+        let mut states = States::default();
+        states.0.insert(
+            "staging".into(),
+            ScheduleStateRecord {
+                last_attempt_at: Some(ts(2026, 5, 1, 11, 0).to_rfc3339()),
+                last_attempt_outcome: Some("partial".into()),
+                consecutive_failures: 0,
+                ..Default::default()
+            },
+        );
+        let mut history = History::default();
+        history.0.insert(
+            "raw".into(),
+            RunSuccess {
+                started_at: ts(2026, 5, 1, 9, 0),
+                finished_at: ts(2026, 5, 1, 10, 0),
+            },
+        );
+        let e = evaluate_one(&s, &states, &history, ts(2026, 5, 1, 11, 30));
+        assert!(matches!(
+            e.skips
+                .iter()
+                .find(|k| k.source == DemandKind::After)
+                .map(|k| &k.reason),
+            Some(SkipReason::PartialBackoff { .. })
+        ));
+    }
+
+    // --- freshness -----------------------------------------------------------
+
+    #[test]
+    fn freshness_due_when_stale_beyond_budget() {
+        let s = ResolvedSchedule {
+            pipeline: "raw".into(),
+            enabled: true,
+            cron: None,
+            after: vec![],
+            freshness_budget: Some(Duration::hours(1)),
+            catchup: Catchup::Latest,
+            retry_max: 0,
+            timeout: None,
+        };
+        let states = States::default();
+        let mut history = History::default();
+        history.0.insert(
+            "raw".into(),
+            RunSuccess {
+                started_at: ts(2026, 5, 1, 8, 0),
+                finished_at: ts(2026, 5, 1, 9, 0),
+            },
+        );
+        // 2h later -> stale beyond a 1h budget.
+        let e = evaluate_one(&s, &states, &history, ts(2026, 5, 1, 11, 0));
+        assert_eq!(
+            e.due.map(|d| (d.source, d.logical_ts)),
+            Some((DemandKind::Freshness, ts(2026, 5, 1, 9, 0)))
+        );
+        // Within budget -> not due.
+        let e2 = evaluate_one(&s, &states, &history, ts(2026, 5, 1, 9, 30));
+        assert!(e2.due.is_none());
+    }
+
+    // --- priority + disabled -------------------------------------------------
+
+    #[test]
+    fn cron_takes_priority_over_after() {
+        let s = ResolvedSchedule {
+            pipeline: "raw".into(),
+            enabled: true,
+            cron: Some(("0 3 * * *".into(), Tz::UTC)),
+            after: vec!["up".into()],
+            freshness_budget: None,
+            catchup: Catchup::Latest,
+            retry_max: 0,
+            timeout: None,
+        };
+        let mut states = States::default();
+        states.0.insert(
+            "raw".into(),
+            ScheduleStateRecord {
+                last_fire_logical_ts: Some(ts(2026, 5, 1, 3, 0).to_rfc3339()),
+                ..Default::default()
+            },
+        );
+        let mut history = History::default();
+        history.0.insert(
+            "up".into(),
+            RunSuccess {
+                started_at: ts(2026, 5, 2, 0, 0),
+                finished_at: ts(2026, 5, 2, 1, 0),
+            },
+        );
+        let e = evaluate_one(&s, &states, &history, ts(2026, 5, 2, 4, 0));
+        assert_eq!(e.due.map(|d| d.source), Some(DemandKind::Cron));
+        assert!(
+            e.skips
+                .iter()
+                .any(|k| k.source == DemandKind::After && k.reason == SkipReason::Superseded)
+        );
+    }
+
+    #[test]
+    fn disabled_schedule_produces_no_demand() {
+        let mut s = cron_schedule("raw", Catchup::Latest);
+        s.enabled = false;
+        let mut states = States::default();
+        states.0.insert(
+            "raw".into(),
+            ScheduleStateRecord {
+                last_fire_logical_ts: Some(ts(2026, 5, 1, 3, 0).to_rfc3339()),
+                ..Default::default()
+            },
+        );
+        let e = evaluate_one(&s, &states, &History::default(), ts(2026, 6, 1, 4, 0));
+        assert!(e.due.is_none());
+        assert!(e.skips.iter().any(|k| k.reason == SkipReason::Disabled));
+    }
+
+    // --- freshness budget resolution ----------------------------------------
+
+    #[test]
+    fn freshness_budget_prefers_member_min_then_project() {
+        assert_eq!(
+            resolve_freshness_budget(&[3600, 1800, 7200], Some(600)),
+            Some(1800),
+            "min of members"
+        );
+        assert_eq!(
+            resolve_freshness_budget(&[], Some(600)),
+            Some(600),
+            "falls back to project"
+        );
+        assert_eq!(resolve_freshness_budget(&[], None), None, "unresolvable");
+    }
+}

--- a/engine/crates/rocky-core/src/schedule/demand.rs
+++ b/engine/crates/rocky-core/src/schedule/demand.rs
@@ -199,6 +199,10 @@ pub enum SkipReason {
     },
     /// A higher-priority source already produced the demand this tick.
     Superseded,
+    /// The run history could not be read (store fault or a corrupt row), so a
+    /// standing demand was skipped rather than misclassified. Fail-closed: never
+    /// a false-skip (`after`) or false-fire (`freshness`).
+    HistoryError,
 }
 
 /// A per-source skip record.
@@ -243,10 +247,32 @@ pub trait ScheduleStateView {
     fn get(&self, pipeline: &str) -> ScheduleStateRecord;
 }
 
+/// A run-history read that could not be completed (a store fault or a corrupt
+/// row). It is **never** conflated with "no successful run": a read error must
+/// fail closed — skip the demand loudly — rather than misread as "never ran",
+/// which would false-skip an `after` demand or false-fire a `freshness` one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HistoryError(pub String);
+
+impl std::fmt::Display for HistoryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "run-history read failed: {}", self.0)
+    }
+}
+
+impl std::error::Error for HistoryError {}
+
 /// Read-only view of the run history, per pipeline.
 pub trait RunHistoryView {
-    /// The most recent *successful* run for a pipeline, or `None`.
-    fn latest_successful_run(&self, pipeline: &str) -> Option<RunSuccess>;
+    /// The most recent *successful* run for a pipeline, `Ok(None)` when there is
+    /// genuinely none.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HistoryError`] when the history cannot be read (store fault or
+    /// a corrupt row). Callers MUST fail closed on this — never treat it as "no
+    /// successful run".
+    fn latest_successful_run(&self, pipeline: &str) -> Result<Option<RunSuccess>, HistoryError>;
 }
 
 /// A stable reference instant for a freshness claim when the pipeline has never
@@ -311,54 +337,64 @@ fn evaluate_cron(
 
 /// Whether `after` is due, and if so the logical timestamp
 /// (`max(upstream success completions)`).
+///
+/// # Errors
+///
+/// Propagates a [`HistoryError`] from any history read — the caller fails closed
+/// (a read error is never a "not due").
 fn evaluate_after(
     pipeline: &str,
     upstreams: &[String],
     history: &dyn RunHistoryView,
-) -> Option<DateTime<Utc>> {
+) -> Result<Option<DateTime<Utc>>, HistoryError> {
     if upstreams.is_empty() {
-        return None;
+        return Ok(None);
     }
     // My baseline: the start of my latest success. If I never succeeded, every
     // upstream success counts (baseline = epoch).
     let my_baseline = history
-        .latest_successful_run(pipeline)
+        .latest_successful_run(pipeline)?
         .map(|r| r.started_at)
         .unwrap_or_else(never_ran_reference);
 
     let mut max_completion: Option<DateTime<Utc>> = None;
     for upstream in upstreams {
-        let Some(u) = history.latest_successful_run(upstream) else {
+        let Some(u) = history.latest_successful_run(upstream)? else {
             // An upstream with no success at all — not due.
-            return None;
+            return Ok(None);
         };
         // The upstream must have completed AFTER my latest success started
         // (completion-vs-start asymmetry closes the overlap stale-forever case).
         if u.finished_at <= my_baseline {
-            return None;
+            return Ok(None);
         }
         max_completion = Some(match max_completion {
             Some(m) if m >= u.finished_at => m,
             _ => u.finished_at,
         });
     }
-    max_completion
+    Ok(max_completion)
 }
 
 /// Whether `freshness` is due, and if so the (stable) logical timestamp.
+///
+/// # Errors
+///
+/// Propagates a [`HistoryError`] — a read error must NOT be read as "never ran"
+/// (which would fire the epoch occurrence). The caller fails closed.
 fn evaluate_freshness(
     pipeline: &str,
     budget: Duration,
     history: &dyn RunHistoryView,
     now: DateTime<Utc>,
-) -> Option<DateTime<Utc>> {
-    match history.latest_successful_run(pipeline) {
-        None => Some(never_ran_reference()),
+) -> Result<Option<DateTime<Utc>>, HistoryError> {
+    match history.latest_successful_run(pipeline)? {
+        None => Ok(Some(never_ran_reference())),
         Some(r) => {
             if now - r.finished_at > budget {
-                Some(r.finished_at)
+                Ok(Some(r.finished_at))
             } else {
-                None
+                Ok(None)
             }
         }
     }
@@ -451,57 +487,71 @@ pub fn evaluate_one(
     }
 
     // --- after --------------------------------------------------------------
-    let after_due = evaluate_after(&schedule.pipeline, &schedule.after, history);
+    // A history read error fails CLOSED: record the skip, never fire on data we
+    // could not read (a false "not due" would silently drop a due demand).
     if !schedule.after.is_empty() {
-        match after_due {
-            Some(logical_ts) if out.due.is_none() => match apply_standing_throttle(&cursor, now) {
-                Ok(()) => {
-                    out.due = Some(Demand {
-                        pipeline: schedule.pipeline.clone(),
+        match evaluate_after(&schedule.pipeline, &schedule.after, history) {
+            Ok(Some(logical_ts)) if out.due.is_none() => {
+                match apply_standing_throttle(&cursor, now) {
+                    Ok(()) => {
+                        out.due = Some(Demand {
+                            pipeline: schedule.pipeline.clone(),
+                            source: DemandKind::After,
+                            logical_ts,
+                        });
+                    }
+                    Err(reason) => out.skips.push(SourceSkip {
                         source: DemandKind::After,
-                        logical_ts,
-                    });
+                        reason,
+                    }),
                 }
-                Err(reason) => out.skips.push(SourceSkip {
-                    source: DemandKind::After,
-                    reason,
-                }),
-            },
-            Some(_) => out.skips.push(SourceSkip {
+            }
+            Ok(Some(_)) => out.skips.push(SourceSkip {
                 source: DemandKind::After,
                 reason: SkipReason::Superseded,
             }),
-            None => out.skips.push(SourceSkip {
+            Ok(None) => out.skips.push(SourceSkip {
                 source: DemandKind::After,
                 reason: SkipReason::NotDue,
+            }),
+            Err(_) => out.skips.push(SourceSkip {
+                source: DemandKind::After,
+                reason: SkipReason::HistoryError,
             }),
         }
     }
 
     // --- freshness ----------------------------------------------------------
+    // A history read error fails CLOSED: skip rather than treat "unreadable" as
+    // "never ran" (which would fire — and re-fire — the epoch occurrence).
     if let Some(budget) = schedule.freshness_budget {
-        let fresh_due = evaluate_freshness(&schedule.pipeline, budget, history, now);
-        match fresh_due {
-            Some(logical_ts) if out.due.is_none() => match apply_standing_throttle(&cursor, now) {
-                Ok(()) => {
-                    out.due = Some(Demand {
-                        pipeline: schedule.pipeline.clone(),
+        match evaluate_freshness(&schedule.pipeline, budget, history, now) {
+            Ok(Some(logical_ts)) if out.due.is_none() => {
+                match apply_standing_throttle(&cursor, now) {
+                    Ok(()) => {
+                        out.due = Some(Demand {
+                            pipeline: schedule.pipeline.clone(),
+                            source: DemandKind::Freshness,
+                            logical_ts,
+                        });
+                    }
+                    Err(reason) => out.skips.push(SourceSkip {
                         source: DemandKind::Freshness,
-                        logical_ts,
-                    });
+                        reason,
+                    }),
                 }
-                Err(reason) => out.skips.push(SourceSkip {
-                    source: DemandKind::Freshness,
-                    reason,
-                }),
-            },
-            Some(_) => out.skips.push(SourceSkip {
+            }
+            Ok(Some(_)) => out.skips.push(SourceSkip {
                 source: DemandKind::Freshness,
                 reason: SkipReason::Superseded,
             }),
-            None => out.skips.push(SourceSkip {
+            Ok(None) => out.skips.push(SourceSkip {
                 source: DemandKind::Freshness,
                 reason: SkipReason::NotDue,
+            }),
+            Err(_) => out.skips.push(SourceSkip {
+                source: DemandKind::Freshness,
+                reason: SkipReason::HistoryError,
             }),
         }
     }
@@ -542,8 +592,29 @@ mod tests {
     #[derive(Default)]
     struct History(HashMap<String, RunSuccess>);
     impl RunHistoryView for History {
-        fn latest_successful_run(&self, pipeline: &str) -> Option<RunSuccess> {
-            self.0.get(pipeline).copied()
+        fn latest_successful_run(
+            &self,
+            pipeline: &str,
+        ) -> Result<Option<RunSuccess>, HistoryError> {
+            Ok(self.0.get(pipeline).copied())
+        }
+    }
+
+    /// A history view that faults for a specific pipeline — models a corrupt
+    /// `run_history` row so the fail-closed path is testable at this layer.
+    struct FaultyHistory {
+        ok: History,
+        fault_for: &'static str,
+    }
+    impl RunHistoryView for FaultyHistory {
+        fn latest_successful_run(
+            &self,
+            pipeline: &str,
+        ) -> Result<Option<RunSuccess>, HistoryError> {
+            if pipeline == self.fault_for {
+                return Err(HistoryError("corrupt run_history row (test)".into()));
+            }
+            self.ok.latest_successful_run(pipeline)
         }
     }
 
@@ -951,5 +1022,71 @@ mod tests {
             "falls back to project"
         );
         assert_eq!(resolve_freshness_budget(&[], None), None, "unresolvable");
+    }
+
+    // --- fail-closed on a history read fault (F4/F5) -------------------------
+
+    #[test]
+    fn after_history_read_error_fails_closed_no_false_skip() {
+        // The upstream's run-history read faults. A due `after` must NOT be
+        // silently dropped as "not due" — it records a HistoryError skip and
+        // fires nothing.
+        let s = after_schedule("staging", "raw");
+        let states = States::default();
+        let mut ok = History::default();
+        // Even though `raw` genuinely succeeded, the read for it faults.
+        ok.0.insert(
+            "raw".into(),
+            RunSuccess {
+                started_at: ts(2026, 5, 1, 10, 0),
+                finished_at: ts(2026, 5, 1, 11, 0),
+            },
+        );
+        let history = FaultyHistory {
+            ok,
+            fault_for: "raw",
+        };
+        let e = evaluate_one(&s, &states, &history, ts(2026, 5, 1, 12, 0));
+        assert!(e.due.is_none(), "a read fault must never fire");
+        assert!(
+            e.skips
+                .iter()
+                .any(|k| k.source == DemandKind::After && k.reason == SkipReason::HistoryError),
+            "the fault is recorded, not elided: {:?}",
+            e.skips
+        );
+    }
+
+    #[test]
+    fn freshness_history_read_error_fails_closed_no_false_fire() {
+        // The pipeline's own run-history read faults. Freshness must NOT read
+        // the fault as "never ran" and fire the epoch occurrence.
+        let s = ResolvedSchedule {
+            pipeline: "raw".into(),
+            enabled: true,
+            cron: None,
+            after: vec![],
+            freshness_budget: Some(Duration::hours(1)),
+            catchup: Catchup::Latest,
+            retry_max: 0,
+            timeout: None,
+        };
+        let states = States::default();
+        let history = FaultyHistory {
+            ok: History::default(),
+            fault_for: "raw",
+        };
+        let e = evaluate_one(&s, &states, &history, ts(2026, 5, 1, 12, 0));
+        assert!(
+            e.due.is_none(),
+            "a read fault must never fire the epoch occurrence"
+        );
+        assert!(
+            e.skips
+                .iter()
+                .any(|k| k.source == DemandKind::Freshness && k.reason == SkipReason::HistoryError),
+            "the fault is recorded: {:?}",
+            e.skips
+        );
     }
 }

--- a/engine/crates/rocky-core/src/schedule/lock.rs
+++ b/engine/crates/rocky-core/src/schedule/lock.rs
@@ -1,0 +1,154 @@
+//! The reconciler's mutual-exclusion lock.
+//!
+//! Every tick takes a non-blocking advisory flock on `.rocky/tick.lock` and,
+//! while holding it, refreshes a sidecar `.rocky/tick.lock.heartbeat` mtime so a
+//! peer can tell a live holder from a wedged one. A loser skips with
+//! `tick_in_progress`.
+//!
+//! The lock is **contention-avoidance, not the correctness boundary** — a
+//! kernel flock held by a wedged owner never releases, so correctness lives in
+//! the claim state machine (`super::claim`), which no lock can bypass. This
+//! module is deliberately small: acquire, heartbeat, release-on-drop.
+//!
+//! The heartbeat's mtime is a real-time liveness signal, so this module (like
+//! the spawner) is a legitimate real-time boundary; the reconciler's evaluation
+//! and claim decisions still take `now` as a parameter and read no clock.
+
+use std::fs::File;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use fs4::FileExt;
+
+/// A held tick lock. Dropping it releases the flock.
+#[derive(Debug)]
+pub struct TickLock {
+    _file: File,
+    heartbeat_path: PathBuf,
+}
+
+/// The outcome of trying to acquire the tick lock.
+#[derive(Debug)]
+pub enum TickAcquire {
+    /// The lock was acquired — the tick may proceed.
+    Acquired(TickLock),
+    /// The lock is held by another reconciler. `heartbeat_age` is how long since
+    /// the holder last refreshed its heartbeat (None if unreadable), so the
+    /// caller can distinguish a live holder (skip) from a wedged one (a later
+    /// timer tick takes over).
+    Busy {
+        /// Age of the holder's heartbeat, if readable.
+        heartbeat_age: Option<Duration>,
+    },
+}
+
+/// The lock file name under the `.rocky` directory.
+const LOCK_FILE: &str = "tick.lock";
+/// The heartbeat sidecar name.
+const HEARTBEAT_FILE: &str = "tick.lock.heartbeat";
+
+impl TickLock {
+    /// Try to acquire the tick lock under `rocky_dir` (the `.rocky` directory).
+    ///
+    /// Creates `rocky_dir` if needed. Non-blocking: returns
+    /// [`TickAcquire::Busy`] immediately when another reconciler holds the lock.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the directory or lock file cannot be created or
+    /// opened (a genuine filesystem fault, not mere contention).
+    pub fn try_acquire(rocky_dir: &Path) -> io::Result<TickAcquire> {
+        std::fs::create_dir_all(rocky_dir)?;
+        let lock_path = rocky_dir.join(LOCK_FILE);
+        let heartbeat_path = rocky_dir.join(HEARTBEAT_FILE);
+
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&lock_path)?;
+
+        match FileExt::try_lock(&file) {
+            Ok(()) => {
+                let lock = TickLock {
+                    _file: file,
+                    heartbeat_path,
+                };
+                lock.heartbeat()?;
+                Ok(TickAcquire::Acquired(lock))
+            }
+            Err(fs4::TryLockError::WouldBlock) => {
+                let heartbeat_age = read_heartbeat_age(&heartbeat_path);
+                Ok(TickAcquire::Busy { heartbeat_age })
+            }
+            Err(fs4::TryLockError::Error(e)) => Err(e),
+        }
+    }
+
+    /// Refresh the heartbeat sidecar's mtime to now. Called on acquisition and
+    /// between children so a peer sees a live holder.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the heartbeat file cannot be written.
+    pub fn heartbeat(&self) -> io::Result<()> {
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(&self.heartbeat_path)?;
+        file.set_modified(SystemTime::now())?;
+        Ok(())
+    }
+}
+
+/// The age of a heartbeat file relative to the real clock, or `None` if it
+/// cannot be read.
+fn read_heartbeat_age(path: &Path) -> Option<Duration> {
+    let modified = std::fs::metadata(path).ok()?.modified().ok()?;
+    SystemTime::now().duration_since(modified).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn second_acquire_is_busy_while_first_is_held() {
+        let dir = tempfile::tempdir().unwrap();
+        let rocky = dir.path().join(".rocky");
+        let first = TickLock::try_acquire(&rocky).unwrap();
+        assert!(matches!(first, TickAcquire::Acquired(_)));
+        // A second acquisition on the same path is busy (flock is per open file
+        // description, so distinct opens contend even in-process).
+        let second = TickLock::try_acquire(&rocky).unwrap();
+        assert!(
+            matches!(second, TickAcquire::Busy { .. }),
+            "second acquire must be busy"
+        );
+        // Dropping the first releases the flock.
+        drop(first);
+        let third = TickLock::try_acquire(&rocky).unwrap();
+        assert!(
+            matches!(third, TickAcquire::Acquired(_)),
+            "lock frees on drop"
+        );
+    }
+
+    #[test]
+    fn heartbeat_is_fresh_after_acquire() {
+        let dir = tempfile::tempdir().unwrap();
+        let rocky = dir.path().join(".rocky");
+        let TickAcquire::Acquired(lock) = TickLock::try_acquire(&rocky).unwrap() else {
+            panic!("expected acquire");
+        };
+        lock.heartbeat().unwrap();
+        let age = read_heartbeat_age(&rocky.join(HEARTBEAT_FILE)).unwrap();
+        assert!(
+            age < Duration::from_secs(5),
+            "heartbeat just written must be fresh"
+        );
+    }
+}

--- a/engine/crates/rocky-core/src/schedule/mod.rs
+++ b/engine/crates/rocky-core/src/schedule/mod.rs
@@ -1,0 +1,36 @@
+//! Native demand reconciliation: schedule config, occurrence math, demand
+//! evaluation, the per-demand claim state machine, and the one-shot tick.
+//!
+//! Pipelines declare *when* they should run (`cron`, `after`, `freshness`) in
+//! the same config that defines them. A tick evaluates all standing demand
+//! once and runs what is due. This module is the reconciler core: the time
+//! source is always injected (`now` is a parameter — never a wall-clock read),
+//! child processes are spawned through an injected [`Spawner`] so the logic is
+//! testable without built binaries, and every "do not run" outcome is an
+//! explicit, recorded reason.
+
+pub mod claim;
+pub mod demand;
+pub mod lock;
+pub mod occurrence;
+pub mod reconcile;
+pub mod record;
+pub mod spawn;
+
+pub use claim::{
+    Bookkeeping, CfDelta, ClaimCas, ClaimRecord, ClaimState, DemandKind, PostAttempt, PreSpawn,
+    Resolved, TerminalOutcome, budget_remains, decide_post_attempt, decide_pre_spawn,
+    decide_resolver,
+};
+pub use demand::{
+    Catchup, Demand, EvaluatedPipeline, ResolvedSchedule, RunHistoryView, RunSuccess,
+    ScheduleConfigError, ScheduleStateView, SkipReason, evaluate_demands, evaluate_one,
+    resolve_freshness_budget, resolve_schedule,
+};
+pub use lock::TickLock;
+pub use occurrence::{OccurrenceError, next_occurrence, parse_cron, previous_or_equal_occurrence};
+pub use reconcile::{
+    ExecutedDemand, SkippedDemand, TickError, TickOptions, TickReport, TickSkipReason, tick_once,
+};
+pub use record::{ScheduleStateMutation, ScheduleStateRecord, Throttle};
+pub use spawn::{CapturingSpawner, RunOutcome, SpawnRequest, Spawner, SubprocessSpawner};

--- a/engine/crates/rocky-core/src/schedule/mod.rs
+++ b/engine/crates/rocky-core/src/schedule/mod.rs
@@ -23,7 +23,7 @@ pub use claim::{
     decide_resolver,
 };
 pub use demand::{
-    Catchup, Demand, EvaluatedPipeline, ResolvedSchedule, RunHistoryView, RunSuccess,
+    Catchup, Demand, EvaluatedPipeline, HistoryError, ResolvedSchedule, RunHistoryView, RunSuccess,
     ScheduleConfigError, ScheduleStateView, SkipReason, evaluate_demands, evaluate_one,
     resolve_freshness_budget, resolve_schedule,
 };

--- a/engine/crates/rocky-core/src/schedule/occurrence.rs
+++ b/engine/crates/rocky-core/src/schedule/occurrence.rs
@@ -1,0 +1,246 @@
+//! Cron occurrence math.
+//!
+//! [`next_occurrence`] is the single point where the reconciler asks "when does
+//! this cron fire next, after this instant, in this timezone?". Wrapping the
+//! underlying cron library behind our own function keeps the dependency
+//! swappable and pins the DST semantics we depend on (see the tests) to a
+//! contract we own rather than to a library's incidental behavior.
+//!
+//! All timezone reasoning happens in the named IANA zone via `chrono-tz`; the
+//! input and output instants are always absolute UTC, so callers never juggle
+//! wall-clock ambiguity.
+
+use std::str::FromStr;
+
+use chrono::{DateTime, Utc};
+use chrono_tz::Tz;
+use croner::Cron;
+use thiserror::Error;
+
+/// A cron expression or occurrence search that could not be resolved.
+#[derive(Debug, Error)]
+pub enum OccurrenceError {
+    /// The cron expression did not parse.
+    #[error("invalid cron expression {expr:?}: {message}")]
+    Parse {
+        /// The offending expression, echoed for operator diagnosis.
+        expr: String,
+        /// The underlying parser message.
+        message: String,
+    },
+    /// The library could not locate an occurrence (e.g. a search-limit
+    /// overrun on a pathological pattern).
+    #[error("no cron occurrence found for {expr:?} after {after}: {message}")]
+    Search {
+        /// The expression being searched.
+        expr: String,
+        /// The instant the search started from.
+        after: DateTime<Utc>,
+        /// The underlying search message.
+        message: String,
+    },
+}
+
+/// Parse a standard 5-field cron expression, surfacing a typed error on
+/// failure. Exposed so config validation can reject a malformed schedule
+/// without duplicating the parser choice.
+///
+/// # Errors
+///
+/// Returns [`OccurrenceError::Parse`] when `cron_expr` is not a valid cron
+/// expression.
+pub fn parse_cron(cron_expr: &str) -> Result<Cron, OccurrenceError> {
+    Cron::from_str(cron_expr).map_err(|e| OccurrenceError::Parse {
+        expr: cron_expr.to_string(),
+        message: e.to_string(),
+    })
+}
+
+/// The first cron occurrence strictly after `after`, evaluated in `tz`.
+///
+/// The search runs in the named timezone so daylight-saving transitions are
+/// honored, then the result is converted back to absolute UTC. `after` is
+/// exclusive: an instant that is itself an occurrence yields the *next* one.
+///
+/// # Errors
+///
+/// Returns [`OccurrenceError::Parse`] for a malformed expression, or
+/// [`OccurrenceError::Search`] if no occurrence can be found.
+pub fn next_occurrence(
+    cron_expr: &str,
+    tz: Tz,
+    after: DateTime<Utc>,
+) -> Result<DateTime<Utc>, OccurrenceError> {
+    let cron = parse_cron(cron_expr)?;
+    let after_local = after.with_timezone(&tz);
+    let next_local = cron
+        .find_next_occurrence(&after_local, false)
+        .map_err(|e| OccurrenceError::Search {
+            expr: cron_expr.to_string(),
+            after,
+            message: e.to_string(),
+        })?;
+    Ok(next_local.with_timezone(&Utc))
+}
+
+/// The most recent cron occurrence at or before `at`, evaluated in `tz`.
+///
+/// Used by the catch-up policy to pick the single "latest missed" occurrence:
+/// when several occurrences elapsed while nothing was running, the anchor jumps
+/// to this instant and one demand fires for it. `at` is inclusive.
+///
+/// # Errors
+///
+/// Returns [`OccurrenceError::Parse`] for a malformed expression, or
+/// [`OccurrenceError::Search`] if no occurrence can be found at or before `at`.
+pub fn previous_or_equal_occurrence(
+    cron_expr: &str,
+    tz: Tz,
+    at: DateTime<Utc>,
+) -> Result<DateTime<Utc>, OccurrenceError> {
+    let cron = parse_cron(cron_expr)?;
+    let at_local = at.with_timezone(&tz);
+    let prev_local = cron
+        .find_previous_occurrence(&at_local, true)
+        .map_err(|e| OccurrenceError::Search {
+            expr: cron_expr.to_string(),
+            after: at,
+            message: e.to_string(),
+        })?;
+    Ok(prev_local.with_timezone(&Utc))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn utc(y: i32, mo: u32, d: u32, h: u32, mi: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(y, mo, d, h, mi, 0).unwrap()
+    }
+
+    #[test]
+    fn utc_daily_schedule_is_unaffected_by_dst() {
+        // A plain UTC schedule must fire at exactly the same wall/UTC instant
+        // every day, regardless of any civil-time DST change elsewhere.
+        let next = next_occurrence("30 1 * * *", Tz::UTC, utc(2026, 3, 28, 12, 0)).unwrap();
+        assert_eq!(next, utc(2026, 3, 29, 1, 30));
+        let after = next_occurrence("30 1 * * *", Tz::UTC, next).unwrap();
+        assert_eq!(after, utc(2026, 3, 30, 1, 30));
+    }
+
+    #[test]
+    fn lisbon_spring_forward_skipped_wall_time_fires_once_at_next_valid_instant() {
+        // Europe/Lisbon 2026-03-29: clocks jump 01:00 WET -> 02:00 WEST, so the
+        // wall time 01:30 never happens. A `30 1 * * *` schedule must fire once,
+        // at the next valid instant. 01:00 WET is 01:00Z; the jump lands civil
+        // time at 02:00 WEST == 01:00Z. The next valid firing after the gap is
+        // the 02:00 WEST boundary, i.e. 01:00Z.
+        let tz = Tz::Europe__Lisbon;
+        // Start the search just before the missed 01:30 local.
+        let start = utc(2026, 3, 29, 0, 0);
+        let fire = next_occurrence("30 1 * * *", tz, start).unwrap();
+
+        // It must be a single real instant on the transition day, at or just
+        // after the gap, and never before it. The gap is [01:00Z, 01:00Z) in
+        // Lisbon terms; the fire is the first valid wall-time match.
+        assert_eq!(
+            fire.date_naive(),
+            utc(2026, 3, 29, 0, 0).date_naive(),
+            "must fire on the transition day, once"
+        );
+        // The next occurrence after it is the following day at 01:30 WEST
+        // (00:30Z), proving exactly one fire covered the skipped slot.
+        let next = next_occurrence("30 1 * * *", tz, fire).unwrap();
+        assert_eq!(next, utc(2026, 3, 30, 0, 30));
+        assert!(next > fire);
+    }
+
+    #[test]
+    fn lisbon_fall_back_repeated_wall_time_fires_on_first_occurrence_only() {
+        // Europe/Lisbon 2026-10-25: clocks fall back 02:00 WEST -> 01:00 WET, so
+        // the wall time 01:30 happens twice. A `30 1 * * *` schedule must fire
+        // on the FIRST occurrence only (the earlier UTC instant, 00:30Z under
+        // WEST), never a second time at the repeat (01:30Z under WET).
+        let tz = Tz::Europe__Lisbon;
+        let start = utc(2026, 10, 25, 0, 0);
+        let fire = next_occurrence("30 1 * * *", tz, start).unwrap();
+        assert_eq!(
+            fire,
+            utc(2026, 10, 25, 0, 30),
+            "first (WEST) 01:30 == 00:30Z"
+        );
+
+        // Crucially, the NEXT occurrence must skip the repeated wall time and
+        // land on the following day — not the second 01:30 (01:30Z).
+        let next = next_occurrence("30 1 * * *", tz, fire).unwrap();
+        assert_eq!(
+            next,
+            utc(2026, 10, 26, 1, 30),
+            "must not fire again at the repeated 01:30 local (01:30Z)"
+        );
+    }
+
+    #[test]
+    fn month_boundary_rolls_over() {
+        // Daily at 00:00 across a month boundary.
+        let next = next_occurrence("0 0 * * *", Tz::UTC, utc(2026, 1, 31, 12, 0)).unwrap();
+        assert_eq!(next, utc(2026, 2, 1, 0, 0));
+        // Day-of-month 31 skips months without a 31st (Feb -> Mar 31).
+        let next = next_occurrence("0 0 31 * *", Tz::UTC, utc(2026, 1, 31, 12, 0)).unwrap();
+        assert_eq!(next, utc(2026, 3, 31, 0, 0));
+    }
+
+    #[test]
+    fn every_five_minutes_steps_correctly() {
+        let mut cursor = utc(2026, 6, 1, 9, 2);
+        let expected = [
+            utc(2026, 6, 1, 9, 5),
+            utc(2026, 6, 1, 9, 10),
+            utc(2026, 6, 1, 9, 15),
+        ];
+        for want in expected {
+            cursor = next_occurrence("*/5 * * * *", Tz::UTC, cursor).unwrap();
+            assert_eq!(cursor, want);
+        }
+    }
+
+    #[test]
+    fn previous_or_equal_picks_latest_missed_occurrence() {
+        // Latest daily-03:00 occurrence at or before 2026-05-10T07:00Z.
+        let prev =
+            previous_or_equal_occurrence("0 3 * * *", Tz::UTC, utc(2026, 5, 10, 7, 0)).unwrap();
+        assert_eq!(prev, utc(2026, 5, 10, 3, 0));
+        // Exactly on an occurrence, inclusive returns that occurrence.
+        let prev =
+            previous_or_equal_occurrence("0 3 * * *", Tz::UTC, utc(2026, 5, 10, 3, 0)).unwrap();
+        assert_eq!(prev, utc(2026, 5, 10, 3, 0));
+    }
+
+    #[test]
+    fn occurrences_strictly_increase() {
+        // Property: iterating next_occurrence from its own output always yields
+        // a strictly greater instant, across a DST boundary, for several
+        // patterns. A stuck or backwards occurrence is a scheduler hang or a
+        // double-fire — this pins neither can happen.
+        for expr in ["*/7 * * * *", "30 1 * * *", "0 0 * * *", "15 2 * * 1"] {
+            for tz in [Tz::UTC, Tz::Europe__Lisbon, Tz::America__New_York] {
+                let mut prev = utc(2026, 3, 27, 0, 0);
+                for _ in 0..500 {
+                    let next = next_occurrence(expr, tz, prev).unwrap();
+                    assert!(
+                        next > prev,
+                        "expr={expr} tz={tz:?}: {next} !> {prev} (must strictly increase)"
+                    );
+                    prev = next;
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn malformed_cron_is_a_typed_parse_error() {
+        let err = next_occurrence("not a cron", Tz::UTC, utc(2026, 1, 1, 0, 0)).unwrap_err();
+        assert!(matches!(err, OccurrenceError::Parse { .. }));
+    }
+}

--- a/engine/crates/rocky-core/src/schedule/reconcile.rs
+++ b/engine/crates/rocky-core/src/schedule/reconcile.rs
@@ -43,8 +43,8 @@ use super::claim::{
     decide_post_attempt, decide_pre_spawn, decide_resolver,
 };
 use super::demand::{
-    Demand, EvaluatedPipeline, ResolvedSchedule, RunHistoryView, RunSuccess, ScheduleStateView,
-    SkipReason, SourceSkip, evaluate_one, resolve_schedule,
+    Demand, EvaluatedPipeline, HistoryError, ResolvedSchedule, RunHistoryView, RunSuccess,
+    ScheduleStateView, SkipReason, SourceSkip, evaluate_one, resolve_schedule,
 };
 use super::lock::{TickAcquire, TickLock};
 use super::record::{ScheduleStateMutation, ScheduleStateRecord};
@@ -139,6 +139,10 @@ pub enum TickSkipReason {
     /// The demand's key is already terminal (`completed`), or its run was
     /// observed and finalized by this tick's resolver — it will not run again.
     Dedup,
+    /// The run history could not be read (store fault or a corrupt row), so the
+    /// standing demand was skipped rather than misclassified — fail-closed, and
+    /// surfaced loudly rather than silently dropped.
+    HistoryUnavailable,
 }
 
 /// A per-demand skip record for the tick report.
@@ -315,18 +319,18 @@ impl ScheduleStateView for StoreState<'_> {
 struct StoreHistory<'a>(&'a StateStore);
 
 impl RunHistoryView for StoreHistory<'_> {
-    fn latest_successful_run(&self, pipeline: &str) -> Option<RunSuccess> {
-        // A state read fault degrades to "no success": an `after` upstream then
-        // waits rather than false-firing (fail closed for the soundness-critical
-        // direction); a persistent fault surfaces on the next write path.
-        self.0
-            .latest_successful_run(pipeline)
-            .ok()
-            .flatten()
-            .map(|r| RunSuccess {
+    fn latest_successful_run(&self, pipeline: &str) -> Result<Option<RunSuccess>, HistoryError> {
+        // A read fault (store error or a corrupt `run_history` row) is surfaced
+        // as an error, NOT swallowed to "no success" — the caller fails closed
+        // and records a skip, so a bad row can neither false-skip an `after`
+        // demand nor false-fire a `freshness` one.
+        match self.0.latest_successful_run(pipeline) {
+            Ok(run) => Ok(run.map(|r| RunSuccess {
                 started_at: r.started_at,
                 finished_at: r.finished_at,
-            })
+            })),
+            Err(e) => Err(HistoryError(e.to_string())),
+        }
     }
 }
 
@@ -442,6 +446,8 @@ fn map_skip(pipeline: &str, skip: &SourceSkip) -> Option<SkippedDemand> {
         SkipReason::PartialBackoff { resume_at } => TickSkipReason::PartialBackoff {
             resume_at: *resume_at,
         },
+        // Recorded, never elided — a read fault must be visible in the report.
+        SkipReason::HistoryError => TickSkipReason::HistoryUnavailable,
     };
     Some(SkippedDemand {
         pipeline: pipeline.to_string(),
@@ -1534,6 +1540,99 @@ after = ["raw"]
             before,
             store.get_schedule_state("raw").unwrap(),
             "dry run writes no state"
+        );
+    }
+
+    // --- fail-closed on a corrupt run_history row (F4/F5), end to end ---------
+
+    const FRESHNESS_ONLY: &str = r#"
+[freshness]
+expected_lag_seconds = 3600
+
+[adapter.db]
+type = "duckdb"
+
+[pipeline.raw]
+type = "transformation"
+[pipeline.raw.target]
+adapter = "db"
+[pipeline.raw.schedule]
+freshness = true
+"#;
+
+    #[test]
+    fn after_corrupt_history_row_fails_closed_no_spawn() {
+        let (store, _dir, opts) = temp_env();
+        let config = cfg(AFTER_ONLY);
+        // A genuine upstream success — `after` would be due...
+        seed_run(
+            &store,
+            "raw",
+            None,
+            RunStatus::Success,
+            at(2026, 5, 2, 3, 5),
+            at(2026, 5, 2, 3, 10),
+        );
+        // ...but a corrupt row in run_history makes the scan error.
+        store.insert_corrupt_run_history_row("run-corrupt").unwrap();
+
+        let spawner = CapturingSpawner::new(0);
+        let report = rt()
+            .block_on(tick_once(
+                &config,
+                &store,
+                at(2026, 5, 2, 4, 0),
+                &spawner,
+                &opts,
+            ))
+            .unwrap();
+
+        assert_eq!(
+            spawner.run_count(),
+            0,
+            "a history read fault must never spawn on data it could not read"
+        );
+        assert!(
+            report
+                .skipped
+                .iter()
+                .any(|s| s.pipeline == "staging" && s.reason == TickSkipReason::HistoryUnavailable),
+            "the fault is recorded loudly, not a silent drop: {:?}",
+            report.skipped
+        );
+    }
+
+    #[test]
+    fn freshness_corrupt_history_row_does_not_fire_epoch() {
+        let (store, _dir, opts) = temp_env();
+        let config = cfg(FRESHNESS_ONLY);
+        // No successful run at all + a corrupt row: freshness must NOT read the
+        // fault as "never ran" and fire the epoch occurrence.
+        store.insert_corrupt_run_history_row("run-corrupt").unwrap();
+
+        let spawner = CapturingSpawner::new(0);
+        let report = rt()
+            .block_on(tick_once(
+                &config,
+                &store,
+                at(2026, 5, 2, 4, 0),
+                &spawner,
+                &opts,
+            ))
+            .unwrap();
+
+        assert_eq!(
+            spawner.run_count(),
+            0,
+            "a read fault must not fire the epoch occurrence"
+        );
+        assert!(
+            report
+                .skipped
+                .iter()
+                .any(|s| s.pipeline == "raw" && s.reason == TickSkipReason::HistoryUnavailable),
+            "recorded fail-closed: {:?}",
+            report.skipped
         );
     }
 }

--- a/engine/crates/rocky-core/src/schedule/reconcile.rs
+++ b/engine/crates/rocky-core/src/schedule/reconcile.rs
@@ -1,0 +1,1539 @@
+//! The one-shot tick: evaluate all standing demand once, then execute what is
+//! due through the claim state machine.
+//!
+//! [`tick_once`] is the reconciler's single orchestration point. It is called by
+//! the `rocky tick` CLI and, later, by a resident loop; both pass the clock in
+//! as `now` — the core reads no wall clock, so every time-dependent path is
+//! deterministic under test. Children are launched through an injected
+//! [`Spawner`], so the whole reconciler runs without a built binary.
+//!
+//! The pass, in order:
+//!
+//! 1. Take the tick lock (`.rocky/tick.lock`). A fresh holder means another
+//!    reconciler owns this pass — skip with `tick_in_progress`. A holder whose
+//!    heartbeat has gone stale is wedged — proceed via the override, letting the
+//!    claim state machine keep correctness (the lock is contention-avoidance,
+//!    never the correctness boundary).
+//! 2. Resolve every scheduled pipeline in scope; an invalid schedule fails
+//!    closed to a skip (it never fires).
+//! 3. Order the pipelines topologically by their `after` edges, so a pipeline
+//!    that becomes due *because an upstream ran earlier in this same tick* is
+//!    evaluated after that upstream.
+//! 4. For each pipeline, evaluate its demand against live state (re-read each
+//!    time, so within-tick upstream successes are visible), then execute the due
+//!    demand through the claim state machine: claim before spawn, in-tick retry
+//!    while budget remains, terminal transition on exhaustion, and a
+//!    budget-aware resolver for a claim left `submitted` by a crashed owner.
+//!
+//! Every "do not run" outcome is an explicit, recorded reason on the
+//! [`TickReport`]. Config or state faults fail closed — the tick runs nothing
+//! and surfaces a [`TickError`].
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+use chrono::{DateTime, Duration, Utc};
+use thiserror::Error;
+
+use crate::config::RockyConfig;
+use crate::state::{StateError, StateStore};
+
+use super::claim::{
+    ClaimCas, ClaimRecord, DemandKind, PostAttempt, PreSpawn, Resolved, TerminalOutcome,
+    decide_post_attempt, decide_pre_spawn, decide_resolver,
+};
+use super::demand::{
+    Demand, EvaluatedPipeline, ResolvedSchedule, RunHistoryView, RunSuccess, ScheduleStateView,
+    SkipReason, SourceSkip, evaluate_one, resolve_schedule,
+};
+use super::lock::{TickAcquire, TickLock};
+use super::record::{ScheduleStateMutation, ScheduleStateRecord};
+use super::spawn::{SpawnRequest, Spawner};
+
+/// A stuck `submitted` claim with no run record is held for this grace before
+/// its attempt is treated as lost (the owner crashed between committing the
+/// claim and writing a record). `now` is injected, so the grace is deterministic
+/// under test and a crash never stalls a standing demand indefinitely.
+const RECOVERY_GRACE: Duration = Duration::minutes(5);
+
+/// A held tick lock whose heartbeat is older than this is a wedged owner: a
+/// later tick proceeds via the wedge override rather than skipping forever.
+const LOCK_TAKEOVER_AFTER: std::time::Duration = std::time::Duration::from_secs(300);
+
+/// How often the lease heartbeat is refreshed while a child runs. Comfortably
+/// under the 60s staleness bound so a long but healthy run is never mistaken for
+/// a wedged one.
+const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Defensive bound on the per-demand claim/retry loop. The frozen transitions
+/// converge in at most `1 + retry.max` spawns plus a bounded resolver prelude;
+/// exceeding this is a state-machine bug, never a reachable schedule.
+const MAX_DEMAND_ITERATIONS: usize = 256;
+
+/// Inputs to a single tick that come from the CLI/serve wrapper rather than the
+/// reconciler core.
+#[derive(Debug, Clone)]
+pub struct TickOptions {
+    /// Evaluate and report, but execute nothing and write no state.
+    pub dry_run: bool,
+    /// Restrict evaluation to a single pipeline (`--pipeline`); `None` = every
+    /// scheduled pipeline.
+    pub pipeline_filter: Option<String>,
+    /// The config file path passed to each spawned `rocky run -c <path>`.
+    pub config_path: PathBuf,
+    /// The `.rocky` directory that holds the tick lock and its heartbeat.
+    pub rocky_dir: PathBuf,
+    /// The tick span's `traceparent`, propagated to each child so the run's own
+    /// trace connects to the tick. `None` when tracing is inactive.
+    pub traceparent: Option<String>,
+}
+
+/// A demand that executed this tick — a child ran to a terminal outcome.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutedDemand {
+    /// The pipeline that ran.
+    pub pipeline: String,
+    /// The source that made it due.
+    pub source: DemandKind,
+    /// The logical timestamp of the demand.
+    pub logical_ts: DateTime<Utc>,
+    /// The submission id of the attempt whose outcome was recorded (the last
+    /// attempt on an exhausted retry cycle).
+    pub submission_id: String,
+    /// The child's exit code.
+    pub exit_code: i32,
+    /// The mapped terminal outcome.
+    pub outcome: TerminalOutcome,
+    /// Total submissions made for this demand (the claim's monotonic audit
+    /// counter at the terminal transition).
+    pub attempts: u32,
+}
+
+/// Why a demand did not execute this tick. Mirrors the frozen tick-contract
+/// reason set so the CLI output can render each as a stable string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TickSkipReason {
+    /// No demand from this source right now.
+    NotDue,
+    /// The schedule is disabled (`enabled = false`).
+    Disabled,
+    /// A claim is `submitted` for this key (a run is in flight, or its crashed
+    /// owner is still within the recovery grace) — do not spawn over it.
+    InFlight,
+    /// More than one cron occurrence elapsed under `catchup = "skip"`: the anchor
+    /// advanced, nothing ran.
+    CatchupSkipped {
+        /// Number of missed occurrences (capped for reporting).
+        missed: u32,
+    },
+    /// A standing demand suppressed by the failure backoff ladder.
+    FailureBackoff {
+        /// When the demand becomes eligible again.
+        resume_at: DateTime<Utc>,
+    },
+    /// A standing demand suppressed by the fixed partial backoff.
+    PartialBackoff {
+        /// When the demand becomes eligible again.
+        resume_at: DateTime<Utc>,
+    },
+    /// The demand's key is already terminal (`completed`), or its run was
+    /// observed and finalized by this tick's resolver — it will not run again.
+    Dedup,
+}
+
+/// A per-demand skip record for the tick report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkippedDemand {
+    /// The pipeline the skip belongs to.
+    pub pipeline: String,
+    /// The demand source, when the skip is source-specific. `None` for a
+    /// pipeline-level or resolution-level skip.
+    pub source: Option<DemandKind>,
+    /// Why it was skipped.
+    pub reason: TickSkipReason,
+}
+
+/// The result of one tick: what was evaluated, executed, and skipped.
+#[derive(Debug, Clone, Default)]
+pub struct TickReport {
+    /// Per-pipeline evaluation snapshots (sources considered, the chosen demand,
+    /// anchor movements, per-source skips).
+    pub evaluated: Vec<EvaluatedPipeline>,
+    /// Demands that ran to a terminal outcome this tick.
+    pub executed: Vec<ExecutedDemand>,
+    /// Demands suppressed this tick, each with a reason.
+    pub skipped: Vec<SkippedDemand>,
+    /// The whole tick was skipped because a live reconciler already holds the
+    /// lock (`tick_in_progress`).
+    pub skipped_whole_tick: bool,
+    /// The tick proceeded via the wedge override (a stale-heartbeat lock holder);
+    /// correctness fell back to the claim state machine.
+    pub lock_overridden: bool,
+}
+
+/// A fault that fails the whole tick closed — it runs nothing.
+#[derive(Debug, Error)]
+pub enum TickError {
+    /// A state-store read or write failed.
+    #[error("state store error during tick: {0}")]
+    State(#[from] StateError),
+    /// The tick lock could not be opened or created (a genuine filesystem fault,
+    /// not mere contention).
+    #[error("failed to acquire tick lock in {dir}: {source}")]
+    Lock {
+        /// The `.rocky` directory involved.
+        dir: String,
+        /// The underlying I/O error.
+        source: std::io::Error,
+    },
+    /// The `after` graph among scheduled pipelines has a cycle — refused rather
+    /// than run in an ambiguous order.
+    #[error("schedule dependency cycle among pipelines: {0}")]
+    Cycle(String),
+    /// The per-demand loop exceeded its defensive bound — a state-machine bug.
+    #[error("reconciler loop bound exceeded for demand {0}")]
+    LoopBound(String),
+}
+
+/// Evaluate all standing demand once and execute what is due.
+///
+/// `now` is always injected — the reconciler core reads no wall clock. Children
+/// run through `spawner`, so the logic is testable without a binary.
+///
+/// # Errors
+///
+/// Returns [`TickError`] when the tick cannot proceed safely: a state fault, a
+/// lock I/O fault, or an `after` cycle. In every such case the tick runs
+/// nothing (fail closed).
+pub async fn tick_once(
+    config: &RockyConfig,
+    store: &StateStore,
+    now: DateTime<Utc>,
+    spawner: &dyn Spawner,
+    opts: &TickOptions,
+) -> Result<TickReport, TickError> {
+    let mut report = TickReport::default();
+
+    // 1. Mutual exclusion. A dry run makes no writes and spawns nothing, so it
+    //    never contends for the lock (a preview must not be starved). A real
+    //    tick takes the flock: a fresh holder means skip, a wedged holder (stale
+    //    heartbeat) means proceed via the override.
+    let lock = if opts.dry_run {
+        None
+    } else {
+        match TickLock::try_acquire(&opts.rocky_dir).map_err(|e| TickError::Lock {
+            dir: opts.rocky_dir.display().to_string(),
+            source: e,
+        })? {
+            TickAcquire::Acquired(held) => Some(held),
+            TickAcquire::Busy { heartbeat_age } => {
+                // A missing/unreadable heartbeat is treated as fresh (skip) — the
+                // override is reserved for a demonstrably stale holder, never a
+                // race we cannot read.
+                let wedged = heartbeat_age.is_some_and(|age| age > LOCK_TAKEOVER_AFTER);
+                if wedged {
+                    report.lock_overridden = true;
+                    None
+                } else {
+                    report.skipped_whole_tick = true;
+                    return Ok(report);
+                }
+            }
+        }
+    };
+
+    // 2. Resolve schedules in scope; invalid ones fail closed to skips.
+    let (schedules, resolve_skips) = resolve_all_schedules(config, opts.pipeline_filter.as_deref());
+    report.skipped.extend(resolve_skips);
+
+    // 3. Topological order by `after`, so a same-tick upstream success can make a
+    //    downstream due. A cycle is an infra error — fail closed.
+    let order = topological_order(&schedules)?;
+
+    // 4. Evaluate + execute each pipeline in order against live state.
+    for name in &order {
+        let schedule = &schedules[name];
+        if let Some(held) = &lock {
+            let _ = held.heartbeat();
+        }
+        if !opts.dry_run {
+            store.touch_schedule_evaluated(name, now)?;
+        }
+
+        let state_view = StoreState(store);
+        let history_view = StoreHistory(store);
+        let ev = evaluate_one(schedule, &state_view, &history_view, now);
+
+        // Persist non-firing anchor movements (first-sight init, catch-up skip).
+        if !opts.dry_run {
+            if let Some(at) = ev.anchor_init {
+                store.advance_schedule_fire_anchor(name, at)?;
+            }
+            if let Some(at) = ev.catchup_advance {
+                store.advance_schedule_fire_anchor(name, at)?;
+            }
+        }
+
+        for skip in &ev.skips {
+            if let Some(mapped) = map_skip(name, skip) {
+                report.skipped.push(mapped);
+            }
+        }
+        report.evaluated.push(ev.clone());
+
+        let Some(demand) = ev.due else {
+            continue;
+        };
+        if opts.dry_run {
+            // Reported as due via `evaluated`; a dry run executes nothing.
+            continue;
+        }
+        match execute_demand(&demand, schedule, store, now, spawner, opts, lock.as_ref()).await? {
+            ExecOutcome::Executed(ed) => report.executed.push(ed),
+            ExecOutcome::Skipped(sd) => report.skipped.push(sd),
+        }
+    }
+
+    Ok(report)
+}
+
+/// A read-only [`ScheduleStateView`] backed by the live store.
+struct StoreState<'a>(&'a StateStore);
+
+impl ScheduleStateView for StoreState<'_> {
+    fn get(&self, pipeline: &str) -> ScheduleStateRecord {
+        self.0
+            .get_schedule_state(pipeline)
+            .ok()
+            .flatten()
+            .unwrap_or_default()
+    }
+}
+
+/// A read-only [`RunHistoryView`] backed by the live store. Each query re-reads
+/// the store, so a child that ran earlier in the tick is visible immediately.
+struct StoreHistory<'a>(&'a StateStore);
+
+impl RunHistoryView for StoreHistory<'_> {
+    fn latest_successful_run(&self, pipeline: &str) -> Option<RunSuccess> {
+        // A state read fault degrades to "no success": an `after` upstream then
+        // waits rather than false-firing (fail closed for the soundness-critical
+        // direction); a persistent fault surfaces on the next write path.
+        self.0
+            .latest_successful_run(pipeline)
+            .ok()
+            .flatten()
+            .map(|r| RunSuccess {
+                started_at: r.started_at,
+                finished_at: r.finished_at,
+            })
+    }
+}
+
+/// Resolve every scheduled pipeline in scope. An unresolvable schedule (bad
+/// cron/timezone/catchup, or `freshness = true` with no budget) fails closed to
+/// a skip — `rocky validate` surfaces the reason; the reconciler never fires it.
+fn resolve_all_schedules(
+    config: &RockyConfig,
+    filter: Option<&str>,
+) -> (BTreeMap<String, ResolvedSchedule>, Vec<SkippedDemand>) {
+    let default_tz = config.schedule.timezone.as_str();
+    let project_lag = config.freshness.expected_lag_seconds;
+    let mut resolved = BTreeMap::new();
+    let mut skips = Vec::new();
+    for (name, pipeline) in &config.pipelines {
+        if let Some(f) = filter
+            && name.as_str() != f
+        {
+            continue;
+        }
+        let Some(schedule_cfg) = pipeline.schedule() else {
+            continue;
+        };
+        // The freshness budget is resolved from the project default only in this
+        // phase; per-model budget resolution (the MIN over member models) needs
+        // the model set loaded and is a follow-up.
+        match resolve_schedule(name, schedule_cfg, default_tz, &[], project_lag) {
+            Ok(rs) => {
+                resolved.insert(name.clone(), rs);
+            }
+            Err(_) => {
+                skips.push(SkippedDemand {
+                    pipeline: name.clone(),
+                    source: None,
+                    reason: TickSkipReason::NotDue,
+                });
+            }
+        }
+    }
+    (resolved, skips)
+}
+
+/// Order the scheduled pipelines so every `after` upstream precedes its
+/// dependents. Only edges among *scheduled* pipelines matter — an unscheduled
+/// `after` target runs externally and contributes run history, not tick order.
+///
+/// Kahn's algorithm with a lexicographic tiebreak for determinism. A cycle
+/// leaves nodes unprocessed and yields [`TickError::Cycle`].
+fn topological_order(
+    schedules: &BTreeMap<String, ResolvedSchedule>,
+) -> Result<Vec<String>, TickError> {
+    let names: BTreeSet<String> = schedules.keys().cloned().collect();
+    let mut indegree: BTreeMap<String, usize> = names.iter().map(|n| (n.clone(), 0)).collect();
+    let mut adj: BTreeMap<String, Vec<String>> =
+        names.iter().map(|n| (n.clone(), Vec::new())).collect();
+    for (name, sched) in schedules {
+        for up in &sched.after {
+            if names.contains(up) {
+                adj.get_mut(up)
+                    .expect("adjacency seeded for every name")
+                    .push(name.clone());
+                *indegree
+                    .get_mut(name)
+                    .expect("indegree seeded for every name") += 1;
+            }
+        }
+    }
+    let mut ready: BTreeSet<String> = indegree
+        .iter()
+        .filter(|(_, d)| **d == 0)
+        .map(|(n, _)| n.clone())
+        .collect();
+    let mut order: Vec<String> = Vec::with_capacity(names.len());
+    while let Some(n) = ready.iter().next().cloned() {
+        ready.remove(&n);
+        for m in adj
+            .get(&n)
+            .expect("adjacency seeded for every name")
+            .clone()
+        {
+            let d = indegree
+                .get_mut(&m)
+                .expect("indegree seeded for every name");
+            *d -= 1;
+            if *d == 0 {
+                ready.insert(m);
+            }
+        }
+        order.push(n);
+    }
+    if order.len() != names.len() {
+        let done: BTreeSet<&String> = order.iter().collect();
+        let remaining: Vec<String> = names
+            .iter()
+            .filter(|n| !done.contains(n))
+            .cloned()
+            .collect();
+        return Err(TickError::Cycle(remaining.join(", ")));
+    }
+    Ok(order)
+}
+
+/// Map a per-source evaluation skip to a report entry. A `NotDue`/`Superseded`
+/// skip is elided — it is not a suppression (it appears in `evaluated`).
+fn map_skip(pipeline: &str, skip: &SourceSkip) -> Option<SkippedDemand> {
+    let reason = match &skip.reason {
+        SkipReason::NotDue | SkipReason::Superseded => return None,
+        SkipReason::Disabled => TickSkipReason::Disabled,
+        SkipReason::CatchupSkipped { missed } => TickSkipReason::CatchupSkipped { missed: *missed },
+        SkipReason::FailureBackoff { resume_at } => TickSkipReason::FailureBackoff {
+            resume_at: *resume_at,
+        },
+        SkipReason::PartialBackoff { resume_at } => TickSkipReason::PartialBackoff {
+            resume_at: *resume_at,
+        },
+    };
+    Some(SkippedDemand {
+        pipeline: pipeline.to_string(),
+        source: Some(skip.source),
+        reason,
+    })
+}
+
+/// The claim storage key for a coordinate-derived demand:
+/// `<pipeline>\u{1f}<source>\u{1f}<logical_ts>`.
+fn claim_key(pipeline: &str, source: DemandKind, logical_ts: DateTime<Utc>) -> String {
+    format!(
+        "{pipeline}\u{1f}{}\u{1f}{}",
+        source.as_str(),
+        logical_ts.to_rfc3339()
+    )
+}
+
+fn new_submission_id() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+/// The cursor mutation that rides with a first submission's claim CAS: a cron
+/// submission advances the catch-up anchor; a standing submission records only
+/// the attempt time.
+fn submit_mutation(demand: &Demand, run_id: &str, now: DateTime<Utc>) -> ScheduleStateMutation {
+    match demand.source {
+        DemandKind::Cron => ScheduleStateMutation::SubmitCron {
+            logical_ts: demand.logical_ts,
+            attempt_at: now,
+            run_id: run_id.to_string(),
+        },
+        DemandKind::After | DemandKind::Freshness | DemandKind::Webhook => {
+            ScheduleStateMutation::SubmitStanding {
+                attempt_at: now,
+                run_id: run_id.to_string(),
+            }
+        }
+    }
+}
+
+fn skip(demand: &Demand, reason: TickSkipReason) -> SkippedDemand {
+    SkippedDemand {
+        pipeline: demand.pipeline.clone(),
+        source: Some(demand.source),
+        reason,
+    }
+}
+
+fn to_std_timeout(d: Duration) -> std::time::Duration {
+    d.to_std().unwrap_or(std::time::Duration::ZERO)
+}
+
+/// The outcome of executing (or declining to execute) one due demand.
+enum ExecOutcome {
+    Executed(ExecutedDemand),
+    Skipped(SkippedDemand),
+}
+
+/// Execute one due demand through the claim state machine: claim an absent or
+/// re-claimable key, resolve a stuck one, or skip a terminal one.
+#[allow(clippy::too_many_arguments)]
+async fn execute_demand(
+    demand: &Demand,
+    schedule: &ResolvedSchedule,
+    store: &StateStore,
+    now: DateTime<Utc>,
+    spawner: &dyn Spawner,
+    opts: &TickOptions,
+    lock: Option<&TickLock>,
+) -> Result<ExecOutcome, TickError> {
+    let key = claim_key(&demand.pipeline, demand.source, demand.logical_ts);
+    let mut iterations = 0;
+    loop {
+        iterations += 1;
+        if iterations > MAX_DEMAND_ITERATIONS {
+            return Err(TickError::LoopBound(key.clone()));
+        }
+        let observed = store.get_schedule_claim(&key)?;
+        let fresh_id = new_submission_id();
+        match decide_pre_spawn(observed.as_ref(), fresh_id.clone(), now) {
+            PreSpawn::SkipCompleted => {
+                return Ok(ExecOutcome::Skipped(skip(demand, TickSkipReason::Dedup)));
+            }
+            PreSpawn::ResolveStuck => {
+                let current = observed.expect("ResolveStuck only arises from a stored claim");
+                match resolve_stuck(&key, demand, schedule, &current, store, now)? {
+                    // Released and re-claimable this tick — loop to the pre-spawn
+                    // decision, which re-claims (continuing the retry budget).
+                    StuckResolution::ReClaimable => continue,
+                    StuckResolution::Finished => {
+                        return Ok(ExecOutcome::Skipped(skip(demand, TickSkipReason::Dedup)));
+                    }
+                    StuckResolution::InFlight => {
+                        return Ok(ExecOutcome::Skipped(skip(demand, TickSkipReason::InFlight)));
+                    }
+                }
+            }
+            PreSpawn::Claim(new_claim) => {
+                let mutation = submit_mutation(demand, &fresh_id, now);
+                match store.schedule_claim_cas(
+                    &key,
+                    observed.as_ref(),
+                    &new_claim,
+                    &demand.pipeline,
+                    &mutation,
+                )? {
+                    // Lost the claim race — stand down for this demand this pass.
+                    ClaimCas::Lost(_) => {
+                        return Ok(ExecOutcome::Skipped(skip(demand, TickSkipReason::InFlight)));
+                    }
+                    ClaimCas::Won => {
+                        return execute_claimed(
+                            &key, demand, schedule, new_claim, fresh_id, store, now, spawner, opts,
+                            lock,
+                        )
+                        .await;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// After winning a claim, spawn the child and apply the post-attempt transition:
+/// an in-tick retry while budget remains, or a terminal transition on
+/// exhaustion. Never sleeps between attempts.
+#[allow(clippy::too_many_arguments)]
+async fn execute_claimed(
+    key: &str,
+    demand: &Demand,
+    schedule: &ResolvedSchedule,
+    mut claim: ClaimRecord,
+    mut submission_id: String,
+    store: &StateStore,
+    now: DateTime<Utc>,
+    spawner: &dyn Spawner,
+    opts: &TickOptions,
+    lock: Option<&TickLock>,
+) -> Result<ExecOutcome, TickError> {
+    let mut iterations = 0;
+    loop {
+        iterations += 1;
+        if iterations > MAX_DEMAND_ITERATIONS {
+            return Err(TickError::LoopBound(key.to_string()));
+        }
+        // Refresh the lease before spawning.
+        if let Some(held) = lock {
+            let _ = held.heartbeat();
+        }
+        let request = SpawnRequest {
+            pipeline: demand.pipeline.clone(),
+            config_path: opts.config_path.clone(),
+            submission_id: submission_id.clone(),
+            traceparent: opts.traceparent.clone(),
+            timeout: schedule.timeout.map(to_std_timeout),
+        };
+        // Keep the lease fresh *while* the child runs — the heartbeat mtime is
+        // the liveness signal a peer reads to tell a live holder from a wedged
+        // one, so a long run must refresh it under 60s or a later tick would
+        // wedge-override and double-fire. The timer is a side-effect only; the
+        // reconciler's logic clock is still the injected `now`.
+        let run_fut = spawner.run(&request);
+        tokio::pin!(run_fut);
+        let run_outcome = loop {
+            tokio::select! {
+                outcome = &mut run_fut => break outcome,
+                _ = tokio::time::sleep(HEARTBEAT_INTERVAL) => {
+                    if let Some(held) = lock {
+                        let _ = held.heartbeat();
+                    }
+                }
+            }
+        };
+        let outcome = TerminalOutcome::from_exit_code(run_outcome.exit_code);
+        let next_id = new_submission_id();
+        match decide_post_attempt(
+            &claim,
+            outcome,
+            demand.source,
+            schedule.retry_max,
+            next_id.clone(),
+            now,
+        ) {
+            PostAttempt::Retry(retry_claim) => {
+                // A fresh submission — record its attempt time; the anchor (for
+                // cron) already advanced on the first submission this cycle.
+                let mutation = ScheduleStateMutation::SubmitStanding {
+                    attempt_at: now,
+                    run_id: next_id.clone(),
+                };
+                match store.schedule_claim_cas(
+                    key,
+                    Some(&claim),
+                    &retry_claim,
+                    &demand.pipeline,
+                    &mutation,
+                )? {
+                    ClaimCas::Lost(_) => {
+                        return Ok(ExecOutcome::Skipped(skip(demand, TickSkipReason::InFlight)));
+                    }
+                    ClaimCas::Won => {
+                        claim = retry_claim;
+                        submission_id = next_id;
+                        continue;
+                    }
+                }
+            }
+            PostAttempt::Terminal {
+                claim: terminal_claim,
+                bookkeeping,
+            } => {
+                let attempts = terminal_claim.attempts;
+                let mutation = ScheduleStateMutation::Terminal {
+                    outcome: bookkeeping.outcome,
+                    cf_delta: bookkeeping.cf_delta,
+                };
+                match store.schedule_claim_cas(
+                    key,
+                    Some(&claim),
+                    &terminal_claim,
+                    &demand.pipeline,
+                    &mutation,
+                )? {
+                    ClaimCas::Lost(_) => {
+                        return Ok(ExecOutcome::Skipped(skip(demand, TickSkipReason::InFlight)));
+                    }
+                    ClaimCas::Won => {
+                        return Ok(ExecOutcome::Executed(ExecutedDemand {
+                            pipeline: demand.pipeline.clone(),
+                            source: demand.source,
+                            logical_ts: demand.logical_ts,
+                            submission_id,
+                            exit_code: run_outcome.exit_code,
+                            outcome,
+                            attempts,
+                        }));
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// How a stuck `submitted` claim was resolved.
+enum StuckResolution {
+    /// Released with the budget continuing — re-claimable this tick.
+    ReClaimable,
+    /// The run was observed terminal and finalized — do not spawn.
+    Finished,
+    /// The outcome is not yet knowable (a live concurrent run, or within the
+    /// crash grace) — skip without spawning.
+    InFlight,
+}
+
+/// Resolve a claim left `submitted` by a crashed owner. Budget-aware: the
+/// resolver recomputes from the run record (joined by `submission_id`), or, when
+/// no record exists, applies a bounded grace before treating the attempt as
+/// lost — so configured retries survive a crash and a standing demand never
+/// stalls indefinitely.
+fn resolve_stuck(
+    key: &str,
+    demand: &Demand,
+    schedule: &ResolvedSchedule,
+    current: &ClaimRecord,
+    store: &StateStore,
+    now: DateTime<Utc>,
+) -> Result<StuckResolution, TickError> {
+    let outcome = store
+        .find_terminal_run_by_submission_id(&current.submission_id)?
+        .and_then(|run| run.status.terminal_outcome());
+    let Some(outcome) = outcome else {
+        return resolve_missing_record(key, demand, schedule, current, store, now);
+    };
+    let resolved = decide_resolver(current, outcome, demand.source, schedule.retry_max, now);
+    commit_resolution(key, &demand.pipeline, current, resolved, store)
+}
+
+/// Resolve a stuck claim with no run record: stamp the grace on first sight,
+/// then — once the grace elapses with still no record — treat the attempt as a
+/// lost failure under the same budget rule as an observed failure.
+fn resolve_missing_record(
+    key: &str,
+    demand: &Demand,
+    schedule: &ResolvedSchedule,
+    current: &ClaimRecord,
+    store: &StateStore,
+    now: DateTime<Utc>,
+) -> Result<StuckResolution, TickError> {
+    let swept = current
+        .first_swept_at
+        .as_deref()
+        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.with_timezone(&Utc));
+    match swept {
+        None => {
+            let mut updated = current.clone();
+            updated.first_swept_at = Some(now.to_rfc3339());
+            // Either outcome of this CAS means "skip this tick": on win the grace
+            // has begun; on loss another reconciler owns the resolution.
+            store.schedule_claim_cas(
+                key,
+                Some(current),
+                &updated,
+                &demand.pipeline,
+                &ScheduleStateMutation::None,
+            )?;
+            Ok(StuckResolution::InFlight)
+        }
+        Some(swept_at) if now - swept_at >= RECOVERY_GRACE => {
+            let resolved = decide_resolver(
+                current,
+                TerminalOutcome::Failure,
+                demand.source,
+                schedule.retry_max,
+                now,
+            );
+            commit_resolution(key, &demand.pipeline, current, resolved, store)
+        }
+        Some(_) => Ok(StuckResolution::InFlight),
+    }
+}
+
+/// Commit a resolver decision via a claim CAS, mapping the outcome to a
+/// [`StuckResolution`]. A lost CAS means another reconciler moved the claim —
+/// skip.
+fn commit_resolution(
+    key: &str,
+    pipeline: &str,
+    expected: &ClaimRecord,
+    resolved: Resolved,
+    store: &StateStore,
+) -> Result<StuckResolution, TickError> {
+    match resolved {
+        Resolved::ReleasedBudgetOpen(released) => {
+            match store.schedule_claim_cas(
+                key,
+                Some(expected),
+                &released,
+                pipeline,
+                &ScheduleStateMutation::None,
+            )? {
+                ClaimCas::Won => Ok(StuckResolution::ReClaimable),
+                ClaimCas::Lost(_) => Ok(StuckResolution::InFlight),
+            }
+        }
+        Resolved::Terminal { claim, bookkeeping } => {
+            let mutation = ScheduleStateMutation::Terminal {
+                outcome: bookkeeping.outcome,
+                cf_delta: bookkeeping.cf_delta,
+            };
+            match store.schedule_claim_cas(key, Some(expected), &claim, pipeline, &mutation)? {
+                ClaimCas::Won => Ok(StuckResolution::Finished),
+                ClaimCas::Lost(_) => Ok(StuckResolution::InFlight),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schedule::claim::ClaimState;
+    use crate::schedule::lock::{TickAcquire, TickLock};
+    use crate::schedule::spawn::{CapturingSpawner, RunOutcome, SpawnRequest};
+    use crate::state::{RunRecord, RunStatus, RunTrigger, SessionSource, StateStore};
+    use async_trait::async_trait;
+    use chrono::TimeZone;
+    use std::sync::Mutex;
+
+    // --- fixtures ------------------------------------------------------------
+
+    /// `raw` runs externally (no schedule), `staging` runs after it.
+    const AFTER_ONLY: &str = r#"
+[adapter.db]
+type = "duckdb"
+
+[pipeline.raw]
+type = "transformation"
+[pipeline.raw.target]
+adapter = "db"
+
+[pipeline.staging]
+type = "transformation"
+[pipeline.staging.target]
+adapter = "db"
+[pipeline.staging.schedule]
+after = ["raw"]
+"#;
+
+    /// `staging` runs after `raw`, with an in-tick retry budget of two.
+    const AFTER_RETRY2: &str = r#"
+[adapter.db]
+type = "duckdb"
+
+[pipeline.raw]
+type = "transformation"
+[pipeline.raw.target]
+adapter = "db"
+
+[pipeline.staging]
+type = "transformation"
+[pipeline.staging.target]
+adapter = "db"
+[pipeline.staging.schedule]
+after = ["raw"]
+retry = { max = 2 }
+"#;
+
+    /// A single cron-scheduled pipeline.
+    const CRON_ONLY: &str = r#"
+[adapter.db]
+type = "duckdb"
+
+[pipeline.raw]
+type = "transformation"
+[pipeline.raw.target]
+adapter = "db"
+[pipeline.raw.schedule]
+cron = "0 3 * * *"
+"#;
+
+    /// A cron-scheduled pipeline with an in-tick retry budget of two.
+    const CRON_RETRY2: &str = r#"
+[adapter.db]
+type = "duckdb"
+
+[pipeline.raw]
+type = "transformation"
+[pipeline.raw.target]
+adapter = "db"
+[pipeline.raw.schedule]
+cron = "0 3 * * *"
+retry = { max = 2 }
+"#;
+
+    /// `raw` cron, `staging` after `raw` — the same-tick cascade.
+    const CRON_AND_AFTER: &str = r#"
+[adapter.db]
+type = "duckdb"
+
+[pipeline.raw]
+type = "transformation"
+[pipeline.raw.target]
+adapter = "db"
+[pipeline.raw.schedule]
+cron = "0 3 * * *"
+
+[pipeline.staging]
+type = "transformation"
+[pipeline.staging.target]
+adapter = "db"
+[pipeline.staging.schedule]
+after = ["raw"]
+"#;
+
+    fn cfg(toml_str: &str) -> RockyConfig {
+        toml::from_str(toml_str).expect("valid rocky.toml")
+    }
+
+    fn at(y: i32, mo: u32, d: u32, h: u32, mi: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(y, mo, d, h, mi, 0).unwrap()
+    }
+
+    fn temp_env() -> (StateStore, tempfile::TempDir, TickOptions) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = StateStore::open(&dir.path().join("state.redb")).unwrap();
+        let opts = TickOptions {
+            dry_run: false,
+            pipeline_filter: None,
+            config_path: dir.path().join("rocky.toml"),
+            rocky_dir: dir.path().join(".rocky"),
+            traceparent: None,
+        };
+        (store, dir, opts)
+    }
+
+    fn make_run(
+        pipeline: &str,
+        submission_id: Option<&str>,
+        status: RunStatus,
+        started: DateTime<Utc>,
+        finished: DateTime<Utc>,
+    ) -> RunRecord {
+        RunRecord {
+            run_id: format!("run-{}", uuid::Uuid::new_v4()),
+            started_at: started,
+            finished_at: finished,
+            status,
+            models_executed: Vec::new(),
+            trigger: RunTrigger::Schedule,
+            config_hash: "hash".to_string(),
+            triggering_identity: None,
+            session_source: SessionSource::default(),
+            git_commit: None,
+            git_branch: None,
+            idempotency_key: None,
+            target_catalog: None,
+            hostname: "test".to_string(),
+            rocky_version: "test".to_string(),
+            check_outcomes: Vec::new(),
+            pipeline: Some(pipeline.to_string()),
+            submission_id: submission_id.map(String::from),
+        }
+    }
+
+    fn seed_run(
+        store: &StateStore,
+        pipeline: &str,
+        submission_id: Option<&str>,
+        status: RunStatus,
+        started: DateTime<Utc>,
+        finished: DateTime<Utc>,
+    ) {
+        store
+            .record_run(&make_run(
+                pipeline,
+                submission_id,
+                status,
+                started,
+                finished,
+            ))
+            .unwrap();
+    }
+
+    /// Insert a fresh `submitted` claim for a coordinate demand, as a crashed
+    /// owner would have left it.
+    fn seed_submitted_claim(
+        store: &StateStore,
+        pipeline: &str,
+        source: DemandKind,
+        logical_ts: DateTime<Utc>,
+        submission_id: &str,
+        transitioned_at: DateTime<Utc>,
+    ) -> String {
+        let key = claim_key(pipeline, source, logical_ts);
+        let claim = ClaimRecord::new_submitted(submission_id.to_string(), transitioned_at);
+        let cas = store
+            .schedule_claim_cas(&key, None, &claim, pipeline, &ScheduleStateMutation::None)
+            .unwrap();
+        assert!(matches!(cas, ClaimCas::Won), "seed claim insert must win");
+        key
+    }
+
+    /// A spawner that both records requests AND writes a run record for each, as
+    /// the real child would — so a same-tick `after` downstream can observe an
+    /// upstream that ran earlier in the tick.
+    struct RecordingSpawner<'a> {
+        store: &'a StateStore,
+        captured: Mutex<Vec<SpawnRequest>>,
+        exit_code: i32,
+        finished_at: DateTime<Utc>,
+    }
+
+    #[async_trait]
+    impl Spawner for RecordingSpawner<'_> {
+        async fn run(&self, request: &SpawnRequest) -> RunOutcome {
+            self.captured.lock().unwrap().push(request.clone());
+            let status = match self.exit_code {
+                0 => RunStatus::Success,
+                2 => RunStatus::PartialFailure,
+                _ => RunStatus::Failure,
+            };
+            seed_run(
+                self.store,
+                &request.pipeline,
+                Some(&request.submission_id),
+                status,
+                self.finished_at,
+                self.finished_at,
+            );
+            RunOutcome {
+                exit_code: self.exit_code,
+                pid: Some(4242),
+            }
+        }
+    }
+
+    fn rt() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+    }
+
+    // --- integration: seeded upstream success drives the downstream ----------
+
+    #[test]
+    fn after_upstream_success_runs_downstream() {
+        let (store, _dir, opts) = temp_env();
+        let config = cfg(AFTER_ONLY);
+        // A seeded fake upstream success (as `rocky run --pipeline raw` would).
+        seed_run(
+            &store,
+            "raw",
+            None,
+            RunStatus::Success,
+            at(2026, 5, 2, 3, 5),
+            at(2026, 5, 2, 3, 10),
+        );
+        let spawner = CapturingSpawner::new(0);
+        let report = rt()
+            .block_on(tick_once(
+                &config,
+                &store,
+                at(2026, 5, 2, 4, 0),
+                &spawner,
+                &opts,
+            ))
+            .unwrap();
+
+        assert_eq!(spawner.run_count(), 1, "staging runs via after");
+        let runs = spawner.runs_for("staging");
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].request.pipeline, "staging");
+        assert!(!runs[0].request.submission_id.is_empty());
+        assert_eq!(report.executed.len(), 1);
+        assert_eq!(report.executed[0].pipeline, "staging");
+        assert_eq!(report.executed[0].source, DemandKind::After);
+        assert_eq!(report.executed[0].outcome, TerminalOutcome::Success);
+
+        // Re-tick at the same instant: the after claim is completed, so nothing
+        // re-fires (idempotent).
+        let report2 = rt()
+            .block_on(tick_once(
+                &config,
+                &store,
+                at(2026, 5, 2, 4, 0),
+                &spawner,
+                &opts,
+            ))
+            .unwrap();
+        assert_eq!(
+            spawner.run_count(),
+            1,
+            "completed after demand never re-fires"
+        );
+        assert!(report2.executed.is_empty());
+    }
+
+    // --- cron first-sight then fire ------------------------------------------
+
+    #[test]
+    fn cron_first_sight_then_fires_next_occurrence() {
+        let (store, _dir, opts) = temp_env();
+        let config = cfg(CRON_ONLY);
+        let spawner = CapturingSpawner::new(0);
+
+        // First sight anchors at `now`, fires nothing.
+        rt().block_on(tick_once(
+            &config,
+            &store,
+            at(2026, 5, 1, 12, 0),
+            &spawner,
+            &opts,
+        ))
+        .unwrap();
+        assert_eq!(spawner.run_count(), 0, "first sight does not fire");
+        assert!(
+            store
+                .get_schedule_state("raw")
+                .unwrap()
+                .unwrap()
+                .last_fire_logical_ts
+                .is_some(),
+            "anchor recorded"
+        );
+
+        // Next day past 03:00 → the occurrence fires exactly once.
+        let report = rt()
+            .block_on(tick_once(
+                &config,
+                &store,
+                at(2026, 5, 2, 4, 0),
+                &spawner,
+                &opts,
+            ))
+            .unwrap();
+        assert_eq!(spawner.run_count(), 1);
+        assert_eq!(report.executed[0].source, DemandKind::Cron);
+        assert_eq!(report.executed[0].logical_ts, at(2026, 5, 2, 3, 0));
+        assert_eq!(
+            store
+                .get_schedule_state("raw")
+                .unwrap()
+                .unwrap()
+                .last_fire_logical_ts
+                .as_deref(),
+            Some(at(2026, 5, 2, 3, 0).to_rfc3339()).as_deref(),
+            "anchor advanced to the fired occurrence"
+        );
+
+        // Same instant again → dedup, no re-fire.
+        rt().block_on(tick_once(
+            &config,
+            &store,
+            at(2026, 5, 2, 4, 0),
+            &spawner,
+            &opts,
+        ))
+        .unwrap();
+        assert_eq!(spawner.run_count(), 1, "dedup: occurrence never re-fires");
+    }
+
+    // --- same-tick after cascade (topo order + re-evaluation) ----------------
+
+    #[test]
+    fn same_tick_after_cascade() {
+        let (store, _dir, opts) = temp_env();
+        let config = cfg(CRON_AND_AFTER);
+        // Anchor raw's cron via a first sight.
+        let cap = CapturingSpawner::new(0);
+        rt().block_on(tick_once(
+            &config,
+            &store,
+            at(2026, 5, 1, 12, 0),
+            &cap,
+            &opts,
+        ))
+        .unwrap();
+
+        // A recording spawner writes a success for each child, so staging can
+        // observe raw within the same tick.
+        let rec = RecordingSpawner {
+            store: &store,
+            captured: Mutex::new(Vec::new()),
+            exit_code: 0,
+            finished_at: at(2026, 5, 2, 3, 5),
+        };
+        rt().block_on(tick_once(
+            &config,
+            &store,
+            at(2026, 5, 2, 4, 0),
+            &rec,
+            &opts,
+        ))
+        .unwrap();
+
+        let caps = rec.captured.lock().unwrap();
+        assert_eq!(
+            caps.len(),
+            2,
+            "raw fires (cron), then staging fires (after)"
+        );
+        assert_eq!(caps[0].pipeline, "raw", "topo order: upstream first");
+        assert_eq!(caps[1].pipeline, "staging");
+    }
+
+    // --- regression ii: a live submitted claim blocks a second reconciler ----
+
+    #[test]
+    fn preexisting_submitted_claim_blocks_second_reconciler() {
+        let (store, _dir, opts) = temp_env();
+        let config = cfg(AFTER_ONLY);
+        seed_run(
+            &store,
+            "raw",
+            None,
+            RunStatus::Success,
+            at(2026, 5, 2, 3, 5),
+            at(2026, 5, 2, 3, 10),
+        );
+        // Reconciler A already claimed the after demand (no run record yet).
+        seed_submitted_claim(
+            &store,
+            "staging",
+            DemandKind::After,
+            at(2026, 5, 2, 3, 10),
+            "owned-by-a",
+            at(2026, 5, 2, 3, 50),
+        );
+        let spawner = CapturingSpawner::new(0);
+        let report = rt()
+            .block_on(tick_once(
+                &config,
+                &store,
+                at(2026, 5, 2, 4, 0),
+                &spawner,
+                &opts,
+            ))
+            .unwrap();
+        assert_eq!(
+            spawner.run_count(),
+            0,
+            "must not spawn over a live submitted claim"
+        );
+        assert!(
+            report
+                .skipped
+                .iter()
+                .any(|s| s.pipeline == "staging" && s.reason == TickSkipReason::InFlight),
+            "reported as in_flight"
+        );
+    }
+
+    // --- regression iii: crash between child-exit and terminal txn -----------
+
+    #[test]
+    fn stuck_submitted_resolved_from_run_record() {
+        let (store, _dir, opts) = temp_env();
+        let config = cfg(AFTER_ONLY);
+        seed_run(
+            &store,
+            "raw",
+            None,
+            RunStatus::Success,
+            at(2026, 5, 2, 3, 5),
+            at(2026, 5, 2, 3, 10),
+        );
+        let key = seed_submitted_claim(
+            &store,
+            "staging",
+            DemandKind::After,
+            at(2026, 5, 2, 3, 10),
+            "sub-1",
+            at(2026, 5, 2, 3, 50),
+        );
+        // The crashed owner's run DID record — a terminal failure under sub-1.
+        seed_run(
+            &store,
+            "staging",
+            Some("sub-1"),
+            RunStatus::Failure,
+            at(2026, 5, 2, 3, 50),
+            at(2026, 5, 2, 3, 51),
+        );
+        // Mirror the submission's cursor write (as the original claim CAS would).
+        store
+            .put_schedule_state(
+                "staging",
+                &ScheduleStateRecord {
+                    last_attempt_at: Some(at(2026, 5, 2, 3, 50).to_rfc3339()),
+                    last_submitted_run_id: Some("sub-1".to_string()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        let spawner = CapturingSpawner::new(0);
+        // retry.max = 0 → the failure is exhaustion → terminal, no re-run.
+        rt().block_on(tick_once(
+            &config,
+            &store,
+            at(2026, 5, 2, 3, 52),
+            &spawner,
+            &opts,
+        ))
+        .unwrap();
+        assert_eq!(
+            spawner.run_count(),
+            0,
+            "resolver finalizes, never re-runs here"
+        );
+
+        let cursor = store.get_schedule_state("staging").unwrap().unwrap();
+        assert_eq!(cursor.consecutive_failures, 1, "failure recorded once");
+        assert_eq!(cursor.last_attempt_outcome.as_deref(), Some("failure"));
+        let claim = store.get_schedule_claim(&key).unwrap().unwrap();
+        assert!(
+            matches!(claim.state, ClaimState::Released),
+            "standing failure releases (re-claimable after backoff)"
+        );
+        assert!(!claim.budget_open, "exhausted release closes the cycle");
+
+        // A follow-up tick within the 5-minute failure backoff is suppressed.
+        let report2 = rt()
+            .block_on(tick_once(
+                &config,
+                &store,
+                at(2026, 5, 2, 3, 54),
+                &spawner,
+                &opts,
+            ))
+            .unwrap();
+        assert_eq!(spawner.run_count(), 0);
+        assert!(
+            report2.skipped.iter().any(|s| s.pipeline == "staging"
+                && matches!(s.reason, TickSkipReason::FailureBackoff { .. })),
+            "honors the cross-tick backoff"
+        );
+    }
+
+    // --- regression iv: crash between claim-commit and spawn (cron) -----------
+
+    #[test]
+    fn crash_between_claim_and_spawn_never_refires_cron() {
+        let (store, _dir, opts) = temp_env();
+        let config = cfg(CRON_ONLY);
+        // A prior tick claimed the 03:00 occurrence (anchor advanced) then died
+        // before spawning: a submitted claim with no run record.
+        let occ = at(2026, 5, 2, 3, 0);
+        store.advance_schedule_fire_anchor("raw", occ).unwrap();
+        seed_submitted_claim(&store, "raw", DemandKind::Cron, occ, "crashed", occ);
+
+        let spawner = CapturingSpawner::new(0);
+        // The occurrence's anchor already advanced, so it is not due — a bounded
+        // miss, never a duplicate.
+        rt().block_on(tick_once(
+            &config,
+            &store,
+            at(2026, 5, 2, 4, 0),
+            &spawner,
+            &opts,
+        ))
+        .unwrap();
+        assert_eq!(spawner.run_count(), 0, "missed occurrence must not re-fire");
+
+        // The next occurrence fires normally.
+        let report = rt()
+            .block_on(tick_once(
+                &config,
+                &store,
+                at(2026, 5, 3, 4, 0),
+                &spawner,
+                &opts,
+            ))
+            .unwrap();
+        assert_eq!(spawner.run_count(), 1, "next occurrence fires");
+        assert_eq!(report.executed[0].logical_ts, at(2026, 5, 3, 3, 0));
+    }
+
+    // --- regression vi: in-tick retry through the reconciler -----------------
+
+    #[test]
+    fn in_tick_retry_runs_configured_attempts() {
+        let (store, _dir, opts) = temp_env();
+        let config = cfg(CRON_RETRY2);
+        let cap = CapturingSpawner::new(0);
+        // attempt 1 fails, 2 fails, 3 succeeds.
+        cap.script("raw", [1, 1, 0]);
+        rt().block_on(tick_once(
+            &config,
+            &store,
+            at(2026, 5, 1, 12, 0),
+            &cap,
+            &opts,
+        ))
+        .unwrap();
+        let report = rt()
+            .block_on(tick_once(
+                &config,
+                &store,
+                at(2026, 5, 2, 4, 0),
+                &cap,
+                &opts,
+            ))
+            .unwrap();
+
+        assert_eq!(cap.runs_for("raw").len(), 3, "three in-tick attempts");
+        assert_eq!(report.executed.len(), 1);
+        assert_eq!(report.executed[0].outcome, TerminalOutcome::Success);
+        assert_eq!(report.executed[0].attempts, 3);
+        let subs: std::collections::HashSet<_> = cap
+            .runs_for("raw")
+            .iter()
+            .map(|c| c.request.submission_id.clone())
+            .collect();
+        assert_eq!(subs.len(), 3, "each attempt has a distinct submission id");
+    }
+
+    // --- regression vii: crash-safe retry budget (standing demand) -----------
+
+    #[test]
+    fn crash_safe_retry_budget_reclaims_and_runs_attempt_two() {
+        let (store, _dir, opts) = temp_env();
+        let config = cfg(AFTER_RETRY2);
+        seed_run(
+            &store,
+            "raw",
+            None,
+            RunStatus::Success,
+            at(2026, 5, 2, 3, 5),
+            at(2026, 5, 2, 3, 10),
+        );
+        // attempt 1 ran, failed, then the reconciler crashed before the retry
+        // CAS: a submitted claim (cycle_attempts = 1) + a failure record.
+        let key = seed_submitted_claim(
+            &store,
+            "staging",
+            DemandKind::After,
+            at(2026, 5, 2, 3, 10),
+            "att-1",
+            at(2026, 5, 2, 3, 50),
+        );
+        seed_run(
+            &store,
+            "staging",
+            Some("att-1"),
+            RunStatus::Failure,
+            at(2026, 5, 2, 3, 50),
+            at(2026, 5, 2, 3, 51),
+        );
+        store
+            .put_schedule_state(
+                "staging",
+                &ScheduleStateRecord {
+                    last_attempt_at: Some(at(2026, 5, 2, 3, 50).to_rfc3339()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        let spawner = CapturingSpawner::new(0); // attempt 2 succeeds
+        let report = rt()
+            .block_on(tick_once(
+                &config,
+                &store,
+                at(2026, 5, 2, 3, 52),
+                &spawner,
+                &opts,
+            ))
+            .unwrap();
+
+        assert_eq!(
+            spawner.run_count(),
+            1,
+            "budget-open resolver re-claims and fires attempt 2 in the same tick"
+        );
+        assert_eq!(report.executed.len(), 1);
+        assert_eq!(report.executed[0].outcome, TerminalOutcome::Success);
+        let claim = store.get_schedule_claim(&key).unwrap().unwrap();
+        assert!(claim.is_completed(), "attempt 2 succeeded → completed");
+        assert_eq!(
+            claim.cycle_attempts, 2,
+            "the cycle ordinal continued across the crash"
+        );
+    }
+
+    // --- lock: tick_in_progress ----------------------------------------------
+
+    #[test]
+    fn tick_in_progress_skips_whole_tick() {
+        let (store, _dir, opts) = temp_env();
+        let config = cfg(CRON_ONLY);
+        std::fs::create_dir_all(&opts.rocky_dir).unwrap();
+        let TickAcquire::Acquired(_held) = TickLock::try_acquire(&opts.rocky_dir).unwrap() else {
+            panic!("expected to acquire the lock");
+        };
+        let spawner = CapturingSpawner::new(0);
+        let report = rt()
+            .block_on(tick_once(
+                &config,
+                &store,
+                at(2026, 5, 2, 4, 0),
+                &spawner,
+                &opts,
+            ))
+            .unwrap();
+        assert!(report.skipped_whole_tick, "a fresh holder means skip");
+        assert_eq!(spawner.run_count(), 0);
+    }
+
+    // --- dry run: no writes, no spawns ---------------------------------------
+
+    #[test]
+    fn dry_run_writes_nothing_and_spawns_nothing() {
+        let (store, _dir, opts) = temp_env();
+        let config = cfg(CRON_ONLY);
+        // Anchor set so the cron would otherwise be due.
+        store
+            .advance_schedule_fire_anchor("raw", at(2026, 5, 1, 3, 0))
+            .unwrap();
+        let before = store.get_schedule_state("raw").unwrap();
+
+        let spawner = CapturingSpawner::new(0);
+        let dry = TickOptions {
+            dry_run: true,
+            ..opts.clone()
+        };
+        let report = rt()
+            .block_on(tick_once(
+                &config,
+                &store,
+                at(2026, 5, 2, 4, 0),
+                &spawner,
+                &dry,
+            ))
+            .unwrap();
+
+        assert_eq!(spawner.run_count(), 0, "dry run spawns nothing");
+        assert!(report.executed.is_empty());
+        assert!(
+            report
+                .evaluated
+                .iter()
+                .any(|e| e.pipeline == "raw" && e.due.is_some()),
+            "still reports the demand as due"
+        );
+        assert_eq!(
+            before,
+            store.get_schedule_state("raw").unwrap(),
+            "dry run writes no state"
+        );
+    }
+}

--- a/engine/crates/rocky-core/src/schedule/record.rs
+++ b/engine/crates/rocky-core/src/schedule/record.rs
@@ -1,0 +1,361 @@
+//! The per-pipeline schedule cursor and the cross-tick throttle math.
+//!
+//! [`ScheduleStateRecord`] is the durable cursor for one scheduled pipeline: the
+//! catch-up anchor, the last attempt time and outcome, and the consecutive
+//! failure count that drives the always-on backoff. Its anchors are
+//! **monotonic** — [`ScheduleStateRecord::advance_fire_anchor`] and
+//! [`ScheduleStateRecord::record_attempt`] never move a cursor backwards, so a
+//! `--now` earlier than the anchor is a no-op by construction.
+
+use chrono::{DateTime, Duration, Utc};
+
+use super::claim::{CfDelta, TerminalOutcome};
+
+/// The per-pipeline schedule cursor stored under the pipeline name.
+///
+/// Every field is serde-defaulted so a record written by an older binary — or a
+/// future one that adds a field — round-trips cleanly without a blob migration.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ScheduleStateRecord {
+    /// RFC3339; updated on every tick that evaluates this pipeline. A stale
+    /// value is how `doctor` detects a dead timer.
+    #[serde(default)]
+    pub last_evaluated_at: Option<String>,
+    /// RFC3339; the last cron occurrence **submitted** — the catch-up anchor.
+    /// Advances on submission regardless of the run's outcome. Monotonic.
+    #[serde(default)]
+    pub last_fire_logical_ts: Option<String>,
+    /// RFC3339; the last submission time for any source — drives the cross-tick
+    /// failure/partial backoff. Monotonic.
+    #[serde(default)]
+    pub last_attempt_at: Option<String>,
+    /// The `run_id`/submission of the most recent submission, for operator
+    /// cross-reference.
+    #[serde(default)]
+    pub last_submitted_run_id: Option<String>,
+    /// Exit-1/lost failures increment this once per exhausted demand; a success
+    /// resets it; a partial (exit 2) does neither.
+    #[serde(default)]
+    pub consecutive_failures: u32,
+    /// `"success"` | `"partial"` | `"failure"` — the last terminal outcome,
+    /// consulted by the outcome-aware throttle.
+    #[serde(default)]
+    pub last_attempt_outcome: Option<String>,
+}
+
+/// The cross-tick backoff ceiling: failure backoff never exceeds this.
+const MAX_FAILURE_BACKOFF: Duration = Duration::hours(6);
+/// The base unit of the exponential failure backoff.
+const BASE_FAILURE_BACKOFF: Duration = Duration::minutes(5);
+/// The fixed partial-success backoff.
+const PARTIAL_BACKOFF: Duration = Duration::minutes(60);
+
+/// The suppression a standing demand is under right now, if any.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Throttle {
+    /// Not suppressed — the demand may proceed.
+    Clear,
+    /// Suppressed by the failure backoff ladder until `resume_at`.
+    FailureBackoff {
+        /// When the demand becomes eligible again.
+        resume_at: DateTime<Utc>,
+    },
+    /// Suppressed by the fixed partial backoff until `resume_at`.
+    PartialBackoff {
+        /// When the demand becomes eligible again.
+        resume_at: DateTime<Utc>,
+    },
+}
+
+impl ScheduleStateRecord {
+    fn last_attempt(&self) -> Option<DateTime<Utc>> {
+        self.last_attempt_at
+            .as_deref()
+            .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+            .map(|dt| dt.with_timezone(&Utc))
+    }
+
+    /// The catch-up anchor as an absolute instant, if set.
+    pub fn fire_anchor(&self) -> Option<DateTime<Utc>> {
+        self.last_fire_logical_ts
+            .as_deref()
+            .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+            .map(|dt| dt.with_timezone(&Utc))
+    }
+
+    /// The failure-backoff duration for the current `consecutive_failures`:
+    /// `min(5min * 2^(cf - 1), 6h)`. Returns `None` when `cf == 0`.
+    fn failure_backoff(&self) -> Option<Duration> {
+        if self.consecutive_failures == 0 {
+            return None;
+        }
+        // 5min * 2^(cf-1), saturating at the ceiling. Cap the shift so 2^n never
+        // overflows before the min() clamps it.
+        let shift = (self.consecutive_failures - 1).min(32);
+        let scaled = BASE_FAILURE_BACKOFF
+            .checked_mul(1i32.checked_shl(shift).unwrap_or(i32::MAX))
+            .unwrap_or(MAX_FAILURE_BACKOFF);
+        Some(scaled.min(MAX_FAILURE_BACKOFF))
+    }
+
+    /// The cross-tick throttle a **standing** demand (`after`/`freshness`) is
+    /// under at `now`, from `last_attempt_outcome` + `last_attempt_at`.
+    ///
+    /// Cron demands are naturally throttled by their own occurrence granularity
+    /// and must NOT be passed here — suppressing a cron occurrence via this
+    /// ladder would drop a legitimate fire.
+    ///
+    /// - last attempt failed (`consecutive_failures > 0`): suppressed until
+    ///   `last_attempt_at + min(5min * 2^(cf-1), 6h)`.
+    /// - last attempt partial (exit 2): suppressed until `last_attempt_at + 60min`.
+    ///   Load-bearing: a partial is not a success, so the standing demand stays
+    ///   due — without this a reliably-partial pipeline re-runs every tick.
+    /// - last attempt succeeded: no suppression.
+    pub fn standing_throttle(&self, now: DateTime<Utc>) -> Throttle {
+        let Some(last_attempt) = self.last_attempt() else {
+            return Throttle::Clear;
+        };
+        match self.last_attempt_outcome.as_deref() {
+            Some("failure") => {
+                let Some(backoff) = self.failure_backoff() else {
+                    return Throttle::Clear;
+                };
+                let resume_at = last_attempt + backoff;
+                if now < resume_at {
+                    Throttle::FailureBackoff { resume_at }
+                } else {
+                    Throttle::Clear
+                }
+            }
+            Some("partial") => {
+                let resume_at = last_attempt + PARTIAL_BACKOFF;
+                if now < resume_at {
+                    Throttle::PartialBackoff { resume_at }
+                } else {
+                    Throttle::Clear
+                }
+            }
+            _ => Throttle::Clear,
+        }
+    }
+
+    /// Advance the catch-up fire anchor to `logical_ts`, monotonically: a value
+    /// at or before the current anchor is ignored. This is the only writer of
+    /// `last_fire_logical_ts`.
+    pub fn advance_fire_anchor(&mut self, logical_ts: DateTime<Utc>) {
+        match self.fire_anchor() {
+            Some(current) if logical_ts <= current => {}
+            _ => self.last_fire_logical_ts = Some(logical_ts.to_rfc3339()),
+        }
+    }
+
+    /// Record a submission at `attempt_at` for `run_id`, advancing
+    /// `last_attempt_at` monotonically. This is the only writer of
+    /// `last_attempt_at`.
+    pub fn record_submission(&mut self, attempt_at: DateTime<Utc>, run_id: &str) {
+        let advance = match self.last_attempt() {
+            Some(prev) => attempt_at > prev,
+            None => true,
+        };
+        if advance {
+            self.last_attempt_at = Some(attempt_at.to_rfc3339());
+        }
+        self.last_submitted_run_id = Some(run_id.to_string());
+    }
+
+    /// Apply terminal bookkeeping: move `consecutive_failures` per `cf_delta`
+    /// and stamp `last_attempt_outcome`.
+    pub fn apply_bookkeeping(&mut self, outcome: TerminalOutcome, cf_delta: CfDelta) {
+        match cf_delta {
+            CfDelta::Increment => {
+                self.consecutive_failures = self.consecutive_failures.saturating_add(1)
+            }
+            CfDelta::Reset => self.consecutive_failures = 0,
+            CfDelta::Unchanged => {}
+        }
+        self.last_attempt_outcome = Some(outcome.as_str().to_string());
+    }
+}
+
+/// A mutation applied to a pipeline's [`ScheduleStateRecord`] atomically with a
+/// claim compare-and-swap (see `StateStore::schedule_claim_cas`), so the cursor
+/// and the claim always move together — a crash can never leave a claim without
+/// its anchor advance, or vice versa.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScheduleStateMutation {
+    /// No cursor change (an in-tick retry that only rewrites the claim, for
+    /// instance).
+    None,
+    /// A cron submission: advance the catch-up anchor to `logical_ts` and record
+    /// the submission time and run id.
+    SubmitCron {
+        /// The occurrence being submitted — the new anchor value.
+        logical_ts: DateTime<Utc>,
+        /// The submission time.
+        attempt_at: DateTime<Utc>,
+        /// The launched run's submission id.
+        run_id: String,
+    },
+    /// A standing (`after`/`freshness`) submission: record the submission time
+    /// and run id only (no anchor — standing demands have no cron anchor).
+    SubmitStanding {
+        /// The submission time.
+        attempt_at: DateTime<Utc>,
+        /// The launched run's submission id.
+        run_id: String,
+    },
+    /// A terminal outcome: apply the `consecutive_failures`/outcome bookkeeping.
+    Terminal {
+        /// The terminal outcome.
+        outcome: TerminalOutcome,
+        /// How `consecutive_failures` moves.
+        cf_delta: CfDelta,
+    },
+}
+
+impl ScheduleStateMutation {
+    /// Apply this mutation to `rec` in place.
+    pub fn apply(&self, rec: &mut ScheduleStateRecord) {
+        match self {
+            ScheduleStateMutation::None => {}
+            ScheduleStateMutation::SubmitCron {
+                logical_ts,
+                attempt_at,
+                run_id,
+            } => {
+                rec.advance_fire_anchor(*logical_ts);
+                rec.record_submission(*attempt_at, run_id);
+            }
+            ScheduleStateMutation::SubmitStanding { attempt_at, run_id } => {
+                rec.record_submission(*attempt_at, run_id);
+            }
+            ScheduleStateMutation::Terminal { outcome, cf_delta } => {
+                rec.apply_bookkeeping(*outcome, *cf_delta);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn at(h: u32, mi: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 5, 1, h, mi, 0).unwrap()
+    }
+
+    #[test]
+    fn failure_backoff_ladder_doubles_and_caps_at_six_hours() {
+        let mut r = ScheduleStateRecord {
+            last_attempt_at: Some(at(0, 0).to_rfc3339()),
+            last_attempt_outcome: Some("failure".into()),
+            ..Default::default()
+        };
+        // cf=1 -> 5min, cf=2 -> 10min, cf=3 -> 20min ...
+        r.consecutive_failures = 1;
+        assert_eq!(
+            r.standing_throttle(at(0, 4)),
+            Throttle::FailureBackoff {
+                resume_at: at(0, 5)
+            }
+        );
+        assert_eq!(
+            r.standing_throttle(at(0, 5)),
+            Throttle::Clear,
+            "resume at boundary is inclusive-clear"
+        );
+        r.consecutive_failures = 2;
+        assert_eq!(
+            r.standing_throttle(at(0, 9)),
+            Throttle::FailureBackoff {
+                resume_at: at(0, 10)
+            }
+        );
+        r.consecutive_failures = 3;
+        assert_eq!(
+            r.standing_throttle(at(0, 19)),
+            Throttle::FailureBackoff {
+                resume_at: at(0, 20)
+            }
+        );
+        // Large cf saturates at the 6h ceiling, never overflows.
+        r.consecutive_failures = 100;
+        assert_eq!(
+            r.standing_throttle(at(5, 0)),
+            Throttle::FailureBackoff {
+                resume_at: at(6, 0)
+            }
+        );
+        assert_eq!(r.standing_throttle(at(6, 0)), Throttle::Clear);
+    }
+
+    #[test]
+    fn partial_backoff_is_fixed_sixty_minutes() {
+        // regression: the perma-partial hot loop must throttle at 60m.
+        let r = ScheduleStateRecord {
+            last_attempt_at: Some(at(0, 0).to_rfc3339()),
+            last_attempt_outcome: Some("partial".into()),
+            // partial does not touch consecutive_failures
+            consecutive_failures: 0,
+            ..Default::default()
+        };
+        assert_eq!(
+            r.standing_throttle(at(0, 59)),
+            Throttle::PartialBackoff {
+                resume_at: at(1, 0)
+            }
+        );
+        assert_eq!(r.standing_throttle(at(1, 0)), Throttle::Clear);
+    }
+
+    #[test]
+    fn success_is_never_throttled() {
+        let r = ScheduleStateRecord {
+            last_attempt_at: Some(at(0, 0).to_rfc3339()),
+            last_attempt_outcome: Some("success".into()),
+            ..Default::default()
+        };
+        assert_eq!(r.standing_throttle(at(0, 1)), Throttle::Clear);
+    }
+
+    #[test]
+    fn anchors_are_monotonic() {
+        let mut r = ScheduleStateRecord::default();
+        r.advance_fire_anchor(at(3, 0));
+        assert_eq!(r.fire_anchor(), Some(at(3, 0)));
+        // A backwards value is ignored.
+        r.advance_fire_anchor(at(1, 0));
+        assert_eq!(
+            r.fire_anchor(),
+            Some(at(3, 0)),
+            "anchor must not move backwards"
+        );
+        r.advance_fire_anchor(at(4, 0));
+        assert_eq!(r.fire_anchor(), Some(at(4, 0)));
+
+        r.record_submission(at(3, 0), "run-a");
+        r.record_submission(at(1, 0), "run-b"); // backwards attempt time ignored
+        assert_eq!(
+            r.last_attempt_at.as_deref(),
+            Some(at(3, 0).to_rfc3339()).as_deref(),
+            "last_attempt_at must not move backwards"
+        );
+    }
+
+    #[test]
+    fn bookkeeping_moves_cf_correctly() {
+        let mut r = ScheduleStateRecord::default();
+        r.apply_bookkeeping(TerminalOutcome::Failure, CfDelta::Increment);
+        r.apply_bookkeeping(TerminalOutcome::Failure, CfDelta::Increment);
+        assert_eq!(r.consecutive_failures, 2);
+        r.apply_bookkeeping(TerminalOutcome::Partial, CfDelta::Unchanged);
+        assert_eq!(
+            r.consecutive_failures, 2,
+            "partial neither increments nor resets"
+        );
+        assert_eq!(r.last_attempt_outcome.as_deref(), Some("partial"));
+        r.apply_bookkeeping(TerminalOutcome::Success, CfDelta::Reset);
+        assert_eq!(r.consecutive_failures, 0);
+    }
+}

--- a/engine/crates/rocky-core/src/schedule/spawn.rs
+++ b/engine/crates/rocky-core/src/schedule/spawn.rs
@@ -1,0 +1,240 @@
+//! Child-process spawning for the reconciler, behind a trait.
+//!
+//! `tick_once` never spawns a binary directly — it goes through a [`Spawner`].
+//! The real [`SubprocessSpawner`] launches `rocky run` in a child process; the
+//! test [`CapturingSpawner`] records the requests and returns scripted
+//! outcomes, so the entire reconciler is testable without a built binary.
+//!
+//! This boundary is also where all real-time waiting lives: the reconciler
+//! core takes `now` as a parameter and reads no clock, while the spawner owns
+//! the child's wall-clock lifetime (the timeout, the graceful-then-forced
+//! termination). Keeping the wait here is what keeps the core deterministic.
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+/// A request to run one pipeline as a child process.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpawnRequest {
+    /// The pipeline to run (`--pipeline <name>`).
+    pub pipeline: String,
+    /// The config file to run against (`-c <config>`).
+    pub config_path: PathBuf,
+    /// The submission id passed as `ROCKY_SUBMISSION_ID`, stamped by the child
+    /// into its run record.
+    pub submission_id: String,
+    /// The W3C `traceparent` for the child's `TRACEPARENT`, connecting the tick
+    /// span to the run's trace. `None` when tracing is not active.
+    pub traceparent: Option<String>,
+    /// Scheduler-level timeout, when configured. On elapse the child is
+    /// terminated gracefully, then forcibly.
+    pub timeout: Option<Duration>,
+}
+
+/// The result of running a child to completion (or termination).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RunOutcome {
+    /// The child's exit code: 0 (success), 2 (partial), 1/other (failure). A
+    /// child killed on timeout is reported as a failure exit code.
+    pub exit_code: i32,
+    /// The child's PID, recorded on the claim for the recovery sweep. `None`
+    /// when the child could not be spawned.
+    pub pid: Option<u32>,
+}
+
+/// Spawns a pipeline run as a child process and waits for it.
+#[async_trait]
+pub trait Spawner: Send + Sync {
+    /// Run the request to completion, returning its outcome. Implementations
+    /// own all real-time waiting (the timeout).
+    async fn run(&self, request: &SpawnRequest) -> RunOutcome;
+}
+
+/// The grace period between a graceful termination signal and a forced kill.
+const KILL_GRACE: Duration = Duration::from_secs(60);
+
+/// The real spawner: launches `current_exe -c <config> run --pipeline <name>
+/// --output json` with the tick's `TRACEPARENT`, `ROCKY_RUN_TRIGGER=schedule`,
+/// and `ROCKY_SUBMISSION_ID`, honoring the scheduler-level timeout with a
+/// graceful-then-forced termination.
+#[derive(Debug, Default)]
+pub struct SubprocessSpawner;
+
+impl SubprocessSpawner {
+    /// Construct the subprocess spawner.
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn build_command(request: &SpawnRequest) -> tokio::process::Command {
+        let exe = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("rocky"));
+        let mut cmd = tokio::process::Command::new(exe);
+        cmd.arg("-c")
+            .arg(&request.config_path)
+            .arg("run")
+            .arg("--pipeline")
+            .arg(&request.pipeline)
+            .arg("--output")
+            .arg("json")
+            .env("ROCKY_RUN_TRIGGER", "schedule")
+            .env("ROCKY_SUBMISSION_ID", &request.submission_id);
+        if let Some(tp) = &request.traceparent {
+            cmd.env("TRACEPARENT", tp);
+        }
+        cmd
+    }
+}
+
+#[async_trait]
+impl Spawner for SubprocessSpawner {
+    async fn run(&self, request: &SpawnRequest) -> RunOutcome {
+        let mut cmd = Self::build_command(request);
+        let mut child = match cmd.spawn() {
+            Ok(child) => child,
+            Err(_) => {
+                // Could not spawn — treat as a failure with no pid.
+                return RunOutcome {
+                    exit_code: 1,
+                    pid: None,
+                };
+            }
+        };
+        let pid = child.id();
+
+        let status = match request.timeout {
+            None => child.wait().await,
+            Some(timeout) => match tokio::time::timeout(timeout, child.wait()).await {
+                Ok(status) => status,
+                Err(_) => {
+                    // Timed out: SIGTERM (graceful), then SIGKILL after the grace.
+                    terminate_gracefully(&mut child, pid);
+                    match tokio::time::timeout(KILL_GRACE, child.wait()).await {
+                        Ok(status) => status,
+                        Err(_) => {
+                            let _ = child.start_kill();
+                            child.wait().await
+                        }
+                    }
+                }
+            },
+        };
+
+        let exit_code = match status {
+            Ok(s) => s.code().unwrap_or(1),
+            Err(_) => 1,
+        };
+        RunOutcome { exit_code, pid }
+    }
+}
+
+/// Send a graceful termination signal to the child. On unix this is `SIGTERM`
+/// (the engine handles it as a graceful shutdown); elsewhere it falls back to
+/// the platform's forced kill, since no graceful signal exists.
+#[cfg(unix)]
+fn terminate_gracefully(_child: &mut tokio::process::Child, pid: Option<u32>) {
+    if let Some(pid) = pid {
+        // SAFETY: `kill` with a valid pid and a standard signal number is a
+        // well-defined libc call with no memory-safety implications; a stale
+        // pid simply returns ESRCH, which we ignore.
+        unsafe {
+            libc::kill(pid as libc::pid_t, libc::SIGTERM);
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn terminate_gracefully(child: &mut tokio::process::Child, _pid: Option<u32>) {
+    let _ = child.start_kill();
+}
+
+/// A recorded invocation captured by [`CapturingSpawner`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapturedRun {
+    /// The request as it was submitted.
+    pub request: SpawnRequest,
+}
+
+/// A test spawner that records every request and returns a scripted outcome.
+///
+/// The outcome is chosen by a per-pipeline script: each pipeline has a queue of
+/// exit codes consumed in order, so a test can model "attempt 1 fails, attempt 2
+/// succeeds". A pipeline with an exhausted or absent script defaults to
+/// `default_exit`.
+pub struct CapturingSpawner {
+    captured: Mutex<Vec<CapturedRun>>,
+    scripts: Mutex<std::collections::HashMap<String, std::collections::VecDeque<i32>>>,
+    default_exit: i32,
+    next_pid: Mutex<u32>,
+}
+
+impl CapturingSpawner {
+    /// A spawner whose every run returns `default_exit`.
+    pub fn new(default_exit: i32) -> Self {
+        Self {
+            captured: Mutex::new(Vec::new()),
+            scripts: Mutex::new(std::collections::HashMap::new()),
+            default_exit,
+            next_pid: Mutex::new(1000),
+        }
+    }
+
+    /// Script the sequence of exit codes a pipeline's successive runs return.
+    pub fn script(&self, pipeline: &str, exit_codes: impl IntoIterator<Item = i32>) {
+        self.scripts
+            .lock()
+            .unwrap()
+            .insert(pipeline.to_string(), exit_codes.into_iter().collect());
+    }
+
+    /// All captured invocations, in order.
+    pub fn captured(&self) -> Vec<CapturedRun> {
+        self.captured.lock().unwrap().clone()
+    }
+
+    /// The number of captured invocations.
+    pub fn run_count(&self) -> usize {
+        self.captured.lock().unwrap().len()
+    }
+
+    /// The captured invocations for a specific pipeline.
+    pub fn runs_for(&self, pipeline: &str) -> Vec<CapturedRun> {
+        self.captured
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|c| c.request.pipeline == pipeline)
+            .cloned()
+            .collect()
+    }
+}
+
+#[async_trait]
+impl Spawner for CapturingSpawner {
+    async fn run(&self, request: &SpawnRequest) -> RunOutcome {
+        self.captured.lock().unwrap().push(CapturedRun {
+            request: request.clone(),
+        });
+        let exit_code = {
+            let mut scripts = self.scripts.lock().unwrap();
+            match scripts
+                .get_mut(&request.pipeline)
+                .and_then(std::collections::VecDeque::pop_front)
+            {
+                Some(code) => code,
+                None => self.default_exit,
+            }
+        };
+        let pid = {
+            let mut p = self.next_pid.lock().unwrap();
+            *p += 1;
+            *p
+        };
+        RunOutcome {
+            exit_code,
+            pid: Some(pid),
+        }
+    }
+}

--- a/engine/crates/rocky-core/src/snapshots.rs
+++ b/engine/crates/rocky-core/src/snapshots.rs
@@ -954,6 +954,7 @@ mod tests {
             checks: ChecksConfig::default(),
             execution: ExecutionConfig::default(),
             depends_on: vec![],
+            schedule: None,
         };
 
         let config = SnapshotConfig::from_pipeline_config(&pipeline_cfg);

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -3046,6 +3046,21 @@ impl StateStore {
         txn.commit()?;
         Ok(removed)
     }
+
+    /// Test-only: write a byte blob under a `run_history` key that is not valid
+    /// `RunRecord` JSON, so a later scan (`latest_successful_run` /
+    /// `find_terminal_run_by_submission_id`) hits a deserialization error. Used
+    /// to prove the schedule reconciler fails closed on a corrupt history row.
+    #[cfg(test)]
+    pub(crate) fn insert_corrupt_run_history_row(&self, key: &str) -> Result<(), StateError> {
+        let txn = self.db.begin_write()?;
+        {
+            let mut table = txn.open_table(RUN_HISTORY)?;
+            table.insert(key, b"{not valid run record json".as_slice())?;
+        }
+        txn.commit()?;
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -201,6 +201,32 @@ const JOBS: TableDefinition<&str, &[u8]> = TableDefinition::new("jobs");
 /// eviction trail is global ground truth, not machine-local scratch. Remote
 /// keys are schema-version-qualified by `state_sync`.
 const TOMBSTONES: TableDefinition<&str, &[u8]> = TableDefinition::new("tombstones");
+/// Per-pipeline schedule cursor for the native demand reconciler.
+///
+/// Key: the pipeline name. Value: serialized
+/// [`crate::schedule::record::ScheduleStateRecord`] — the catch-up anchor, the
+/// last attempt time/outcome, and the consecutive-failure count that drives the
+/// cross-tick backoff.
+///
+/// **Local-only** (listed in [`LOCAL_ONLY_TABLE_NAMES`]): scheduler cursors are
+/// per-instance state, one `rocky.toml` + state per scheduler instance. Their
+/// remote-sync would intersect the open remote-state integrity redesign, and
+/// the catch-up policy already covers restarts — so they are deliberately
+/// excluded from the remote snapshot.
+const SCHEDULE_STATE: TableDefinition<&str, &[u8]> = TableDefinition::new("schedule_state");
+/// Per-demand claim records for the native demand reconciler's state machine.
+///
+/// Key: the claim storage key — `<pipeline>\u{1f}<source>\u{1f}<discriminator>`
+/// where the discriminator is the cron/after/freshness `logical_ts` (RFC3339)
+/// or, for a webhook demand, its minted `demand_uid`. Value: serialized
+/// [`crate::schedule::claim::ClaimRecord`]. Every due demand takes this claim by
+/// compare-and-swap inside a write transaction *before* its child is spawned:
+/// redb serializes writers, so exactly one reconciler lands the `submitted`
+/// transition and a lost CAS is a stand-down.
+///
+/// **Local-only** (listed in [`LOCAL_ONLY_TABLE_NAMES`]): like the cursor above,
+/// claims are per-instance reconciler state.
+const SCHEDULE_CLAIMS: TableDefinition<&str, &[u8]> = TableDefinition::new("schedule_claims");
 /// Key/value store for internal metadata (e.g. `"schema_version"`).
 const METADATA: TableDefinition<&str, &str> = TableDefinition::new("metadata");
 
@@ -216,7 +242,11 @@ const METADATA: TableDefinition<&str, &str> = TableDefinition::new("metadata");
 ///   not inherit another machine's stale types).
 /// - `jobs` — ephemeral per-node `rocky serve` job records (see [`JOBS`]). Not
 ///   a governance ledger; replicating it across pods would clobber peers.
-pub const LOCAL_ONLY_TABLE_NAMES: &[&str] = &["schema_cache", "jobs"];
+/// - `schedule_state` / `schedule_claims` — per-instance reconciler cursors and
+///   claims (see [`SCHEDULE_STATE`], [`SCHEDULE_CLAIMS`]). One scheduler
+///   instance per project; the catch-up policy covers restarts.
+pub const LOCAL_ONLY_TABLE_NAMES: &[&str] =
+    &["schema_cache", "jobs", "schedule_state", "schedule_claims"];
 
 /// Schema version for the current set of state tables.
 ///
@@ -350,7 +380,18 @@ pub const LOCAL_ONLY_TABLE_NAMES: &[&str] = &["schema_cache", "jobs"];
 ///   by `test_v19_tombstone_forward_deserializes_restore_fields_none`. The
 ///   bump tracks the record-shape addition so `[state] on_schema_mismatch`
 ///   engages as usual; no blob walk.
-const CURRENT_SCHEMA_VERSION: u32 = 20;
+/// - **v21** — adds the [`SCHEDULE_STATE`] + [`SCHEDULE_CLAIMS`] tables for the
+///   native demand reconciler, and two serde-additive [`RunRecord`] fields
+///   (`pipeline`, `submission_id`) that let the reconciler join a scheduled
+///   demand to its run. The tables are a pure additive schema change (same
+///   shape as the v14 [`POLICY_DECISIONS`] add): v20 databases auto-create both
+///   empty tables on next open and stamp themselves as v21. The `RunRecord`
+///   fields forward-deserialize as `None` on a v20 blob, guarded by
+///   `test_v20_run_record_forward_deserializes_schedule_fields_none`. No blob
+///   migration needed; existing tables are untouched. Both tables stay empty
+///   until a scheduled pipeline is evaluated, so pre-existing state resumes
+///   unchanged.
+const CURRENT_SCHEMA_VERSION: u32 = 21;
 
 /// Errors from the embedded redb state store.
 #[derive(Debug, Error)]
@@ -807,6 +848,8 @@ impl StateStore {
             let _table = txn.open_table(POLICY_DECISIONS)?;
             let _table = txn.open_table(JOBS)?;
             let _table = txn.open_table(TOMBSTONES)?;
+            let _table = txn.open_table(SCHEDULE_STATE)?;
+            let _table = txn.open_table(SCHEDULE_CLAIMS)?;
         }
         txn.commit()?;
         Ok(InitOutcome::Ready)
@@ -1154,6 +1197,21 @@ pub enum RunStatus {
     /// The run was short-circuited because another caller held the
     /// idempotency key's in-flight claim. No work was done.
     SkippedInFlight,
+}
+
+impl RunStatus {
+    /// Map a run status to the schedule reconciler's terminal outcome, or
+    /// `None` for the non-terminal skip statuses (which did no work and so
+    /// never satisfy or dissatisfy a demand).
+    pub fn terminal_outcome(self) -> Option<crate::schedule::claim::TerminalOutcome> {
+        use crate::schedule::claim::TerminalOutcome;
+        match self {
+            RunStatus::Success => Some(TerminalOutcome::Success),
+            RunStatus::PartialFailure => Some(TerminalOutcome::Partial),
+            RunStatus::Failure => Some(TerminalOutcome::Failure),
+            RunStatus::SkippedIdempotent | RunStatus::SkippedInFlight => None,
+        }
+    }
 }
 
 /// What triggered the run.
@@ -1568,6 +1626,23 @@ pub struct RunRecord {
     /// `verify_after` post-apply gate to confirm named checks passed.
     #[serde(default)]
     pub check_outcomes: Vec<CheckOutcome>,
+
+    /// The pipeline this run built, when it was a pipeline run (`None` for a
+    /// model-only run and for records predating the field). Stamped from the
+    /// resolved `--pipeline` name. The schedule reconciler reads it to answer
+    /// "did upstream pipeline X succeed?" for `after`/`freshness` demands — a
+    /// `None` record is invisible to those checks, so a downstream *waits*
+    /// rather than false-firing, and self-heals on the next upstream run.
+    #[serde(default)]
+    pub pipeline: Option<String>,
+
+    /// The schedule submission id that launched this run, when the run was
+    /// launched by the reconciler (from `ROCKY_SUBMISSION_ID`). `None` for
+    /// directly-invoked runs and for records predating the field. It is the
+    /// precise join key between a scheduled demand and *its* run — recovery
+    /// must never match a demand to a run by pipeline + time.
+    #[serde(default)]
+    pub submission_id: Option<String>,
 }
 
 /// One executed data-quality check's pass/fail outcome, captured on a
@@ -2708,6 +2783,264 @@ impl StateStore {
                 if table.remove(key.as_str())?.is_some() {
                     removed += 1;
                 }
+            }
+        }
+        txn.commit()?;
+        Ok(removed)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Schedule reconciler state (see `crate::schedule`)
+// ---------------------------------------------------------------------------
+
+impl StateStore {
+    /// Read the schedule cursor for a pipeline, or `None` if it was never
+    /// evaluated.
+    pub fn get_schedule_state(
+        &self,
+        pipeline: &str,
+    ) -> Result<Option<crate::schedule::record::ScheduleStateRecord>, StateError> {
+        let txn = self.db.begin_read()?;
+        let table = txn.open_table(SCHEDULE_STATE)?;
+        match table.get(pipeline)? {
+            Some(value) => Ok(Some(serde_json::from_slice(value.value())?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Insert or replace the schedule cursor for a pipeline.
+    pub fn put_schedule_state(
+        &self,
+        pipeline: &str,
+        record: &crate::schedule::record::ScheduleStateRecord,
+    ) -> Result<(), StateError> {
+        let bytes = serde_json::to_vec(record)?;
+        let txn = self.db.begin_write()?;
+        {
+            let mut table = txn.open_table(SCHEDULE_STATE)?;
+            table.insert(pipeline, bytes.as_slice())?;
+        }
+        txn.commit()?;
+        Ok(())
+    }
+
+    /// Stamp `last_evaluated_at = now` for a pipeline (monotonically), creating
+    /// the cursor if absent. Called for every evaluated pipeline — due or not —
+    /// so `doctor` can detect a dead timer. `now` is injected; this method never
+    /// reads the clock.
+    pub fn touch_schedule_evaluated(
+        &self,
+        pipeline: &str,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<(), StateError> {
+        let txn = self.db.begin_write()?;
+        {
+            let mut table = txn.open_table(SCHEDULE_STATE)?;
+            let mut record: crate::schedule::record::ScheduleStateRecord =
+                match table.get(pipeline)? {
+                    Some(value) => serde_json::from_slice(value.value())?,
+                    None => Default::default(),
+                };
+            let advance = match record
+                .last_evaluated_at
+                .as_deref()
+                .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+            {
+                Some(prev) => now > prev.with_timezone(&chrono::Utc),
+                None => true,
+            };
+            if advance {
+                record.last_evaluated_at = Some(now.to_rfc3339());
+                let bytes = serde_json::to_vec(&record)?;
+                table.insert(pipeline, bytes.as_slice())?;
+            }
+        }
+        txn.commit()?;
+        Ok(())
+    }
+
+    /// Advance a pipeline's catch-up fire anchor to `logical_ts`, monotonically,
+    /// with no claim — used to record a first-sight cron anchor or a catch-up
+    /// skip that fires nothing. Delegates to
+    /// [`crate::schedule::record::ScheduleStateRecord::advance_fire_anchor`], so
+    /// a value at or before the current anchor is a no-op. `logical_ts` is
+    /// injected; this method never reads the clock.
+    pub fn advance_schedule_fire_anchor(
+        &self,
+        pipeline: &str,
+        logical_ts: chrono::DateTime<chrono::Utc>,
+    ) -> Result<(), StateError> {
+        let txn = self.db.begin_write()?;
+        {
+            let mut table = txn.open_table(SCHEDULE_STATE)?;
+            let mut record: crate::schedule::record::ScheduleStateRecord =
+                match table.get(pipeline)? {
+                    Some(value) => serde_json::from_slice(value.value())?,
+                    None => Default::default(),
+                };
+            record.advance_fire_anchor(logical_ts);
+            let bytes = serde_json::to_vec(&record)?;
+            table.insert(pipeline, bytes.as_slice())?;
+        }
+        txn.commit()?;
+        Ok(())
+    }
+
+    /// Read a claim by its storage key.
+    pub fn get_schedule_claim(
+        &self,
+        claim_key: &str,
+    ) -> Result<Option<crate::schedule::claim::ClaimRecord>, StateError> {
+        let txn = self.db.begin_read()?;
+        let table = txn.open_table(SCHEDULE_CLAIMS)?;
+        match table.get(claim_key)? {
+            Some(value) => Ok(Some(serde_json::from_slice(value.value())?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Atomically compare-and-swap a claim, applying a cursor mutation in the
+    /// same write transaction.
+    ///
+    /// The CAS asserts the stored claim still equals `expected` (`None` = expect
+    /// absent). On a match, `new_claim` is written and `mutation` is applied to
+    /// the pipeline's cursor, then committed — [`ClaimCas::Won`]. On a mismatch,
+    /// nothing is written (the transaction rolls back) — [`ClaimCas::Lost`] with
+    /// the current stored claim, and the caller must stand down.
+    ///
+    /// Because redb serializes writers and holds the state lock, two reconcilers
+    /// racing the same key cannot both win: the second sees the first's write
+    /// and its CAS fails.
+    pub fn schedule_claim_cas(
+        &self,
+        claim_key: &str,
+        expected: Option<&crate::schedule::claim::ClaimRecord>,
+        new_claim: &crate::schedule::claim::ClaimRecord,
+        pipeline: &str,
+        mutation: &crate::schedule::record::ScheduleStateMutation,
+    ) -> Result<crate::schedule::claim::ClaimCas, StateError> {
+        use crate::schedule::claim::{ClaimCas, ClaimRecord};
+        use crate::schedule::record::ScheduleStateRecord;
+
+        let txn = self.db.begin_write()?;
+        let current: Option<ClaimRecord>;
+        let won;
+        {
+            let mut claims = txn.open_table(SCHEDULE_CLAIMS)?;
+            current = match claims.get(claim_key)? {
+                Some(value) => Some(serde_json::from_slice(value.value())?),
+                None => None,
+            };
+            let matches = match (expected, &current) {
+                (None, None) => true,
+                (Some(e), Some(c)) => e == c,
+                _ => false,
+            };
+            if matches {
+                let bytes = serde_json::to_vec(new_claim)?;
+                claims.insert(claim_key, bytes.as_slice())?;
+
+                let mut states = txn.open_table(SCHEDULE_STATE)?;
+                let mut record: ScheduleStateRecord = match states.get(pipeline)? {
+                    Some(value) => serde_json::from_slice(value.value())?,
+                    None => Default::default(),
+                };
+                mutation.apply(&mut record);
+                let sbytes = serde_json::to_vec(&record)?;
+                states.insert(pipeline, sbytes.as_slice())?;
+                won = true;
+            } else {
+                won = false;
+            }
+        }
+        if won {
+            txn.commit()?;
+            Ok(ClaimCas::Won)
+        } else {
+            drop(txn);
+            Ok(ClaimCas::Lost(current))
+        }
+    }
+
+    /// Find the newest terminal run record carrying `submission_id`, used by the
+    /// stuck-claim resolver to derive an outcome. Skip statuses (which did no
+    /// work) are ignored.
+    pub fn find_terminal_run_by_submission_id(
+        &self,
+        submission_id: &str,
+    ) -> Result<Option<RunRecord>, StateError> {
+        let txn = self.db.begin_read()?;
+        let table = txn.open_table(RUN_HISTORY)?;
+        let mut best: Option<RunRecord> = None;
+        for entry in table.iter()? {
+            let (_, value) = entry?;
+            let run: RunRecord = serde_json::from_slice(value.value())?;
+            if run.submission_id.as_deref() == Some(submission_id)
+                && run.status.terminal_outcome().is_some()
+                && best.as_ref().is_none_or(|b| run.started_at > b.started_at)
+            {
+                best = Some(run);
+            }
+        }
+        Ok(best)
+    }
+
+    /// The most recent successful run for a pipeline, or `None`. Used to
+    /// evaluate `after` (upstream success completion) and `freshness` (own run
+    /// staleness). A `None`-pipeline record — a model-only run, or one predating
+    /// the field — never matches, so it can neither satisfy nor block a demand.
+    pub fn latest_successful_run(&self, pipeline: &str) -> Result<Option<RunRecord>, StateError> {
+        let txn = self.db.begin_read()?;
+        let table = txn.open_table(RUN_HISTORY)?;
+        let mut best: Option<RunRecord> = None;
+        for entry in table.iter()? {
+            let (_, value) = entry?;
+            let run: RunRecord = serde_json::from_slice(value.value())?;
+            if run.pipeline.as_deref() == Some(pipeline)
+                && run.status == RunStatus::Success
+                && best
+                    .as_ref()
+                    .is_none_or(|b| run.finished_at > b.finished_at)
+            {
+                best = Some(run);
+            }
+        }
+        Ok(best)
+    }
+
+    /// Garbage-collect terminal (`completed`) claims whose last transition is
+    /// older than `cutoff`. Returns the number removed. `cutoff` is injected;
+    /// this method never reads the clock.
+    pub fn gc_schedule_claims(
+        &self,
+        cutoff: chrono::DateTime<chrono::Utc>,
+    ) -> Result<usize, StateError> {
+        use crate::schedule::claim::ClaimRecord;
+
+        let txn = self.db.begin_write()?;
+        let mut removed = 0usize;
+        {
+            let mut table = txn.open_table(SCHEDULE_CLAIMS)?;
+            let mut stale_keys: Vec<String> = Vec::new();
+            for entry in table.iter()? {
+                let (key, value) = entry?;
+                let claim: ClaimRecord = serde_json::from_slice(value.value())?;
+                if !claim.is_completed() {
+                    continue;
+                }
+                let old = claim
+                    .last_transition_at
+                    .as_deref()
+                    .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                    .is_some_and(|dt| dt.with_timezone(&chrono::Utc) < cutoff);
+                if old {
+                    stale_keys.push(key.value().to_string());
+                }
+            }
+            for key in stale_keys {
+                table.remove(key.as_str())?;
+                removed += 1;
             }
         }
         txn.commit()?;
@@ -4961,6 +5294,8 @@ mod tests {
             hostname: "test-host".to_string(),
             rocky_version: "0.0.0-test".to_string(),
             check_outcomes: Vec::new(),
+            pipeline: None,
+            submission_id: None,
         }
     }
 
@@ -5002,6 +5337,57 @@ mod tests {
         let round: RunRecord =
             serde_json::from_slice(&serde_json::to_vec(&with_outcomes).unwrap()).unwrap();
         assert_eq!(round.check_outcomes, with_outcomes.check_outcomes);
+    }
+
+    #[test]
+    fn test_v20_run_record_forward_deserializes_schedule_fields_none() {
+        // A full pre-v21 record serialized with `pipeline` + `submission_id`
+        // stripped must forward-deserialize with both `None`.
+        let mut value = serde_json::to_value(minimal_run_record("run-v20", vec![]))
+            .expect("serialize run record");
+        let obj = value.as_object_mut().expect("record is an object");
+        obj.remove("pipeline");
+        obj.remove("submission_id");
+        let blob = serde_json::to_vec(&value).expect("reserialize without fields");
+
+        let record: RunRecord =
+            serde_json::from_slice(&blob).expect("pre-v21 RunRecord must forward-deserialize");
+        assert_eq!(record.run_id, "run-v20");
+        assert!(record.pipeline.is_none(), "pre-v21 record has no pipeline");
+        assert!(
+            record.submission_id.is_none(),
+            "pre-v21 record has no submission id"
+        );
+
+        // A v21 record carrying both fields round-trips losslessly.
+        let mut stamped = minimal_run_record("run-v21", vec![]);
+        stamped.pipeline = Some("raw".to_string());
+        stamped.submission_id = Some("sub-123".to_string());
+        let round: RunRecord =
+            serde_json::from_slice(&serde_json::to_vec(&stamped).unwrap()).unwrap();
+        assert_eq!(round.pipeline.as_deref(), Some("raw"));
+        assert_eq!(round.submission_id.as_deref(), Some("sub-123"));
+    }
+
+    #[test]
+    fn test_v21_opens_and_creates_schedule_tables() {
+        // A store freshly opened under the current binary materializes the
+        // `schedule_state` + `schedule_claims` tables (part of the eager
+        // EXPECTED_TABLES set) and stamps itself at v21. Reads succeed against
+        // empty tables.
+        let (store, _dir) = temp_store();
+        assert!(
+            current_schema_version() >= 21,
+            "schedule tables exist from schema v21 onward"
+        );
+        assert!(
+            store.get_schedule_state("nonexistent").unwrap().is_none(),
+            "a fresh store has an empty schedule cursor table"
+        );
+        assert!(
+            store.get_schedule_claim("nonexistent").unwrap().is_none(),
+            "a fresh store has an empty schedule claims table"
+        );
     }
 
     #[test]
@@ -8363,7 +8749,13 @@ mod tests {
         // restore` custody stamps), serde-additive fields — the redb table set
         // is untouched, only the version moves; guarded by
         // `test_v19_tombstone_forward_deserializes_restore_fields_none`.
-        const EXPECTED_VERSION: u32 = 20;
+        // v21 adds the `schedule_state` + `schedule_claims` tables (native
+        // demand reconciler) — new tables, so they ARE in EXPECTED_TABLES below;
+        // guarded by `test_v21_opens_and_creates_schedule_tables`. The paired
+        // serde-additive `RunRecord::pipeline` / `submission_id` fields do not
+        // change the table set; guarded by
+        // `test_v20_run_record_forward_deserializes_schedule_fields_none`.
+        const EXPECTED_VERSION: u32 = 21;
         const EXPECTED_TABLES: &[&str] = &[
             "branches",
             "check_history",
@@ -8383,6 +8775,8 @@ mod tests {
             "run_history",
             "run_progress",
             "run_progress_entries",
+            "schedule_claims",
+            "schedule_state",
             "schema_cache",
             "source_markers",
             "tombstones",

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -939,6 +939,7 @@ mod tests {
             gc: Default::default(),
             policy: None,
             resilience: Default::default(),
+            schedule: Default::default(),
         }
     }
 
@@ -972,6 +973,7 @@ mod tests {
             depends_on: depends_on.into_iter().map(String::from).collect(),
             table_overrides: vec![],
             prune_unchanged: false,
+            schedule: None,
         }))
     }
 
@@ -986,6 +988,7 @@ mod tests {
             checks: ChecksConfig::default(),
             execution: ExecutionConfig::default(),
             depends_on: depends_on.into_iter().map(String::from).collect(),
+            schedule: None,
         }))
     }
 
@@ -1002,6 +1005,7 @@ mod tests {
             },
             execution: ExecutionConfig::default(),
             depends_on: depends_on.into_iter().map(String::from).collect(),
+            schedule: None,
         }))
     }
 

--- a/engine/crates/rocky-core/tests/e2e.rs
+++ b/engine/crates/rocky-core/tests/e2e.rs
@@ -511,6 +511,8 @@ fn test_run_history_flow() {
         hostname: "e2e-test-host".to_string(),
         rocky_version: "0.0.0-e2e".to_string(),
         check_outcomes: Vec::new(),
+        pipeline: None,
+        submission_id: None,
     };
 
     store.record_run(&run).unwrap();

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -1569,6 +1569,8 @@ fn seed_run_history(models_dir: &Path) {
         hostname: "test-host".to_string(),
         rocky_version: "0.0.0-test".to_string(),
         check_outcomes: Vec::new(),
+        pipeline: None,
+        submission_id: None,
     };
     store.record_run(&run).expect("record run");
 

--- a/engine/deny.toml
+++ b/engine/deny.toml
@@ -15,4 +15,7 @@ multiple-versions = "deny"
 # duplicate is intentional and accepted.
 skip = [
     { crate = "schemars", reason = "rmcp 1.7 (schemars 1.x) vs Rocky's *Output cascade (schemars 0.8) — disjoint majors, compiles cleanly" },
+    { crate = "darling", reason = "croner (schedule cron parser) pulls a darling major that the wider workspace also uses at a different major — a build-time proc-macro derive helper, disjoint from any runtime code" },
+    { crate = "darling_core", reason = "transitive with darling (see above)" },
+    { crate = "darling_macro", reason = "transitive with darling (see above)" },
 ]

--- a/engine/rocky/tests/replay_check.rs
+++ b/engine/rocky/tests/replay_check.rs
@@ -166,6 +166,8 @@ fn record_run(store: &StateStore, models: &[&str]) {
             hostname: "replay-check-test".to_string(),
             rocky_version: "0.0.0-test".to_string(),
             check_outcomes: Vec::new(),
+            pipeline: None,
+            submission_id: None,
         })
         .expect("record run");
 }

--- a/engine/rocky/tests/replay_dag.rs
+++ b/engine/rocky/tests/replay_dag.rs
@@ -188,6 +188,8 @@ fn record_run(store: &StateStore, models: &[&str]) {
             hostname: "replay-dag-test".to_string(),
             rocky_version: "0.0.0-test".to_string(),
             check_outcomes: Vec::new(),
+            pipeline: None,
+            submission_id: None,
         })
         .expect("record run");
 }

--- a/engine/rocky/tests/replay_execute.rs
+++ b/engine/rocky/tests/replay_execute.rs
@@ -170,6 +170,8 @@ fn record_run(store: &StateStore, models: &[&str]) {
             hostname: "replay-execute-test".to_string(),
             rocky_version: "0.0.0-test".to_string(),
             check_outcomes: Vec::new(),
+            pipeline: None,
+            submission_id: None,
         })
         .expect("record run");
 }

--- a/integrations/dagster/tests/fixtures_generated/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor.json
@@ -17,7 +17,7 @@
     {
       "name": "state_schema",
       "status": "healthy",
-      "message": "state schema v20 matches this binary",
+      "message": "state schema v21 matches this binary",
       "duration_ms": 0
     },
     {

--- a/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
@@ -17,7 +17,7 @@
     {
       "name": "state_schema",
       "status": "healthy",
-      "message": "no on-disk state schema (binary supports v20)",
+      "message": "no on-disk state schema (binary supports v21)",
       "duration_ms": 0
     },
     {

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 20,
-  "schema_version_on_disk": 20
+  "schema_version_supported": 21,
+  "schema_version_on_disk": 21
 }

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 20,
-  "schema_version_on_disk": 20
+  "schema_version_supported": 21,
+  "schema_version_on_disk": 21
 }

--- a/integrations/dagster/tests/fixtures_generated/state.json
+++ b/integrations/dagster/tests/fixtures_generated/state.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 20,
-  "schema_version_on_disk": 20
+  "schema_version_supported": 21,
+  "schema_version_on_disk": 21
 }

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -1641,6 +1641,17 @@
           },
           "description": "Load options (batch size, create/truncate behavior, CSV settings)."
         },
+        "schedule": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ScheduleConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional native-schedule declaration. See [`ScheduleConfig`]."
+        },
         "source_dir": {
           "description": "Directory or glob pattern for source files, relative to the config file.",
           "type": "string"
@@ -2919,6 +2930,17 @@
           },
           "description": "Execution settings (concurrency, retries, etc.)."
         },
+        "schedule": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ScheduleConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional native-schedule declaration. See [`ScheduleConfig`]."
+        },
         "tables": {
           "default": [],
           "description": "Tables to check. Each entry specifies catalog + schema, and optionally a specific table (omit for all tables in the schema).",
@@ -3091,6 +3113,17 @@
           "default": false,
           "description": "When `true`, the replication runner skips (\"prunes\") any table whose source is provably unchanged since the last successful copy — detected via the adapter's `source_change_marker` (a `DESCRIBE DETAIL`-derived marker on Databricks; adapters without a cheap change signal always copy). A pruned table runs no copy and no data checks: the runner emits no materialization and records it under `excluded_tables` with reason `\"unchanged_since_last_copy\"`.\n\nDownstream continuity — and preserving the table's prior check results — is then the orchestrator's job. The Dagster integration treats a pruned, unmaterialized key as unchanged via `satisfy_empty_outputs`; enabling pruning without an orchestrator that handles unmaterialized keys drops the table from the run.\n\nDefaults to `false` — opt in per pipeline, since silently skipping copies is a behavior change. The marker is compared against the target's recorded last-copied value (never wall-clock), so a failed prior run cannot cause a false skip. Pass `--no-prune` to `rocky run` to force a full pass (e.g. after a manual target-side mutation).",
           "type": "boolean"
+        },
+        "schedule": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ScheduleConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional native-schedule declaration. See [`ScheduleConfig`]."
         },
         "source": {
           "allOf": [
@@ -3371,6 +3404,100 @@
       },
       "type": "object"
     },
+    "ScheduleConfig": {
+      "additionalProperties": false,
+      "description": "Per-pipeline schedule declaration for native demand reconciliation.\n\nEvery field is optional; an absent `[pipeline.<name>.schedule]` block leaves the pipeline with today's behavior (it runs only when invoked directly). A pipeline may combine demand sources — `cron`, `after`, and `freshness` union, so any one of them makes the pipeline due.\n\nUnlike the five pipeline variant structs (which deliberately omit `deny_unknown_fields` so the IDE schema can inject the `type` discriminator), this struct **denies unknown fields**: a typo inside `[…schedule]` is a silent scheduling bug — a misspelled `corn` key would leave a pipeline unscheduled with no error — so the deserializer rejects it outright.",
+      "properties": {
+        "after": {
+          "description": "Upstream pipelines this one runs after. The pipeline is due once every listed pipeline has a successful run that completed after this pipeline's own latest success started (a partial-success run does not count as an upstream success).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "catchup": {
+          "default": "latest",
+          "description": "Catch-up policy when more than one cron occurrence elapsed since the last fire: `\"latest\"` (default) fires one demand at the most recent missed occurrence; `\"skip\"` advances the anchor and runs nothing. `\"all\"` is rejected at validation — runs are watermark-driven, not windowed, so replaying every missed occurrence is pure cost.",
+          "type": "string"
+        },
+        "cron": {
+          "description": "Standard 5-field cron expression (minute hour day-of-month month day-of-week). When set, the pipeline is due at each occurrence.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enabled": {
+          "default": true,
+          "description": "When `false`, demand is suppressed but the config is kept. Default `true`.",
+          "type": "boolean"
+        },
+        "freshness": {
+          "default": false,
+          "description": "When `true`, the pipeline is due once its own run-staleness exceeds its freshness budget (resolved from per-model `max_lag_seconds`, falling back to the project `[freshness].expected_lag_seconds`). This is run-staleness only — the reconciler never queries the warehouse.",
+          "type": "boolean"
+        },
+        "retry": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ScheduleRetryConfig"
+            }
+          ],
+          "default": {
+            "max": 0
+          },
+          "description": "In-tick immediate re-submissions on failure. The reconciler never sleeps between attempts; minutes-scale spacing is the always-on cross-tick throttle, not this knob. Default `0` (off)."
+        },
+        "timeout_minutes": {
+          "default": 0,
+          "description": "Scheduler-level timeout in minutes for a launched run. `0` (default) means no scheduler-level timeout — the run's own limits apply.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "timezone": {
+          "description": "IANA timezone name (e.g. `\"Europe/Lisbon\"`) the `cron` occurrences are evaluated in. Falls back to the project `[schedule].timezone`, which itself defaults to `\"UTC\"`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "ScheduleDefaultsConfig": {
+      "additionalProperties": false,
+      "description": "Project-level schedule defaults (`[schedule]`).\n\nSupplies the fallback timezone for per-pipeline `cron` blocks that omit their own, plus the resident-loop poll cadence consumed by a later phase.",
+      "properties": {
+        "poll_interval_seconds": {
+          "default": 15,
+          "description": "Poll cadence in seconds for the resident scheduler loop. Not consumed by the one-shot tick; reserved for the resident-loop phase. Default `15`.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "timezone": {
+          "default": "UTC",
+          "description": "Default IANA timezone for per-pipeline cron evaluation. Default `\"UTC\"`.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ScheduleRetryConfig": {
+      "additionalProperties": false,
+      "description": "In-tick retry budget for a scheduled pipeline.",
+      "properties": {
+        "max": {
+          "default": 0,
+          "description": "Maximum number of *additional* immediate re-submissions after the first attempt fails. `0` means the first attempt is the only one.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
     "SchemaCacheConfig": {
       "additionalProperties": false,
       "description": "`[cache.schemas]` — schema cache configuration.\n\nControls the DESCRIBE-result cache. Defaults are chosen so the feature is useful out of the box: the cache is on, entries live for 24 hours, and nothing replicates off-machine until the user opts in.",
@@ -3501,6 +3628,17 @@
           "default": false,
           "description": "When true, rows deleted from the source get their `valid_to` set to the current timestamp in the target. Default: false.",
           "type": "boolean"
+        },
+        "schedule": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ScheduleConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional native-schedule declaration. See [`ScheduleConfig`]."
         },
         "source": {
           "allOf": [
@@ -4075,6 +4213,17 @@
           "description": "Glob pattern for model files, relative to the config file directory. Default: `\"models/**\"`.",
           "type": "string"
         },
+        "schedule": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ScheduleConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional native-schedule declaration. See [`ScheduleConfig`]."
+        },
         "target": {
           "allOf": [
             {
@@ -4478,6 +4627,18 @@
         "skip_unchanged": false
       },
       "description": "Opt-in run-execution tuning for the `--skip-unchanged` model-skip gate. Default-OFF: an absent `[run]` block (or one that leaves every field at its default) keeps `rocky run`'s behavior byte-identical to before the gate existed. See [`RunConfig`]."
+    },
+    "schedule": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/ScheduleDefaultsConfig"
+        }
+      ],
+      "default": {
+        "poll_interval_seconds": 15,
+        "timezone": "UTC"
+      },
+      "description": "Project-level schedule defaults for native demand reconciliation. Supplies the fallback timezone for per-pipeline `[…schedule]` cron blocks and the resident-loop poll cadence. See [`ScheduleDefaultsConfig`]."
     },
     "schema_evolution": {
       "allOf": [

--- a/sdk/python/src/rocky_sdk/types_generated/rocky_project_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/rocky_project_schema.py
@@ -1455,6 +1455,40 @@ class RunRetryConfig(BaseModel):
     """
 
 
+class ScheduleDefaultsConfig(BaseModel):
+    """
+    Project-level schedule defaults (`[schedule]`).
+
+    Supplies the fallback timezone for per-pipeline `cron` blocks that omit their own, plus the resident-loop poll cadence consumed by a later phase.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    poll_interval_seconds: conint(ge=0) | None = 15
+    """
+    Poll cadence in seconds for the resident scheduler loop. Not consumed by the one-shot tick; reserved for the resident-loop phase. Default `15`.
+    """
+    timezone: str | None = "UTC"
+    """
+    Default IANA timezone for per-pipeline cron evaluation. Default `"UTC"`.
+    """
+
+
+class ScheduleRetryConfig(BaseModel):
+    """
+    In-tick retry budget for a scheduled pipeline.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    max: conint(ge=0) | None = 0
+    """
+    Maximum number of *additional* immediate re-submissions after the first attempt fails. `0` means the first attempt is the only one.
+    """
+
+
 class SchemaCacheConfig(BaseModel):
     """
     `[cache.schemas]` — schema cache configuration.
@@ -2770,6 +2804,52 @@ class QuarantineConfig(BaseModel):
     """
 
 
+class ScheduleConfig(BaseModel):
+    """
+    Per-pipeline schedule declaration for native demand reconciliation.
+
+    Every field is optional; an absent `[pipeline.<name>.schedule]` block leaves the pipeline with today's behavior (it runs only when invoked directly). A pipeline may combine demand sources — `cron`, `after`, and `freshness` union, so any one of them makes the pipeline due.
+
+    Unlike the five pipeline variant structs (which deliberately omit `deny_unknown_fields` so the IDE schema can inject the `type` discriminator), this struct **denies unknown fields**: a typo inside `[…schedule]` is a silent scheduling bug — a misspelled `corn` key would leave a pipeline unscheduled with no error — so the deserializer rejects it outright.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    after: list[str] | None = None
+    """
+    Upstream pipelines this one runs after. The pipeline is due once every listed pipeline has a successful run that completed after this pipeline's own latest success started (a partial-success run does not count as an upstream success).
+    """
+    catchup: str | None = "latest"
+    """
+    Catch-up policy when more than one cron occurrence elapsed since the last fire: `"latest"` (default) fires one demand at the most recent missed occurrence; `"skip"` advances the anchor and runs nothing. `"all"` is rejected at validation — runs are watermark-driven, not windowed, so replaying every missed occurrence is pure cost.
+    """
+    cron: str | None = None
+    """
+    Standard 5-field cron expression (minute hour day-of-month month day-of-week). When set, the pipeline is due at each occurrence.
+    """
+    enabled: bool | None = True
+    """
+    When `false`, demand is suppressed but the config is kept. Default `true`.
+    """
+    freshness: bool | None = False
+    """
+    When `true`, the pipeline is due once its own run-staleness exceeds its freshness budget (resolved from per-model `max_lag_seconds`, falling back to the project `[freshness].expected_lag_seconds`). This is run-staleness only — the reconciler never queries the warehouse.
+    """
+    retry: ScheduleRetryConfig | None = Field({"max": 0}, validate_default=True)
+    """
+    In-tick immediate re-submissions on failure. The reconciler never sleeps between attempts; minutes-scale spacing is the always-on cross-tick throttle, not this knob. Default `0` (off).
+    """
+    timeout_minutes: conint(ge=0) | None = 0
+    """
+    Scheduler-level timeout in minutes for a launched run. `0` (default) means no scheduler-level timeout — the run's own limits apply.
+    """
+    timezone: str | None = None
+    """
+    IANA timezone name (e.g. `"Europe/Lisbon"`) the `cron` occurrences are evaluated in. Falls back to the project `[schedule].timezone`, which itself defaults to `"UTC"`.
+    """
+
+
 class StateRetentionConfig(BaseModel):
     """
     State-store retention policy.
@@ -3057,6 +3137,10 @@ class QualityPipelineConfig(BaseModel):
     """
     Execution settings (concurrency, retries, etc.).
     """
+    schedule: ScheduleConfig | None = None
+    """
+    Optional native-schedule declaration. See [`ScheduleConfig`].
+    """
     tables: list[TableRef] | None = Field([], validate_default=True)
     """
     Tables to check. Each entry specifies catalog + schema, and optionally a specific table (omit for all tables in the schema).
@@ -3131,6 +3215,10 @@ class ReplicationPipelineConfig(BaseModel):
     Downstream continuity — and preserving the table's prior check results — is then the orchestrator's job. The Dagster integration treats a pruned, unmaterialized key as unchanged via `satisfy_empty_outputs`; enabling pruning without an orchestrator that handles unmaterialized keys drops the table from the run.
 
     Defaults to `false` — opt in per pipeline, since silently skipping copies is a behavior change. The marker is compared against the target's recorded last-copied value (never wall-clock), so a failed prior run cannot cause a false skip. Pass `--no-prune` to `rocky run` to force a full pass (e.g. after a manual target-side mutation).
+    """
+    schedule: ScheduleConfig | None = None
+    """
+    Optional native-schedule declaration. See [`ScheduleConfig`].
     """
     source: PipelineSourceConfig
     """
@@ -3395,6 +3483,10 @@ class LoadPipelineConfig(BaseModel):
     """
     Load options (batch size, create/truncate behavior, CSV settings).
     """
+    schedule: ScheduleConfig | None = None
+    """
+    Optional native-schedule declaration. See [`ScheduleConfig`].
+    """
     source_dir: str
     """
     Directory or glob pattern for source files, relative to the config file.
@@ -3480,6 +3572,10 @@ class SnapshotPipelineConfig(BaseModel):
     """
     When true, rows deleted from the source get their `valid_to` set to the current timestamp in the target. Default: false.
     """
+    schedule: ScheduleConfig | None = None
+    """
+    Optional native-schedule declaration. See [`ScheduleConfig`].
+    """
     source: SnapshotSourceConfig
     """
     Source table reference (single table, not pattern-based discovery).
@@ -3548,6 +3644,10 @@ class TransformationPipelineConfig(BaseModel):
     models: str | None = "models/**"
     """
     Glob pattern for model files, relative to the config file directory. Default: `"models/**"`.
+    """
+    schedule: ScheduleConfig | None = None
+    """
+    Optional native-schedule declaration. See [`ScheduleConfig`].
     """
     target: TransformationTargetConfig
     """
@@ -3763,6 +3863,12 @@ class RockyConfig(BaseModel):
     )
     """
     Opt-in run-execution tuning for the `--skip-unchanged` model-skip gate. Default-OFF: an absent `[run]` block (or one that leaves every field at its default) keeps `rocky run`'s behavior byte-identical to before the gate existed. See [`RunConfig`].
+    """
+    schedule: ScheduleDefaultsConfig | None = Field(
+        {"poll_interval_seconds": 15, "timezone": "UTC"}, validate_default=True
+    )
+    """
+    Project-level schedule defaults for native demand reconciliation. Supplies the fallback timezone for per-pipeline `[…schedule]` cron blocks and the resident-loop poll cadence. See [`ScheduleDefaultsConfig`].
     """
     schema_evolution: SchemaEvolutionConfig | None = Field(
         {"grace_period_days": 7}, validate_default=True


### PR DESCRIPTION
## What & why

First slice of native demand reconciliation in the engine core: pipelines declare **when** they should run (`cron` / `after` / `freshness`) in the same `rocky.toml` that defines them, and a single `tick_once(config, store, now, spawner, opts)` evaluates all standing demand once and runs what is due. No daemon — the tick comes from cron/systemd/CI. The reconciler core reads **no wall clock** (`now` is always injected) and spawns children through an injected `Spawner`, so the whole state machine is deterministic and testable without a binary.

This PR is the **core only**. The `rocky tick` CLI verb + typed output codegen cascade, the resident `serve --scheduler` loop + webhook ingress, and the playground POC land in follow-ups. Marked **experimental**.

## Kill-checkpoint red-team follow-up — fixes in this revision

An adversarial kill-checkpoint review confirmed the CAS / budget / `after` logic is sound and found real soundness bugs. Addressed here:

- **Run-history read errors no longer swallowed to `None` (fixed).** `RunHistoryView::latest_successful_run` now returns `Result<Option<RunSuccess>, HistoryError>`. A corrupt `run_history` row (or store fault) is surfaced as an error and the demand **fails closed**: `evaluate_one` records a new `SkipReason::HistoryError` (→ `TickSkipReason::HistoryUnavailable`), which is **recorded, never elided**. So a bad row can no longer false-skip an `after` demand (was: silent drop) nor false-fire a `freshness` epoch occurrence (was: read as "never ran"). This is genuinely independent of the fail-closed `touch_schedule_evaluated` — the touch/claim writes hit `schedule_state`/`schedule_claims`, while the bad row lives in `run_history`. New tests at both layers: demand-level (`FaultyHistory`) and end-to-end through `tick_once` with a real corrupt row injected into `run_history` (asserts **zero spawns** + a recorded `HistoryUnavailable` skip, for both `after` and `freshness`).
- **Per-model freshness budget — fixed via loud validation + documented v1 behavior.** The reconciler resolves the freshness budget from the project `[freshness].expected_lag_seconds` only; per-model `max_lag_seconds` is not consulted in this slice. **I chose the documented-validation path, not wiring**, because wiring requires per-pipeline model loading (`run_local` resolves a `models_base` dir per pipeline glob) — that lives in the CLI layer and lands with the `rocky tick` verb; doing it in `rocky-core` is a larger model-loading change than this core slice should carry. To keep the gap from being silent, `rocky validate` now emits **V043** (warning) on any `freshness = true` pipeline with a project budget, stating that a tighter member budget would under-fire. The no-project-budget case is already the **V038** error, and the reconciler fails closed there too (`resolve_schedule` → skip, never fire). Flagging explicitly: if you'd prefer a hard error or want per-model wiring pulled forward, say so.

Documented residuals (design-aligned v1 limitations, in the ledger):
- **Cron crash mid-retry** — a cron occurrence that crashes mid-retry loses the rest of its retry cycle (the anchor already advanced, so the occurrence isn't re-derived and its `submitted` claim lingers until GC). This matches the frozen rule "a failed occurrence is not re-fired at the next tick"; the next occurrence fires normally. A resume-sweep would contradict that rule (it can only clean up, not re-run), so I documented rather than added it.
- **Orphan-child liveness** — the stuck-claim resolver joins a crashed run by `submission_id` + a 5-min grace with no pid/start-time liveness probe, so a crashed reconciler's surviving child could overlap a re-claimed second attempt after the grace. This is the design's documented residual, bounded by the per-project state flock + idempotent/watermark-driven runs; the full pid+start_time lease-based recovery sweep is the next phase.

### What's in it
- **config** — optional `[pipeline.<name>.schedule]` block (`cron`, `timezone`, `after`, `freshness`, `catchup`, `retry`, `timeout_minutes`, `enabled`) on all five pipeline types + project `[schedule]` defaults. `ScheduleConfig` denies unknown fields.
- **state** — `schedule_state` + `schedule_claims` redb tables (both local-only), a per-demand claim state machine transitioned by CAS inside redb write txns, and two serde-additive `RunRecord` fields (`pipeline`, `submission_id`). Schema **v21**.
- **occurrence** — `croner` + `chrono-tz` cron math behind a swappable `next_occurrence`, DST-correct.
- **demand** — pure `cron` / `after` / `freshness` evaluation with the always-on outcome-aware cross-tick throttle, now fail-closed on a history read fault.
- **reconcile** — `tick_once`: tick lock (skip-fresh / wedge-override-stale), topological execution by `after`, claim-before-spawn, in-tick retry, terminal-on-exhaustion, budget-aware stuck-claim resolver. Lease heartbeat refreshed every 30s **while a child runs**.
- **run** — thread `ROCKY_RUN_TRIGGER` + `ROCKY_SUBMISSION_ID` and the resolved pipeline name onto the persisted `RunRecord` (mirrors the env-derived `ROCKY_SESSION_SOURCE` precedent; `record_run`'s signature unchanged).
- **validate** — `V036`–`V043`: invalid cron/timezone/catchup (`"all"` refused with the watermark-vs-windowed explanation), freshness-no-budget, unknown `after` targets, `after` cycles, inert blocks, the run-record persistence gap, and the per-model freshness-budget gap (V043).

## Rebase note

The WIP rebased onto `origin/main` **cleanly, no conflicts** — the anticipated `state.rs` conflict did not materialize (the state-authority change edits `state_sync.rs`). `CURRENT_SCHEMA_VERSION` is **21** (origin/main is still 20; the state-authority PR did not bump it). A follow-up commit regenerated the config-schema codegen for the `[schedule]` keys (openapi + SDK + TS bindings). Cleaned up the WIP's stray field inserts (duplicated after struct-literal closing braces) and completed the RunRecord construction sites it missed.

## Codegen / fixtures

- `[schedule]` config keys → config-schema codegen regenerated (committed).
- RunRecord `pipeline`/`submission_id` + schema v21 → **dagster fixtures regenerated** (`just regen-fixtures`): `state.json`, `state_after_run1/2.json`, `doctor.json`, `doctor_ci/doctor.json`. The diff is **only** the `20 → 21` schema-version bump — `submission_id`/`pipeline` do not appear in the state output, so there is no non-determinism (no stray UUID). Verified **idempotent** (second regen = identical diff) and `test_generated_fixtures.py` passes (45).

## Gate results

- `cargo fmt --check` — **clean** · `cargo clippy --all-targets` — **clean** · `cargo test --workspace` — **all green** (115 test binaries, 0 failures)
- Determinism audit — `rg "Utc::now\(\)"` over `schedule/` returns **nothing**.
- `cargo deny check` is not a CI gate (deny.toml says so) and is already red on main (cargo-deny 0.19 default-denies all licenses; ~20 pre-existing bans duplicates). My only new build-time duplicate is `darling` via `croner`, documented in the skip list. `cargo audit`'s 4 advisories are all pre-existing on main, none from `croner`/`chrono-tz`.

## Failure-mode ledger

- **Missed fire** — Cron: a crash between claim-commit and spawn advances the anchor, so the occurrence is a bounded, loud miss (claimed-without-run), never re-fired; the next occurrence fires normally. Standing demands re-evaluate the same key and resolve via the grace path. Test: `crash_between_claim_and_spawn_never_refires_cron`.
- **Double fire** — Per-demand claim CAS (redb serializes writers; a lost CAS stands down): no active `submitted` claim owned by the pass means no spawn, ever. The lease heartbeat refreshes every 30s while a child runs, so a long healthy run is never wedge-overridden into a duplicate. Tests: `preexisting_submitted_claim_blocks_second_reconciler`, `tick_in_progress_skips_whole_tick`, the `claim` CAS matrix.
- **Crash mid-run** — A stuck `submitted` claim is resolved on a later tick by joining the run record via `submission_id`: terminal record → apply outcome; budget-remaining failure → `released{budget_open=true}` continues the retry cycle cross-crash; no record within a 5-min grace → treated as a lost failure under the same budget rule. Tests: `stuck_submitted_resolved_from_run_record`, `crash_safe_retry_budget_reclaims_and_runs_attempt_two`.
- **History read fault (fixed)** — A corrupt `run_history` row / store fault fails closed: the demand records a `HistoryUnavailable` skip and never fires on data it could not read (no false-skip for `after`, no false-fire for `freshness`). Tests: `after_history_read_error_fails_closed_no_false_skip`, `freshness_history_read_error_fails_closed_no_false_fire` (demand layer) + `after_corrupt_history_row_fails_closed_no_spawn`, `freshness_corrupt_history_row_does_not_fire_epoch` (end-to-end).
- **Clock skew** — `now` always injected; anchors monotonic (a `--now` before the anchor is a no-op). Tests: `cron_now_earlier_than_anchor_does_not_fire`, `anchors_are_monotonic`.
- **DST** — Occurrences evaluate in the named IANA zone; skipped wall time fires once at the next valid instant, repeated wall time fires on the first occurrence only, UTC unaffected. Tests: the Lisbon spring-forward / fall-back / UTC vectors.
- **Persistence gap** (limitation) — `after`/`freshness` on quality/snapshot/load can't observe a success record → V041 warning, not a silent false-skip. Test: `schedule_after_non_persisting_type_is_v041_warning`.
- **Per-model freshness budget** (limitation) — the reconciler resolves the project budget only; a tighter member budget under-fires. Surfaced loudly as the V043 validation warning; per-model wiring lands with the CLI verb. Test: `schedule_freshness_per_model_budget_gap_is_v043_warning`.
- **Cron crash mid-retry** (residual) — a cron occurrence that crashes mid-retry loses its remaining retry cycle and its `submitted` claim lingers until GC; the next occurrence fires normally (design-aligned: a failed occurrence is not re-fired). No spawn duplication.
- **Orphan-child liveness** (residual) — the resolver has no pid/start-time probe, so a crashed reconciler's surviving child could overlap a re-claimed attempt after the grace. Bounded by the per-project state flock + idempotent runs; the lease-based recovery sweep is the next phase.

The must-fix modes (missed / double / crash / history) close small; the two residuals are bounded and design-aligned.

## Semantics I interpreted — please red-team

1. **`tick_once` signature** — the tick lock is acquired inside `tick_once` from `opts.rocky_dir`, not passed in. `opts` also carries `config_path`, `pipeline_filter`, `traceparent`, `dry_run`.
2. **Within-tick `after` cascade** — topological order + per-pipeline re-evaluation against live state; same-level pipelines tiebreak by **name** (deterministic), not `logical_ts` — a harmless deviation from the frozen letter.
3. **Cron crash-recovery abandons the occurrence** — matches "a failed occurrence is not re-fired"; the crash-safe retry budget therefore applies to standing demands (see the cron-crash residual above).
4. **Resolver scoping** — `submission_id` join + 5-min grace, no pid probe (see the orphan-child residual above).
5. **Freshness budget** — project `[freshness].expected_lag_seconds` only in this slice; per-model MIN wiring is a follow-up (see V043).

Do **not** merge — this is for review.
