### PR TITLE
feat(engine): WP-01 PR-C — consistent state snapshot (torn-read-free uploader)

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1773,6 +1773,12 @@ pub async fn run(
         )
         .await;
 
+        // WP-01 PR-C: drop the owned state store BEFORE the finalize upload so
+        // its copy runs against a quiescent, unlocked file (the redb `Database`
+        // + advisory writer lock are released here). This is the model-only arm's
+        // last use of `state_store`.
+        drop(state_store);
+
         // WP-01 PR-B (2b): terminal upload AFTER the arm's terminal state
         // writes (run record → idempotency stamp) so they ride it — the same
         // reposition as the replication seam. Runs before the soft-failure
@@ -3196,7 +3202,15 @@ pub async fn run(
             cadence_secs, "adaptive state-sync cadence configured"
         );
         if let Some(session) = session_opt.as_mut() {
-            session.start_periodic_uploader(Duration::from_secs(cadence_secs));
+            // Hand the uploader a `Weak` handle to the live store (never a strong
+            // `Arc` clone): the serial tail below recovers the owned store with
+            // `Arc::try_unwrap`, which a lingering strong clone would block —
+            // silently no-op'ing every terminal write. The uploader snapshots the
+            // store via `begin_read` (MVCC) and uploads a consistent copy.
+            session.start_periodic_uploader(
+                Arc::downgrade(&shared_state),
+                Duration::from_secs(cadence_secs),
+            );
         }
     }
 
@@ -4874,6 +4888,10 @@ pub async fn run(
             &output,
         )
         .await;
+        // WP-01 PR-C: drop the owned state store BEFORE finalize so its copy is
+        // structurally lock-free. Legal here because this failure branch returns
+        // `verify_after_result` below and never touches `state_store` again.
+        drop(state_store);
         // WP-01 PR-B: finalize the state session on this failure branch too,
         // so the failing verify-after's custody row (re-persisted just above)
         // reaches the remote ledger — a deliberate improvement: before the
@@ -4920,6 +4938,12 @@ pub async fn run(
         &output,
     )
     .await;
+
+    // WP-01 PR-C: drop the owned state store BEFORE the terminal finalize so its
+    // copy runs against a quiescent, unlocked file (redb `Database` + advisory
+    // writer lock released here). This is the happy path's last use of
+    // `state_store` — every terminal state write above already completed.
+    drop(state_store);
 
     // WP-01 PR-B (§5): the terminal state upload, repositioned AFTER the
     // terminal state writes (run record → verify-after custody → idempotency

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -1,8 +1,10 @@
 use std::fs::File;
 use std::path::Path;
 
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use fs4::FileExt;
-use redb::{Database, ReadableTable, TableDefinition};
+use redb::{Database, ReadableTable, TableDefinition, TableHandle, WriteTransaction};
 use thiserror::Error;
 
 use crate::config::SchemaMismatchPolicy;
@@ -249,6 +251,80 @@ const METADATA: TableDefinition<&str, &str> = TableDefinition::new("metadata");
 pub const LOCAL_ONLY_TABLE_NAMES: &[&str] =
     &["schema_cache", "jobs", "schedule_state", "schedule_claims"];
 
+/// The redb key/value shape of a state table, for the logical snapshot export.
+///
+/// The full table set is a **closed 2-type split**: exactly two tables are
+/// `TableDefinition<&str, &str>` ([`SOURCE_MARKERS`] and [`METADATA`]); every
+/// other table is `TableDefinition<&str, &[u8]>`. redb 2.6.3 has no
+/// `Database::backup` and no untyped row iteration, so
+/// [`StateStore::snapshot_to_excluding`] must open each table with its concrete
+/// typed definition to iterate it — this enum records which of the two to use.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum TableShape {
+    /// `TableDefinition<&str, &str>` — the two string-valued tables.
+    StrStr,
+    /// `TableDefinition<&str, &[u8]>` — every blob-valued table.
+    StrBytes,
+}
+
+/// Closed registry of every state table and its [`TableShape`], co-located with
+/// the table definitions above so the shape travels with the table name.
+///
+/// [`StateStore::snapshot_to_excluding`] consults this to open each live table
+/// with its concrete typed definition (redb has no untyped iteration). A table
+/// present in a fresh store's `list_tables()` but **absent here** is a hard
+/// error at snapshot time — never a silent drop, which would lose a replicated
+/// table on the next pod's download. The `snapshot_registry_matches_schema`
+/// test pins these names against the eager table set the golden
+/// (`on_disk_state_schema_format_is_pinned`) enumerates, so adding a table
+/// without registering it fails the build.
+const SNAPSHOT_TABLE_REGISTRY: &[(&str, TableShape)] = &[
+    ("watermarks", TableShape::StrBytes),
+    ("source_markers", TableShape::StrStr),
+    ("check_history", TableShape::StrBytes),
+    ("run_history", TableShape::StrBytes),
+    ("quality_history", TableShape::StrBytes),
+    ("dag_snapshots", TableShape::StrBytes),
+    ("run_progress", TableShape::StrBytes),
+    ("run_progress_entries", TableShape::StrBytes),
+    ("partitions", TableShape::StrBytes),
+    ("grace_periods", TableShape::StrBytes),
+    ("loaded_files", TableShape::StrBytes),
+    ("branches", TableShape::StrBytes),
+    ("schema_cache", TableShape::StrBytes),
+    ("idempotency_keys", TableShape::StrBytes),
+    ("output_artifacts", TableShape::StrBytes),
+    ("input_index", TableShape::StrBytes),
+    ("input_provenance", TableShape::StrBytes),
+    ("discover_snapshots", TableShape::StrBytes),
+    ("policy_decisions", TableShape::StrBytes),
+    ("jobs", TableShape::StrBytes),
+    ("tombstones", TableShape::StrBytes),
+    ("schedule_state", TableShape::StrBytes),
+    ("schedule_claims", TableShape::StrBytes),
+    ("metadata", TableShape::StrStr),
+];
+
+/// Look up a table's [`TableShape`] in [`SNAPSHOT_TABLE_REGISTRY`].
+fn snapshot_table_shape(name: &str) -> Option<TableShape> {
+    SNAPSHOT_TABLE_REGISTRY
+        .iter()
+        .find(|(n, _)| *n == name)
+        .map(|(_, shape)| *shape)
+}
+
+/// Soft warning threshold for a logical snapshot's in-transaction footprint.
+///
+/// [`StateStore::snapshot_to_excluding`] materializes the export in a single
+/// redb write transaction, so peak memory is proportional to the total
+/// replicated state size. State files this large are far outside the expected
+/// envelope (watermarks + run history + governance ledgers for a typical
+/// project are single-digit megabytes), so crossing this bound `warn!`s rather
+/// than failing. Deliberately NOT multipart: `PutMultipartOptions` has no
+/// conditional mode in object_store 0.14, so a streaming upload would fork off
+/// the CAS semantics a later PR needs.
+const SNAPSHOT_MEMORY_WARN_BYTES: u64 = 128 * 1024 * 1024;
+
 /// Schema version for the current set of state tables.
 ///
 /// Increment this constant whenever a table is added, removed, or structurally
@@ -447,6 +523,13 @@ pub enum StateError {
         #[source]
         source: std::io::Error,
     },
+
+    #[error(
+        "state snapshot: table {0:?} exists on disk but is not registered in \
+         SNAPSHOT_TABLE_REGISTRY — refusing to produce a snapshot that would silently \
+         drop a replicated table"
+    )]
+    UnknownSnapshotTable(String),
 }
 
 impl From<redb::TransactionError> for StateError {
@@ -513,6 +596,17 @@ pub struct StateStore {
     // end-of-run upload, so a downgraded state is never written back over the
     // newer state that upgraded pods depend on.
     recreated_for_forward_incompat: bool,
+    // Monotonic counter bumped by [`StateStore::commit_write`] after every
+    // production write-transaction commit. **In-memory only — NEVER persisted
+    // to redb** (persisting it would break the byte-identical-on-local guard).
+    // The mid-run periodic uploader reads it via [`StateStore::write_epoch`] to
+    // dirty-gate its snapshot: a tick whose captured epoch matches the last
+    // uploaded one skips all I/O. Construction-time writes (`init_db`) happen
+    // before the store exists and leave this at its `0` baseline — the periodic
+    // uploader treats `0` as "nothing new since open", which is correct because
+    // the as-opened state is exactly what the start-of-run download already
+    // established remotely.
+    write_epoch: AtomicU64,
 }
 
 /// The schema version this binary supports.
@@ -700,6 +794,44 @@ impl StateStore {
         self.recreated_for_forward_incompat
     }
 
+    /// Commit a live-store write transaction and bump [`write_epoch`].
+    ///
+    /// **Every** production write path MUST commit through this rather than
+    /// calling [`redb::WriteTransaction::commit`] directly. redb's `commit` is
+    /// public, so the compiler cannot enforce it — the invariant is held by
+    /// grep-closure: the only bare `.commit()` calls left in this module are
+    /// this body, the construction-time `init_db` commit (pre-`self`, baseline
+    /// epoch), the snapshot export commit (writes a different database), the
+    /// test-support `force_schema_version` helper, and test code.
+    ///
+    /// A missed conversion is silent staleness: the mutation lands on disk but
+    /// the epoch stays put, so the periodic uploader's dirty-gate skips the tick
+    /// that would have replicated it. The epoch is bumped **after** a successful
+    /// commit — a failed commit changed nothing, so it must not advance the
+    /// counter.
+    ///
+    /// [`Ordering::Release`] pairs with the periodic uploader's
+    /// [`Ordering::Acquire`] load so a reader that observes the new epoch also
+    /// observes the committed bytes.
+    fn commit_write(&self, txn: WriteTransaction) -> Result<(), StateError> {
+        txn.commit()?;
+        self.write_epoch.fetch_add(1, Ordering::Release);
+        Ok(())
+    }
+
+    /// The current write epoch — a monotonic count of committed production write
+    /// transactions since this store was opened (see [`commit_write`]).
+    ///
+    /// The mid-run periodic uploader captures this **before** its `begin_read`
+    /// and re-uploads only when it has advanced since the last upload, so a
+    /// clean tick costs zero I/O. Capturing before the read is the safe
+    /// direction: recording an epoch `<=` the snapshot's content merely triggers
+    /// a harmless re-upload next tick, whereas recording `>` the content would
+    /// permanently skip a real change.
+    pub fn write_epoch(&self) -> u64 {
+        self.write_epoch.load(Ordering::Acquire)
+    }
+
     fn open_inner(
         path: &Path,
         mode: OpenMode,
@@ -722,6 +854,7 @@ impl StateStore {
                 db,
                 _lock: lock,
                 recreated_for_forward_incompat: false,
+                write_epoch: AtomicU64::new(0),
             }),
             InitOutcome::RecreateForwardIncompat { found } => {
                 // Forward-incompatible store under `SchemaMismatchPolicy::Recreate`.
@@ -764,6 +897,7 @@ impl StateStore {
                         db,
                         _lock: lock,
                         recreated_for_forward_incompat: true,
+                        write_epoch: AtomicU64::new(0),
                     }),
                     // A file we just created cannot carry a newer schema version.
                     InitOutcome::RecreateForwardIncompat { found } => {
@@ -882,8 +1016,107 @@ impl StateStore {
             let _table = txn.open_table(SCHEDULE_STATE)?;
             let _table = txn.open_table(SCHEDULE_CLAIMS)?;
         }
+        // Construction-time commit: this runs on the raw `db` handle before any
+        // `StateStore` (and thus any `write_epoch`) exists, so it deliberately
+        // does NOT go through `commit_write`. The tables + version stamp it
+        // writes are the epoch-0 baseline the periodic uploader treats as
+        // "already on the remote from the start-of-run download".
         txn.commit()?;
         Ok(InitOutcome::Ready)
+    }
+
+    /// Export a **consistent logical snapshot** of the live state store to a
+    /// fresh redb database at `dest`, omitting every table named in `excluded`.
+    ///
+    /// This is the torn-read-free replacement for the mid-run periodic upload's
+    /// `std::fs::copy` of the live file: that copy races the run's own write
+    /// transactions (a redb file mutated under an unsynchronized `copy` yields a
+    /// torn read). Here the export runs against a single [`begin_read`] MVCC
+    /// snapshot, so every row it emits is drawn from **one** committed state —
+    /// no concurrent `commit_write` can tear a correlated row pair across
+    /// tables. The live store keeps taking writers throughout (this method only
+    /// holds a read transaction), so the run is never blocked.
+    ///
+    /// redb 2.6.3 exposes no `Database::backup` and no untyped row iteration, so
+    /// each table is opened with its concrete typed definition via the closed
+    /// [`SNAPSHOT_TABLE_REGISTRY`]. A table present in the live store's
+    /// `list_tables()` but **absent from the registry** is a hard
+    /// [`StateError::UnknownSnapshotTable`] — never a silent drop, which would
+    /// lose a replicated table on the next pod's download.
+    ///
+    /// The whole export commits under **one** write transaction on `dest`, so
+    /// peak memory is proportional to the total replicated state size; see
+    /// [`SNAPSHOT_MEMORY_WARN_BYTES`] for the soft bound this `warn!`s past.
+    ///
+    /// `dest` must not be a live state file — it is created fresh and written in
+    /// full. Callers use a scratch path guarded for cleanup.
+    pub fn snapshot_to_excluding(&self, dest: &Path, excluded: &[&str]) -> Result<(), StateError> {
+        let read_txn = self.db.begin_read()?;
+        // Enumerate the live table set from the consistent MVCC read snapshot.
+        let table_names: Vec<String> = read_txn
+            .list_tables()?
+            .map(|h| h.name().to_string())
+            .collect();
+
+        let dest_db = Database::create(dest)?;
+        let write_txn = dest_db.begin_write()?;
+        let mut total_bytes: u64 = 0;
+        {
+            for name in &table_names {
+                if excluded.contains(&name.as_str()) {
+                    continue;
+                }
+                let shape = snapshot_table_shape(name)
+                    .ok_or_else(|| StateError::UnknownSnapshotTable(name.clone()))?;
+                match shape {
+                    TableShape::StrStr => {
+                        let def: TableDefinition<&str, &str> = TableDefinition::new(name);
+                        let src = read_txn.open_table(def)?;
+                        let mut dst = write_txn.open_table(def)?;
+                        for entry in src.iter()? {
+                            let (k, v) = entry?;
+                            let (key, value) = (k.value(), v.value());
+                            total_bytes += (key.len() + value.len()) as u64;
+                            dst.insert(key, value)?;
+                        }
+                    }
+                    TableShape::StrBytes => {
+                        let def: TableDefinition<&str, &[u8]> = TableDefinition::new(name);
+                        let src = read_txn.open_table(def)?;
+                        let mut dst = write_txn.open_table(def)?;
+                        for entry in src.iter()? {
+                            let (k, v) = entry?;
+                            let (key, value) = (k.value(), v.value());
+                            total_bytes += (key.len() + value.len()) as u64;
+                            dst.insert(key, value)?;
+                        }
+                    }
+                }
+            }
+        }
+        // Commits the EXPORT database (`dest`), not the live store (`self.db`):
+        // deliberately NOT routed through `commit_write` — this writes the file
+        // being uploaded, it is not a live-state mutation, so it must not bump
+        // `write_epoch`.
+        write_txn.commit()?;
+        // Drop the export handle so the OS fully releases the file's flock + mmap
+        // before the caller uploads (or reopens) the scratch — same discipline as
+        // `state_sync::strip_local_only_tables`.
+        drop(dest_db);
+
+        if total_bytes > SNAPSHOT_MEMORY_WARN_BYTES {
+            tracing::warn!(
+                target: "rocky::state",
+                snapshot_bytes = total_bytes,
+                warn_bytes = SNAPSHOT_MEMORY_WARN_BYTES,
+                dest = %dest.display(),
+                "state snapshot exceeds the soft memory bound; the logical export is \
+                 materialized in a single redb write transaction (peak memory scales with \
+                 total replicated state size). Not multipart by design (object_store 0.14 \
+                 has no conditional multipart)."
+            );
+        }
+        Ok(())
     }
 
     /// Gets the watermark for a table (keyed by `catalog.schema.table`).
@@ -912,7 +1145,7 @@ impl StateStore {
             let mut table = txn.open_table(WATERMARKS)?;
             table.insert(table_key, bytes.as_slice())?;
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 
@@ -934,7 +1167,7 @@ impl StateStore {
             let mut table = txn.open_table(SOURCE_MARKERS)?;
             table.insert(table_key, marker)?;
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 
@@ -963,7 +1196,7 @@ impl StateStore {
                 table.insert(*key, bytes.as_slice())?;
             }
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(entries.len())
     }
 
@@ -975,7 +1208,7 @@ impl StateStore {
             let mut table = txn.open_table(WATERMARKS)?;
             removed = table.remove(table_key)?.is_some();
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(removed)
     }
 
@@ -1022,7 +1255,7 @@ impl StateStore {
             let mut table = txn.open_table(CHECK_HISTORY)?;
             table.insert(table_key, bytes.as_slice())?;
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 
@@ -1058,7 +1291,7 @@ impl StateStore {
             let mut table = txn.open_table(PARTITIONS)?;
             table.insert(key.as_str(), bytes.as_slice())?;
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 
@@ -1135,7 +1368,7 @@ impl StateStore {
             let mut table = txn.open_table(PARTITIONS)?;
             removed = table.remove(key.as_str())?.is_some();
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(removed)
     }
 }
@@ -1876,7 +2109,7 @@ impl StateStore {
             let mut table = txn.open_table(JOBS)?;
             table.insert(job.job_id.as_str(), bytes.as_slice())?;
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 
@@ -1916,7 +2149,7 @@ impl StateStore {
             let mut table = txn.open_table(RUN_HISTORY)?;
             table.insert(run.run_id.as_str(), bytes.as_slice())?;
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 
@@ -1988,7 +2221,7 @@ impl StateStore {
             let mut table = txn.open_table(QUALITY_HISTORY)?;
             table.insert(key.as_str(), bytes.as_slice())?;
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 
@@ -2023,7 +2256,7 @@ impl StateStore {
             let mut table = txn.open_table(DAG_SNAPSHOTS)?;
             table.insert(key.as_str(), bytes.as_slice())?;
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 
@@ -2063,7 +2296,7 @@ impl StateStore {
             let mut table = txn.open_table(RUN_PROGRESS)?;
             table.insert(run_id, bytes.as_slice())?;
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 
@@ -2093,7 +2326,7 @@ impl StateStore {
             let mut table = txn.open_table(RUN_PROGRESS_ENTRIES)?;
             table.insert(key.as_str(), bytes.as_slice())?;
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 
@@ -2310,7 +2543,7 @@ impl StateStore {
                     table.remove(key.as_str())?;
                 }
             }
-            txn.commit()?;
+            self.commit_write(txn)?;
         }
 
         Ok((deleted, total.saturating_sub(deleted)))
@@ -2383,7 +2616,7 @@ impl StateStore {
                     table.remove(key.as_str())?;
                 }
             }
-            txn.commit()?;
+            self.commit_write(txn)?;
         }
 
         Ok((deleted, total.saturating_sub(deleted)))
@@ -2452,7 +2685,7 @@ impl StateStore {
                     table.remove(key.as_str())?;
                 }
             }
-            txn.commit()?;
+            self.commit_write(txn)?;
         }
 
         Ok((deleted, total.saturating_sub(deleted)))
@@ -2550,7 +2783,7 @@ impl StateStore {
             let mut table = txn.open_table(METADATA)?;
             table.insert(LAST_RETENTION_SWEEP_AT_KEY, formatted.as_str())?;
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 
@@ -2590,7 +2823,7 @@ impl StateStore {
             let mut table = txn.open_table(METADATA)?;
             table.insert(LAST_BRIEF_AT_KEY, formatted.as_str())?;
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 }
@@ -2634,7 +2867,7 @@ impl StateStore {
             let mut table = txn.open_table(IDEMPOTENCY_KEYS)?;
             table.insert(entry.key.as_str(), bytes.as_slice())?;
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 
@@ -2646,7 +2879,7 @@ impl StateStore {
             let mut table = txn.open_table(IDEMPOTENCY_KEYS)?;
             removed = table.remove(key)?.is_some();
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(removed)
     }
 
@@ -2695,7 +2928,7 @@ impl StateStore {
                 }
             };
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(result)
     }
 
@@ -2758,7 +2991,7 @@ impl StateStore {
                 }
             }
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 
@@ -2816,7 +3049,7 @@ impl StateStore {
                 }
             }
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(removed)
     }
 }
@@ -2852,7 +3085,7 @@ impl StateStore {
             let mut table = txn.open_table(SCHEDULE_STATE)?;
             table.insert(pipeline, bytes.as_slice())?;
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 
@@ -2887,7 +3120,7 @@ impl StateStore {
                 table.insert(pipeline, bytes.as_slice())?;
             }
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 
@@ -2914,7 +3147,7 @@ impl StateStore {
             let bytes = serde_json::to_vec(&record)?;
             table.insert(pipeline, bytes.as_slice())?;
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 
@@ -2986,7 +3219,7 @@ impl StateStore {
             }
         }
         if won {
-            txn.commit()?;
+            self.commit_write(txn)?;
             Ok(ClaimCas::Won)
         } else {
             drop(txn);
@@ -3074,7 +3307,7 @@ impl StateStore {
                 removed += 1;
             }
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(removed)
     }
 
@@ -3089,7 +3322,7 @@ impl StateStore {
             let mut table = txn.open_table(RUN_HISTORY)?;
             table.insert(key, b"{not valid run record json".as_slice())?;
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 }
@@ -3129,7 +3362,7 @@ impl StateStore {
             let mut table = txn.open_table(GRACE_PERIODS)?;
             table.insert(key.as_str(), bytes.as_slice())?;
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 
@@ -3186,7 +3419,7 @@ impl StateStore {
             let mut table = txn.open_table(GRACE_PERIODS)?;
             removed = table.remove(key.as_str())?.is_some();
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(removed)
     }
 
@@ -3210,7 +3443,7 @@ impl StateStore {
             let mut table = txn.open_table(LOADED_FILES)?;
             table.insert(key.as_str(), bytes.as_slice())?;
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 
@@ -3263,7 +3496,7 @@ impl StateStore {
             let mut table = txn.open_table(LOADED_FILES)?;
             removed = table.remove(key.as_str())?.is_some();
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(removed)
     }
 
@@ -3293,7 +3526,7 @@ impl StateStore {
             let mut table = txn.open_table(OUTPUT_ARTIFACTS)?;
             table.insert(key.as_str(), bytes.as_slice())?;
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 
@@ -3391,7 +3624,7 @@ impl StateStore {
             };
         }
         if matches!(outcome, EvictOutcome::Evicted) {
-            txn.commit()?;
+            self.commit_write(txn)?;
         } else {
             // Nothing evicted — drop the transaction without committing so no
             // tombstone is recorded for a row that was absent or hash-mismatched.
@@ -3415,7 +3648,7 @@ impl StateStore {
             let mut table = txn.open_table(TOMBSTONES)?;
             table.insert(key.as_str(), bytes.as_slice())?;
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 
@@ -3540,7 +3773,7 @@ impl StateStore {
             };
         }
         match outcome {
-            RestoreOutcome::Restored | RestoreOutcome::AlreadyRestored => txn.commit()?,
+            RestoreOutcome::Restored | RestoreOutcome::AlreadyRestored => self.commit_write(txn)?,
             _ => drop(txn),
         }
         Ok(outcome)
@@ -3568,7 +3801,7 @@ impl StateStore {
             let mut table = txn.open_table(POLICY_DECISIONS)?;
             table.insert(key.as_str(), bytes.as_slice())?;
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 
@@ -3637,7 +3870,7 @@ impl StateStore {
                 prov.insert(key.as_str(), bytes.as_slice())?;
             }
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 
@@ -3824,7 +4057,7 @@ impl StateStore {
             let mut table = txn.open_table(BRANCHES)?;
             table.insert(branch.name.as_str(), bytes.as_slice())?;
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 
@@ -3859,7 +4092,7 @@ impl StateStore {
             let mut table = txn.open_table(BRANCHES)?;
             removed = table.remove(name)?.is_some();
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(removed)
     }
 
@@ -3903,7 +4136,7 @@ impl StateStore {
             let mut table = txn.open_table(SCHEMA_CACHE)?;
             table.insert(key, bytes.as_slice())?;
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 
@@ -3935,7 +4168,7 @@ impl StateStore {
                 table.insert(*key, bytes.as_slice())?;
             }
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(entries.len())
     }
 
@@ -3968,7 +4201,7 @@ impl StateStore {
             let mut table = txn.open_table(DISCOVER_SNAPSHOTS)?;
             table.insert(pipeline, bytes.as_slice())?;
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(())
     }
 
@@ -3985,7 +4218,7 @@ impl StateStore {
             let mut table = txn.open_table(SCHEMA_CACHE)?;
             removed = table.remove(key)?.is_some();
         }
-        txn.commit()?;
+        self.commit_write(txn)?;
         Ok(removed)
     }
 
@@ -8844,6 +9077,467 @@ mod tests {
              different set of redb tables than the pinned format contract. If intentional, \
              update EXPECTED_TABLES (and bump CURRENT_SCHEMA_VERSION + add the migration) in \
              the same PR."
+        );
+
+        // Registry-integrity: the snapshot table registry MUST enumerate exactly
+        // the same table set a fresh store materializes. `snapshot_to_excluding`
+        // hard-errors on any live table missing from the registry, so a table
+        // added to `init_db` without a `SNAPSHOT_TABLE_REGISTRY` row would break
+        // the mid-run upload — this pins them in lockstep at build time instead.
+        let mut registry_names: Vec<String> = SNAPSHOT_TABLE_REGISTRY
+            .iter()
+            .map(|(name, _)| name.to_string())
+            .collect();
+        registry_names.sort_unstable();
+        assert_eq!(
+            registry_names, actual,
+            "SNAPSHOT_TABLE_REGISTRY drifted from the on-disk table set. Every table \
+             `init_db` eagerly creates must have a registry row (with its key/value shape) \
+             so `snapshot_to_excluding` can export it; adding a table without registering \
+             it would make the mid-run snapshot fail closed."
+        );
+
+        // The closed 2-type split the registry is built on: exactly two tables
+        // are `<&str, &str>` (metadata + source_markers); every other is
+        // `<&str, &[u8]>`. A drift here means a new string-valued table needs a
+        // `TableShape::StrStr` row (and this count updated).
+        let str_str = SNAPSHOT_TABLE_REGISTRY
+            .iter()
+            .filter(|(_, shape)| *shape == TableShape::StrStr)
+            .count();
+        assert_eq!(
+            str_str, 2,
+            "the closed 2-type split changed: exactly two tables are TableShape::StrStr \
+             (metadata, source_markers)"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // PR-C — consistent snapshot (`snapshot_to_excluding`) + write epoch
+    // -----------------------------------------------------------------------
+
+    fn wm_at(secs: i64) -> WatermarkState {
+        let ts = chrono::DateTime::from_timestamp(secs, 0).unwrap();
+        WatermarkState {
+            last_value: ts,
+            updated_at: ts,
+        }
+    }
+
+    /// The snapshot omits every `LOCAL_ONLY` table, copies every replicated
+    /// table byte-for-byte, and the exported blob reopens as a live store.
+    #[test]
+    fn snapshot_excludes_local_only_and_keeps_replicated_rows_byte_equal() {
+        let (store, dir) = temp_store();
+
+        // Replicated rows across both key/value shapes: watermarks (<&str,&[u8]>),
+        // source_markers + metadata (<&str,&str>).
+        store
+            .set_watermark("cat.sch.orders", &wm_at(1_700_000_000))
+            .unwrap();
+        store
+            .set_source_marker("cat.sch.orders", "2026-01-01T00:00:00Z|3|2048")
+            .unwrap();
+        // A local-only row that must NOT travel.
+        store.record_job(&sample_job("job-1", "running")).unwrap();
+
+        let dest = dir.path().join("snapshot.redb");
+        store
+            .snapshot_to_excluding(&dest, LOCAL_ONLY_TABLE_NAMES)
+            .unwrap();
+
+        // Verify the exported blob via raw redb (a fresh pod opens the downloaded
+        // snapshot with no contending handle; opening it in-process races the
+        // just-dropped export handle's flock, which is a test-only artifact).
+        let snap_db = Database::open(&dest).unwrap();
+        let read = snap_db.begin_read().unwrap();
+
+        // A replicated <&str,&[u8]> watermark survives byte-for-byte.
+        let wm_def: TableDefinition<&str, &[u8]> = TableDefinition::new("watermarks");
+        let wm_tbl = read.open_table(wm_def).unwrap();
+        let got: WatermarkState =
+            serde_json::from_slice(wm_tbl.get("cat.sch.orders").unwrap().unwrap().value()).unwrap();
+        assert_eq!(got.last_value, wm_at(1_700_000_000).last_value);
+        assert_eq!(got.updated_at, wm_at(1_700_000_000).updated_at);
+
+        // A replicated <&str,&str> source marker survives byte-for-byte.
+        let sm_def: TableDefinition<&str, &str> = TableDefinition::new("source_markers");
+        let sm_tbl = read.open_table(sm_def).unwrap();
+        assert_eq!(
+            sm_tbl.get("cat.sch.orders").unwrap().unwrap().value(),
+            "2026-01-01T00:00:00Z|3|2048"
+        );
+
+        // The replicated metadata table carries the schema version.
+        let md_def: TableDefinition<&str, &str> = TableDefinition::new("metadata");
+        let md_tbl = read.open_table(md_def).unwrap();
+        assert_eq!(
+            md_tbl.get("schema_version").unwrap().unwrap().value(),
+            CURRENT_SCHEMA_VERSION.to_string()
+        );
+
+        // The local-only `jobs` table was excluded entirely — it is not even
+        // created in the snapshot.
+        let jobs_def: TableDefinition<&str, &[u8]> = TableDefinition::new("jobs");
+        assert!(
+            matches!(
+                read.open_table(jobs_def),
+                Err(redb::TableError::TableDoesNotExist(_))
+            ),
+            "the local-only `jobs` table must be excluded from the snapshot"
+        );
+    }
+
+    /// The snapshot reads via `begin_read` (MVCC), NOT a second `Database` open,
+    /// so it succeeds while the live handle still holds the redb flock — and the
+    /// flock is genuinely exclusive (a second `Database` open on the live path
+    /// errors, pinning that the snapshot did not take that path).
+    #[test]
+    fn snapshot_uses_begin_read_not_a_second_database_open() {
+        let (store, dir) = temp_store();
+        let live_path = dir.path().join("state.redb");
+        store.set_watermark("c.s.t", &wm_at(1_700_000_100)).unwrap();
+
+        // A second `Database` handle on the LIVE path is blocked by redb's flock
+        // (the `DatabaseAlreadyOpen` guard). If the snapshot opened the live file
+        // this way it would deadlock/err against the run's own handle.
+        assert!(
+            Database::create(&live_path).is_err(),
+            "a second Database open on the live path must be blocked by the flock"
+        );
+
+        // The snapshot nevertheless succeeds — it only takes a read txn on the
+        // already-open handle.
+        let dest = dir.path().join("snap.redb");
+        store
+            .snapshot_to_excluding(&dest, LOCAL_ONLY_TABLE_NAMES)
+            .unwrap();
+        let snap_db = Database::open(&dest).unwrap();
+        let read = snap_db.begin_read().unwrap();
+        let wm_def: TableDefinition<&str, &[u8]> = TableDefinition::new("watermarks");
+        let wm_tbl = read.open_table(wm_def).unwrap();
+        let got: WatermarkState =
+            serde_json::from_slice(wm_tbl.get("c.s.t").unwrap().unwrap().value()).unwrap();
+        assert_eq!(got.last_value, wm_at(1_700_000_100).last_value);
+    }
+
+    /// A table present on disk but absent from `SNAPSHOT_TABLE_REGISTRY` is a
+    /// hard error — never a silent drop (which would lose a replicated table on
+    /// the next pod's download).
+    #[test]
+    fn snapshot_errors_on_an_unregistered_table() {
+        let (store, dir) = temp_store();
+        // Fabricate a stray table directly on the live db (as a future schema
+        // addition that forgot its registry row would look).
+        {
+            let txn = store.db.begin_write().unwrap();
+            {
+                let def: TableDefinition<&str, &[u8]> =
+                    TableDefinition::new("__unregistered_future_table");
+                let mut t = txn.open_table(def).unwrap();
+                t.insert("k", b"v".as_slice()).unwrap();
+            }
+            txn.commit().unwrap();
+        }
+        let dest = dir.path().join("snap.redb");
+        let err = store
+            .snapshot_to_excluding(&dest, LOCAL_ONLY_TABLE_NAMES)
+            .unwrap_err();
+        assert!(
+            matches!(err, StateError::UnknownSnapshotTable(ref n) if n == "__unregistered_future_table"),
+            "an unregistered table must fail closed, got: {err:?}"
+        );
+    }
+
+    /// The consistency crux: under a concurrent writer committing a correlated
+    /// row pair atomically, the MVCC snapshot NEVER observes a torn pair — while
+    /// a naive, non-atomic byte copy of the same live file under the same load
+    /// DOES tear. The byte-copy half is the RED demo that proves the MVCC
+    /// assertion is a real discriminator, not vacuously green.
+    ///
+    /// The RED demo uses an explicit chunked read/write (with a small pause
+    /// between chunks) rather than `std::fs::copy`: on macOS APFS `std::fs::copy`
+    /// is an atomic `clonefile` that captures a crash-consistent point-in-time
+    /// and would NOT tear, hiding the hazard — but on the Linux pods where
+    /// RD-004's torn read bites, a byte-level copy of a live redb file smears
+    /// across the writer's commits exactly like this stand-in.
+    #[test]
+    fn snapshot_under_concurrent_writes_never_tears_a_correlated_pair() {
+        use std::io::{Read, Write};
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering as O};
+        use std::thread;
+        use std::time::Duration;
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("state.redb");
+        let store = Arc::new(StateStore::open(&path).unwrap());
+
+        // Pad the store so the file spans enough pages that a chunked copy
+        // overlaps several writer commits — a few-KB file copies faster than the
+        // writer can move a page, hiding the hazard.
+        {
+            let pad: Vec<(String, WatermarkState)> = (0..600)
+                .map(|i| (format!("pad.table.{i}"), wm_at(1_600_000_000 + i)))
+                .collect();
+            let refs: Vec<(&str, &WatermarkState)> =
+                pad.iter().map(|(k, v)| (k.as_str(), v)).collect();
+            store.batch_set_watermarks(&refs).unwrap();
+        }
+        // Seed the correlated pair so both keys always exist for readers.
+        store
+            .batch_set_watermarks(&[
+                ("pair.a", &wm_at(1_700_000_000)),
+                ("pair.b", &wm_at(1_700_000_000)),
+            ])
+            .unwrap();
+
+        // Writer: set BOTH keys to the SAME value in ONE txn (so any consistent
+        // view sees `pair.a == pair.b`) and churn a growth key, so a byte-level
+        // copy is very likely to smear across a commit. redb commits atomically.
+        let stop = Arc::new(AtomicBool::new(false));
+        let writer = {
+            let store = Arc::clone(&store);
+            let stop = Arc::clone(&stop);
+            thread::spawn(move || {
+                let mut n: i64 = 0;
+                while !stop.load(O::Relaxed) {
+                    n += 1;
+                    let wm = wm_at(1_700_000_000 + n);
+                    store
+                        .batch_set_watermarks(&[("pair.a", &wm), ("pair.b", &wm)])
+                        .unwrap();
+                    store.set_watermark(&format!("grow.{n}"), &wm).unwrap();
+                }
+            })
+        };
+
+        // Read the correlated pair from a copied/exported redb file. `None` means
+        // the file could not be opened or a key was missing (a torn read).
+        let read_pair = |p: &std::path::Path| -> Option<(WatermarkState, WatermarkState)> {
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let db = Database::open(p).ok()?;
+                let txn = db.begin_read().ok()?;
+                let def: TableDefinition<&str, &[u8]> = TableDefinition::new("watermarks");
+                let table = txn.open_table(def).ok()?;
+                let a: WatermarkState =
+                    serde_json::from_slice(table.get("pair.a").ok()??.value()).ok()?;
+                let b: WatermarkState =
+                    serde_json::from_slice(table.get("pair.b").ok()??.value()).ok()?;
+                Some((a, b))
+            }))
+            .unwrap_or(None)
+        };
+
+        // Non-atomic, chunked byte copy: pauses between chunks so the writer's
+        // commits smear across the read — the torn read `std::fs::copy` produces
+        // on the Linux pods where the bug bites.
+        let smeared_copy = |src: &std::path::Path, dst: &std::path::Path| -> std::io::Result<()> {
+            let mut r = std::fs::File::open(src)?;
+            let mut w = std::fs::File::create(dst)?;
+            let mut buf = vec![0u8; 8 * 1024];
+            loop {
+                let n = r.read(&mut buf)?;
+                if n == 0 {
+                    break;
+                }
+                w.write_all(&buf[..n])?;
+                thread::sleep(Duration::from_millis(1));
+            }
+            Ok(())
+        };
+
+        // GREEN — the MVCC snapshot is always internally consistent under load.
+        let mut snapshot_checks = 0usize;
+        for _ in 0..8 {
+            let snap = dir.path().join("snap.redb");
+            let _ = std::fs::remove_file(&snap);
+            store
+                .snapshot_to_excluding(&snap, LOCAL_ONLY_TABLE_NAMES)
+                .unwrap();
+            let (a, b) = read_pair(&snap).expect("the MVCC snapshot always reopens with both keys");
+            assert_eq!(
+                a.last_value, b.last_value,
+                "the MVCC snapshot must never tear the correlated pair"
+            );
+            snapshot_checks += 1;
+        }
+
+        // RED — the naive byte copy tears (unopenable OR a mismatched pair).
+        let mut torn = 0usize;
+        for _ in 0..60 {
+            let raw = dir.path().join("raw.redb");
+            let _ = std::fs::remove_file(&raw);
+            let is_torn = match smeared_copy(&path, &raw) {
+                Ok(()) => match read_pair(&raw) {
+                    Some((a, b)) => a.last_value != b.last_value,
+                    None => true,
+                },
+                Err(_) => true,
+            };
+            if is_torn {
+                torn += 1;
+                if torn >= 3 {
+                    break;
+                }
+            }
+        }
+
+        stop.store(true, O::Relaxed);
+        writer.join().unwrap();
+
+        assert!(snapshot_checks > 0);
+        assert!(
+            torn > 0,
+            "RED demo failed to observe any torn read from a non-atomic byte copy under \
+             writer load ({snapshot_checks} snapshot checks); without an observed tear the \
+             MVCC consistency assertion above is not a real discriminator"
+        );
+    }
+
+    /// `write_epoch` starts at 0 (construction does not bump) and every
+    /// production write method advances it by exactly 1 via `commit_write`.
+    ///
+    /// The EXHAUSTIVE guarantee that no write method skips the epoch is the
+    /// grep-closure (every production `.commit()` in this module routes through
+    /// `commit_write`); this is the behavioral confirmation that `commit_write`
+    /// itself bumps, across both table shapes and both insert + delete paths.
+    #[test]
+    fn write_epoch_bumps_on_production_write_methods() {
+        let (store, _dir) = temp_store();
+        assert_eq!(
+            store.write_epoch(),
+            0,
+            "a freshly opened store starts at epoch 0 — init_db's construction commit \
+             does not bump the epoch"
+        );
+
+        type WriteOp = (&'static str, Box<dyn Fn(&StateStore)>);
+        let ops: Vec<WriteOp> = vec![
+            (
+                "set_watermark",
+                Box::new(|s: &StateStore| s.set_watermark("c.s.t", &wm_at(1)).unwrap()),
+            ),
+            (
+                "batch_set_watermarks",
+                Box::new(|s: &StateStore| {
+                    s.batch_set_watermarks(&[("c.s.u", &wm_at(2))]).unwrap();
+                }),
+            ),
+            (
+                "set_source_marker",
+                Box::new(|s: &StateStore| s.set_source_marker("c.s.t", "m").unwrap()),
+            ),
+            (
+                "record_job",
+                Box::new(|s: &StateStore| s.record_job(&sample_job("j", "running")).unwrap()),
+            ),
+            (
+                "delete_watermark",
+                Box::new(|s: &StateStore| {
+                    s.delete_watermark("c.s.t").unwrap();
+                }),
+            ),
+            (
+                "delete_branch (no-op still commits)",
+                Box::new(|s: &StateStore| {
+                    s.delete_branch("nope").unwrap();
+                }),
+            ),
+            (
+                "delete_schema_cache_entry (no-op still commits)",
+                Box::new(|s: &StateStore| {
+                    s.delete_schema_cache_entry("nope").unwrap();
+                }),
+            ),
+        ];
+
+        let mut expected = 0u64;
+        for (name, op) in &ops {
+            op(&store);
+            expected += 1;
+            assert_eq!(
+                store.write_epoch(),
+                expected,
+                "`{name}` must bump write_epoch by exactly 1"
+            );
+        }
+    }
+
+    /// The safe epoch-capture direction: capturing the epoch BEFORE the read
+    /// snapshot means a write landing between the capture and the read is
+    /// INCLUDED in the snapshot content but recorded under the SMALLER epoch — so
+    /// the recorded epoch is always `<=` the content (a harmless re-upload next
+    /// tick), never `>` it (which would permanently skip a real change).
+    #[test]
+    fn epoch_capture_before_begin_read_is_the_safe_direction() {
+        let (store, dir) = temp_store();
+        store.set_watermark("c.s.a", &wm_at(10)).unwrap();
+
+        let captured = store.write_epoch(); // captured BEFORE the snapshot
+
+        // A write lands after the capture but before the snapshot's begin_read.
+        store.set_watermark("c.s.b", &wm_at(20)).unwrap();
+
+        let dest = dir.path().join("snap.redb");
+        store
+            .snapshot_to_excluding(&dest, LOCAL_ONLY_TABLE_NAMES)
+            .unwrap();
+
+        // The snapshot CONTENT includes the post-capture write...
+        let snap_db = Database::open(&dest).unwrap();
+        let read = snap_db.begin_read().unwrap();
+        let wm_def: TableDefinition<&str, &[u8]> = TableDefinition::new("watermarks");
+        let wm_tbl = read.open_table(wm_def).unwrap();
+        assert!(
+            wm_tbl.get("c.s.b").unwrap().is_some(),
+            "the snapshot content includes the write that landed after the epoch capture"
+        );
+        // ...so the captured epoch is strictly LESS than the content's epoch: the
+        // recorded 'uploaded-through' marker never overstates what shipped.
+        assert!(
+            captured < store.write_epoch(),
+            "captured epoch ({captured}) must be <= the snapshot content epoch ({}) — \
+             the safe direction",
+            store.write_epoch()
+        );
+    }
+
+    /// Lock-free discriminator for the end-of-run finalize (Step 4): once the
+    /// owned `StateStore` is dropped, the state file's writer lock is free, so
+    /// the finalize copy runs against a quiescent, unlocked file. This is a
+    /// genuine RED→GREEN test — the first assertion pins that the lock IS held
+    /// while the store is open, so removing the `drop` makes the second
+    /// assertion (run while the store is still open) FAIL.
+    #[test]
+    fn dropping_store_before_finalize_makes_upload_lock_free() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("state.redb");
+        let state_store = Some(StateStore::open(&path).unwrap());
+
+        // A terminal write, exactly as the run tail does before finalize.
+        state_store
+            .as_ref()
+            .unwrap()
+            .set_watermark("c.s.t", &wm_at(1_700_000_000))
+            .unwrap();
+
+        // While the store is open the writer lock is held — this guards the
+        // second assertion from being vacuous.
+        assert!(
+            try_acquire_writer_lock(&path).is_err(),
+            "the writer lock must be held while the state store is open"
+        );
+
+        // The drop-before-finalize under test.
+        drop(state_store);
+
+        // Now the end-of-run finalize copy runs lock-free. This assertion FAILS
+        // if the store is still open at finalize (i.e. if the drop is removed).
+        assert!(
+            try_acquire_writer_lock(&path).is_ok(),
+            "after dropping the state store the writer lock is free — the finalize copy \
+             is provably lock-free"
         );
     }
 

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -3827,13 +3827,16 @@ mod tests {
     /// (the thread-local [`test_support::install`] only covers the test thread).
     /// Hold the returned guard for the test's duration; pair with
     /// [`test_support::serial_guard`] (the global override is shared state).
-    fn install_counting_provider_global()
-    -> (crate::fault_store::FaultHandle, test_support::GlobalOverrideGuard) {
+    fn install_counting_provider_global() -> (
+        crate::fault_store::FaultHandle,
+        test_support::GlobalOverrideGuard,
+    ) {
         let (store, faults) = crate::fault_store::FaultingStore::wrap(std::sync::Arc::new(
             object_store::memory::InMemory::new(),
         ));
-        let guard =
-            test_support::install_global(ObjectStoreProvider::from_store(store, "s3", "bucket", ""));
+        let guard = test_support::install_global(ObjectStoreProvider::from_store(
+            store, "s3", "bucket", "",
+        ));
         (faults, guard)
     }
 
@@ -4177,30 +4180,36 @@ mod tests {
         // First dirty tick uploads.
         let uploaded = poll_until(
             || faults.count(crate::fault_store::FaultOp::Put) >= 1,
-            Duration::from_secs(5),
+            Duration::from_secs(10),
         )
         .await;
-        assert!(uploaded, "a dirty tick must upload the snapshot");
         let after_first = faults.count(crate::fault_store::FaultOp::Put);
 
         // No new writes → subsequent ticks are clean and skip (zero new Puts).
         tokio::time::sleep(Duration::from_millis(300)).await;
-        assert_eq!(
-            faults.count(crate::fault_store::FaultOp::Put),
-            after_first,
-            "clean ticks must skip — the dirty-gate spends zero I/O when the epoch is unchanged"
-        );
+        let clean_skipped = faults.count(crate::fault_store::FaultOp::Put) == after_first;
 
         // A fresh write re-dirties the epoch → the uploader picks it up.
         store.set_watermark("c.s.u", &wm_now()).unwrap();
         let re_uploaded = poll_until(
             || faults.count(crate::fault_store::FaultOp::Put) > after_first,
-            Duration::from_secs(5),
+            Duration::from_secs(10),
         )
         .await;
-        assert!(re_uploaded, "a new epoch bump must trigger another upload");
 
+        // Consume the session BEFORE asserting: a failing assertion must not
+        // leave the session unconsumed, or its Drop tripwire fires during unwind
+        // (a destructor panic on top of the assert's panic) and aborts the
+        // process with truncated output — turning a clean, retryable FAIL into an
+        // un-debuggable SIGABRT.
         session.abandon("test complete").await;
+
+        assert!(uploaded, "a dirty tick must upload the snapshot");
+        assert!(
+            clean_skipped,
+            "clean ticks must skip — the dirty-gate spends zero I/O when the epoch is unchanged"
+        );
+        assert!(re_uploaded, "a new epoch bump must trigger another upload");
     }
 
     /// Cooperative drain: after `stop_periodic` no late upload happens and no
@@ -4227,13 +4236,9 @@ mod tests {
         // Let at least one upload happen so a tick has genuinely run.
         let uploaded = poll_until(
             || faults.count(crate::fault_store::FaultOp::Put) >= 1,
-            Duration::from_secs(5),
+            Duration::from_secs(10),
         )
         .await;
-        assert!(
-            uploaded,
-            "the uploader must run at least one tick before stop"
-        );
 
         // Cooperative drain + join.
         session.stop_periodic().await;
@@ -4241,11 +4246,7 @@ mod tests {
 
         // No further upload after the drain returns.
         tokio::time::sleep(Duration::from_millis(200)).await;
-        assert_eq!(
-            faults.count(crate::fault_store::FaultOp::Put),
-            after_stop,
-            "no late upload may fire after a cooperative stop"
-        );
+        let no_late_upload = faults.count(crate::fault_store::FaultOp::Put) == after_stop;
 
         // No scratch snapshot leaked for this process (the ScratchGuard removed
         // every temp file in-task, uncancelled).
@@ -4256,12 +4257,23 @@ mod tests {
             .map(|e| e.file_name().to_string_lossy().into_owned())
             .filter(|name| name.starts_with(&pid_prefix))
             .collect();
+
+        // Consume the session BEFORE asserting (clean FAIL, never a Drop-tripwire
+        // double-panic SIGABRT on assertion failure — see the uploads/skips test).
+        session.abandon("test complete").await;
+
+        assert!(
+            uploaded,
+            "the uploader must run at least one tick before stop"
+        );
+        assert!(
+            no_late_upload,
+            "no late upload may fire after a cooperative stop"
+        );
         assert!(
             leaked.is_empty(),
             "cooperative drain must leave no scratch snapshot behind, found: {leaked:?}"
         );
-
-        session.abandon("test complete").await;
     }
 
     /// The `Weak`-handle safety net (mirrors run.rs's serial tail): with the
@@ -4292,33 +4304,38 @@ mod tests {
         // Weak at least once — the case a strong clone would have made fatal).
         let ticked = poll_until(
             || faults.count(crate::fault_store::FaultOp::Put) >= 1,
-            Duration::from_secs(5),
+            Duration::from_secs(10),
         )
         .await;
+
+        // Run tail: `abandon` drains the periodic (cooperative stop + join), and
+        // consuming the session here — BEFORE the recovery assertions — keeps a
+        // failure a clean FAIL rather than a Drop-tripwire double-panic SIGABRT.
+        session.abandon("test complete").await;
+
+        // The Weak periodic handle never blocked the run tail's try_unwrap.
+        let recovered = Arc::try_unwrap(shared_state).ok();
+        let terminal_persisted = if let Some(store) = recovered.as_ref() {
+            // The recovered store is real (not a no-op `None`): a terminal write
+            // persists. `store` drops at the end of scope, freeing the writer
+            // lock — the drop-before-finalize discipline.
+            store.set_watermark("c.s.terminal", &wm_now()).unwrap();
+            store.get_watermark("c.s.terminal").unwrap().is_some()
+        } else {
+            false
+        };
+
         assert!(
             ticked,
             "the uploader must run a tick so the Weak is upgraded"
         );
-
-        // Run tail: drain the periodic, then recover the owned store.
-        session.stop_periodic().await;
-        let recovered = Arc::try_unwrap(shared_state).ok();
         assert!(
             recovered.is_some(),
             "Arc::try_unwrap must succeed — the Weak periodic handle never blocks the run tail"
         );
-        let store = recovered.unwrap();
-
-        // The recovered store is real (not a no-op `None`): a terminal write
-        // persists.
-        store.set_watermark("c.s.terminal", &wm_now()).unwrap();
         assert!(
-            store.get_watermark("c.s.terminal").unwrap().is_some(),
+            terminal_persisted,
             "the terminal write must persist on the recovered owned store"
         );
-
-        // Drop-before-finalize: dropping the owned store frees the writer lock.
-        drop(store);
-        session.abandon("test complete").await;
     }
 }

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -8,6 +8,7 @@
 //! so credential resolution follows the standard AWS SDK / GCP ADC chains.
 
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Weak};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use bytes::Bytes;
@@ -20,6 +21,7 @@ use crate::object_store::{ObjectStoreError, ObjectStoreProvider};
 use crate::redacted::RedactedString;
 use crate::retry::compute_backoff;
 use crate::retry_budget::RetryBudget;
+use crate::state::StateStore;
 
 #[derive(Debug, Error)]
 pub enum StateSyncError {
@@ -524,6 +526,13 @@ pub struct RemoteStateSession {
     finalized: bool,
     /// The owned mid-run periodic uploader, when started.
     periodic: Option<tokio::task::JoinHandle<()>>,
+    /// Cooperative-drain signal for the periodic uploader. `stop_periodic` fires
+    /// it and joins, so an in-flight tick's `spawn_blocking` snapshot runs to
+    /// completion (releasing its `Arc<StateStore>` upgrade and cleaning up its
+    /// scratch guard) BEFORE the task exits — a plain `abort()` would instead
+    /// detach the blocking closure, leaking the scratch it recreates and holding
+    /// the upgrade past the run tail's `Arc::try_unwrap`.
+    periodic_shutdown: Option<Arc<tokio::sync::Notify>>,
 }
 
 impl RemoteStateSession {
@@ -541,6 +550,7 @@ impl RemoteStateSession {
             suppress_reason: None,
             finalized: false,
             periodic: None,
+            periodic_shutdown: None,
         }
     }
 
@@ -643,37 +653,110 @@ impl RemoteStateSession {
         }
     }
 
-    /// Start the owned mid-run periodic uploader: [`upload_state`] on the
-    /// session's config/path every `cadence`. The caller applies its own
-    /// spawn gating (estimated duration, suppression) — the session only owns
-    /// the task so [`stop_periodic`][Self::stop_periodic] /
-    /// [`finalize`][Self::finalize] can abort **and join** it. A no-op when a
+    /// Start the owned mid-run periodic uploader over a **`Weak`** handle to the
+    /// live [`StateStore`], dirty-gated on its [`write_epoch`][StateStore::write_epoch].
+    ///
+    /// Each tick, if the store's epoch has advanced since the last upload, it
+    /// exports a torn-read-free [`snapshot_to_excluding`][StateStore::snapshot_to_excluding]
+    /// (on the blocking pool) and uploads it via [`upload_state_snapshot`]; a
+    /// clean tick (epoch unchanged) costs zero I/O.
+    ///
+    /// The handle is [`Weak`], never a strong [`Arc`][std::sync::Arc] clone: the
+    /// run tail recovers the owned store with `Arc::try_unwrap`, which a lingering
+    /// strong clone here would block — silently dropping the owned store and
+    /// no-op'ing every terminal write. With `Weak`, `try_unwrap` is never held
+    /// up; a tick that races the run tail's `drop` simply fails to `upgrade` and
+    /// exits.
+    ///
+    /// The caller applies its own spawn gating (estimated duration, suppression)
+    /// — the session only owns the task so [`stop_periodic`][Self::stop_periodic]
+    /// / [`finalize`][Self::finalize] can drain **and join** it. A no-op when a
     /// periodic task is already running.
-    pub fn start_periodic_uploader(&mut self, cadence: Duration) {
+    ///
+    /// Shutdown is **cooperative**, not an `abort()`: an idle tick (parked on the
+    /// cadence sleep) breaks instantly, but a tick already inside its
+    /// `spawn_blocking` snapshot runs that snapshot to completion. `abort()`
+    /// would drop the `.await` and detach the blocking closure, which would then
+    /// (1) recreate the scratch file its [`ScratchGuard`] just removed on
+    /// cancellation (a leak) and (2) hold its `Arc<StateStore>` upgrade past the
+    /// run tail's `Arc::try_unwrap`, silently no-op'ing every terminal write.
+    pub fn start_periodic_uploader(&mut self, store: Weak<StateStore>, cadence: Duration) {
         if self.periodic.is_some() {
             return;
         }
         let cfg = self.cfg.clone();
         let path = self.state_path.clone();
+        // Derive the remote key ONCE from the REAL state path (namespace-correct)
+        // — never from the scratch temp path, which would resolve to the legacy
+        // `state.redb` key and clobber namespaced state (mirrors the invariant in
+        // `upload_state_with_excluded_tables`).
+        let remote_key = remote_state_key(&path);
+        let shutdown = Arc::new(tokio::sync::Notify::new());
+        self.periodic_shutdown = Some(Arc::clone(&shutdown));
         self.periodic = Some(tokio::spawn(async move {
+            let mut last_uploaded_epoch: u64 = 0;
             loop {
-                tokio::time::sleep(cadence).await;
-                if let Err(e) = upload_state(&cfg, &path).await {
-                    warn!(error = %e, "periodic state sync failed");
+                // Cooperative wait: a shutdown signal breaks the loop instead of
+                // sleeping out the cadence. `notify_one` sets a permit even with
+                // no waiter parked, so a signal that arrives mid-tick is consumed
+                // by the next iteration's `notified()`.
+                tokio::select! {
+                    _ = tokio::time::sleep(cadence) => {}
+                    _ = shutdown.notified() => break,
                 }
+
+                // The run tail dropped the owned store → nothing left to sync.
+                let Some(store) = store.upgrade() else {
+                    break;
+                };
+
+                // Capture the epoch BEFORE the read snapshot: recording an epoch
+                // <= the snapshot's content is a harmless re-upload next tick;
+                // recording > content would permanently skip a real change.
+                let epoch = store.write_epoch();
+                if epoch == last_uploaded_epoch {
+                    // Clean tick — no mutation since the last upload; zero I/O.
+                    continue;
+                }
+
+                // Build the consistent snapshot on the blocking pool (the redb
+                // export is fsync-bearing). Cooperative shutdown lets this
+                // `.await` finish rather than being cancelled, so the scratch
+                // guard's cleanup and the `Arc` release both happen in-task.
+                let scratch = ScratchGuard::new();
+                let scratch_path = scratch.path().to_path_buf();
+                let snapshot = tokio::task::spawn_blocking(move || {
+                    store.snapshot_to_excluding(&scratch_path, crate::state::LOCAL_ONLY_TABLE_NAMES)
+                })
+                .await;
+
+                match snapshot {
+                    Ok(Ok(())) => {
+                        match upload_state_snapshot(&cfg, scratch.path(), &remote_key).await {
+                            Ok(()) => last_uploaded_epoch = epoch,
+                            Err(e) => warn!(error = %e, "periodic state sync upload failed"),
+                        }
+                    }
+                    Ok(Err(e)) => warn!(error = %e, "periodic state snapshot failed"),
+                    Err(e) => warn!(error = %e, "periodic state snapshot task panicked"),
+                }
+                // `scratch` drops here → the temp snapshot file is removed.
             }
         }));
     }
 
-    /// Abort AND JOIN the periodic uploader (the RD-004 abort-without-await
-    /// fix: an aborted-but-unjoined task could still be mid-`put` when the
-    /// caller proceeds to its terminal upload). Idempotent — a no-op when no
-    /// periodic task is running.
+    /// Cooperatively DRAIN and JOIN the periodic uploader (the RD-004
+    /// stop-before-terminal-upload fix, hardened for the snapshot path): signal
+    /// shutdown, then await the task so it exits after any in-flight tick's
+    /// snapshot + upload complete — never mid-`put`, never leaking a detached
+    /// blocking closure. Idempotent — a no-op when no periodic task is running.
     pub async fn stop_periodic(&mut self) {
+        if let Some(shutdown) = self.periodic_shutdown.take() {
+            shutdown.notify_one();
+        }
         if let Some(handle) = self.periodic.take() {
-            handle.abort();
-            // Cancelled is the expected outcome; a JoinError panics-variant is
-            // surfaced by the task's own panic hook, not here.
+            // Cooperative exit is the expected outcome; a JoinError panics-variant
+            // is surfaced by the task's own panic hook, not here.
             let _ = handle.await;
         }
     }
@@ -817,8 +900,14 @@ impl Drop for RemoteStateSession {
             return;
         }
         // Resource net first (the debug_assert below panics in debug builds):
-        // a leaked periodic handle must not outlive the run. Abort only —
-        // `Drop` cannot await a join.
+        // a leaked periodic handle must not outlive the run. Signal cooperative
+        // shutdown, then `abort()` as the hard net — `Drop` cannot await a join,
+        // so this cannot guarantee the in-tick drain the normal
+        // `stop_periodic`/`finalize` paths provide; it is the leaked-session bug
+        // path, where the resource net wins over the drain guarantee.
+        if let Some(shutdown) = self.periodic_shutdown.take() {
+            shutdown.notify_one();
+        }
         if let Some(handle) = self.periodic.take() {
             handle.abort();
         }
@@ -1381,6 +1470,63 @@ pub async fn upload_state_with_excluded_tables(
     // cost the OS cleans up at reboot.
     let _ = std::fs::remove_file(&scratch);
     apply_upload_failure_policy(config, result)
+}
+
+/// Upload an already-built, already-filtered state **snapshot** to the remote.
+///
+/// Unlike [`upload_state`], this performs NO local-only table stripping — the
+/// snapshot was produced by [`StateStore::snapshot_to_excluding`], which already
+/// omitted the excluded tables under a single MVCC read (torn-read-free). The
+/// caller passes the schema-namespaced `remote_key`, derived ONCE from the real
+/// state path — NEVER re-derived from the scratch temp path, which would resolve
+/// to the legacy `state.redb` key and clobber namespaced state (the same
+/// invariant [`upload_state_with_excluded_tables`] documents). The configured
+/// `on_upload_failure` policy applies exactly as in [`upload_state`].
+pub async fn upload_state_snapshot(
+    config: &StateConfig,
+    snapshot_path: &Path,
+    remote_key: &str,
+) -> Result<(), StateSyncError> {
+    if !snapshot_path.exists() {
+        debug!("No state snapshot to upload");
+        return Ok(());
+    }
+    let result = dispatch_upload(config, snapshot_path, remote_key).await;
+    apply_upload_failure_policy(config, result)
+}
+
+/// A temp snapshot path removed on drop, so an aborted-mid-tick periodic upload
+/// leaks neither a scratch snapshot file nor a late upload.
+struct ScratchGuard {
+    path: PathBuf,
+}
+
+impl ScratchGuard {
+    /// Reserve a unique scratch path under the system temp dir. The file itself
+    /// is created by [`StateStore::snapshot_to_excluding`]; this owns its name
+    /// and its cleanup.
+    fn new() -> Self {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "rocky-state-snapshot-{}-{}.redb",
+            std::process::id(),
+            nanos
+        ));
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for ScratchGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
 }
 
 /// Build a temp redb copy of `local_path` with `excluded_tables` removed.
@@ -3676,6 +3822,21 @@ mod tests {
         faults
     }
 
+    /// Like [`install_counting_provider`] but PROCESS-GLOBAL, so the counting
+    /// store is visible from the periodic uploader's own tokio worker thread
+    /// (the thread-local [`test_support::install`] only covers the test thread).
+    /// Hold the returned guard for the test's duration; pair with
+    /// [`test_support::serial_guard`] (the global override is shared state).
+    fn install_counting_provider_global()
+    -> (crate::fault_store::FaultHandle, test_support::GlobalOverrideGuard) {
+        let (store, faults) = crate::fault_store::FaultingStore::wrap(std::sync::Arc::new(
+            object_store::memory::InMemory::new(),
+        ));
+        let guard =
+            test_support::install_global(ObjectStoreProvider::from_store(store, "s3", "bucket", ""));
+        (faults, guard)
+    }
+
     /// Seed a real (empty) redb state file at `path` so the upload path has a
     /// file to strip/dispatch.
     fn seed_state_file(path: &Path) {
@@ -3952,13 +4113,14 @@ mod tests {
         );
         let _ = session.acquire().await.unwrap();
         // A cadence far beyond the test's lifetime: the loop must never fire,
-        // so the only Put observed below is the terminal finalize upload.
-        session.start_periodic_uploader(Duration::from_secs(3600));
+        // so the only Put observed below is the terminal finalize upload. A
+        // dangling Weak is fine — the loop never reaches an upgrade.
+        session.start_periodic_uploader(Weak::<StateStore>::new(), Duration::from_secs(3600));
         // Idempotent no-op while one is running.
-        session.start_periodic_uploader(Duration::from_secs(3600));
+        session.start_periodic_uploader(Weak::<StateStore>::new(), Duration::from_secs(3600));
         session.stop_periodic().await;
         session.stop_periodic().await; // idempotent after stop
-        session.start_periodic_uploader(Duration::from_secs(3600));
+        session.start_periodic_uploader(Weak::<StateStore>::new(), Duration::from_secs(3600));
         session
             .finalize()
             .await
@@ -3969,5 +4131,194 @@ mod tests {
             1,
             "exactly the terminal upload — the periodic loop must never have fired"
         );
+    }
+
+    fn wm_now() -> rocky_ir::WatermarkState {
+        let now = chrono::Utc::now();
+        rocky_ir::WatermarkState {
+            last_value: now,
+            updated_at: now,
+        }
+    }
+
+    async fn poll_until<F: Fn() -> bool>(f: F, budget: Duration) -> bool {
+        let deadline = std::time::Instant::now() + budget;
+        while std::time::Instant::now() < deadline {
+            if f() {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(15)).await;
+        }
+        f()
+    }
+
+    /// The dirty-gated periodic uploader uploads when the store's write epoch
+    /// advances and SKIPS clean ticks (zero I/O when nothing changed) — the
+    /// `FaultHandle` put-counter is the instrument.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn periodic_uploader_uploads_on_dirty_epoch_and_skips_clean_ticks() {
+        let _serial = test_support::serial_guard();
+        let (faults, _override) = install_counting_provider_global();
+        let dir = TempDir::new().unwrap();
+        let local = dir.path().join(".rocky-state.redb");
+
+        let store = Arc::new(StateStore::open(&local).unwrap());
+        // Dirty the store so the first tick has a change to replicate.
+        store.set_watermark("c.s.t", &wm_now()).unwrap();
+
+        let mut session = RemoteStateSession::new(
+            &s3_session_config(StateUploadFailureMode::Fail),
+            &local,
+            FinalizeDurability::ConfigDefault,
+        );
+        let _ = session.acquire().await.unwrap();
+        session.start_periodic_uploader(Arc::downgrade(&store), Duration::from_millis(40));
+
+        // First dirty tick uploads.
+        let uploaded = poll_until(
+            || faults.count(crate::fault_store::FaultOp::Put) >= 1,
+            Duration::from_secs(5),
+        )
+        .await;
+        assert!(uploaded, "a dirty tick must upload the snapshot");
+        let after_first = faults.count(crate::fault_store::FaultOp::Put);
+
+        // No new writes → subsequent ticks are clean and skip (zero new Puts).
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert_eq!(
+            faults.count(crate::fault_store::FaultOp::Put),
+            after_first,
+            "clean ticks must skip — the dirty-gate spends zero I/O when the epoch is unchanged"
+        );
+
+        // A fresh write re-dirties the epoch → the uploader picks it up.
+        store.set_watermark("c.s.u", &wm_now()).unwrap();
+        let re_uploaded = poll_until(
+            || faults.count(crate::fault_store::FaultOp::Put) > after_first,
+            Duration::from_secs(5),
+        )
+        .await;
+        assert!(re_uploaded, "a new epoch bump must trigger another upload");
+
+        session.abandon("test complete").await;
+    }
+
+    /// Cooperative drain: after `stop_periodic` no late upload happens and no
+    /// scratch snapshot file is leaked — the in-flight tick's `spawn_blocking`
+    /// runs to completion in-task rather than being detached by an `abort()`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stopping_the_uploader_drains_without_scratch_leak_or_late_upload() {
+        let _serial = test_support::serial_guard();
+        let (faults, _override) = install_counting_provider_global();
+        let dir = TempDir::new().unwrap();
+        let local = dir.path().join(".rocky-state.redb");
+
+        let store = Arc::new(StateStore::open(&local).unwrap());
+        store.set_watermark("c.s.t", &wm_now()).unwrap();
+
+        let mut session = RemoteStateSession::new(
+            &s3_session_config(StateUploadFailureMode::Fail),
+            &local,
+            FinalizeDurability::ConfigDefault,
+        );
+        let _ = session.acquire().await.unwrap();
+        session.start_periodic_uploader(Arc::downgrade(&store), Duration::from_millis(30));
+
+        // Let at least one upload happen so a tick has genuinely run.
+        let uploaded = poll_until(
+            || faults.count(crate::fault_store::FaultOp::Put) >= 1,
+            Duration::from_secs(5),
+        )
+        .await;
+        assert!(
+            uploaded,
+            "the uploader must run at least one tick before stop"
+        );
+
+        // Cooperative drain + join.
+        session.stop_periodic().await;
+        let after_stop = faults.count(crate::fault_store::FaultOp::Put);
+
+        // No further upload after the drain returns.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(
+            faults.count(crate::fault_store::FaultOp::Put),
+            after_stop,
+            "no late upload may fire after a cooperative stop"
+        );
+
+        // No scratch snapshot leaked for this process (the ScratchGuard removed
+        // every temp file in-task, uncancelled).
+        let pid_prefix = format!("rocky-state-snapshot-{}-", std::process::id());
+        let leaked: Vec<String> = std::fs::read_dir(std::env::temp_dir())
+            .expect("read temp dir")
+            .filter_map(Result::ok)
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.starts_with(&pid_prefix))
+            .collect();
+        assert!(
+            leaked.is_empty(),
+            "cooperative drain must leave no scratch snapshot behind, found: {leaked:?}"
+        );
+
+        session.abandon("test complete").await;
+    }
+
+    /// The `Weak`-handle safety net (mirrors run.rs's serial tail): with the
+    /// periodic uploader wired and having run at least one tick, the run tail's
+    /// `Arc::try_unwrap` still recovers the owned store — a strong `Arc` clone
+    /// held by the uploader would have blocked it, leaving `None` and silently
+    /// no-op'ing every terminal write. After the drain, `try_unwrap` succeeds and
+    /// a terminal write persists.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn terminal_writes_persist_with_periodic_wired() {
+        let _serial = test_support::serial_guard();
+        let (faults, _override) = install_counting_provider_global();
+        let dir = TempDir::new().unwrap();
+        let local = dir.path().join(".rocky-state.redb");
+
+        let shared_state = Arc::new(StateStore::open(&local).unwrap());
+        shared_state.set_watermark("c.s.t", &wm_now()).unwrap();
+
+        let mut session = RemoteStateSession::new(
+            &s3_session_config(StateUploadFailureMode::Fail),
+            &local,
+            FinalizeDurability::ConfigDefault,
+        );
+        let _ = session.acquire().await.unwrap();
+        session.start_periodic_uploader(Arc::downgrade(&shared_state), Duration::from_millis(20));
+
+        // Ensure a tick actually ran (so the uploader genuinely upgraded the
+        // Weak at least once — the case a strong clone would have made fatal).
+        let ticked = poll_until(
+            || faults.count(crate::fault_store::FaultOp::Put) >= 1,
+            Duration::from_secs(5),
+        )
+        .await;
+        assert!(
+            ticked,
+            "the uploader must run a tick so the Weak is upgraded"
+        );
+
+        // Run tail: drain the periodic, then recover the owned store.
+        session.stop_periodic().await;
+        let recovered = Arc::try_unwrap(shared_state).ok();
+        assert!(
+            recovered.is_some(),
+            "Arc::try_unwrap must succeed — the Weak periodic handle never blocks the run tail"
+        );
+        let store = recovered.unwrap();
+
+        // The recovered store is real (not a no-op `None`): a terminal write
+        // persists.
+        store.set_watermark("c.s.terminal", &wm_now()).unwrap();
+        assert!(
+            store.get_watermark("c.s.terminal").unwrap().is_some(),
+            "the terminal write must persist on the recovered owned store"
+        );
+
+        // Drop-before-finalize: dropping the owned store frees the writer lock.
+        drop(store);
+        session.abandon("test complete").await;
     }
 }


### PR DESCRIPTION
## Consistent state snapshot for the remote-`[state]` uploader

Part of the remote-state hardening series (follows the typed-authority + `RemoteStateSession` spine and the add-wins freeze markers). This PR removes the torn read from the mid-run state upload and is the prerequisite for the upcoming CAS work.

### Problem

The mid-run periodic uploader snapshotted the live ledger with an **unlocked `std::fs::copy`** while the run's `StateStore` held the file open and kept committing write transactions. On the Linux pods where this bites, a byte copy can smear across a commit — the uploaded blob is a torn read (an internally inconsistent redb file, or one that won't reopen). redb 2.6.3 offers no `Database::backup` and no untyped row iteration, so a plain copy was the only tool in reach.

### Change

- **`StateStore::snapshot_to_excluding`** — a consistent logical export under one `begin_read` (MVCC) snapshot: every row is drawn from a single committed state, so no concurrent writer can tear a correlated pair. The live store keeps taking writers throughout (the method holds only a read txn), so the run is never blocked. Tables are opened via a **closed static registry** (the state schema is exactly two key/value shapes); a table present on disk but absent from the registry is a hard error, never a silent drop.
- **`write_epoch` dirty signal** — an in-memory `AtomicU64` bumped by a single `commit_write` chokepoint that every production write transaction routes through. The periodic uploader captures the epoch *before* its read and re-uploads only when it has advanced, so a clean tick costs zero I/O. (In-memory only — the local-backend blob stays byte-identical.)
- **Periodic uploader over a `Weak` handle** — the uploader holds a `Weak<StateStore>`, never a strong clone, so the run tail's `Arc::try_unwrap` (which recovers the owned store for the terminal writes) is never blocked. Shutdown is **cooperative** (signal + join) rather than a bare `abort()`: an aborted task would detach the in-flight `spawn_blocking` snapshot, leaking its scratch file and holding its store upgrade past `try_unwrap`. The snapshot runs on the blocking pool and its scratch file is removed by a Drop guard.
- **End-of-run finalize is now lock-free** — the owned `StateStore` is dropped before `session.finalize()` at every finalize site, so its copy runs against a quiescent, unlocked file (the redb `Database` and its advisory writer lock are released first).
- Snapshots larger than 128 MiB `warn!` (documented; streaming is deferred to keep the CAS put path single-shot).

### Tests

- MVCC snapshot never tears a correlated pair under concurrent writer load, with a **RED demo** proving a non-atomic byte copy *does* tear (the test fails if it can't observe a tear).
- Registry matches the on-disk table set and pins the closed two-shape split; an unregistered table errors.
- `write_epoch` bumps on every production write method (both shapes, insert + delete); epoch is captured in the safe direction (recorded value never overstates snapshot content).
- Periodic uploader uploads on a dirty epoch and skips clean ticks (put-count instrumented); cooperative stop drains with no late upload and no leaked scratch.
- Drop-before-finalize is a genuine RED→GREEN discriminator (the writer lock is held while the store is open, free after the drop); terminal writes still persist with the periodic wired.

### Compatibility

No `rocky.toml` surface change, no redb bump, no remote-key change, no `*Output`/schema change (no codegen or fixture cascade). Local-backend blob byte-identical; short runs (no periodic) unchanged.

Gates green locally: `cargo nextest run -p rocky-core -p rocky-cli` (2968 passed), `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`.
