### PR TITLE
fix(engine/rocky-mcp): classify unknown plan_preview model as model_not_found

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `rocky plan --model <name>` now previews only the selected model and reports the same model scope that `rocky apply` executes, instead of advertising skipped replication SQL and unrelated models. (#1165)
 - `rocky plan --model <name>` no longer silently degrades to a full replication that `rocky apply` would execute without review. An unknown model reached via `--models <dir>`, or a run-plan persistence failure, now errors instead of persisting a replication plan; a model-scoped plan can only resolve to that model or fail. `--model` combined with `--dag` is now rejected at plan time (the two are contradictory — the DAG runner ignores the model selector and applies every pipeline). (#1171)
+- The `rocky mcp` `plan_preview` tool now classifies an unknown `model` argument as `model_not_found` (with its "list the models, retry" remediation) rather than the generic `compile_failed`, so an agent that typo'd or hallucinated a model name recovers correctly. (#1165)
 
 ## [1.65.0] - 2026-07-18
 

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -145,8 +145,8 @@ pub use lsp::run_lsp;
 pub use metrics::{metrics_output, run_metrics};
 pub use optimize::{optimize_output, run_optimize};
 pub use plan::{
-    PlanRunOptions, compute_embedded_capabilities, plan, plan_preview_output, plan_promote,
-    populate_governance_actions,
+    ModelNotFound, PlanRunOptions, compute_embedded_capabilities, plan, plan_preview_output,
+    plan_promote, populate_governance_actions,
 };
 pub use playground::{run_playground, run_playground_with_template};
 pub use policy::{run_policy_check, run_policy_freeze, run_policy_test};

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -18,6 +18,20 @@ use crate::registry;
 use super::run::PartitionRunOptions;
 use super::{filter_table_matches, matches_filter, parse_filter};
 
+/// A model filter (`--model` / the MCP `plan_preview` `model` arg) named a model
+/// that does not exist in the compiled project.
+///
+/// [`plan_preview_output`] returns this as a typed error (rather than a bare
+/// `anyhow` string) so callers that speak a stable error taxonomy — the
+/// `rocky mcp` `plan_preview` tool — can downcast and classify it as
+/// `model_not_found` instead of the generic compile-failure bucket. The
+/// `Display` text is byte-identical to the message `rocky run --model <name>`
+/// emits for the same condition (see `commands::run`), so CLI output is
+/// unchanged.
+#[derive(Debug, thiserror::Error)]
+#[error("model '{0}' not found (no transformation model with that name)")]
+pub struct ModelNotFound(pub String);
+
 /// Bundle of `rocky plan` execution flags persisted into `RunPlan` so
 /// `rocky apply <plan-id>` can honour them. Mirrors the flag surface of
 /// `rocky run`; `model` also scopes the SQL preview and model metadata.
@@ -862,14 +876,16 @@ pub fn plan_preview_output(
     // Project the compile result to typed IR, reusing the shared
     // `project_ir_from_compile` helper so we don't re-derive IR by hand.
     let project_ir = super::ci_diff::project_ir_from_compile(&result);
-    if let Some(model) = filter {
-        anyhow::ensure!(
-            project_ir
-                .models
-                .iter()
-                .any(|candidate| candidate.name.as_ref() == model),
-            "model '{model}' not found (no transformation model with that name)"
-        );
+    if let Some(model) = filter
+        && !project_ir
+            .models
+            .iter()
+            .any(|candidate| candidate.name.as_ref() == model)
+    {
+        // Typed so `rocky mcp`'s `plan_preview` can classify it as
+        // `model_not_found`; `Display` is unchanged from the previous
+        // `anyhow::ensure!` string.
+        return Err(anyhow::Error::new(ModelNotFound(model.to_string())));
     }
 
     for model_ir in &project_ir.models {
@@ -2683,6 +2699,12 @@ table = "known"
         assert!(
             err.to_string()
                 .contains("model 'missing' not found (no transformation model with that name)")
+        );
+        // The typed error must survive as an anyhow cause so `rocky mcp`'s
+        // `plan_preview` can downcast it and classify it as `model_not_found`.
+        assert!(
+            err.downcast_ref::<ModelNotFound>().is_some(),
+            "error must downcast to ModelNotFound"
         );
     }
 

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -538,7 +538,14 @@ impl RockyMcpServer {
         let model = params.0.model.as_deref();
         let output =
             commands::plan_preview_output(Some(&self.config_path), &self.models_dir, model, None)
-                .map_err(|e| ToolError::compile_failed(format!("{e:#}")))?;
+                .map_err(|e| match e.downcast_ref::<commands::ModelNotFound>() {
+                // Preserve the stable taxonomy: an unknown `model` is
+                // `model_not_found` (with its "list the models, retry" hint),
+                // not the generic compile-failure bucket — so an agent that
+                // typo'd or hallucinated a model name recovers correctly.
+                Some(commands::ModelNotFound(name)) => ToolError::model_not_found(name),
+                None => ToolError::compile_failed(format!("{e:#}")),
+            })?;
         let statements = output
             .statements
             .into_iter()
@@ -3967,6 +3974,46 @@ mod tests {
         let server = RockyMcpServer::new(PathBuf::from("/tmp/proj/rocky.toml"));
         assert_eq!(server.models_dir, PathBuf::from("/tmp/proj/models"));
         assert_eq!(server.root, PathBuf::from("/tmp/proj"));
+    }
+
+    /// `plan_preview` with an unknown model must surface the stable
+    /// `model_not_found` error class (with its "list the models, retry" hint),
+    /// not the generic `compile_failed` bucket — so an agent branches correctly.
+    #[tokio::test]
+    async fn plan_preview_unknown_model_is_model_not_found() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        std::fs::write(
+            root.join("rocky.toml"),
+            "[adapter.default]\ntype = \"duckdb\"\ndatabase = \":memory:\"\n",
+        )
+        .expect("write config");
+        let models = root.join("models");
+        std::fs::create_dir(&models).expect("create models");
+        std::fs::write(models.join("known.sql"), "SELECT 1 AS id").expect("write sql");
+        std::fs::write(
+            models.join("known.toml"),
+            "name = \"known\"\n\n[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"c\"\nschema = \"s\"\ntable = \"known\"\n",
+        )
+        .expect("write sidecar");
+
+        let server = RockyMcpServer::new(root.join("rocky.toml"));
+        // `Json<PlanPreviewResult>` is not `Debug`, so match rather than `expect_err`.
+        let err = match server
+            .plan_preview(Parameters(PlanPreviewArgs {
+                model: Some("missing".into()),
+            }))
+            .await
+        {
+            Ok(_) => panic!("unknown model must error"),
+            Err(e) => e,
+        };
+        assert_eq!(err.0.code, crate::error::ToolErrorCode::ModelNotFound);
+        assert!(
+            err.0.message.contains("missing"),
+            "message should name the model: {:?}",
+            err.0
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The `rocky mcp` `plan_preview` tool reports an unknown/typo'd `model` argument
as the generic `compile_failed` error class instead of `model_not_found`.
That sends an AI agent to the wrong recovery — "call `compile` and fix
diagnostics" — instead of `model_not_found`'s "list the models with `list`,
retry with an exact name." A hallucinated or mistyped model name is a common
agent failure mode, so this is a grounding defect on the MCP surface.

Relates to #1165. Follow-up to #1166; #1172 covered the CLI `plan`/`apply`
path and deliberately left `plan_preview_output` untouched, so this is the
remaining, non-overlapping residual.

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)

## Changes

- `plan_preview_output` now returns a typed `ModelNotFound` error when a model
  filter names a model that is not in the compiled project (previously a bare
  `anyhow::ensure!` string). Its `Display` is byte-identical to the previous
  message and to what `rocky run --model`/`rocky apply` emit, so CLI output is
  unchanged.
- `rocky mcp` `plan_preview` downcasts `ModelNotFound` and maps it to
  `ToolError::model_not_found` (stable taxonomy + "list the models, retry"
  remediation), falling back to `compile_failed` for any other error.

No CLI JSON output struct or schema changed; the `ToolErrorCode::ModelNotFound`
variant already existed. No change to `plan()` control flow, so #1172's
model-scope guards are untouched.

## Test Plan

- `cargo test -p rocky-cli --lib commands::plan::tests::plan_preview_unknown_filter_is_error`
  (now also asserts the error downcasts to `ModelNotFound`)
- `cargo test -p rocky-mcp --lib plan_preview_unknown_model` (asserts the
  `ModelNotFound` taxonomy code + message)
- `cargo clippy -p rocky-cli -p rocky-mcp --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`

## Out of scope (deliberate)

- **Zero-model projects.** When the project compiles to *zero* models,
  `plan_preview_output` still returns empty statements (not an error) for a
  specified `model`, so `plan_preview({"model": "x"})` returns an empty success
  rather than `model_not_found`. This path is pre-existing (it predates #1166)
  and is left untouched on purpose: erroring there would require guarding
  `plan_preview_output`'s zero-model early-returns, which would make #1172's
  just-merged `plan()`-level `--model` guards redundant. The common case — an
  unknown model in a project that *has* models — is fixed here.
- `rocky plan --model` against an empty conventional `models/` still fails at
  the governance-action preview with a less specific message; orthogonal to the
  MCP taxonomy and unchanged.