### PR TITLE
fix(engine): fail fast on unknown model in rocky plan --model

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `rocky plan --model <name>` now previews only the selected model and reports the same model scope that `rocky apply` executes, instead of advertising skipped replication SQL and unrelated models. (#1165)
+- `rocky plan --model <name>` now fails fast with a "model not found" error when the named model does not exist — including a project that compiles to zero models — matching what `rocky apply` reports. Previously this surfaced as a confusing governance-preview failure, or (with a `--models` override pointing at a model-less directory) as an empty preview that masked a persisted full-replication plan `rocky apply` would then execute. The `rocky mcp` `plan_preview` tool now classifies an unknown model as `model_not_found` rather than `compile_failed`. (#1165)
 
 ## [1.65.0] - 2026-07-18
 

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -145,8 +145,8 @@ pub use lsp::run_lsp;
 pub use metrics::{metrics_output, run_metrics};
 pub use optimize::{optimize_output, run_optimize};
 pub use plan::{
-    PlanRunOptions, compute_embedded_capabilities, plan, plan_preview_output, plan_promote,
-    populate_governance_actions,
+    ModelNotFound, PlanRunOptions, compute_embedded_capabilities, plan, plan_preview_output,
+    plan_promote, populate_governance_actions,
 };
 pub use playground::{run_playground, run_playground_with_template};
 pub use policy::{run_policy_check, run_policy_freeze, run_policy_test};

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -18,6 +18,19 @@ use crate::registry;
 use super::run::PartitionRunOptions;
 use super::{filter_table_matches, matches_filter, parse_filter};
 
+/// A `--model` / filter named a model that does not exist in the compiled
+/// project.
+///
+/// Returned as a typed error (rather than a bare `anyhow` string) so callers
+/// that speak a stable error taxonomy — the `rocky mcp` `plan_preview` tool —
+/// can downcast and classify it as `model_not_found` instead of the generic
+/// compile-failure bucket. The `Display` text is byte-identical to the message
+/// `rocky run --model <name>` emits for the same condition (see
+/// `commands::run`), so CLI output and existing assertions are unchanged.
+#[derive(Debug, thiserror::Error)]
+#[error("model '{0}' not found (no transformation model with that name)")]
+pub struct ModelNotFound(pub String);
+
 /// Bundle of `rocky plan` execution flags persisted into `RunPlan` so
 /// `rocky apply <plan-id>` can honour them. Mirrors the flag surface of
 /// `rocky run`; `model` also scopes the SQL preview and model metadata.
@@ -312,6 +325,33 @@ pub async fn plan(
         models_dir_exists = models_dir.exists(),
         "plan: models_dir check"
     );
+
+    // Resolve the transformation models directory once: an explicit `--models`
+    // override, else the conventional `models/` beside the config. Used both for
+    // the `--model` preview here and the run-plan blueprint below.
+    let blueprint_models_dir = run_options
+        .models_dir
+        .clone()
+        .unwrap_or_else(|| models_dir.clone());
+
+    // `--model` scoping — validated BEFORE the governance/budget preview below.
+    // An unknown model (including a project that compiles to zero models) fails
+    // fast here with the same "model not found" error `rocky run` / `rocky apply`
+    // emit, rather than surfacing as a confusing governance-preview failure or —
+    // when no conventional `models/` exists — an empty preview that would mask a
+    // persisted full-replication plan `apply` then executes. On success the SQL
+    // preview is scoped to just the selected model.
+    if let Some(model) = run_options.model.as_deref() {
+        anyhow::ensure!(
+            blueprint_models_dir.exists(),
+            "models directory '{}' not found (required for --model)",
+            blueprint_models_dir.display()
+        );
+        output.statements =
+            plan_preview_output(Some(config_path), &blueprint_models_dir, Some(model), env)?
+                .statements;
+    }
+
     if models_dir.exists() {
         let adapter_type = rocky_cfg
             .adapters
@@ -391,22 +431,9 @@ pub async fn plan(
     // in CI environments without `.rocky/` write access still emit the
     // statement preview.
     //
-    // The run-plan compile honours `--models` when set; otherwise the
-    // conventional `models/` directory next to the config is used.
-    let blueprint_models_dir = run_options
-        .models_dir
-        .clone()
-        .unwrap_or_else(|| models_dir.clone());
-    if let Some(model) = run_options.model.as_deref() {
-        anyhow::ensure!(
-            blueprint_models_dir.exists(),
-            "models directory '{}' not found (required for --model)",
-            blueprint_models_dir.display()
-        );
-        output.statements =
-            plan_preview_output(Some(config_path), &blueprint_models_dir, Some(model), env)?
-                .statements;
-    }
+    // The run-plan compile honours `--models` when set (resolved into
+    // `blueprint_models_dir` above); otherwise the conventional `models/`
+    // directory next to the config is used.
     let mut run_plan_persisted = false;
     if blueprint_models_dir.exists() {
         match build_and_persist_run_plan(
@@ -793,6 +820,13 @@ pub fn plan_preview_output(
         Err(rocky_compiler::compile::CompileError::Project(
             rocky_compiler::project::ProjectError::NoModels { .. },
         )) => {
+            // A `--model` filter against a project with zero compiled models
+            // cannot name an existing model — fail loudly rather than returning
+            // an empty preview while `plan()` falls through to persist a
+            // full-replication plan that `apply` would silently execute.
+            if let Some(model) = filter {
+                return Err(anyhow::Error::new(ModelNotFound(model.to_string())));
+            }
             tracing::info!(
                 models_dir = %models_dir.display(),
                 "plan_preview: project has no compiled models — replication SQL preview \
@@ -806,6 +840,12 @@ pub fn plan_preview_output(
     };
 
     if result.project.models.is_empty() {
+        // Same guard as the `NoModels` arm above: a `--model` filter cannot
+        // match anything in a zero-model project, so error rather than emit an
+        // empty preview that masks a persisted full-replication plan.
+        if let Some(model) = filter {
+            return Err(anyhow::Error::new(ModelNotFound(model.to_string())));
+        }
         tracing::info!(
             models_dir = %models_dir.display(),
             "plan_preview: project has no compiled models — returning empty statements"
@@ -816,14 +856,13 @@ pub fn plan_preview_output(
     // Project the compile result to typed IR, reusing the shared
     // `project_ir_from_compile` helper so we don't re-derive IR by hand.
     let project_ir = super::ci_diff::project_ir_from_compile(&result);
-    if let Some(model) = filter {
-        anyhow::ensure!(
-            project_ir
-                .models
-                .iter()
-                .any(|candidate| candidate.name.as_ref() == model),
-            "model '{model}' not found (no transformation model with that name)"
-        );
+    if let Some(model) = filter
+        && !project_ir
+            .models
+            .iter()
+            .any(|candidate| candidate.name.as_ref() == model)
+    {
+        return Err(anyhow::Error::new(ModelNotFound(model.to_string())));
     }
 
     for model_ir in &project_ir.models {
@@ -2640,8 +2679,44 @@ table = "known"
         );
     }
 
-    /// A `models/` directory with no compiled models (replication-only)
-    /// returns empty statements rather than erroring.
+    /// A `--model` filter against a `models/` directory that compiles to zero
+    /// models must error — the model cannot exist. Otherwise `plan()` returns an
+    /// empty preview and falls through to persist a full-replication plan that
+    /// `apply` would silently execute (the regression this closes).
+    #[test]
+    fn plan_preview_filter_on_empty_models_dir_errors() {
+        let tmp = TempDir::new().unwrap();
+        let cfg_path = tmp.path().join("rocky.toml");
+        fs::write(
+            &cfg_path,
+            r#"
+[adapter.default]
+type = "duckdb"
+database = ":memory:"
+"#,
+        )
+        .unwrap();
+        // models_dir exists but holds no model sidecars → zero compiled models.
+        let models_dir = tmp.path().join("models");
+        fs::create_dir_all(&models_dir).unwrap();
+
+        let err = plan_preview_output(Some(&cfg_path), &models_dir, Some("known"), None)
+            .expect_err("filter against a zero-model project must fail");
+        assert!(
+            err.to_string()
+                .contains("model 'known' not found (no transformation model with that name)"),
+            "unexpected error: {err}"
+        );
+        // The typed error must survive as an anyhow cause so the MCP tool can
+        // downcast it and classify it as `model_not_found`.
+        assert!(
+            err.downcast_ref::<ModelNotFound>().is_some(),
+            "error must downcast to ModelNotFound"
+        );
+    }
+
+    /// The zero-model, no-filter path is unchanged: a replication-only project
+    /// still returns empty statements rather than erroring.
     #[test]
     fn plan_preview_replication_only_returns_empty_statements() {
         let tmp = TempDir::new().unwrap();

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -538,7 +538,13 @@ impl RockyMcpServer {
         let model = params.0.model.as_deref();
         let output =
             commands::plan_preview_output(Some(&self.config_path), &self.models_dir, model, None)
-                .map_err(|e| ToolError::compile_failed(format!("{e:#}")))?;
+                .map_err(|e| match e.downcast_ref::<commands::ModelNotFound>() {
+                // Preserve the stable taxonomy: an unknown `model` is
+                // `model_not_found` (with its "list the models, retry"
+                // hint), not the generic compile-failure bucket.
+                Some(commands::ModelNotFound(name)) => ToolError::model_not_found(name),
+                None => ToolError::compile_failed(format!("{e:#}")),
+            })?;
         let statements = output
             .statements
             .into_iter()
@@ -3967,6 +3973,46 @@ mod tests {
         let server = RockyMcpServer::new(PathBuf::from("/tmp/proj/rocky.toml"));
         assert_eq!(server.models_dir, PathBuf::from("/tmp/proj/models"));
         assert_eq!(server.root, PathBuf::from("/tmp/proj"));
+    }
+
+    /// `plan_preview` with an unknown model must surface the stable
+    /// `model_not_found` error class (with its "list the models, retry" hint),
+    /// not the generic `compile_failed` bucket — so an agent branches correctly.
+    #[tokio::test]
+    async fn plan_preview_unknown_model_is_model_not_found() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        std::fs::write(
+            root.join("rocky.toml"),
+            "[adapter.default]\ntype = \"duckdb\"\ndatabase = \":memory:\"\n",
+        )
+        .expect("write config");
+        let models = root.join("models");
+        std::fs::create_dir(&models).expect("create models");
+        std::fs::write(models.join("known.sql"), "SELECT 1 AS id").expect("write sql");
+        std::fs::write(
+            models.join("known.toml"),
+            "name = \"known\"\n\n[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"c\"\nschema = \"s\"\ntable = \"known\"\n",
+        )
+        .expect("write sidecar");
+
+        let server = RockyMcpServer::new(root.join("rocky.toml"));
+        // `Json<PlanPreviewResult>` is not `Debug`, so match rather than `expect_err`.
+        let err = match server
+            .plan_preview(Parameters(PlanPreviewArgs {
+                model: Some("missing".into()),
+            }))
+            .await
+        {
+            Ok(_) => panic!("unknown model must error"),
+            Err(e) => e,
+        };
+        assert_eq!(err.0.code, crate::error::ToolErrorCode::ModelNotFound);
+        assert!(
+            err.0.message.contains("missing"),
+            "message should name the model: {:?}",
+            err.0
+        );
     }
 
     #[test]

--- a/engine/rocky/tests/plan_model_scope.rs
+++ b/engine/rocky/tests/plan_model_scope.rs
@@ -117,3 +117,58 @@ fn model_plan_matches_applied_scope() {
         );
     }
 }
+
+/// Regression: `rocky plan --model <name>` against a project whose `models/`
+/// directory exists but compiles to zero models must FAIL with "model not
+/// found" — not succeed with an empty preview while silently persisting a
+/// full-replication plan that `apply` would then execute against every
+/// discovered table.
+#[test]
+fn model_plan_on_empty_models_dir_errors() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path();
+    let config = dir.join("rocky.toml");
+
+    {
+        let conn = duckdb::Connection::open(dir.join("fixture.duckdb")).expect("open duckdb");
+        conn.execute_batch(
+            "CREATE SCHEMA raw__orders;
+             CREATE TABLE raw__orders.orders AS SELECT 1 AS id;",
+        )
+        .expect("seed source");
+    }
+
+    fs::write(&config, ROCKY_TOML).expect("write config");
+    // The models directory exists but holds no model sidecars → zero compiled
+    // models. `--model` cannot name anything here.
+    fs::create_dir(dir.join("models")).expect("create empty models dir");
+
+    let plan = Command::new(env!("CARGO_BIN_EXE_rocky"))
+        .args(["--output", "json"])
+        .arg("--config")
+        .arg(&config)
+        .args(["plan", "--model", "known"])
+        .current_dir(dir)
+        .env("RUST_LOG", "error")
+        .output()
+        .expect("run plan");
+
+    assert!(
+        !plan.status.success(),
+        "plan --model against a zero-model project must fail, got success with stdout: {}",
+        String::from_utf8_lossy(&plan.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&plan.stderr);
+    assert!(
+        stderr.contains("model 'known' not found (no transformation model with that name)"),
+        "expected a model-not-found error, got stderr: {stderr}"
+    );
+
+    // No plan may have been persisted — otherwise a later `apply` would run the
+    // full replication the empty preview never advertised.
+    let plans_dir = dir.join(".rocky").join("plans");
+    let persisted = fs::read_dir(&plans_dir)
+        .map(|rd| rd.filter_map(Result::ok).count())
+        .unwrap_or(0);
+    assert_eq!(persisted, 0, "a failed model plan must not persist a plan");
+}


### PR DESCRIPTION
## Summary

Follow-up to #1166. Make `rocky plan --model <name>` fail fast with a clear
"model not found" error — matching what `rocky apply` reports — when the named
model does not exist, instead of a confusing governance error or a misleading
empty preview.

Relates to #1165.

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)

## What was wrong (post-#1166)

#1166 correctly scoped `plan --model` for the common case (a real model in a
populated `models/` dir). Two residual gaps remained for the *unknown/zero-model*
case:

1. **Confusing error.** `rocky plan --model typo` in a project whose `models/`
   directory compiles to zero models failed at the governance-action preview
   with `failed to compute governance action preview`, because that step runs
   before the model selector was validated.
2. **Silent, misleading preview (the dangerous one).** With a `--models`
   override pointing at a model-less directory (and no conventional `models/`),
   the governance preview was skipped, `plan_preview_output` returned an *empty*
   statement list, and `plan()` fell through to persist a **full-replication**
   plan. Applying that plan id then ran replication across every discovered
   table — work the empty preview never advertised.

Reachability, stated honestly: (2) is not a routine invocation — it needs a
`--models` override to a zero-model directory. The common case in (1) already
errored (non-silently), just with the wrong message.

## Changes

- Move `--model` validation ahead of the governance/budget preview in `plan()`,
  so an unknown model (including a zero-model project) fails fast with the same
  `model 'X' not found (no transformation model with that name)` message
  `rocky run`/`rocky apply` emit — before any plan is persisted.
- Make `plan_preview_output` return a typed `ModelNotFound` error for a `--model`
  filter against a zero-model project (both the `NoModels` and empty-project
  paths), instead of returning an empty preview.
- `rocky mcp` `plan_preview` now classifies an unknown model as `model_not_found`
  (with its "list the models, retry" hint) rather than the generic
  `compile_failed` bucket, by downcasting the typed error.

No CLI JSON output struct or schema changed; the `ToolErrorCode::ModelNotFound`
variant already existed. `ModelNotFound`'s `Display` is byte-identical to the
run/apply message, so CLI output is unchanged.

## Test Plan

- `cargo test -p rocky-cli --lib commands::plan` (33 pass, incl. new
  `plan_preview_filter_on_empty_models_dir_errors`)
- `cargo test -p rocky --test plan_model_scope` (adds real-binary
  `model_plan_on_empty_models_dir_errors`: plan fails, persists no plan)
- `cargo test -p rocky-mcp --lib plan_preview_unknown_model` (asserts
  `ModelNotFound` taxonomy)
- `cargo clippy -p rocky-cli -p rocky-mcp -p rocky --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`

## Out of scope (pre-existing, non-silent)

- `rocky plan` (no `--model`) against an empty conventional `models/` still fails
  at the governance preview; that behavior is unchanged and orthogonal to model
  scoping.