### PR TITLE
fix(engine/rocky-cli): reject unknown tick pipeline

### DIFF
--- a/engine/crates/rocky-cli/src/commands/tick.rs
+++ b/engine/crates/rocky-cli/src/commands/tick.rs
@@ -47,9 +47,10 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 ///
 /// # Errors
 ///
-/// Returns an error (exit 1) when the config cannot be loaded, the state store
-/// cannot be opened, or the tick itself faults (state I/O, lock I/O, an `after`
-/// cycle). Every such case runs nothing — fail closed.
+/// Returns an error (exit 1) when the config cannot be loaded, the selected
+/// pipeline does not exist, the state store cannot be opened, or the tick itself
+/// faults (state I/O, lock I/O, an `after` cycle). Every such case runs nothing
+/// — fail closed.
 pub async fn run_tick(
     config_path: &Path,
     state_path: &Path,
@@ -71,6 +72,9 @@ pub async fn run_tick(
     // Config parse error ⇒ exit 1, nothing runs.
     let config = load_rocky_config(config_path)
         .with_context(|| format!("failed to load config from {}", config_path.display()))?;
+    if let Some(name) = pipeline.as_deref() {
+        crate::registry::resolve_pipeline(&config, Some(name))?;
+    }
 
     // The only wall-clock read in the reconciler. Everything downstream takes
     // this instant as a parameter.
@@ -492,6 +496,46 @@ mod tests {
 
     fn ts(s: &str) -> DateTime<Utc> {
         DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    #[tokio::test]
+    async fn unknown_pipeline_filter_fails_before_state_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("rocky.toml");
+        let state_path = dir.path().join("state.redb");
+        std::fs::write(
+            &config_path,
+            r#"
+[adapter.db]
+type = "duckdb"
+
+[pipeline.raw]
+type = "transformation"
+[pipeline.raw.target]
+adapter = "db"
+[pipeline.raw.schedule]
+cron = "0 3 * * *"
+"#,
+        )
+        .unwrap();
+
+        let error = run_tick(
+            &config_path,
+            &state_path,
+            true,
+            Some("typo".to_string()),
+            Some("2026-07-18T03:00:00Z".to_string()),
+            false,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("pipeline 'typo' not found in config")
+        );
+        assert!(!state_path.exists());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reject `rocky tick --pipeline <name>` when `<name>` is not configured
- reuse the existing pipeline resolver, including its typo suggestion
- prove the error happens before scheduler state is created

## Why

An unknown pipeline filter currently produces an empty successful tick:
exit `0`, zero evaluated pipelines, and no skip or error entry. A typo in an
unattended cron/systemd/CI command can therefore stop scheduled work silently.

## Root cause

The tick wrapper passed the optional name directly to
`resolve_all_schedules`, where it was used only as a filter predicate. A name
that matched nothing became an empty schedule map. The wrapper now validates
explicit names through the same `registry::resolve_pipeline` helper used by
other CLI commands before any state I/O.

Closes #1163.

## Test plan

- `cargo test -p rocky-cli --lib unknown_pipeline_filter_fails_before_state_open`
- `cargo test -p rocky-cli --lib commands::tick::tests`
- `cargo fmt --all -- --check`
- `git diff --check`

Local Rust 1.93.1 clippy is blocked by existing warnings in unchanged
`rocky-lang`, `rocky-sql`, and `rocky-cli/src/commands/list.rs` code. The
canonical PR CI remains the readiness gate.
