### PR TITLE
fix(engine): align model plan scope with apply

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `rocky plan --model <name>` now previews only the selected model and reports the same model scope that `rocky apply` executes, instead of advertising skipped replication SQL and unrelated models. (#1165)
+
 ## [1.65.0] - 2026-07-18
 
 ### Security

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -18,9 +18,9 @@ use crate::registry;
 use super::run::PartitionRunOptions;
 use super::{filter_table_matches, matches_filter, parse_filter};
 
-/// Bundle of `rocky plan` flags that are not consumed by the SQL-generation
-/// preview but are persisted into `RunPlan` so `rocky apply <plan-id>` can
-/// honour them. Mirrors the flag surface of `rocky run`.
+/// Bundle of `rocky plan` execution flags persisted into `RunPlan` so
+/// `rocky apply <plan-id>` can honour them. Mirrors the flag surface of
+/// `rocky run`; `model` also scopes the SQL preview and model metadata.
 #[derive(Debug, Default, Clone)]
 pub struct PlanRunOptions {
     pub model: Option<String>,
@@ -397,6 +397,16 @@ pub async fn plan(
         .models_dir
         .clone()
         .unwrap_or_else(|| models_dir.clone());
+    if let Some(model) = run_options.model.as_deref() {
+        anyhow::ensure!(
+            blueprint_models_dir.exists(),
+            "models directory '{}' not found (required for --model)",
+            blueprint_models_dir.display()
+        );
+        output.statements =
+            plan_preview_output(Some(config_path), &blueprint_models_dir, Some(model), env)?
+                .statements;
+    }
     let mut run_plan_persisted = false;
     if blueprint_models_dir.exists() {
         match build_and_persist_run_plan(
@@ -806,6 +816,15 @@ pub fn plan_preview_output(
     // Project the compile result to typed IR, reusing the shared
     // `project_ir_from_compile` helper so we don't re-derive IR by hand.
     let project_ir = super::ci_diff::project_ir_from_compile(&result);
+    if let Some(model) = filter {
+        anyhow::ensure!(
+            project_ir
+                .models
+                .iter()
+                .any(|candidate| candidate.name.as_ref() == model),
+            "model '{model}' not found (no transformation model with that name)"
+        );
+    }
 
     for model_ir in &project_ir.models {
         let model_name = model_ir.name.as_ref();
@@ -902,16 +921,19 @@ fn build_and_persist_run_plan(
         return Ok(None);
     }
 
-    // Collect qualified model names from the project.
-    let models: Vec<String> = result
-        .project
-        .models
-        .iter()
-        .map(|m| m.config.name.clone())
-        .collect();
-
-    // Execution layers from the DAG (names only — informational).
-    let execution_layers: Vec<Vec<String>> = result.project.layers.clone();
+    let (models, execution_layers) = if let Some(model) = run_options.model.as_deref() {
+        (vec![model.to_string()], vec![vec![model.to_string()]])
+    } else {
+        (
+            result
+                .project
+                .models
+                .iter()
+                .map(|m| m.config.name.clone())
+                .collect(),
+            result.project.layers.clone(),
+        )
+    };
 
     let partition = &run_options.partition_opts;
     let run_plan = RunPlan {
@@ -2583,6 +2605,39 @@ database = ":memory:"
         assert_eq!(out.filter, "a");
         assert_eq!(out.statements.len(), 1);
         assert_eq!(out.statements[0].target, "c.s.a");
+    }
+
+    #[test]
+    fn plan_preview_unknown_filter_is_error() {
+        let tmp = TempDir::new().unwrap();
+        let (cfg_path, models_dir) = write_project(
+            &tmp,
+            r#"
+[adapter.default]
+type = "duckdb"
+database = ":memory:"
+"#,
+            &[(
+                "known",
+                r#"name = "known"
+
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "c"
+schema = "s"
+table = "known"
+"#,
+            )],
+        );
+
+        let err = plan_preview_output(Some(&cfg_path), &models_dir, Some("missing"), None)
+            .expect_err("unknown model filter must fail");
+        assert!(
+            err.to_string()
+                .contains("model 'missing' not found (no transformation model with that name)")
+        );
     }
 
     /// A `models/` directory with no compiled models (replication-only)

--- a/engine/rocky/tests/plan_model_scope.rs
+++ b/engine/rocky/tests/plan_model_scope.rs
@@ -1,0 +1,119 @@
+//! `rocky plan --model` must describe exactly what `rocky apply` executes.
+
+use std::fs;
+use std::process::Command;
+
+const ROCKY_TOML: &str = r#"
+[adapter]
+type = "duckdb"
+path = "fixture.duckdb"
+
+[pipeline.ingest]
+strategy = "full_refresh"
+
+[pipeline.ingest.source.discovery]
+adapter = "default"
+
+[pipeline.ingest.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.ingest.target]
+catalog_template = "fixture"
+schema_template = "staging__{source}"
+
+[pipeline.ingest.target.governance]
+auto_create_schemas = true
+"#;
+
+const MODEL_TOML: &str = r#"
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "fixture"
+schema = "main"
+"#;
+
+#[test]
+fn model_plan_matches_applied_scope() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path();
+    let config = dir.join("rocky.toml");
+
+    {
+        let conn = duckdb::Connection::open(dir.join("fixture.duckdb")).expect("open duckdb");
+        conn.execute_batch(
+            "CREATE SCHEMA raw__orders;
+             CREATE TABLE raw__orders.orders AS SELECT 1 AS id;",
+        )
+        .expect("seed source");
+    }
+
+    fs::write(&config, ROCKY_TOML).expect("write config");
+    let models = dir.join("models");
+    fs::create_dir(&models).expect("create models");
+    for (name, sql) in [("known", "SELECT 1 AS id"), ("other", "SELECT 2 AS id")] {
+        fs::write(models.join(format!("{name}.sql")), sql).expect("write model sql");
+        fs::write(models.join(format!("{name}.toml")), MODEL_TOML).expect("write model config");
+    }
+
+    let plan = Command::new(env!("CARGO_BIN_EXE_rocky"))
+        .args(["--output", "json"])
+        .arg("--config")
+        .arg(&config)
+        .args(["plan", "--model", "known"])
+        .current_dir(dir)
+        .env("RUST_LOG", "error")
+        .output()
+        .expect("run plan");
+    assert!(
+        plan.status.success(),
+        "plan failed: {}",
+        String::from_utf8_lossy(&plan.stderr)
+    );
+
+    let plan: serde_json::Value =
+        serde_json::from_slice(&plan.stdout).expect("plan output should be JSON");
+    assert_eq!(plan["models"], serde_json::json!(["known"]));
+    assert_eq!(plan["execution_layers"], serde_json::json!([["known"]]));
+    assert_eq!(plan["statements"].as_array().map(Vec::len), Some(1));
+    assert_eq!(plan["statements"][0]["target"], "fixture.main.known");
+
+    let plan_id = plan["plan_id"].as_str().expect("persisted plan ID");
+    let apply = Command::new(env!("CARGO_BIN_EXE_rocky"))
+        .args(["--output", "json"])
+        .arg("--config")
+        .arg(&config)
+        .args(["apply", plan_id])
+        .current_dir(dir)
+        .env("RUST_LOG", "error")
+        .output()
+        .expect("apply plan");
+    assert!(
+        apply.status.success(),
+        "apply failed: {}",
+        String::from_utf8_lossy(&apply.stderr)
+    );
+
+    let conn = duckdb::Connection::open(dir.join("fixture.duckdb")).expect("reopen duckdb");
+    for (schema, table, expected) in [
+        ("main", "known", 1_i64),
+        ("main", "other", 0),
+        ("staging__orders", "orders", 0),
+    ] {
+        let count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM information_schema.tables
+                 WHERE table_schema = ? AND table_name = ?",
+                [schema, table],
+                |row| row.get(0),
+            )
+            .expect("query table scope");
+        assert_eq!(
+            count, expected,
+            "unexpected materialization of {schema}.{table}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Make `rocky plan --model <name>` describe the same execution scope that
`rocky apply` will run.

Closes #1165.

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Changes

- Reuse the existing transformation SQL preview for model-scoped plans instead
  of returning unrelated replication statements.
- Persist and report only the selected model and its execution layer.
- Reject an unknown model during preview instead of producing an empty or
  misleading plan.
- Add a real-binary DuckDB regression proving the previewed, persisted, and
  applied scopes match.

## Why

The model selector was persisted for apply-time execution but ignored by the
live SQL preview and informational model metadata. A valid plan therefore
advertised replication SQL and unrelated models that a successful apply
silently skipped, undermining the plan/apply review boundary.

## Impact

Operators and CI can now trust that a model-scoped plan's SQL, `models`, and
`execution_layers` describe what apply will execute. The JSON schema is
unchanged.

## Test Plan

- `cargo test -p rocky --test plan_model_scope`
- `cargo test -p rocky-cli --lib commands::plan`
- `cargo test -p rocky-cli -p rocky --lib --bins --tests`
- `cargo fmt -- --check`
- `cargo clippy -p rocky-cli -p rocky --all-targets --all-features -- -D warnings -A unused-assignments -A clippy::collapsible-else-if`

The two clippy allowances cover existing Rust 1.93 warnings outside this diff;
all other warnings remain denied.

## Checklist

- [x] Commit messages follow conventional commits
- [x] No `Co-Authored-By` trailers
- [x] CLI JSON schema shape is unchanged
- [x] Engine tests pass
- [x] Clippy is clean apart from explicitly identified upstream baseline lints
- [x] `cargo fmt --check` passes
