### PR TITLE
feat(engine): restore in-place type evolution on Databricks (scoped Delta widening)

### DIFF
--- a/engine/crates/rocky-core/src/drift.rs
+++ b/engine/crates/rocky-core/src/drift.rs
@@ -195,6 +195,12 @@ pub fn generate_alter_column_sql(
     let table_ref = dialect.format_table_ref(&table.catalog, &table.schema, &table.table)?;
 
     let mut statements = Vec::new();
+    // Some dialects need a one-time prelude before the widenings — Databricks
+    // enables the Delta type-widening table feature so the `ALTER COLUMN … TYPE`
+    // is accepted. Emit it once, ahead of the per-column ALTERs.
+    if let Some(prelude) = dialect.pre_alter_column_type_sql(&table_ref) {
+        statements.push(prelude?);
+    }
     for col in drifted_columns {
         statements.push(dialect.alter_column_type_sql(&table_ref, &col.name, &col.source_type)?);
     }

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -1213,6 +1213,24 @@ pub trait SqlDialect: Send + Sync {
             "ALTER TABLE {table_ref} ALTER COLUMN {column} TYPE {new_type}"
         ))
     }
+
+    /// Optional statement to run **once** immediately before the per-column
+    /// `alter_column_type_sql` widenings, e.g. to enable a table feature the
+    /// `ALTER` depends on.
+    ///
+    /// Returns `None` when no prelude is needed — the default for every
+    /// dialect except Databricks, which enables the Delta
+    /// `delta.enableTypeWidening` table feature here so the subsequent
+    /// `ALTER COLUMN … TYPE …` is accepted on both freshly-created and
+    /// pre-existing tables. Emitted by
+    /// [`crate::drift::generate_alter_column_sql`] as the first statement of
+    /// the returned batch, so it runs before any column is altered.
+    ///
+    /// `table_ref` is already a fully formatted dialect-specific reference —
+    /// the caller obtains it via `format_table_ref`.
+    fn pre_alter_column_type_sql(&self, _table_ref: &str) -> Option<AdapterResult<String>> {
+        None
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/crates/rocky-databricks/src/dialect.rs
+++ b/engine/crates/rocky-databricks/src/dialect.rs
@@ -253,19 +253,84 @@ impl SqlDialect for DatabricksSqlDialect {
         Ok(format!("xxhash64({arg_list})"))
     }
 
-    fn is_safe_type_widening(&self, _source_type: &str, _target_type: &str) -> bool {
-        // Delta tables reject `ALTER TABLE … ALTER COLUMN … TYPE …` for a type
-        // change unless the `delta.enableTypeWidening` table feature is enabled
-        // (Rocky never sets it), and numeric → STRING is not a supported Delta
-        // widening at all. So every widening the shared default classifies as
-        // safe would emit an `ALTER` the warehouse rejects, failing the table
-        // run instead of evolving in place (#1115).
+    fn is_safe_type_widening(&self, source_type: &str, target_type: &str) -> bool {
+        // Delta's `delta.enableTypeWidening` table feature (DBR 15.4 LTS+)
+        // accepts a fixed, lossless set of in-place `ALTER COLUMN … TYPE`
+        // conversions. Rocky enables the feature on the ALTER path (see
+        // `pre_alter_column_type_sql`) and classifies only that set as
+        // ALTER-safe; everything else degrades to a full refresh.
         //
-        // Report no widening as ALTER-safe: type drift then degrades to a full
-        // refresh (`DropAndRecreate`) — the same path other unsafe drifts take —
-        // which succeeds. Graceful in-place evolution (set `enableTypeWidening`
-        // at CREATE + a Delta-scoped allowlist, live-verified) is a follow-up.
-        false
+        // Scoped to the lossless subset live-verified against a real Delta
+        // table (`tests/drift_widening_live.rs`): integer → wider integer, the
+        // exactly-lossless integer → DOUBLE (tinyint/smallint/int — NOT
+        // bigint, whose range exceeds a double's 53-bit mantissa), FLOAT →
+        // DOUBLE, and DECIMAL precision widening at fixed scale. Deliberately
+        // EXCLUDES numeric → STRING (Delta does not support it) and integer →
+        // DECIMAL (safe only when the decimal is wide enough for the integer's
+        // range — a flat rule would re-admit the #1115 loud failure). #1157.
+        let src = normalize_delta_type(source_type);
+        let tgt = normalize_delta_type(target_type);
+        // Tuple is (target = current type, source = new/incoming type): the
+        // current type widens to the new type.
+        matches!(
+            (tgt.as_str(), src.as_str()),
+            // integer → wider integer
+            ("TINYINT", "SMALLINT")
+                | ("TINYINT", "INT")
+                | ("TINYINT", "BIGINT")
+                | ("SMALLINT", "INT")
+                | ("SMALLINT", "BIGINT")
+                | ("INT", "BIGINT")
+                // exactly-lossless integer → DOUBLE (excludes BIGINT → DOUBLE)
+                | ("TINYINT", "DOUBLE")
+                | ("SMALLINT", "DOUBLE")
+                | ("INT", "DOUBLE")
+                // float → double
+                | ("FLOAT", "DOUBLE"),
+        ) || is_safe_delta_decimal_widening(&tgt, &src)
+    }
+
+    fn pre_alter_column_type_sql(&self, table_ref: &str) -> Option<AdapterResult<String>> {
+        // Enable Delta type widening before the `ALTER COLUMN … TYPE` widenings
+        // so they are accepted on both freshly-created and pre-existing tables
+        // (a CREATE-time-only property can't cover tables that already exist).
+        // Idempotent + metadata-only; `table_ref` is pre-validated by
+        // `format_table_ref`.
+        Some(Ok(format!(
+            "ALTER TABLE {table_ref} SET TBLPROPERTIES ('delta.enableTypeWidening' = 'true')"
+        )))
+    }
+}
+
+/// Normalizes a Databricks/Spark type name for widening comparison: uppercases
+/// and folds the common synonyms Spark accepts (`INTEGER`→`INT`, `LONG`→
+/// `BIGINT`, `SHORT`→`SMALLINT`, `BYTE`→`TINYINT`, `REAL`→`FLOAT`) to the
+/// canonical `DESCRIBE TABLE` spelling. `DECIMAL(p,s)` and every other type
+/// pass through uppercased.
+fn normalize_delta_type(t: &str) -> String {
+    match t.trim().to_uppercase().as_str() {
+        "INTEGER" => "INT".to_string(),
+        "LONG" => "BIGINT".to_string(),
+        "SHORT" => "SMALLINT".to_string(),
+        "BYTE" => "TINYINT".to_string(),
+        "REAL" => "FLOAT".to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// `DECIMAL(p,s)` → `DECIMAL(p2,s)` at fixed scale with `p2 >= p` — the
+/// lossless precision-widening subset of Delta's decimal type widening.
+/// Scale changes are excluded (they can drop integer digits, i.e. lose range).
+/// Both arguments are expected already normalized (uppercased).
+fn is_safe_delta_decimal_widening(target: &str, source: &str) -> bool {
+    fn parse(t: &str) -> Option<(u32, u32)> {
+        let inner = t.trim().strip_prefix("DECIMAL(")?.strip_suffix(')')?;
+        let (p, s) = inner.split_once(',')?;
+        Some((p.trim().parse().ok()?, s.trim().parse().ok()?))
+    }
+    match (parse(target), parse(source)) {
+        (Some((tp, ts)), Some((sp, ss))) => sp >= tp && ss == ts,
+        _ => false,
     }
 }
 
@@ -575,19 +640,82 @@ mod tests {
     }
 
     #[test]
-    fn type_widening_degrades_to_full_refresh() {
-        // Delta can't execute the trait-default `ALTER COLUMN … TYPE` widenings,
-        // so drift the shared default classifies as a safe in-place widening must
-        // instead degrade to a full refresh (`DropAndRecreate`) rather than emit
-        // an `ALTER` Databricks rejects (#1115).
+    fn type_widening_scoped_to_delta_lossless_set() {
+        // `is_safe_type_widening(new, current)` — the current type widens to the
+        // new type. Only Delta's live-verified lossless set is ALTER-safe (#1157).
+        let d = dialect();
+
+        // Safe — in Delta's lossless widening set.
+        assert!(d.is_safe_type_widening("BIGINT", "INT")); // INT → BIGINT
+        assert!(d.is_safe_type_widening("INT", "SMALLINT")); // SMALLINT → INT
+        assert!(d.is_safe_type_widening("BIGINT", "TINYINT")); // TINYINT → BIGINT
+        assert!(d.is_safe_type_widening("DOUBLE", "INT")); // INT → DOUBLE
+        assert!(d.is_safe_type_widening("DOUBLE", "SMALLINT")); // SMALLINT → DOUBLE
+        assert!(d.is_safe_type_widening("DOUBLE", "FLOAT")); // FLOAT → DOUBLE
+        assert!(d.is_safe_type_widening("DECIMAL(20,2)", "DECIMAL(10,2)")); // precision widen
+        // Spark synonyms fold to the canonical spelling.
+        assert!(d.is_safe_type_widening("LONG", "INTEGER")); // INT → BIGINT
+        assert!(d.is_safe_type_widening("DOUBLE", "REAL")); // FLOAT → DOUBLE
+
+        // Unsafe — degrade to a full refresh.
+        assert!(!d.is_safe_type_widening("STRING", "INT")); // numeric → STRING (Delta unsupported)
+        assert!(!d.is_safe_type_widening("STRING", "BOOLEAN")); // → STRING
+        assert!(!d.is_safe_type_widening("DOUBLE", "BIGINT")); // BIGINT → DOUBLE is lossy
+        assert!(!d.is_safe_type_widening("DECIMAL(10,2)", "INT")); // integer → DECIMAL deferred
+        assert!(!d.is_safe_type_widening("INT", "BIGINT")); // BIGINT → INT is narrowing
+        assert!(!d.is_safe_type_widening("DECIMAL(20,4)", "DECIMAL(10,2)")); // scale change
+        assert!(!d.is_safe_type_widening("DECIMAL(5,2)", "DECIMAL(10,2)")); // precision narrowing
+    }
+
+    #[test]
+    fn pre_alter_enables_delta_type_widening() {
+        let d = dialect();
+        let prelude = d
+            .pre_alter_column_type_sql("cat.sch.tbl")
+            .expect("Databricks emits a prelude")
+            .expect("valid prelude SQL");
+        assert_eq!(
+            prelude,
+            "ALTER TABLE cat.sch.tbl SET TBLPROPERTIES ('delta.enableTypeWidening' = 'true')"
+        );
+    }
+
+    #[test]
+    fn generate_alter_prepends_enable_type_widening() {
+        // The full ALTER batch enables the feature once, then widens each column.
+        use rocky_core::drift::generate_alter_column_sql;
+        use rocky_ir::{DriftedColumn, TableRef};
+
+        let table = TableRef {
+            catalog: "acme".into(),
+            schema: "raw".into(),
+            table: "orders".into(),
+        };
+        let drifted = vec![DriftedColumn {
+            name: "amount".into(),
+            source_type: "BIGINT".into(),
+            target_type: "INT".into(),
+        }];
+        let stmts = generate_alter_column_sql(&table, &drifted, &dialect()).unwrap();
+        assert_eq!(stmts.len(), 2, "prelude + one ALTER");
+        assert_eq!(
+            stmts[0],
+            "ALTER TABLE acme.raw.orders SET TBLPROPERTIES ('delta.enableTypeWidening' = 'true')"
+        );
+        assert_eq!(
+            stmts[1],
+            "ALTER TABLE acme.raw.orders ALTER COLUMN amount TYPE BIGINT"
+        );
+    }
+
+    #[test]
+    fn type_widening_drives_alter_and_full_refresh_actions() {
+        // Safe widenings evolve in place; unsupported ones degrade to a full
+        // refresh — the same path other unsafe drifts take (#1115 / #1157).
         use rocky_core::drift::detect_drift;
         use rocky_ir::{ColumnInfo, DriftAction, TableRef};
 
         let d = dialect();
-        // Both of these are safe widenings under the shared default.
-        assert!(!d.is_safe_type_widening("BIGINT", "INT")); // INT → BIGINT
-        assert!(!d.is_safe_type_widening("STRING", "INT")); // numeric → STRING
-
         let table = TableRef {
             catalog: "acme".into(),
             schema: "raw".into(),
@@ -598,15 +726,23 @@ mod tests {
             data_type: ty.to_string(),
             nullable: true,
         };
-        for (src_ty, tgt_ty) in [("BIGINT", "INT"), ("STRING", "INT")] {
-            let source = vec![col("amount", src_ty)];
-            let target = vec![col("amount", tgt_ty)];
-            let result = detect_drift(&table, &source, &target, &d);
-            assert_eq!(
-                result.action,
-                DriftAction::DropAndRecreate,
-                "{tgt_ty} → {src_ty} must degrade to full refresh on Databricks"
-            );
-        }
+
+        // INT → BIGINT now evolves in place.
+        let r = detect_drift(
+            &table,
+            &[col("amount", "BIGINT")],
+            &[col("amount", "INT")],
+            &d,
+        );
+        assert_eq!(r.action, DriftAction::AlterColumnTypes);
+
+        // numeric → STRING still degrades to a full refresh.
+        let r = detect_drift(
+            &table,
+            &[col("amount", "STRING")],
+            &[col("amount", "INT")],
+            &d,
+        );
+        assert_eq!(r.action, DriftAction::DropAndRecreate);
     }
 }

--- a/engine/crates/rocky-databricks/tests/drift_widening_live.rs
+++ b/engine/crates/rocky-databricks/tests/drift_widening_live.rs
@@ -1,0 +1,420 @@
+//! Live Databricks conformance test for the safe-type-widening drift path.
+//!
+//! `#[ignore]`-gated because it requires a real Databricks workspace on
+//! Databricks Runtime 15.4 LTS or above (the floor for the Delta
+//! `delta.enableTypeWidening` table feature). Reads the SAME env vars as
+//! the other live tests:
+//!   DATABRICKS_HOST, DATABRICKS_HTTP_PATH,
+//!   DATABRICKS_TOKEN (or DATABRICKS_CLIENT_ID + DATABRICKS_CLIENT_SECRET),
+//!   DATABRICKS_TEST_CATALOG (or DATABRICKS_CATALOG_PREFIX)
+//!
+//! Every schema/table is `hc_`-prefixed and dropped CASCADE on exit.
+//!
+//! Run with:
+//!   cargo test -p rocky-databricks --test drift_widening_live -- --ignored --nocapture
+//!
+//! What this pins (mirrors `rocky-snowflake/tests/drift_widening_live.rs`):
+//!
+//! 1. Delta type widening actually accepts the widenings the scoped
+//!    `DatabricksSqlDialect::is_safe_type_widening` allowlist advertises, when
+//!    `delta.enableTypeWidening` is set — so `detect_drift` returning
+//!    `AlterColumnTypes` does not ship an `ALTER` Databricks rejects (#1115 /
+//!    #1157).
+//! 2. The `SET TBLPROPERTIES('delta.enableTypeWidening' = 'true')` +
+//!    `ALTER COLUMN … TYPE …` SQL Rocky emits is accepted, both at CREATE
+//!    time and on a pre-existing table created without the feature.
+//! 3. Existing rows survive the in-place widening (no data loss).
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use rocky_core::traits::{SqlDialect, WarehouseAdapter};
+use rocky_databricks::adapter::DatabricksWarehouseAdapter;
+use rocky_databricks::auth::{Auth, AuthConfig};
+use rocky_databricks::connector::{ConnectorConfig, DatabricksConnector};
+use rocky_databricks::dialect::DatabricksSqlDialect;
+use rocky_ir::TableRef;
+
+fn adapter_from_env() -> Option<DatabricksWarehouseAdapter> {
+    let host = std::env::var("DATABRICKS_HOST").ok()?;
+    let http_path = std::env::var("DATABRICKS_HTTP_PATH").ok()?;
+    let warehouse_id = ConnectorConfig::warehouse_id_from_http_path(&http_path)?;
+
+    let auth = Auth::from_config(AuthConfig {
+        host: host.clone(),
+        token: std::env::var("DATABRICKS_TOKEN").ok(),
+        client_id: std::env::var("DATABRICKS_CLIENT_ID").ok(),
+        client_secret: std::env::var("DATABRICKS_CLIENT_SECRET").ok(),
+    })
+    .ok()?;
+
+    let config = ConnectorConfig {
+        host,
+        warehouse_id,
+        timeout: Duration::from_secs(180),
+        retry: Default::default(),
+    };
+    Some(DatabricksWarehouseAdapter::new(DatabricksConnector::new(
+        config, auth,
+    )))
+}
+
+fn catalog_from_env() -> Option<String> {
+    std::env::var("DATABRICKS_TEST_CATALOG")
+        .or_else(|_| std::env::var("DATABRICKS_CATALOG_PREFIX"))
+        .ok()
+}
+
+fn suffix() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros()
+}
+
+async fn exec(adapter: &DatabricksWarehouseAdapter, sql: &str) {
+    adapter
+        .execute_statement(sql)
+        .await
+        .unwrap_or_else(|e| panic!("statement failed: {sql}\nerror: {e:?}"));
+}
+
+fn col_type(cols: &[rocky_ir::ColumnInfo], name: &str) -> String {
+    cols.iter()
+        .find(|c| c.name.eq_ignore_ascii_case(name))
+        .map(|c| c.data_type.clone())
+        .unwrap_or_default()
+}
+
+/// CAPABILITY PROBE — raw SQL only, no dependency on the scoped allowlist.
+///
+/// Confirms the Delta feature + ALTER forms Rocky needs actually work on the
+/// target warehouse before the allowlist re-classifies anything as ALTER-safe.
+/// Prints the canonical DESCRIBE type spellings so the allowlist tuples can be
+/// pinned to what the warehouse actually reports.
+#[tokio::test]
+#[ignore = "requires live Databricks workspace on DBR 15.4 LTS+"]
+async fn live_delta_type_widening_capability_probe() {
+    let Some(adapter) = adapter_from_env() else {
+        eprintln!("SKIP: Databricks env not set");
+        return;
+    };
+    let Some(catalog) = catalog_from_env() else {
+        eprintln!("SKIP: DATABRICKS_TEST_CATALOG / DATABRICKS_CATALOG_PREFIX not set");
+        return;
+    };
+
+    // CONNECTIVITY PROOF first.
+    let probe = adapter.execute_query("SELECT 1 AS n").await;
+    let dialect = DatabricksSqlDialect;
+    let schema = format!("hc_drift_widen_{}", suffix());
+
+    let _ = adapter
+        .execute_statement(&format!("DROP SCHEMA IF EXISTS {catalog}.{schema} CASCADE"))
+        .await;
+    exec(
+        &adapter,
+        &format!("CREATE SCHEMA IF NOT EXISTS {catalog}.{schema}"),
+    )
+    .await;
+
+    // ---- Probe A: enableTypeWidening at CREATE, then widen each type ----
+    let a = "hc_widen_create";
+    exec(
+        &adapter,
+        &format!(
+            "CREATE OR REPLACE TABLE {catalog}.{schema}.{a} \
+             (n INT, f FLOAT, d DECIMAL(10,2), i2 INT, s SMALLINT) \
+             TBLPROPERTIES ('delta.enableTypeWidening' = 'true')"
+        ),
+    )
+    .await;
+    exec(
+        &adapter,
+        &format!(
+            "INSERT INTO {catalog}.{schema}.{a} VALUES \
+             (2147483647, CAST(1.5 AS FLOAT), CAST(123.45 AS DECIMAL(10,2)), 100, CAST(7 AS SMALLINT))"
+        ),
+    )
+    .await;
+
+    let a_ref = dialect
+        .format_table_ref(&catalog, &schema, a)
+        .expect("format_table_ref a");
+    // Each widening via the dialect emitter (current ANSI `ALTER COLUMN … TYPE`).
+    for (col, ty) in [
+        ("n", "BIGINT"),
+        ("f", "DOUBLE"),
+        ("d", "DECIMAL(20,2)"),
+        ("i2", "DOUBLE"),
+        ("s", "INT"),
+    ] {
+        let sql = dialect
+            .alter_column_type_sql(&a_ref, col, ty)
+            .unwrap_or_else(|e| panic!("alter_column_type_sql {col}->{ty}: {e:?}"));
+        adapter
+            .execute_statement(&sql)
+            .await
+            .unwrap_or_else(|e| panic!("WIDEN FAILED {col}->{ty}\nsql: {sql}\nerr: {e:?}"));
+    }
+
+    let a_table = TableRef {
+        catalog: catalog.clone(),
+        schema: schema.clone(),
+        table: a.to_string(),
+    };
+    let a_desc = adapter.describe_table(&a_table).await.expect("describe a");
+    let a_rows = adapter
+        .execute_query(&format!(
+            "SELECT n, f, d, i2, s FROM {catalog}.{schema}.{a}"
+        ))
+        .await
+        .ok();
+
+    // ---- Probe B: pre-existing table (no feature), SET then widen ----
+    let b = "hc_widen_set";
+    exec(
+        &adapter,
+        &format!("CREATE OR REPLACE TABLE {catalog}.{schema}.{b} (n INT)"),
+    )
+    .await;
+    exec(
+        &adapter,
+        &format!("INSERT INTO {catalog}.{schema}.{b} VALUES (5)"),
+    )
+    .await;
+    let b_ref = dialect
+        .format_table_ref(&catalog, &schema, b)
+        .expect("format_table_ref b");
+    let set_sql =
+        format!("ALTER TABLE {b_ref} SET TBLPROPERTIES ('delta.enableTypeWidening' = 'true')");
+    let set_res = adapter.execute_statement(&set_sql).await;
+    let widen_b = dialect
+        .alter_column_type_sql(&b_ref, "n", "BIGINT")
+        .unwrap();
+    let widen_b_res = if set_res.is_ok() {
+        Some(adapter.execute_statement(&widen_b).await)
+    } else {
+        None
+    };
+    let b_table = TableRef {
+        catalog: catalog.clone(),
+        schema: schema.clone(),
+        table: b.to_string(),
+    };
+    let b_desc = adapter.describe_table(&b_table).await.ok();
+
+    // Cleanup before assertions so a failure still leaves the sandbox clean.
+    let _ = adapter
+        .execute_statement(&format!("DROP SCHEMA IF EXISTS {catalog}.{schema} CASCADE"))
+        .await;
+
+    // ---- Report ----
+    println!("\n=== #1157 Databricks Delta type-widening capability probe ===");
+    let p = probe.expect("CONNECTIVITY: SELECT 1 must succeed");
+    println!("CONNECTIVITY: SELECT 1 -> {:?}", p.rows);
+    println!("PROBE A canonical DESCRIBE spellings (post-widen):");
+    for c in &["n", "f", "d", "i2", "s"] {
+        println!("   {c:>3} -> {}", col_type(&a_desc, c));
+    }
+    println!("PROBE A rows preserved: {a_rows:?}");
+    println!("PROBE B SET TBLPROPERTIES on existing table -> {set_res:?}");
+    println!("PROBE B widen result -> {widen_b_res:?}");
+    if let Some(bd) = &b_desc {
+        println!("PROBE B n -> {}", col_type(bd, "n"));
+    }
+
+    // ---- Assertions: every widening Rocky needs must have taken ----
+    assert_eq!(
+        col_type(&a_desc, "n").to_lowercase(),
+        "bigint",
+        "INT->BIGINT"
+    );
+    assert_eq!(
+        col_type(&a_desc, "f").to_lowercase(),
+        "double",
+        "FLOAT->DOUBLE"
+    );
+    assert_eq!(
+        col_type(&a_desc, "d").to_lowercase(),
+        "decimal(20,2)",
+        "DECIMAL(10,2)->DECIMAL(20,2)"
+    );
+    assert_eq!(
+        col_type(&a_desc, "i2").to_lowercase(),
+        "double",
+        "INT->DOUBLE"
+    );
+    assert_eq!(
+        col_type(&a_desc, "s").to_lowercase(),
+        "int",
+        "SMALLINT->INT"
+    );
+
+    set_res.expect("SET TBLPROPERTIES enableTypeWidening on existing table must succeed");
+    widen_b_res
+        .expect("widen attempted")
+        .expect("ALTER COLUMN n TYPE BIGINT must succeed after SET TBLPROPERTIES");
+    assert_eq!(
+        col_type(b_desc.as_deref().unwrap_or(&[]), "n").to_lowercase(),
+        "bigint",
+        "pre-existing table widened after SET TBLPROPERTIES"
+    );
+
+    println!("VERDICT: Delta type widening CONFIRMED for the scoped allowlist set.");
+}
+
+/// END-TO-END — the SQL Rocky actually emits, driven by the real
+/// `detect_drift` + `generate_alter_column_sql` + `DatabricksSqlDialect`.
+///
+/// Creates a table WITHOUT `enableTypeWidening` (so the `pre_alter` prelude is
+/// exercised), drives every allowlist widening through `detect_drift`, executes
+/// the emitted batch, and asserts the columns widened and the seeded row
+/// survived. This is the receipt that `AlterColumnTypes` no longer ships an
+/// `ALTER` Databricks rejects (#1115 / #1157).
+#[tokio::test]
+#[ignore = "requires live Databricks workspace on DBR 15.4 LTS+"]
+async fn live_drift_safe_widening_alters_in_place() {
+    use rocky_core::drift::{detect_drift, generate_alter_column_sql};
+    use rocky_ir::{ColumnInfo, DriftAction};
+
+    let Some(adapter) = adapter_from_env() else {
+        eprintln!("SKIP: Databricks env not set");
+        return;
+    };
+    let Some(catalog) = catalog_from_env() else {
+        eprintln!("SKIP: DATABRICKS_TEST_CATALOG / DATABRICKS_CATALOG_PREFIX not set");
+        return;
+    };
+
+    let dialect = DatabricksSqlDialect;
+    let schema = format!("hc_drift_e2e_{}", suffix());
+    let table = "hc_widen_e2e";
+
+    let _ = adapter
+        .execute_statement(&format!("DROP SCHEMA IF EXISTS {catalog}.{schema} CASCADE"))
+        .await;
+    exec(
+        &adapter,
+        &format!("CREATE SCHEMA IF NOT EXISTS {catalog}.{schema}"),
+    )
+    .await;
+    // Deliberately created WITHOUT the type-widening feature — the emitted
+    // batch's prelude must turn it on.
+    exec(
+        &adapter,
+        &format!(
+            "CREATE OR REPLACE TABLE {catalog}.{schema}.{table} \
+             (id INT, amt FLOAT, price DECIMAL(10,2), qty SMALLINT, big INT)"
+        ),
+    )
+    .await;
+    exec(
+        &adapter,
+        &format!(
+            "INSERT INTO {catalog}.{schema}.{table} VALUES \
+             (2147483647, CAST(2.5 AS FLOAT), CAST(999.99 AS DECIMAL(10,2)), CAST(12 AS SMALLINT), 42)"
+        ),
+    )
+    .await;
+
+    let table_ref = TableRef {
+        catalog: catalog.clone(),
+        schema: schema.clone(),
+        table: table.to_string(),
+    };
+    let current = adapter
+        .describe_table(&table_ref)
+        .await
+        .expect("describe current");
+
+    // Desired (new) types — every one an allowlist widening.
+    let desired = vec![
+        ColumnInfo {
+            name: "id".into(),
+            data_type: "BIGINT".into(),
+            nullable: true,
+        },
+        ColumnInfo {
+            name: "amt".into(),
+            data_type: "DOUBLE".into(),
+            nullable: true,
+        },
+        ColumnInfo {
+            name: "price".into(),
+            data_type: "DECIMAL(20,2)".into(),
+            nullable: true,
+        },
+        ColumnInfo {
+            name: "qty".into(),
+            data_type: "INT".into(),
+            nullable: true,
+        },
+        ColumnInfo {
+            name: "big".into(),
+            data_type: "DOUBLE".into(),
+            nullable: true,
+        },
+    ];
+
+    let drift = detect_drift(&table_ref, &desired, &current, &dialect);
+    let stmts = generate_alter_column_sql(&table_ref, &drift.drifted_columns, &dialect)
+        .expect("generate_alter_column_sql");
+    // Execute the emitted batch exactly as the run path would.
+    let mut exec_err = None;
+    for s in &stmts {
+        if let Err(e) = adapter.execute_statement(s).await {
+            exec_err = Some(format!("stmt failed: {s}\nerr: {e:?}"));
+            break;
+        }
+    }
+
+    let widened = adapter
+        .describe_table(&table_ref)
+        .await
+        .expect("describe after");
+    let row = adapter
+        .execute_query(&format!(
+            "SELECT id, amt, price, qty, big FROM {catalog}.{schema}.{table}"
+        ))
+        .await
+        .ok();
+
+    let _ = adapter
+        .execute_statement(&format!("DROP SCHEMA IF EXISTS {catalog}.{schema} CASCADE"))
+        .await;
+
+    println!("\n=== #1157 Databricks end-to-end drift widening ===");
+    println!("detect_drift action = {:?}", drift.action);
+    println!("emitted batch ({} stmts):", stmts.len());
+    for s in &stmts {
+        println!("   {s}");
+    }
+    println!("post-widen: {widened:?}");
+    println!("row preserved: {row:?}");
+
+    assert_eq!(
+        drift.action,
+        DriftAction::AlterColumnTypes,
+        "every drifted column is a Delta lossless widening"
+    );
+    assert!(
+        stmts
+            .first()
+            .map(|s| s.contains("enableTypeWidening"))
+            .unwrap_or(false),
+        "batch must enable the type-widening feature first"
+    );
+    if let Some(e) = exec_err {
+        panic!("emitted widening batch failed: {e}");
+    }
+    assert_eq!(col_type(&widened, "id").to_lowercase(), "bigint");
+    assert_eq!(col_type(&widened, "amt").to_lowercase(), "double");
+    assert_eq!(col_type(&widened, "price").to_lowercase(), "decimal(20,2)");
+    assert_eq!(col_type(&widened, "qty").to_lowercase(), "int");
+    assert_eq!(col_type(&widened, "big").to_lowercase(), "double");
+
+    let row = row.expect("row queryable");
+    assert_eq!(row.rows.len(), 1, "the seeded row survives the widening");
+
+    println!("VERDICT: detect_drift → AlterColumnTypes; emitted batch accepted; rows preserved.");
+}


### PR DESCRIPTION
## What

Restores graceful in-place type evolution on Databricks. #1156 fixed the #1115 correctness bug by degrading *all* Databricks type drift to a full refresh; this brings back in-place `ALTER` for the subset Delta's type-widening feature actually supports.

## Changes

- **`rocky-databricks`** — `is_safe_type_widening` scoped to Delta's lossless widening set: integer → wider integer, `tinyint`/`smallint`/`int` → `double`, `float` → `double`, and `DECIMAL` precision widening at fixed scale. Excludes numeric → STRING (Delta doesn't support it) and integer → DECIMAL (deferred — needs a precision-fits guard, else it re-admits the #1115 failure).
- **`rocky-core`** — new `SqlDialect::pre_alter_column_type_sql` hook (default `None`), emitted once at the head of the ALTER batch by `generate_alter_column_sql`. Databricks overrides it to `SET TBLPROPERTIES('delta.enableTypeWidening' = 'true')` so the widening `ALTER` is accepted on both new and pre-existing tables. Idempotent, metadata-only.

## Verification

Live-verified against a Databricks DBR 15.4 LTS+ sandbox (new `drift_widening_live.rs`, `#[ignore]`-gated):

- **Capability probe** — CREATE-with-`enableTypeWidening` + SET-on-existing-then-`ALTER` both accepted; canonical `DESCRIBE` spellings captured.
- **End-to-end** — `detect_drift` → `AlterColumnTypes`; the emitted 6-statement batch (`SET TBLPROPERTIES` then 5× `ALTER COLUMN … TYPE`) executes against the warehouse; every column widened (`bigint` / `double` / `decimal(20,2)` / `int` / `double`) and the seeded row survived.

Per the issue's bar, the exact per-warehouse set is confirmed against the live warehouse, not stub tests. Unit tests, `clippy --all-targets --all-features`, and `fmt --check` are green.

## Not in this PR

Trino's equivalent (scoped Iceberg allowlist + `ALTER COLUMN … SET DATA TYPE` form) — its live-verification bar needs a writable-Iceberg conformance harness (the current `trino-conformance` uses the `memory` connector, which can't exercise `SET DATA TYPE`). Tracked as a follow-up under #1157.

Refs #1157
