### PR TITLE
fix(engine): never degrade a --model plan to replication (#1171)

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `rocky plan --model <name>` now previews only the selected model and reports the same model scope that `rocky apply` executes, instead of advertising skipped replication SQL and unrelated models. (#1165)
-- `rocky plan --model <name>` no longer silently degrades to a replication plan when the model cannot be resolved to a run plan — an unknown model reached via `--models <dir>`, or a run-plan persistence failure, now errors instead of persisting a replication plan that `rocky apply` would execute as a full replication. A model-scoped plan can only resolve to that model or fail. (#1171)
+- `rocky plan --model <name>` no longer silently degrades to a full replication that `rocky apply` would execute without review. An unknown model reached via `--models <dir>`, or a run-plan persistence failure, now errors instead of persisting a replication plan; a model-scoped plan can only resolve to that model or fail. `--model` combined with `--dag` is now rejected at plan time (the two are contradictory — the DAG runner ignores the model selector and applies every pipeline). (#1171)
 
 ## [1.65.0] - 2026-07-18
 

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `rocky plan --model <name>` now previews only the selected model and reports the same model scope that `rocky apply` executes, instead of advertising skipped replication SQL and unrelated models. (#1165)
+- `rocky plan --model <name>` no longer silently degrades to a replication plan when the model cannot be resolved to a run plan — an unknown model reached via `--models <dir>`, or a run-plan persistence failure, now errors instead of persisting a replication plan that `rocky apply` would execute as a full replication. A model-scoped plan can only resolve to that model or fail. (#1171)
 
 ## [1.65.0] - 2026-07-18
 

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -428,13 +428,32 @@ pub async fn plan(
                 run_plan_persisted = true;
             }
             Ok(None) => {
-                // `models/` exists but compile produced zero models —
+                // `models/` exists but compile produced zero models.
+                if let Some(model) = run_options.model.as_deref() {
+                    // `--model` names a transformation model, but the models
+                    // directory compiled to zero models — the requested model
+                    // does not exist. A model-scoped plan must never silently
+                    // degrade to a replication plan (#1171).
+                    anyhow::bail!(
+                        "model '{model}' not found (no transformation model with that name)"
+                    );
+                }
                 // fall through to the replication-plan branch below.
                 tracing::debug!(
                     "`models/` directory has no compiled models — building replication plan instead"
                 );
             }
             Err(e) => {
+                if run_options.model.is_some() {
+                    // A model-scoped plan must never silently degrade to a
+                    // replication plan (#1171): surface the run-plan
+                    // build/persist failure instead of falling through to the
+                    // replication-plan branch below.
+                    return Err(e).context(
+                        "failed to build a model-scoped run plan for --model; \
+                         refusing to fall back to a replication plan",
+                    );
+                }
                 tracing::warn!(
                     error = %e,
                     "failed to build/persist run plan; `rocky apply` will not be available for this invocation"
@@ -445,10 +464,12 @@ pub async fn plan(
 
     // Replication-plan branch — fires when there is no `models/`
     // directory or the directory exists but contains zero compiled
-    // models. The plan_id is content-addressed by the canonical
-    // `RockyConfig` snapshot + the discovered source state (sorted
-    // connectors + tables), so identical inputs produce an identical
-    // plan_id across machines.
+    // models. Never fires when `--model` is set: that path either
+    // persists a model-scoped run plan or errors above (#1171), so a
+    // model-scoped intent can never resolve to replication. The plan_id
+    // is content-addressed by the canonical `RockyConfig` snapshot + the
+    // discovered source state (sorted connectors + tables), so identical
+    // inputs produce an identical plan_id across machines.
     if !run_plan_persisted {
         match build_and_persist_replication_plan(
             &rocky_cfg,

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -398,6 +398,18 @@ pub async fn plan(
         .clone()
         .unwrap_or_else(|| models_dir.clone());
     if let Some(model) = run_options.model.as_deref() {
+        // `--model` runs a single compiled model and skips replication;
+        // `--dag` runs every pipeline as a unified DAG (including
+        // replication). The two are contradictory, and the apply-time DAG
+        // runner is flag-light — it ignores the persisted model selector — so
+        // a `--model --dag` plan would apply the whole DAG rather than the
+        // named model (#1171). Reject the combination at plan time instead of
+        // persisting a plan that apply would over-execute.
+        anyhow::ensure!(
+            !run_options.dag,
+            "--model and --dag are mutually exclusive: --model runs a single model and skips \
+             replication, while --dag runs every pipeline as a unified DAG"
+        );
         anyhow::ensure!(
             blueprint_models_dir.exists(),
             "models directory '{}' not found (required for --model)",
@@ -460,6 +472,19 @@ pub async fn plan(
                 );
             }
         }
+    }
+
+    // Structural guard (#1171): a model-scoped plan must never reach the
+    // replication branch. The match arms above already fail on the reachable
+    // zero-model / persist-failure cases with specific messages; this closes
+    // any residual path — e.g. a models-directory TOCTOU that flips the
+    // `exists()` check between the preview and persistence — so replication is
+    // provably unreachable whenever `--model` is set.
+    if run_options.model.is_some() && !run_plan_persisted {
+        anyhow::bail!(
+            "failed to build a model-scoped run plan for --model; \
+             refusing to fall back to a replication plan"
+        );
     }
 
     // Replication-plan branch — fires when there is no `models/`

--- a/engine/rocky/tests/plan_model_scope.rs
+++ b/engine/rocky/tests/plan_model_scope.rs
@@ -268,3 +268,51 @@ fn model_plan_persist_failure_errors_not_replication() {
         "must not emit a replication plan for a --model invocation; stdout: {stdout}"
     );
 }
+
+/// #1171 (Edge 3): `--model` and `--dag` are contradictory — `--model` runs a
+/// single model and skips replication, while the apply-time DAG runner ignores
+/// the model selector and executes every pipeline (including replication). The
+/// combination must be rejected at plan time so a plan that `apply` would
+/// over-execute as a full DAG is never persisted.
+#[test]
+fn model_plan_with_dag_is_rejected() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path();
+
+    {
+        let conn = duckdb::Connection::open(dir.join("fixture.duckdb")).expect("open duckdb");
+        conn.execute_batch(
+            "CREATE SCHEMA raw__orders;
+             CREATE TABLE raw__orders.orders AS SELECT 1 AS id;",
+        )
+        .expect("seed source");
+    }
+
+    let config = dir.join("rocky.toml");
+    fs::write(&config, ROCKY_TOML).expect("write config");
+    let models = dir.join("models");
+    fs::create_dir(&models).expect("create models");
+    fs::write(models.join("known.sql"), "SELECT 1 AS id").expect("write model sql");
+    fs::write(models.join("known.toml"), MODEL_TOML).expect("write model config");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_rocky"))
+        .args(["--output", "json"])
+        .arg("--config")
+        .arg(&config)
+        .args(["plan", "--model", "known", "--dag"])
+        .current_dir(dir)
+        .env("RUST_LOG", "error")
+        .output()
+        .expect("run plan");
+
+    assert!(
+        !out.status.success(),
+        "--model + --dag must be rejected at plan time; stdout: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--model and --dag are mutually exclusive"),
+        "expected a mutual-exclusion error, got stderr: {stderr}"
+    );
+}

--- a/engine/rocky/tests/plan_model_scope.rs
+++ b/engine/rocky/tests/plan_model_scope.rs
@@ -117,3 +117,154 @@ fn model_plan_matches_applied_scope() {
         );
     }
 }
+
+/// #1171 (Edge 2): `--model <name>` against a `--models <dir>` that compiles to
+/// zero models must ERROR, not silently degrade to a replication plan that
+/// `rocky apply` would execute as a full replication. This path skips the
+/// conventional-`models/` governance preview (no conventional `models/` dir),
+/// so before the fix it fell through to the replication-plan branch and exited
+/// 0 with `plan_kind = "replication"`.
+#[test]
+fn model_plan_via_empty_models_dir_errors_not_replication() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path();
+
+    {
+        let conn = duckdb::Connection::open(dir.join("fixture.duckdb")).expect("open duckdb");
+        conn.execute_batch(
+            "CREATE SCHEMA raw__orders;
+             CREATE TABLE raw__orders.orders AS SELECT 1 AS id;",
+        )
+        .expect("seed source");
+    }
+
+    let config = dir.join("rocky.toml");
+    fs::write(&config, ROCKY_TOML).expect("write config");
+    // No conventional `models/` dir. A separate `--models` dir that holds only
+    // a `_defaults.toml` stub compiles to zero models.
+    let alt = dir.join("altmodels");
+    fs::create_dir(&alt).expect("create altmodels");
+    fs::write(
+        alt.join("_defaults.toml"),
+        "[strategy]\ntype = \"full_refresh\"\n",
+    )
+    .expect("write stub");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_rocky"))
+        .args(["--output", "json"])
+        .arg("--config")
+        .arg(&config)
+        .args(["plan", "--models"])
+        .arg(&alt)
+        .args(["--model", "foo"])
+        .current_dir(dir)
+        .env("RUST_LOG", "error")
+        .output()
+        .expect("run plan");
+
+    assert!(
+        !out.status.success(),
+        "a model-scoped plan over a zero-model dir must fail, not degrade to replication; \
+         stdout: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("refusing to fall back to a replication plan"),
+        "expected a model-scope error, got stderr: {stderr}"
+    );
+    // Nothing on stdout should describe a replication plan the operator could apply.
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("\"plan_kind\":\"replication\""),
+        "must not emit a replication plan for a --model invocation; stdout: {stdout}"
+    );
+}
+
+/// #1171 (Edge 1): when a run-plan persist failure occurs while `--model` is
+/// set, `rocky plan` must ERROR rather than fall through to the replication
+/// branch and pair transformation statements with a replication `plan_id`
+/// (which `apply` would run as replication). Reproduced by squatting the
+/// content-addressed run-plan path with a directory so the write fails; the
+/// plan_id is stable across runs, so the squat is deterministic.
+#[test]
+fn model_plan_persist_failure_errors_not_replication() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path();
+
+    {
+        let conn = duckdb::Connection::open(dir.join("fixture.duckdb")).expect("open duckdb");
+        conn.execute_batch(
+            "CREATE SCHEMA raw__orders;
+             CREATE TABLE raw__orders.orders AS SELECT 1 AS id;",
+        )
+        .expect("seed source");
+    }
+
+    let config = dir.join("rocky.toml");
+    fs::write(&config, ROCKY_TOML).expect("write config");
+    let models = dir.join("models");
+    fs::create_dir(&models).expect("create models");
+    for (name, sql) in [("known", "SELECT 1 AS id"), ("other", "SELECT 2 AS id")] {
+        fs::write(models.join(format!("{name}.sql")), sql).expect("write model sql");
+        fs::write(models.join(format!("{name}.toml")), MODEL_TOML).expect("write model config");
+    }
+
+    // First run succeeds and persists a run plan; capture its (content-addressed) id.
+    let first = Command::new(env!("CARGO_BIN_EXE_rocky"))
+        .args(["--output", "json"])
+        .arg("--config")
+        .arg(&config)
+        .args(["plan", "--model", "known"])
+        .current_dir(dir)
+        .env("RUST_LOG", "error")
+        .output()
+        .expect("run first plan");
+    assert!(
+        first.status.success(),
+        "first plan failed: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    let first: serde_json::Value =
+        serde_json::from_slice(&first.stdout).expect("plan output should be JSON");
+    assert_eq!(first["plan_kind"], "run");
+    let plan_id = first["plan_id"]
+        .as_str()
+        .expect("persisted plan ID")
+        .to_string();
+
+    // Squat the run-plan path with a directory so the next persist fails.
+    let plan_path = dir
+        .join(".rocky")
+        .join("plans")
+        .join(format!("{plan_id}.json"));
+    fs::remove_file(&plan_path).expect("remove first plan file");
+    fs::create_dir_all(&plan_path).expect("squat plan path with a directory");
+
+    let second = Command::new(env!("CARGO_BIN_EXE_rocky"))
+        .args(["--output", "json"])
+        .arg("--config")
+        .arg(&config)
+        .args(["plan", "--model", "known"])
+        .current_dir(dir)
+        .env("RUST_LOG", "error")
+        .output()
+        .expect("run second plan");
+
+    assert!(
+        !second.status.success(),
+        "a run-plan persist failure under --model must fail, not degrade to replication; \
+         stdout: {}",
+        String::from_utf8_lossy(&second.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&second.stderr);
+    assert!(
+        stderr.contains("refusing to fall back to a replication plan"),
+        "expected a model-scope error, got stderr: {stderr}"
+    );
+    let stdout = String::from_utf8_lossy(&second.stdout);
+    assert!(
+        !stdout.contains("\"plan_kind\":\"replication\""),
+        "must not emit a replication plan for a --model invocation; stdout: {stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #1171 (follow-up to #1166). A `rocky plan --model <name>` invocation must resolve to that model's run plan or fail — it must never silently result in a **full replication / DAG** execution that `rocky apply` runs without review.

Three paths allowed that degradation (all verified **red before green** against a locally-built pre-fix binary, real DuckDB):

1. **`--models <dir>` at a zero-model directory** with no conventional `models/` (so the governance preview, which compiles the conventional dir, is skipped): `build_and_persist_run_plan` returned `Err`/`Ok(None)` and `plan()` fell through to the replication branch — exit `0`, `plan_kind = "replication"`.
2. **A run-plan persistence failure while `--model` was set** was swallowed as a warning and fell back to a replication plan, pairing the model's transformation `statements` with a replication `plan_id`.
3. **`--model` + `--dag`**: the plan persists a run plan, but the apply-time DAG runner is flag-light and ignores the model selector, so `apply` executes every pipeline (including replication). Confirmed empirically: `plan --model known --dag` advertised only `known`, yet apply materialized the replication target `staging__orders.orders`.

## Fix (all in `plan()`, `engine/crates/rocky-cli/src/commands/plan.rs`)

- The `build_and_persist_run_plan` `Ok(None)` (zero compiled models) and `Err` (build/persist failure) arms now **hard-error** when `--model` is set instead of falling through to replication (edges 1 & 2).
- A **structural guard** before the replication branch — `if run_options.model.is_some() && !run_plan_persisted { bail }` — makes the replication branch **provably unreachable** whenever `--model` is set, closing any residual path such as a models-directory TOCTOU that flips the `exists()` check.
- **`--model` + `--dag` is rejected at plan time** as a contradictory combination, so no plan that apply would over-execute as a full DAG is ever persisted (edge 3).

`--model` + `--all` was checked and is already safe (the runner honours the model scope over `--all`). `plan_preview_output` (also used by `rocky mcp`) is left untouched — no MCP-contract blast radius. Behaviour with `--model` **absent**, including the legitimate replication fallback, is unchanged.

Follow-up (not this PR): an apply-side fail-closed guard rejecting a persisted `--model`+`--dag` plan would add defence-in-depth for any plan persisted before this change; the DAG runner's flag unification is deferred work per its own code comment.

## Test Plan

- `cargo test -p rocky --test plan_model_scope` — 4 real-binary DuckDB regressions: existing scope-parity test + `model_plan_via_empty_models_dir_errors_not_replication`, `model_plan_persist_failure_errors_not_replication`, `model_plan_with_dag_is_rejected`. (No race test for the TOCTOU guard — the window isn't deterministically stageable; the guard is correct by inspection.)
- `cargo test -p rocky-cli --lib commands::plan` — 32 pass (incl. the unchanged `plan_preview_replication_only_returns_empty_statements`).
- `cargo fmt -- --check`
- `cargo clippy -p rocky-cli -p rocky --all-targets --all-features -- -D warnings -A unused-assignments -A clippy::collapsible-else-if`