### PR TITLE
chore: release engine 1.65.0 + rocky-sdk 0.9.0 + dagster-rocky 1.61.0 + vscode 1.35.0

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.35.0] — 2026-07-18
+
+### Added
+
+- Generated TypeScript types for the engine-v1.65.0 output surface — the `rocky tick` scheduler and the freeze-marker fields on the policy and brief outputs. Additive; the LSP client and existing commands are unchanged.
+
 ## [1.34.4] — 2026-07-12
 
 ### Added

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.34.4",
+  "version": "1.35.0",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,9 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.65.0] - 2026-07-18
+
+### Security
+
+- **Remote-state protocol hardening for concurrent multi-writer deployments.** A series of correctness fixes to the remote `[state]` backend used by multi-pod / multi-host deployments:
+  - State authority is now typed and fail-closed. A run whose start-of-run remote-state download fails is treated as non-authoritative: it refuses to make governed decisions or to push local state over the remote it could not read, rather than silently proceeding as last-writer-wins. Uploads are suppressed whenever the ledger could not be read. (#1139, #1144)
+  - Governance decisions (apply gates, masking and tag reconciliation) are taken from the configuration and compiled-model snapshot captured at the policy gate, so a `rocky.toml` or model edit that lands mid-run can no longer change what a governed run applies (config-swap and within-apply time-of-check/time-of-use). (#1144)
+  - Mid-run state uploads capture a consistent MVCC snapshot instead of copying the live database file, eliminating a torn read that could publish an internally inconsistent ledger under write load. (#1158)
+  - `rocky policy freeze` gains an opt-in, upload-durable kill switch: with `[policy] freeze_markers = true`, a freeze is recorded as an object-store marker that survives a concurrent whole-ledger upload from another writer (previously the freeze row could be erased). Off by default; readers always honor any existing markers. (#1154)
+  - Additional garbage-collection liveness and remote-state integrity follow-ups from the earlier hardening waves. (#1089, #1090, #1095)
+- **CI credential containment.** Pull-request-triggered CI no longer exposes release or AI credentials to untrusted candidate code; the credentialed workflows run only trusted base code pinned to a frozen root. (#1107)
+
 ### Added
 
-- **`rocky tick` — a one-shot native demand reconciler (experimental).** Pipelines can declare when they should run directly in `rocky.toml` via `[pipeline.<name>.schedule]` (`cron`, `after`, `freshness`); `rocky tick` evaluates all standing demand once, runs what is due sequentially through child `rocky run` processes, records scheduler state, and emits a typed `TickOutput`. There is no daemon — drive it from cron, a systemd timer, or CI on a short interval and it becomes SLO/cron/dependency scheduling with nothing resident. `--dry-run` previews demand without executing or writing state; `--now <rfc3339>` pins the evaluation instant for deterministic previews and tests (the reconciler core reads no wall clock). Exit codes mirror `rocky run`: `0` nothing-due-or-all-succeeded, `2` a launched run failed or was partial, `1` the tick could not proceed (fails closed, runs nothing). The reconciler releases the state store around each child spawn (so the child `rocky run` can open it) and forwards the resolved `--state-path` to the child; contention with another live `rocky` process surfaces as an exit-`0` `state_busy` skip, never a failure. Tick-launched runs record `"trigger": "Schedule"` in `rocky history`, joined to their demand by `submission_id` (now surfaced on `rocky history --output json`, alongside `pipeline`). Scheduling supports replication, transformation, quality, and snapshot pipelines — each persists a submission-linked run record, so `after`/`freshness` and recovery work. Load pipelines cannot declare a `[schedule]` yet (a load re-ingests every discovered file each run rather than incrementally, so scheduling it would duplicate data — validation rejects it with `V044`); native load scheduling is a follow-up. Freshness budgets resolve from the tightest member-model `max_lag_seconds` (MIN), falling back to the project `[freshness]` default. Run one `rocky tick` timer per project: scheduler state is machine-local and remote state has no cross-host lock, so two hosts ticking the same project double-fire. Marked experimental while the reconciler soaks; external orchestrators (Dagster, Airflow) remain first-class. (#TBD)
+- **`rocky tick` — a one-shot native demand reconciler (experimental).** Pipelines can declare when they should run directly in `rocky.toml` via `[pipeline.<name>.schedule]` (`cron`, `after`, `freshness`); `rocky tick` evaluates all standing demand once, runs what is due sequentially through child `rocky run` processes, records scheduler state, and emits a typed `TickOutput`. There is no daemon — drive it from cron, a systemd timer, or CI on a short interval and it becomes SLO/cron/dependency scheduling with nothing resident. `--dry-run` previews demand without executing or writing state; `--now <rfc3339>` pins the evaluation instant for deterministic previews and tests (the reconciler core reads no wall clock). Exit codes mirror `rocky run`: `0` nothing-due-or-all-succeeded, `2` a launched run failed or was partial, `1` the tick could not proceed (fails closed, runs nothing). The reconciler releases the state store around each child spawn (so the child `rocky run` can open it) and forwards the resolved `--state-path` to the child; contention with another live `rocky` process surfaces as an exit-`0` `state_busy` skip, never a failure. Tick-launched runs record `"trigger": "Schedule"` in `rocky history`, joined to their demand by `submission_id` (now surfaced on `rocky history --output json`, alongside `pipeline`). Scheduling supports replication, transformation, quality, and snapshot pipelines — each persists a submission-linked run record, so `after`/`freshness` and recovery work. Load pipelines cannot declare a `[schedule]` yet (a load re-ingests every discovered file each run rather than incrementally, so scheduling it would duplicate data — validation rejects it with `V044`); native load scheduling is a follow-up. Freshness budgets resolve from the tightest member-model `max_lag_seconds` (MIN), falling back to the project `[freshness]` default. Run one `rocky tick` timer per project: scheduler state is machine-local and remote state has no cross-host lock, so two hosts ticking the same project double-fire. Marked experimental while the reconciler soaks; external orchestrators (Dagster, Airflow) remain first-class. (#1142, #1161)
 
 ### Changed
 
@@ -18,6 +30,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Released binaries now include the OpenTelemetry exporter; `OTEL_EXPORTER_OTLP_ENDPOINT` was previously a no-op on release builds.
+- Type drift on Databricks and Trino now degrades to a full refresh instead of erroring, matching the other adapters. (#1156)
+- `TRY_CAST` and `SAFE_CAST` result columns are typed as nullable, and cast alias target types are inferred correctly. (#1155, #1147)
+- `rocky compare` fails closed on a cell read error rather than reporting a spurious match. (#1153)
+- Interval placeholders are no longer double-quoted in generated SQL. (#1151)
+- DAG transformation nodes are scoped to their models. (#1141)
+- An unrecognized `--model` selection is rejected instead of silently matching nothing. (#1160)
 
 ## [1.64.0] - 2026-07-12
 

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4041,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4054,7 +4054,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "indexmap",
  "reqwest 0.12.28",
@@ -4075,7 +4075,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4092,7 +4092,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4120,7 +4120,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "redis",
  "serde",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4201,7 +4201,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4281,7 +4281,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4308,7 +4308,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4327,7 +4327,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4376,7 +4376,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4401,7 +4401,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -4414,7 +4414,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "logos",
  "miette",
@@ -4426,7 +4426,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "rocky-server",
  "rustls",
@@ -4435,7 +4435,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4461,7 +4461,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4479,7 +4479,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4508,7 +4508,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -4535,7 +4535,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "miette",
  "regex",
@@ -4548,7 +4548,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.64.0"
+version = "1.65.0"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.64.0"
+version = "1.65.0"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.64.0"
+version = "1.65.0"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.64.0"
+version = "1.65.0"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.64.0"
+version = "1.65.0"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.64.0"
+version = "1.65.0"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.64.0"
+version = "1.65.0"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.64.0"
+version = "1.65.0"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.64.0"
+version = "1.65.0"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.64.0"
+version = "1.65.0"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.64.0"
+version = "1.65.0"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.64.0"
+version = "1.65.0"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.64.0"
+version = "1.65.0"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.64.0"
+version = "1.65.0"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.64.0"
+version = "1.65.0"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.64.0"
+version = "1.65.0"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.64.0"
+version = "1.65.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.64.0"
+version = "1.65.0"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.64.0"
+version = "1.65.0"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.64.0"
+version = "1.65.0"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.64.0"
+version = "1.65.0"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.64.0"
+version = "1.65.0"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.64.0"
+version = "1.65.0"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.64.0"
+version = "1.65.0"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.64.0"
+version = "1.65.0"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.61.0] — 2026-07-18
+
+### Added
+
+- Re-exports the engine-v1.65.0 / rocky-sdk 0.9.0 output types — the `rocky tick` scheduler and the freeze-marker surfaces — via `dagster_rocky.types`.
+
+### Changed
+
+- Floors on `rocky-sdk>=0.9.0` so the re-exported result types (freeze markers, scheduler output) are guaranteed present in the published wheel.
+
 ### Fixed
 
 - **Model-aware resource methods now scan the configured `models_dir`** (via

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.60.0"
+version = "1.61.0"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"
@@ -22,11 +22,12 @@ dependencies = [
     # The typed result models + RockyClient now live in the standalone rocky-sdk
     # package; RockyResource is a thin Dagster adapter over RockyClient. In-repo
     # dev/CI resolves this from the local path (see [tool.uv.sources]); the
-    # published wheel floors on the released SDK. Floored at 0.8.3: the
-    # model-aware resource methods (optimize / branch_promote / plan_promote / ai
-    # / retention_status) inherit their `--models` forwarding + retention `env`
-    # guard from the SDK, so an older SDK would silently reintroduce those bugs.
-    "rocky-sdk>=0.8.3",
+    # published wheel floors on the released SDK. Floored at 0.9.0: dagster_rocky.types
+    # re-exports the SDK's generated result models, which as of 0.9.0 include the
+    # freeze-marker and schedule/tick output types; an older SDK would be missing
+    # them (and also the 0.8.3 `--models` forwarding + retention `env` guard fixes
+    # the model-aware resource methods depend on).
+    "rocky-sdk>=0.9.0",
     # Floor matches the version CI actually resolves and tests (uv.lock). The
     # RockyComponent path uses dagster.components.* APIs from preview namespaces,
     # so we advertise a tested floor rather than an older, never-exercised one.

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-07-18
+
+### Added
+
+- Generated Pydantic models for the engine-v1.65.0 output surface: the `rocky tick` scheduler (`TickOutput`) and the object-store freeze markers surfaced by `rocky policy freeze` and `rocky brief`. `rocky history --output json` now carries the scheduler `submission_id` and `pipeline` join keys. Additive — existing models and every `RockyClient` method are unchanged.
+
 ## [0.8.3] — 2026-07-17
 
 ### Fixed

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rocky-sdk"
-version = "0.8.3"
+version = "0.9.0"
 description = "Typed Python client for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Consolidated release across all four artifacts (24 engine commits + accumulated SDK/dagster/vscode work since their last tags, including a codegen cascade).

## Versions

| Artifact | From | To |
|---|---|---|
| engine (`rocky`) | 1.64.0 | **1.65.0** |
| `rocky-sdk` | 0.8.3 | **0.9.0** |
| `dagster-rocky` | 1.60.0 | **1.61.0** (floors `rocky-sdk>=0.9.0`) |
| VS Code extension | 1.34.4 | **1.35.0** |

All minor bumps — feature-bearing, no breaking changes.

## Highlights (engine 1.65.0)

**Security — remote-`[state]` protocol hardening for concurrent multi-writer deployments:**
- Typed, fail-closed state authority: a run whose start-of-run remote-state download fails no longer proceeds as last-writer-wins — it refuses governed decisions and suppresses uploads over the unread remote (#1139, #1144).
- Governance decisions are taken from the config + compiled-model snapshot captured at the policy gate, closing the config-swap / within-apply TOCTOU windows (#1144).
- Mid-run state uploads capture a consistent MVCC snapshot instead of copying the live DB file — no more torn reads under write load (#1158).
- `rocky policy freeze` gains an opt-in upload-durable kill switch (`[policy] freeze_markers`), so a freeze survives a concurrent whole-ledger upload (#1154).
- CI credential containment: PR-triggered CI no longer exposes release/AI credentials to candidate code (#1107).

**Added:** `rocky tick` — an experimental one-shot native demand reconciler (`[pipeline.*.schedule]` cron/after/freshness → runs what's due via child `rocky run`; no daemon) (#1142, #1161).

**Fixed:** type drift → full refresh on Databricks/Trino (#1156); TRY_CAST/SAFE_CAST nullable typing + cast alias inference (#1155, #1147); `rocky compare` fail-closed on read errors (#1153); interval placeholder quoting (#1151); DAG node scoping (#1141); unknown model filter rejected (#1160); OTel exporter in default builds.

**Changed:** rmcp 1.7 → 2.2 (wire-compatible) (#1109).

SDK/dagster/vscode carry the regenerated bindings for the new `rocky tick` + freeze-marker output surface (dagster floors on `rocky-sdk>=0.9.0`).

## Merge → tag order

After this merges, tag the merged commit and push in this order (SDK before dagster — the dagster wheel resolves the SDK from PyPI):

```
engine-v1.65.0  →  sdk-v0.9.0  →  dagster-v1.61.0  →  vscode-v1.35.0
```

Each tag push triggers its `*-release.yml` (engine: 5-platform matrix; sdk/dagster: build + PyPI via OIDC; vscode: VSIX + Marketplace).

## Notes

- Full CHANGELOGs updated for all four artifacts.
- No `*Output` schema changes in this PR (version + changelog only), so no codegen/fixture regeneration was needed; `codegen-drift` CI confirms.
