### PR TITLE
fix(engine/rocky-compiler): type TRY_CAST/SAFE_CAST output as nullable

### DIFF
--- a/engine/crates/rocky-compiler/src/typecheck.rs
+++ b/engine/crates/rocky-compiler/src/typecheck.rs
@@ -463,7 +463,14 @@ fn compute_model_typecheck(
 
             match &edge.transform {
                 rocky_sql::lineage::TransformKind::Direct => upstream_type,
+                // Infallible cast: type is refined in Step 2; nullability is the
+                // input's (a non-null input stays non-null).
                 rocky_sql::lineage::TransformKind::Cast => (RockyType::Unknown, upstream_type.1),
+                // Fallible cast (`TRY_CAST` / `SAFE_CAST`): returns NULL on a
+                // failed conversion, so the output is nullable regardless of the
+                // input's nullability (#1148). The target type is still refined
+                // in Step 2 — only the nullable bit differs from `Cast`.
+                rocky_sql::lineage::TransformKind::TryCast => (RockyType::Unknown, true),
                 rocky_sql::lineage::TransformKind::Aggregation(func) => {
                     let func_upper = func.to_uppercase();
                     infer_aggregation_type(&func_upper, &upstream_type.0)
@@ -486,9 +493,7 @@ fn compute_model_typecheck(
         col.data_type == RockyType::Unknown
             && graph
                 .producing_edge(model_name, &col.name)
-                .is_some_and(|edge| {
-                    matches!(&edge.transform, rocky_sql::lineage::TransformKind::Cast)
-                })
+                .is_some_and(|edge| edge.transform.is_cast())
     });
     let inferred_cols = if has_unknown_cast {
         model_by_name
@@ -1247,10 +1252,16 @@ fn infer_aggregation_type(func: &str, input_type: &RockyType) -> (RockyType, boo
 
 /// Refine explicit casts by parsing their target types from the model SQL.
 ///
-/// Only columns that lineage left `Unknown` **and** that are produced by an
-/// explicit `Cast` edge whose input type is known are refined, substituting the
-/// parsed cast target (so `CAST(id AS STRING) AS id` resolves to `String`, not
-/// the source's pre-cast type — see #1145).
+/// Only columns that lineage left `Unknown` **and** that are produced by a cast
+/// edge — infallible [`Cast`] or fallible [`TryCast`] — whose input type is
+/// known are refined, substituting the parsed cast target (so `CAST(id AS
+/// STRING) AS id` resolves to `String`, not the source's pre-cast type — see
+/// #1145). This refines only the *type*; the nullable bit was already set in
+/// Step 1 (a `TryCast` output is nullable regardless of input — #1148) and is
+/// left untouched here.
+///
+/// [`Cast`]: rocky_sql::lineage::TransformKind::Cast
+/// [`TryCast`]: rocky_sql::lineage::TransformKind::TryCast
 ///
 /// Two deliberate restrictions, both erring toward `Unknown` — the safe
 /// "cannot type-check" state, where a contract on the column is skipped rather
@@ -1284,7 +1295,7 @@ fn enhanced_inference(
         let Some(edge) = graph.producing_edge(model_name, &col.name) else {
             continue;
         };
-        if !matches!(&edge.transform, rocky_sql::lineage::TransformKind::Cast) {
+        if !edge.transform.is_cast() {
             continue;
         }
 
@@ -2394,6 +2405,128 @@ mod tests {
         let result = typecheck_project_with_models(&graph, &sources, None, &project.models, None);
         let cast_id = &result.typed_models["cast_unknown"][0];
         assert_eq!(cast_id.data_type, RockyType::Unknown);
+    }
+
+    #[test]
+    fn test_try_cast_over_non_null_is_nullable() {
+        // A fallible cast (`TRY_CAST` / `SAFE_CAST`) returns NULL on a failed
+        // conversion, so its output is nullable even when the input column is
+        // non-null. The target type is still refined from the SQL (Int64), only
+        // the nullable bit differs from a plain `CAST`. A `nullable = false`
+        // contract on such a column must fail with the nullability diagnostic
+        // E012 (#1148).
+        for cast in ["TRY_CAST", "SAFE_CAST"] {
+            let models = vec![make_model(
+                "casted",
+                &format!("SELECT {cast}(id AS BIGINT) AS id FROM source.raw.users"),
+            )];
+            let project = Project::from_models(models).unwrap();
+
+            let mut external = HashMap::new();
+            external.insert(
+                "source.raw.users".to_string(),
+                vec![rocky_ir::ColumnInfo {
+                    name: "id".to_string(),
+                    data_type: "BIGINT".to_string(),
+                    nullable: false,
+                }],
+            );
+            let graph = build_semantic_graph(&project, &external).unwrap();
+
+            let mut sources = HashMap::new();
+            sources.insert(
+                "source.raw.users".to_string(),
+                source_schema(&[("id", RockyType::Int64, false)]),
+            );
+
+            let result =
+                typecheck_project_with_models(&graph, &sources, None, &project.models, None);
+            let casted = &result.typed_models["casted"][0];
+            assert_eq!(
+                casted.data_type,
+                RockyType::Int64,
+                "{cast} target type should still resolve"
+            );
+            assert!(
+                casted.nullable,
+                "{cast} output must be nullable even over a non-null input"
+            );
+
+            // Contract type matches (Int64) so only the nullability mismatch
+            // surfaces — E012, not E011.
+            let wrong_contract = CompilerContract {
+                columns: vec![ContractColumn {
+                    name: "id".to_string(),
+                    type_name: Some("Int64".to_string()),
+                    nullable: Some(false),
+                    description: None,
+                }],
+                rules: ContractRules::default(),
+            };
+            let diags = validate_contract("casted", std::slice::from_ref(casted), &wrong_contract);
+            assert!(
+                diags.iter().any(|diagnostic| &*diagnostic.code == "E012"),
+                "{cast}: expected E012 nullability diagnostic, got {diags:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_infallible_cast_over_fallible_cast_is_nullable() {
+        // Fallibility is sticky through an outer infallible cast:
+        // `CAST(TRY_CAST(id AS INT) AS BIGINT)` still returns NULL when the
+        // inner conversion fails, so the output must be nullable even over a
+        // non-null input. The target type is the outer cast's (BIGINT → Int64).
+        // Regression guard for the nested-cast hole (#1148).
+        let models = vec![make_model(
+            "casted",
+            "SELECT CAST(TRY_CAST(id AS INT) AS BIGINT) AS id FROM source.raw.users",
+        )];
+        let project = Project::from_models(models).unwrap();
+
+        let mut external = HashMap::new();
+        external.insert(
+            "source.raw.users".to_string(),
+            vec![rocky_ir::ColumnInfo {
+                name: "id".to_string(),
+                data_type: "STRING".to_string(),
+                nullable: false,
+            }],
+        );
+        let graph = build_semantic_graph(&project, &external).unwrap();
+
+        let mut sources = HashMap::new();
+        sources.insert(
+            "source.raw.users".to_string(),
+            source_schema(&[("id", RockyType::String, false)]),
+        );
+
+        let result = typecheck_project_with_models(&graph, &sources, None, &project.models, None);
+        let casted = &result.typed_models["casted"][0];
+        assert_eq!(
+            casted.data_type,
+            RockyType::Int64,
+            "outer cast target (BIGINT) should resolve"
+        );
+        assert!(
+            casted.nullable,
+            "an infallible cast over a fallible one must stay nullable"
+        );
+
+        let wrong_contract = CompilerContract {
+            columns: vec![ContractColumn {
+                name: "id".to_string(),
+                type_name: Some("Int64".to_string()),
+                nullable: Some(false),
+                description: None,
+            }],
+            rules: ContractRules::default(),
+        };
+        let diags = validate_contract("casted", std::slice::from_ref(casted), &wrong_contract);
+        assert!(
+            diags.iter().any(|diagnostic| &*diagnostic.code == "E012"),
+            "expected E012 nullability diagnostic, got {diags:?}"
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-sql/src/lineage.rs
+++ b/engine/crates/rocky-sql/src/lineage.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::{Expr, Query, SelectItem, SetExpr, Statement, TableFactor, TableWithJoins};
+use sqlparser::ast::{
+    CastKind, Expr, Query, SelectItem, SetExpr, Statement, TableFactor, TableWithJoins,
+};
 use sqlparser::parser::Parser;
 
 use crate::dialect::DatabricksDialect;
@@ -12,12 +14,30 @@ use crate::dialect::DatabricksDialect;
 pub enum TransformKind {
     /// Direct column reference (no transformation).
     Direct,
-    /// Explicit type cast.
+    /// Infallible type cast (`CAST(...)` or `expr :: type`). Preserves the
+    /// input's nullability — a non-null input yields a non-null output.
     Cast,
+    /// Fallible type cast (`TRY_CAST(...)` / `SAFE_CAST(...)`) that returns
+    /// `NULL` when the conversion fails. The output is nullable regardless of
+    /// the input's nullability.
+    TryCast,
     /// Aggregate function (SUM, COUNT, etc.).
     Aggregation(String),
     /// Complex expression (arithmetic, CASE, etc.).
     Expression,
+}
+
+impl TransformKind {
+    /// Whether this edge is a type cast — either the infallible [`Cast`] form or
+    /// the fallible [`TryCast`] form. The two differ only in output nullability;
+    /// both let the compiler recover the cast's target type from the SQL.
+    ///
+    /// [`Cast`]: TransformKind::Cast
+    /// [`TryCast`]: TransformKind::TryCast
+    #[must_use]
+    pub fn is_cast(&self) -> bool {
+        matches!(self, TransformKind::Cast | TransformKind::TryCast)
+    }
 }
 
 impl fmt::Display for TransformKind {
@@ -25,6 +45,7 @@ impl fmt::Display for TransformKind {
         match self {
             TransformKind::Direct => write!(f, "direct"),
             TransformKind::Cast => write!(f, "cast"),
+            TransformKind::TryCast => write!(f, "try_cast"),
             TransformKind::Aggregation(func) => write!(f, "aggregation: {}", func.to_lowercase()),
             TransformKind::Expression => write!(f, "expression"),
         }
@@ -334,9 +355,30 @@ fn extract_expr_lineage(
                 transform: TransformKind::Direct,
             })
         }
-        Expr::Cast { expr, .. } => {
+        Expr::Cast { expr, kind, .. } => {
             let mut lineage = extract_expr_lineage(expr, alias_map, source_tables)?;
-            lineage.transform = TransformKind::Cast;
+            // A fallible cast (`TRY_CAST` / `SAFE_CAST`) yields NULL on a failed
+            // conversion, so its output is nullable even over a non-null input.
+            // Track it distinctly so typecheck doesn't carry the input's
+            // non-null bit through (#1148).
+            lineage.transform = match kind {
+                // Fallible outer cast: nullable output regardless of the inner.
+                CastKind::TryCast | CastKind::SafeCast => TransformKind::TryCast,
+                // Infallible outer cast: fallibility is sticky — an inner edge
+                // already classified `TryCast` (e.g.
+                // `CAST(TRY_CAST(x AS INT) AS BIGINT)`) still returns NULL when
+                // the inner conversion fails, so the output stays nullable. A
+                // cast chain with no fallible link keeps the plain `Cast`
+                // classification (the outer cast's target type is recovered in
+                // typecheck Step 2 either way).
+                CastKind::Cast | CastKind::DoubleColon => {
+                    if lineage.transform == TransformKind::TryCast {
+                        TransformKind::TryCast
+                    } else {
+                        TransformKind::Cast
+                    }
+                }
+            };
             Some(lineage)
         }
         Expr::Function(func) => {
@@ -578,8 +620,72 @@ mod tests {
     }
 
     #[test]
+    fn test_transform_kind_display_try_cast() {
+        assert_eq!(TransformKind::TryCast.to_string(), "try_cast");
+    }
+
+    #[test]
     fn test_transform_kind_display_expression() {
         assert_eq!(TransformKind::Expression.to_string(), "expression");
+    }
+
+    #[test]
+    fn test_transform_kind_is_cast() {
+        assert!(TransformKind::Cast.is_cast());
+        assert!(TransformKind::TryCast.is_cast());
+        assert!(!TransformKind::Direct.is_cast());
+        assert!(!TransformKind::Expression.is_cast());
+        assert!(!TransformKind::Aggregation("SUM".to_string()).is_cast());
+    }
+
+    #[test]
+    fn test_fallible_casts_classified_distinctly() {
+        // TRY_CAST / SAFE_CAST return NULL on a failed conversion, so lineage
+        // must classify them as `TryCast` (nullable output) rather than the
+        // infallible `Cast` — the input's non-null bit must not carry through
+        // (#1148). `CAST` and `::` stay `Cast`.
+        let try_cast =
+            extract_lineage("SELECT TRY_CAST(id AS BIGINT) AS id FROM catalog.schema.users")
+                .unwrap();
+        assert_eq!(try_cast.columns[0].transform, TransformKind::TryCast);
+
+        let safe_cast =
+            extract_lineage("SELECT SAFE_CAST(id AS BIGINT) AS id FROM catalog.schema.users")
+                .unwrap();
+        assert_eq!(safe_cast.columns[0].transform, TransformKind::TryCast);
+
+        let plain_cast =
+            extract_lineage("SELECT CAST(id AS BIGINT) AS id FROM catalog.schema.users").unwrap();
+        assert_eq!(plain_cast.columns[0].transform, TransformKind::Cast);
+
+        let double_colon =
+            extract_lineage("SELECT id::BIGINT AS id FROM catalog.schema.users").unwrap();
+        assert_eq!(double_colon.columns[0].transform, TransformKind::Cast);
+    }
+
+    #[test]
+    fn test_fallible_cast_nested_in_infallible_stays_try_cast() {
+        // Fallibility is sticky: an infallible `CAST` / `::` wrapping an inner
+        // `TRY_CAST` still returns NULL when the inner conversion fails, so the
+        // whole edge must remain `TryCast` — the outer cast must not overwrite
+        // the inner fallibility back to `Cast` (#1148).
+        let nested_cast = extract_lineage(
+            "SELECT CAST(TRY_CAST(id AS INT) AS BIGINT) AS id FROM catalog.schema.users",
+        )
+        .unwrap();
+        assert_eq!(nested_cast.columns[0].transform, TransformKind::TryCast);
+
+        let nested_colon =
+            extract_lineage("SELECT TRY_CAST(id AS INT)::BIGINT AS id FROM catalog.schema.users")
+                .unwrap();
+        assert_eq!(nested_colon.columns[0].transform, TransformKind::TryCast);
+
+        // Two infallible casts with no fallible link stay `Cast`.
+        let nested_plain = extract_lineage(
+            "SELECT CAST(CAST(id AS STRING) AS BIGINT) AS id FROM catalog.schema.users",
+        )
+        .unwrap();
+        assert_eq!(nested_plain.columns[0].transform, TransformKind::Cast);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #1148. Lineage classified **every** cast — including `TRY_CAST` / `SAFE_CAST` — as `TransformKind::Cast`, and typecheck derived the cast output's nullability straight from the input column. So `TRY_CAST(non_null_col AS INT)` was typed **non-null**, even though a failed `TRY_CAST` returns `NULL` — and a contract asserting `nullable = false` on such a column passed incorrectly.

## Change

- **`rocky-sql` (lineage):** add a distinct `TransformKind::TryCast` for the fallible cast forms (`TRY_CAST` / `SAFE_CAST`). Plain `CAST(...)` and `expr :: type` stay `TransformKind::Cast`. Both forms verified to reach `Expr::Cast` with the right `CastKind` under the dialect lineage actually parses with.
- **`rocky-compiler` (typecheck):** a `TryCast` output is nullable **regardless** of input nullability, while its target type is still refined from the SQL — only the nullable bit differs from `Cast`. The two cast-target inference gates key off a new `TransformKind::is_cast()` so `TRY_CAST` columns keep resolving their declared type.
- **Fallibility is sticky:** an infallible `CAST` / `::` wrapping an inner cast already classified `TryCast` (e.g. `CAST(TRY_CAST(x AS INT) AS BIGINT)`) still returns `NULL` when the inner conversion fails, so the output stays nullable. The output *type* is still the outer cast's target.

## Not a codegen change

`TransformKind` is emitted as a **Display string** in CLI lineage output (`transform: String`), so there's no JSON-schema / Pydantic / TypeScript cascade and no fixture drift. `rocky lineage` now reports `transform: "try_cast"` for fallible casts.

## Tests

- `rocky-sql`: fallible casts classify as `TryCast`, `CAST` / `::` stay `Cast`, nested `CAST(TRY_CAST(...))` stays `TryCast`, `is_cast()` + Display coverage.
- `rocky-compiler`: `TRY_CAST` **and** `SAFE_CAST` over a non-null input → nullable `Int64` output, and a `nullable = false` contract fails with **E012**; same for the nested `CAST(TRY_CAST(...))` form.
- Existing plain-`CAST` behavior (non-null preserved, #1145 target-type resolution) is unchanged.

Verified end-to-end against the built binary (`rocky lineage` reports `try_cast` for both the direct and nested forms). Plain-`CAST` non-null semantics and the whole `rocky-sql` + `rocky-compiler` + consumer-crate suites remain green.
