### PR TITLE
Fix quoted time-window placeholder SQL generation

### DIFF
--- a/engine/crates/rocky-cli/tests/ir-golden/09-transformation-time-interval-bootstrap/bigquery.sql
+++ b/engine/crates/rocky-cli/tests/ir-golden/09-transformation-time-interval-bootstrap/bigquery.sql
@@ -1,2 +1,2 @@
 CREATE OR REPLACE TABLE `tgtwarehouse`.`marts__demo`.`events_daily` AS
-SELECT event_date, COUNT(*) AS event_count FROM tgtwarehouse.raw__demo.events WHERE event_date >= ''1900-01-01 00:00:00'' AND event_date < ''1900-01-01 00:00:00'' GROUP BY 1
+SELECT event_date, COUNT(*) AS event_count FROM tgtwarehouse.raw__demo.events WHERE event_date >= '1900-01-01 00:00:00' AND event_date < '1900-01-01 00:00:00' GROUP BY 1

--- a/engine/crates/rocky-cli/tests/ir-golden/09-transformation-time-interval-bootstrap/databricks.sql
+++ b/engine/crates/rocky-cli/tests/ir-golden/09-transformation-time-interval-bootstrap/databricks.sql
@@ -1,2 +1,2 @@
 CREATE OR REPLACE TABLE tgtwarehouse.marts__demo.events_daily AS
-SELECT event_date, COUNT(*) AS event_count FROM tgtwarehouse.raw__demo.events WHERE event_date >= ''1900-01-01 00:00:00'' AND event_date < ''1900-01-01 00:00:00'' GROUP BY 1
+SELECT event_date, COUNT(*) AS event_count FROM tgtwarehouse.raw__demo.events WHERE event_date >= '1900-01-01 00:00:00' AND event_date < '1900-01-01 00:00:00' GROUP BY 1

--- a/engine/crates/rocky-cli/tests/ir-golden/09-transformation-time-interval-bootstrap/duckdb.sql
+++ b/engine/crates/rocky-cli/tests/ir-golden/09-transformation-time-interval-bootstrap/duckdb.sql
@@ -1,2 +1,2 @@
 CREATE OR REPLACE TABLE tgtwarehouse.marts__demo.events_daily AS
-SELECT event_date, COUNT(*) AS event_count FROM tgtwarehouse.raw__demo.events WHERE event_date >= ''1900-01-01 00:00:00'' AND event_date < ''1900-01-01 00:00:00'' GROUP BY 1
+SELECT event_date, COUNT(*) AS event_count FROM tgtwarehouse.raw__demo.events WHERE event_date >= '1900-01-01 00:00:00' AND event_date < '1900-01-01 00:00:00' GROUP BY 1

--- a/engine/crates/rocky-cli/tests/ir-golden/09-transformation-time-interval-bootstrap/snowflake.sql
+++ b/engine/crates/rocky-cli/tests/ir-golden/09-transformation-time-interval-bootstrap/snowflake.sql
@@ -1,2 +1,2 @@
 CREATE OR REPLACE TABLE "tgtwarehouse"."marts__demo"."events_daily" AS
-SELECT event_date, COUNT(*) AS event_count FROM tgtwarehouse.raw__demo.events WHERE event_date >= ''1900-01-01 00:00:00'' AND event_date < ''1900-01-01 00:00:00'' GROUP BY 1
+SELECT event_date, COUNT(*) AS event_count FROM tgtwarehouse.raw__demo.events WHERE event_date >= '1900-01-01 00:00:00' AND event_date < '1900-01-01 00:00:00' GROUP BY 1

--- a/engine/crates/rocky-core/src/sql_gen.rs
+++ b/engine/crates/rocky-core/src/sql_gen.rs
@@ -588,20 +588,16 @@ pub fn generate_transformation_initial_ddl(
 /// Substitute `@start_date` / `@end_date` placeholders in the model SQL with
 /// quoted timestamp literals from the partition window.
 ///
-/// Word-boundary aware via simple string replace — `@start_date_extra` would
-/// not be matched by a more careful tokenizer, but the compiler's
-/// `check_time_interval_placeholders` already rejects models that don't
-/// reference the bare placeholders, so a malformed `@start_date_extra`
-/// reference would have failed compilation upstream.
+/// The documented form is bare, but tolerate an already single-quoted
+/// placeholder without adding a second pair of quotes.
 fn substitute_partition_placeholders(sql: &str, window: &PartitionWindow) -> String {
-    sql.replace(
-        "@start_date",
-        &format!("'{}'", window.start.format("%Y-%m-%d %H:%M:%S")),
-    )
-    .replace(
-        "@end_date",
-        &format!("'{}'", window.end.format("%Y-%m-%d %H:%M:%S")),
-    )
+    let start = format!("'{}'", window.start.format("%Y-%m-%d %H:%M:%S"));
+    let end = format!("'{}'", window.end.format("%Y-%m-%d %H:%M:%S"));
+
+    sql.replace("'@start_date'", &start)
+        .replace("@start_date", &start)
+        .replace("'@end_date'", &end)
+        .replace("@end_date", &end)
 }
 
 /// Generates CREATE OR REPLACE VIEW SQL for a transformation model.
@@ -1912,6 +1908,17 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
         // Direct unit test for the placeholder substitution helper.
         let win = april_7_window();
         let sql = "SELECT * FROM t WHERE ts >= @start_date AND ts < @end_date";
+        let out = substitute_partition_placeholders(sql, &win);
+        assert_eq!(
+            out,
+            "SELECT * FROM t WHERE ts >= '2026-04-07 00:00:00' AND ts < '2026-04-08 00:00:00'"
+        );
+    }
+
+    #[test]
+    fn test_substitute_partition_placeholders_does_not_double_quote() {
+        let win = april_7_window();
+        let sql = "SELECT * FROM t WHERE ts >= '@start_date' AND ts < '@end_date'";
         let out = substitute_partition_placeholders(sql, &win);
         assert_eq!(
             out,


### PR DESCRIPTION
## Summary

- preserve already-single-quoted time-window placeholders when substituting partition timestamps
- keep the documented bare `@start_date` and `@end_date` form unchanged
- correct the BigQuery, Databricks, DuckDB, and Snowflake bootstrap SQL snapshots

## Root cause

`substitute_partition_placeholders` always inserted a quoted timestamp literal. When a model already wrote `'@start_date'` or `'@end_date'`, the surrounding quotes remained and Rocky generated invalid doubled quotes such as `''1900-01-01 00:00:00''`.

The shared substitution helper now normalizes the exactly quoted form before replacing bare placeholders, covering both normal partition generation and bootstrap SQL.

## Impact

Quoted time-window placeholders now generate valid SQL instead of failing at execution time. Existing models using the documented bare placeholders retain the same output.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p rocky-core` (1,640 unit tests passed; integration and doc tests passed)
- `cargo test -p rocky-cli --test ir_golden` (4 passed)
- `cargo clippy -p rocky-core --lib --no-deps -- -D warnings`
- executed the corrected DuckDB bootstrap golden against an in-memory catalog and source table

The workspace-wide clippy command is locally blocked on Rust 1.93.1 by pre-existing `unused_assignments` diagnostics in the miette-derived `rocky-sql` and `rocky-lang` error types; the latest canonical `main` Engine CI run is green.

Closes #1150
