### PR TITLE
chore: sync stale lockfile versions with shipped releases

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocky",
-  "version": "1.34.4",
+  "version": "1.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocky",
-      "version": "1.34.4",
+      "version": "1.36.0",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^10.1.0"

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.8.3"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Two lockfiles still recorded pre-release versions of their own package. Neither is covered by `codegen-drift.yml` (which checks only `schemas/`, `docs/public/openapi.json`, generated SDK/editor types, and dagster fixtures), so the drift went unnoticed across the 1.65.0 and 1.66.0 cuts.

| File | Recorded | Shipped |
|---|---|---|
| `sdk/python/uv.lock` | `rocky-sdk 0.8.3` | `0.9.1` (`sdk-v0.9.1`) |
| `editors/vscode/package-lock.json` | `rocky 1.34.4` | `1.36.0` (`vscode-v1.36.0`) |

Surfaced by a `just codegen-all` run while cutting `engine-v1.66.1` (#1181); split out to keep that release focused.

## Subproject(s) touched

- [ ] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [x] `editors/vscode/` (TypeScript extension)
- [x] `sdk/python/` (rocky-sdk)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Changes

Version fields only — three lines total. Edited surgically rather than by regenerating the lockfiles: a full `npm install` also strips `libc` fields from optional platform deps (npm-version-dependent churn, ~20 unrelated lines) that would flip back under a different npm. No dependency resolution is altered.

## Test Plan

- [x] `uv lock --check` (in `sdk/python/`) — resolves clean, no update needed
- [x] `npm ci --dry-run` (in `editors/vscode/`) — succeeds; `npm ci` hard-fails on any `package.json`/lock mismatch
- [x] `package-lock.json` parses as valid JSON; both `.version` and `.packages[""].version` read `1.36.0`
- [x] No remaining `1.34.4` or `0.8.3` self-references

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/), scoped by subproject when relevant.
- [x] No `Co-Authored-By` trailers.
- [x] No CLI JSON schema or DSL syntax changed.