### PR TITLE
fix(engine): degrade type drift to full refresh on Databricks and Trino

### DIFF
--- a/engine/crates/rocky-core/src/drift.rs
+++ b/engine/crates/rocky-core/src/drift.rs
@@ -93,14 +93,18 @@ pub fn generate_drop_table_sql(
     Ok(dialect.drop_table_sql(&ref_str))
 }
 
-/// Default body of [`SqlDialect::is_safe_type_widening`] — Databricks /
-/// Spark / DuckDB / Snowflake share enough type-name conventions that
-/// a single allowlist covers them.
+/// Default body of [`SqlDialect::is_safe_type_widening`] — the
+/// Spark/ANSI type-name allowlist (`INT → BIGINT`, `DECIMAL(p,s)`
+/// precision, `VARCHAR(n)` length, numeric → `STRING`).
 ///
-/// Dialects with different type spellings (BigQuery `INT64` /
-/// `NUMERIC` / `FLOAT64` / `BIGNUMERIC`) override
-/// [`SqlDialect::is_safe_type_widening`] in their dialect impl rather
-/// than bolting names onto this list — keeping the global default
+/// Only DuckDB uses this default today: it executes the emitted
+/// `ALTER COLUMN … TYPE` widenings as-is. Every other adapter overrides
+/// [`SqlDialect::is_safe_type_widening`] in its dialect impl —
+/// Snowflake (`NUMBER`/`VARCHAR` precision) and BigQuery (`INT64` /
+/// `NUMERIC` / `BIGNUMERIC`) scope the allowlist to their own type
+/// system, while Databricks and Trino override to `false` because they
+/// can't execute the ANSI `ALTER COLUMN … TYPE` form and degrade type
+/// drift to a full refresh instead (#1115). Keeping the global default
 /// dialect-neutral (no BQ types here) avoids the asymmetry of having
 /// e.g. both `BIGINT → STRING` and `INT64 → STRING` for what is
 /// semantically the same conversion.

--- a/engine/crates/rocky-databricks/src/dialect.rs
+++ b/engine/crates/rocky-databricks/src/dialect.rs
@@ -252,6 +252,21 @@ impl SqlDialect for DatabricksSqlDialect {
             .join(", ");
         Ok(format!("xxhash64({arg_list})"))
     }
+
+    fn is_safe_type_widening(&self, _source_type: &str, _target_type: &str) -> bool {
+        // Delta tables reject `ALTER TABLE … ALTER COLUMN … TYPE …` for a type
+        // change unless the `delta.enableTypeWidening` table feature is enabled
+        // (Rocky never sets it), and numeric → STRING is not a supported Delta
+        // widening at all. So every widening the shared default classifies as
+        // safe would emit an `ALTER` the warehouse rejects, failing the table
+        // run instead of evolving in place (#1115).
+        //
+        // Report no widening as ALTER-safe: type drift then degrades to a full
+        // refresh (`DropAndRecreate`) — the same path other unsafe drifts take —
+        // which succeeds. Graceful in-place evolution (set `enableTypeWidening`
+        // at CREATE + a Delta-scoped allowlist, live-verified) is a follow-up.
+        false
+    }
 }
 
 #[cfg(test)]
@@ -557,5 +572,41 @@ mod tests {
         let d = dialect();
         // SQL-injection attempt: column name carrying a quote.
         assert!(d.row_hash_expr(&["a`; DROP TABLE x; --".into()]).is_err());
+    }
+
+    #[test]
+    fn type_widening_degrades_to_full_refresh() {
+        // Delta can't execute the trait-default `ALTER COLUMN … TYPE` widenings,
+        // so drift the shared default classifies as a safe in-place widening must
+        // instead degrade to a full refresh (`DropAndRecreate`) rather than emit
+        // an `ALTER` Databricks rejects (#1115).
+        use rocky_core::drift::detect_drift;
+        use rocky_ir::{ColumnInfo, DriftAction, TableRef};
+
+        let d = dialect();
+        // Both of these are safe widenings under the shared default.
+        assert!(!d.is_safe_type_widening("BIGINT", "INT")); // INT → BIGINT
+        assert!(!d.is_safe_type_widening("STRING", "INT")); // numeric → STRING
+
+        let table = TableRef {
+            catalog: "acme".into(),
+            schema: "raw".into(),
+            table: "orders".into(),
+        };
+        let col = |name: &str, ty: &str| ColumnInfo {
+            name: name.to_string(),
+            data_type: ty.to_string(),
+            nullable: true,
+        };
+        for (src_ty, tgt_ty) in [("BIGINT", "INT"), ("STRING", "INT")] {
+            let source = vec![col("amount", src_ty)];
+            let target = vec![col("amount", tgt_ty)];
+            let result = detect_drift(&table, &source, &target, &d);
+            assert_eq!(
+                result.action,
+                DriftAction::DropAndRecreate,
+                "{tgt_ty} → {src_ty} must degrade to full refresh on Databricks"
+            );
+        }
     }
 }

--- a/engine/crates/rocky-duckdb/src/dialect.rs
+++ b/engine/crates/rocky-duckdb/src/dialect.rs
@@ -646,4 +646,33 @@ mod tests {
         assert!(stmts[2].starts_with("INSERT INTO marts.fct_daily_orders"));
         assert_eq!(stmts[3], "COMMIT");
     }
+
+    #[test]
+    fn type_widening_still_evolves_in_place() {
+        // DuckDB executes the shared-default `ALTER COLUMN … TYPE` widenings
+        // (verified live), so — unlike Databricks / Trino — it keeps inheriting
+        // the default and a safe widening stays `AlterColumnTypes` rather than a
+        // full refresh. Guards the working adapter against a regression to the
+        // default allowlist (#1115).
+        use rocky_core::drift::detect_drift;
+        use rocky_ir::{ColumnInfo, DriftAction, TableRef};
+
+        let d = dialect();
+        assert!(d.is_safe_type_widening("BIGINT", "INT")); // INT → BIGINT is safe
+
+        let table = TableRef {
+            catalog: "memory".into(),
+            schema: "raw".into(),
+            table: "orders".into(),
+        };
+        let col = |name: &str, ty: &str| ColumnInfo {
+            name: name.to_string(),
+            data_type: ty.to_string(),
+            nullable: true,
+        };
+        let source = vec![col("amount", "BIGINT")];
+        let target = vec![col("amount", "INT")];
+        let result = detect_drift(&table, &source, &target, &d);
+        assert_eq!(result.action, DriftAction::AlterColumnTypes);
+    }
 }

--- a/engine/crates/rocky-trino/src/dialect.rs
+++ b/engine/crates/rocky-trino/src/dialect.rs
@@ -188,6 +188,21 @@ impl SqlDialect for TrinoDialect {
         ])
     }
 
+    fn is_safe_type_widening(&self, _source_type: &str, _target_type: &str) -> bool {
+        // The trait-default `alter_column_type_sql` emits the ANSI `ALTER TABLE
+        // … ALTER COLUMN … TYPE …` form, which is not valid Trino syntax (Trino
+        // requires `… SET DATA TYPE …`), and the in-place type changes Trino
+        // accepts are connector-specific and narrow (e.g. no numeric → VARCHAR).
+        // So every widening the shared default classifies as safe would emit a
+        // statement Trino rejects, failing the table run (#1115).
+        //
+        // Report no widening as ALTER-safe: type drift then degrades to a full
+        // refresh (`DropAndRecreate`), which succeeds. A connector-scoped
+        // allowlist paired with the `SET DATA TYPE` form (live-verified via the
+        // `trino-conformance` harness) is a follow-up.
+        false
+    }
+
     // `view_ddl` defaults to `CREATE OR REPLACE VIEW <target> AS …`,
     // which Trino accepts natively (connector-gated — Iceberg + Hive
     // both support it) so the default impl is correct here.
@@ -435,5 +450,42 @@ mod tests {
         // refactor that changes the trait default is caught here.
         let d = TrinoDialect::new();
         assert_eq!(d.quote_identifier("col"), "\"col\"");
+    }
+
+    #[test]
+    fn type_widening_degrades_to_full_refresh() {
+        // The trait-default `ALTER COLUMN … TYPE` form is invalid Trino syntax
+        // and Trino's accepted in-place widenings are connector-specific, so
+        // drift the shared default classifies as a safe widening must degrade to
+        // a full refresh (`DropAndRecreate`) rather than emit a statement Trino
+        // rejects (#1115).
+        use rocky_core::drift::detect_drift;
+        use rocky_ir::{ColumnInfo, DriftAction, TableRef};
+
+        let d = TrinoDialect::new();
+        // Both of these are safe widenings under the shared default.
+        assert!(!d.is_safe_type_widening("BIGINT", "INT")); // INT → BIGINT
+        assert!(!d.is_safe_type_widening("STRING", "INT")); // numeric → STRING
+
+        let table = TableRef {
+            catalog: "iceberg".into(),
+            schema: "raw".into(),
+            table: "orders".into(),
+        };
+        let col = |name: &str, ty: &str| ColumnInfo {
+            name: name.to_string(),
+            data_type: ty.to_string(),
+            nullable: true,
+        };
+        for (src_ty, tgt_ty) in [("BIGINT", "INT"), ("STRING", "INT")] {
+            let source = vec![col("amount", src_ty)];
+            let target = vec![col("amount", tgt_ty)];
+            let result = detect_drift(&table, &source, &target, &d);
+            assert_eq!(
+                result.action,
+                DriftAction::DropAndRecreate,
+                "{tgt_ty} → {src_ty} must degrade to full refresh on Trino"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1115. `drift::default_is_safe_type_widening` (the `SqlDialect` trait default) classifies integer/float/decimal widenings and numeric/BOOLEAN → STRING as safe, and the run path then executes the ANSI `ALTER TABLE … ALTER COLUMN … TYPE …` form. **Databricks and Trino both inherited that default but cannot execute it:**

- **Databricks (Delta):** rejects `ALTER … ALTER COLUMN … TYPE` for a type change unless the `delta.enableTypeWidening` table feature is enabled (Rocky never sets it), and numeric → STRING isn't a supported Delta widening at all.
- **Trino:** the ANSI `ALTER COLUMN y TYPE z` form isn't valid Trino syntax (Trino requires `… SET DATA TYPE …`), and the accepted in-place changes are connector-specific and narrow.

So source type drift the engine classified as a *safe widening* **failed the table run** on both warehouses (loud failure, `run.rs` propagates the `execute_statement` error) instead of evolving the target in place.

## Change

Override `is_safe_type_widening` to return `false` in the Databricks and Trino dialects, so type drift degrades to a full refresh (`DropAndRecreate`) — the same path other unsafe drifts already take, which both warehouses execute correctly. This is the precise answer given current adapter state: *zero* in-place `ALTER COLUMN TYPE` widenings work on either warehouse today, so "no widening is ALTER-safe" is literally true. It replaces a guaranteed loud failure with correct (if blunter) evolution — no working behavior is lost.

- **DuckDB** keeps inheriting the default (it executes the ANSI ALTER — verified live per #1115), so it still evolves in place.
- **Snowflake / BigQuery** keep their existing type-system-scoped overrides.
- Corrects the stale default-impl doc comment (it claimed Snowflake shares the default; Snowflake overrides).

## Tests

Asserted at the `detect_drift` **decision level** (not just the predicate) with the real dialects:

- **Databricks / Trino:** `INT → BIGINT` and numeric → `STRING` both degrade to `DropAndRecreate`.
- **DuckDB (guard):** the same `INT → BIGINT` still resolves to `AlterColumnTypes` — pins the one adapter that works so a future edit to the default allowlist can't silently regress it.

## Scope / follow-up

This resolves the titled bug: the engine no longer advertises `ALTER` paths these warehouses can't execute. **Graceful in-place evolution** (Databricks `delta.enableTypeWidening` + a Delta-scoped allowlist; Trino `SET DATA TYPE` + a connector-scoped allowlist, live-verified via the `trino-conformance` harness) is tracked as a follow-up — it needs live Databricks/Trino verification to get the per-warehouse allowlists right. The run-path fallback (catch a failed `ALTER`, silently full-refresh) was **consciously rejected**: it would mask real errors (e.g. permissions) and make an expensive/destructive operation happen by accident; the up-front per-adapter decision is safer and more predictable.
