### PR TITLE
fix(engine): fail closed on compare read errors

### DIFF
--- a/engine/crates/rocky-cli/src/commands/branch.rs
+++ b/engine/crates/rocky-cli/src/commands/branch.rs
@@ -185,9 +185,8 @@ pub fn run_branch_list(state_path: &Path, json: bool) -> Result<()> {
 /// whose `schema_override` points at the branch's schema. Mirrors how
 /// `rocky run --branch <name>` wires the same prefix into the write path.
 ///
-/// Branches with no materialized tables yet surface as missing rows/columns
-/// on the production side of the diff rather than crashing — the underlying
-/// compare path uses `unwrap_or_default` for describe/count failures.
+/// Branches with no materialized tables yet surface as failed comparisons
+/// rather than crashing.
 pub async fn run_branch_compare(
     state_path: &Path,
     config_path: &Path,

--- a/engine/crates/rocky-cli/src/commands/compare.rs
+++ b/engine/crates/rocky-cli/src/commands/compare.rs
@@ -277,6 +277,13 @@ fn read_or_default<T: Default, E: std::fmt::Display>(
 }
 
 /// Get the row count for a target table.
+///
+/// Returns `Err` when the `COUNT(*)` result is absent or not a non-negative
+/// integer, so a garbled read fails the comparison closed instead of silently
+/// counting as zero. Parsing goes through `cell_as_u64`, which handles the
+/// JSON-integer (Trino), integer-as-string (Databricks/Snowflake/DuckDB), and
+/// integral-float cell shapes adapters return — a bare `as_str()` would drop
+/// numeric cells to `0` and let a real mismatch pass.
 async fn get_row_count(adapter: &dyn WarehouseAdapter, target: &TargetRef) -> Result<u64> {
     let table_name = target
         .validated_full_name()
@@ -286,11 +293,8 @@ async fn get_row_count(adapter: &dyn WarehouseAdapter, target: &TargetRef) -> Re
         .execute_query(&sql)
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;
-    let count = result.rows[0][0]
-        .as_str()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
-    Ok(count)
+    rocky_core::checks::cell_as_u64(result.rows.first().and_then(|row| row.first()))
+        .ok_or_else(|| anyhow::anyhow!("COUNT(*) for {table_name} returned no parseable row count"))
 }
 
 #[cfg(all(test, feature = "duckdb"))]

--- a/engine/crates/rocky-cli/src/commands/compare.rs
+++ b/engine/crates/rocky-cli/src/commands/compare.rs
@@ -101,11 +101,25 @@ pub async fn compare(
             let shadow_target = rocky_core::shadow::shadow_target(&prod_target, shadow_config);
 
             // Get row counts
-            let prod_count = get_row_count(&*adapter, &prod_target).await.unwrap_or(0);
-            let shadow_count = get_row_count(&*adapter, &shadow_target).await.unwrap_or(0);
+            let (prod_count, prod_count_error) = read_or_default(
+                get_row_count(&*adapter, &prod_target).await,
+                &format!(
+                    "failed to read production row count for {}",
+                    prod_target.full_name()
+                ),
+            );
+            let (shadow_count, shadow_count_error) = read_or_default(
+                get_row_count(&*adapter, &shadow_target).await,
+                &format!(
+                    "failed to read shadow row count for {}",
+                    shadow_target.full_name()
+                ),
+            );
+            let counts_read = prod_count_error.is_none() && shadow_count_error.is_none();
 
             let (row_count_match, row_count_diff, row_count_diff_pct) =
                 compare::compare_row_counts(shadow_count, prod_count);
+            let row_count_match = counts_read && row_count_match;
 
             // Get schemas
             let prod_table_ref = rocky_ir::TableRef {
@@ -119,17 +133,24 @@ pub async fn compare(
                 table: shadow_target.table.clone(),
             };
 
-            let prod_cols = adapter
-                .describe_table(&prod_table_ref)
-                .await
-                .unwrap_or_default();
-            let shadow_cols = adapter
-                .describe_table(&shadow_table_ref)
-                .await
-                .unwrap_or_default();
+            let (prod_cols, prod_schema_error) = read_or_default(
+                adapter.describe_table(&prod_table_ref).await,
+                &format!(
+                    "failed to read production schema for {}",
+                    prod_target.full_name()
+                ),
+            );
+            let (shadow_cols, shadow_schema_error) = read_or_default(
+                adapter.describe_table(&shadow_table_ref).await,
+                &format!(
+                    "failed to read shadow schema for {}",
+                    shadow_target.full_name()
+                ),
+            );
+            let schemas_read = prod_schema_error.is_none() && shadow_schema_error.is_none();
 
             let schema_diffs = compare::compare_schemas(&shadow_cols, &prod_cols);
-            let schema_match = schema_diffs.is_empty();
+            let schema_match = schemas_read && schema_diffs.is_empty();
 
             // Build comparison result and evaluate
             let comparison = ComparisonResult {
@@ -145,7 +166,20 @@ pub async fn compare(
                 sample_mismatches: vec![],
             };
 
-            let verdict = compare::evaluate_comparison(&comparison, thresholds);
+            let read_failures: Vec<String> = [
+                prod_count_error,
+                shadow_count_error,
+                prod_schema_error,
+                shadow_schema_error,
+            ]
+            .into_iter()
+            .flatten()
+            .collect();
+            let verdict = if read_failures.is_empty() {
+                compare::evaluate_comparison(&comparison, thresholds)
+            } else {
+                ComparisonVerdict::Fail(read_failures)
+            };
 
             let verdict_str = match &verdict {
                 ComparisonVerdict::Pass => "pass",
@@ -232,7 +266,17 @@ pub async fn compare(
     Ok(())
 }
 
-/// Get row count for a target table, returning 0 if table doesn't exist.
+fn read_or_default<T: Default, E: std::fmt::Display>(
+    result: std::result::Result<T, E>,
+    context: &str,
+) -> (T, Option<String>) {
+    match result {
+        Ok(value) => (value, None),
+        Err(error) => (T::default(), Some(format!("{context}: {error}"))),
+    }
+}
+
+/// Get the row count for a target table.
 async fn get_row_count(adapter: &dyn WarehouseAdapter, target: &TargetRef) -> Result<u64> {
     let table_name = target
         .validated_full_name()
@@ -247,4 +291,70 @@ async fn get_row_count(adapter: &dyn WarehouseAdapter, target: &TargetRef) -> Re
         .and_then(|s| s.parse().ok())
         .unwrap_or(0);
     Ok(count)
+}
+
+#[cfg(all(test, feature = "duckdb"))]
+mod tests {
+    use super::*;
+    use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+
+    #[tokio::test]
+    async fn unreadable_target_pair_fails_comparison() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let db_path = temp.path().join("compare.duckdb");
+
+        {
+            let adapter = DuckDbWarehouseAdapter::open(&db_path).expect("open DuckDB");
+            adapter
+                .execute_statement("CREATE SCHEMA raw__orders")
+                .await
+                .expect("create source schema");
+            adapter
+                .execute_statement("CREATE TABLE raw__orders.orders (id INTEGER)")
+                .await
+                .expect("create source table");
+        }
+
+        let config_path = temp.path().join("rocky.toml");
+        let escaped_db_path = db_path.to_string_lossy().replace('\\', "\\\\");
+        std::fs::write(
+            &config_path,
+            format!(
+                r#"
+[adapter]
+type = "duckdb"
+path = "{escaped_db_path}"
+
+[pipeline.poc]
+strategy = "full_refresh"
+
+[pipeline.poc.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.poc.target]
+catalog_template = "compare"
+schema_template = "staging__{{source}}"
+"#
+            ),
+        )
+        .expect("write config");
+
+        let error = compare(
+            &config_path,
+            Some("source=orders"),
+            None,
+            &ShadowConfig::default(),
+            &ComparisonThresholds::default(),
+            false,
+        )
+        .await
+        .expect_err("two unreadable targets must not pass comparison");
+
+        assert!(
+            error.to_string().contains("1 table(s) failed comparison"),
+            "unexpected error: {error:#}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Make `rocky compare` fail closed when either production or shadow row-count
or schema reads fail.

Closes #1152.

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Changes

- Preserve target-read errors while retaining the existing placeholder values
  used by structured compare output.
- Force the table verdict to `fail` whenever any required read failed, instead
  of allowing equal `0` counts and empty schemas to produce `pass`.
- Add a DuckDB regression test that discovers a source while both production
  and shadow targets are absent.
- Update the branch-compare documentation to describe missing materializations
  as failed comparisons.

## Root cause and impact

The CLI discarded row-count and schema errors with `unwrap_or(0)` and
`unwrap_or_default()`. It then evaluated `0` versus `0` and an empty schema
versus an empty schema as exact matches. That could let the validation step
used before shadow promotion report success without reading either target.

This change keeps the existing output schema and missing-target behavior, but
ensures read failures can never produce a passing verdict.

## Test Plan

- `cargo test --all-targets`
- `cargo nextest run --all-features` — 5,378 passed, 102 skipped
- `cargo test -p rocky-cli commands::compare::tests::unreadable_target_pair_fails_comparison -- --exact`
- `cargo fmt -- --check`
- `cargo clippy -p rocky-cli --all-targets --all-features --no-deps -- -D warnings -A unused-assignments -A clippy::collapsible-else-if`

The unmodified workspace-wide `cargo clippy --all-targets --all-features --
-D warnings` command is currently blocked on `main` by pre-existing
`unused_assignments` warnings in generated diagnostic structs and
`collapsible_else_if` warnings in `commands/list.rs`. The patch-scoped
deny-warnings run above is clean.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/), scoped by subproject when relevant (e.g. `feat(engine/rocky-databricks): ...`, `fix(dagster): ...`)
- [x] No `Co-Authored-By` trailers
- [x] If this is a CLI JSON schema or DSL syntax change, all consumers (`integrations/dagster/`, `editors/vscode/`) are updated in this same PR

### Engine (`engine/`)

- [x] `cargo test --all-targets` passes
- [ ] `cargo clippy --all-targets -- -D warnings` is clean
- [x] `cargo fmt --check` passes

### Dagster (`integrations/dagster/`)

- [ ] `uv run pytest` passes
- [ ] `uv run ruff check` is clean
- [ ] `uv run ruff format --check` passes

### VS Code (`editors/vscode/`)

- [ ] `npm run compile` succeeds
- [ ] `npm run test:unit` passes (electron tests run in CI)
- [ ] `npm run lint` is clean
