### PR TITLE
feat(engine/rocky-trino): restore in-place type evolution on Trino Iceberg (scoped SET DATA TYPE)

### DIFF
--- a/engine/crates/rocky-trino/src/dialect.rs
+++ b/engine/crates/rocky-trino/src/dialect.rs
@@ -188,19 +188,40 @@ impl SqlDialect for TrinoDialect {
         ])
     }
 
-    fn is_safe_type_widening(&self, _source_type: &str, _target_type: &str) -> bool {
-        // The trait-default `alter_column_type_sql` emits the ANSI `ALTER TABLE
-        // … ALTER COLUMN … TYPE …` form, which is not valid Trino syntax (Trino
-        // requires `… SET DATA TYPE …`), and the in-place type changes Trino
-        // accepts are connector-specific and narrow (e.g. no numeric → VARCHAR).
-        // So every widening the shared default classifies as safe would emit a
-        // statement Trino rejects, failing the table run (#1115).
+    fn is_safe_type_widening(&self, source_type: &str, target_type: &str) -> bool {
+        // Trino's Iceberg connector allows a narrow set of in-place column type
+        // promotions via `ALTER TABLE … ALTER COLUMN … SET DATA TYPE …` (see
+        // `alter_column_type_sql`): INTEGER → BIGINT, REAL → DOUBLE, and
+        // DECIMAL(p,s) → DECIMAL(p2,s) with p2 > p at fixed scale. Everything
+        // else — notably numeric → VARCHAR — is rejected, so it degrades to a
+        // full refresh instead of failing the run (#1115 / #1157).
         //
-        // Report no widening as ALTER-safe: type drift then degrades to a full
-        // refresh (`DropAndRecreate`), which succeeds. A connector-scoped
-        // allowlist paired with the `SET DATA TYPE` form (live-verified via the
-        // `trino-conformance` harness) is a follow-up.
-        false
+        // Scoped to the Iceberg connector — Trino's common lakehouse target;
+        // other connectors accept a different (often empty) set and would fall
+        // back to a full refresh. Live-verified via the `trino-conformance`
+        // harness against an Iceberg REST catalog.
+        let src = normalize_trino_type(source_type);
+        let tgt = normalize_trino_type(target_type);
+        // Tuple is (target = current type, source = new/incoming type).
+        matches!(
+            (tgt.as_str(), src.as_str()),
+            ("INTEGER", "BIGINT") | ("REAL", "DOUBLE"),
+        ) || is_safe_iceberg_decimal_widening(&tgt, &src)
+    }
+
+    fn alter_column_type_sql(
+        &self,
+        table_ref: &str,
+        column: &str,
+        new_type: &str,
+    ) -> AdapterResult<String> {
+        // Trino requires the `SET DATA TYPE` form; the trait-default ANSI
+        // `ALTER COLUMN … TYPE …` is a syntax error in Trino.
+        validation::validate_identifier(column).map_err(AdapterError::new)?;
+        rocky_core::sql_gen::validate_sql_type(new_type).map_err(AdapterError::new)?;
+        Ok(format!(
+            "ALTER TABLE {table_ref} ALTER COLUMN {column} SET DATA TYPE {new_type}"
+        ))
     }
 
     // `view_ddl` defaults to `CREATE OR REPLACE VIEW <target> AS …`,
@@ -223,6 +244,31 @@ impl SqlDialect for TrinoDialect {
     // `xxhash64(varbinary)` and `to_hex(sha256(...))` but neither is
     // wired up in v0 — checksum-bisection diff against Trino is a
     // follow-up.
+}
+
+/// Normalizes a Trino type name for widening comparison: uppercases and folds
+/// the `INT` synonym to Trino's canonical `INTEGER` spelling. `DECIMAL(p,s)`
+/// and every other type pass through uppercased.
+fn normalize_trino_type(t: &str) -> String {
+    match t.trim().to_uppercase().as_str() {
+        "INT" => "INTEGER".to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// `DECIMAL(p,s)` → `DECIMAL(p2,s)` at fixed scale with `p2 > p` — Iceberg's
+/// decimal promotion rule (precision may increase, scale cannot change). Both
+/// arguments are expected already normalized (uppercased).
+fn is_safe_iceberg_decimal_widening(target: &str, source: &str) -> bool {
+    fn parse(t: &str) -> Option<(u32, u32)> {
+        let inner = t.trim().strip_prefix("DECIMAL(")?.strip_suffix(')')?;
+        let (p, s) = inner.split_once(',')?;
+        Some((p.trim().parse().ok()?, s.trim().parse().ok()?))
+    }
+    match (parse(target), parse(source)) {
+        (Some((tp, ts)), Some((sp, ss))) => sp > tp && ss == ts,
+        _ => false,
+    }
 }
 
 #[cfg(test)]
@@ -453,20 +499,51 @@ mod tests {
     }
 
     #[test]
-    fn type_widening_degrades_to_full_refresh() {
-        // The trait-default `ALTER COLUMN … TYPE` form is invalid Trino syntax
-        // and Trino's accepted in-place widenings are connector-specific, so
-        // drift the shared default classifies as a safe widening must degrade to
-        // a full refresh (`DropAndRecreate`) rather than emit a statement Trino
-        // rejects (#1115).
+    fn type_widening_scoped_to_iceberg_promotions() {
+        // `is_safe_type_widening(new, current)` — the current type widens to the
+        // new type. Only Iceberg's promotion set is ALTER-safe (#1157).
+        let d = TrinoDialect::new();
+
+        // Safe — Iceberg promotions.
+        assert!(d.is_safe_type_widening("BIGINT", "INTEGER")); // INTEGER → BIGINT
+        assert!(d.is_safe_type_widening("BIGINT", "INT")); // INT synonym folds
+        assert!(d.is_safe_type_widening("DOUBLE", "REAL")); // REAL → DOUBLE
+        assert!(d.is_safe_type_widening("DECIMAL(20,2)", "DECIMAL(10,2)")); // precision widen
+
+        // Unsafe — degrade to full refresh.
+        assert!(!d.is_safe_type_widening("VARCHAR", "INTEGER")); // numeric → VARCHAR
+        assert!(!d.is_safe_type_widening("DOUBLE", "INTEGER")); // int → double not an Iceberg promotion
+        assert!(!d.is_safe_type_widening("INTEGER", "BIGINT")); // BIGINT → INTEGER narrowing
+        assert!(!d.is_safe_type_widening("DECIMAL(10,2)", "DECIMAL(20,2)")); // precision narrowing
+        assert!(!d.is_safe_type_widening("DECIMAL(20,4)", "DECIMAL(10,2)")); // scale change
+        assert!(!d.is_safe_type_widening("DECIMAL(10,2)", "DECIMAL(10,2)")); // equal (p2 not > p)
+    }
+
+    #[test]
+    fn alter_column_type_uses_set_data_type_form() {
+        let d = TrinoDialect::new();
+        let sql = d
+            .alter_column_type_sql("\"iceberg\".\"raw\".\"orders\"", "amount", "BIGINT")
+            .expect("valid alter");
+        assert_eq!(
+            sql,
+            "ALTER TABLE \"iceberg\".\"raw\".\"orders\" ALTER COLUMN amount SET DATA TYPE BIGINT"
+        );
+        // Injection guard still applies.
+        assert!(
+            d.alter_column_type_sql("\"t\"", "bad; DROP", "BIGINT")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn type_widening_drives_alter_and_full_refresh_actions() {
+        // Iceberg promotions evolve in place; unsupported changes degrade to a
+        // full refresh — the same path other unsafe drifts take (#1115 / #1157).
         use rocky_core::drift::detect_drift;
         use rocky_ir::{ColumnInfo, DriftAction, TableRef};
 
         let d = TrinoDialect::new();
-        // Both of these are safe widenings under the shared default.
-        assert!(!d.is_safe_type_widening("BIGINT", "INT")); // INT → BIGINT
-        assert!(!d.is_safe_type_widening("STRING", "INT")); // numeric → STRING
-
         let table = TableRef {
             catalog: "iceberg".into(),
             schema: "raw".into(),
@@ -477,15 +554,23 @@ mod tests {
             data_type: ty.to_string(),
             nullable: true,
         };
-        for (src_ty, tgt_ty) in [("BIGINT", "INT"), ("STRING", "INT")] {
-            let source = vec![col("amount", src_ty)];
-            let target = vec![col("amount", tgt_ty)];
-            let result = detect_drift(&table, &source, &target, &d);
-            assert_eq!(
-                result.action,
-                DriftAction::DropAndRecreate,
-                "{tgt_ty} → {src_ty} must degrade to full refresh on Trino"
-            );
-        }
+
+        // INTEGER → BIGINT now evolves in place.
+        let r = detect_drift(
+            &table,
+            &[col("amount", "BIGINT")],
+            &[col("amount", "INTEGER")],
+            &d,
+        );
+        assert_eq!(r.action, DriftAction::AlterColumnTypes);
+
+        // numeric → VARCHAR still degrades to a full refresh.
+        let r = detect_drift(
+            &table,
+            &[col("amount", "VARCHAR")],
+            &[col("amount", "INTEGER")],
+            &d,
+        );
+        assert_eq!(r.action, DriftAction::DropAndRecreate);
     }
 }

--- a/engine/crates/rocky-trino/src/dialect.rs
+++ b/engine/crates/rocky-trino/src/dialect.rs
@@ -196,10 +196,16 @@ impl SqlDialect for TrinoDialect {
         // else — notably numeric → VARCHAR — is rejected, so it degrades to a
         // full refresh instead of failing the run (#1115 / #1157).
         //
-        // Scoped to the Iceberg connector — Trino's common lakehouse target;
-        // other connectors accept a different (often empty) set and would fall
-        // back to a full refresh. Live-verified via the `trino-conformance`
-        // harness against an Iceberg REST catalog.
+        // Scoped to the Iceberg connector — Trino's common lakehouse target.
+        // NOTE: this classifier is connector-BLIND (the dialect can't see which
+        // Trino connector backs the table), so on a non-Iceberg connector an
+        // allowlisted widening is still ATTEMPTED — it emits `SET DATA TYPE` and
+        // the connector either accepts it or errors loudly; it is NOT silently
+        // downgraded to a full refresh. Only widenings OUTSIDE this allowlist
+        // degrade to a full refresh. The set here is Iceberg's (also broadly
+        // accepted by Delta); connector-aware scoping is a follow-up. Live-
+        // verified via the `trino-conformance` harness against an Iceberg REST
+        // catalog.
         let src = normalize_trino_type(source_type);
         let tgt = normalize_trino_type(target_type);
         // Tuple is (target = current type, source = new/incoming type).

--- a/engine/crates/rocky-trino/tests/conformance.rs
+++ b/engine/crates/rocky-trino/tests/conformance.rs
@@ -216,3 +216,171 @@ async fn round_trip_create_insert_select_drop() {
         .await
         .expect("DROP should succeed");
 }
+
+/// Live Iceberg type-widening receipt (#1157): the SQL Rocky emits for a scoped
+/// safe widening — `detect_drift` → `generate_alter_column_sql` →
+/// `ALTER … SET DATA TYPE` — is accepted by Trino's Iceberg connector and
+/// preserves the seeded row.
+///
+/// Requires the writable-Iceberg stack in `tests/iceberg/`:
+///   docker compose -f engine/crates/rocky-trino/tests/iceberg/docker-compose.yml up -d
+/// Skips gracefully against a coordinator without an `iceberg` catalog (e.g.
+/// the stock memory-only image).
+#[tokio::test]
+#[ignore = "requires the Trino+Iceberg conformance stack (tests/iceberg/docker-compose.yml); run with --ignored"]
+async fn drift_widening_alters_iceberg_in_place() {
+    use rocky_core::drift::{detect_drift, generate_alter_column_sql};
+    use rocky_ir::{ColumnInfo, DriftAction, TableRef};
+
+    let adapter = build_adapter();
+
+    // Skip (don't fail) if this coordinator has no `iceberg` catalog.
+    let has_iceberg = adapter
+        .execute_query("SHOW CATALOGS")
+        .await
+        .map(|r| {
+            r.rows
+                .iter()
+                .any(|row| row.first().and_then(|v| v.as_str()) == Some("iceberg"))
+        })
+        .unwrap_or(false);
+    if !has_iceberg {
+        eprintln!("SKIP drift_widening_alters_iceberg_in_place: no `iceberg` catalog");
+        return;
+    }
+
+    let dialect = adapter.dialect();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let schema = format!("rocky_widen_{nanos}");
+    let table = "widen_target";
+
+    let _ = adapter
+        .execute_statement(&format!("DROP SCHEMA IF EXISTS iceberg.{schema}"))
+        .await;
+    adapter
+        .execute_statement(&format!("CREATE SCHEMA IF NOT EXISTS iceberg.{schema}"))
+        .await
+        .expect("create iceberg schema");
+    let table_ref = dialect
+        .format_table_ref("iceberg", &schema, table)
+        .expect("format table ref");
+    adapter
+        .execute_statement(&format!(
+            "CREATE TABLE {table_ref} (id INTEGER, amt REAL, price DECIMAL(10,2))"
+        ))
+        .await
+        .expect("create iceberg table");
+    adapter
+        .execute_statement(&format!(
+            "INSERT INTO {table_ref} VALUES (2147483647, REAL '2.5', DECIMAL '999.99')"
+        ))
+        .await
+        .expect("seed row");
+
+    let tref = TableRef {
+        catalog: "iceberg".into(),
+        schema: schema.clone(),
+        table: table.into(),
+    };
+    let current = adapter
+        .describe_table(&tref)
+        .await
+        .expect("describe current");
+    // Desired (new) types — each an Iceberg promotion.
+    let desired = vec![
+        ColumnInfo {
+            name: "id".into(),
+            data_type: "BIGINT".into(),
+            nullable: true,
+        },
+        ColumnInfo {
+            name: "amt".into(),
+            data_type: "DOUBLE".into(),
+            nullable: true,
+        },
+        ColumnInfo {
+            name: "price".into(),
+            data_type: "DECIMAL(20,2)".into(),
+            nullable: true,
+        },
+    ];
+
+    let drift = detect_drift(&tref, &desired, &current, dialect);
+    let stmts =
+        generate_alter_column_sql(&tref, &drift.drifted_columns, dialect).expect("emit alters");
+    let mut exec_err = None;
+    for s in &stmts {
+        if let Err(e) = adapter.execute_statement(s).await {
+            exec_err = Some(format!("{s}: {e:?}"));
+            break;
+        }
+    }
+
+    let after = adapter.describe_table(&tref).await.expect("describe after");
+    let rows = adapter
+        .execute_query(&format!("SELECT id, amt, price FROM {table_ref}"))
+        .await
+        .ok();
+
+    let _ = adapter
+        .execute_statement(&format!("DROP TABLE IF EXISTS {table_ref}"))
+        .await;
+    let _ = adapter
+        .execute_statement(&format!("DROP SCHEMA IF EXISTS iceberg.{schema}"))
+        .await;
+
+    println!("detect_drift action = {:?}", drift.action);
+    println!("emitted: {stmts:?}");
+    println!("after: {after:?}");
+    println!("rows: {rows:?}");
+
+    assert_eq!(
+        drift.action,
+        DriftAction::AlterColumnTypes,
+        "Iceberg promotions must evolve in place"
+    );
+    assert!(
+        stmts.iter().all(|s| s.contains("SET DATA TYPE")),
+        "Trino must use the SET DATA TYPE form"
+    );
+    if let Some(e) = exec_err {
+        panic!("emitted widening rejected by Trino Iceberg: {e}");
+    }
+    let ty = |n: &str| {
+        after
+            .iter()
+            .find(|c| c.name.eq_ignore_ascii_case(n))
+            .map(|c| c.data_type.to_lowercase())
+            .unwrap_or_default()
+    };
+    assert_eq!(ty("id"), "bigint");
+    assert_eq!(ty("amt"), "double");
+    assert_eq!(ty("price"), "decimal(20,2)");
+    assert_eq!(
+        rows.expect("rows queryable").rows.len(),
+        1,
+        "the seeded row survives the widening"
+    );
+
+    // Negative: numeric -> VARCHAR is not an Iceberg promotion → full refresh.
+    let neg = detect_drift(
+        &tref,
+        &[ColumnInfo {
+            name: "id".into(),
+            data_type: "VARCHAR".into(),
+            nullable: true,
+        }],
+        &[ColumnInfo {
+            name: "id".into(),
+            data_type: "integer".into(),
+            nullable: true,
+        }],
+        dialect,
+    );
+    assert_eq!(neg.action, DriftAction::DropAndRecreate);
+
+    println!("VERDICT: Iceberg SET DATA TYPE widening accepted; rows preserved.");
+}

--- a/engine/crates/rocky-trino/tests/iceberg/docker-compose.yml
+++ b/engine/crates/rocky-trino/tests/iceberg/docker-compose.yml
@@ -1,0 +1,76 @@
+# Writable Iceberg stack for the rocky-trino drift-widening conformance test.
+#
+# The stock `trinodb/trino` image only ships `tpch` (read-only) + `memory`
+# (no `ALTER COLUMN … SET DATA TYPE`), so type-widening evolution can't be
+# exercised there. This stack adds a REST-catalog-backed Iceberg connector so
+# the emitted `SET DATA TYPE` ALTERs run against a real Iceberg table.
+#
+#   Trino (8080)  ──▶  Iceberg REST catalog (8181)  ──▶  MinIO / S3 (9000)
+#
+# Start:
+#   docker compose -f engine/crates/rocky-trino/tests/iceberg/docker-compose.yml up -d
+# Wait for Trino health (starting:false), then:
+#   cargo test -p rocky-trino --features trino-conformance \
+#     --test conformance drift_widening -- --ignored --nocapture
+# Tear down:
+#   docker compose -f .../iceberg/docker-compose.yml down -v
+
+name: rocky-trino-iceberg
+
+services:
+  minio:
+    image: minio/minio:latest
+    container_name: rocky-trino-minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+      MINIO_DOMAIN: minio
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+
+  mc:
+    image: minio/mc:latest
+    container_name: rocky-trino-mc
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+      until (/usr/bin/mc alias set minio http://minio:9000 minioadmin minioadmin); do echo 'waiting for minio'; sleep 1; done;
+      /usr/bin/mc mb --ignore-existing minio/warehouse;
+      echo 'warehouse bucket ready';
+      tail -f /dev/null
+      "
+
+  iceberg-rest:
+    image: apache/iceberg-rest-fixture:latest
+    container_name: rocky-trino-iceberg-rest
+    depends_on:
+      - minio
+    ports:
+      - "8181:8181"
+    environment:
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
+      AWS_REGION: us-east-1
+      CATALOG_WAREHOUSE: s3://warehouse/
+      CATALOG_IO__IMPL: org.apache.iceberg.aws.s3.S3FileIO
+      CATALOG_S3_ENDPOINT: http://minio:9000
+      CATALOG_S3_PATH__STYLE__ACCESS: "true"
+
+  trino:
+    image: trinodb/trino:latest
+    container_name: rocky-trino-iceberg
+    depends_on:
+      - iceberg-rest
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./trino-catalog/iceberg.properties:/etc/trino/catalog/iceberg.properties:ro
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/v1/info | grep -q '\"starting\":false'"]
+      interval: 5s
+      timeout: 5s
+      retries: 40
+      start_period: 20s

--- a/engine/crates/rocky-trino/tests/iceberg/trino-catalog/iceberg.properties
+++ b/engine/crates/rocky-trino/tests/iceberg/trino-catalog/iceberg.properties
@@ -1,0 +1,13 @@
+# Trino Iceberg connector backed by the REST catalog + MinIO (S3) in this
+# compose stack. Enables `ALTER TABLE … ALTER COLUMN … SET DATA TYPE …`, the
+# form rocky-trino emits for scoped type-widening drift.
+connector.name=iceberg
+iceberg.catalog.type=rest
+iceberg.rest-catalog.uri=http://iceberg-rest:8181
+iceberg.rest-catalog.warehouse=s3://warehouse/
+fs.native-s3.enabled=true
+s3.endpoint=http://minio:9000
+s3.region=us-east-1
+s3.path-style-access=true
+s3.aws-access-key=minioadmin
+s3.aws-secret-key=minioadmin


### PR DESCRIPTION
## What

Restores graceful in-place type evolution on **Trino** (Iceberg connector) — the second half of #1157. #1156 degraded all Trino type drift to a full refresh (#1115) because the trait-default ANSI `ALTER COLUMN … TYPE` is invalid Trino syntax.

## Changes

- **`rocky-trino`** — `is_safe_type_widening` scoped to Iceberg's promotion set: `INTEGER → BIGINT`, `REAL → DOUBLE`, `DECIMAL(p,s) → DECIMAL(p2,s)` with `p2 > p` at fixed scale. Excludes numeric → VARCHAR. Scoped to Iceberg's promotion set (Trino's common lakehouse target). The classifier is connector-blind, so on a non-Iceberg connector an allowlisted widening is still *attempted* (emits `SET DATA TYPE`, accepted or errored loudly), not silently downgraded; only widenings *outside* the allowlist degrade to a full refresh. Connector-aware scoping is a follow-up.
- **`rocky-trino`** — `alter_column_type_sql` override emitting Trino's `ALTER COLUMN … SET DATA TYPE …` form (the ANSI `… TYPE …` is a syntax error in Trino).

## Verification

Live-verified against a **writable Iceberg stack** added under `tests/iceberg/` (Trino + Iceberg REST catalog + MinIO, `docker-compose.yml` + `iceberg.properties`):

```
docker compose -f engine/crates/rocky-trino/tests/iceberg/docker-compose.yml up -d
cargo test -p rocky-trino --features trino-conformance --test conformance \
  drift_widening_alters_iceberg_in_place -- --ignored --nocapture
```

The `#[ignore]` conformance test creates an Iceberg table, drives `detect_drift` + `generate_alter_column_sql` + the real adapter, executes the emitted `SET DATA TYPE` ALTERs, and asserts every column widened (`bigint` / `double` / `decimal(20,2)`) and the seeded row survived. It skips gracefully against a coordinator without an `iceberg` catalog (e.g. the stock memory-only image), so the default `--features trino-conformance` run is unaffected. Unit tests, `clippy --all-targets --all-features`, and `fmt --check` are green.

## Relationship to #1157

Together with **#1167** (Databricks half), this completes #1157. Both PRs are independent; #1157 can be closed once both land.

Refs #1157
