### PR TITLE
docs(engine): clarify DAG model-scoping behavior notes

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1434,6 +1434,14 @@ pub async fn run(
         );
 
         let adapter_registry = AdapterRegistry::from_config(rocky_cfg)?;
+        // An explicit `--pipeline` alongside `--model` (also how the unified-DAG
+        // sub-runner drives each transformation node) resolves the model against
+        // THAT pipeline's target adapter and schema-creation policy — not the
+        // first-transformation-adapter fallback used when no pipeline is named.
+        // A model only has meaning under a transformation pipeline, so pointing
+        // `--model` at a non-transformation pipeline fails fast rather than
+        // silently running against an unrelated adapter. Bare `rocky run --model
+        // <X>` (no `--pipeline`) keeps the fallback via the `else` arm below.
         let (target_adapter_name, auto_create_schemas) = if let Some(pipeline_name) =
             pipeline_name_arg
         {

--- a/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
+++ b/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
@@ -54,6 +54,15 @@ type SubRunner = Arc<
 /// the ONE snapshot `run_with_dag` captured, never a per-node reload, and
 /// transformation nodes supply their model name so each node materializes only
 /// itself; other pipeline nodes pass `None`.
+///
+/// Because each transformation model runs as its own sub-run — with its own
+/// [`super::skip_gate::SkipGate`] instance — `--skip-unchanged` cannot observe a
+/// sibling model's this-run build/skip verdict across nodes. A model with a
+/// Rocky-model upstream therefore always rebuilds under `--dag --skip-unchanged`:
+/// the gate treats an upstream carrying no in-run verdict as changed (see
+/// `SkipGate::upstream_unchanged`). That is fail-safe — never a stale skip — but
+/// more conservative than a single monolithic run, where the per-layer barrier
+/// makes every upstream verdict visible. Raw-source freshness skips still apply.
 fn default_sub_runner() -> SubRunner {
     Arc::new(
         |config_path: PathBuf,


### PR DESCRIPTION
## Summary

Follow-up to #1141 (which fixed #1140 — `run --dag` executing each transformation model once per model node). Adds two doc comments capturing non-obvious behaviors of the per-model DAG dispatch that surfaced during review. **Comments only — no behavior change.**

- **`run()`** — an explicit `--pipeline` alongside `--model` (also how the unified-DAG sub-runner drives each transformation node) resolves the model against *that* pipeline's target adapter and schema-creation policy, and fails fast if the named pipeline isn't a transformation pipeline. Bare `rocky run --model <X>` (no `--pipeline`) keeps the first-transformation-adapter fallback. Documenting the intentional fail-fast so it doesn't read as an oversight.
- **`default_sub_runner()`** — under `--dag --skip-unchanged`, each transformation model runs as its own sub-run (its own `SkipGate`), so a model with a Rocky-model upstream always rebuilds: the gate treats an upstream carrying no in-run verdict as changed (`SkipGate::upstream_unchanged`). This is fail-safe (never a stale skip) but more conservative than a single monolithic run. Raw-source freshness skips still apply.

## Note on re-run idempotency

While reviewing I checked repeated `run --dag` invocations. Append-`incremental` models re-append once per invocation (linear growth), which is the fix working correctly — the pre-fix multiplicative behavior (the `4,10` compounding in #1140) is gone. The exact re-run counts pin incremental-watermark semantics orthogonal to this fix, so I deliberately did not add a re-run assertion to the regression test; the existing single-invocation `(1,1)` assertion is the clean guard.

## Validation

- `cargo test -p rocky-cli --features duckdb run_dag_exec` — 4 passed
- `cargo clippy -p rocky-cli --all-targets --features duckdb -- -D warnings`
- `cargo fmt --all -- --check`
