### PR TITLE
chore: release engine 1.66.0, rocky-sdk 0.9.1, dagster-rocky 1.61.1, vscode 1.36.0

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.36.0] — 2026-07-19
+
+### Added
+
+- `rocky.toml` config completion + validation for the new `[state] concurrency_control` field (`"off"` | `"cas"`) from engine-v1.66.0, via regenerated project-schema types. The LSP client and existing commands are unchanged.
+
 ## [1.35.0] — 2026-07-18
 
 ### Added

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,10 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.66.0] - 2026-07-19
+
+### Added
+
+- In-place column type evolution is restored on Databricks: a safe type widening now emits a scoped Delta `ALTER COLUMN ... TYPE` instead of forcing a full table refresh. (#1167)
+- In-place column type evolution is restored on Trino Iceberg: a safe widening now emits a scoped `ALTER TABLE ... SET DATA TYPE`. (#1169)
+- `[state] concurrency_control = "cas"` for remote object-store state backends. The end-of-run state upload becomes a compare-and-swap conditional on the generation the run downloaded, so a run that lost a cross-pod race fail-closes (nonzero exit) instead of silently overwriting the winner's committed state. The default (`off`) keeps the previous last-writer-wins behaviour; `cas` requires a backend with a conditional-write object tier (`s3` / `gcs`) and auto-downgrades to `off` with a warning elsewhere. (#1170)
+
 ### Fixed
 
 - `rocky plan --model <name>` now previews only the selected model and reports the same model scope that `rocky apply` executes, instead of advertising skipped replication SQL and unrelated models. (#1165)
 - `rocky plan --model <name>` no longer silently degrades to a full replication that `rocky apply` would execute without review. An unknown model reached via `--models <dir>`, or a run-plan persistence failure, now errors instead of persisting a replication plan; a model-scoped plan can only resolve to that model or fail. `--model` combined with `--dag` is now rejected at plan time (the two are contradictory — the DAG runner ignores the model selector and applies every pipeline). (#1171)
+- `rocky tick` now rejects an unknown `--pipeline` instead of silently scheduling nothing. (#1164)
 - The `rocky mcp` `plan_preview` tool now classifies an unknown `model` argument as `model_not_found` (with its "list the models, retry" remediation) rather than the generic `compile_failed`, so an agent that typo'd or hallucinated a model name recovers correctly. (#1165)
 
 ## [1.65.0] - 2026-07-18

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4041,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4054,7 +4054,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "indexmap",
  "reqwest 0.12.28",
@@ -4075,7 +4075,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4092,7 +4092,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4120,7 +4120,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "redis",
  "serde",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4201,7 +4201,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4281,7 +4281,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4308,7 +4308,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4327,7 +4327,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4376,7 +4376,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4401,7 +4401,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -4414,7 +4414,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "logos",
  "miette",
@@ -4426,7 +4426,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "rocky-server",
  "rustls",
@@ -4435,7 +4435,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4461,7 +4461,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4479,7 +4479,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4508,7 +4508,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -4535,7 +4535,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "miette",
  "regex",
@@ -4548,7 +4548,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.65.0"
+version = "1.66.0"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.65.0"
+version = "1.66.0"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.65.0"
+version = "1.66.0"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.65.0"
+version = "1.66.0"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.65.0"
+version = "1.66.0"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.65.0"
+version = "1.66.0"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.65.0"
+version = "1.66.0"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.65.0"
+version = "1.66.0"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.65.0"
+version = "1.66.0"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.65.0"
+version = "1.66.0"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.65.0"
+version = "1.66.0"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.65.0"
+version = "1.66.0"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.65.0"
+version = "1.66.0"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.65.0"
+version = "1.66.0"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.65.0"
+version = "1.66.0"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.65.0"
+version = "1.66.0"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.65.0"
+version = "1.66.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.65.0"
+version = "1.66.0"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.65.0"
+version = "1.66.0"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.65.0"
+version = "1.66.0"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.65.0"
+version = "1.66.0"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.65.0"
+version = "1.66.0"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.65.0"
+version = "1.66.0"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.65.0"
+version = "1.66.0"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.65.0"
+version = "1.66.0"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.61.1] — 2026-07-19
+
+### Changed
+
+- Floors on `rocky-sdk>=0.9.1`, picking up the regenerated engine-v1.66.0 config bindings (the `[state] concurrency_control` compare-and-swap option) re-exported via `dagster_rocky.types`. No resource or asset behaviour changes.
+
 ## [1.61.0] — 2026-07-18
 
 ### Added

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.61.0"
+version = "1.61.1"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"
@@ -27,7 +27,7 @@ dependencies = [
     # freeze-marker and schedule/tick output types; an older SDK would be missing
     # them (and also the 0.8.3 `--models` forwarding + retention `env` guard fixes
     # the model-aware resource methods depend on).
-    "rocky-sdk>=0.9.0",
+    "rocky-sdk>=0.9.1",
     # Floor matches the version CI actually resolves and tests (uv.lock). The
     # RockyComponent path uses dagster.components.* APIs from preview namespaces,
     # so we advertise a tested floor rather than an older, never-exercised one.

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] — 2026-07-19
+
+### Changed
+
+- Regenerated config bindings for engine-v1.66.0: the `rocky.toml` `[state]` block gains a `concurrency_control` field (`"off"` | `"cas"`) for compare-and-swap remote-state writes. Additive; every `RockyClient` method is unchanged.
+
 ## [0.9.0] — 2026-07-18
 
 ### Added

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rocky-sdk"
-version = "0.9.0"
+version = "0.9.1"
 description = "Typed Python client for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Consolidated quad-cut release off the backlog accumulated since the 1.65.0 cut (#1162). Version bumps + CHANGELOGs only — no code changes.

| Artifact | 1.65.0 line | New |
|---|---|---|
| engine (`rocky`) | 1.65.0 | **1.66.0** |
| `rocky-sdk` | 0.9.0 | **0.9.1** |
| `dagster-rocky` | 1.61.0 | **1.61.1** |
| vscode | 1.35.0 | **1.36.0** |

## engine 1.66.0

**Added**
- In-place column type evolution restored on Databricks (scoped Delta `ALTER COLUMN … TYPE`). (#1167)
- In-place column type evolution restored on Trino Iceberg (scoped `ALTER TABLE … SET DATA TYPE`). (#1169)
- `[state] concurrency_control = "cas"` — compare-and-swap remote-state writes; a run that lost a cross-pod race fail-closes instead of overwriting the winner. Default `off` (last-writer-wins). (#1170)

**Fixed**
- `rocky plan --model` scope now matches what `apply` executes. (#1166)
- `rocky plan --model` never silently degrades to a full replication plan; `--model`+`--dag` rejected at plan time. (#1172)
- `rocky tick` rejects an unknown `--pipeline`. (#1164)
- `rocky mcp` `plan_preview` classifies an unknown model as `model_not_found`, not `compile_failed`. (#1177)

## rocky-sdk 0.9.1 / dagster-rocky 1.61.1 / vscode 1.36.0

Regenerated config bindings for the new `[state] concurrency_control` field (#1170): the sdk Pydantic model, the vscode config completion/validation, and the JSON schema. `dagster-rocky` floors on `rocky-sdk>=0.9.1`. No behavioural changes in the sdk/dagster/vscode surfaces.

## Release mechanics (after merge)

Tag the merged commit in order (each tag push triggers its `*-release.yml`):

```
engine-v1.66.0  →  sdk-v0.9.1  →  dagster-v1.61.1  →  vscode-v1.36.0
```

`rocky-sdk` is tagged before `dagster-rocky` because dagster raises its `rocky-sdk>=…` floor to 0.9.1 and resolves it from PyPI.

## Notes

- Engine version bumped across all 25 crate `Cargo.toml` files + `Cargo.lock`.
- No CLI JSON output schema changed; the only binding delta is the `rocky_project` config schema (the new `[state]` field).
- vscode `package-lock.json` root version is intentionally left as-is (it was already out of lockstep at the 1.35.0 cut; `vsce` reads `package.json`).