### PR TITLE
feat(engine): WP-01 PR-F — rollout-independent add-wins freeze markers

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -15555,6 +15555,7 @@
             ],
             "default": {
               "backend": "local",
+              "freeze_marker_writes": false,
               "gcs_bucket": null,
               "gcs_prefix": null,
               "idempotency": {
@@ -16945,6 +16946,11 @@
             ],
             "default": "local",
             "description": "Storage backend: local (default), s3, gcs, valkey, or tiered (valkey + s3 fallback)"
+          },
+          "freeze_marker_writes": {
+            "default": false,
+            "description": "Enable writing durable freeze/unfreeze marker objects (under `<prefix>/freeze/` and `<prefix>/unfreeze/`, beside the remote state file) when `rocky policy freeze` / `unfreeze` run against an object-store backend. Marker reading and enforcement are always on wherever a durable object tier exists; this flag gates only the write side, so a fleet can be upgraded to marker readers everywhere before any marker is written. Default `false`. Requires a backend with a durable object tier (`s3`, `gcs`, or `tiered`).",
+            "type": "boolean"
           },
           "gcs_bucket": {
             "description": "GCS bucket for state persistence",

--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -3798,6 +3798,11 @@
           "default": "local",
           "description": "Storage backend: local (default), s3, gcs, valkey, or tiered (valkey + s3 fallback)"
         },
+        "freeze_marker_writes": {
+          "default": false,
+          "description": "Enable writing durable freeze/unfreeze marker objects (under `<prefix>/freeze/` and `<prefix>/unfreeze/`, beside the remote state file) when `rocky policy freeze` / `unfreeze` run against an object-store backend. Marker reading and enforcement are always on wherever a durable object tier exists; this flag gates only the write side, so a fleet can be upgraded to marker readers everywhere before any marker is written. Default `false`. Requires a backend with a durable object tier (`s3`, `gcs`, or `tiered`).",
+          "type": "boolean"
+        },
         "gcs_bucket": {
           "description": "GCS bucket for state persistence",
           "type": [
@@ -4660,6 +4665,7 @@
       ],
       "default": {
         "backend": "local",
+        "freeze_marker_writes": false,
         "gcs_bucket": null,
         "gcs_prefix": null,
         "idempotency": {

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -2209,6 +2209,10 @@ export interface StateConfig {
    */
   backend?: StateBackend & string;
   /**
+   * Enable writing durable freeze/unfreeze marker objects (under `<prefix>/freeze/` and `<prefix>/unfreeze/`, beside the remote state file) when `rocky policy freeze` / `unfreeze` run against an object-store backend. Marker reading and enforcement are always on wherever a durable object tier exists; this flag gates only the write side, so a fleet can be upgraded to marker readers everywhere before any marker is written. Default `false`. Requires a backend with a durable object tier (`s3`, `gcs`, or `tiered`).
+   */
+  freeze_marker_writes?: boolean;
+  /**
    * GCS bucket for state persistence
    */
   gcs_bucket?: string | null;

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -262,6 +262,10 @@ async fn run_apply_run_plan(
     // the gate reads it, so a cross-pod freeze is enforced (fail-closed). Skipped
     // when the gate won't read the ledger (no policy / empty touched — finding 8).
     sync_remote_ledger_before_gate(&loaded.config, state_path, &touched).await?;
+    // The durable freeze-marker LIST, hoisted beside the ledger sync — a
+    // marker-only freeze (its ledger row erased by a concurrent state upload)
+    // must still deny at this gate. Same guard, fail-closed on transport error.
+    let marker_freezes = marker_freezes_before_gate(&loaded.config, &touched).await?;
     let gate = evaluate_apply_policy_with_policy(
         loaded.config.policy.as_ref(),
         plan_id,
@@ -269,6 +273,7 @@ async fn run_apply_run_plan(
         &touched,
         models_dir,
         state_path,
+        &marker_freezes,
     );
     apply_policy_gate(root, plan_id, gate)?;
 
@@ -889,6 +894,79 @@ fn sync_remote_ledger_before_gate_blocking(
     Ok(())
 }
 
+/// Resolve the durable-tier object-store provider for a governed gate's
+/// freeze-marker LIST, or `None` when the gate will not read markers.
+///
+/// Guarded exactly like [`remote_state_backend_for_gate`]: an empty `touched`
+/// set or a missing `[policy]` block means the gate reads nothing, so no LIST
+/// is performed. A backend with no durable object tier (Local, Valkey-only)
+/// also yields `None` — a documented limitation; ledger-row enforcement is
+/// unchanged there. FAIL-CLOSED: with a `[policy]` plane configured, a
+/// provider-resolution failure (e.g. a missing bucket) is an `Err` — an
+/// unresolvable durable tier means an active freeze marker cannot be seen.
+fn marker_gate_provider(
+    cfg: &rocky_core::config::RockyConfig,
+    touched: &BTreeMap<String, PolicyCapability>,
+) -> Result<Option<rocky_core::object_store::ObjectStoreProvider>> {
+    if touched.is_empty() || cfg.policy.is_none() {
+        return Ok(None);
+    }
+    rocky_core::state_sync::durable_tier_provider(&cfg.state).with_context(|| {
+        "refusing a governed mutation: the durable `[state]` tier for freeze markers could not \
+         be resolved, so an active freeze marker cannot be seen (fail-closed)"
+    })
+}
+
+/// Async: durable-tier freeze-marker LIST + projection for a governed gate.
+///
+/// Returns the projected active marker set the caller threads into the
+/// `evaluate_apply_policy*` stack (which is synchronous — the async LIST
+/// hoists to each async command entry, beside the pre-gate ledger sync).
+/// Guarded like [`sync_remote_ledger_before_gate`]: empty `touched` or no
+/// `[policy]` ⇒ the gate reads nothing ⇒ `Ok(vec![])`; no durable tier
+/// (Local / Valkey-only) ⇒ `Ok(vec![])` — documented limitation. FAIL-CLOSED:
+/// with a `[policy]` plane configured and a durable tier present, a LIST/GET
+/// transport failure is an `Err` — an error is never an empty active set.
+///
+/// `pub` (not `pub(crate)`) because the MCP `propose`/draft gates hoist the
+/// same LIST out-of-crate, mirroring `evaluate_apply_policy`'s visibility.
+pub async fn marker_freezes_before_gate(
+    cfg: &rocky_core::config::RockyConfig,
+    touched: &BTreeMap<String, PolicyCapability>,
+) -> Result<Vec<rocky_core::freeze_marker::ActiveMarkerFreeze>> {
+    let Some(provider) = marker_gate_provider(cfg, touched)? else {
+        return Ok(Vec::new());
+    };
+    rocky_core::freeze_marker::load_active_marker_freezes(&provider)
+        .await
+        .with_context(marker_list_fail_closed_context)
+}
+
+/// Blocking sibling of [`marker_freezes_before_gate`] for the SYNC promote
+/// gate ([`gate_promote_plan`]) — drives the same LIST on a dedicated
+/// state-sync runtime (mirrors [`sync_remote_ledger_before_gate_blocking`]).
+fn marker_freezes_before_gate_blocking(
+    cfg: &rocky_core::config::RockyConfig,
+    touched: &BTreeMap<String, PolicyCapability>,
+) -> Result<Vec<rocky_core::freeze_marker::ActiveMarkerFreeze>> {
+    let Some(provider) = marker_gate_provider(cfg, touched)? else {
+        return Ok(Vec::new());
+    };
+    crate::commands::policy::block_on_state_sync(async {
+        rocky_core::freeze_marker::load_active_marker_freezes(&provider)
+            .await
+            .map_err(rocky_core::state_sync::StateSyncError::ObjectStore)
+    })
+    .with_context(marker_list_fail_closed_context)
+}
+
+/// The shared fail-closed context for a marker LIST failure at a governed
+/// gate. Mirrors the governed download-fail posture in `run`.
+fn marker_list_fail_closed_context() -> &'static str {
+    "refusing a governed mutation: durable freeze-marker listing failed, so an active freeze \
+     marker cannot be seen (fail-closed). Retry once the `[state]` backend is reachable."
+}
+
 /// Download the remote `[state]` ledger UNCONDITIONALLY for a remote backend
 /// (fail-closed), regardless of `[policy]` presence.
 ///
@@ -979,6 +1057,7 @@ pub fn evaluate_apply_policy(
     touched: &BTreeMap<String, PolicyCapability>,
     models_dir: &Path,
     state_path: &Path,
+    marker_freezes: &[rocky_core::freeze_marker::ActiveMarkerFreeze],
 ) -> PolicyGate {
     // Load the config here for callers that don't already hold a snapshot (gc,
     // the MCP propose gate, tests). Governed apply/restore/promote paths call
@@ -996,6 +1075,7 @@ pub fn evaluate_apply_policy(
         touched,
         models_dir,
         state_path,
+        marker_freezes,
     )
 }
 
@@ -1007,6 +1087,12 @@ pub fn evaluate_apply_policy(
 /// remote-state sync decision AND this evaluation, so a config that gains a
 /// `[policy]` block between the two can't make the guard skip the sync while this
 /// gate then reads stale local decisions (finding A).
+///
+/// `marker_freezes` is the projected durable freeze-marker set the async entry
+/// hoisted via [`marker_freezes_before_gate`] — OR-ed into the freeze breaker
+/// beside the ledger projection so a marker-only freeze (its ledger row erased
+/// by a concurrent state upload) still denies.
+#[allow(clippy::too_many_arguments)]
 pub fn evaluate_apply_policy_with_policy(
     policy: Option<&rocky_core::config::PolicyConfig>,
     plan_id: &str,
@@ -1014,6 +1100,7 @@ pub fn evaluate_apply_policy_with_policy(
     touched: &BTreeMap<String, PolicyCapability>,
     models_dir: &Path,
     state_path: &Path,
+    marker_freezes: &[rocky_core::freeze_marker::ActiveMarkerFreeze],
 ) -> PolicyGate {
     let (policy, attrs_map) = match resolve_policy_and_attrs(policy, touched, models_dir) {
         Ok(pair) => pair,
@@ -1059,6 +1146,7 @@ pub fn evaluate_apply_policy_with_policy(
         touched,
         &attrs_map,
         &prior_decisions,
+        marker_freezes,
         snapshot_unreadable,
         |record| {
             // Durability is critical only when THIS record's WINNING rule uses an
@@ -1176,6 +1264,7 @@ pub(crate) fn evaluate_apply_policy_with_store(
     touched: &BTreeMap<String, PolicyCapability>,
     models_dir: &Path,
     ledger: &StateStore,
+    marker_freezes: &[rocky_core::freeze_marker::ActiveMarkerFreeze],
 ) -> PolicyGate {
     // Finding 1: takes the SAME `[policy]` snapshot `run` already holds (its L1212
     // `rocky_cfg`), not a reload — the in-run replication gate must evaluate the
@@ -1198,6 +1287,7 @@ pub(crate) fn evaluate_apply_policy_with_store(
         touched,
         &attrs_map,
         &prior_decisions,
+        marker_freezes,
         snapshot_unreadable,
         |record| {
             if let Err(e) = ledger.record_policy_decision(record) {
@@ -1249,6 +1339,11 @@ fn evaluate_apply_policy_core(
     touched: &BTreeMap<String, PolicyCapability>,
     attrs_map: &BTreeMap<String, ModelAttributes>,
     prior_decisions: &[PolicyDecisionRecord],
+    // The projected durable freeze-marker set, hoisted at the async command
+    // entry. OR-ed with the ledger freeze projection inside
+    // `autonomy_degradation` — a marker-only freeze must deny even when the
+    // ledger row was erased by a concurrent whole-blob state upload.
+    marker_freezes: &[rocky_core::freeze_marker::ActiveMarkerFreeze],
     // Fail-closed floor: when the snapshot is genuinely unreadable (a corrupt /
     // forward-incompatible store, or a real cross-process run holding a live
     // redb handle so even the read-only open exhausts its retries), an AGENT
@@ -1287,6 +1382,7 @@ fn evaluate_apply_policy_core(
             principal,
             attrs,
             prior_decisions,
+            marker_freezes,
             now,
         );
         let mut reason = decision.reason;
@@ -1977,6 +2073,7 @@ impl GovernedRunContext<'_> {
         target_names: &BTreeSet<String>,
         ledger: &StateStore,
         cfg: &rocky_core::config::RockyConfig,
+        marker_freezes: &[rocky_core::freeze_marker::ActiveMarkerFreeze],
     ) -> Result<()> {
         if target_names.is_empty() {
             return Ok(());
@@ -1998,6 +2095,7 @@ impl GovernedRunContext<'_> {
             &touched,
             &models_dir,
             ledger,
+            marker_freezes,
         );
         apply_policy_gate(self.root, self.plan_id, gate)?;
 
@@ -2070,6 +2168,9 @@ pub(crate) fn gate_promote_plan(
     // `rocky branch promote --plan`) are covered. Fail-closed, but skipped when
     // the gate won't read the ledger (no policy / empty touched — finding 8).
     sync_remote_ledger_before_gate_blocking(&loaded.config, state_path, &touched)?;
+    // Durable freeze-marker LIST beside the ledger sync — one blocking seam
+    // covers both promote entry points (same guard, fail-closed).
+    let marker_freezes = marker_freezes_before_gate_blocking(&loaded.config, &touched)?;
     let gate = evaluate_apply_policy_with_policy(
         loaded.config.policy.as_ref(),
         plan_id,
@@ -2077,6 +2178,7 @@ pub(crate) fn gate_promote_plan(
         &touched,
         &promote_models_dir,
         state_path,
+        &marker_freezes,
     );
     apply_policy_gate(root, plan_id, gate)?;
     Ok(loaded)
@@ -2435,6 +2537,9 @@ async fn run_apply_ai_authored_plan(
     // the gate reads it, so a cross-pod freeze is enforced (fail-closed). Skipped
     // when the gate won't read the ledger (no policy / empty touched — finding 8).
     sync_remote_ledger_before_gate(&loaded.config, state_path, &touched).await?;
+    // Durable freeze-marker LIST, hoisted beside the ledger sync (same guard,
+    // fail-closed) — see the twin note in `run_apply_run_plan`.
+    let marker_freezes = marker_freezes_before_gate(&loaded.config, &touched).await?;
     let gate = evaluate_apply_policy_with_policy(
         loaded.config.policy.as_ref(),
         plan_id,
@@ -2442,6 +2547,7 @@ async fn run_apply_ai_authored_plan(
         &touched,
         models_dir,
         state_path,
+        &marker_freezes,
     );
     match gate {
         PolicyGate::NotConfigured => {
@@ -2633,6 +2739,23 @@ async fn run_apply_backfill_plan(
         ));
     }
 
+    // Durable freeze-marker LIST for the gate below, hoisted here (the `prep`
+    // closure is synchronous) so a fail-closed refusal abandons the session
+    // like every other pre-execution refusal. An absent config has no
+    // `[policy]` to enforce ⇒ empty set.
+    let marker_freezes = match cfg.as_ref() {
+        Some(loaded) => match marker_freezes_before_gate(&loaded.config, &touched).await {
+            Ok(markers) => markers,
+            Err(e) => {
+                session
+                    .abandon("backfill marker listing failure (fail-closed)")
+                    .await;
+                return Err(e);
+            }
+        },
+        None => Vec::new(),
+    };
+
     // Gate + preparation, captured so EVERY pre-execution refusal (policy
     // deny, malformed plan window, snapshot preflight, routing mismatch,
     // unloadable config) consumes the session before returning — a refused
@@ -2653,6 +2776,7 @@ async fn run_apply_backfill_plan(
             &touched,
             models_dir,
             state_path,
+            &marker_freezes,
         );
         if let PolicyGate::Deny {
             model,
@@ -2759,6 +2883,26 @@ async fn run_apply_backfill_plan(
         }
     };
 
+    // Mid-run freeze fence for the rebuild, built from the SAME verified
+    // config snapshot and threaded alongside `exec_fp_gate`. Fail-closed
+    // build errors abandon the session like the other pre-execution refusals.
+    let freeze_fence = match crate::commands::freeze_fence::FreezeFence::build(
+        &loaded.config.state,
+        loaded.config.policy.is_some(),
+        // The same enforcement principal the backfill gate uses (a backfill is
+        // agent-by-kind even when a human applies it) so the fence withholds
+        // exactly what the gate would deny.
+        Some(plan.enforcement_principal(runtime_principal)),
+    ) {
+        Ok(fence) => fence,
+        Err(e) => {
+            session
+                .abandon("backfill freeze-fence build failure (fail-closed)")
+                .await;
+            return Err(e);
+        }
+    };
+
     // Finding 5: a backfill MUTATES the warehouse + local ledger (run/artifact/
     // provenance rows) as it executes, so a mid-run failure can still have
     // committed state. The session moves into `execute_backfill_set`, whose
@@ -2773,6 +2917,7 @@ async fn run_apply_backfill_plan(
         &set,
         &partition_opts,
         exec_fp_gate.as_ref(),
+        Some(&freeze_fence),
         output_json,
     )
     .await
@@ -3871,6 +4016,7 @@ effect = "deny"
             &touched,
             &models_dir,
             &state,
+            &[],
         );
         assert!(
             matches!(gate, PolicyGate::Deny { .. }),
@@ -3885,6 +4031,7 @@ effect = "deny"
             &touched,
             &models_dir,
             &state,
+            &[],
         );
         assert!(
             matches!(gate_none, PolicyGate::NotConfigured),
@@ -3915,6 +4062,7 @@ effect = "deny"
             &touched,
             &dir.path().join("models"),
             &dir.path().join("state.redb"),
+            &[],
         );
         assert!(matches!(gate, PolicyGate::Deny { .. }), "got {gate:?}");
         Ok(())
@@ -3943,6 +4091,7 @@ effect = "deny"
             &touched,
             &dir.path().join("models"),
             &dir.path().join("state.redb"),
+            &[],
         );
         assert_eq!(gate, PolicyGate::Allow);
         Ok(())
@@ -3961,6 +4110,7 @@ effect = "deny"
             &touched,
             &dir.path().join("models"),
             &dir.path().join("state.redb"),
+            &[],
         );
         assert_eq!(gate, PolicyGate::NotConfigured);
         Ok(())
@@ -3994,6 +4144,7 @@ effect = "deny"
             &BTreeMap::new(),
             &dir.path().join("models"),
             &dir.path().join("state.redb"),
+            &[],
         );
         assert_eq!(
             gate,
@@ -4041,6 +4192,7 @@ effect = "deny"
             &touched,
             &dir.path().join("models"),
             &dir.path().join("state.redb"),
+            &[],
         );
         assert!(
             matches!(gate, PolicyGate::Deny { .. }),
@@ -4077,6 +4229,7 @@ effect = "deny"
             &touched,
             &dir.path().join("models"),
             &state,
+            &[],
         );
         assert!(
             matches!(gate, PolicyGate::Deny { .. }),
@@ -4107,6 +4260,7 @@ effect = "deny"
             &touched,
             &dir.path().join("models"),
             &dir.path().join("state.redb"),
+            &[],
         );
         assert_eq!(gate, PolicyGate::Allow, "a human is never gated in v0");
         Ok(())
@@ -4192,6 +4346,7 @@ effect = "deny"
             &touched,
             &models_dir,
             &dir.path().join("state.redb"),
+            &[],
         );
         assert!(
             matches!(gate, PolicyGate::Deny { .. }),
@@ -4240,6 +4395,7 @@ effect = "deny"
             &touched,
             &models_dir,
             &dir.path().join("state.redb"),
+            &[],
         );
         assert!(
             !matches!(gate, PolicyGate::Deny { .. }),
@@ -4296,6 +4452,7 @@ effect = "allow"
             &touched,
             &dir.path().join("models"),
             &dir.path().join("state.redb"),
+            &[],
         );
         assert!(
             matches!(gate, PolicyGate::Deny { .. }),
@@ -4344,6 +4501,7 @@ effect = "allow"
             &touched,
             &dir.path().join("models"),
             &state,
+            &[],
         );
         FileExt::unlock(&external_lock).ok();
         assert!(
@@ -4391,6 +4549,7 @@ effect = "allow"
             &touched,
             &dir.path().join("models"),
             &state,
+            &[],
         );
         assert!(
             matches!(gate, PolicyGate::Deny { .. }),
@@ -4438,6 +4597,7 @@ effect = "allow"
             &touched,
             &dir.path().join("models"),
             &state,
+            &[],
         );
         assert!(
             matches!(gate, PolicyGate::Deny { .. }),
@@ -4466,6 +4626,7 @@ effect = "allow"
             &touched,
             &dir.path().join("models"),
             &state,
+            &[],
         );
         assert_eq!(gate, PolicyGate::Allow, "a human is never gated in v0");
         Ok(())
@@ -5210,12 +5371,12 @@ effect = "deny"
         let loaded_cfg = rocky_core::config::load_rocky_config(&config)?;
         let targets: BTreeSet<String> = ["raw_orders".to_string()].into_iter().collect();
         let err = ctx
-            .gate_replication_targets(&targets, &ledger, &loaded_cfg)
+            .gate_replication_targets(&targets, &ledger, &loaded_cfg, &[])
             .expect_err("an agent replication under a deny rule must be refused");
         assert!(err.to_string().contains("DENIES"), "got: {err}");
 
         // An empty target set is a no-op (nothing executes).
-        ctx.gate_replication_targets(&BTreeSet::new(), &ledger, &loaded_cfg)
+        ctx.gate_replication_targets(&BTreeSet::new(), &ledger, &loaded_cfg, &[])
             .expect("no targets ⇒ nothing to gate");
         Ok(())
     }
@@ -5259,7 +5420,7 @@ effect = "allow"
         let targets: BTreeSet<String> = ["raw_orders".to_string()].into_iter().collect();
 
         // Through the held handle → reads fine → allow (no spurious deny).
-        ctx.gate_replication_targets(&targets, &held, &loaded_cfg)
+        ctx.gate_replication_targets(&targets, &held, &loaded_cfg, &[])
             .expect(
                 "the replication gate must read through the held handle and not spuriously deny \
                  under an `allow` rule",
@@ -5279,6 +5440,7 @@ effect = "allow"
             &touched,
             &dir.path().join("models"),
             &state,
+            &[],
         );
         assert!(
             matches!(reopen_gate, PolicyGate::Deny { .. }),
@@ -5309,7 +5471,7 @@ effect = "allow"
         let loaded_cfg =
             rocky_core::config::load_rocky_config(&dir.path().join("rocky.toml")).unwrap();
         let targets: BTreeSet<String> = ["raw_orders".to_string()].into_iter().collect();
-        ctx.gate_replication_targets(&targets, &ledger, &loaded_cfg)
+        ctx.gate_replication_targets(&targets, &ledger, &loaded_cfg, &[])
             .expect("no [policy] block ⇒ replication gate is a no-op");
         Ok(())
     }
@@ -5348,7 +5510,7 @@ verify_after = ["row_count"]
         };
         let targets: BTreeSet<String> = ["raw_orders".to_string()].into_iter().collect();
         let err = ctx
-            .gate_replication_targets(&targets, &ledger, &loaded_cfg)
+            .gate_replication_targets(&targets, &ledger, &loaded_cfg, &[])
             .expect_err(
                 "a replication apply under a verify_after rule must be refused (finding 7)",
             );
@@ -5393,6 +5555,7 @@ autonomy_budget = { failures = 3, window = "7d" }
             &touched,
             &dir.path().join("models"),
             &state,
+            &[],
         );
         drop(held);
         assert!(
@@ -5450,6 +5613,7 @@ effect = "allow"
             &touched,
             &models,
             &state,
+            &[],
         );
         assert!(
             !matches!(&gate_a, PolicyGate::Deny { reason, .. } if reason.contains("fail-closed")),
@@ -5478,6 +5642,7 @@ autonomy_budget = { failures = 3, window = "7d" }
             &touched,
             &models,
             &state,
+            &[],
         );
         assert!(
             matches!(&gate_b, PolicyGate::Deny { reason, .. } if reason.contains("fail-closed")),

--- a/engine/crates/rocky-cli/src/commands/brief.rs
+++ b/engine/crates/rocky-cli/src/commands/brief.rs
@@ -20,7 +20,7 @@
 //! is the machine surface for a Dagster asset or the governor's own agent.
 
 use std::cmp::Reverse;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
 use anyhow::{Context, Result};
@@ -698,16 +698,21 @@ fn build_budget(ceiling: f64, per_run: &[BriefRunCost]) -> BriefBudgetStatus {
 /// Build the autonomy section: rules whose autonomy budget is exhausted right
 /// now (auto-degraded to `require_review`) and policy freezes in force.
 ///
-/// Freezes come from the ledger alone; budget degradations additionally need
-/// the `[policy]` block to know which rules carry a budget and its window. Both
-/// are current-state projections over the full `decisions` slice. Fails closed:
-/// an unreadable config still shows freezes but notes budgets are unavailable.
+/// Freezes come from two sources, merged: the ledger projection and — when the
+/// `[state]` backend has a durable object tier — the durable freeze-marker
+/// set, so reporting cannot disagree with enforcement (a marker-only freeze,
+/// its ledger row erased by a concurrent state upload, still shows here).
+/// Budget degradations additionally need the `[policy]` block to know which
+/// rules carry a budget and its window. All are current-state projections.
+/// Fails closed: an unreadable config still shows ledger freezes but notes
+/// budgets are unavailable, and an unreachable marker tier sets the section
+/// note rather than silently rendering ledger-only.
 fn build_autonomy(
     config_path: &Path,
     decisions: &[PolicyDecisionRecord],
     now: DateTime<Utc>,
 ) -> BriefAutonomySection {
-    let active_freezes: Vec<BriefActiveFreeze> = policy::active_freezes(decisions)
+    let mut active_freezes: Vec<BriefActiveFreeze> = policy::active_freezes(decisions)
         .into_iter()
         .map(|f| BriefActiveFreeze {
             principal: f.principal,
@@ -720,6 +725,41 @@ fn build_autonomy(
     let cfg = load_rocky_config(config_path).ok();
     let mut degraded_rules: Vec<BriefDegradedRule> = Vec::new();
     let mut note: Option<String> = None;
+
+    // Durable freeze-marker merge. Not gated on `[policy]` presence — the
+    // brief is reporting, and `rocky policy freeze` works without a `[policy]`
+    // block. Skipped when there is no durable object tier (Local /
+    // Valkey-only). Driven on the dedicated state-sync runtime so this is
+    // safe from both the sync CLI arm and the async MCP `estate_brief` tool.
+    let marker_note: Option<String> = match cfg.as_ref() {
+        None => None, // config note below already covers the unloadable case
+        Some(cfg) => match rocky_core::state_sync::durable_tier_provider(&cfg.state) {
+            Ok(None) => None,
+            Ok(Some(provider)) => {
+                let listed = crate::commands::policy::block_on_state_sync(async {
+                    rocky_core::freeze_marker::load_active_marker_freezes(&provider)
+                        .await
+                        .map_err(rocky_core::state_sync::StateSyncError::ObjectStore)
+                });
+                match listed {
+                    Ok(markers) => {
+                        merge_marker_freezes(&mut active_freezes, markers);
+                        None
+                    }
+                    // Never a silent all-clear: an unreadable marker tier is
+                    // surfaced as a note while enforcement fails closed.
+                    Err(e) => Some(format!(
+                        "durable freeze markers unreachable ({e}) — marker freezes not shown; \
+                         enforcement fails closed where `[policy]` is configured"
+                    )),
+                }
+            }
+            Err(e) => Some(format!(
+                "durable `[state]` tier unresolvable ({e}) — marker freezes not shown; \
+                 enforcement fails closed where `[policy]` is configured"
+            )),
+        },
+    };
 
     match cfg.as_ref() {
         Some(cfg) => match &cfg.policy {
@@ -753,6 +793,13 @@ fn build_autonomy(
         }
     }
 
+    // Fold the marker-tier note in — it must survive both availability arms
+    // below (an unreadable marker tier is never an unqualified all-clear).
+    let note = match (note, marker_note) {
+        (Some(a), Some(b)) => Some(format!("{a}; {b}")),
+        (a, b) => a.or(b),
+    };
+
     if degraded_rules.is_empty() && active_freezes.is_empty() {
         return BriefAutonomySection {
             availability: SectionAvailability::NoData,
@@ -769,6 +816,44 @@ fn build_autonomy(
         note,
         degraded_rules,
         active_freezes,
+    }
+}
+
+/// Merge the durable freeze-marker projection into the ledger-projected
+/// freeze list — union with dedupe on `(principal, scope)`, keeping the
+/// ledger entry when both exist (a marker-writing freeze records both). A
+/// marker whose `principal` is `None` (unreadable body, conservatively
+/// matching both principals) maps to one entry per principal — display parity
+/// with enforcement. The marker's `freeze:<freeze_id>` citation fills the
+/// `plan_id` slot, distinguishing marker entries from ledger ones
+/// (`freeze:<principal>:<rfc3339>`).
+fn merge_marker_freezes(
+    active: &mut Vec<BriefActiveFreeze>,
+    markers: Vec<rocky_core::freeze_marker::ActiveMarkerFreeze>,
+) {
+    let existing: BTreeSet<(u8, String)> = active
+        .iter()
+        .map(|f| (principal_rank(f.principal), f.scope.clone()))
+        .collect();
+    for marker in markers {
+        let principals = match marker.principal {
+            Some(p) => vec![p],
+            None => vec![PolicyPrincipal::Agent, PolicyPrincipal::Human],
+        };
+        for principal in principals {
+            if existing.contains(&(principal_rank(principal), marker.scope.clone())) {
+                continue;
+            }
+            active.push(BriefActiveFreeze {
+                principal,
+                scope: marker.scope.clone(),
+                frozen_at: marker
+                    .created_at
+                    .map(|t| t.to_rfc3339())
+                    .unwrap_or_default(),
+                plan_id: format!("freeze:{}", marker.freeze_id),
+            });
+        }
     }
 }
 

--- a/engine/crates/rocky-cli/src/commands/drift_governance.rs
+++ b/engine/crates/rocky-cli/src/commands/drift_governance.rs
@@ -92,6 +92,13 @@ pub(crate) struct DriftGovernor {
     /// budget recorded elsewhere is invisible, so auto-apply must refuse
     /// (fail-closed) rather than proceed with no memory of it.
     ledger_authoritative: bool,
+    /// The durable freeze-marker set projected at run entry, OR-ed into the
+    /// dynamic freeze breaker beside the ledger projection — a marker-only
+    /// freeze (its ledger row erased by a concurrent state upload) must refuse
+    /// auto-apply too. This is the run-entry snapshot; per-`govern` refreshes
+    /// would be one LIST per drifted table, so mid-run freezes are instead
+    /// caught by the run's freeze fence at the documented boundaries.
+    marker_freezes: Vec<rocky_core::freeze_marker::ActiveMarkerFreeze>,
 }
 
 impl DriftGovernor {
@@ -113,6 +120,7 @@ impl DriftGovernor {
         run_id: &str,
         model_name: &str,
         ledger_authoritative: bool,
+        marker_freezes: &[rocky_core::freeze_marker::ActiveMarkerFreeze],
     ) -> Option<Self> {
         if !cfg.resilience.auto_apply_additive_drift {
             return None;
@@ -140,6 +148,7 @@ impl DriftGovernor {
                 policy: None,
                 attrs,
                 ledger_authoritative,
+                marker_freezes: marker_freezes.to_vec(),
             });
         };
         let decision = policy::evaluate(
@@ -163,6 +172,7 @@ impl DriftGovernor {
             policy: Some(policy.clone()),
             attrs,
             ledger_authoritative,
+            marker_freezes: marker_freezes.to_vec(),
         })
     }
 
@@ -228,6 +238,7 @@ impl DriftGovernor {
                             PolicyPrincipal::Agent,
                             &self.attrs,
                             &prior,
+                            &self.marker_freezes,
                             chrono::Utc::now(),
                         );
                         (effect, degradation.reason_suffix())
@@ -661,7 +672,7 @@ mod tests {
         // a breaking change ungoverned. Pre-fix, `build` returned `None` and the
         // `.expect` below panics; post-fix it governs and refuses.
         let cfg = cfg_opt_in_no_policy();
-        let gov = DriftGovernor::build(&cfg, "run-x", "wh.raw.orders", true)
+        let gov = DriftGovernor::build(&cfg, "run-x", "wh.raw.orders", true, &[])
             .expect("opt-in on ⇒ a governor must exist even without a [policy] block");
         assert_eq!(
             gov.effect,
@@ -717,8 +728,8 @@ mod tests {
         // grant ⇒ nothing auto-applies) — recording a require-review custody
         // row and never authorising a mutation.
         let cfg = cfg_opt_in_no_policy();
-        let gov =
-            DriftGovernor::build(&cfg, "run-x", "wh.raw.orders", true).expect("governor present");
+        let gov = DriftGovernor::build(&cfg, "run-x", "wh.raw.orders", true, &[])
+            .expect("governor present");
         let (store, _d) = temp_store();
         let state = Arc::new(store);
 
@@ -960,8 +971,8 @@ mod tests {
     #[tokio::test]
     async fn active_freeze_blocks_auto_apply_even_with_a_granting_rule() {
         let cfg = cfg_opt_in_with_policy(granting_policy(&[], None));
-        let gov =
-            DriftGovernor::build(&cfg, "run-fz", "wh.raw.orders", true).expect("governor present");
+        let gov = DriftGovernor::build(&cfg, "run-fz", "wh.raw.orders", true, &[])
+            .expect("governor present");
         assert_eq!(
             gov.effect,
             PolicyEffect::Allow,
@@ -1000,7 +1011,8 @@ mod tests {
     #[tokio::test]
     async fn human_scoped_freeze_does_not_block_agent_auto_apply() {
         let cfg = cfg_opt_in_with_policy(granting_policy(&[], None));
-        let gov = DriftGovernor::build(&cfg, "run-hfz", "wh.raw.orders", true).expect("governor");
+        let gov =
+            DriftGovernor::build(&cfg, "run-hfz", "wh.raw.orders", true, &[]).expect("governor");
         let (store, _d) = temp_store();
         store
             .record_policy_decision(&freeze_record(PolicyPrincipal::Human, "any"))
@@ -1026,7 +1038,8 @@ mod tests {
             window: "7d".to_string(),
         };
         let cfg = cfg_opt_in_with_policy(granting_policy(&["row_count"], Some(budget)));
-        let gov = DriftGovernor::build(&cfg, "run-b2", "wh.raw.orders", true).expect("governor");
+        let gov =
+            DriftGovernor::build(&cfg, "run-b2", "wh.raw.orders", true, &[]).expect("governor");
         assert_eq!(gov.effect, PolicyEffect::Allow);
 
         let (store, _d) = temp_store();
@@ -1076,7 +1089,8 @@ mod tests {
     async fn auto_heal_verify_failure_burns_the_granting_rules_budget() {
         let policy = granting_policy(&["row_count"], None);
         let cfg = cfg_opt_in_with_policy(policy.clone());
-        let gov = DriftGovernor::build(&cfg, "run-burn", "wh.raw.orders", true).expect("governor");
+        let gov =
+            DriftGovernor::build(&cfg, "run-burn", "wh.raw.orders", true, &[]).expect("governor");
 
         let (store, _d) = temp_store();
         let state = Arc::new(store);
@@ -1145,6 +1159,7 @@ mod tests {
             "run-na",
             "wh.raw.orders",
             /* authoritative */ false,
+            &[],
         )
         .expect("governor");
         let (store, _d) = temp_store();
@@ -1162,7 +1177,8 @@ mod tests {
         );
         // Sanity: the SAME governor with an authoritative ledger applies — proves
         // the refusal is authority-driven, not policy-driven (non-vacuous).
-        let gov_ok = DriftGovernor::build(&cfg, "run-ok", "wh.raw.orders", true).expect("governor");
+        let gov_ok =
+            DriftGovernor::build(&cfg, "run-ok", "wh.raw.orders", true, &[]).expect("governor");
         let (store2, _d2) = temp_store();
         let d2 = gov_ok
             .govern(&additive_add_drift(), "wh.raw.orders", &Arc::new(store2))
@@ -1190,8 +1206,9 @@ mod tests {
         // false: authority alone decides.
         let ledger_authoritative = authority.is_usable();
         assert!(!ledger_authoritative);
-        let gov_dl = DriftGovernor::build(&cfg, "run-dl", "wh.raw.orders", ledger_authoritative)
-            .expect("governor");
+        let gov_dl =
+            DriftGovernor::build(&cfg, "run-dl", "wh.raw.orders", ledger_authoritative, &[])
+                .expect("governor");
         let (store3, _d3) = temp_store();
         let d3 = gov_dl
             .govern(&additive_add_drift(), "wh.raw.orders", &Arc::new(store3))
@@ -1215,7 +1232,8 @@ mod tests {
     #[tokio::test]
     async fn freeze_plus_non_additive_records_deny_not_require_review() {
         let cfg = cfg_opt_in_with_policy(granting_policy(&[], None));
-        let gov = DriftGovernor::build(&cfg, "run-d6", "wh.raw.orders", true).expect("governor");
+        let gov =
+            DriftGovernor::build(&cfg, "run-d6", "wh.raw.orders", true, &[]).expect("governor");
         let (store, _d) = temp_store();
         store
             .record_policy_decision(&freeze_record(PolicyPrincipal::Agent, "any"))

--- a/engine/crates/rocky-cli/src/commands/freeze_fence.rs
+++ b/engine/crates/rocky-cli/src/commands/freeze_fence.rs
@@ -1,0 +1,373 @@
+//! Mid-run freeze fence — fresh durable-tier freeze-marker LISTs at the
+//! documented execution boundaries.
+//!
+//! The gate stack consults the marker set once, at command entry. A freeze
+//! landing *after* that LIST must still fence the run, so the run loop
+//! re-checks at three boundaries: the exec-fingerprint choke-point (governed
+//! paths), each execution-layer boundary, and before the post-run governance
+//! reconcile; the replication fan-out (no layer boundaries) gets one check
+//! bounding the gate-to-copy window. On a fence hit the *remaining* work is
+//! withheld fail-closed while already-committed work's state still flows to
+//! the normal terminal path (persist + finalize upload) — partial failure,
+//! never state loss.
+
+// Fence granularity and the withhold-vs-abandon semantics are specified in
+// docs/adr/ADR-CONCURRENCY.md, section "D3 — Freeze = rollout-independent
+// ADD-WINS MARKER" (gate-to-mutation race).
+
+use anyhow::Result;
+
+use rocky_core::config::{PolicyPrincipal, StateConfig};
+use rocky_core::freeze_marker::{self, ActiveMarkerFreeze};
+use rocky_core::object_store::ObjectStoreProvider;
+use rocky_core::policy::ModelAttributes;
+
+/// Mid-run freeze fence — a COARSE, name-only, principal-aware breaker over
+/// the models that are actually executing. Holds the durable-tier provider
+/// (`None` ⇒ inert — Local / Valkey-only backends have no marker tier, and an
+/// ungoverned run with no `[policy]` plane) plus the executing run's principal.
+/// Every [`Self::check`] performs a FRESH LIST — never a cached set.
+///
+/// The precise principal+scope decision is the ENTRY GATE's job
+/// (`policy::autonomy_degradation`); this fence only catches a freeze that
+/// LANDS after that gate's LIST. It matches name-only: bare
+/// [`ModelAttributes`] resolve `any` and `model=<glob>` selectors, but never
+/// `layer=`/`classification=`/`tag=` — those scoped freezes are deferred to
+/// the entry gate and the next run (see docs/adr/ADR-CONCURRENCY.md D3, "the
+/// next boundary or the next run").
+pub(crate) struct FreezeFence {
+    /// The durable-tier marker provider — `Some` ONLY on a governed run (a
+    /// `[policy]` plane configured); `None` on any ungoverned run and on
+    /// Local / Valkey-only backends. So a present provider always implies
+    /// governed, and every listing failure is therefore fail-closed.
+    provider: Option<ObjectStoreProvider>,
+    /// The executing run's principal, tested against each active marker via
+    /// the SAME predicate the entry gate uses
+    /// ([`rocky_core::policy::marker_freeze_binds`]), so for an AGENT-governed
+    /// run the fence withholds exactly what the gate would deny — an agent-only
+    /// freeze binds the agent, not a different principal.
+    ///
+    /// `None` means the acting principal is unknown, and the fence then binds
+    /// ANY marker principal (the coarse, monotone-safe direction). Note this
+    /// covers TWO cases in v0: a bare `rocky run`, AND a human apply — the
+    /// governed context only exists for agent applies (`governed_run_context`
+    /// returns `None` for non-agents, since "humans are ungated in v0"), so a
+    /// human apply arrives here as `None`. Consequence: while any freeze is
+    /// active, the fence halts a non-agent-governed run too. That is
+    /// over-restriction (monotone-safe per docs/adr/ADR-CONCURRENCY.md D3 — the
+    /// kill switch never fails to engage), but it is STRICTER than the entry
+    /// gate, which leaves humans ungated in v0. Whether the freeze kill switch
+    /// should gate humans at all — and per `--principal` — is a v0 product
+    /// decision left open here; the safe default halts them.
+    run_principal: Option<PolicyPrincipal>,
+}
+
+/// One active marker freeze whose scope matched a fenced name.
+pub(crate) struct FenceHit {
+    /// The matching marker's `freeze_id`.
+    pub freeze_id: String,
+    /// The marker's scope selector (`"any"` for an unreadable body).
+    pub scope: String,
+    /// The marker's human-readable reason.
+    pub reason: String,
+}
+
+impl FreezeFence {
+    /// Build the fence from the run's owned `[state]` snapshot and the
+    /// executing run's principal.
+    ///
+    /// The fence keys on `[policy]` presence, never on the governed-apply
+    /// context: a bare `rocky run` under a `[policy]` plane is fenced too, and
+    /// a run with NO `[policy]` plane is inert — the freeze kill switch
+    /// enforces nothing without a policy plane (the ledger freeze, the apply
+    /// gate, and the drift governor all sit at their no-policy floors), so the
+    /// mid-run fence must not be the lone seam that enforces it. This mirrors
+    /// `rocky policy freeze`'s "recorded but NOT enforced until a `[policy]`
+    /// block exists" contract; no durable-tier resolution is attempted without
+    /// one.
+    ///
+    /// `run_principal` is the acting principal the fence matches against
+    /// (`None` ⇒ unknown, a bare run, binds any marker principal).
+    ///
+    /// Fail-closed (governed only): an unresolvable durable tier (e.g. a
+    /// missing bucket) is an error — an active freeze marker could not be seen.
+    pub(crate) fn build(
+        state_cfg: &StateConfig,
+        policy_configured: bool,
+        run_principal: Option<PolicyPrincipal>,
+    ) -> Result<Self> {
+        if !policy_configured {
+            return Ok(Self {
+                provider: None,
+                run_principal,
+            });
+        }
+        match rocky_core::state_sync::durable_tier_provider(state_cfg) {
+            Ok(provider) => Ok(Self {
+                provider,
+                run_principal,
+            }),
+            Err(e) => Err(anyhow::Error::new(e).context(
+                "refusing a governed run: the durable `[state]` tier for freeze markers could \
+                 not be resolved, so an active freeze marker cannot be seen (fail-closed)",
+            )),
+        }
+    }
+
+    /// Fresh LIST + projection of the full active marker set — the run-entry
+    /// snapshot threaded into the seams that consume a projection (the in-run
+    /// replication gate, the drift auto-apply governor).
+    ///
+    /// A provider is present only on a governed run (see [`Self::build`]), so a
+    /// listing failure is always **fail-closed** — an error is never an empty
+    /// active set. No durable tier (ungoverned run, Local / Valkey-only) ⇒
+    /// empty set.
+    pub(crate) async fn active_snapshot(&self) -> Result<Vec<ActiveMarkerFreeze>> {
+        let Some(provider) = &self.provider else {
+            return Ok(Vec::new());
+        };
+        freeze_marker::load_active_marker_freezes(provider)
+            .await
+            .map_err(|e| {
+                anyhow::Error::new(e).context(
+                    "refusing a governed run: durable freeze-marker listing failed, so an active \
+                     freeze marker cannot be seen (fail-closed). Retry once the `[state]` backend \
+                     is reachable.",
+                )
+            })
+    }
+
+    /// Fresh LIST, then match the active set against `names`.
+    ///
+    /// `None` = clear. `Some(hit)` = an active marker freeze that BINDS any of
+    /// `names` under the shared [`rocky_core::policy::marker_freeze_binds`]
+    /// predicate — name-only and principal-aware. Each name is tested with bare
+    /// [`ModelAttributes`], which resolve `any` and `model=<glob>` selectors;
+    /// `layer=`/`classification=`/`tag=` scoped freezes never bind at the fence
+    /// (they carry no mid-run attribute map — that precision is the entry
+    /// gate's job, deferred to the next run per ADR-CONCURRENCY.md D3). The run
+    /// principal is honoured via the shared predicate: a `Some(p)` run is
+    /// bound only by markers for `p` (or both principals), so an agent-only
+    /// freeze does not withhold a `Some(Human)` run; a `None` principal binds
+    /// any marker principal (see the `run_principal` field for which runs
+    /// arrive as `None` in v0). An empty `names` fences nothing (no LIST).
+    /// Transport failure on a governed run ⇒ `Err` (fail-closed).
+    pub(crate) async fn check<'a>(
+        &self,
+        names: impl Iterator<Item = &'a str>,
+    ) -> Result<Option<FenceHit>> {
+        if self.provider.is_none() {
+            return Ok(None);
+        }
+        let names: Vec<&str> = names.collect();
+        if names.is_empty() {
+            return Ok(None);
+        }
+        let active = self.active_snapshot().await?;
+        for marker in active {
+            let matched = names.iter().any(|name| {
+                let attrs = ModelAttributes {
+                    name: (*name).to_string(),
+                    ..Default::default()
+                };
+                rocky_core::policy::marker_freeze_binds(&marker, self.run_principal, &attrs)
+            });
+            if matched {
+                return Ok(Some(FenceHit {
+                    freeze_id: marker.freeze_id,
+                    scope: marker.scope,
+                    reason: marker.reason,
+                }));
+            }
+        }
+        Ok(None)
+    }
+
+    /// [`Self::check`], folding both a hit and a fail-closed transport error
+    /// into the withhold message the run loop RECORDS (`Some` = withhold,
+    /// `None` = clear) — never an `Err`.
+    ///
+    /// The recorded-failure shape is load-bearing at the mid-run boundaries:
+    /// an `Err` escaping the run body routes to `session.abandon`, stranding
+    /// already-committed layers' local state un-uploaded. Recording instead
+    /// flows to the normal terminal path (persist run record → finalize
+    /// upload), so a fence hit is a partial failure, never state loss.
+    pub(crate) async fn check_withhold<'a>(
+        &self,
+        names: impl Iterator<Item = &'a str>,
+    ) -> Option<String> {
+        match self.check(names).await {
+            Ok(None) => None,
+            Ok(Some(hit)) => Some(format!(
+                "freeze fence: active freeze marker {} (scope '{}', reason: {}) — remaining \
+                 work withheld fail-closed",
+                hit.freeze_id, hit.scope, hit.reason
+            )),
+            Err(e) => Some(format!(
+                "freeze fence: durable freeze-marker listing failed ({e:#}) — an active freeze \
+                 marker cannot be ruled out, remaining work withheld fail-closed"
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rocky_core::config::{PolicyPrincipal, StateBackend, StateConfig};
+    use rocky_core::fault_store::{FaultMode, FaultOp};
+    use rocky_core::freeze_marker::FreezeMarker;
+    use rocky_core::state_sync::remote_testing;
+    use rocky_core::test_harness::CrossPodHarness;
+
+    fn s3_cfg() -> StateConfig {
+        StateConfig {
+            backend: StateBackend::S3,
+            s3_bucket: Some("test".into()),
+            ..StateConfig::default()
+        }
+    }
+
+    async fn seed_marker(harness: &CrossPodHarness, id: &str, scope: &str) {
+        rocky_core::freeze_marker::write_freeze_marker(
+            &harness.provider,
+            &FreezeMarker {
+                freeze_id: id.to_string(),
+                principal: PolicyPrincipal::Agent,
+                scope: scope.to_string(),
+                reason: format!("test freeze {id}"),
+                created_at: chrono::Utc::now(),
+            },
+        )
+        .await
+        .expect("seed marker");
+    }
+
+    /// The gate-to-mutation recheck property: every `check` performs a FRESH
+    /// LIST, so a freeze landing AFTER a clear check is caught by the very
+    /// next one — a cached set would sail past it.
+    #[tokio::test]
+    async fn fence_recheck_catches_freeze_landing_after_gate_list() {
+        let _serial = remote_testing::serial_guard();
+        let harness = CrossPodHarness::new_s3_like();
+        let fence = FreezeFence::build(&s3_cfg(), true, None).expect("build fence");
+
+        assert!(
+            fence
+                .check(["orders"].into_iter())
+                .await
+                .expect("clear check")
+                .is_none(),
+            "no marker yet — the fence must be clear"
+        );
+
+        // The freeze lands between the two checks — the gate-to-mutation race.
+        seed_marker(&harness, "f-race", "any").await;
+
+        let hit = fence
+            .check(["orders"].into_iter())
+            .await
+            .expect("recheck")
+            .expect("the fresh LIST must catch the freeze that landed after the first check");
+        assert_eq!(hit.freeze_id, "f-race");
+        assert_eq!(hit.scope, "any");
+    }
+
+    /// `check_withhold` folds a fail-closed transport failure into the
+    /// RECORDED withhold message — never an `Err` — so the mid-run
+    /// boundaries flow to the terminal persist + finalize path instead of
+    /// `session.abandon`.
+    #[tokio::test]
+    async fn check_withhold_folds_transport_failure_into_recorded_message() {
+        let _serial = remote_testing::serial_guard();
+        let harness = CrossPodHarness::new_s3_like();
+        let fence = FreezeFence::build(&s3_cfg(), true, None).expect("build fence");
+
+        harness.faults.arm(FaultOp::List, FaultMode::FailAll);
+        let msg = fence
+            .check_withhold(["orders"].into_iter())
+            .await
+            .expect("a fail-closed LIST failure must fold into a recorded withhold");
+        harness.faults.clear();
+        assert!(
+            msg.contains("withheld fail-closed"),
+            "the recorded message must state the fail-closed withhold; got: {msg}"
+        );
+    }
+
+    /// With NO `[policy]` plane the fence is inert even on a durable-tier
+    /// backend carrying an active marker: the kill switch enforces nothing
+    /// without a policy plane (matching the ledger / apply-gate / drift-governor
+    /// no-policy floors and `rocky policy freeze`'s "recorded but NOT enforced"
+    /// contract). Inertness is proven by performing NO durable-tier LIST — the
+    /// run path must never be the lone seam that enforces a freeze without a
+    /// policy plane.
+    #[tokio::test]
+    async fn no_policy_fence_is_inert_and_does_not_list() {
+        let _serial = remote_testing::serial_guard();
+        let harness = CrossPodHarness::new_s3_like();
+        seed_marker(&harness, "f-nopolicy", "any").await;
+
+        let fence = FreezeFence::build(&s3_cfg(), false, None).expect("build inert fence");
+        harness.faults.arm(FaultOp::List, FaultMode::FailAll);
+        assert!(
+            fence
+                .check(["orders"].into_iter())
+                .await
+                .expect("an inert fence never errors")
+                .is_none(),
+            "a no-[policy] fence must not enforce an active marker"
+        );
+        assert_eq!(
+            harness.faults.count(FaultOp::List),
+            0,
+            "the inert fence must perform NO durable-tier LIST"
+        );
+        harness.faults.clear();
+    }
+
+    /// The fence honours the run principal exactly as the entry gate does
+    /// (`marker_freeze_binds`): an agent-only freeze must NOT withhold a
+    /// policy-allowed human run, but DOES withhold an agent run; and a bare run
+    /// (unknown principal) binds any marker principal — the coarse fallback.
+    #[tokio::test]
+    async fn fence_is_principal_aware_like_the_gate() {
+        let _serial = remote_testing::serial_guard();
+        let harness = CrossPodHarness::new_s3_like();
+        // `seed_marker` writes an AGENT-scoped `any` freeze.
+        seed_marker(&harness, "f-agent", "any").await;
+
+        // A human run is NOT fenced by an agent-only freeze (matches the gate).
+        let human_fence = FreezeFence::build(&s3_cfg(), true, Some(PolicyPrincipal::Human))
+            .expect("build human fence");
+        assert!(
+            human_fence
+                .check(["orders"].into_iter())
+                .await
+                .expect("human check")
+                .is_none(),
+            "a human run must not be withheld by an agent-only freeze"
+        );
+
+        // An agent run IS fenced by the same freeze.
+        let agent_fence = FreezeFence::build(&s3_cfg(), true, Some(PolicyPrincipal::Agent))
+            .expect("build agent fence");
+        let hit = agent_fence
+            .check(["orders"].into_iter())
+            .await
+            .expect("agent check")
+            .expect("an agent run must be withheld by the agent freeze");
+        assert_eq!(hit.freeze_id, "f-agent");
+
+        // A bare run (unknown principal) binds any marker principal.
+        let bare_fence = FreezeFence::build(&s3_cfg(), true, None).expect("build bare fence");
+        assert!(
+            bare_fence
+                .check(["orders"].into_iter())
+                .await
+                .expect("bare check")
+                .is_some(),
+            "an unknown principal (bare run) must bind any marker principal"
+        );
+    }
+}

--- a/engine/crates/rocky-cli/src/commands/gc.rs
+++ b/engine/crates/rocky-cli/src/commands/gc.rs
@@ -1537,6 +1537,16 @@ pub(crate) async fn run_gc_apply_in_with(
                 })?;
     }
 
+    // Durable freeze-marker LIST for the gate below, hoisted beside the ledger
+    // download above (same guard as the governed apply seams, fail-closed) — a
+    // marker-only freeze whose ledger row was erased by a concurrent state
+    // upload must still deny this gc. An absent config has no `[policy]` to
+    // enforce ⇒ empty set.
+    let marker_freezes = match loaded_cfg.as_ref() {
+        Some(cfg) => crate::commands::apply::marker_freezes_before_gate(cfg, &touched).await?,
+        None => Vec::new(),
+    };
+
     // Finding 1: gate on the SAME `loaded_cfg` snapshot used for the state
     // backend + models-dir above, rather than reloading the config inside
     // `evaluate_apply_policy` — a `rocky.toml` swap between the loads must not let
@@ -1548,6 +1558,7 @@ pub(crate) async fn run_gc_apply_in_with(
         &touched,
         &models_dir,
         state_path,
+        &marker_freezes,
     );
     if let PolicyGate::Deny {
         model,

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -31,6 +31,7 @@ mod estimate;
 mod export_openapi;
 mod export_schemas;
 mod fmt;
+mod freeze_fence;
 mod gc;
 pub mod groups;
 mod history;
@@ -89,8 +90,8 @@ pub use ai::{
 };
 pub use ai_contract::run_ai_contract;
 pub use apply::{
-    PolicyGate, evaluate_apply_policy, evaluate_apply_policy_with_policy, run_apply,
-    run_apply_inline_for_run,
+    PolicyGate, evaluate_apply_policy, evaluate_apply_policy_with_policy,
+    marker_freezes_before_gate, run_apply, run_apply_inline_for_run,
 };
 pub use archive::{run_archive, run_archive_apply, run_archive_catalog};
 pub use audit::{

--- a/engine/crates/rocky-cli/src/commands/policy.rs
+++ b/engine/crates/rocky-cli/src/commands/policy.rs
@@ -25,8 +25,10 @@ use rocky_core::config::{
     ConfigError, PolicyCapability, PolicyConfig, PolicyEffect, PolicyPrincipal, StateBackend,
     StateConfig,
 };
+use rocky_core::freeze_marker::{self, FreezeMarker, FreezeMarkerError, UnfreezeMarker};
 use rocky_core::policy::{self, ModelAttributes};
 use rocky_core::state::{PolicyDecisionRecord, StateStore};
+use rocky_core::state_sync::StateSyncError;
 
 use crate::output::{
     PolicyCheckOutput, PolicyFreezeEntry, PolicyFreezeOutput, PolicyModelAttributes,
@@ -377,6 +379,16 @@ where
     })
 }
 
+/// Map a freeze-marker write error into the state-sync error type
+/// [`block_on_state_sync`] is typed over, preserving the object-store variant
+/// verbatim so transport causes stay legible in the fail-closed context.
+fn marker_error_to_sync(e: FreezeMarkerError) -> StateSyncError {
+    match e {
+        FreezeMarkerError::ObjectStore(inner) => StateSyncError::ObjectStore(inner),
+        other => StateSyncError::Io(std::io::Error::other(other.to_string())),
+    }
+}
+
 /// Execute `rocky policy freeze` — the kill switch.
 ///
 /// Flips every matched `(principal, scope)` to `deny` by recording a **freeze
@@ -402,24 +414,30 @@ where
 /// switch, failing loudly beats appearing to engage and then silently
 /// disengaging.
 ///
-/// KNOWN LIMITATION — no-CAS concurrent overwrite (finding 4): this closes only
-/// the *sequential* between-runs clobber. The remote state object is a
-/// whole-file blob published with a plain last-writer-wins upload and **no
-/// compare-and-swap**, so a concurrent writer — e.g. a `rocky run` whose
-/// start-download completed *before* this freeze — can still overwrite the
-/// freeze on its own end-upload (a cross-pod / concurrent-writer lost update).
-/// This narrows the window, it does NOT make concurrent writes safe. A
-/// **reliable cross-pod kill switch** cannot be built on whole-file
-/// last-writer-wins; it needs one of: an atomic **compare-and-swap** publish
-/// (conditional PUT / `If-Match`), a **separate monotonic freeze object** that a
-/// run-upload can never clobber (a freeze marker written to its own key and only
-/// ever OR-ed into the gate), or **serialization** of writers (a lease/lock).
-/// Tracked as a follow-up; out of scope here.
+/// # Durable freeze markers — the un-erasable enforcement half
+///
+/// The seam-scoped sync above closes only the *sequential* between-runs
+/// clobber: the remote state object is a whole-file blob published
+/// last-writer-wins, so a concurrent `rocky run` whose start-download
+/// preceded this freeze can still erase the ledger row on its own end-upload.
+/// The enforcement truth that survives that is a separate **add-wins marker
+/// set** beside the state file (see [`rocky_core::freeze_marker`]): `freeze`
+/// writes one create-once object `<prefix>/freeze/<freeze_id>.json` per
+/// principal, `unfreeze` writes `<prefix>/unfreeze/<unfreeze_id>.json` naming
+/// the exact `freeze_id`s it lifts, and enforcement projects the
+/// order-independent active set from the durable object tier — which a run's
+/// blob upload can never clobber. Marker **writes** are gated by `[state]
+/// freeze_marker_writes` so a fleet can be upgraded to marker readers
+/// everywhere before the first marker is written; reading and enforcement are
+/// always on wherever a durable object tier exists. The ledger row stays as
+/// the audit trail and the feed for the ledger-based apply gate;
+/// compare-and-swap on the row itself is a separate follow-up.
 pub fn run_policy_freeze(
     config_path: &Path,
     state_path: &Path,
     principal: Option<PolicyPrincipal>,
     scope: Option<String>,
+    reason: Option<String>,
     lift: bool,
     json: bool,
 ) -> Result<()> {
@@ -436,7 +454,7 @@ pub fn run_policy_freeze(
     // freeze binds nothing. Recording it is still useful (it takes effect the
     // moment a `[policy]` block is added), so this is a loud warning — stderr +
     // an output note — not an error; the exit code stays 0.
-    let notes = freeze_enforcement_notes(config_path, lift);
+    let mut notes = freeze_enforcement_notes(config_path, lift);
     for note in &notes {
         eprintln!("warning: {note}");
     }
@@ -464,6 +482,29 @@ pub fn run_policy_freeze(
         }
     };
     let remote_state = !matches!(state_cfg.backend, StateBackend::Local);
+
+    // Durable marker writes (two-phase rollout, write side): resolved up
+    // front so a `freeze_marker_writes` flag pointing at a tier that cannot
+    // hold markers aborts BEFORE anything is recorded. Config validation
+    // already rejects the local/valkey-only combinations at load; the
+    // re-check here is defensive. See docs/adr/ADR-CONCURRENCY.md (D3).
+    let marker_provider = if remote_state && state_cfg.freeze_marker_writes {
+        match rocky_core::state_sync::durable_tier_provider(&state_cfg)
+            .context("resolving the durable object tier for freeze markers")?
+        {
+            Some(provider) => Some(provider),
+            None => {
+                bail!(
+                    "[state] freeze_marker_writes = true requires a backend with a durable \
+                     object tier (s3, gcs, or tiered); backend = \"{}\" cannot store durable \
+                     freeze markers",
+                    state_cfg.backend
+                );
+            }
+        }
+    } else {
+        None
+    };
 
     // SEAM-SCOPED SYNC — download half. Pull the authoritative remote ledger
     // (overwriting the local file) BEFORE opening the store, so the freeze is
@@ -493,7 +534,8 @@ pub fn run_policy_freeze(
     };
 
     let mut entries = Vec::new();
-    for p in principals {
+    let mut freeze_markers: Vec<FreezeMarker> = Vec::new();
+    for p in principals.iter().copied() {
         let principal_label = serde_plain(&p);
         // The plan_id carries the principal so a "freeze all" (two records at
         // the same timestamp + scope) does not collide on the ledger key
@@ -504,11 +546,29 @@ pub fn run_policy_freeze(
         } else {
             PolicyEffect::Deny
         };
-        let reason = if lift {
-            format!("policy unfreeze: lifted freeze for {principal_label} on scope '{scope}'")
-        } else {
-            format!("policy freeze: {principal_label} actions on scope '{scope}' frozen to deny")
-        };
+        // The operator-supplied `--reason` is shared by the ledger row and
+        // the durable marker; the synthesized description is the fallback.
+        let reason = reason.clone().unwrap_or_else(|| {
+            if lift {
+                format!("policy unfreeze: lifted freeze for {principal_label} on scope '{scope}'")
+            } else {
+                format!(
+                    "policy freeze: {principal_label} actions on scope '{scope}' frozen to deny"
+                )
+            }
+        });
+        // One durable marker per principal, mirroring the per-principal
+        // ledger rows: fresh UUID, same `now`, same resolved reason. Minted
+        // here, written after the store is dropped (see below).
+        if !lift && marker_provider.is_some() {
+            freeze_markers.push(FreezeMarker {
+                freeze_id: uuid::Uuid::new_v4().to_string(),
+                principal: p,
+                scope: scope.clone(),
+                reason: reason.clone(),
+                created_at: now,
+            });
+        }
         let record = PolicyDecisionRecord {
             timestamp: now,
             plan_id: plan_id.clone(),
@@ -544,6 +604,30 @@ pub fn run_policy_freeze(
     // remote — while the command reports success — would leave every other pod
     // unfrozen. A failed upload aborts (finding 5).
     drop(store);
+
+    // Durable freeze markers are written BEFORE the ledger upload (engage
+    // early): if the blob upload then fails, the un-erasable marker is
+    // already durable — the kill switch engaged even though the command exits
+    // non-zero. Over-enforcement is the monotone-safe direction; the inverse
+    // (unfreeze) writes its marker AFTER the upload, below.
+    if !lift && let Some(provider) = &marker_provider {
+        for marker in &freeze_markers {
+            let key = freeze_marker::freeze_marker_key(&marker.freeze_id);
+            block_on_state_sync(async {
+                freeze_marker::write_freeze_marker(provider, marker)
+                    .await
+                    .map_err(marker_error_to_sync)
+            })
+            .with_context(|| {
+                format!("failed to write durable freeze marker '{key}' (fail-closed)")
+            })?;
+            notes.push(format!(
+                "durable freeze marker written: {key} ({})",
+                serde_plain(&marker.principal)
+            ));
+        }
+    }
+
     if remote_state {
         // WP-01 PR-B (2b): the half-seam owns the forced-`Fail` durability
         // policy (previously a local `StateConfig` clone here).
@@ -555,6 +639,66 @@ pub fn run_policy_freeze(
             ),
         )
         .with_context(|| "failed to upload remote state after recording the policy freeze")?;
+    }
+
+    // The unfreeze marker lands only once the superseding audit row is
+    // durably visible (lift late) — until then other pods keep denying,
+    // which is the safe direction (over-restriction).
+    if lift && let Some(provider) = &marker_provider {
+        // A kill-switch lift must not guess: a LIST/GET transport failure
+        // aborts the command rather than lifting blind.
+        let active = block_on_state_sync(async {
+            freeze_marker::load_active_marker_freezes(provider)
+                .await
+                .map_err(StateSyncError::from)
+        })
+        .context(
+            "failed to list durable freeze markers before lifting; an unfreeze must name the \
+             exact markers it lifts (fail-closed)",
+        )?;
+
+        // Selection mirrors the ledger's `(principal, scope-string)` keying:
+        // exact selector-string equality, not selector-overlap semantics. An
+        // unreadable marker body (conservatively active for both principals
+        // on scope "any") is lifted only by the broadest possible explicit
+        // lift — no `--principal`, scope "any" — the deliberate escape hatch
+        // for a corrupt marker.
+        let covers_both_principals = principals.len() == 2;
+        let lifted_ids: Vec<String> = active
+            .iter()
+            .filter(|m| match m.principal {
+                Some(p) => principals.contains(&p) && m.scope == scope,
+                None => covers_both_principals && scope == "any",
+            })
+            .map(|m| m.freeze_id.clone())
+            .collect();
+
+        if lifted_ids.is_empty() {
+            // Writing a tombstone that lifts nothing would be noise.
+            notes.push("no matching active freeze markers to lift".to_string());
+        } else {
+            let marker = UnfreezeMarker {
+                unfreeze_id: uuid::Uuid::new_v4().to_string(),
+                lifts: lifted_ids,
+                principal: (principals.len() == 1).then_some(principals[0]),
+                // Last use of the `--reason` argument: moved, not cloned.
+                reason,
+                created_at: now,
+            };
+            let key = freeze_marker::unfreeze_marker_key(&marker.unfreeze_id);
+            block_on_state_sync(async {
+                freeze_marker::write_unfreeze_marker(provider, &marker)
+                    .await
+                    .map_err(marker_error_to_sync)
+            })
+            .with_context(|| {
+                format!("failed to write durable unfreeze marker '{key}' (fail-closed)")
+            })?;
+            notes.push(format!(
+                "durable unfreeze marker written: {key} lifting [{}]",
+                marker.lifts.join(", ")
+            ));
+        }
     }
 
     let output = PolicyFreezeOutput {
@@ -922,6 +1066,7 @@ expect = \"deny\"
             &state,
             Some(PolicyPrincipal::Agent),
             None,
+            None,
             false,
             true,
         )
@@ -951,6 +1096,7 @@ expect = \"deny\"
             &path,
             &state,
             Some(PolicyPrincipal::Agent),
+            None,
             None,
             false,
             true,
@@ -1066,6 +1212,7 @@ expcet = \"deny\"
             &state,
             Some(PolicyPrincipal::Agent),
             None,
+            None,
             false,
             true,
         )
@@ -1094,6 +1241,7 @@ expcet = \"deny\"
             &path,
             &state,
             Some(PolicyPrincipal::Agent),
+            None,
             None,
             false,
             true,

--- a/engine/crates/rocky-cli/src/commands/restore.rs
+++ b/engine/crates/rocky-cli/src/commands/restore.rs
@@ -951,6 +951,14 @@ pub(crate) async fn run_restore_apply_in_with(
         "restore apply",
     )
     .await?;
+    // Durable freeze-marker LIST for the gate below (same guard as the
+    // governed apply seams, fail-closed) — a marker-only freeze whose ledger
+    // row was erased by a concurrent state upload must still deny this
+    // restore. An absent config has no `[policy]` to enforce ⇒ empty set.
+    let marker_freezes = match loaded_cfg.as_ref() {
+        Some(cfg) => crate::commands::apply::marker_freezes_before_gate(cfg, &touched).await?,
+        None => Vec::new(),
+    };
     let gate = evaluate_apply_policy_with_policy(
         loaded_cfg.as_ref().and_then(|c| c.policy.as_ref()),
         plan_id,
@@ -958,6 +966,7 @@ pub(crate) async fn run_restore_apply_in_with(
         &touched,
         &models_dir,
         state_path,
+        &marker_freezes,
     );
     if let PolicyGate::Deny {
         model,

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -160,6 +160,21 @@ pub struct PartialFailure {
     pub run_id: String,
 }
 
+/// Sentinel error signalling that `rocky run` completed its terminal state
+/// writes with no successful materialization (`RunStatus::Failure`). The
+/// message keeps the generic exit-1 contract (no `main.rs` mapping); the
+/// TYPE exists so a dispatch site that still holds the arm's remote-state
+/// session (the transformation arm) can distinguish this post-terminal
+/// recorded failure — whose persisted `RunRecord` and recorded errors must
+/// ride the terminal upload via `finalize` — from a pre-terminal hard error,
+/// which must abandon the session without uploading.
+#[derive(Debug, thiserror::Error)]
+#[error("{count} model(s) failed (run_id: {run_id}, see the `errors` array in the JSON output)")]
+pub struct RunFailed {
+    pub count: usize,
+    pub run_id: String,
+}
+
 /// Map a finalized [`RunOutput`]'s derived status onto the CLI exit-code
 /// contract for the transformation / model-only execution paths.
 ///
@@ -181,10 +196,11 @@ pub(crate) fn run_status_exit_result(output: &RunOutput, run_id: &str) -> Result
             run_id: run_id.to_string(),
         }
         .into()),
-        rocky_core::state::RunStatus::Failure => anyhow::bail!(
-            "{} model(s) failed (run_id: {run_id}, see the `errors` array in the JSON output)",
-            output.tables_failed
-        ),
+        rocky_core::state::RunStatus::Failure => Err(RunFailed {
+            count: output.tables_failed,
+            run_id: run_id.to_string(),
+        }
+        .into()),
         _ => Ok(()),
     }
 }
@@ -1508,6 +1524,17 @@ pub async fn run(
         // enforce, so availability wins there (#1089's no-policy no-abort).
         let governed = exec_fp_gate.is_some();
         let governed_with_policy = governed && rocky_cfg.policy.is_some();
+        // Freeze fence (ADR-CONCURRENCY.md D3 fence granularity): fresh
+        // durable-tier marker LISTs at this arm's boundaries — the
+        // exec-fingerprint choke-point / layer boundaries inside
+        // `execute_models` and the pre-governance-reconcile check below. Keys
+        // on `[policy]` presence, never the governed context. Built BEFORE
+        // the session so a fail-closed build error leaks nothing.
+        let freeze_fence = super::freeze_fence::FreezeFence::build(
+            &loaded.config.state,
+            rocky_cfg.policy.is_some(),
+            governed_ctx.map(|c| c.principal),
+        )?;
         let mut model_session = rocky_core::state_sync::RemoteStateSession::new(
             &loaded.config.state,
             state_path,
@@ -1618,6 +1645,7 @@ pub async fn run(
             rocky_cfg.resilience.clone(),
             super::resilience::retry_policy_allows(rocky_cfg),
             exec_fp_gate.as_ref(),
+            Some(&freeze_fence),
             // Finding #4: the `--model` path reconciles no masks.
             false,
         )
@@ -1640,25 +1668,54 @@ pub async fn run(
             // a soft compile/runtime failure returns `Ok`, so `Ok` alone is
             // not enough to authorize governance/manifest writes.
             Ok(snapshot) if output.tables_failed == failures_before => {
-                // Per-model `[governance.tags]` apply (scoped to the built
-                // model). The model-only path is one of the entry points the
-                // SDK / Dagster drive; without this its tags were silently
-                // dropped. Best-effort; no-op on DuckDB's Noop adapter.
-                // #1093: reads the snapshot `execute_models` captured at the
-                // fingerprint gate, never a fresh disk compile.
-                let governance_adapter =
-                    adapter_registry.governance_adapter(&target_adapter_name);
-                apply_model_governance_tags(
-                    &snapshot,
-                    governance_adapter.as_ref(),
-                    Some(target_model),
-                )
-                .await;
-                // Write the recipe-identity attestation into the built table's
-                // warehouse metadata (Databricks Delta TBLPROPERTIES; no-op
-                // elsewhere). Reads the triple off the materialization; never
-                // recomputes it.
-                write_recipe_manifests(&output, governance_adapter.as_ref(), &run_id).await;
+                // Pre-reconcile freeze fence (fresh LIST): a freeze landing
+                // after the model built must withhold the governance
+                // reconcile, recorded as a failure so the terminal path
+                // (persist + session finalize) still runs on the committed
+                // build.
+                if let Some(msg) = freeze_fence
+                    .check_withhold(
+                        // Only the EXECUTING model — the captured snapshot
+                        // carries every COMPILED model, so a freeze on an
+                        // unselected model must not withhold this `--model`
+                        // run's reconcile (the reconcile itself is scoped to
+                        // `target_model` below).
+                        snapshot
+                            .models
+                            .iter()
+                            .map(|m| m.name.as_str())
+                            .filter(|name| *name == target_model),
+                    )
+                    .await
+                {
+                    output.tables_failed += 1;
+                    output.errors.push(crate::output::TableErrorOutput {
+                        asset_key: vec!["<freeze>".to_string()],
+                        error: msg,
+                        failure_kind: crate::output::FailureKind::Unknown,
+                        cooldown_seconds: None,
+                    });
+                } else {
+                    // Per-model `[governance.tags]` apply (scoped to the built
+                    // model). The model-only path is one of the entry points the
+                    // SDK / Dagster drive; without this its tags were silently
+                    // dropped. Best-effort; no-op on DuckDB's Noop adapter.
+                    // #1093: reads the snapshot `execute_models` captured at the
+                    // fingerprint gate, never a fresh disk compile.
+                    let governance_adapter =
+                        adapter_registry.governance_adapter(&target_adapter_name);
+                    apply_model_governance_tags(
+                        &snapshot,
+                        governance_adapter.as_ref(),
+                        Some(target_model),
+                    )
+                    .await;
+                    // Write the recipe-identity attestation into the built table's
+                    // warehouse metadata (Databricks Delta TBLPROPERTIES; no-op
+                    // elsewhere). Reads the triple off the materialization; never
+                    // recomputes it.
+                    write_recipe_manifests(&output, governance_adapter.as_ref(), &run_id).await;
+                }
             }
             // Finding #1: a SOFT model failure (`Ok` but a new failure was
             // recorded) — skip governance/manifest, fall through to the failure
@@ -1840,7 +1897,19 @@ pub async fn run(
             // `expects_models` fail-closed bail — neither opens a store.
             skip_end_of_run_sweep = tx_noop;
             let mut tx_session = None;
+            let mut tx_freeze_fence = None;
             if !tx_noop {
+                // Freeze fence (ADR-CONCURRENCY.md D3): fresh marker LISTs at
+                // this arm's boundaries — layer boundaries inside
+                // `execute_models` plus its pre-reconcile check. Built BEFORE
+                // the session so a fail-closed build error leaks nothing; a
+                // no-op run (no models dir) mutates nothing and needs no
+                // fence.
+                tx_freeze_fence = Some(super::freeze_fence::FreezeFence::build(
+                    &loaded.config.state,
+                    rocky_cfg.policy.is_some(),
+                    governed_ctx.map(|c| c.principal),
+                )?);
                 let mut session = rocky_core::state_sync::RemoteStateSession::new(
                     &loaded.config.state,
                     state_path,
@@ -1920,6 +1989,7 @@ pub async fn run(
                 // values (or inline defaults) at compile time.
                 run_vars,
                 exec_fp_gate.as_ref(),
+                tx_freeze_fence.as_ref(),
                 // Finding #2 (missing-dir): fail closed at the transformation
                 // executor when a governed plan reviewed a non-empty model set but
                 // its models directory is gone. `false` for a bare run.
@@ -1943,12 +2013,30 @@ pub async fn run(
                     return Ok(());
                 }
                 Err(e) => {
-                    // Error exits never uploaded; the `?` this replaces would
-                    // have leaked the session past this arm's return.
+                    // A typed run-status failure (`RunFailed` / the
+                    // `PartialFailure` sentinel) means `run_transformation`
+                    // completed its terminal state writes — the recorded
+                    // errors and the `RunRecord` are already persisted — so
+                    // the session must FINALIZE: the Failure record and any
+                    // committed models' state ride the terminal upload. A
+                    // freeze-fence withhold or a failed model is a partial
+                    // failure, never state loss (docs/adr/ADR-CONCURRENCY.md
+                    // D3); abandoning here stranded the persisted record
+                    // locally, invisible to every other pod. Every other
+                    // error is a pre-terminal hard exit: abandon, never
+                    // upload (the `?` this replaces would have leaked the
+                    // session past this arm's return).
                     if let Some(session) = tx_session {
-                        session
-                            .abandon("transformation exited before terminal state writes")
-                            .await;
+                        if e.is::<RunFailed>() || e.is::<PartialFailure>() {
+                            session.finalize().await.context(
+                                "the run's recorded failure state could not be persisted to \
+                                 the remote [state] backend",
+                            )?;
+                        } else {
+                            session
+                                .abandon("transformation exited before terminal state writes")
+                                .await;
+                        }
                     }
                     return Err(e);
                 }
@@ -2108,6 +2196,23 @@ pub async fn run(
             authority
         }
     };
+
+    // Freeze fence (ADR-CONCURRENCY.md D3 fence granularity): fresh
+    // durable-tier marker LISTs at this run's boundaries — before the
+    // replication fan-out, at each execution-layer boundary inside
+    // `execute_models`, and before the post-run governance reconcile. The
+    // entry snapshot below (ONE LIST) additionally feeds the seams that
+    // consume a projection: the in-run replication gate and the drift
+    // auto-apply governor. Keys on `[policy]` presence, never the governed
+    // context; entry failures are fail-closed under a `[policy]` plane (the
+    // `?` routes to the outer session-abandon wrapper — nothing has executed
+    // yet, so nothing is stranded).
+    let freeze_fence = super::freeze_fence::FreezeFence::build(
+        &loaded.config.state,
+        rocky_cfg.policy.is_some(),
+        governed_ctx.map(|c| c.principal),
+    )?;
+    let entry_marker_freezes = freeze_fence.active_snapshot().await?;
 
     // Build adapter registry and resolve adapters
     let adapter_registry = AdapterRegistry::from_config(rocky_cfg)?;
@@ -2275,7 +2380,15 @@ pub async fn run(
         // Finding 1: thread `run`'s single `rocky_cfg` snapshot into the in-run
         // replication gate so it evaluates `[policy]` / models-dir from the config
         // `run` executed against, not a reload a mid-run swap could redirect.
-        ctx.gate_replication_targets(&replication_targets, &state_store, rocky_cfg)?;
+        // `entry_marker_freezes` is the run-entry durable freeze-marker
+        // projection (ONE LIST, taken above) — a marker-only freeze must deny
+        // here too; mid-run freezes are the fence's job.
+        ctx.gate_replication_targets(
+            &replication_targets,
+            &state_store,
+            rocky_cfg,
+            &entry_marker_freezes,
+        )?;
     }
 
     // --- Sequential: catalog/schema setup + table collection ---
@@ -2779,6 +2892,9 @@ pub async fn run(
                         &run_id,
                         &table.name,
                         ledger_authoritative,
+                        // The run-entry durable freeze-marker projection — a
+                        // marker-only freeze must refuse auto-apply too.
+                        &entry_marker_freezes,
                     ),
                 });
             }
@@ -3114,8 +3230,31 @@ pub async fn run(
         tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).ok();
     let mut interrupted = false;
 
+    // Freeze fence — ONE fresh LIST bounding the gate-to-copy window (the
+    // replication fan-out has no layer boundaries, so this is the documented
+    // recheck for it; no in-fan-out rechecks — the pre-reconcile fence covers
+    // the tail). On a hit (or a fail-closed LIST failure) the copy tasks are
+    // withheld rather than spawned, recorded as a failure so the normal
+    // drain/terminal path (stop-periodic, persist run record, session
+    // finalize) still runs over the committed setup phase.
+    let freeze_withheld = freeze_fence
+        .check_withhold(tables_to_process.iter().map(|t| t.table_name.as_str()))
+        .await;
+    if let Some(msg) = &freeze_withheld {
+        table_errors.push(TableError {
+            asset_key: vec!["<freeze>".to_string()],
+            error: format!(
+                "{msg} — {} replication table task(s) withheld",
+                tables_to_process.len()
+            ),
+            task_index: None,
+            failure_kind: crate::output::FailureKind::Unknown,
+            cooldown_seconds: None,
+        });
+    }
+
     for (idx, task) in tables_to_process.iter().enumerate() {
-        if interrupted {
+        if interrupted || freeze_withheld.is_some() {
             break;
         }
 
@@ -4438,6 +4577,7 @@ pub async fn run(
                     rocky_cfg.resilience.clone(),
                     super::resilience::retry_policy_allows(rocky_cfg),
                     exec_fp_gate.as_ref(),
+                    Some(&freeze_fence),
                     // Finding #4: THE mask-reconciling path — bind the mask.
                     true,
                 )
@@ -4454,7 +4594,7 @@ pub async fn run(
             // governance to the warehouse *despite the gate detecting the change*.
             // On any failure we record it and SKIP all post-model governance
             // below, falling through to the failure payload + non-zero exit.
-            let exec_ok = model_phase_ok(&exec_result, failures_before, output.tables_failed);
+            let mut exec_ok = model_phase_ok(&exec_result, failures_before, output.tables_failed);
             model_phase_clean = exec_ok;
             let governance_snapshot = match exec_result {
                 // #1093: keep the gated snapshot for the reconcile below.
@@ -4482,6 +4622,28 @@ pub async fn run(
                     None
                 }
             };
+
+            // Pre-reconcile freeze fence (fresh LIST): a freeze landing after
+            // the final layer must withhold the mask/classification,
+            // role-graph, and recipe-manifest reconciles below, while the
+            // terminal writes + session finalize run unchanged (recorded
+            // failure, never an `Err` — see the fence's withhold contract).
+            if exec_ok
+                && let Some(snapshot) = &governance_snapshot
+                && let Some(msg) = freeze_fence
+                    .check_withhold(snapshot.models.iter().map(|m| m.name.as_str()))
+                    .await
+            {
+                exec_ok = false;
+                model_phase_clean = false;
+                table_errors.push(TableError {
+                    asset_key: vec!["<freeze>".to_string()],
+                    error: msg,
+                    task_index: None,
+                    failure_kind: crate::output::FailureKind::Unknown,
+                    cooldown_seconds: None,
+                });
+            }
 
             // Governance: column classification + masking reconcile (§1.1 + §1.2).
             // Walks the model set after a successful DAG run and applies
@@ -5489,6 +5651,10 @@ pub(crate) async fn execute_backfill_set(
     partition_opts: &PartitionRunOptions,
     // Governed-apply TOCTOU gate (E) — `Some` for an agent backfill apply.
     exec_fp_gate: Option<&crate::commands::apply::ExecFingerprintGate>,
+    // Mid-run freeze fence, built by the caller from the same verified config
+    // snapshot — threaded like `exec_fp_gate` (see the `execute_models`
+    // parameter docs for the withhold contract).
+    freeze_fence: Option<&super::freeze_fence::FreezeFence>,
     output_json: bool,
 ) -> Result<()> {
     // The whole body runs inside a captured block so EVERY exit — the early
@@ -5605,6 +5771,7 @@ pub(crate) async fn execute_backfill_set(
             rocky_cfg.resilience.clone(),
             super::resilience::retry_policy_allows(rocky_cfg),
             exec_fp_gate,
+            freeze_fence,
             // Finding #4: a backfill reconciles only tags, not masks.
             false,
         )
@@ -5613,23 +5780,58 @@ pub(crate) async fn execute_backfill_set(
         match exec_result {
             // Finding #1: only when the model phase is CLEAN (no new soft failures).
             Ok(snapshot) if output.tables_failed == failures_before => {
-                // Re-apply each rebuilt model's `[governance.tags]`, scoped to the
-                // closure so unrelated models are untouched.
-                // #1093: every iteration reuses the ONE snapshot captured at
-                // the fingerprint gate inside `execute_models` — the old
-                // signature fresh-compiled the whole project from disk once
-                // PER model in the closure (N recompiles), and each of those
-                // compiles could pick up a post-execution sidecar edit.
-                let governance_adapter = adapter_registry.governance_adapter(&target_adapter_name);
-                for model in model_set {
-                    apply_model_governance_tags(
-                        &snapshot,
-                        governance_adapter.as_ref(),
-                        Some(model.as_str()),
-                    )
-                    .await;
+                // Pre-reconcile freeze fence (fresh LIST): a freeze landing
+                // after the rebuild must withhold the governance reconcile,
+                // recorded so the ALWAYS-finalize below still uploads the
+                // committed rebuild state.
+                let fence_withhold = match freeze_fence {
+                    Some(fence) => {
+                        fence
+                            .check_withhold(
+                                // Only the EXECUTING backfill closure — the
+                                // captured snapshot carries every COMPILED
+                                // model, so a freeze on a model outside this
+                                // backfill's `model_set` must not withhold its
+                                // reconcile (the reconcile below iterates
+                                // exactly `model_set`).
+                                snapshot
+                                    .models
+                                    .iter()
+                                    .map(|m| m.name.as_str())
+                                    .filter(|name| model_set.contains(*name)),
+                            )
+                            .await
+                    }
+                    None => None,
+                };
+                if let Some(msg) = fence_withhold {
+                    output.tables_failed += 1;
+                    output.errors.push(crate::output::TableErrorOutput {
+                        asset_key: vec!["<freeze>".to_string()],
+                        error: msg,
+                        failure_kind: crate::output::FailureKind::Unknown,
+                        cooldown_seconds: None,
+                    });
+                } else {
+                    // Re-apply each rebuilt model's `[governance.tags]`, scoped to the
+                    // closure so unrelated models are untouched.
+                    // #1093: every iteration reuses the ONE snapshot captured at
+                    // the fingerprint gate inside `execute_models` — the old
+                    // signature fresh-compiled the whole project from disk once
+                    // PER model in the closure (N recompiles), and each of those
+                    // compiles could pick up a post-execution sidecar edit.
+                    let governance_adapter =
+                        adapter_registry.governance_adapter(&target_adapter_name);
+                    for model in model_set {
+                        apply_model_governance_tags(
+                            &snapshot,
+                            governance_adapter.as_ref(),
+                            Some(model.as_str()),
+                        )
+                        .await;
+                    }
+                    write_recipe_manifests(&output, governance_adapter.as_ref(), &run_id).await;
                 }
-                write_recipe_manifests(&output, governance_adapter.as_ref(), &run_id).await;
             }
             // Soft model failure — skip governance/manifest, fall through.
             Ok(_) => {}
@@ -5965,6 +6167,15 @@ pub(crate) async fn execute_models(
     // EXACT set about to execute and refuses (fail-closed) on mismatch —
     // checked == executed. `None` for bare `rocky run` and human applies.
     exec_fp_gate: Option<&crate::commands::apply::ExecFingerprintGate>,
+    // Mid-run freeze fence (ADR-CONCURRENCY.md D3 fence granularity): a fresh
+    // durable freeze-marker LIST at the exec-fingerprint choke-point and at
+    // each execution-layer boundary. On a hit (or a fail-closed LIST failure)
+    // the remaining layers are withheld as a RECORDED failure and this
+    // function returns `Ok` — never `Err` — so already-committed layers'
+    // state flows to the caller's terminal persist + session finalize instead
+    // of being abandoned. `None` on the inert paths (`rocky local` / watch /
+    // tests), which build no fence.
+    freeze_fence: Option<&super::freeze_fence::FreezeFence>,
     // Finding #4: `true` ONLY at the full replication `--all` call site, the sole
     // path that reconciles masks post-model. On every other path (model-only,
     // backfill, the transformation route) masking is NOT reconciled, so the mask
@@ -6085,6 +6296,59 @@ pub(crate) async fn execute_models(
     // `rocky run` loads exactly once, as before — byte-identical.
     let surrogate_keys = rocky_core::models::load_surrogate_keys_from_dir(models_dir)
         .context("invalid surrogate_key configuration")?;
+
+    // Freeze fence at the exec-fingerprint choke-point (governed paths): a
+    // freeze landing between the entry gate's LIST and this execution must
+    // withhold it before any model runs. The governance snapshot is not yet
+    // captured here, so a withhold records the failure and returns the
+    // default (empty) snapshot — mirroring the compile-failure exit above.
+    // Models that failed to compile are excluded from execution (the
+    // `compile_failed_models` set is built just below, after this
+    // choke-point), so a freeze on one must not withhold the run's valid
+    // models here either. Derived locally because that set does not exist yet.
+    let exec_compile_failed: std::collections::BTreeSet<&str> = if compile_result.has_errors {
+        compile_result
+            .diagnostics
+            .iter()
+            .filter(|d| d.is_error())
+            .map(|d| d.model.as_str())
+            .collect()
+    } else {
+        std::collections::BTreeSet::new()
+    };
+    if let Some(gate) = exec_fp_gate
+        && let Some(fence) = freeze_fence
+        && let Some(msg) = fence
+            .check_withhold(
+                // Only the EXECUTING models — the same `model_name_filter` /
+                // `model_set` / compile-failure narrowing the layer loop
+                // applies below — so a freeze on a model this run won't build
+                // (unselected, or failed to compile) never withholds the
+                // models it does build.
+                compile_result
+                    .project
+                    .models
+                    .iter()
+                    .map(|m| m.config.name.as_str())
+                    .filter(|name| model_name_filter.is_none_or(|target| target == *name))
+                    .filter(|name| model_set.is_none_or(|set| set.contains(*name)))
+                    .filter(|name| !exec_compile_failed.contains(name)),
+            )
+            .await
+    {
+        warn!(
+            plan_id = gate.plan_id.as_str(),
+            "freeze fence hit before execution"
+        );
+        output.tables_failed += 1;
+        output.errors.push(crate::output::TableErrorOutput {
+            asset_key: vec!["<freeze>".to_string()],
+            error: msg,
+            failure_kind: crate::output::FailureKind::Unknown,
+            cooldown_seconds: None,
+        });
+        return Ok(GovernanceSnapshot::default());
+    }
 
     // ‼️ Governed-apply TOCTOU gate (E) — the single execution choke-point. The
     // fingerprint is recomputed over the EXACT compiled set about to execute
@@ -6446,6 +6710,44 @@ pub(crate) async fn execute_models(
     };
 
     for layer in execution_layers {
+        // Freeze fence — one fresh LIST per execution-layer boundary
+        // (ADR-CONCURRENCY.md D3 fence granularity): a freeze landing mid-run
+        // withholds this and all remaining layers fail-closed. The `Ok`
+        // return is load-bearing: it flows to the caller's terminal persist +
+        // session finalize, so already-committed layers' state is uploaded —
+        // partial failure, never state loss (an `Err` would route to
+        // `session.abandon`). A fail-closed LIST failure records the same
+        // withhold.
+        if let Some(fence) = freeze_fence
+            && let Some(msg) = fence
+                .check_withhold(
+                    // Only this layer's SELECTED, COMPILABLE names — the same
+                    // `model_name_filter` / `model_set` / compile-failure
+                    // narrowing the matched set below applies — so a freeze on
+                    // a model this run won't actually build (unselected, or one
+                    // that failed to compile) never withholds the models it
+                    // does build.
+                    layer
+                        .iter()
+                        .filter(|name| {
+                            model_name_filter.is_none_or(|target| target == name.as_str())
+                        })
+                        .filter(|name| model_set.is_none_or(|set| set.contains(name.as_str())))
+                        .filter(|name| !compile_failed_models.contains(name.as_str()))
+                        .map(String::as_str),
+                )
+                .await
+        {
+            output.tables_failed += 1;
+            output.errors.push(crate::output::TableErrorOutput {
+                asset_key: vec!["<freeze>".to_string()],
+                error: msg,
+                failure_kind: crate::output::FailureKind::Unknown,
+                cooldown_seconds: None,
+            });
+            return Ok(governance_snapshot);
+        }
+
         // Collect this layer's matched models (honouring the name filter),
         // tagged with their stable within-layer index so concurrent results
         // can be re-ordered to match serial output exactly.
@@ -13149,6 +13451,7 @@ merge_keys = ["id"]
             rocky_core::config::ResilienceConfig::default(),
             true,
             None, // exec_fp_gate (test)
+            None, // freeze_fence (test)
             false,
         )
         .await;
@@ -13225,6 +13528,7 @@ merge_keys = ["id"]
             rocky_core::config::ResilienceConfig::default(),
             true,
             Some(&gate),
+            None, // freeze_fence (test)
             false,
         )
         .await;
@@ -13261,6 +13565,7 @@ merge_keys = ["id"]
             rocky_core::config::ResilienceConfig::default(),
             true,
             Some(&gate),
+            None, // freeze_fence (test)
             false,
         )
         .await
@@ -13447,6 +13752,7 @@ merge_keys = ["id"]
             rocky_core::config::ResilienceConfig::default(),
             true,
             Some(&gate),
+            None, // freeze_fence (test)
             reconciles_masks,
         )
         .await
@@ -13686,6 +13992,7 @@ merge_keys = ["id"]
             rocky_core::config::ResilienceConfig::default(),
             true,
             Some(&gate),
+            None, // freeze_fence (test)
             false,
         )
         .await
@@ -13772,6 +14079,7 @@ merge_keys = ["id"]
             rocky_core::config::ResilienceConfig::default(),
             true,
             Some(&gate),
+            None, // freeze_fence (test)
             false,
         )
         .await
@@ -13827,6 +14135,7 @@ merge_keys = ["id"]
             rocky_core::config::ResilienceConfig::default(),
             true,
             Some(&gate),
+            None, // freeze_fence (test)
             false,
         )
         .await
@@ -14014,6 +14323,7 @@ merge_keys = ["id"]
             resilience,
             true,
             None, // exec_fp_gate (test)
+            None, // freeze_fence (test)
             false,
         )
         .await;
@@ -14057,6 +14367,7 @@ merge_keys = ["id"]
             resilience,
             true,
             None, // exec_fp_gate (test)
+            None, // freeze_fence (test)
             false,
         )
         .await;
@@ -14106,6 +14417,7 @@ merge_keys = ["id"]
             resilience,
             true,
             None, // exec_fp_gate (test)
+            None, // freeze_fence (test)
             false,
         )
         .await;
@@ -15185,6 +15497,7 @@ merge_keys = ["id"]
             rocky_core::config::ResilienceConfig::default(),
             true,
             None, // exec_fp_gate (test)
+            None, // freeze_fence (test)
             false,
         )
         .await
@@ -15292,6 +15605,7 @@ merge_keys = ["id"]
             rocky_core::config::ResilienceConfig::default(),
             true,
             None, // exec_fp_gate (test)
+            None, // freeze_fence (test)
             false,
         )
         .await
@@ -15414,6 +15728,7 @@ merge_keys = ["id"]
             rocky_core::config::ResilienceConfig::default(),
             true,
             None, // exec_fp_gate (test)
+            None, // freeze_fence (test)
             false,
         )
         .await;
@@ -15697,6 +16012,7 @@ merge_keys = ["id"]
                 rocky_core::config::ResilienceConfig::default(),
                 true,
                 None, // exec_fp_gate (test)
+                None, // freeze_fence (test)
                 false,
             )
             .await
@@ -15823,6 +16139,7 @@ merge_keys = ["id"]
             rocky_core::config::ResilienceConfig::default(),
             true,
             None, // exec_fp_gate (test)
+            None, // freeze_fence (test)
             false,
         )
         .await
@@ -16799,6 +17116,7 @@ merge_keys = ["id"]
                 rocky_core::config::ResilienceConfig::default(),
                 true,
                 None, // exec_fp_gate (test)
+                None, // freeze_fence (test)
                 false,
             )
             .await

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -108,6 +108,11 @@ pub async fn run_transformation(
     run_vars: &rocky_core::run_vars::RunVars,
     // Governed-apply TOCTOU gate (E) — `Some` for an agent transformation apply.
     exec_fp_gate: Option<&super::apply::ExecFingerprintGate>,
+    // Mid-run freeze fence, built by the dispatch site beside this arm's
+    // session — threaded like `exec_fp_gate` (see the `execute_models`
+    // parameter docs for the withhold contract). `None` only for the no-op
+    // (no-models-dir) dispatch, which executes nothing.
+    freeze_fence: Option<&super::freeze_fence::FreezeFence>,
     // Finding #2 (missing-dir): the governed plan reviewed a non-empty model set,
     // so a missing models directory at execution is a fail-closed error rather than
     // the legitimate no-op silent-skip. `false` for a bare `rocky run` and for a
@@ -173,6 +178,7 @@ pub async fn run_transformation(
                 rocky_cfg.resilience.clone(),
                 super::resilience::retry_policy_allows(rocky_cfg),
                 exec_fp_gate,
+                freeze_fence,
                 // Finding #4: the transformation route reconciles no masks.
                 false,
             )
@@ -182,22 +188,44 @@ pub async fn run_transformation(
                 // Finding #1: only when the model phase is CLEAN (no new soft
                 // failures) — a soft failure returns `Ok`.
                 Ok(snapshot) if output.tables_failed == failures_before => {
-                    // --- Governance: per-model `[governance.tags]` ---
-                    //
-                    // After every model materializes, apply each model's
-                    // `[governance.tags]` to its target securable. `None` filter:
-                    // the full-DAG path builds every model, so every model is
-                    // tagged. Best-effort; no-op on DuckDB's Noop adapter.
-                    // #1093: reads the snapshot `execute_models` captured at the
-                    // fingerprint gate, never a fresh disk compile.
-                    let governance_adapter =
-                        adapter_registry.governance_adapter(&pipeline.target.adapter);
-                    super::run::apply_model_governance_tags(
-                        &snapshot,
-                        governance_adapter.as_ref(),
-                        None,
-                    )
-                    .await;
+                    // Pre-reconcile freeze fence (fresh LIST): a freeze landing
+                    // after the final layer must withhold the governance
+                    // reconcile, recorded so the terminal persist below still
+                    // covers the committed build.
+                    let fence_withhold = match freeze_fence {
+                        Some(fence) => {
+                            fence
+                                .check_withhold(snapshot.models.iter().map(|m| m.name.as_str()))
+                                .await
+                        }
+                        None => None,
+                    };
+                    if let Some(msg) = fence_withhold {
+                        output.tables_failed += 1;
+                        output.errors.push(crate::output::TableErrorOutput {
+                            asset_key: vec!["<freeze>".to_string()],
+                            error: msg,
+                            failure_kind: crate::output::FailureKind::Unknown,
+                            cooldown_seconds: None,
+                        });
+                    } else {
+                        // --- Governance: per-model `[governance.tags]` ---
+                        //
+                        // After every model materializes, apply each model's
+                        // `[governance.tags]` to its target securable. `None` filter:
+                        // the full-DAG path builds every model, so every model is
+                        // tagged. Best-effort; no-op on DuckDB's Noop adapter.
+                        // #1093: reads the snapshot `execute_models` captured at the
+                        // fingerprint gate, never a fresh disk compile.
+                        let governance_adapter =
+                            adapter_registry.governance_adapter(&pipeline.target.adapter);
+                        super::run::apply_model_governance_tags(
+                            &snapshot,
+                            governance_adapter.as_ref(),
+                            None,
+                        )
+                        .await;
+                    }
                 }
                 // Soft model failure — skip governance, fall through.
                 Ok(_) => {}
@@ -1680,6 +1708,7 @@ auto_create_schemas = true
             None, // idempotency_key
             &rocky_core::run_vars::RunVars::new(),
             None,  // exec_fp_gate
+            None,  // freeze_fence
             false, // expects_models
         )
         .await

--- a/engine/crates/rocky-cli/tests/freeze_marker_enforcement.rs
+++ b/engine/crates/rocky-cli/tests/freeze_marker_enforcement.rs
@@ -1,0 +1,1001 @@
+//! WP-01 PR-F integration tests: durable freeze/unfreeze markers — the
+//! rollout-independent kill switch (ADR-CONCURRENCY.md D3).
+//!
+//! Drives the REAL CLI paths (`rocky policy freeze`/`unfreeze`, the governed
+//! apply gate stack, `commands::run`, `compute_brief`) end-to-end against
+//! temp DuckDB projects, with the PR-1 remote-state rig — a fault-injecting
+//! in-memory "S3" installed as the process-global provider override —
+//! standing in for `[state] backend = "s3"`. Each test holds
+//! `remote_testing::serial_guard()` because the override is process-global.
+//!
+//! What is pinned here:
+//! - **Phase-2 write path:** with `[state] freeze_marker_writes = true`,
+//!   `policy freeze` writes one marker per principal (bodies carry
+//!   principal/scope/reason) IN ADDITION to the ledger rows; `unfreeze`
+//!   writes a marker naming the exact `freeze_id`s it lifts.
+//! - **Two-phase default OFF:** with the flag unset no marker is ever
+//!   written — the write path is byte-identical to today's.
+//! - **Phase-1 reader semantics:** marker READING + enforcement are always
+//!   on — a gate denies a seeded marker even when this pod's own write flag
+//!   is off, and a marker-only freeze (no ledger row at all — the erasure
+//!   shape) denies with the `freeze:<id>` citation.
+//! - **Fences:** a marker present at run time withholds the transformation
+//!   layer loop and the replication fan-out fail-closed, while the run still
+//!   persists + finalizes (uploads) — partial failure, never state loss.
+//! - **Fail-closed LIST:** a marker-LIST transport failure refuses a
+//!   `[policy]`-configured run at entry, and warns-and-continues without one.
+//! - **Reader-less pod (negative documentation):** a gate driven with the
+//!   marker projection forced empty ignores a present marker — exactly why
+//!   the two-phase rollout (readers everywhere first) is mandatory.
+//! - **Status parity:** `rocky brief` merges marker-only freezes, and an
+//!   unreachable marker tier is a section note, never a silent all-clear.
+
+#![cfg(feature = "duckdb")]
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use rocky_cli::commands::PolicyGate;
+use rocky_core::config::{PolicyCapability, PolicyPrincipal};
+use rocky_core::fault_store::{FaultMode, FaultOp};
+use rocky_core::freeze_marker::{self, FreezeMarker, UnfreezeMarker};
+use rocky_core::state::{RunStatus, StateStore};
+use rocky_core::state_sync::remote_testing;
+use rocky_core::test_harness::CrossPodHarness;
+use rocky_core::traits::WarehouseAdapter;
+use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+
+/// Drive an async assertion block from a sync `#[test]` body (the freeze
+/// command itself is synchronous).
+fn block_on<T>(fut: impl std::future::Future<Output = T>) -> T {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build assertion runtime")
+        .block_on(fut)
+}
+
+fn seed_marker(id: &str, principal: PolicyPrincipal, scope: &str) -> FreezeMarker {
+    FreezeMarker {
+        freeze_id: id.to_string(),
+        principal,
+        scope: scope.to_string(),
+        reason: format!("test freeze {id}"),
+        created_at: chrono::Utc::now(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// project fixtures
+// ---------------------------------------------------------------------------
+
+/// A `[state]`-only project (no adapter, no pipeline) — the shape
+/// `rocky policy freeze` / `compute_brief` / the gate stack run against.
+/// `extra` lands inside the `[state]` table (e.g. `freeze_marker_writes =
+/// true`); `with_policy` appends a rule-less `[policy]` block.
+struct StateOnlyProject {
+    dir: tempfile::TempDir,
+    config_path: PathBuf,
+    state_path: PathBuf,
+}
+
+impl StateOnlyProject {
+    fn new(extra: &str, with_policy: bool) -> Self {
+        let dir = tempfile::tempdir().expect("create project temp dir");
+        let policy_block = if with_policy {
+            "\n[policy]\nversion = 1\n"
+        } else {
+            ""
+        };
+        let config_path = dir.path().join("rocky.toml");
+        std::fs::write(
+            &config_path,
+            format!(
+                "[state]\nbackend = \"s3\"\ns3_bucket = \"test\"\n{extra}\n\
+                 [state.retry]\nmax_retries = 0\n{policy_block}"
+            ),
+        )
+        .expect("write rocky.toml");
+        let state_path = dir.path().join(".rocky-state.redb");
+        Self {
+            dir,
+            config_path,
+            state_path,
+        }
+    }
+}
+
+/// Seed `raw__acme.orders` in the persistent DuckDB file, dropping the
+/// connection before returning so `rocky run` can reopen the file.
+async fn seed_source(db: &Path) {
+    let a = DuckDbWarehouseAdapter::open(db).expect("seed open");
+    a.execute_statement("CREATE SCHEMA IF NOT EXISTS raw__acme")
+        .await
+        .unwrap();
+    a.execute_statement("DROP TABLE IF EXISTS raw__acme.orders")
+        .await
+        .unwrap();
+    a.execute_statement("CREATE TABLE raw__acme.orders AS SELECT 1 AS id, 'widget' AS name")
+        .await
+        .unwrap();
+}
+
+/// A minimal temp DuckDB replication project with remote `[state]` and an
+/// optional rule-less `[policy]` block (the fence keys on its presence).
+struct ReplicationProject {
+    _dir: tempfile::TempDir,
+    config_path: PathBuf,
+    state_path: PathBuf,
+}
+
+impl ReplicationProject {
+    async fn new(with_policy: bool) -> Self {
+        let dir = tempfile::tempdir().expect("create project temp dir");
+        let db = dir.path().join("wh.duckdb");
+        seed_source(&db).await;
+        let policy_block = if with_policy {
+            "\n[policy]\nversion = 1\n"
+        } else {
+            ""
+        };
+        let config_path = dir.path().join("rocky.toml");
+        std::fs::write(
+            &config_path,
+            format!(
+                r#"
+[adapter]
+type = "duckdb"
+path = "{db}"
+
+[pipeline.poc]
+strategy = "full_refresh"
+
+[pipeline.poc.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.poc.target]
+catalog_template = "wh"
+schema_template = "staging__{{source}}"
+
+[pipeline.poc.target.governance]
+auto_create_schemas = true
+
+[state]
+backend = "s3"
+s3_bucket = "test"
+
+[state.retry]
+max_retries = 0
+{policy_block}"#,
+                db = db.display()
+            ),
+        )
+        .expect("write rocky.toml");
+        let state_path = dir.path().join(".rocky-state.redb");
+        Self {
+            _dir: dir,
+            config_path,
+            state_path,
+        }
+    }
+}
+
+/// A temp DuckDB transformation project with one model (`m1` → `wh.main.m1`),
+/// remote `[state]`, and an optional rule-less `[policy]` block.
+struct ModelProject {
+    _dir: tempfile::TempDir,
+    config_path: PathBuf,
+    state_path: PathBuf,
+    models_dir: PathBuf,
+}
+
+impl ModelProject {
+    fn new(with_policy: bool) -> Self {
+        let dir = tempfile::tempdir().expect("create project temp dir");
+        let db = dir.path().join("wh.duckdb");
+        let models_dir = dir.path().join("models");
+        std::fs::create_dir(&models_dir).expect("create models dir");
+        std::fs::write(models_dir.join("m1.sql"), "SELECT 1 AS id\n").expect("write m1.sql");
+        std::fs::write(
+            models_dir.join("m1.toml"),
+            r#"
+name = "m1"
+
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "wh"
+schema = "main"
+table = "m1"
+"#,
+        )
+        .expect("write m1.toml");
+        let policy_block = if with_policy {
+            "\n[policy]\nversion = 1\n"
+        } else {
+            ""
+        };
+        let config_path = dir.path().join("rocky.toml");
+        std::fs::write(
+            &config_path,
+            format!(
+                r#"
+[adapter.wh]
+type = "duckdb"
+path = "{db}"
+
+[pipeline.silver]
+type = "transformation"
+models = "models/**"
+
+[pipeline.silver.target]
+adapter = "wh"
+
+[state]
+backend = "s3"
+s3_bucket = "test"
+
+[state.retry]
+max_retries = 0
+{policy_block}"#,
+                db = db.display()
+            ),
+        )
+        .expect("write rocky.toml");
+        let state_path = dir.path().join(".rocky-state.redb");
+        Self {
+            _dir: dir,
+            config_path,
+            state_path,
+            models_dir,
+        }
+    }
+}
+
+/// A temp DuckDB transformation project with TWO independent models (`keep`
+/// and `drop`, each `SELECT` → `wh.main.<name>`), remote `[state]`, and a
+/// rule-less `[policy]` block (the fence keys on its presence). Used to prove
+/// the fence sees only the EXECUTING (selected) models.
+struct TwoModelProject {
+    _dir: tempfile::TempDir,
+    config_path: PathBuf,
+    state_path: PathBuf,
+    models_dir: PathBuf,
+}
+
+impl TwoModelProject {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().expect("create project temp dir");
+        let db = dir.path().join("wh.duckdb");
+        let models_dir = dir.path().join("models");
+        std::fs::create_dir(&models_dir).expect("create models dir");
+        for (name, expr) in [("keep", "1"), ("drop", "2")] {
+            std::fs::write(
+                models_dir.join(format!("{name}.sql")),
+                format!("SELECT {expr} AS id\n"),
+            )
+            .expect("write model sql");
+            std::fs::write(
+                models_dir.join(format!("{name}.toml")),
+                format!(
+                    r#"
+name = "{name}"
+
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "wh"
+schema = "main"
+table = "{name}"
+"#
+                ),
+            )
+            .expect("write model toml");
+        }
+        let config_path = dir.path().join("rocky.toml");
+        std::fs::write(
+            &config_path,
+            format!(
+                r#"
+[adapter.wh]
+type = "duckdb"
+path = "{db}"
+
+[pipeline.silver]
+type = "transformation"
+models = "models/**"
+
+[pipeline.silver.target]
+adapter = "wh"
+
+[state]
+backend = "s3"
+s3_bucket = "test"
+
+[state.retry]
+max_retries = 0
+
+[policy]
+version = 1
+"#,
+                db = db.display()
+            ),
+        )
+        .expect("write rocky.toml");
+        let state_path = dir.path().join(".rocky-state.redb");
+        Self {
+            _dir: dir,
+            config_path,
+            state_path,
+            models_dir,
+        }
+    }
+}
+
+/// Drive the real `commands::run` (ungoverned). `models_dir` selects the
+/// transformation shape; `None` lets the replication pipeline resolve.
+/// `model_name_filter` mirrors `rocky run --model <name>`.
+async fn drive_run(
+    config_path: &Path,
+    state_path: &Path,
+    models_dir: Option<&Path>,
+    model_name_filter: Option<&str>,
+    run_id_override: Option<&str>,
+) -> anyhow::Result<()> {
+    let loaded = std::sync::Arc::new(rocky_core::config::load_rocky_config_fingerprinted(
+        config_path,
+    )?);
+    rocky_cli::commands::run(
+        config_path,
+        loaded,
+        None, // filter
+        None, // pipeline_name_arg — single pipeline resolves
+        state_path,
+        None,  // governance_override
+        false, // output_json
+        models_dir,
+        false, // run_all
+        None,  // resume_run_id
+        false, // resume_latest
+        None,  // shadow_config
+        &rocky_cli::commands::PartitionRunOptions::default(),
+        model_name_filter,
+        None, // cache_ttl_override
+        None, // idempotency_key
+        None, // env
+        &rocky_cli::commands::DeferOptions::default(),
+        &rocky_cli::commands::SkipRunOptions::default(),
+        &rocky_core::run_vars::RunVars::new(),
+        run_id_override,
+        None,  // governed_ctx
+        false, // assume_fresh_state
+    )
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// Phase-2 write path (`[state] freeze_marker_writes = true`)
+// ---------------------------------------------------------------------------
+
+/// `policy freeze` with the write flag on: one parseable marker per principal
+/// (fresh UUID key, shared scope/reason), written IN ADDITION to the ledger
+/// rows — the audit trail is unchanged.
+#[test]
+fn policy_freeze_writes_one_marker_per_principal_when_enabled() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+    let project = StateOnlyProject::new("freeze_marker_writes = true\n", false);
+
+    rocky_cli::commands::run_policy_freeze(
+        &project.config_path,
+        &project.state_path,
+        None, // principal — both
+        None, // scope — any
+        Some("stop everything".to_string()),
+        false, // lift
+        false, // json
+    )
+    .expect("a marker-writing freeze succeeds");
+
+    block_on(async {
+        let keys = harness
+            .provider
+            .list("freeze")
+            .await
+            .expect("list marker prefix");
+        assert_eq!(keys.len(), 2, "one marker per principal, got {keys:?}");
+        let mut principals = Vec::new();
+        for key in &keys {
+            let bytes = harness.provider.get(key).await.expect("get marker body");
+            let m: FreezeMarker = serde_json::from_slice(&bytes).expect("marker body must parse");
+            assert_eq!(
+                format!("freeze/{}.json", m.freeze_id),
+                *key,
+                "the body's id must match the key stem"
+            );
+            assert_eq!(m.scope, "any");
+            assert_eq!(
+                m.reason, "stop everything",
+                "--reason rides the marker body"
+            );
+            principals.push(m.principal);
+        }
+        assert!(
+            principals.contains(&PolicyPrincipal::Agent)
+                && principals.contains(&PolicyPrincipal::Human),
+            "a both-principals freeze writes one marker per principal, got {principals:?}"
+        );
+    });
+
+    // The ledger rows are still recorded — markers are IN ADDITION.
+    let store = StateStore::open_read_only(&project.state_path).expect("open ledger");
+    let decisions = store.list_policy_decisions().expect("list decisions");
+    assert_eq!(decisions.len(), 2, "the audit-trail rows are unchanged");
+    assert!(decisions.iter().all(|d| d.plan_id.starts_with("freeze:")));
+}
+
+/// Two-phase default: with `freeze_marker_writes` unset the freeze writes NO
+/// marker objects — the write path is byte-identical to today's (ledger rows
+/// + blob upload only).
+#[test]
+fn policy_freeze_writes_no_markers_by_default() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+    let project = StateOnlyProject::new("", false);
+
+    rocky_cli::commands::run_policy_freeze(
+        &project.config_path,
+        &project.state_path,
+        None,
+        None,
+        None,
+        false,
+        false,
+    )
+    .expect("a default-config freeze succeeds");
+
+    block_on(async {
+        assert!(
+            harness
+                .provider
+                .list("freeze")
+                .await
+                .expect("list freeze prefix")
+                .is_empty()
+                && harness
+                    .provider
+                    .list("unfreeze")
+                    .await
+                    .expect("list unfreeze prefix")
+                    .is_empty(),
+            "with the flag unset no marker object may ever be written"
+        );
+    });
+    assert!(
+        harness.faults.count(FaultOp::Put) >= 1,
+        "the seam-scoped ledger upload itself is unchanged"
+    );
+}
+
+/// `policy unfreeze` resolves WHICH markers it lifts: the written unfreeze
+/// body names exactly the active freeze ids matching `(principal, scope)`,
+/// and the projection is empty afterwards.
+#[test]
+fn policy_unfreeze_writes_marker_referencing_lifted_ids() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+    let project = StateOnlyProject::new("freeze_marker_writes = true\n", false);
+
+    rocky_cli::commands::run_policy_freeze(
+        &project.config_path,
+        &project.state_path,
+        None,
+        None,
+        None,
+        false,
+        false,
+    )
+    .expect("freeze succeeds");
+    let mut frozen_ids: Vec<String> = block_on(async {
+        harness
+            .provider
+            .list("freeze")
+            .await
+            .expect("list freeze prefix")
+    })
+    .into_iter()
+    .map(|k| {
+        k.strip_prefix("freeze/")
+            .and_then(|rest| rest.strip_suffix(".json"))
+            .expect("marker key shape")
+            .to_string()
+    })
+    .collect();
+    frozen_ids.sort();
+    assert_eq!(frozen_ids.len(), 2);
+
+    rocky_cli::commands::run_policy_freeze(
+        &project.config_path,
+        &project.state_path,
+        None,
+        None,
+        Some("all clear".to_string()),
+        true, // lift
+        false,
+    )
+    .expect("unfreeze succeeds");
+
+    block_on(async {
+        let keys = harness
+            .provider
+            .list("unfreeze")
+            .await
+            .expect("list unfreeze prefix");
+        assert_eq!(keys.len(), 1, "one unfreeze marker, got {keys:?}");
+        let bytes = harness.provider.get(&keys[0]).await.expect("get body");
+        let m: UnfreezeMarker = serde_json::from_slice(&bytes).expect("unfreeze body must parse");
+        let mut lifted = m.lifts.clone();
+        lifted.sort();
+        assert_eq!(
+            lifted, frozen_ids,
+            "the unfreeze must name exactly the freeze ids it lifts"
+        );
+        assert!(
+            freeze_marker::load_active_marker_freezes(&harness.provider)
+                .await
+                .expect("project active set")
+                .is_empty(),
+            "the projection must be empty after the lift"
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Phase-1 reader semantics (writes off, enforcement on)
+// ---------------------------------------------------------------------------
+
+/// A pod whose own write flag is OFF still ENFORCES a marker another
+/// (Phase-2) pod wrote: the hoisted gate LIST projects it and the gate
+/// denies. Reader enforcement is unconditional — deploying the reader IS
+/// Phase 1.
+#[tokio::test]
+async fn reader_enforces_marker_with_writes_flag_off() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+    // Flag deliberately UNSET; `[policy]` configured (the gate's guard).
+    let project = StateOnlyProject::new("", true);
+
+    // Another pod's Phase-2 write, simulated via the real marker write path.
+    freeze_marker::write_freeze_marker(
+        &harness.provider,
+        &seed_marker("f-reader", PolicyPrincipal::Agent, "any"),
+    )
+    .await
+    .expect("seed marker");
+
+    let cfg =
+        rocky_core::config::load_rocky_config(&project.config_path).expect("load project config");
+    let mut touched = BTreeMap::new();
+    touched.insert("orders".to_string(), PolicyCapability::Apply);
+
+    let markers = rocky_cli::commands::marker_freezes_before_gate(&cfg, &touched)
+        .await
+        .expect("the gate hoist must project the marker");
+    assert_eq!(markers.len(), 1);
+    assert_eq!(markers[0].freeze_id, "f-reader");
+
+    let gate = rocky_cli::commands::evaluate_apply_policy_with_policy(
+        cfg.policy.as_ref(),
+        "plan-reader",
+        PolicyPrincipal::Agent,
+        &touched,
+        &project.dir.path().join("no-models"),
+        &project.state_path,
+        &markers,
+    );
+    match gate {
+        PolicyGate::Deny { reason, .. } => assert!(
+            reason.contains("freeze:f-reader"),
+            "the deny must cite the marker; got: {reason}"
+        ),
+        other => panic!("a marker freeze must deny even with the write flag off, got {other:?}"),
+    }
+}
+
+/// The erasure shape the marker exists for: NO ledger row anywhere (a
+/// concurrent blob upload erased it, or it never synced) — the marker alone
+/// still denies, citing `freeze:<id>`.
+#[tokio::test]
+async fn marker_only_freeze_denies_gate_with_empty_ledger() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+    let project = StateOnlyProject::new("", true);
+
+    freeze_marker::write_freeze_marker(
+        &harness.provider,
+        &seed_marker("f-marker-only", PolicyPrincipal::Agent, "any"),
+    )
+    .await
+    .expect("seed marker");
+
+    // The prior ledger is genuinely EMPTY — no freeze row exists anywhere.
+    {
+        let store = StateStore::open(&project.state_path).expect("create empty ledger");
+        assert!(store.list_policy_decisions().expect("list").is_empty());
+    }
+
+    let cfg =
+        rocky_core::config::load_rocky_config(&project.config_path).expect("load project config");
+    let mut touched = BTreeMap::new();
+    touched.insert("orders".to_string(), PolicyCapability::Apply);
+    let markers = rocky_cli::commands::marker_freezes_before_gate(&cfg, &touched)
+        .await
+        .expect("gate hoist");
+
+    let gate = rocky_cli::commands::evaluate_apply_policy_with_policy(
+        cfg.policy.as_ref(),
+        "plan-marker-only",
+        PolicyPrincipal::Agent,
+        &touched,
+        &project.dir.path().join("no-models"),
+        &project.state_path,
+        &markers,
+    );
+    match gate {
+        PolicyGate::Deny { reason, .. } => assert!(
+            reason.contains("freeze:f-marker-only"),
+            "a marker-only freeze must deny with the freeze:<id> citation; got: {reason}"
+        ),
+        other => panic!("a marker-only freeze must deny with an empty ledger, got {other:?}"),
+    }
+}
+
+/// NEGATIVE DOCUMENTATION — the reader-less pod. A gate driven with the
+/// marker projection forced empty (`&[]`, the shape of a pre-reader binary
+/// that never LISTs the marker prefixes) IGNORES a marker that is durably
+/// present: the human base effect stays Allow. This is exactly why the
+/// two-phase rollout is mandatory — readers must be deployed to every pod
+/// BEFORE the first marker is written, or a reader-less pod sails past the
+/// kill switch.
+#[tokio::test]
+async fn pre_reader_pod_ignores_marker_documented() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+    let project = StateOnlyProject::new("", true);
+
+    freeze_marker::write_freeze_marker(
+        &harness.provider,
+        &seed_marker("f-unread", PolicyPrincipal::Human, "any"),
+    )
+    .await
+    .expect("seed marker");
+
+    let cfg =
+        rocky_core::config::load_rocky_config(&project.config_path).expect("load project config");
+    let mut touched = BTreeMap::new();
+    touched.insert("orders".to_string(), PolicyCapability::Apply);
+
+    let gate = rocky_cli::commands::evaluate_apply_policy_with_policy(
+        cfg.policy.as_ref(),
+        "plan-pre-reader",
+        PolicyPrincipal::Human,
+        &touched,
+        &project.dir.path().join("no-models"),
+        &project.state_path,
+        &[], // a pre-PR-F pod has no reader code — no projection exists
+    );
+    assert_eq!(
+        gate,
+        PolicyGate::Allow,
+        "a reader-less pod ignores the marker — the gap the mandatory readers-first \
+         rollout phase closes"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// fences: mid-run withhold + finalize (never abandon)
+// ---------------------------------------------------------------------------
+
+/// A marker active at run time withholds the transformation layer loop
+/// fail-closed: the run exits nonzero with the recorded `<freeze>` failure,
+/// AND the terminal path still ran — the run record rides the finalize
+/// upload to the remote (partial failure, never state loss).
+#[tokio::test]
+async fn layer_fence_withholds_remaining_layers_and_finalizes() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+    let project = ModelProject::new(true);
+
+    freeze_marker::write_freeze_marker(
+        &harness.provider,
+        &seed_marker("f-layer", PolicyPrincipal::Agent, "any"),
+    )
+    .await
+    .expect("seed marker");
+
+    let err = drive_run(
+        &project.config_path,
+        &project.state_path,
+        Some(&project.models_dir),
+        None,
+        Some("run-layer-freeze"),
+    )
+    .await
+    .expect_err("a layer-fenced run must exit nonzero");
+    assert!(
+        format!("{err:#}").contains("model(s) failed"),
+        "the exit must be the recorded freeze failure, not an abandon; got: {err:#}"
+    );
+
+    assert!(
+        harness.faults.count(FaultOp::Put) >= 1,
+        "the fenced run must still FINALIZE (upload) — an abandon would strand state"
+    );
+    // The run record rode the finalize upload: a second pod sees the fenced
+    // run as a recorded Failure.
+    let _authority = harness
+        .download(&harness.pod_b)
+        .await
+        .expect("pod B start-download");
+    let store = harness.open_store(&harness.pod_b);
+    let record = store
+        .get_run("run-layer-freeze")
+        .expect("read run record")
+        .expect("the fenced run's record must ride the finalize upload");
+    assert_eq!(
+        record.status,
+        RunStatus::Failure,
+        "every layer was withheld — the run records as a Failure, not a success"
+    );
+}
+
+/// The fence sees only the EXECUTING (selected) models: a `model=drop` freeze
+/// does NOT withhold a `--model keep` run, because the layer loop filters the
+/// fenced names by the same `model_name_filter` the build honours. Paired with
+/// its positive control below: without the executing-set narrowing this run
+/// would have been fenced on the unselected `drop` model.
+#[tokio::test]
+async fn freeze_on_unselected_model_does_not_fence_selected_run() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+    let project = TwoModelProject::new();
+
+    freeze_marker::write_freeze_marker(
+        &harness.provider,
+        &seed_marker("f-drop", PolicyPrincipal::Agent, "model=drop"),
+    )
+    .await
+    .expect("seed marker");
+
+    // Selecting only `keep`: the freeze on the unselected `drop` must not fence.
+    drive_run(
+        &project.config_path,
+        &project.state_path,
+        Some(&project.models_dir),
+        Some("keep"),
+        Some("run-select-keep"),
+    )
+    .await
+    .expect("a model=drop freeze must NOT fence a run that selects only keep");
+}
+
+/// Positive control on the SAME 2-model fixture: a `model=keep` freeze DOES
+/// withhold a `--model keep` run. Proves the filtered fence still fires on a
+/// selected match — so the negative test above narrows away a non-selected
+/// match rather than never reaching the fence at all.
+#[tokio::test]
+async fn freeze_on_selected_model_fences_selected_run() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+    let project = TwoModelProject::new();
+
+    freeze_marker::write_freeze_marker(
+        &harness.provider,
+        &seed_marker("f-keep", PolicyPrincipal::Agent, "model=keep"),
+    )
+    .await
+    .expect("seed marker");
+
+    let err = drive_run(
+        &project.config_path,
+        &project.state_path,
+        Some(&project.models_dir),
+        Some("keep"),
+        Some("run-fence-keep"),
+    )
+    .await
+    .expect_err("a model=keep freeze must fence a run that selects keep");
+    assert!(
+        format!("{err:#}").contains("model(s) failed"),
+        "the exit must be the recorded freeze failure; got: {err:#}"
+    );
+}
+
+/// The replication fan-out fence (no layer boundaries — one check bounding
+/// the gate-to-copy window): a marker active at spawn time withholds every
+/// copy, the run exits nonzero, and the terminal drain/persist/finalize path
+/// still runs.
+#[tokio::test]
+async fn replication_fanout_withholds_and_finalizes() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+    let project = ReplicationProject::new(true).await;
+
+    freeze_marker::write_freeze_marker(
+        &harness.provider,
+        &seed_marker("f-fanout", PolicyPrincipal::Agent, "any"),
+    )
+    .await
+    .expect("seed marker");
+
+    let err = drive_run(
+        &project.config_path,
+        &project.state_path,
+        None,
+        None,
+        Some("run-fanout-freeze"),
+    )
+    .await
+    .expect_err("a fan-out-fenced replication run must exit nonzero");
+    assert!(
+        format!("{err:#}").contains("table(s) failed"),
+        "the exit must be the recorded withhold; got: {err:#}"
+    );
+
+    assert!(
+        harness.faults.count(FaultOp::Put) >= 1,
+        "the fenced replication run must still finalize (upload)"
+    );
+    let _authority = harness
+        .download(&harness.pod_b)
+        .await
+        .expect("pod B start-download");
+    let store = harness.open_store(&harness.pod_b);
+    assert!(
+        store
+            .get_run("run-fanout-freeze")
+            .expect("read run record")
+            .is_some(),
+        "the fenced run's record must ride the finalize upload"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// fail-closed LIST at the run entry
+// ---------------------------------------------------------------------------
+
+/// A marker-LIST transport failure with a `[policy]` plane configured
+/// refuses the run at entry — an error is never an empty active set — and
+/// nothing is uploaded.
+#[tokio::test]
+async fn list_failure_refuses_governed_entry() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+    let project = ReplicationProject::new(true).await;
+
+    harness.faults.arm(FaultOp::List, FaultMode::FailAll);
+    let err = drive_run(&project.config_path, &project.state_path, None, None, None)
+        .await
+        .expect_err("a [policy]-configured run must refuse on a failed marker LIST");
+    harness.faults.clear();
+
+    assert!(
+        format!("{err:#}").contains("durable freeze-marker listing failed"),
+        "the refusal must cite the fail-closed marker LIST; got: {err:#}"
+    );
+    assert_eq!(
+        harness.faults.count(FaultOp::Put),
+        0,
+        "a refused entry must not upload anything"
+    );
+}
+
+/// Without a `[policy]` plane the run fence is INERT — it enforces no freeze
+/// marker (matching the ledger / apply-gate / drift-governor no-policy floors
+/// and `rocky policy freeze`'s "recorded but NOT enforced" contract), so it
+/// performs NO durable-tier LIST at all. Proven here by arming a LIST fault
+/// that never fires: the ungoverned run completes and finalizes normally, and
+/// zero LISTs are attempted. Guards against the run path becoming the lone
+/// seam that enforces a freeze without a policy plane.
+#[tokio::test]
+async fn no_policy_run_fence_is_inert_and_does_not_list() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+    let project = ReplicationProject::new(false).await;
+
+    harness.faults.arm(FaultOp::List, FaultMode::FailAll);
+    drive_run(&project.config_path, &project.state_path, None, None, None)
+        .await
+        .expect("an ungoverned run must not be affected by markers");
+    let lists = harness.faults.count(FaultOp::List);
+    let puts = harness.faults.count(FaultOp::Put);
+    harness.faults.clear();
+
+    assert_eq!(
+        lists, 0,
+        "an ungoverned run's inert fence must perform NO durable-tier marker LIST"
+    );
+    assert!(
+        puts >= 1,
+        "the ungoverned run must complete and finalize normally"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// status parity: `rocky brief`
+// ---------------------------------------------------------------------------
+
+/// A marker-only freeze (no ledger row) shows in the brief's autonomy
+/// section with the `freeze:<id>` citation — reporting cannot disagree with
+/// enforcement.
+#[test]
+fn brief_merges_marker_only_freeze() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+    let project = StateOnlyProject::new("", false);
+
+    block_on(freeze_marker::write_freeze_marker(
+        &harness.provider,
+        &seed_marker("f-brief", PolicyPrincipal::Agent, "any"),
+    ))
+    .expect("seed marker");
+    // The brief needs an existing (empty) state store to project from.
+    drop(StateStore::open(&project.state_path).expect("create state store"));
+
+    let output = rocky_cli::commands::compute_brief(
+        project.dir.path(),
+        &project.state_path,
+        &project.config_path,
+        rocky_cli::commands::BriefSince::Hours24,
+        chrono::Utc::now(),
+    )
+    .expect("compute brief");
+
+    assert_eq!(
+        output.autonomy.active_freezes.len(),
+        1,
+        "the marker-only freeze must surface in the autonomy section"
+    );
+    let shown = &output.autonomy.active_freezes[0];
+    assert_eq!(
+        shown.plan_id, "freeze:f-brief",
+        "the citation slot carries the marker id"
+    );
+    assert_eq!(shown.principal, PolicyPrincipal::Agent);
+    assert_eq!(shown.scope, "any");
+}
+
+/// An unreachable marker tier is surfaced as a section note — never a
+/// silent, unqualified all-clear.
+#[test]
+fn brief_notes_marker_list_failure() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+    let project = StateOnlyProject::new("", false);
+    drop(StateStore::open(&project.state_path).expect("create state store"));
+
+    harness.faults.arm(FaultOp::List, FaultMode::FailAll);
+    let output = rocky_cli::commands::compute_brief(
+        project.dir.path(),
+        &project.state_path,
+        &project.config_path,
+        rocky_cli::commands::BriefSince::Hours24,
+        chrono::Utc::now(),
+    )
+    .expect("the brief itself must still compose");
+    harness.faults.clear();
+
+    let note = output
+        .autonomy
+        .note
+        .as_deref()
+        .expect("an unreachable marker tier must set the section note");
+    assert!(
+        note.contains("durable freeze markers unreachable"),
+        "the note must qualify the all-clear; got: {note}"
+    );
+}

--- a/engine/crates/rocky-cli/tests/remote_state_authority.rs
+++ b/engine/crates/rocky-cli/tests/remote_state_authority.rs
@@ -235,6 +235,7 @@ fn policy_freeze_download_failure_fails_closed() {
         &state_path,
         None,  // principal — both
         None,  // scope — any
+        None,  // reason — synthesized
         false, // lift
         false, // json
     )

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -322,6 +322,14 @@ pub enum ConfigError {
          allow at least one failure before it degrades the rule (use `failures = 1` or higher)"
     )]
     PolicyBudgetZeroFailures { rule_index: usize },
+
+    #[error(
+        "[state] freeze_marker_writes = true requires a backend with a durable object tier \
+         (s3, gcs, or tiered); backend = \"{backend}\" cannot store durable freeze markers — \
+         a silent no-op would report the kill switch as engaged without durably engaging it. \
+         Disable the flag or switch the [state] backend."
+    )]
+    StateFreezeMarkerWritesUnsupportedBackend { backend: String },
 }
 
 /// Concurrency strategy for table processing.
@@ -698,6 +706,16 @@ pub struct StateConfig {
     /// a forward-incompatible store. See [`SchemaMismatchPolicy`].
     #[serde(default)]
     pub on_schema_mismatch: SchemaMismatchPolicy,
+    /// Enable writing durable freeze/unfreeze marker objects (under
+    /// `<prefix>/freeze/` and `<prefix>/unfreeze/`, beside the remote state
+    /// file) when `rocky policy freeze` / `unfreeze` run against an
+    /// object-store backend. Marker reading and enforcement are always on
+    /// wherever a durable object tier exists; this flag gates only the write
+    /// side, so a fleet can be upgraded to marker readers everywhere before
+    /// any marker is written. Default `false`. Requires a backend with a
+    /// durable object tier (`s3`, `gcs`, or `tiered`).
+    #[serde(default)]
+    pub freeze_marker_writes: bool,
 }
 
 impl Default for StateConfig {
@@ -717,6 +735,7 @@ impl Default for StateConfig {
             retention: crate::retention::StateRetentionConfig::default(),
             namespacing: StateNamespacing::default(),
             on_schema_mismatch: SchemaMismatchPolicy::default(),
+            freeze_marker_writes: false,
         }
     }
 }
@@ -3068,6 +3087,28 @@ pub fn validate_policy(config: &RockyConfig) -> Vec<ConfigError> {
                 });
             }
         }
+    }
+    errors
+}
+
+/// Validate the `[state] freeze_marker_writes` flag against the backend.
+///
+/// Enabling marker writes on a backend with no durable object tier (`local`,
+/// `valkey`-only) is a **hard error**, not a silent no-op: the flag promises
+/// kill-switch durability those backends cannot deliver, and a freeze that
+/// reports success without writing a durable marker would be a false sense of
+/// engagement. Mirrors the `[gc] physical_delete` fail-loud posture.
+pub fn validate_freeze_marker_writes(config: &RockyConfig) -> Vec<ConfigError> {
+    let mut errors = Vec::new();
+    if config.state.freeze_marker_writes
+        && matches!(
+            config.state.backend,
+            StateBackend::Local | StateBackend::Valkey
+        )
+    {
+        errors.push(ConfigError::StateFreezeMarkerWritesUnsupportedBackend {
+            backend: config.state.backend.to_string(),
+        });
     }
     errors
 }
@@ -5753,6 +5794,9 @@ fn validate_loaded_config(config: &RockyConfig) -> Result<(), ConfigError> {
     if let Some(first) = validate_policy(config).into_iter().next() {
         return Err(first);
     }
+    if let Some(first) = validate_freeze_marker_writes(config).into_iter().next() {
+        return Err(first);
+    }
     Ok(())
 }
 
@@ -6611,6 +6655,53 @@ autonomy_budget = { failures = 2, window = "banana" }
             ),
             "got {errors:?}"
         );
+    }
+
+    // --- [state] freeze_marker_writes validation ---
+
+    /// `freeze_marker_writes = true` on a backend with no durable object
+    /// tier is a hard error — the flag would otherwise be a silent no-op
+    /// that reports the kill switch as engaged without durably engaging it.
+    #[test]
+    fn freeze_marker_writes_rejected_without_durable_tier() {
+        for backend in ["local", "valkey"] {
+            let cfg = parse(&format!(
+                "[state]\nbackend = \"{backend}\"\nfreeze_marker_writes = true\n"
+            ));
+            let errors = validate_freeze_marker_writes(&cfg);
+            assert!(
+                matches!(
+                    errors.as_slice(),
+                    [ConfigError::StateFreezeMarkerWritesUnsupportedBackend { backend: got }]
+                        if got == backend
+                ),
+                "backend {backend}: got {errors:?}"
+            );
+            // The load-time chain rejects it too.
+            assert!(validate_loaded_config(&cfg).is_err());
+        }
+    }
+
+    /// The flag is accepted on every backend with a durable object tier, and
+    /// the default (unset) is valid everywhere.
+    #[test]
+    fn freeze_marker_writes_accepted_on_durable_tiers_and_defaults_off() {
+        for backend in ["s3", "gcs", "tiered"] {
+            let cfg = parse(&format!(
+                "[state]\nbackend = \"{backend}\"\nfreeze_marker_writes = true\n"
+            ));
+            assert!(
+                validate_freeze_marker_writes(&cfg).is_empty(),
+                "backend {backend} has a durable tier and must accept the flag"
+            );
+        }
+        // Default off — valid even on valkey/local.
+        let cfg = parse("[state]\nbackend = \"valkey\"\n");
+        assert!(
+            !cfg.state.freeze_marker_writes,
+            "flag must default to false"
+        );
+        assert!(validate_freeze_marker_writes(&cfg).is_empty());
     }
 
     #[test]

--- a/engine/crates/rocky-core/src/freeze_marker.rs
+++ b/engine/crates/rocky-core/src/freeze_marker.rs
@@ -1,0 +1,631 @@
+//! Durable freeze/unfreeze marker objects — the un-erasable kill switch.
+//!
+//! `rocky policy freeze` records a row in the policy-decision ledger inside
+//! `state.redb`; that blob is republished whole-file by every remote-state
+//! upload, so a concurrent writer can silently erase the row. The marker set
+//! here is the enforcement truth that survives that: each freeze is its own
+//! create-once object at `<prefix>/freeze/<freeze_id>.json`, each unfreeze an
+//! object at `<prefix>/unfreeze/<unfreeze_id>.json` naming the exact
+//! `freeze_id`s it lifts, and the active set is the order-independent
+//! projection `{all freezes} − {ids lifted by any parseable unfreeze}` — no
+//! total sequence, no wall-clock comparison, no id allocator. Re-freezing
+//! mints a new `freeze_id`, so an old unfreeze can never suppress a later
+//! freeze.
+//!
+//! The marker keys deliberately carry **no schema-version segment** (unlike
+//! the `v{N}/state.redb` state key): a mixed-version fleet reads one active
+//! set. Markers live on the **durable object tier** only:
+//!
+//! | `[state]` backend | Markers |
+//! |---|---|
+//! | `s3` / `gcs` | Full support (writes gated by `[state] freeze_marker_writes`; reads unconditional). |
+//! | `tiered` | Durable S3 leg only — Valkey is never read or written for markers, so a stale cache cannot shadow a freeze. |
+//! | `valkey` (only) | Unsupported: no object store exists. Marker reads are skipped (ledger-row enforcement is unchanged); setting `freeze_marker_writes` is a config error. |
+//! | `local` | Not applicable — no remote writer can erase local state; ledger enforcement is unchanged. |
+//!
+//! Callers obtain the provider via
+//! [`durable_tier_provider`][crate::state_sync::durable_tier_provider] so the
+//! backend→tier mapping (and the test-override seam) lives in one place.
+
+// Design + rollout rationale: docs/adr/ADR-CONCURRENCY.md, section
+// "D3 — Freeze = rollout-independent ADD-WINS MARKER" and the mandatory
+// two-phase (readers-first, then writes) rollout table.
+
+use std::collections::BTreeSet;
+
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tracing::warn;
+
+use crate::config::PolicyPrincipal;
+use crate::object_store::{ObjectStoreError, ObjectStoreProvider, PutIfNotExistsOutcome};
+
+/// Sub-prefix (relative to the `[state]` prefix root) holding freeze markers.
+pub const FREEZE_MARKER_PREFIX: &str = "freeze";
+/// Sub-prefix (relative to the `[state]` prefix root) holding unfreeze markers.
+pub const UNFREEZE_MARKER_PREFIX: &str = "unfreeze";
+
+/// Relative object key for a freeze marker: `freeze/<freeze_id>.json`.
+///
+/// Deliberately NOT routed through the schema-versioned state-key derivation:
+/// marker keys are schema-version-independent so a mixed-version fleet reads
+/// one active set.
+#[must_use]
+pub fn freeze_marker_key(freeze_id: &str) -> String {
+    format!("{FREEZE_MARKER_PREFIX}/{freeze_id}.json")
+}
+
+/// Relative object key for an unfreeze marker: `unfreeze/<unfreeze_id>.json`.
+#[must_use]
+pub fn unfreeze_marker_key(unfreeze_id: &str) -> String {
+    format!("{UNFREEZE_MARKER_PREFIX}/{unfreeze_id}.json")
+}
+
+/// Body of a `freeze/<freeze_id>.json` marker object.
+///
+/// One marker is written per frozen principal, mirroring the per-principal
+/// ledger rows `rocky policy freeze` records. `created_at` is informational
+/// only — the active-set projection never orders by it.
+// No `deny_unknown_fields`: a future writer adding a field must not make
+// today's reader classify the marker as malformed (which would flip every
+// marker onto the conservative unreadable-body path).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FreezeMarker {
+    /// Unique id (UUID v4). Also the key stem, so the object is
+    /// self-describing even when the body is unreadable.
+    pub freeze_id: String,
+    /// The frozen principal.
+    pub principal: PolicyPrincipal,
+    /// The validated scope selector string the freeze targets.
+    pub scope: String,
+    /// Human-readable reason, shared with the ledger row.
+    pub reason: String,
+    /// Wall clock at write time. Informational only — never used for
+    /// ordering.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Body of an `unfreeze/<unfreeze_id>.json` marker object.
+///
+/// Lifts freezes strictly by id: `lifts` names the exact `freeze_id`s this
+/// unfreeze tombstones. A later re-freeze mints a new id, so an existing
+/// unfreeze can never suppress it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UnfreezeMarker {
+    /// Unique id (UUID v4); also the key stem.
+    pub unfreeze_id: String,
+    /// The `freeze_id`s this unfreeze lifts — the OR-set tombstones.
+    pub lifts: Vec<String>,
+    /// The principal the lift was scoped to, or `None` when it covered both.
+    #[serde(default)]
+    pub principal: Option<PolicyPrincipal>,
+    /// Optional operator-supplied reason.
+    #[serde(default)]
+    pub reason: Option<String>,
+    /// Wall clock at write time. Informational only.
+    pub created_at: DateTime<Utc>,
+}
+
+/// One marker object as fetched from the store: parsed cleanly, or fetched
+/// but unreadable.
+///
+/// `Unreadable` carries the id recovered from the key stem — which is what
+/// keeps a corrupt freeze marker liftable by id even though its body is
+/// gone. Transport failures never produce this variant; they propagate as
+/// errors from [`load_markers`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LoadedMarker<T> {
+    /// The body was fetched and parsed cleanly.
+    Parsed(T),
+    /// The body was fetched but is not a parseable marker.
+    Unreadable {
+        /// Marker id recovered from the object key stem.
+        id: String,
+        /// The parse error, for diagnostics.
+        error: String,
+    },
+}
+
+/// One active freeze in the projected marker set, as consumed by enforcement
+/// and status surfaces.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActiveMarkerFreeze {
+    /// The freeze marker's id (`freeze/<freeze_id>.json`).
+    pub freeze_id: String,
+    /// The frozen principal. `None` means the marker body was unreadable and
+    /// the freeze conservatively matches BOTH principals.
+    pub principal: Option<PolicyPrincipal>,
+    /// The freeze's scope selector. An unreadable body widens to `"any"`.
+    pub scope: String,
+    /// Human-readable reason (a placeholder for an unreadable body).
+    pub reason: String,
+    /// When the freeze was written, when the body was readable.
+    pub created_at: Option<DateTime<Utc>>,
+}
+
+/// Errors from the marker write path.
+#[derive(Debug, Error)]
+pub enum FreezeMarkerError {
+    /// Transport / backend failure.
+    #[error("object store error: {0}")]
+    ObjectStore(#[from] ObjectStoreError),
+
+    /// The marker body failed to serialize (unreachable in practice).
+    #[error("failed to encode marker body: {0}")]
+    Encode(#[from] serde_json::Error),
+
+    /// The create-once write found an object already at the marker's key.
+    /// Ids are fresh UUIDs, so this is unreachable in practice and surfaced
+    /// as a hard error — never a retry loop.
+    #[error(
+        "freeze marker id collision at '{key}' — an object already exists there; \
+         re-run the command to mint a fresh id"
+    )]
+    IdCollision { key: String },
+}
+
+/// Project the active freeze set: `{all freeze ids} − {ids referenced by any
+/// parseable unfreeze}`.
+///
+/// An order-independent OR-set projection — no total sequence, no wall-clock
+/// comparison, no id allocator — so the result is identical under any LIST or
+/// arrival order of either input slice. Re-freezing mints a new `freeze_id`,
+/// so an unfreeze referencing an older id can never suppress a later freeze,
+/// structurally.
+///
+/// Unreadable bodies are handled fail-closed, asymmetrically by direction of
+/// risk:
+///
+/// - an unreadable **freeze** stays in the active set, conservatively widened
+///   (`principal: None` = both principals, `scope: "any"`) — corruption must
+///   not silently disengage the kill switch. It remains liftable: unfreeze is
+///   by id, and the id comes from the key, not the body.
+/// - an unreadable **unfreeze** lifts **nothing** — its `lifts` list is
+///   unknowable, and a corrupt unfreeze must not lift freezes it cannot name.
+///
+/// The output is sorted by `freeze_id` for determinism.
+#[must_use]
+pub fn project_active(
+    freezes: &[LoadedMarker<FreezeMarker>],
+    unfreezes: &[LoadedMarker<UnfreezeMarker>],
+) -> Vec<ActiveMarkerFreeze> {
+    let mut lifted: BTreeSet<&str> = BTreeSet::new();
+    for unfreeze in unfreezes {
+        match unfreeze {
+            LoadedMarker::Parsed(m) => lifted.extend(m.lifts.iter().map(String::as_str)),
+            LoadedMarker::Unreadable { id, error } => {
+                warn!(
+                    unfreeze_id = %id,
+                    error = %error,
+                    "unreadable unfreeze marker body lifts nothing (fail-closed)"
+                );
+            }
+        }
+    }
+
+    let mut active: Vec<ActiveMarkerFreeze> = freezes
+        .iter()
+        .filter_map(|freeze| match freeze {
+            LoadedMarker::Parsed(m) => {
+                (!lifted.contains(m.freeze_id.as_str())).then(|| ActiveMarkerFreeze {
+                    freeze_id: m.freeze_id.clone(),
+                    principal: Some(m.principal),
+                    scope: m.scope.clone(),
+                    reason: m.reason.clone(),
+                    created_at: Some(m.created_at),
+                })
+            }
+            LoadedMarker::Unreadable { id, error } => {
+                (!lifted.contains(id.as_str())).then(|| ActiveMarkerFreeze {
+                    freeze_id: id.clone(),
+                    principal: None,
+                    scope: "any".to_string(),
+                    reason: format!("unreadable freeze marker body ({error})"),
+                    created_at: None,
+                })
+            }
+        })
+        .collect();
+    active.sort_by(|a, b| a.freeze_id.cmp(&b.freeze_id));
+    active
+}
+
+/// LIST both marker prefixes on the durable tier and GET + parse every body,
+/// returning the raw loaded sets. Projection ([`project_active`]) is the
+/// caller's separate, pure step.
+///
+/// Only **transport** failures (a LIST error, or a GET error on a listed key)
+/// propagate as `Err` — the caller cannot distinguish a network blip from a
+/// suppressed marker, so an error is never an empty active set. Parse
+/// failures of successfully-fetched bytes become
+/// [`LoadedMarker::Unreadable`] entries instead. Keys not shaped like
+/// `<prefix>/<id>.json` are ignored.
+pub async fn load_markers(
+    provider: &ObjectStoreProvider,
+) -> Result<
+    (
+        Vec<LoadedMarker<FreezeMarker>>,
+        Vec<LoadedMarker<UnfreezeMarker>>,
+    ),
+    ObjectStoreError,
+> {
+    let freezes =
+        load_prefix::<FreezeMarker>(provider, FREEZE_MARKER_PREFIX, |m| m.freeze_id.as_str())
+            .await?;
+    let unfreezes =
+        load_prefix::<UnfreezeMarker>(provider, UNFREEZE_MARKER_PREFIX, |m| m.unfreeze_id.as_str())
+            .await?;
+    Ok((freezes, unfreezes))
+}
+
+/// Convenience: [`load_markers`] + [`project_active`] in one call.
+pub async fn load_active_marker_freezes(
+    provider: &ObjectStoreProvider,
+) -> Result<Vec<ActiveMarkerFreeze>, ObjectStoreError> {
+    let (freezes, unfreezes) = load_markers(provider).await?;
+    Ok(project_active(&freezes, &unfreezes))
+}
+
+/// Create-write one freeze marker at `freeze/<freeze_id>.json`.
+///
+/// Uses the atomic create-if-absent primitive, so a marker write never
+/// conflicts with concurrent state uploads. An `AlreadyExists` on the fresh
+/// UUID key is unreachable in practice and returned as
+/// [`FreezeMarkerError::IdCollision`] — a hard error, never a retry.
+pub async fn write_freeze_marker(
+    provider: &ObjectStoreProvider,
+    marker: &FreezeMarker,
+) -> Result<(), FreezeMarkerError> {
+    let key = freeze_marker_key(&marker.freeze_id);
+    let body = serde_json::to_vec(marker)?;
+    match provider.put_if_not_exists(&key, Bytes::from(body)).await? {
+        PutIfNotExistsOutcome::Created => Ok(()),
+        PutIfNotExistsOutcome::AlreadyExists => Err(FreezeMarkerError::IdCollision { key }),
+    }
+}
+
+/// Create-write one unfreeze marker at `unfreeze/<unfreeze_id>.json`.
+///
+/// Same create-once semantics as [`write_freeze_marker`].
+pub async fn write_unfreeze_marker(
+    provider: &ObjectStoreProvider,
+    marker: &UnfreezeMarker,
+) -> Result<(), FreezeMarkerError> {
+    let key = unfreeze_marker_key(&marker.unfreeze_id);
+    let body = serde_json::to_vec(marker)?;
+    match provider.put_if_not_exists(&key, Bytes::from(body)).await? {
+        PutIfNotExistsOutcome::Created => Ok(()),
+        PutIfNotExistsOutcome::AlreadyExists => Err(FreezeMarkerError::IdCollision { key }),
+    }
+}
+
+/// LIST one marker prefix and fetch + classify every `<prefix>/<id>.json`
+/// object under it.
+///
+/// `id_of` recovers the id the body claims (`freeze_id` / `unfreeze_id`). The
+/// authoritative id is the KEY stem, not the body: a parsed body whose claimed
+/// id disagrees with its key is classified [`LoadedMarker::Unreadable`] keyed
+/// on the stem, so the projection can never trust a body that lies about which
+/// object it is. Fail-closed by direction of risk — a freeze then stays active
+/// and widened, an unfreeze then lifts nothing.
+async fn load_prefix<T: serde::de::DeserializeOwned>(
+    provider: &ObjectStoreProvider,
+    prefix: &str,
+    id_of: impl Fn(&T) -> &str,
+) -> Result<Vec<LoadedMarker<T>>, ObjectStoreError> {
+    let mut out = Vec::new();
+    for key in provider.list(prefix).await? {
+        // Recover the id from the key stem: `<prefix>/<id>.json`. Anything
+        // else under the prefix (wrong extension, nested path) is not a
+        // marker and is ignored.
+        let Some(id) = key
+            .strip_prefix(prefix)
+            .and_then(|rest| rest.strip_prefix('/'))
+            .and_then(|rest| rest.strip_suffix(".json"))
+        else {
+            continue;
+        };
+        if id.is_empty() || id.contains('/') {
+            continue;
+        }
+        let bytes = provider.get(&key).await?;
+        match serde_json::from_slice::<T>(&bytes) {
+            // The body's claimed id must match the key stem, or the object is
+            // not trustworthy — treat it as unreadable, keyed on the stem.
+            Ok(marker) if id_of(&marker) == id => out.push(LoadedMarker::Parsed(marker)),
+            Ok(_) => out.push(LoadedMarker::Unreadable {
+                id: id.to_string(),
+                error: "marker id does not match its object key".to_string(),
+            }),
+            Err(e) => out.push(LoadedMarker::Unreadable {
+                id: id.to_string(),
+                error: e.to_string(),
+            }),
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn ts() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap()
+    }
+
+    fn freeze(id: &str) -> LoadedMarker<FreezeMarker> {
+        LoadedMarker::Parsed(FreezeMarker {
+            freeze_id: id.to_string(),
+            principal: PolicyPrincipal::Agent,
+            scope: "any".to_string(),
+            reason: format!("test freeze {id}"),
+            created_at: ts(),
+        })
+    }
+
+    fn unfreeze(id: &str, lifts: &[&str]) -> LoadedMarker<UnfreezeMarker> {
+        LoadedMarker::Parsed(UnfreezeMarker {
+            unfreeze_id: id.to_string(),
+            lifts: lifts.iter().map(ToString::to_string).collect(),
+            principal: None,
+            reason: None,
+            created_at: ts(),
+        })
+    }
+
+    fn active_ids(active: &[ActiveMarkerFreeze]) -> Vec<&str> {
+        active.iter().map(|m| m.freeze_id.as_str()).collect()
+    }
+
+    /// The OR-set is order-independent: every permutation of both input
+    /// slices projects the identical active set. Pins the projection against
+    /// unsorted LIST results and arbitrary arrival order.
+    #[test]
+    fn or_set_projection_is_order_independent() {
+        let freezes = [freeze("a"), freeze("b"), freeze("c")];
+        let unfreezes = [unfreeze("u1", &["a"]), unfreeze("u2", &["c"])];
+
+        let freeze_perms: [[usize; 3]; 6] = [
+            [0, 1, 2],
+            [0, 2, 1],
+            [1, 0, 2],
+            [1, 2, 0],
+            [2, 0, 1],
+            [2, 1, 0],
+        ];
+        let unfreeze_perms: [[usize; 2]; 2] = [[0, 1], [1, 0]];
+
+        for fp in freeze_perms {
+            for up in unfreeze_perms {
+                let fs: Vec<_> = fp.iter().map(|&i| freezes[i].clone()).collect();
+                let us: Vec<_> = up.iter().map(|&i| unfreezes[i].clone()).collect();
+                let active = project_active(&fs, &us);
+                assert_eq!(
+                    active_ids(&active),
+                    vec!["b"],
+                    "projection must be identical under permutation {fp:?} / {up:?}"
+                );
+            }
+        }
+    }
+
+    /// Re-freeze = a new `freeze_id`: an unfreeze referencing the older id
+    /// can never suppress the later freeze, structurally.
+    #[test]
+    fn refreeze_new_id_survives_prior_unfreeze() {
+        let freezes = [freeze("gen-1"), freeze("gen-2")];
+        let unfreezes = [unfreeze("u", &["gen-1"])];
+        let active = project_active(&freezes, &unfreezes);
+        assert_eq!(active_ids(&active), vec!["gen-2"]);
+    }
+
+    /// One unfreeze can lift multiple freezes by naming each id.
+    #[test]
+    fn one_unfreeze_lifts_multiple_ids() {
+        let freezes = [freeze("a"), freeze("b"), freeze("c")];
+        let unfreezes = [unfreeze("u", &["a", "c"])];
+        let active = project_active(&freezes, &unfreezes);
+        assert_eq!(active_ids(&active), vec!["b"]);
+    }
+
+    /// An unfreeze referencing an id no freeze carries is inert — it lifts
+    /// nothing and suppresses nothing.
+    #[test]
+    fn unfreeze_referencing_unknown_id_is_inert() {
+        let freezes = [freeze("a")];
+        let unfreezes = [unfreeze("u", &["ghost"])];
+        let active = project_active(&freezes, &unfreezes);
+        assert_eq!(active_ids(&active), vec!["a"]);
+    }
+
+    /// An unreadable freeze body stays active, conservatively widened to
+    /// both principals on scope "any" — corruption must not disengage the
+    /// kill switch.
+    #[test]
+    fn unreadable_freeze_body_projects_conservative_any_scope() {
+        let freezes = [LoadedMarker::<FreezeMarker>::Unreadable {
+            id: "corrupt".to_string(),
+            error: "not json".to_string(),
+        }];
+        let active = project_active(&freezes, &[]);
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].freeze_id, "corrupt");
+        assert_eq!(active[0].principal, None, "None = matches BOTH principals");
+        assert_eq!(active[0].scope, "any");
+        assert_eq!(active[0].created_at, None);
+        assert!(active[0].reason.contains("unreadable freeze marker body"));
+    }
+
+    /// An unreadable unfreeze body lifts nothing — it cannot name what it
+    /// lifts.
+    #[test]
+    fn unreadable_unfreeze_body_lifts_nothing() {
+        let freezes = [freeze("a")];
+        let unfreezes = [LoadedMarker::<UnfreezeMarker>::Unreadable {
+            id: "corrupt-unfreeze".to_string(),
+            error: "truncated".to_string(),
+        }];
+        let active = project_active(&freezes, &unfreezes);
+        assert_eq!(active_ids(&active), vec!["a"]);
+    }
+
+    /// The escape hatch for a corrupt marker: unfreeze is by id (recovered
+    /// from the key), so a parseable unfreeze naming an unreadable freeze's
+    /// id still clears it.
+    #[test]
+    fn unfreeze_by_id_lifts_unreadable_freeze() {
+        let freezes = [LoadedMarker::<FreezeMarker>::Unreadable {
+            id: "corrupt".to_string(),
+            error: "not json".to_string(),
+        }];
+        let unfreezes = [unfreeze("u", &["corrupt"])];
+        let active = project_active(&freezes, &unfreezes);
+        assert!(active.is_empty());
+    }
+
+    /// Marker keys are flat `<prefix>/<id>.json` with no schema-version
+    /// segment — the schema-version-independent layout a mixed fleet reads.
+    #[test]
+    fn marker_keys_carry_no_schema_version_segment() {
+        assert_eq!(freeze_marker_key("abc"), "freeze/abc.json");
+        assert_eq!(unfreeze_marker_key("def"), "unfreeze/def.json");
+    }
+
+    /// Write → LIST → GET → project roundtrip against an in-memory store:
+    /// the real create-once write path, id recovery from the key stem,
+    /// non-marker keys ignored, corrupt bodies classified (not dropped), and
+    /// duplicate creates surfaced as a hard collision error.
+    #[tokio::test]
+    async fn write_load_project_roundtrip_in_memory() {
+        let provider = ObjectStoreProvider::in_memory();
+        let a = FreezeMarker {
+            freeze_id: "id-a".to_string(),
+            principal: PolicyPrincipal::Agent,
+            scope: "any".to_string(),
+            reason: "freeze a".to_string(),
+            created_at: ts(),
+        };
+        let b = FreezeMarker {
+            freeze_id: "id-b".to_string(),
+            principal: PolicyPrincipal::Human,
+            scope: "layer=gold".to_string(),
+            reason: "freeze b".to_string(),
+            created_at: ts(),
+        };
+        write_freeze_marker(&provider, &a).await.unwrap();
+        write_freeze_marker(&provider, &b).await.unwrap();
+        write_unfreeze_marker(
+            &provider,
+            &UnfreezeMarker {
+                unfreeze_id: "u-1".to_string(),
+                lifts: vec!["id-a".to_string()],
+                principal: Some(PolicyPrincipal::Agent),
+                reason: Some("lift a".to_string()),
+                created_at: ts(),
+            },
+        )
+        .await
+        .unwrap();
+        // Non-marker keys under the prefix are ignored; a corrupt body is
+        // classified, not dropped.
+        provider
+            .put("freeze/README.txt", Bytes::from_static(b"not a marker"))
+            .await
+            .unwrap();
+        provider
+            .put("freeze/id-c.json", Bytes::from_static(b"{ corrupt"))
+            .await
+            .unwrap();
+
+        let (freezes, unfreezes) = load_markers(&provider).await.unwrap();
+        assert_eq!(freezes.len(), 3, "two parsed + one unreadable");
+        assert_eq!(unfreezes.len(), 1);
+
+        let active = load_active_marker_freezes(&provider).await.unwrap();
+        assert_eq!(active_ids(&active), vec!["id-b", "id-c"]);
+        assert_eq!(active[0].principal, Some(PolicyPrincipal::Human));
+        assert_eq!(active[0].scope, "layer=gold");
+        assert_eq!(active[1].principal, None);
+
+        let err = write_freeze_marker(&provider, &a)
+            .await
+            .expect_err("duplicate create on an existing key must be a hard error");
+        assert!(matches!(err, FreezeMarkerError::IdCollision { .. }));
+
+        // The key layout is version-independent: nothing lands under `v{N}/`.
+        let keys = provider.list("").await.unwrap();
+        assert!(
+            keys.iter()
+                .all(|k| k.starts_with("freeze/") || k.starts_with("unfreeze/")),
+            "markers must live under freeze/ and unfreeze/ only, got {keys:?}"
+        );
+    }
+
+    /// The id comes from the KEY, not the body: a body that parses cleanly but
+    /// whose `freeze_id`/`unfreeze_id` disagrees with its object key is treated
+    /// as unreadable, keyed on the stem. A mismatched freeze then stays active
+    /// and conservatively widened (it cannot smuggle a narrower principal/scope
+    /// past the fence); a mismatched unfreeze lifts nothing.
+    #[tokio::test]
+    async fn body_id_mismatch_is_classified_unreadable() {
+        let provider = ObjectStoreProvider::in_memory();
+
+        // A freeze whose body claims a DIFFERENT id than its key stem, written
+        // directly so the key/body disagree (the write path always agrees).
+        let mismatched_freeze = FreezeMarker {
+            freeze_id: "not-the-key".to_string(),
+            principal: PolicyPrincipal::Human,
+            scope: "layer=gold".to_string(),
+            reason: "mismatched".to_string(),
+            created_at: ts(),
+        };
+        provider
+            .put(
+                "freeze/key-stem.json",
+                Bytes::from(serde_json::to_vec(&mismatched_freeze).unwrap()),
+            )
+            .await
+            .unwrap();
+
+        // An unfreeze naming that stem, whose own body id disagrees with ITS key.
+        let mismatched_unfreeze = UnfreezeMarker {
+            unfreeze_id: "not-this-key".to_string(),
+            lifts: vec!["key-stem".to_string()],
+            principal: None,
+            reason: None,
+            created_at: ts(),
+        };
+        provider
+            .put(
+                "unfreeze/other-stem.json",
+                Bytes::from(serde_json::to_vec(&mismatched_unfreeze).unwrap()),
+            )
+            .await
+            .unwrap();
+
+        let (freezes, unfreezes) = load_markers(&provider).await.unwrap();
+        assert!(
+            matches!(&freezes[0], LoadedMarker::Unreadable { id, error }
+                if id == "key-stem" && error.contains("does not match")),
+            "a body-id mismatch must classify Unreadable keyed on the stem, got {:?}",
+            freezes[0]
+        );
+        assert!(
+            matches!(&unfreezes[0], LoadedMarker::Unreadable { id, .. } if id == "other-stem"),
+            "a mismatched unfreeze is Unreadable keyed on the stem, got {:?}",
+            unfreezes[0]
+        );
+
+        // Projection: the freeze stays active, widened to both principals /
+        // "any" (its body's narrower layer=gold scope is discarded). The
+        // unreadable unfreeze lifts nothing, so the freeze is NOT cleared.
+        let active = project_active(&freezes, &unfreezes);
+        assert_eq!(active_ids(&active), vec!["key-stem"]);
+        assert_eq!(active[0].principal, None, "None = matches BOTH principals");
+        assert_eq!(active[0].scope, "any");
+    }
+}

--- a/engine/crates/rocky-core/src/lib.rs
+++ b/engine/crates/rocky-core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod drift;
 pub mod failure_class;
 #[cfg(any(test, feature = "test-support"))]
 pub mod fault_store;
+pub mod freeze_marker;
 pub mod hooks;
 pub mod idempotency;
 pub mod imports;

--- a/engine/crates/rocky-core/src/policy.rs
+++ b/engine/crates/rocky-core/src/policy.rs
@@ -792,6 +792,28 @@ pub fn validate_scope_selector(selector: &str) -> Result<(), String> {
     ))
 }
 
+/// Whether an active marker freeze binds a given subject principal + model.
+///
+/// The single match predicate shared by the entry gate ([`autonomy_degradation`])
+/// and the mid-run freeze fence, so principal handling can never drift between
+/// them. Two orthogonal conditions, both required:
+///
+/// - **Principal.** `subject = Some(p)` binds a marker whose principal is `p`,
+///   or `None` (an unreadable body, which conservatively matches BOTH
+///   principals). `subject = None` means the caller does not know the acting
+///   principal — the coarse bare-run fence case — and binds any marker
+///   principal.
+/// - **Scope.** [`scope_selector_matches`] against the model's attributes.
+#[must_use]
+pub fn marker_freeze_binds(
+    marker: &crate::freeze_marker::ActiveMarkerFreeze,
+    subject: Option<PolicyPrincipal>,
+    attrs: &ModelAttributes,
+) -> bool {
+    (subject.is_none() || marker.principal.is_none() || marker.principal == subject)
+        && scope_selector_matches(&marker.scope, attrs)
+}
+
 /// Apply the dynamic breakers to a base effect: an active freeze forces `deny`;
 /// an exhausted autonomy budget on the winning rule degrades `allow` to
 /// `require_review`. Returns the (possibly tightened) effect and a description
@@ -803,8 +825,16 @@ pub fn validate_scope_selector(selector: &str) -> Result<(), String> {
 /// decision ledger snapshot read before the current action's rows are written.
 ///
 /// Freeze is checked first and independent of `matched_rule`, so it overrides
-/// even the default posture; budget applies only to the winning rule.
+/// even the default posture; budget applies only to the winning rule. Two
+/// freeze sources are consulted and OR-ed: the ledger projection
+/// ([`active_freezes`] over `decisions`) and `marker_freezes` — the durable
+/// object-store marker set the caller LISTed from the `[state]` backend's
+/// durable tier. A marker-only freeze (no ledger row visible, e.g. because a
+/// concurrent state upload erased the row) still denies; a marker whose
+/// `principal` is `None` (unreadable body) conservatively matches BOTH
+/// principals. Callers on a backend with no durable object tier pass `&[]`.
 #[must_use]
+#[allow(clippy::too_many_arguments)]
 pub fn autonomy_degradation(
     base: PolicyEffect,
     matched_rule: Option<usize>,
@@ -812,6 +842,7 @@ pub fn autonomy_degradation(
     principal: PolicyPrincipal,
     attrs: &ModelAttributes,
     decisions: &[PolicyDecisionRecord],
+    marker_freezes: &[crate::freeze_marker::ActiveMarkerFreeze],
     now: DateTime<Utc>,
 ) -> (PolicyEffect, AutonomyDegradation) {
     // 1. Freeze — a kill switch that forces deny for a matching principal+scope.
@@ -823,6 +854,22 @@ pub fn autonomy_degradation(
                     principal,
                     scope: freeze.scope,
                     plan_id: freeze.plan_id,
+                },
+            );
+        }
+    }
+    // 1b. Marker freezes — the durable object-store OR-set. Independent of the
+    // ledger row above: the marker survives a concurrent whole-blob state
+    // upload, so it must deny even when no ledger row is visible (see
+    // docs/adr/ADR-CONCURRENCY.md, D3).
+    for marker in marker_freezes {
+        if marker_freeze_binds(marker, Some(principal), attrs) {
+            return (
+                tighten_to_at_least(base, PolicyEffect::Deny),
+                AutonomyDegradation::Frozen {
+                    principal,
+                    scope: marker.scope.clone(),
+                    plan_id: format!("{FREEZE_PLAN_PREFIX}{}", marker.freeze_id),
                 },
             );
         }
@@ -1723,6 +1770,7 @@ mod tests {
             PolicyPrincipal::Agent,
             &attrs,
             &two,
+            &[],
             n,
         );
         assert_eq!(effect, PolicyEffect::Allow, "2 < 3 must not degrade");
@@ -1737,6 +1785,7 @@ mod tests {
             PolicyPrincipal::Agent,
             &attrs,
             &three,
+            &[],
             n,
         );
         assert_eq!(effect, PolicyEffect::RequireReview, "3 >= 3 must degrade");
@@ -1785,6 +1834,7 @@ mod tests {
                     PolicyPrincipal::Agent,
                     &attrs,
                     ledger,
+                    &[],
                     n,
                 );
                 assert!(
@@ -1847,6 +1897,7 @@ mod tests {
             PolicyPrincipal::Agent,
             &attrs,
             &ledger,
+            &[],
             n,
         );
         assert_eq!(effect, PolicyEffect::Deny);
@@ -1883,6 +1934,7 @@ mod tests {
             PolicyPrincipal::Agent,
             &bronze,
             &ledger,
+            &[],
             n,
         );
         let (silver_effect, _) = autonomy_degradation(
@@ -1892,6 +1944,7 @@ mod tests {
             PolicyPrincipal::Agent,
             &silver,
             &ledger,
+            &[],
             n,
         );
         assert_eq!(bronze_effect, PolicyEffect::Deny, "bronze is frozen");
@@ -1917,6 +1970,7 @@ mod tests {
             PolicyPrincipal::Human,
             &attrs,
             &ledger,
+            &[],
             n,
         );
         assert_eq!(
@@ -1971,5 +2025,139 @@ mod tests {
         assert!(validate_scope_selector("layer=").is_err());
         assert!(validate_scope_selector("tag==prod").is_err());
         assert!(validate_scope_selector("nonsense").is_err());
+    }
+
+    fn marker(
+        id: &str,
+        principal: Option<PolicyPrincipal>,
+        scope: &str,
+    ) -> crate::freeze_marker::ActiveMarkerFreeze {
+        crate::freeze_marker::ActiveMarkerFreeze {
+            freeze_id: id.to_string(),
+            principal,
+            scope: scope.to_string(),
+            reason: "test marker".to_string(),
+            created_at: Some(now()),
+        }
+    }
+
+    /// A durable marker freeze forces deny for a matching principal + scope,
+    /// citing the marker's `freeze:<id>` plan id.
+    #[test]
+    fn marker_freeze_forces_deny_for_matching_principal_and_scope() {
+        let n = now();
+        let attrs = bronze_additive_model(Some(0));
+        let markers = [marker("m-1", Some(PolicyPrincipal::Agent), "any")];
+        let p = policy(vec![]);
+        let (effect, deg) = autonomy_degradation(
+            PolicyEffect::Allow,
+            None,
+            &p,
+            PolicyPrincipal::Agent,
+            &attrs,
+            &[],
+            &markers,
+            n,
+        );
+        assert_eq!(effect, PolicyEffect::Deny);
+        assert!(matches!(
+            deg,
+            AutonomyDegradation::Frozen { ref plan_id, .. } if plan_id == "freeze:m-1"
+        ));
+    }
+
+    /// A marker-only freeze — no ledger row visible at all (e.g. a concurrent
+    /// state upload erased it) — MUST still deny. This is the un-erasable
+    /// enforcement path the marker set exists for.
+    #[test]
+    fn marker_only_freeze_denies_with_empty_ledger() {
+        let n = now();
+        let attrs = bronze_additive_model(Some(0));
+        let markers = [marker("m-only", Some(PolicyPrincipal::Agent), "any")];
+        let p = budget_policy(3, "7d");
+        let (effect, deg) = autonomy_degradation(
+            PolicyEffect::Allow,
+            Some(0),
+            &p,
+            PolicyPrincipal::Agent,
+            &attrs,
+            &[], // empty ledger — the erasure scenario
+            &markers,
+            n,
+        );
+        assert_eq!(effect, PolicyEffect::Deny);
+        assert!(matches!(deg, AutonomyDegradation::Frozen { .. }));
+    }
+
+    /// A marker with `principal: None` (unreadable body, conservatively
+    /// widened) denies BOTH principals.
+    #[test]
+    fn unreadable_marker_denies_both_principals() {
+        let n = now();
+        let attrs = bronze_additive_model(Some(0));
+        let markers = [marker("m-corrupt", None, "any")];
+        let p = policy(vec![]);
+        for principal in [PolicyPrincipal::Agent, PolicyPrincipal::Human] {
+            let (effect, _) = autonomy_degradation(
+                PolicyEffect::Allow,
+                None,
+                &p,
+                principal,
+                &attrs,
+                &[],
+                &markers,
+                n,
+            );
+            assert_eq!(
+                effect,
+                PolicyEffect::Deny,
+                "an unreadable-body marker must deny {principal:?}"
+            );
+        }
+    }
+
+    /// A scoped marker freeze only bites models its selector matches, through
+    /// the same [`scope_selector_matches`] grammar as ledger freezes.
+    #[test]
+    fn marker_freeze_respects_scope_selector() {
+        let n = now();
+        let markers = [marker(
+            "m-scoped",
+            Some(PolicyPrincipal::Agent),
+            "layer=bronze",
+        )];
+        let p = policy(vec![]);
+        let bronze = ModelAttributes {
+            name: "raw_events".to_string(),
+            layer: Some("bronze".to_string()),
+            ..Default::default()
+        };
+        let silver = ModelAttributes {
+            name: "dim_customer".to_string(),
+            layer: Some("silver".to_string()),
+            ..Default::default()
+        };
+        let (bronze_effect, _) = autonomy_degradation(
+            PolicyEffect::Allow,
+            None,
+            &p,
+            PolicyPrincipal::Agent,
+            &bronze,
+            &[],
+            &markers,
+            n,
+        );
+        let (silver_effect, _) = autonomy_degradation(
+            PolicyEffect::Allow,
+            None,
+            &p,
+            PolicyPrincipal::Agent,
+            &silver,
+            &[],
+            &markers,
+            n,
+        );
+        assert_eq!(bronze_effect, PolicyEffect::Deny, "bronze is frozen");
+        assert_eq!(silver_effect, PolicyEffect::Allow, "silver is not frozen");
     }
 }

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -161,6 +161,44 @@ fn cloud_provider(
     Ok(ObjectStoreProvider::from_uri(&uri)?)
 }
 
+/// Object-store handle for the **durable tier** of a remote `[state]`
+/// backend, or `None` when no durable object tier exists (`local`,
+/// `valkey`-only).
+///
+/// The single place the backend enum maps to a marker-capable tier for
+/// [`crate::freeze_marker`]: `tiered` resolves to its S3 leg — Valkey is
+/// bypassed entirely, so a stale cached blob can never shadow a durable
+/// freeze marker. Bucket resolution mirrors the state download/upload
+/// dispatch (`MissingConfig` when the required bucket is absent), and
+/// construction goes through [`cloud_provider`] so the test-override seams
+/// intercept it exactly like every other state transfer.
+///
+/// # Errors
+///
+/// [`StateSyncError::MissingConfig`] when the backend has a durable tier but
+/// its bucket is not configured; provider-construction failures propagate.
+pub fn durable_tier_provider(
+    config: &StateConfig,
+) -> Result<Option<ObjectStoreProvider>, StateSyncError> {
+    match config.backend {
+        StateBackend::S3 | StateBackend::Tiered => {
+            let bucket = config.s3_bucket.as_deref().ok_or_else(|| {
+                StateSyncError::MissingConfig("s3".into(), "state.s3_bucket".into())
+            })?;
+            let prefix = config.s3_prefix.as_deref().unwrap_or(DEFAULT_S3_PREFIX);
+            Ok(Some(cloud_provider("s3", bucket, prefix)?))
+        }
+        StateBackend::Gcs => {
+            let bucket = config.gcs_bucket.as_deref().ok_or_else(|| {
+                StateSyncError::MissingConfig("gcs".into(), "state.gcs_bucket".into())
+            })?;
+            let prefix = config.gcs_prefix.as_deref().unwrap_or(DEFAULT_GCS_PREFIX);
+            Ok(Some(cloud_provider("gs", bucket, prefix)?))
+        }
+        StateBackend::Local | StateBackend::Valkey => Ok(None),
+    }
+}
+
 /// Test-only support for injecting an in-memory object store into the upload
 /// dispatch path. Lets a test drive the real
 /// `upload_state → strip → dispatch → upload_to_object_store → cloud_provider`
@@ -2222,6 +2260,67 @@ mod tests {
     #[test]
     fn test_state_backend_display_includes_gcs() {
         assert_eq!(StateBackend::Gcs.to_string(), "gcs");
+    }
+
+    /// `durable_tier_provider` maps each backend to its marker-capable tier:
+    /// s3/gcs directly, tiered to its S3 leg (never Valkey), and local /
+    /// valkey-only to `None`. A durable backend with no bucket is
+    /// `MissingConfig`, mirroring the transfer dispatch.
+    #[test]
+    fn durable_tier_provider_maps_backends() {
+        // Route provider construction to an in-memory store so no cloud
+        // client (or credentials) is needed.
+        let _handle = test_support::install(ObjectStoreProvider::in_memory());
+
+        let s3 = StateConfig {
+            backend: StateBackend::S3,
+            s3_bucket: Some("bucket".into()),
+            ..Default::default()
+        };
+        assert!(durable_tier_provider(&s3).unwrap().is_some());
+
+        let gcs = StateConfig {
+            backend: StateBackend::Gcs,
+            gcs_bucket: Some("bucket".into()),
+            ..Default::default()
+        };
+        assert!(durable_tier_provider(&gcs).unwrap().is_some());
+
+        let tiered = StateConfig {
+            backend: StateBackend::Tiered,
+            s3_bucket: Some("bucket".into()),
+            ..Default::default()
+        };
+        assert!(
+            durable_tier_provider(&tiered).unwrap().is_some(),
+            "tiered maps to its durable S3 leg"
+        );
+
+        assert!(
+            durable_tier_provider(&StateConfig::default())
+                .unwrap()
+                .is_none(),
+            "local has no durable object tier"
+        );
+        let valkey = StateConfig {
+            backend: StateBackend::Valkey,
+            ..Default::default()
+        };
+        assert!(
+            durable_tier_provider(&valkey).unwrap().is_none(),
+            "valkey-only has no durable object tier"
+        );
+
+        let s3_no_bucket = StateConfig {
+            backend: StateBackend::S3,
+            ..Default::default()
+        };
+        assert!(matches!(
+            durable_tier_provider(&s3_no_bucket),
+            Err(StateSyncError::MissingConfig(..))
+        ));
+
+        test_support::clear();
     }
 
     // R8 (part 1) — remote key derivation. The legacy global file maps to the

--- a/engine/crates/rocky-core/tests/freeze_markers_cross_pod.rs
+++ b/engine/crates/rocky-core/tests/freeze_markers_cross_pod.rs
@@ -1,0 +1,332 @@
+//! Cross-pod freeze-marker integration tests (WP-01 rig).
+//!
+//! Drives the REAL marker write/read paths ([`rocky_core::freeze_marker`])
+//! against the shared fault-injectable in-memory "S3" the PR-1 rig installs
+//! via the process-global provider override, resolving the durable tier the
+//! way production does ([`rocky_core::state_sync::durable_tier_provider`]).
+//! Each test holds `remote_testing::serial_guard()` because the override is
+//! process-global.
+//!
+//! What is pinned here (see docs/adr/ADR-CONCURRENCY.md, D3 + Validation
+//! Rung 2):
+//! - markers live OUTSIDE `state.redb`: a stale-base whole-blob overwrite
+//!   (RD-002 last-writer-wins, still live until CAS lands) cannot erase a
+//!   freeze marker;
+//! - the deterministic half of the kill-switch drill: a freeze landing
+//!   between a run's download and its upload survives the upload;
+//! - a LIST/GET transport failure surfaces as `Err` — never an empty active
+//!   set;
+//! - the tiered backend's marker read is pinned to the durable S3 leg, with
+//!   zero Valkey traffic;
+//! - the create → LIST → project roundtrip through the real write path, on a
+//!   schema-version-INDEPENDENT key layout beside the `v{N}/state.redb`
+//!   object.
+//!
+//! Requires the `test-support` feature (on by default for test targets via
+//! rocky-core's self-referential dev-dependency).
+
+use chrono::Utc;
+use rocky_core::config::{PolicyPrincipal, StateBackend, StateConfig};
+use rocky_core::fault_store::{FaultMode, FaultOp};
+use rocky_core::freeze_marker::{self, FreezeMarker, UnfreezeMarker};
+use rocky_core::object_store::ObjectStoreProvider;
+use rocky_core::redacted::RedactedString;
+use rocky_core::state_sync::{durable_tier_provider, remote_testing};
+use rocky_core::test_harness::CrossPodHarness;
+use rocky_ir::WatermarkState;
+
+fn wm_now() -> WatermarkState {
+    let now = Utc::now();
+    WatermarkState {
+        last_value: now,
+        updated_at: now,
+    }
+}
+
+fn marker(id: &str, principal: PolicyPrincipal, scope: &str) -> FreezeMarker {
+    FreezeMarker {
+        freeze_id: id.to_string(),
+        principal,
+        scope: scope.to_string(),
+        reason: format!("test freeze {id}"),
+        created_at: Utc::now(),
+    }
+}
+
+/// Resolve the durable-tier provider for `cfg` exactly the way every
+/// production marker reader/writer does — through `durable_tier_provider`,
+/// so the process-global override intercepts it.
+fn provider_for(cfg: &StateConfig) -> ObjectStoreProvider {
+    durable_tier_provider(cfg)
+        .expect("durable tier resolves")
+        .expect("an s3-like backend has a durable object tier")
+}
+
+/// Markers live OUTSIDE `state.redb`: a pod that full-uploads from a stale
+/// base wholesale-replaces the shared blob (RD-002 last-writer-wins, still
+/// live until CAS), but the freeze marker beside it is untouched and still
+/// projects active.
+#[tokio::test]
+async fn stale_base_blob_overwrite_leaves_marker_intact() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+
+    // Pod A publishes a baseline; pod B downloads it — pod B's upload base
+    // is stale the moment anything else lands on the remote.
+    {
+        let store = harness.open_store(&harness.pod_a);
+        store.set_watermark("cat.sch.from_a", &wm_now()).unwrap();
+    }
+    harness.upload(&harness.pod_a).await.expect("pod A upload");
+    assert_eq!(
+        harness
+            .download(&harness.pod_b)
+            .await
+            .expect("pod B download"),
+        rocky_core::state_sync::StateAuthority::Authoritative,
+        "pod B's base is the restored remote object"
+    );
+
+    // A freeze marker lands (another pod's `rocky policy freeze`), via the
+    // REAL create-once write path on the durable-tier provider.
+    let provider = provider_for(&harness.pod_b.cfg);
+    freeze_marker::write_freeze_marker(
+        &provider,
+        &marker("f-stale", PolicyPrincipal::Agent, "any"),
+    )
+    .await
+    .expect("marker create");
+
+    // Pod B mutates and full-uploads from its stale base — the blob is
+    // wholesale-replaced.
+    {
+        let store = harness.open_store(&harness.pod_b);
+        store.set_watermark("cat.sch.from_b", &wm_now()).unwrap();
+    }
+    harness
+        .upload(&harness.pod_b)
+        .await
+        .expect("pod B stale-base upload");
+
+    // The marker is separate from `state.redb`: still listed, still active.
+    let keys = harness
+        .provider
+        .list("freeze")
+        .await
+        .expect("list marker prefix");
+    assert_eq!(
+        keys,
+        vec!["freeze/f-stale.json".to_string()],
+        "the stale-base blob overwrite must leave the marker object intact"
+    );
+    let active = freeze_marker::load_active_marker_freezes(&provider)
+        .await
+        .expect("project active set");
+    assert_eq!(active.len(), 1, "the freeze must still project active");
+    assert_eq!(active[0].freeze_id, "f-stale");
+}
+
+/// The deterministic half of the kill-switch drill: a freeze marker created
+/// BETWEEN a run's start-of-run download and its end-of-run upload survives
+/// that upload and projects active — the marker write path
+/// (`put_if_not_exists` on a unique key) never contends with the blob
+/// upload. (The fence-denial half is driven at the CLI level in
+/// rocky-cli/tests/freeze_marker_enforcement.rs; the live half is the
+/// operational drill.)
+#[tokio::test]
+async fn freeze_between_download_and_upload_survives() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+
+    // The "run": start-of-run download (fresh start on an empty remote),
+    // then local mutation while in flight.
+    assert_eq!(
+        harness
+            .download(&harness.pod_a)
+            .await
+            .expect("start-of-run download"),
+        rocky_core::state_sync::StateAuthority::FreshStart,
+        "an empty remote is a genuine fresh start"
+    );
+    {
+        let store = harness.open_store(&harness.pod_a);
+        store.set_watermark("cat.sch.mid_run", &wm_now()).unwrap();
+    }
+
+    // The kill switch engages between the run's download and its upload.
+    let provider = provider_for(&harness.pod_a.cfg);
+    freeze_marker::write_freeze_marker(
+        &provider,
+        &marker("f-drill", PolicyPrincipal::Agent, "any"),
+    )
+    .await
+    .expect("freeze marker create");
+
+    // The run's end-of-run upload fires anyway (this rig has no fence).
+    harness
+        .upload(&harness.pod_a)
+        .await
+        .expect("end-of-run upload");
+
+    let active = freeze_marker::load_active_marker_freezes(&provider)
+        .await
+        .expect("project active set");
+    assert_eq!(
+        active.len(),
+        1,
+        "the freeze must survive the racing run's upload"
+    );
+    assert_eq!(active[0].freeze_id, "f-drill");
+    assert_eq!(active[0].principal, Some(PolicyPrincipal::Agent));
+}
+
+/// Fail-closed transport posture: a LIST failure — or a GET failure on a
+/// listed key — propagates as `Err`. An error is never an empty active set:
+/// the caller cannot distinguish a network blip from a suppressed marker.
+#[tokio::test]
+async fn list_failure_surfaces_transport_error() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+    let provider = provider_for(&harness.pod_a.cfg);
+
+    // A marker exists, so a swallowed error WOULD look like an empty set.
+    freeze_marker::write_freeze_marker(&provider, &marker("f-net", PolicyPrincipal::Agent, "any"))
+        .await
+        .expect("marker create");
+
+    harness.faults.arm(FaultOp::List, FaultMode::FailAll);
+    assert!(
+        freeze_marker::load_active_marker_freezes(&provider)
+            .await
+            .is_err(),
+        "a LIST transport failure must be an Err, never an empty active set"
+    );
+    harness.faults.clear();
+
+    harness.faults.arm(FaultOp::Get, FaultMode::FailAll);
+    assert!(
+        freeze_marker::load_active_marker_freezes(&provider)
+            .await
+            .is_err(),
+        "a GET transport failure on a listed key must be an Err, never a dropped marker"
+    );
+    harness.faults.clear();
+
+    // Recovery: the same call sees the marker once the transport heals.
+    let active = freeze_marker::load_active_marker_freezes(&provider)
+        .await
+        .expect("recovered projection");
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0].freeze_id, "f-net");
+}
+
+/// Tiered backends resolve markers to the durable S3 leg ONLY — Valkey is
+/// never read or written for markers, so a stale (or poisoned) cache can
+/// never shadow a freeze. The Valkey URL here is unroutable (TEST-NET-1):
+/// any attempted Valkey traffic would fail, so success + the durable store's
+/// call counters prove the read went to the durable tier.
+#[tokio::test]
+async fn tiered_marker_read_bypasses_valkey() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+    let tiered_cfg = StateConfig {
+        backend: StateBackend::Tiered,
+        valkey_url: Some(RedactedString::new("redis://192.0.2.1:1".into())),
+        s3_bucket: Some("test".into()),
+        ..StateConfig::default()
+    };
+
+    let provider = durable_tier_provider(&tiered_cfg)
+        .expect("tiered durable tier resolves")
+        .expect("tiered maps to its durable S3 leg");
+    freeze_marker::write_freeze_marker(
+        &provider,
+        &marker("f-tiered", PolicyPrincipal::Human, "layer=gold"),
+    )
+    .await
+    .expect("marker create on the durable leg");
+
+    let lists_before = harness.faults.count(FaultOp::List);
+    let active = freeze_marker::load_active_marker_freezes(&provider)
+        .await
+        .expect("tiered marker read must succeed with zero Valkey traffic");
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0].freeze_id, "f-tiered");
+    assert_eq!(active[0].scope, "layer=gold");
+    assert!(
+        harness.faults.count(FaultOp::List) > lists_before,
+        "the marker LIST must land on the durable object store, not a cache"
+    );
+}
+
+/// Create → LIST → project roundtrip via the real write path, beside a real
+/// state upload: the state object is schema-versioned (`v{N}/state.redb`)
+/// while every marker key is a version-INDEPENDENT sibling — a mixed-version
+/// fleet reads one active set.
+#[tokio::test]
+async fn marker_create_roundtrip_lists_and_projects() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+
+    // A real state upload, so the version-segmented state key exists beside
+    // the markers.
+    {
+        let store = harness.open_store(&harness.pod_a);
+        store.set_watermark("cat.sch.orders", &wm_now()).unwrap();
+    }
+    harness.upload(&harness.pod_a).await.expect("state upload");
+
+    let provider = provider_for(&harness.pod_a.cfg);
+    freeze_marker::write_freeze_marker(&provider, &marker("f-a", PolicyPrincipal::Agent, "any"))
+        .await
+        .expect("create f-a");
+    freeze_marker::write_freeze_marker(
+        &provider,
+        &marker("f-b", PolicyPrincipal::Human, "layer=gold"),
+    )
+    .await
+    .expect("create f-b");
+    freeze_marker::write_unfreeze_marker(
+        &provider,
+        &UnfreezeMarker {
+            unfreeze_id: "u-1".to_string(),
+            lifts: vec!["f-a".to_string()],
+            principal: Some(PolicyPrincipal::Agent),
+            reason: Some("lift f-a".to_string()),
+            created_at: Utc::now(),
+        },
+    )
+    .await
+    .expect("create u-1");
+
+    // OR-set projection against the real listing: f-a is lifted, f-b stays.
+    let active = freeze_marker::load_active_marker_freezes(&provider)
+        .await
+        .expect("project active set");
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0].freeze_id, "f-b");
+    assert_eq!(active[0].principal, Some(PolicyPrincipal::Human));
+    assert_eq!(active[0].scope, "layer=gold");
+
+    // Key layout: the state object carries the schema-version segment; the
+    // marker keys are flat `freeze/<id>.json` / `unfreeze/<id>.json` with NO
+    // `v{N}/` segment.
+    let keys = harness.provider.list("").await.expect("list root");
+    assert!(
+        keys.iter()
+            .any(|k| k.starts_with('v') && k.contains("state.redb")),
+        "the state object must live under its schema-version segment, got {keys:?}"
+    );
+    assert!(
+        keys.contains(&"freeze/f-a.json".to_string())
+            && keys.contains(&"freeze/f-b.json".to_string())
+            && keys.contains(&"unfreeze/u-1.json".to_string()),
+        "marker keys must be flat version-independent siblings, got {keys:?}"
+    );
+    assert!(
+        keys.iter()
+            .filter(|k| k.contains("freeze"))
+            .all(|k| k.starts_with("freeze/") || k.starts_with("unfreeze/")),
+        "no marker key may carry a schema-version segment, got {keys:?}"
+    );
+}

--- a/engine/crates/rocky-core/tests/state_sync_s3_live.rs
+++ b/engine/crates/rocky-core/tests/state_sync_s3_live.rs
@@ -25,7 +25,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use bytes::Bytes;
 use chrono::Utc;
-use rocky_core::config::{StateBackend, StateConfig, StateUploadFailureMode};
+use rocky_core::config::{PolicyPrincipal, StateBackend, StateConfig, StateUploadFailureMode};
+use rocky_core::freeze_marker::{
+    FreezeMarker, FreezeMarkerError, UnfreezeMarker, load_active_marker_freezes,
+    write_freeze_marker, write_unfreeze_marker,
+};
 use rocky_core::object_store::{ObjectStoreProvider, PutIfNotExistsOutcome};
 use rocky_core::state::StateStore;
 use rocky_core::state_sync::{download_state, upload_state};
@@ -192,4 +196,82 @@ async fn live_put_if_not_exists_conflict() {
     );
 
     provider.delete(&key).await.expect("cleanup delete");
+}
+
+/// The freeze-marker LIST + Create roundtrip against a REAL bucket — the
+/// OR-set projection over a real (unordered, paginated) object listing, not
+/// InMemory-only: freeze A and B, unfreeze lifting A, and the active set
+/// projects exactly {B}. A duplicate Create on an existing marker key must
+/// report the collision rather than overwrite — the create-once primitive
+/// the un-erasable kill switch stands on.
+#[tokio::test]
+#[ignore]
+async fn live_freeze_marker_list_create_roundtrip() {
+    let _serial = live_serial();
+    let Some(live) = live_s3_from_env() else {
+        eprintln!("SKIP live_freeze_marker_list_create_roundtrip: ROCKY_TEST_S3_* env not set");
+        return;
+    };
+    // A per-run prefix sandbox so cleanup can sweep everything it wrote.
+    let run_prefix = format!("{}/freeze-markers-{}", live.prefix, unique_suffix());
+    let provider = ObjectStoreProvider::from_uri(&format!("s3://{}/{run_prefix}", live.bucket))
+        .expect("live provider");
+
+    let marker = |id: &str| FreezeMarker {
+        freeze_id: id.to_string(),
+        principal: PolicyPrincipal::Agent,
+        scope: "any".to_string(),
+        reason: format!("live marker probe {id}"),
+        created_at: Utc::now(),
+    };
+    write_freeze_marker(&provider, &marker("live-a"))
+        .await
+        .expect("create live-a");
+    write_freeze_marker(&provider, &marker("live-b"))
+        .await
+        .expect("create live-b");
+    write_unfreeze_marker(
+        &provider,
+        &UnfreezeMarker {
+            unfreeze_id: "live-u".to_string(),
+            lifts: vec!["live-a".to_string()],
+            principal: Some(PolicyPrincipal::Agent),
+            reason: Some("lift live-a".to_string()),
+            created_at: Utc::now(),
+        },
+    )
+    .await
+    .expect("create live-u");
+
+    let active = load_active_marker_freezes(&provider)
+        .await
+        .expect("project the active set against the real bucket listing");
+    let ids: Vec<&str> = active.iter().map(|m| m.freeze_id.as_str()).collect();
+    assert_eq!(
+        ids,
+        vec!["live-b"],
+        "the OR-set projection must lift live-a and keep live-b"
+    );
+
+    // Duplicate Create on live-a's still-present key: refused, never an
+    // overwrite.
+    let err = write_freeze_marker(&provider, &marker("live-a"))
+        .await
+        .expect_err("a duplicate Create on an existing marker key must be refused");
+    assert!(
+        matches!(err, FreezeMarkerError::IdCollision { .. }),
+        "the collision must surface as the hard id-collision error, got: {err}"
+    );
+
+    // Best-effort cleanup: sweep the per-run prefix (all three markers).
+    match provider.list("").await {
+        Ok(keys) => {
+            for key in keys {
+                if let Err(e) = provider.delete(&key).await {
+                    eprintln!("cleanup: failed to delete {key}: {e}");
+                }
+            }
+        }
+        Err(e) => eprintln!("cleanup: failed to list {run_prefix}: {e}"),
+    }
 }

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -1843,10 +1843,15 @@ impl RockyMcpServer {
     /// `propose` tool share (`evaluate_apply_policy`) so a write into a governed
     /// scope gets a structured verdict WITH the write. Absent a `[policy]` block
     /// this resolves to `NotConfigured` and behaviour is unchanged.
+    ///
+    /// `marker_freezes` is the durable freeze-marker set hoisted by the async
+    /// tool body (via [`Self::draft_marker_freezes`]) — the evaluation itself
+    /// is synchronous.
     fn evaluate_draft_policy(
         &self,
         stem: &str,
         decision_id: &str,
+        marker_freezes: &[rocky_core::freeze_marker::ActiveMarkerFreeze],
     ) -> rocky_cli::commands::PolicyGate {
         let touched: std::collections::BTreeMap<String, rocky_core::config::PolicyCapability> =
             std::iter::once((
@@ -1861,7 +1866,42 @@ impl RockyMcpServer {
             &touched,
             &self.models_dir,
             &self.state_path(),
+            marker_freezes,
         )
+    }
+
+    /// Durable freeze-marker LIST for a draft-class gate over `stem` — a
+    /// frozen agent must not keep minting drafts, so the draft tools consult
+    /// the same marker set the propose/apply gates enforce. Bounded by the
+    /// shared gate guard (no `[policy]` ⇒ no LIST ⇒ zero behavior change; an
+    /// unloadable config resolves to `NotConfigured` in the gate, so it reads
+    /// no markers either). Fail-closed on a transport failure, mirroring the
+    /// governed apply seams.
+    async fn draft_marker_freezes(
+        &self,
+        stem: &str,
+    ) -> Result<
+        Vec<rocky_core::freeze_marker::ActiveMarkerFreeze>,
+        rmcp::handler::server::wrapper::Json<ToolError>,
+    > {
+        let Ok(cfg) = rocky_core::config::load_rocky_config(&self.config_path) else {
+            return Ok(Vec::new());
+        };
+        let touched: std::collections::BTreeMap<String, rocky_core::config::PolicyCapability> =
+            std::iter::once((
+                stem.to_string(),
+                rocky_core::config::PolicyCapability::Propose,
+            ))
+            .collect();
+        rocky_cli::commands::marker_freezes_before_gate(&cfg, &touched)
+            .await
+            .map_err(|e| {
+                ToolError::internal(
+                    format!("failed to list durable freeze markers before the policy gate: {e:#}"),
+                    "The durable `[state]` tier must be reachable so an active freeze marker is \
+                     enforced before authoring into a governed scope (fail-closed).",
+                )
+            })
     }
 
     /// Compile the project scoped to `stem` and reduce it to the lite
@@ -1983,6 +2023,10 @@ impl RockyMcpServer {
         // A draft has no plan; the decision is recorded against a draft-scoped id
         // so the audit ledger stays honest about what it is.
         let decision_id = format!("draft:{}", paths.stem);
+        // Durable freeze-marker LIST, hoisted here (the gate is synchronous) —
+        // a frozen agent must not keep minting drafts. Fail-closed; bounded by
+        // the shared guard (no `[policy]` ⇒ no LIST ⇒ zero behavior change).
+        let marker_freezes = self.draft_marker_freezes(&paths.stem).await?;
         let gate = rocky_cli::commands::evaluate_apply_policy(
             &self.config_path,
             &decision_id,
@@ -1990,6 +2034,7 @@ impl RockyMcpServer {
             &touched,
             &self.models_dir,
             &state_path,
+            &marker_freezes,
         );
 
         match gate {
@@ -2108,7 +2153,10 @@ impl RockyMcpServer {
         let compiled = self.compile_drafted(&paths.stem)?;
 
         let decision_id = format!("draft-contract:{}", paths.stem);
-        match self.evaluate_draft_policy(&paths.stem, &decision_id) {
+        // Durable freeze-marker LIST, hoisted in the async body (the gate is
+        // synchronous). Fail-closed; no `[policy]` ⇒ no LIST.
+        let marker_freezes = self.draft_marker_freezes(&paths.stem).await?;
+        match self.evaluate_draft_policy(&paths.stem, &decision_id, &marker_freezes) {
             rocky_cli::commands::PolicyGate::NotConfigured
             | rocky_cli::commands::PolicyGate::Allow => {
                 rollback.defuse();
@@ -2241,7 +2289,10 @@ impl RockyMcpServer {
         let compiled = self.compile_drafted(&paths.stem)?;
 
         let decision_id = format!("draft-check:{}", paths.stem);
-        match self.evaluate_draft_policy(&paths.stem, &decision_id) {
+        // Durable freeze-marker LIST, hoisted in the async body (the gate is
+        // synchronous). Fail-closed; no `[policy]` ⇒ no LIST.
+        let marker_freezes = self.draft_marker_freezes(&paths.stem).await?;
+        match self.evaluate_draft_policy(&paths.stem, &decision_id, &marker_freezes) {
             rocky_cli::commands::PolicyGate::NotConfigured
             | rocky_cli::commands::PolicyGate::Allow => {
                 rollback.defuse();
@@ -2414,6 +2465,25 @@ impl RockyMcpServer {
                     )
                 })?;
         }
+        // Durable freeze-marker LIST, hoisted beside the ledger download —
+        // a marker-only freeze (its ledger row erased by a concurrent state
+        // upload) must still deny the propose. Same guard shape (the helper
+        // short-circuits without `[policy]` / an empty touched set /
+        // no durable tier); fail-closed on a transport failure.
+        let marker_freezes = match &cfg {
+            Some(cfg) => rocky_cli::commands::marker_freezes_before_gate(cfg, &touched)
+                .await
+                .map_err(|e| {
+                    ToolError::internal(
+                        format!(
+                            "failed to list durable freeze markers before the policy gate: {e:#}"
+                        ),
+                        "The durable `[state]` tier must be reachable so an active freeze marker \
+                         is enforced before proposing a plan (fail-closed).",
+                    )
+                })?,
+            None => Vec::new(),
+        };
         let gate = rocky_cli::commands::evaluate_apply_policy_with_policy(
             cfg.as_ref().and_then(|c| c.policy.as_ref()),
             &plan_id,
@@ -2421,6 +2491,7 @@ impl RockyMcpServer {
             &touched,
             &self.models_dir,
             &state_path,
+            &marker_freezes,
         );
 
         let write_plan = || {

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -2329,6 +2329,11 @@ enum PolicySubcommand {
         /// `model=<glob>`, `classification=<v>`, or `tag=<key>[=<value>]`.
         #[arg(long)]
         scope: Option<String>,
+        /// Human-readable reason recorded with the freeze (on the ledger row
+        /// and the durable freeze marker). Defaults to a synthesized
+        /// description.
+        #[arg(long)]
+        reason: Option<String>,
     },
 
     /// Lift a matching freeze (records a superseding decision).
@@ -2342,6 +2347,11 @@ enum PolicySubcommand {
         /// Scope selector to unfreeze (must match the freeze's scope).
         #[arg(long)]
         scope: Option<String>,
+        /// Human-readable reason recorded with the unfreeze (on the ledger
+        /// row and the durable unfreeze marker). Defaults to a synthesized
+        /// description.
+        #[arg(long)]
+        reason: Option<String>,
     },
 }
 
@@ -2897,26 +2907,32 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                 json,
             ),
             PolicySubcommand::Test {} => rocky_cli::commands::run_policy_test(&cli.config, json),
-            PolicySubcommand::Freeze { principal, scope } => {
-                rocky_cli::commands::run_policy_freeze(
-                    &cli.config,
-                    &state_path,
-                    principal.map(Into::into),
-                    scope,
-                    false,
-                    json,
-                )
-            }
-            PolicySubcommand::Unfreeze { principal, scope } => {
-                rocky_cli::commands::run_policy_freeze(
-                    &cli.config,
-                    &state_path,
-                    principal.map(Into::into),
-                    scope,
-                    true,
-                    json,
-                )
-            }
+            PolicySubcommand::Freeze {
+                principal,
+                scope,
+                reason,
+            } => rocky_cli::commands::run_policy_freeze(
+                &cli.config,
+                &state_path,
+                principal.map(Into::into),
+                scope,
+                reason,
+                false,
+                json,
+            ),
+            PolicySubcommand::Unfreeze {
+                principal,
+                scope,
+                reason,
+            } => rocky_cli::commands::run_policy_freeze(
+                &cli.config,
+                &state_path,
+                principal.map(Into::into),
+                scope,
+                reason,
+                true,
+                json,
+            ),
         },
         Command::Audit {
             for_subject,

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -3797,6 +3797,11 @@
           "default": "local",
           "description": "Storage backend: local (default), s3, gcs, valkey, or tiered (valkey + s3 fallback)"
         },
+        "freeze_marker_writes": {
+          "default": false,
+          "description": "Enable writing durable freeze/unfreeze marker objects (under `<prefix>/freeze/` and `<prefix>/unfreeze/`, beside the remote state file) when `rocky policy freeze` / `unfreeze` run against an object-store backend. Marker reading and enforcement are always on wherever a durable object tier exists; this flag gates only the write side, so a fleet can be upgraded to marker readers everywhere before any marker is written. Default `false`. Requires a backend with a durable object tier (`s3`, `gcs`, or `tiered`).",
+          "type": "boolean"
+        },
         "gcs_bucket": {
           "description": "GCS bucket for state persistence",
           "type": [
@@ -4659,6 +4664,7 @@
       ],
       "default": {
         "backend": "local",
+        "freeze_marker_writes": false,
         "gcs_bucket": null,
         "gcs_prefix": null,
         "idempotency": {

--- a/sdk/python/src/rocky_sdk/types_generated/rocky_project_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/rocky_project_schema.py
@@ -3304,6 +3304,10 @@ class StateConfig(BaseModel):
     """
     Storage backend: local (default), s3, gcs, valkey, or tiered (valkey + s3 fallback)
     """
+    freeze_marker_writes: bool | None = False
+    """
+    Enable writing durable freeze/unfreeze marker objects (under `<prefix>/freeze/` and `<prefix>/unfreeze/`, beside the remote state file) when `rocky policy freeze` / `unfreeze` run against an object-store backend. Marker reading and enforcement are always on wherever a durable object tier exists; this flag gates only the write side, so a fleet can be upgraded to marker readers everywhere before any marker is written. Default `false`. Requires a backend with a durable object tier (`s3`, `gcs`, or `tiered`).
+    """
     gcs_bucket: str | None = None
     """
     GCS bucket for state persistence
@@ -3879,6 +3883,7 @@ class RockyConfig(BaseModel):
     state: StateConfig | None = Field(
         {
             "backend": "local",
+            "freeze_marker_writes": False,
             "gcs_bucket": None,
             "gcs_prefix": None,
             "idempotency": {


### PR DESCRIPTION
## WP-01 PR-F — rollout-independent add-wins freeze markers

Third implementation PR of the WP-01 remote-state redesign (after PR-A `StateAuthority` #1139 and PR-B `RemoteStateSession` #1144). Implements **[`docs/adr/ADR-CONCURRENCY.md` §D3](../blob/main/docs/adr/ADR-CONCURRENCY.md)** — the un-erasable freeze kill switch.

### The problem

`rocky policy freeze` records a deny row inside `state.redb`. On a remote `[state]` backend that ledger is republished as a whole-file blob by every state upload, so a concurrent `rocky run` whose start-download preceded the freeze can silently erase the row on its own end-upload — the kill switch fails to engage while the racing run proceeds unfrozen.

### The fix — a separate add-wins marker set

Enforcement truth moves to write-once objects **beside** the state file, which a run's blob upload can never clobber:

- **freeze** → create-once `<prefix>/freeze/<uuid>.json`; **unfreeze** → `<prefix>/unfreeze/<uuid>.json` naming the exact `freeze_id`s it lifts.
- Active set = `{all freezes} − {ids lifted by any parseable unfreeze}` — an **order-independent OR-set** (no sequence, no clock, no allocator). Re-freeze mints a new id, so an old unfreeze can never suppress a later freeze.
- **Fail-closed on corruption:** an unreadable freeze body stays active and widens to both principals / scope `any`; an unreadable unfreeze lifts nothing (but the freeze stays liftable by id, recovered from the key stem).
- Keys carry **no schema-version segment** → a mixed-version fleet reads one active set.
- Enforcement ORs the marker set into the policy gate alongside the ledger projection, so a **marker-only freeze** (its ledger row erased) still denies.

### Two-phase rollout

Marker **writes** are gated by `[state] freeze_marker_writes` (default **off**; a hard config error on backends with no durable tier). Marker **reads/enforcement** are on wherever a durable tier exists — so the fleet is upgraded to markers-everywhere readers first, then writes are enabled. No redb schema bump.

### Coverage

Enforcement is wired into every governed gate — **apply, promote, gc, restore, backfill, the in-run replication gate, and MCP propose** — plus the **drift-governance** seam, and **mid-run freeze fences** at the exec-fingerprint choke-point, each execution-layer boundary, and before the post-run governance reconcile. Each fence does a **fresh LIST**; a fence hit **withholds** remaining work while **finalizing** already-committed state (partial failure, never state loss). `tiered` reads/writes markers on the **durable S3 leg only** (Valkey bypassed). `rocky brief` / MCP `estate_brief` merge marker freezes so reporting cannot disagree with enforcement.

---

### ⚠️ Design decision to review: the run fence is `[policy]`-gated

Adversarial review flagged that the initial wiring enforced markers on **any durable-tier backend, even with no `[policy]` plane** — inconsistent with `rocky policy freeze`'s own "recorded but NOT enforced until a `[policy]` block exists" contract, with the apply gate (which already gates on `cfg.policy.is_some()`), and with the drift governor (which sits at a require-review floor and enforces no freeze without `[policy]`).

**This PR makes the run fence inert without a `[policy]` plane** — the minimal change that makes every seam consistent. The alternative (make the freeze a *policy-independent* kill switch) would mean the opposite change across apply/promote/MCP/gc/restore too, and contradicts §D3's "governed paths" language. Flagging it explicitly because it reverses a deliberate choice in the first draft — **if the intent is a policy-independent kill switch, this is the place to say so.**

### ⚠️ Second decision: should the freeze kill switch gate humans (and per `--principal`)?

`governed_run_context` returns `None` for non-agent principals ("humans are ungated in v0, so their apply behaviour stays byte-identical"), so a **human apply** — and a bare `rocky run` — reaches the run path with no governed principal. The fence therefore treats them as an unknown principal and, while any freeze is active, **halts them too**. That is over-restriction (monotone-safe per §D3 — the kill switch never fails to engage), but it is **stricter than the entry gate**, which leaves humans ungated in v0.

The safe default (halt everyone under an active freeze) ships here. The open question is a v0 product decision, not derivable from the code: **should the freeze kill switch gate human applies at all, and if so, respect `--principal human`/`agent`?** If yes, `governed_run_context`'s agent-only scoping needs to extend to carry a human principal through to the fence (and the entry gate). Flagged for your call; not fixed here to avoid contradicting the v0 "humans ungated" model.

### Red-team

PR-F's OR-set + two-phase rollout got their own adversarial pass (mandated by the ADR), plus two independent Codex rounds and a full deterministic gate-coverage sweep.

The fence went through the most iteration. The net design: the freeze fence is a **coarse, name-only, principal-aware breaker over only the executing models**, sharing one match predicate (`marker_freeze_binds`) with the entry gate's `autonomy_degradation` so principal handling can't drift; precise scope enforcement (`layer=`/`classification=`/`tag=`) stays at the entry gate and the next run per §D3. Findings fixed along the way:
- **Projection keyed on the body id, not the object key** → a JSON-valid body claiming a different id could be suppressed or smuggle a narrower scope. Fixed: a body-id/key-stem mismatch is now classified fail-closed (`Unreadable`, keyed on the stem) — the freeze stays active + widened; an unfreeze lifts nothing.
- **Fence ignored principal / checked the whole compiled project / a replication target could inherit a name-colliding model's tags** → false-denies of runs the gate allows. Fixed by the shared predicate + narrowing every fence to the executing (selected, compilable) set.

The remaining two Codex notes were both **over-restriction** (the fence halting *too much*, monotone-safe per §D3, never a bypass): the compile-failed-model exclusion is fixed here; the human-apply case is the v0 product decision surfaced above.

### Testing

`cargo fmt`, `cargo clippy --all-targets --all-features -D warnings`, full-workspace `cargo nextest` — all green. New coverage maps to every §D3 Validation bullet (OR-set order-independence, marker-only-denies, reader-enforcement with writes off, fail-closed LIST, tiered-durable-pin, scoped-fence match/precision, no-policy inertness, kill-switch survival). The live-S3 `#[ignore]` marker roundtrip is compiled but **not run here** (no `ROCKY_TEST_S3_*` creds) — please run the live rung; unlike PR-D's CAS, PR-F's primitives (`put_if_not_exists`/LIST/GET) are already exercised by the in-memory + cross-pod rungs.

### Follow-up (not blocking)

The scoped-fence fix recompiles the project via `model_attributes(models_dir)` at fence build (one extra compile per governed run, and a disk re-read that cuts slightly against PR-B's execute-from-owned-snapshot ethos). Defensible — it drives coarse-breaker scope matching only, never execution — but threading the already-compiled set lazily is a reasonable follow-up.

### Not in scope

No CAS / `PutMode::Update` / consistent snapshot / `concurrency_control` flag — those are PR-C/PR-D. RD-002 stays open until the CAS rollout gate; the interim one-governed-writer-per-`[state]`-prefix serialization remains in force.
