### PR TITLE
feat(engine): WP-01 PR-D — compare-and-swap state writes (REFUSE-class finalize)

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -5205,6 +5205,25 @@
           }
         ]
       },
+      "ConcurrencyControl": {
+        "description": "Concurrency control for remote `[state]` object writes.\n\nGuards the cross-pod lost update where two runs sharing one `[state]` prefix race: one downloads the state, the other commits, and the first's end-of-run upload silently overwrites the second (last-writer-wins). See [`StateConfig::concurrency_control`].",
+        "oneOf": [
+          {
+            "description": "Unconditional last-writer-wins upload (default) — byte-identical to the pre-CAS behaviour. Correct for single-writer-per-prefix deployments (one run at a time, orchestrator-serialized).",
+            "enum": [
+              "off"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Compare-and-swap: the end-of-run upload is conditional on the remote object still carrying the generation the run downloaded. A run that lost a cross-pod race fail-closes (nonzero exit) instead of erasing the winner. Requires a backend with a conditional-write object tier (`s3` / `gcs`); auto-downgrades to `off` (with a warn) on other backends.",
+            "enum": [
+              "cas"
+            ],
+            "type": "string"
+          }
+        ]
+      },
       "ConcurrencyMode": {
         "anyOf": [
           {
@@ -15643,6 +15662,7 @@
             ],
             "default": {
               "backend": "local",
+              "concurrency_control": "off",
               "freeze_marker_writes": false,
               "gcs_bucket": null,
               "gcs_prefix": null,
@@ -17127,6 +17147,15 @@
             ],
             "default": "local",
             "description": "Storage backend: local (default), s3, gcs, valkey, or tiered (valkey + s3 fallback)"
+          },
+          "concurrency_control": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConcurrencyControl"
+              }
+            ],
+            "default": "off",
+            "description": "Concurrency control for remote state writes. Default [`ConcurrencyControl::Off`] (unconditional last-writer-wins, byte- identical to pre-CAS). Set to `\"cas\"` on live multi-pod object-store deployments so a run that lost a cross-pod race fail-closes instead of silently overwriting the winner's committed state. Auto-downgrades to `off` (with a warn) on backends without a conditional-write object tier."
           },
           "freeze_marker_writes": {
             "default": false,

--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -699,6 +699,25 @@
         }
       ]
     },
+    "ConcurrencyControl": {
+      "description": "Concurrency control for remote `[state]` object writes.\n\nGuards the cross-pod lost update where two runs sharing one `[state]` prefix race: one downloads the state, the other commits, and the first's end-of-run upload silently overwrites the second (last-writer-wins). See [`StateConfig::concurrency_control`].",
+      "oneOf": [
+        {
+          "description": "Unconditional last-writer-wins upload (default) — byte-identical to the pre-CAS behaviour. Correct for single-writer-per-prefix deployments (one run at a time, orchestrator-serialized).",
+          "enum": [
+            "off"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Compare-and-swap: the end-of-run upload is conditional on the remote object still carrying the generation the run downloaded. A run that lost a cross-pod race fail-closes (nonzero exit) instead of erasing the winner. Requires a backend with a conditional-write object tier (`s3` / `gcs`); auto-downgrades to `off` (with a warn) on other backends.",
+          "enum": [
+            "cas"
+          ],
+          "type": "string"
+        }
+      ]
+    },
     "ConcurrencyMode": {
       "anyOf": [
         {
@@ -3798,6 +3817,15 @@
           "default": "local",
           "description": "Storage backend: local (default), s3, gcs, valkey, or tiered (valkey + s3 fallback)"
         },
+        "concurrency_control": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConcurrencyControl"
+            }
+          ],
+          "default": "off",
+          "description": "Concurrency control for remote state writes. Default [`ConcurrencyControl::Off`] (unconditional last-writer-wins, byte- identical to pre-CAS). Set to `\"cas\"` on live multi-pod object-store deployments so a run that lost a cross-pod race fail-closes instead of silently overwriting the winner's committed state. Auto-downgrades to `off` (with a warn) on backends without a conditional-write object tier."
+        },
         "freeze_marker_writes": {
           "default": false,
           "description": "Enable writing durable freeze/unfreeze marker objects (under `<prefix>/freeze/` and `<prefix>/unfreeze/`, beside the remote state file) when `rocky policy freeze` / `unfreeze` run against an object-store backend. Marker reading and enforcement are always on wherever a durable object tier exists; this flag gates only the write side, so a fleet can be upgraded to marker readers everywhere before any marker is written. Default `false`. Requires a backend with a durable object tier (`s3`, `gcs`, or `tiered`).",
@@ -4665,6 +4693,7 @@
       ],
       "default": {
         "backend": "local",
+        "concurrency_control": "off",
         "freeze_marker_writes": false,
         "gcs_bucket": null,
         "gcs_prefix": null,

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -347,6 +347,12 @@ export type Dialect = "databricks" | "snowflake" | "bigquery" | "duckdb";
  */
 export type StateBackend = "local" | "s3" | "gcs" | "valkey" | "tiered";
 /**
+ * Concurrency control for remote `[state]` object writes.
+ *
+ * Guards the cross-pod lost update where two runs sharing one `[state]` prefix race: one downloads the state, the other commits, and the first's end-of-run upload silently overwrites the second (last-writer-wins). See [`StateConfig::concurrency_control`].
+ */
+export type ConcurrencyControl = "off" | "cas";
+/**
  * Policy controlling which terminal outcomes count for [`IdempotencyConfig::dedup_on`].
  */
 export type DedupPolicy = "success" | "any";
@@ -2208,6 +2214,10 @@ export interface StateConfig {
    * Storage backend: local (default), s3, gcs, valkey, or tiered (valkey + s3 fallback)
    */
   backend?: StateBackend & string;
+  /**
+   * Concurrency control for remote state writes. Default [`ConcurrencyControl::Off`] (unconditional last-writer-wins, byte- identical to pre-CAS). Set to `"cas"` on live multi-pod object-store deployments so a run that lost a cross-pod race fail-closes instead of silently overwriting the winner's committed state. Auto-downgrades to `off` (with a warn) on backends without a conditional-write object tier.
+   */
+  concurrency_control?: ConcurrencyControl & string;
   /**
    * Enable writing durable freeze/unfreeze marker objects (under `<prefix>/freeze/` and `<prefix>/unfreeze/`, beside the remote state file) when `rocky policy freeze` / `unfreeze` run against an object-store backend. Marker reading and enforcement are always on wherever a durable object tier exists; this flag gates only the write side, so a fleet can be upgraded to marker readers everywhere before any marker is written. Default `false`. Requires a backend with a durable object tier (`s3`, `gcs`, or `tiered`).
    */

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -537,6 +537,37 @@ impl std::fmt::Display for StateBackend {
     }
 }
 
+/// Concurrency control for remote `[state]` object writes.
+///
+/// Guards the cross-pod lost update where two runs sharing one `[state]` prefix
+/// race: one downloads the state, the other commits, and the first's end-of-run
+/// upload silently overwrites the second (last-writer-wins). See
+/// [`StateConfig::concurrency_control`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum ConcurrencyControl {
+    /// Unconditional last-writer-wins upload (default) — byte-identical to the
+    /// pre-CAS behaviour. Correct for single-writer-per-prefix deployments
+    /// (one run at a time, orchestrator-serialized).
+    #[default]
+    Off,
+    /// Compare-and-swap: the end-of-run upload is conditional on the remote
+    /// object still carrying the generation the run downloaded. A run that lost
+    /// a cross-pod race fail-closes (nonzero exit) instead of erasing the
+    /// winner. Requires a backend with a conditional-write object tier (`s3` /
+    /// `gcs`); auto-downgrades to `off` (with a warn) on other backends.
+    Cas,
+}
+
+impl std::fmt::Display for ConcurrencyControl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConcurrencyControl::Off => write!(f, "off"),
+            ConcurrencyControl::Cas => write!(f, "cas"),
+        }
+    }
+}
+
 /// Policy applied when state upload fails after retries + circuit-breaker
 /// are exhausted. See [`StateConfig::on_upload_failure`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
@@ -716,6 +747,15 @@ pub struct StateConfig {
     /// durable object tier (`s3`, `gcs`, or `tiered`).
     #[serde(default)]
     pub freeze_marker_writes: bool,
+
+    /// Concurrency control for remote state writes. Default
+    /// [`ConcurrencyControl::Off`] (unconditional last-writer-wins, byte-
+    /// identical to pre-CAS). Set to `"cas"` on live multi-pod object-store
+    /// deployments so a run that lost a cross-pod race fail-closes instead of
+    /// silently overwriting the winner's committed state. Auto-downgrades to
+    /// `off` (with a warn) on backends without a conditional-write object tier.
+    #[serde(default)]
+    pub concurrency_control: ConcurrencyControl,
 }
 
 impl Default for StateConfig {
@@ -736,6 +776,7 @@ impl Default for StateConfig {
             namespacing: StateNamespacing::default(),
             on_schema_mismatch: SchemaMismatchPolicy::default(),
             freeze_marker_writes: false,
+            concurrency_control: ConcurrencyControl::default(),
         }
     }
 }

--- a/engine/crates/rocky-core/src/object_store.rs
+++ b/engine/crates/rocky-core/src/object_store.rs
@@ -89,6 +89,50 @@ pub enum PutIfNotExistsOutcome {
     AlreadyExists,
 }
 
+/// An object's version identity, for compare-and-swap writes.
+///
+/// Captured from the read that seeds a writer's *base*, then presented on the
+/// writer's next write so the store rejects it ([`PutIfMatchOutcome::Conflict`])
+/// if another writer committed in between. S3/Azure key on `e_tag` (`If-Match`),
+/// GCS on `version` (`x-goog-if-generation-match`) — both are carried so the
+/// primitive stays backend-agnostic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Generation {
+    /// Entity tag (S3 / Azure).
+    pub e_tag: Option<String>,
+    /// Version / generation id (GCS).
+    pub version: Option<String>,
+}
+
+impl Generation {
+    fn to_update_version(&self) -> object_store::UpdateVersion {
+        object_store::UpdateVersion {
+            e_tag: self.e_tag.clone(),
+            version: self.version.clone(),
+        }
+    }
+
+    fn from_put_result(result: &object_store::PutResult) -> Self {
+        Self {
+            e_tag: result.e_tag.clone(),
+            version: result.version.clone(),
+        }
+    }
+}
+
+/// Outcome of a compare-and-swap write
+/// ([`put_if_match`](ObjectStoreProvider::put_if_match)).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PutIfMatchOutcome {
+    /// The write committed. Carries the NEW [`Generation`] the caller must
+    /// CAS against on its next write.
+    Committed(Generation),
+    /// Another writer committed since the base was read; no bytes were
+    /// written. The caller must re-read and decide (refuse, or replay a
+    /// single ledger record onto the winner's object).
+    Conflict,
+}
+
 /// Wraps an [`ObjectStore`] with a root path, providing a simple async API for
 /// reading and writing objects.
 ///
@@ -315,7 +359,41 @@ impl ObjectStoreProvider {
         local_path: &Path,
     ) -> ObjectStoreResult<()> {
         let bytes = self.get(relative_path).await?;
+        self.atomic_write(&bytes, local_path).await
+    }
 
+    /// Download an object, capturing its [`Generation`] from the same read.
+    ///
+    /// Like [`download_file`](Self::download_file) but returns the object's
+    /// version identity (S3 ETag / GCS generation) from the SAME GET that
+    /// fetched the bytes — never a separate HEAD, which would open a TOCTOU
+    /// between reading the version and reading the bytes the writer will
+    /// mutate. Returns `None` when the backend surfaces no version metadata.
+    pub async fn download_file_capturing_version(
+        &self,
+        relative_path: &str,
+        local_path: &Path,
+    ) -> ObjectStoreResult<Option<Generation>> {
+        let path = self.absolute_path(relative_path);
+        debug!(path = %path, "object_store download_file_capturing_version");
+        let result = self.store.get(&path).await?;
+        let generation = {
+            let meta = &result.meta;
+            (meta.e_tag.is_some() || meta.version.is_some()).then(|| Generation {
+                e_tag: meta.e_tag.clone(),
+                version: meta.version.clone(),
+            })
+        };
+        let bytes = result.bytes().await?;
+        self.atomic_write(&bytes, local_path).await?;
+        Ok(generation)
+    }
+
+    /// Atomically publish `bytes` to `local_path` via a same-directory temp
+    /// file + `rename` (POSIX rename is atomic within a filesystem), so a
+    /// reader never observes a half-written file. Writing in place would leave
+    /// a corrupt `state.redb` if the process died mid-write.
+    async fn atomic_write(&self, bytes: &[u8], local_path: &Path) -> ObjectStoreResult<()> {
         let parent = local_path.parent().unwrap_or_else(|| Path::new("."));
         let file_name = local_path
             .file_name()
@@ -335,13 +413,77 @@ impl ObjectStoreProvider {
         );
         let tmp_path = parent.join(unique);
 
-        tokio::fs::write(&tmp_path, &bytes).await?;
+        tokio::fs::write(&tmp_path, bytes).await?;
         // Atomic publish. On failure, best-effort clean up the temp file.
         if let Err(e) = tokio::fs::rename(&tmp_path, local_path).await {
             let _ = tokio::fs::remove_file(&tmp_path).await;
             return Err(e.into());
         }
         Ok(())
+    }
+
+    /// Compare-and-swap write — the primitive behind `[state]
+    /// concurrency_control = "cas"`.
+    ///
+    /// - `expected = None` → create-if-absent ([`PutMode::Create`],
+    ///   `If-None-Match: *`); a concurrent first writer yields
+    ///   [`PutIfMatchOutcome::Conflict`]. This path is used only for the
+    ///   first-ever write to an empty key — it must **never** fall through to
+    ///   an unconditional put, which would reintroduce the lost update this
+    ///   primitive exists to prevent.
+    /// - `expected = Some(gen)` → conditional overwrite ([`PutMode::Update`],
+    ///   `If-Match: <etag>`); a base that no longer matches the object yields
+    ///   `Conflict`.
+    ///
+    /// On success returns [`PutIfMatchOutcome::Committed`] carrying the new
+    /// [`Generation`] so the caller can advance its base for a subsequent
+    /// write. A backend / transport error is returned as `Err` and is **never**
+    /// reported as a `Conflict` — only the store's own precondition failure is.
+    pub async fn put_if_match(
+        &self,
+        relative_path: &str,
+        data: Bytes,
+        expected: Option<&Generation>,
+    ) -> ObjectStoreResult<PutIfMatchOutcome> {
+        let path = self.absolute_path(relative_path);
+        let mode = match expected {
+            Some(base) => PutMode::Update(base.to_update_version()),
+            None => PutMode::Create,
+        };
+        debug!(
+            path = %path,
+            size = data.len(),
+            conditional = expected.is_some(),
+            "object_store put_if_match"
+        );
+        let opts = PutOptions {
+            mode,
+            ..Default::default()
+        };
+        match self.store.put_opts(&path, data.into(), opts).await {
+            Ok(result) => Ok(PutIfMatchOutcome::Committed(Generation::from_put_result(
+                &result,
+            ))),
+            // `Precondition` = failed `If-Match` (steady-state CAS miss);
+            // `AlreadyExists` = failed `If-None-Match: *` (bootstrap race).
+            // Both mean another writer won — a conflict, not an error.
+            Err(object_store::Error::Precondition { .. })
+            | Err(object_store::Error::AlreadyExists { .. }) => Ok(PutIfMatchOutcome::Conflict),
+            Err(e) => Err(ObjectStoreError::Backend(e)),
+        }
+    }
+
+    /// Upload a local file with compare-and-swap semantics — see
+    /// [`put_if_match`](Self::put_if_match).
+    pub async fn upload_file_if_match(
+        &self,
+        local_path: &Path,
+        relative_path: &str,
+        expected: Option<&Generation>,
+    ) -> ObjectStoreResult<PutIfMatchOutcome> {
+        let data = tokio::fs::read(local_path).await?;
+        self.put_if_match(relative_path, Bytes::from(data), expected)
+            .await
     }
 
     /// List objects under a relative prefix, returning their paths relative to
@@ -457,6 +599,77 @@ mod tests {
         // Original value preserved — second call was a no-op.
         let stored = provider.get("claim-key").await.unwrap();
         assert_eq!(stored.as_ref(), b"first");
+    }
+
+    #[tokio::test]
+    async fn put_if_match_create_conflicts_on_second_bootstrap() {
+        let provider = ObjectStoreProvider::in_memory();
+        let first = provider
+            .put_if_match("state", Bytes::from_static(b"v0"), None)
+            .await
+            .unwrap();
+        assert!(matches!(first, PutIfMatchOutcome::Committed(_)));
+        // A second create against the now-existing key is a bootstrap-race loss,
+        // NOT a blind overwrite.
+        let second = provider
+            .put_if_match("state", Bytes::from_static(b"v0b"), None)
+            .await
+            .unwrap();
+        assert_eq!(second, PutIfMatchOutcome::Conflict);
+        assert_eq!(provider.get("state").await.unwrap().as_ref(), b"v0");
+    }
+
+    #[tokio::test]
+    async fn put_if_match_updates_on_matching_base_conflicts_on_stale() {
+        let provider = ObjectStoreProvider::in_memory();
+        let PutIfMatchOutcome::Committed(g0) = provider
+            .put_if_match("state", Bytes::from_static(b"v0"), None)
+            .await
+            .unwrap()
+        else {
+            panic!("first write should commit");
+        };
+
+        // Matching base → commits, yields a fresh generation.
+        let PutIfMatchOutcome::Committed(g1) = provider
+            .put_if_match("state", Bytes::from_static(b"v1"), Some(&g0))
+            .await
+            .unwrap()
+        else {
+            panic!("matching-base write should commit");
+        };
+        assert_ne!(g0, g1, "a committed write advances the generation");
+        assert_eq!(provider.get("state").await.unwrap().as_ref(), b"v1");
+
+        // Stale base (g0, superseded by g1) → conflict, no write.
+        let stale = provider
+            .put_if_match("state", Bytes::from_static(b"v2"), Some(&g0))
+            .await
+            .unwrap();
+        assert_eq!(stale, PutIfMatchOutcome::Conflict);
+        assert_eq!(provider.get("state").await.unwrap().as_ref(), b"v1");
+    }
+
+    #[tokio::test]
+    async fn download_file_capturing_version_yields_a_cas_matchable_base() {
+        let provider = ObjectStoreProvider::in_memory();
+        provider
+            .put_if_match("state", Bytes::from_static(b"seed"), None)
+            .await
+            .unwrap();
+        let out = tempfile::NamedTempFile::new().unwrap();
+        let base = provider
+            .download_file_capturing_version("state", out.path())
+            .await
+            .unwrap();
+        assert_eq!(std::fs::read(out.path()).unwrap(), b"seed");
+        // The base captured from the download must CAS-match the live object.
+        let base = base.expect("in-memory backend surfaces a version");
+        let committed = provider
+            .put_if_match("state", Bytes::from_static(b"next"), Some(&base))
+            .await
+            .unwrap();
+        assert!(matches!(committed, PutIfMatchOutcome::Committed(_)));
     }
 
     #[tokio::test]

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -16,8 +16,10 @@ use thiserror::Error;
 use tracing::{Instrument, debug, info, info_span, warn};
 
 use crate::circuit_breaker::TransitionOutcome;
-use crate::config::{RetryConfig, StateBackend, StateConfig, StateUploadFailureMode};
-use crate::object_store::{ObjectStoreError, ObjectStoreProvider};
+use crate::config::{
+    ConcurrencyControl, RetryConfig, StateBackend, StateConfig, StateUploadFailureMode,
+};
+use crate::object_store::{Generation, ObjectStoreError, ObjectStoreProvider, PutIfMatchOutcome};
 use crate::redacted::RedactedString;
 use crate::retry::compute_backoff;
 use crate::retry_budget::RetryBudget;
@@ -59,6 +61,12 @@ pub enum StateSyncError {
 
     #[error("state retry budget exhausted (limit {limit}); aborting remaining retries")]
     RetryBudgetExhausted { limit: u32 },
+
+    #[error(
+        "state compare-and-swap conflict on '{key}': another writer committed since this run \
+         downloaded state; refusing to overwrite the winner (fail-closed)"
+    )]
+    CasConflict { key: String },
 }
 
 /// State file name within the configured prefix.
@@ -491,10 +499,16 @@ pub enum FinalizeDurability {
 ///   (around its merge + atomic publish), so a session-held store would
 ///   contend with the download's publish. Callers open/close their store
 ///   around the session as today.
-/// - **A `base` generation.** Deliberately absent this stage: the observed
-///   remote generation (the field the CAS PR reads and CAS-writes at
-///   `finalize`) is the concurrency PR's forward extension of this struct, not
-///   part of the lifecycle spine.
+/// - **The `StateStore` merge lock** — see above.
+///
+/// # Held only under CAS
+///
+/// - **A `base` generation** is captured at [`acquire`][Self::acquire] and held
+///   ONLY under `concurrency_control = "cas"` on an object-store backend: it is
+///   the remote object's generation at download time, which
+///   [`finalize`][Self::finalize] CAS-commits against so a run that lost a
+///   cross-pod race fail-closes instead of erasing the winner. `None` on the
+///   default `off` path (an unconditional upload, byte-identical to pre-CAS).
 ///
 /// # Drop tripwire
 ///
@@ -533,6 +547,11 @@ pub struct RemoteStateSession {
     /// detach the blocking closure, leaking the scratch it recreates and holding
     /// the upgrade past the run tail's `Arc::try_unwrap`.
     periodic_shutdown: Option<Arc<tokio::sync::Notify>>,
+    /// The remote object's generation captured at `acquire`, held ONLY under
+    /// `concurrency_control = "cas"` on an object-store backend. `finalize`
+    /// CAS-commits against it. `None` on the `off` path, on non-object-store
+    /// backends, or when the object was absent (bootstrap → create-if-absent).
+    base: Option<Generation>,
 }
 
 impl RemoteStateSession {
@@ -551,7 +570,17 @@ impl RemoteStateSession {
             finalized: false,
             periodic: None,
             periodic_shutdown: None,
+            base: None,
         }
+    }
+
+    /// Whether this session performs compare-and-swap state writes: configured
+    /// `concurrency_control = "cas"` AND a backend with a conditional-write
+    /// object tier (`s3` / `gcs`). On other backends `cas` auto-downgrades to
+    /// an unconditional upload.
+    fn cas_enabled(&self) -> bool {
+        self.cfg.concurrency_control == ConcurrencyControl::Cas
+            && matches!(self.cfg.backend, StateBackend::S3 | StateBackend::Gcs)
     }
 
     /// Download-before-read: resolve, record, and return the ledger's
@@ -590,7 +619,29 @@ impl RemoteStateSession {
             return Ok(self.authority);
         }
 
-        match download_state(&self.cfg, &self.state_path).await {
+        // Under CAS on an object-store backend, capture the downloaded object's
+        // generation as this run's base so `finalize` can conditionally commit
+        // against it. Other backends fall back to the plain download (and warn
+        // once if `cas` was configured but unsupported here).
+        let result = if self.cas_enabled() {
+            download_state_with_generation(&self.cfg, &self.state_path)
+                .await
+                .map(|(authority, base)| {
+                    self.base = base;
+                    authority
+                })
+        } else {
+            if self.cfg.concurrency_control == ConcurrencyControl::Cas {
+                warn!(
+                    backend = %self.cfg.backend,
+                    "concurrency_control = cas is not supported on this backend; using an \
+                     unconditional state upload (auto-downgraded to off)"
+                );
+            }
+            download_state(&self.cfg, &self.state_path).await
+        };
+
+        match result {
             Ok(authority) => {
                 self.authority = authority;
                 Ok(authority)
@@ -682,6 +733,18 @@ impl RemoteStateSession {
     /// run tail's `Arc::try_unwrap`, silently no-op'ing every terminal write.
     pub fn start_periodic_uploader(&mut self, store: Weak<StateStore>, cadence: Duration) {
         if self.periodic.is_some() {
+            return;
+        }
+        if self.cas_enabled() {
+            // Under CAS the mid-run periodic uploader is disabled: a correct
+            // periodic CAS write must advance a base shared with `finalize` and
+            // stop-without-refresh on conflict (ADR-CONCURRENCY §D2) — a
+            // follow-up. Finalize-only CAS against the acquire base is correct
+            // precisely because no mid-run upload bumps the remote generation.
+            debug!(
+                "periodic state uploader disabled under concurrency_control = cas \
+                 (finalize-only CAS)"
+            );
             return;
         }
         let cfg = self.cfg.clone();
@@ -806,6 +869,21 @@ impl RemoteStateSession {
             );
             return Ok(());
         }
+        // CAS terminal commit: conditionally upload against the base captured at
+        // acquire. A lost cross-pod race surfaces `CasConflict` (fail-closed,
+        // never swallowed). `Durable` still forces `on_upload_failure = Fail`
+        // for the transport-error case.
+        if self.cas_enabled() {
+            let cfg = match self.durability {
+                FinalizeDurability::Durable => StateConfig {
+                    on_upload_failure: StateUploadFailureMode::Fail,
+                    ..self.cfg.clone()
+                },
+                FinalizeDurability::ConfigDefault => self.cfg.clone(),
+            };
+            return upload_state_cas(&cfg, &self.state_path, self.base.as_ref()).await;
+        }
+
         match self.durability {
             FinalizeDurability::Durable => {
                 let durable_cfg = StateConfig {
@@ -990,6 +1068,31 @@ pub async fn download_state(
     config: &StateConfig,
     local_path: &Path,
 ) -> Result<StateAuthority, StateSyncError> {
+    download_state_impl(config, local_path, None).await
+}
+
+/// Download-before-read that ALSO captures the remote object's [`Generation`]
+/// for a compare-and-swap writer (`[state] concurrency_control = "cas"`).
+///
+/// The captured generation is the *base* the writer CAS-commits against at
+/// [`RemoteStateSession::finalize`]. `Ok((_, None))` means the object was
+/// absent (a bootstrap first-write, which CASes with `PutMode::Create`) or the
+/// backend surfaced no version metadata. Behaviour is otherwise identical to
+/// [`download_state`] — same staging, publish-lock, and local-only merge.
+pub async fn download_state_with_generation(
+    config: &StateConfig,
+    local_path: &Path,
+) -> Result<(StateAuthority, Option<Generation>), StateSyncError> {
+    let mut generation = None;
+    let authority = download_state_impl(config, local_path, Some(&mut generation)).await?;
+    Ok((authority, generation))
+}
+
+async fn download_state_impl(
+    config: &StateConfig,
+    local_path: &Path,
+    mut gen_sink: Option<&mut Option<Generation>>,
+) -> Result<StateAuthority, StateSyncError> {
     let remote_key = remote_state_key(local_path);
 
     // Local backend never replaces the file — nothing to stage, merge, or lock.
@@ -1001,7 +1104,7 @@ pub async fn download_state(
     // source of truth and must never be treated as an empty ledger to
     // bootstrap over.
     if matches!(config.backend, StateBackend::Local) {
-        download_state_inner(config, local_path, &remote_key).await?;
+        download_state_inner(config, local_path, &remote_key, gen_sink.take()).await?;
         return Ok(StateAuthority::Authoritative);
     }
 
@@ -1009,7 +1112,7 @@ pub async fn download_state(
     //    untouched; `Absent` leaves the staging file unwritten.
     let scratch_dir = sibling_scratch_dir(local_path);
     let staged = unique_scratch_path(&scratch_dir, "download");
-    let outcome = match download_state_inner(config, &staged, &remote_key).await {
+    let outcome = match download_state_inner(config, &staged, &remote_key, gen_sink.take()).await {
         Ok(outcome) => outcome,
         Err(e) => {
             let _ = std::fs::remove_file(&staged);
@@ -1271,6 +1374,7 @@ async fn download_state_inner(
     config: &StateConfig,
     dest_path: &Path,
     remote_key: &str,
+    gen_sink: Option<&mut Option<Generation>>,
 ) -> Result<DownloadOutcome, StateSyncError> {
     match config.backend {
         StateBackend::Local => {
@@ -1289,6 +1393,7 @@ async fn download_state_inner(
                 dest_path,
                 remote_key,
                 transfer_timeout(config),
+                gen_sink,
             )
             .await
         }
@@ -1304,6 +1409,7 @@ async fn download_state_inner(
                 dest_path,
                 remote_key,
                 transfer_timeout(config),
+                gen_sink,
             )
             .await
         }
@@ -1336,18 +1442,35 @@ async fn download_state_inner(
             // stale local file left by a previous run must NOT be mistaken for a
             // fresh Valkey hit (which would skip the S3 fallback and resume from
             // stale state).
-            match Box::pin(download_state_inner(&valkey_config, dest_path, remote_key)).await {
+            // CAS generation capture is deferred on tiered (D5 cache-coherence
+            // is a follow-up), so the recursive legs pass `None`; a tiered
+            // backend under `concurrency_control = cas` auto-downgrades to an
+            // unconditional upload at finalize.
+            match Box::pin(download_state_inner(
+                &valkey_config,
+                dest_path,
+                remote_key,
+                None,
+            ))
+            .await
+            {
                 Ok(DownloadOutcome::Restored) => {
                     debug!("State restored from Valkey");
                     Ok(DownloadOutcome::Restored)
                 }
                 Ok(DownloadOutcome::Absent) => {
                     debug!("Valkey miss, trying S3");
-                    Box::pin(download_state_inner(&s3_config, dest_path, remote_key)).await
+                    Box::pin(download_state_inner(
+                        &s3_config, dest_path, remote_key, None,
+                    ))
+                    .await
                 }
                 Err(e) => {
                     debug!(error = %e, "Valkey error, trying S3");
-                    Box::pin(download_state_inner(&s3_config, dest_path, remote_key)).await
+                    Box::pin(download_state_inner(
+                        &s3_config, dest_path, remote_key, None,
+                    ))
+                    .await
                 }
             }
         }
@@ -1690,6 +1813,118 @@ async fn dispatch_upload(
     }
 }
 
+/// End-of-run compare-and-swap upload for `concurrency_control = "cas"` on an
+/// object-store backend (`s3` / `gcs`).
+///
+/// Strips local-only tables exactly as [`upload_state`] does, then conditionally
+/// uploads against `base` (the generation captured at
+/// [`download_state_with_generation`]):
+/// - `Committed` → `Ok(())`.
+/// - `Conflict` → [`StateSyncError::CasConflict`] — another writer committed
+///   since this run's download; fail-closed, and NEVER swallowed by
+///   `on_upload_failure` (a lost cross-pod race is not a transient upload blip).
+/// - A genuine transport error is subject to `on_upload_failure` exactly as
+///   [`upload_state`].
+///
+/// `base = None` (the object was absent at acquire) maps to a create-if-absent
+/// write, so a concurrent bootstrap writer also conflicts rather than
+/// blind-overwriting.
+async fn upload_state_cas(
+    config: &StateConfig,
+    local_path: &Path,
+    base: Option<&Generation>,
+) -> Result<(), StateSyncError> {
+    if !local_path.exists() {
+        debug!("No local state file to upload");
+        return Ok(());
+    }
+    let remote_key = remote_state_key(local_path);
+    let excluded = crate::state::LOCAL_ONLY_TABLE_NAMES;
+
+    // Resolve the file to upload: a stripped copy when there are local-only
+    // tables, else the file as-is. Same fail-closed filter contract as
+    // `upload_state_with_excluded_tables` — never upload the unfiltered file.
+    let (upload_path, scratch) = if excluded.is_empty() {
+        (local_path.to_path_buf(), None)
+    } else {
+        match strip_local_only_tables(local_path, excluded) {
+            Ok(p) => (p.clone(), Some(p)),
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    outcome = "filter_failed",
+                    "failed to build replicate-filtered state copy; refusing to upload \
+                     unfiltered local-only data (fail-closed)"
+                );
+                return apply_upload_failure_policy(config, Err(e));
+            }
+        }
+    };
+
+    let outcome = dispatch_upload_cas(config, &upload_path, &remote_key, base).await;
+    if let Some(scratch) = scratch {
+        let _ = std::fs::remove_file(&scratch);
+    }
+    match outcome {
+        Ok(PutIfMatchOutcome::Committed(_)) => Ok(()),
+        Ok(PutIfMatchOutcome::Conflict) => Err(StateSyncError::CasConflict { key: remote_key }),
+        // A transport / backend error is not a conflict — apply the configured
+        // liveness policy (Durable forces Fail upstream).
+        Err(e) => apply_upload_failure_policy(config, Err(e)),
+    }
+}
+
+/// CAS upload dispatch for the object-store backends. A non-object-store backend
+/// never reaches here — the session downgrades `cas` to an unconditional
+/// [`upload_state`] on `local` / `valkey` / `tiered`.
+async fn dispatch_upload_cas(
+    config: &StateConfig,
+    local_path: &Path,
+    remote_key: &str,
+    base: Option<&Generation>,
+) -> Result<PutIfMatchOutcome, StateSyncError> {
+    match config.backend {
+        StateBackend::S3 => {
+            let bucket = config.s3_bucket.as_deref().ok_or_else(|| {
+                StateSyncError::MissingConfig("s3".into(), "state.s3_bucket".into())
+            })?;
+            let prefix = config.s3_prefix.as_deref().unwrap_or(DEFAULT_S3_PREFIX);
+            upload_to_object_store_cas(
+                "s3",
+                bucket,
+                prefix,
+                local_path,
+                remote_key,
+                transfer_timeout(config),
+                base,
+            )
+            .await
+        }
+        StateBackend::Gcs => {
+            let bucket = config.gcs_bucket.as_deref().ok_or_else(|| {
+                StateSyncError::MissingConfig("gcs".into(), "state.gcs_bucket".into())
+            })?;
+            let prefix = config.gcs_prefix.as_deref().unwrap_or(DEFAULT_GCS_PREFIX);
+            upload_to_object_store_cas(
+                "gs",
+                bucket,
+                prefix,
+                local_path,
+                remote_key,
+                transfer_timeout(config),
+                base,
+            )
+            .await
+        }
+        // Unreachable in practice — the session downgrades `cas` to an
+        // unconditional upload on non-object-store backends. Defensive only.
+        _ => Err(StateSyncError::MissingConfig(
+            config.backend.to_string(),
+            "an object-store backend (s3/gcs) for concurrency_control = cas".into(),
+        )),
+    }
+}
+
 /// Apply the `on_upload_failure` policy to a terminal upload result. `Skip`
 /// converts Err → Ok with a structured warn; `Fail` propagates Err unchanged.
 fn apply_upload_failure_policy(
@@ -1698,6 +1933,11 @@ fn apply_upload_failure_policy(
 ) -> Result<(), StateSyncError> {
     match result {
         Ok(()) => Ok(()),
+        // A CAS conflict ("another writer won the race") is a hard fail-closed
+        // regardless of `on_upload_failure` — `Skip` must never convert it to a
+        // silent success that erases the winner. (The CAS path returns this
+        // directly today; this guard keeps the invariant if it ever routes here.)
+        Err(e @ StateSyncError::CasConflict { .. }) => Err(e),
         Err(e) => match config.on_upload_failure {
             StateUploadFailureMode::Skip => {
                 warn!(
@@ -1751,6 +1991,11 @@ async fn download_from_object_store(
     dest_path: &Path,
     remote_key: &str,
     timeout: Duration,
+    // When `Some`, capture the downloaded object's [`Generation`] into the sink
+    // from the SAME GET that fetched the bytes (never a separate HEAD — that
+    // would open a TOCTOU between the version read and the bytes the writer
+    // mutates). `None` (every non-CAS caller) uses the plain download.
+    gen_sink: Option<&mut Option<Generation>>,
 ) -> Result<DownloadOutcome, StateSyncError> {
     let provider = cloud_provider(scheme, bucket, prefix)?;
     // Qualify the object key by schema version so a v7 pod and a v9 pod never
@@ -1773,7 +2018,16 @@ async fn download_from_object_store(
         with_transfer_timeout(timeout, async {
             match probe_exists(&provider, &key).await {
                 Ok(true) => {
-                    provider.download_file(&key, dest_path).await?;
+                    match gen_sink {
+                        Some(sink) => {
+                            *sink = provider
+                                .download_file_capturing_version(&key, dest_path)
+                                .await?;
+                        }
+                        None => {
+                            provider.download_file(&key, dest_path).await?;
+                        }
+                    }
                     info!(
                         size = dest_path.metadata().map(|m| m.len()).unwrap_or(0),
                         outcome = "ok",
@@ -1850,6 +2104,58 @@ async fn upload_to_object_store(
             "state upload complete"
         );
         Ok(())
+    }
+    .instrument(span)
+    .await
+}
+
+/// Compare-and-swap variant of [`upload_to_object_store`]: conditionally upload
+/// `local_path` against `base`, returning the [`PutIfMatchOutcome`].
+///
+/// A `Conflict` is returned as `Ok(Conflict)` (never an `Err`), so the caller
+/// maps it to a fail-closed refusal. The `object_store` client applies its own
+/// transient-retry and, on S3, `retry_on_conflict` already absorbs the
+/// transient 409 — so a surfaced conflict is a genuine stale base, and the
+/// state-level `retry_transient` (which carries no return value) is not used on
+/// this path.
+async fn upload_to_object_store_cas(
+    scheme: &str,
+    bucket: &str,
+    prefix: &str,
+    local_path: &Path,
+    key: &str,
+    timeout: Duration,
+    base: Option<&Generation>,
+) -> Result<PutIfMatchOutcome, StateSyncError> {
+    let provider = cloud_provider(scheme, bucket, prefix)?;
+    let key = object_store_state_key(key);
+    let size_bytes = local_path.metadata().map(|m| m.len()).unwrap_or(0);
+    let span = info_span!(
+        "state.upload.cas",
+        backend = %provider.scheme(),
+        bucket = %provider.bucket(),
+        size_bytes,
+    );
+    async {
+        info!(
+            uri = format!("{scheme}://{bucket}/{prefix}{key}"),
+            conditional = base.is_some(),
+            "CAS-uploading state to object store"
+        );
+        let outcome = with_transfer_timeout(timeout, async {
+            provider
+                .upload_file_if_match(local_path, &key, base)
+                .await
+                .map_err(StateSyncError::from)
+        })
+        .await?;
+        info!(
+            bytes = size_bytes,
+            committed = matches!(outcome, PutIfMatchOutcome::Committed(_)),
+            outcome = "ok",
+            "CAS state upload complete"
+        );
+        Ok(outcome)
     }
     .instrument(span)
     .await
@@ -2321,7 +2627,11 @@ fn is_transient(err: &StateSyncError) -> bool {
         | StateSyncError::Io(_)
         | StateSyncError::MissingConfig(..)
         | StateSyncError::CircuitOpen { .. }
-        | StateSyncError::RetryBudgetExhausted { .. } => false,
+        | StateSyncError::RetryBudgetExhausted { .. }
+        // A CAS conflict is definitive (another writer won) — retrying against
+        // the same stale base would just conflict again and burn the budget.
+        // Fail closed immediately.
+        | StateSyncError::CasConflict { .. } => false,
     }
 }
 
@@ -3162,7 +3472,7 @@ mod tests {
             // before URL resolution, proving the fall-through independently.
             ..Default::default()
         };
-        let outcome = download_state_inner(&config, &local, &remote_state_key(&local))
+        let outcome = download_state_inner(&config, &local, &remote_state_key(&local), None)
             .await
             .unwrap();
         test_support::clear();
@@ -3199,7 +3509,7 @@ mod tests {
             s3_bucket: Some("bucket".into()),
             ..Default::default()
         };
-        let outcome = download_state_inner(&config, &local, &remote_state_key(&local))
+        let outcome = download_state_inner(&config, &local, &remote_state_key(&local), None)
             .await
             .unwrap();
         test_support::clear();
@@ -4096,6 +4406,86 @@ mod tests {
             .finalize()
             .await
             .expect("ConfigDefault must honor the configured skip (warn-and-Ok)");
+        test_support::clear();
+    }
+
+    /// CAS finalize fail-closes when the remote object advanced since acquire:
+    /// pod B captures its base, a racer commits and bumps the generation, and
+    /// B's terminal CAS upload conflicts instead of blind-overwriting the
+    /// winner. (Exercised against the InMemory conditional-put backend; the S3
+    /// wire path is covered by `tests/state_sync_s3_live.rs`.)
+    #[tokio::test]
+    async fn session_cas_finalize_conflicts_when_remote_advanced() {
+        test_support::clear();
+        let _faults = install_counting_provider();
+        let dir = TempDir::new().unwrap();
+        let local = dir.path().join(".rocky-state.redb");
+        seed_state_file(&local);
+
+        let cfg = StateConfig {
+            backend: StateBackend::S3,
+            s3_bucket: Some("bucket".into()),
+            concurrency_control: ConcurrencyControl::Cas,
+            retry: RetryConfig {
+                max_retries: 0,
+                ..RetryConfig::default()
+            },
+            ..Default::default()
+        };
+
+        // Bootstrap: first run creates the remote object (base None → Create).
+        let mut first = RemoteStateSession::new(&cfg, &local, FinalizeDurability::ConfigDefault);
+        let _ = first.acquire().await.unwrap();
+        first
+            .finalize()
+            .await
+            .expect("first CAS finalize creates the object");
+
+        // Pod B acquires and captures the current generation as its base.
+        let mut pod_b = RemoteStateSession::new(&cfg, &local, FinalizeDurability::ConfigDefault);
+        let _ = pod_b.acquire().await.unwrap();
+
+        // A racer commits in between, advancing the remote generation.
+        let mut racer = RemoteStateSession::new(&cfg, &local, FinalizeDurability::ConfigDefault);
+        let _ = racer.acquire().await.unwrap();
+        racer
+            .finalize()
+            .await
+            .expect("racer commits and advances the remote generation");
+
+        // Pod B's terminal CAS now conflicts (stale base) — fail-closed, not a
+        // silent overwrite of the racer's committed state.
+        let err = pod_b
+            .finalize()
+            .await
+            .expect_err("pod B lost the cross-pod race → CasConflict");
+        assert!(
+            matches!(err, StateSyncError::CasConflict { .. }),
+            "expected CasConflict, got: {err:?}"
+        );
+        test_support::clear();
+    }
+
+    /// The `off` default routes an unconditional upload even against an
+    /// already-present object — byte-identical to pre-CAS: two sequential runs
+    /// both finalize successfully, the second overwriting without a base.
+    #[tokio::test]
+    async fn session_off_default_overwrites_unconditionally() {
+        test_support::clear();
+        let _faults = install_counting_provider();
+        let dir = TempDir::new().unwrap();
+        let local = dir.path().join(".rocky-state.redb");
+        seed_state_file(&local);
+        // s3_session_config leaves concurrency_control at its Off default.
+        let cfg = s3_session_config(StateUploadFailureMode::Fail);
+
+        for _ in 0..2 {
+            let mut s = RemoteStateSession::new(&cfg, &local, FinalizeDurability::ConfigDefault);
+            let _ = s.acquire().await.unwrap();
+            s.finalize()
+                .await
+                .expect("off finalize is an unconditional put (no conflict)");
+        }
         test_support::clear();
     }
 

--- a/engine/crates/rocky-core/tests/state_sync_s3_live.rs
+++ b/engine/crates/rocky-core/tests/state_sync_s3_live.rs
@@ -30,7 +30,7 @@ use rocky_core::freeze_marker::{
     FreezeMarker, FreezeMarkerError, UnfreezeMarker, load_active_marker_freezes,
     write_freeze_marker, write_unfreeze_marker,
 };
-use rocky_core::object_store::{ObjectStoreProvider, PutIfNotExistsOutcome};
+use rocky_core::object_store::{ObjectStoreProvider, PutIfMatchOutcome, PutIfNotExistsOutcome};
 use rocky_core::state::StateStore;
 use rocky_core::state_sync::{download_state, upload_state};
 use rocky_ir::WatermarkState;
@@ -274,4 +274,92 @@ async fn live_freeze_marker_list_create_roundtrip() {
         }
         Err(e) => eprintln!("cleanup: failed to list {run_prefix}: {e}"),
     }
+}
+
+/// The compare-and-swap primitive against a real bucket — the S3-wire receipt
+/// for `concurrency_control = "cas"`, the path the InMemory harness cannot
+/// prove (ETag threading, `If-Match`, `PutResult` → new generation): a
+/// create-if-absent bootstrap, a matching-base conditional overwrite, and a
+/// stale-base conflict that never overwrites the winner.
+///
+/// Runs against any S3-compatible endpoint the AWS env chain resolves — real
+/// AWS, or a local MinIO (`AWS_ENDPOINT` + `AWS_ALLOW_HTTP=true` +
+/// path-style).
+#[tokio::test]
+#[ignore]
+async fn live_put_if_match_cas_roundtrip() {
+    let _serial = live_serial();
+    let Some(live) = live_s3_from_env() else {
+        eprintln!("SKIP live_put_if_match_cas_roundtrip: ROCKY_TEST_S3_* env not set");
+        return;
+    };
+    let provider = ObjectStoreProvider::from_uri(&format!("s3://{}/{}", live.bucket, live.prefix))
+        .expect("live provider");
+    let key = format!("cas-probe-{}", unique_suffix());
+
+    // 1. Bootstrap: create-if-absent commits, yields the first generation.
+    let PutIfMatchOutcome::Committed(g0) = provider
+        .put_if_match(&key, Bytes::from_static(b"v0"), None)
+        .await
+        .expect("bootstrap put")
+    else {
+        panic!("first CAS write must commit against an absent key");
+    };
+
+    // 2. A second bootstrap against the now-present key conflicts (no overwrite).
+    assert_eq!(
+        provider
+            .put_if_match(&key, Bytes::from_static(b"v0b"), None)
+            .await
+            .expect("bootstrap race put"),
+        PutIfMatchOutcome::Conflict,
+        "a concurrent first-writer must conflict, not blind-overwrite"
+    );
+
+    // 3. Matching base commits and advances the generation.
+    let PutIfMatchOutcome::Committed(g1) = provider
+        .put_if_match(&key, Bytes::from_static(b"v1"), Some(&g0))
+        .await
+        .expect("matching-base put")
+    else {
+        panic!("matching-base CAS must commit");
+    };
+    assert_ne!(g0, g1, "a committed write advances the generation");
+
+    // 4. Stale base (g0, superseded by g1) conflicts — the winner's bytes stand.
+    assert_eq!(
+        provider
+            .put_if_match(&key, Bytes::from_static(b"v2"), Some(&g0))
+            .await
+            .expect("stale-base put"),
+        PutIfMatchOutcome::Conflict,
+        "a stale base must conflict"
+    );
+    assert_eq!(
+        provider.get(&key).await.expect("read back").as_ref(),
+        b"v1",
+        "the losing CAS must not have overwritten the winner"
+    );
+
+    // 5. A base captured via download_file_capturing_version CAS-matches the live object.
+    let out = tempfile::tempdir().unwrap();
+    let out_path = out.path().join("dl");
+    let base = provider
+        .download_file_capturing_version(&key, &out_path)
+        .await
+        .expect("download capturing version")
+        .expect("S3 surfaces an ETag");
+    assert!(
+        matches!(
+            provider
+                .put_if_match(&key, Bytes::from_static(b"v3"), Some(&base))
+                .await
+                .expect("cas after download"),
+            PutIfMatchOutcome::Committed(_)
+        ),
+        "the base captured from download must CAS-match the live object"
+    );
+
+    let _ = provider.delete(&key).await;
+    println!("OK: S3 CAS roundtrip (bootstrap + match + stale-conflict + download-base) verified");
 }

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -698,6 +698,25 @@
         }
       ]
     },
+    "ConcurrencyControl": {
+      "description": "Concurrency control for remote `[state]` object writes.\n\nGuards the cross-pod lost update where two runs sharing one `[state]` prefix race: one downloads the state, the other commits, and the first's end-of-run upload silently overwrites the second (last-writer-wins). See [`StateConfig::concurrency_control`].",
+      "oneOf": [
+        {
+          "description": "Unconditional last-writer-wins upload (default) — byte-identical to the pre-CAS behaviour. Correct for single-writer-per-prefix deployments (one run at a time, orchestrator-serialized).",
+          "enum": [
+            "off"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Compare-and-swap: the end-of-run upload is conditional on the remote object still carrying the generation the run downloaded. A run that lost a cross-pod race fail-closes (nonzero exit) instead of erasing the winner. Requires a backend with a conditional-write object tier (`s3` / `gcs`); auto-downgrades to `off` (with a warn) on other backends.",
+          "enum": [
+            "cas"
+          ],
+          "type": "string"
+        }
+      ]
+    },
     "ConcurrencyMode": {
       "anyOf": [
         {
@@ -3797,6 +3816,15 @@
           "default": "local",
           "description": "Storage backend: local (default), s3, gcs, valkey, or tiered (valkey + s3 fallback)"
         },
+        "concurrency_control": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConcurrencyControl"
+            }
+          ],
+          "default": "off",
+          "description": "Concurrency control for remote state writes. Default [`ConcurrencyControl::Off`] (unconditional last-writer-wins, byte- identical to pre-CAS). Set to `\"cas\"` on live multi-pod object-store deployments so a run that lost a cross-pod race fail-closes instead of silently overwriting the winner's committed state. Auto-downgrades to `off` (with a warn) on backends without a conditional-write object tier."
+        },
         "freeze_marker_writes": {
           "default": false,
           "description": "Enable writing durable freeze/unfreeze marker objects (under `<prefix>/freeze/` and `<prefix>/unfreeze/`, beside the remote state file) when `rocky policy freeze` / `unfreeze` run against an object-store backend. Marker reading and enforcement are always on wherever a durable object tier exists; this flag gates only the write side, so a fleet can be upgraded to marker readers everywhere before any marker is written. Default `false`. Requires a backend with a durable object tier (`s3`, `gcs`, or `tiered`).",
@@ -4664,6 +4692,7 @@
       ],
       "default": {
         "backend": "local",
+        "concurrency_control": "off",
         "freeze_marker_writes": false,
         "gcs_bucket": null,
         "gcs_prefix": null,

--- a/sdk/python/src/rocky_sdk/types_generated/rocky_project_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/rocky_project_schema.py
@@ -267,6 +267,22 @@ class CompositeKind(RootModel[CompositeKind1]):
     """
 
 
+class ConcurrencyControl1(StrEnum):
+    """
+    Unconditional last-writer-wins upload (default) — byte-identical to the pre-CAS behaviour. Correct for single-writer-per-prefix deployments (one run at a time, orchestrator-serialized).
+    """
+
+    off = "off"
+
+
+class ConcurrencyControl2(StrEnum):
+    """
+    Compare-and-swap: the end-of-run upload is conditional on the remote object still carrying the generation the run downloaded. A run that lost a cross-pod race fail-closes (nonzero exit) instead of erasing the winner. Requires a backend with a conditional-write object tier (`s3` / `gcs`); auto-downgrades to `off` (with a warn) on other backends.
+    """
+
+    cas = "cas"
+
+
 class ConcurrencyMode1(StrEnum):
     """
     Concurrency strategy: the literal `"adaptive"` for AIMD-based throttling, or a positive integer for fixed concurrency.
@@ -3304,6 +3320,10 @@ class StateConfig(BaseModel):
     """
     Storage backend: local (default), s3, gcs, valkey, or tiered (valkey + s3 fallback)
     """
+    concurrency_control: ConcurrencyControl1 | ConcurrencyControl2 | None = "off"
+    """
+    Concurrency control for remote state writes. Default [`ConcurrencyControl::Off`] (unconditional last-writer-wins, byte- identical to pre-CAS). Set to `"cas"` on live multi-pod object-store deployments so a run that lost a cross-pod race fail-closes instead of silently overwriting the winner's committed state. Auto-downgrades to `off` (with a warn) on backends without a conditional-write object tier.
+    """
     freeze_marker_writes: bool | None = False
     """
     Enable writing durable freeze/unfreeze marker objects (under `<prefix>/freeze/` and `<prefix>/unfreeze/`, beside the remote state file) when `rocky policy freeze` / `unfreeze` run against an object-store backend. Marker reading and enforcement are always on wherever a durable object tier exists; this flag gates only the write side, so a fleet can be upgraded to marker readers everywhere before any marker is written. Default `false`. Requires a backend with a durable object tier (`s3`, `gcs`, or `tiered`).
@@ -3883,6 +3903,7 @@ class RockyConfig(BaseModel):
     state: StateConfig | None = Field(
         {
             "backend": "local",
+            "concurrency_control": "off",
             "freeze_marker_writes": False,
             "gcs_bucket": None,
             "gcs_prefix": None,


### PR DESCRIPTION
## What

Delivers the **compare-and-swap** capability for remote `[state]` object writes — the last residual (residual 2) of #1120. A run whose start-download preceded a concurrent commit could previously overwrite it on end-upload (last-writer-wins); under `[state] concurrency_control = "cas"` the losing run now fail-closes instead of erasing the winner.

Residuals 1 (config-swap TOCTOU) and 3 (freeze-marker coherence) are already closed (PR-B threading; PR-F markers — see #1168). The freeze kill-switch itself is durable via PR-F markers; **this PR hardens the `state.redb` blob** against silent overwrite.

## Changes

**Primitives (`rocky-core/object_store.rs`)** — `Generation`, `PutIfMatchOutcome`, `put_if_match` (`PutMode::Create` for bootstrap, `PutMode::Update`/`If-Match` for steady-state; never an unconditional fall-through), `upload_file_if_match`, and `download_file_capturing_version` (base captured from the SAME GET — TOCTOU-free). `object_store` 0.14 already pins `S3ConditionalPut::ETagMatch`, so no client re-config and no redb schema bump.

**Session (`rocky-core/state_sync.rs`)** —
- `[state] concurrency_control = "off" | "cas"` (default `off` = today's unconditional put, **byte-identical**).
- Under `cas` on s3/gcs: `acquire` captures the base generation, `finalize` conditionally commits; a lost race → `CasConflict` (fail-closed, never `Skip`-swallowed, never retried as transient).
- Periodic uploader disabled under `cas` (finalize-only CAS is correct when nothing bumps the generation mid-run).
- Non-object-store backends auto-downgrade `cas` → unconditional + warn.

## Scope (one WP-01 slice)

REFUSE-class (run / backfill / load) whole-blob finalize CAS. **Follow-ups** (ADR-CONCURRENCY): the RETRY-class ledger seams (policy-freeze row, budget pair, gc/restore external-proof), tiered D5 cache coherence, and the shared-advancing-base periodic CAS write.

## Verification ladder

- **InMemory** — primitive tests (`put_if_match` create / update / stale-conflict; download-captured base) + a session-level cross-pod conflict test.
- **MinIO (real S3 wire path)** — ran `live_put_if_match_cas_roundtrip` against a local MinIO: bootstrap create-if-absent, matching-base commit, stale-base conflict, and download-captured base all verified. This drives the exact `AmazonS3Builder` / `PutMode::Update` / `If-Match` / `PutResult → generation` path InMemory can't.
- **Live AWS** — the same `#[ignore]` test is the formal gate (`ROCKY_TEST_S3_*` + the AWS env credential chain; also runs against MinIO via `AWS_ENDPOINT`). I couldn't run it against AWS this session — the sandbox IAM user lacks `s3:CreateBucket` / `ListAllMyBuckets` and I found no writable bucket. **Point me at a bucket + prefix I can write under and I'll run the AWS rung.**

`clippy --all-targets --all-features`, `fmt --check`, and the full `rocky-core` suite are green. Codegen regenerated (`concurrency_control` in schema + Pydantic + TS + openapi).

## Closure

Even a complete PR-D does not *close* #1120: RD-002 closure needs the operational rollout (deploy fleet-wide, set `concurrency_control = "cas"` on live prefixes, verify, then drop the interim one-writer-per-prefix serialization). This PR delivers the capability; #1120 stays open.

## Note (RD-006 / WP-02)

Refuse-on-conflict leaves a warehouse a run already wrote ahead of committed state; for append strategies an operator re-run can duplicate rows. Pre-exists (crash-between-write-and-commit), but refuse-on-conflict adds a trigger — tracked separately, not solved here.

Refs #1120
