### PR TITLE
fix(engine): refuse unsafe raw dbt incrementals

### DIFF
--- a/docs/src/content/docs/guides/migrate-from-dbt.md
+++ b/docs/src/content/docs/guides/migrate-from-dbt.md
@@ -290,7 +290,6 @@ What the importer translates cleanly:
 - `{{ var('name') }}` / `{{ var('name', default) }}` → an `@var(name)` / `@var(name, default)` run-variable marker left in the emitted SQL, resolved at run time by `rocky run --var name=value` (see [Handle unsupported Jinja](#3-handle-unsupported-jinja))
 - dbt **tags** (node- and folder-level) → the sidecar `[tags]` block (`<tag> = "true"`)
 - `{{ this }}` → the model's own fully-qualified `catalog.schema.table`
-- `is_incremental()` branches → stripped (Rocky derives the watermark filter from `[strategy]`)
 - **dbt generic tests** (`unique`, `not_null`, `accepted_values`, `relationships`) are translated column-by-column to `[[tests]]` blocks — including the *configured* forms that carry `severity:` (a `warn` becomes a Rocky warning, not a hard error) and `where:` (a row filter) (see [Generic test mapping](#generic-test-mapping) below)
 - model-level **`dbt_utils.unique_combination_of_columns`** → a Rocky `composite` uniqueness `[[tests]]` block over the same column tuple (the columns come from the test config, so no model schema is needed)
 - Top-level `dbt_project.yml`, used to detect project name and seeds path
@@ -302,7 +301,8 @@ By design, the importer does not translate the following. Rocky has no Jinja run
 - **dbt tests with no native Rocky equivalent.** Beyond the canonical four, the importer now converts several `dbt_utils` / `dbt_expectations` tests to native Rocky assertions — `unique_combination_of_columns`, `accepted_range` / `expect_column_values_to_be_between` (→ `in_range`), `expect_column_values_to_match_regex` (→ `regex_match`), `expect_column_values_to_be_in_set` (→ `accepted_values`), and `dbt_utils.expression_is_true` (→ `expression`); see [Generic test mapping](#generic-test-mapping). Everything still outside that set — other `dbt_utils.*` / `dbt_expectations.*` tests, project-defined generics, and other model-level tests — is surfaced as a structured `UnsupportedTest` warning per occurrence and not stubbed in the emitted TOML. Rewrite those as a Rocky `expression` test or a quality-pipeline check.
 - **Singular tests** in `tests/` (custom SQL): copy and rewrite manually.
 - **dbt macros and `dbt_packages/`.** Rocky has no Jinja runtime, so macro bodies do not expand.
-- **`{% for %}` / `{% set %}`** outside `is_incremental()` on the no-manifest path: **refused** — the model is listed as a failure rather than half-rendered into broken SQL (the loop/assignment body would survive exactly once). Re-run after `dbt compile` (the manifest path resolves them) or rewrite the model. A `{% if %}` is still emitted verbatim with a TODO marker — its body applies *unconditionally*, so review it. (`{{ var() }}` is not in this list: it converts to an `@var()` run-variable marker — see above.)
+- **Raw Jinja that invokes `is_incremental()`** on the no-manifest/raw-manifest path: **refused** — stripping the branch can delete bounded logic, while preserving it can reference a target that does not exist during bootstrap. This includes compound `if`/`elif` conditions and indirect `{% set %}` forms, and applies even when a `unique_key` would map the model to `merge`: a full-source merge is idempotent by key, but it is not equivalent to dbt's bounded query. Compile dbt in an incremental context and import that manifest only after verifying the compiled SQL retains its intended predicate and is valid for Rocky's initial target state; otherwise, rewrite the model with a Rocky-supported strategy.
+- **`{% for %}` / `{% set %}`** on the no-manifest path: **refused** — the model is listed as a failure rather than half-rendered into broken SQL (the loop/assignment body would survive exactly once). Re-run after `dbt compile` (the manifest path resolves them) or rewrite the model. Another `{% if %}` is still emitted verbatim with a TODO marker — its body applies *unconditionally*, so review it. (`{{ var() }}` is not in this list: it converts to an `@var()` run-variable marker — see above.)
 - **Unmapped `materialized` values** (`dynamic_table`, `seed`): flattened to `full_refresh` and listed in `MIGRATION-NOTES.md`. (`materialized_view` maps natively to Rocky's `materialized_view` strategy.)
 - **Adapters Rocky does not natively support** (e.g. Postgres, Redshift): the generated repo stubs DuckDB so the project still loads. Replace the `[adapter]` block once a Rocky adapter for the warehouse exists, or pass `--target-adapter <kind>` to skip detection.
 - **Custom Jinja macros emitting SQL** (e.g. `{{ generate_schema_name() }}`, dynamic `UNION ALL` macros): surfaced as failed models with the macro name in the reason.
@@ -406,10 +406,6 @@ SELECT
     total_amount,
     _fivetran_synced
 FROM {{ source('shopify', 'orders') }}
-
-{% if is_incremental() %}
-WHERE _fivetran_synced > (SELECT MAX(_fivetran_synced) FROM {{ this }})
-{% endif %}
 ```
 
 ### After (Rocky)
@@ -446,7 +442,7 @@ schema = "shopify"
 table = "orders"
 ```
 
-Notice that the `{{ config() }}` block became `[strategy]` and `{{ source() }}` became a fully qualified reference. A `config(unique_key=...)` with no explicit `incremental_strategy` maps to Rocky's `merge` strategy keyed on `unique_key` (not a bare `incremental` block). The `[[sources]]` block and its qualified coordinates come from the `sources.yml` definition for `shopify.orders`; without a matching `sources.yml` entry the importer emits a warning and no `[[sources]]` block. The `is_incremental()` guard and `{{ this }}` are gone: Rocky derives the merge logic from `[strategy]` and the target table from `[target]`.
+Notice that the `{{ config() }}` block became `[strategy]` and `{{ source() }}` became a fully qualified reference. A `config(unique_key=...)` with no explicit `incremental_strategy` maps to Rocky's `merge` strategy keyed on `unique_key` (not a bare `incremental` block). The `[[sources]]` block and its qualified coordinates come from the `sources.yml` definition for `shopify.orders`; without a matching `sources.yml` entry the importer emits a warning and no `[[sources]]` block.
 
 ## 3. Handle Unsupported Jinja
 
@@ -967,7 +963,7 @@ The importer names models after the SQL file's stem (e.g., `stg_orders.sql` beco
 
 ### Incremental models do not pick up the right watermark
 
-Rocky uses the `timestamp_column` from the `[strategy]` section, not Jinja logic. Make sure the column name matches what your data actually contains (e.g., `_fivetran_synced`, `updated_at`).
+Rocky transformation incrementals expect the model SQL to own its row filter; `timestamp_column` does not add one. The raw/no-manifest importer therefore refuses unresolved Jinja that invokes `is_incremental()` instead of silently deleting bounded logic. With manifest import, inspect the compiled SQL and make sure it contains the intended bound (for example on `_fivetran_synced` or `updated_at`).
 
 ### Environment-specific logic
 

--- a/docs/src/content/docs/reference/commands/development.md
+++ b/docs/src/content/docs/reference/commands/development.md
@@ -116,7 +116,7 @@ rocky import-dbt --dbt-project <PATH> [flags]
 
 Connection secrets (passwords, API tokens, service-account JSON) are emitted as `${VAR}` env-var placeholders in `rocky.toml`; they are **never inlined**. The required env vars are listed in `MIGRATION-NOTES.md` so users know what to export before `rocky plan` + `rocky apply`.
 
-`materialized` mapping: `view → ephemeral`, `table → full_refresh`, `incremental` (with `unique_key`) → `merge`, `incremental` (without) → `incremental`, `microbatch` → `merge` (default) or `time_interval`, selected by [`--microbatch-as`](#flags). Anything else falls back to `full_refresh` with a TODO line in `MIGRATION-NOTES.md`. Profile types Rocky doesn't natively support stub a DuckDB `[adapter]` so the project still compiles, with the original type preserved under "Not Translated".
+`materialized` mapping: `view → view`, `table → full_refresh`, `incremental` (with `unique_key`) → `merge`, `incremental` (without) → `incremental`, `microbatch` → `merge` (default) or `time_interval`, selected by [`--microbatch-as`](#flags). On either raw SQL path — `--no-manifest` or a manifest node without `compiled_code` — a model whose raw Jinja invokes `is_incremental()` is refused and listed under `failed_details` because Rocky cannot preserve dbt's first-run/subsequent-run distinction without compiled SQL. Anything else falls back to `full_refresh` with a TODO line in `MIGRATION-NOTES.md`. Profile types Rocky doesn't natively support stub a DuckDB `[adapter]` so the project still compiles, with the original type preserved under "Not Translated".
 
 When reading `profiles.yml`, the importer resolves YAML anchors/aliases (`&anchor` / `*alias`) and `{{ env_var('VAR', 'default') }}` expressions in the adapter `type` field, so a profile that templates its warehouse type detects the right adapter instead of silently stubbing DuckDB. Override detection entirely with `--target-adapter`.
 
@@ -164,7 +164,7 @@ rocky import-dbt --dbt-project ~/projects/acme-dbt
 }
 ```
 
-`import_method` is `"manifest"` when a compiled `target/manifest.json` was found (pre-resolved Jinja), or `"regex"` when Rocky parsed the raw `.sql` files directly. The `emission` block is populated whenever `--output-dir` writes succeeded.
+`import_method` is `"manifest"` when a compiled `target/manifest.json` was found (pre-resolved Jinja), or `"regex"` when Rocky parsed the raw `.sql` files directly. The `emission` block is populated whenever `--output-dir` writes succeeded. Model-level import failures use the command's partial-import contract and do not make the process exit non-zero, so automation must check `failed` and `failed_details` before consuming the emitted repository.
 
 Import into a custom directory and override the target adapter (e.g. migrating a Postgres dbt project to Rocky-on-Snowflake):
 

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `rocky import-dbt` now refuses models whose unresolved raw Jinja invokes `is_incremental()` (`--no-manifest` or an uncompiled manifest node), instead of deleting bounded logic and potentially emitting an unbounded transformation. (#1183)
+
 ## [1.66.1] - 2026-07-20
 
 ### Fixed

--- a/engine/crates/rocky-compiler/src/import/dbt.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt.rs
@@ -8,7 +8,8 @@
 //! - `{{ source('source_name', 'table_name') }}` -> fully qualified ref
 //! - `{{ config(materialized='incremental', unique_key='id') }}` -> ModelConfig
 //! - `{{ this }}` -> target table ref
-//! - `{% if is_incremental() %}` -> Rocky incremental strategy
+//! - Raw Jinja that invokes `is_incremental()` -> refused because dbt's
+//!   first-run/subsequent-run distinction cannot be preserved
 //!
 //! **Import paths:**
 //! - **Manifest (preferred):** uses `compiled_code` from `target/manifest.json`
@@ -31,6 +32,13 @@ use super::dbt_manifest::{
 };
 use super::dbt_project::{self, DbtProjectConfig};
 use super::dbt_sources;
+
+const RAW_INCREMENTAL_ERROR: &str = "contains an unresolved `is_incremental()` guard; \
+the raw SQL importer cannot preserve dbt's false-on-bootstrap, true-on-existing-target semantics \
+without either referencing a missing target during bootstrap or deleting bounded incremental \
+logic. Compile dbt in an incremental context, verify the compiled SQL retains its intended \
+predicate and is valid for Rocky's initial target state, and import that manifest; otherwise, \
+rewrite the model with a Rocky-supported strategy";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -83,7 +91,7 @@ pub enum ImportMethod {
 pub enum WarningCategory {
     /// View or ephemeral materialization not natively supported.
     UnsupportedMaterialization,
-    /// Jinja control flow other than `is_incremental()`.
+    /// Jinja control flow that cannot be translated faithfully.
     JinjaControlFlow,
     /// Custom Jinja macro that couldn't be resolved.
     UnsupportedMacro,
@@ -997,6 +1005,13 @@ fn import_manifest_node(
     let mut sql = match &node.compiled_code {
         Some(code) => rewrite_upstream_refs_to_bare(code, node, model_relations),
         None => {
+            if contains_unresolved_is_incremental(&node.raw_code) {
+                result.failed.push(ImportFailure {
+                    name: node.name.clone(),
+                    reason: RAW_INCREMENTAL_ERROR.to_string(),
+                });
+                return;
+            }
             result.warnings.push(ImportWarning {
                 model: node.name.clone(),
                 category: WarningCategory::JinjaControlFlow,
@@ -1937,8 +1952,13 @@ fn import_single_model(
 
     let mut warnings = Vec::new();
 
-    // Detect is_incremental() before general Jinja handling
-    let (content_processed, incr_result) = detect_is_incremental(&content);
+    // Refuse is_incremental() before general Jinja handling. This must catch
+    // compound conditions too: otherwise the generic fallback removes the
+    // control tags and applies the guarded body unconditionally.
+    if contains_unresolved_is_incremental(&content) {
+        return Err(RAW_INCREMENTAL_ERROR.to_string());
+    }
+    let content_processed = content;
 
     // Check for remaining unsupported Jinja patterns
     if content_processed.contains("{%") {
@@ -1999,16 +2019,6 @@ fn import_single_model(
             "set `type = \"full_refresh\"` (or `\"ephemeral\"` for staging models) in the emitted sidecar".to_string(),
         ),
     }));
-
-    // If is_incremental() was detected and config didn't already set incremental,
-    // override the strategy
-    if let Some(ref incr) = incr_result
-        && matches!(strategy, StrategyConfig::FullRefresh)
-    {
-        strategy = StrategyConfig::Incremental {
-            timestamp_column: incr.timestamp_column.clone(),
-        };
-    }
 
     // Apply project config inheritance
     let (resolved_schema, resolved_tags) = if let Some(proj) = project_config {
@@ -2119,6 +2129,21 @@ fn import_single_model(
 // ---------------------------------------------------------------------------
 // is_incremental() detection
 // ---------------------------------------------------------------------------
+
+/// Whether a raw Jinja statement or expression invokes dbt's
+/// `is_incremental()` macro.
+///
+/// This includes compound conditions and indirect forms such as assigning the
+/// result with `{% set %}`. Raw import cannot evaluate any of them faithfully.
+fn contains_unresolved_is_incremental(sql: &str) -> bool {
+    let jinja_re = Regex::new(r"(?s)(?:\{%-?(.*?)-?%\}|\{\{-?(.*?)-?\}\})").unwrap();
+    let invocation_re = Regex::new(r"\bis_incremental\s*\(\s*\)").unwrap();
+    jinja_re.captures_iter(sql).any(|caps| {
+        caps.get(1)
+            .or_else(|| caps.get(2))
+            .is_some_and(|body| invocation_re.is_match(body.as_str()))
+    })
+}
 
 /// Result of detecting `{% if is_incremental() %}` in SQL.
 #[derive(Debug, Clone)]
@@ -2649,6 +2674,26 @@ mod tests {
     // --- is_incremental() detection tests ---
 
     #[test]
+    fn unresolved_incremental_detects_compound_and_indirect_jinja() {
+        assert!(contains_unresolved_is_incremental(
+            "{% if execute and is_incremental ( ) %}SELECT 1{% endif %}"
+        ));
+        assert!(contains_unresolved_is_incremental(
+            "{% if execute %}SELECT 1{% elif target.name == 'prod' and is_incremental() %}SELECT 2{% endif %}"
+        ));
+        assert!(contains_unresolved_is_incremental(
+            "{% if batch_id % 2 == 0 and is_incremental() %}SELECT 1{% endif %}"
+        ));
+        assert!(contains_unresolved_is_incremental(
+            "{% set incremental = is_incremental() %}"
+        ));
+        assert!(contains_unresolved_is_incremental("{{ is_incremental() }}"));
+        assert!(!contains_unresolved_is_incremental(
+            "SELECT 'is_incremental()' AS text"
+        ));
+    }
+
+    #[test]
     fn test_detect_is_incremental_standard() {
         let sql = r#"
 SELECT *
@@ -3024,7 +3069,7 @@ sources:
     }
 
     #[test]
-    fn test_import_dbt_project_is_incremental_integration() {
+    fn raw_append_incremental_guard_is_refused() {
         let dir = tempfile::TempDir::new().unwrap();
 
         std::fs::create_dir_all(dir.path().join("models")).unwrap();
@@ -3032,6 +3077,41 @@ sources:
         std::fs::write(
             dir.path().join("models/fct_events.sql"),
             r#"
+{{ config(materialized='incremental') }}
+
+SELECT *
+FROM {{ ref('stg_events') }}
+{% if execute and is_incremental ( ) %}
+  WHERE event_time > (SELECT MAX(event_time) FROM {{ this }})
+{% endif %}
+"#,
+        )
+        .unwrap();
+
+        let target = TargetConfig {
+            catalog: "warehouse".to_string(),
+            schema: "staging".to_string(),
+            table: String::new(),
+        };
+
+        let result = import_dbt_project(dir.path(), &target).unwrap();
+        assert!(result.imported.is_empty());
+        assert_eq!(result.failed.len(), 1);
+        assert_eq!(result.failed[0].name, "fct_events");
+        assert!(result.failed[0].reason.contains("is_incremental()"));
+        assert!(result.failed[0].reason.contains("unresolved"));
+        assert!(result.failed[0].reason.contains("compiled SQL"));
+    }
+
+    #[test]
+    fn raw_incremental_guard_is_refused_for_keyed_merge() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join("models")).unwrap();
+        std::fs::write(
+            dir.path().join("models/fct_events.sql"),
+            r#"
+{{ config(materialized='incremental', unique_key='id') }}
+
 SELECT *
 FROM {{ ref('stg_events') }}
 {% if is_incremental() %}
@@ -3048,15 +3128,10 @@ FROM {{ ref('stg_events') }}
         };
 
         let result = import_dbt_project(dir.path(), &target).unwrap();
-        assert_eq!(result.imported.len(), 1);
-        assert!(matches!(
-            result.imported[0].config.strategy,
-            StrategyConfig::Incremental {
-                ref timestamp_column
-            } if timestamp_column == "event_time"
-        ));
-        // Incremental block should be removed from SQL
-        assert!(!result.imported[0].sql.contains("is_incremental"));
+        assert!(result.imported.is_empty());
+        assert_eq!(result.failed.len(), 1);
+        assert_eq!(result.failed[0].name, "fct_events");
+        assert!(result.failed[0].reason.contains("is_incremental()"));
     }
 
     #[test]
@@ -3470,6 +3545,49 @@ FROM {{ ref('stg_events') }}
                 .any(|w| matches!(w.category, WarningCategory::StaleManifest)),
             "a manifest with no compiled SQL must warn loudly"
         );
+    }
+
+    #[test]
+    fn manifest_raw_fallback_refuses_append_incremental_guard() {
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": { "model.p.events": {
+                "unique_id": "model.p.events", "name": "events", "resource_type": "model",
+                "raw_code": "SELECT * FROM raw.events\n{% if target.name == 'prod' and is_incremental() %}\nWHERE event_time > (SELECT MAX(event_time) FROM {{ this }})\n{% endif %}",
+                "depends_on": { "nodes": [], "macros": [] },
+                "config": { "materialized": "incremental" },
+                "columns": {}, "tags": [], "schema": "s", "database": "d"
+            }},
+            "sources": {}
+        });
+
+        let result = import_from_manifest_json(&manifest);
+        assert!(result.imported.is_empty());
+        assert_eq!(result.failed.len(), 1);
+        assert_eq!(result.failed[0].name, "events");
+        assert!(result.failed[0].reason.contains("is_incremental()"));
+        assert!(result.failed[0].reason.contains("unresolved"));
+    }
+
+    #[test]
+    fn manifest_raw_fallback_refuses_incremental_guard_for_keyed_merge() {
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": { "model.p.events": {
+                "unique_id": "model.p.events", "name": "events", "resource_type": "model",
+                "raw_code": "SELECT * FROM raw.events\n{% if is_incremental() %}\nWHERE event_time > (SELECT MAX(event_time) FROM {{ this }})\n{% endif %}",
+                "depends_on": { "nodes": [], "macros": [] },
+                "config": { "materialized": "incremental", "unique_key": "id" },
+                "columns": {}, "tags": [], "schema": "s", "database": "d"
+            }},
+            "sources": {}
+        });
+
+        let result = import_from_manifest_json(&manifest);
+        assert!(result.imported.is_empty());
+        assert_eq!(result.failed.len(), 1);
+        assert_eq!(result.failed[0].name, "events");
+        assert!(result.failed[0].reason.contains("is_incremental()"));
     }
 
     #[test]

--- a/engine/crates/rocky-compiler/src/import/emit.rs
+++ b/engine/crates/rocky-compiler/src/import/emit.rs
@@ -954,9 +954,12 @@ fn write_migration_notes(path: &Path, ctx: &MigrationContext<'_>) -> Result<(), 
     out.push_str("- **Singular tests** in `tests/` (custom SQL) — copy and rewrite manually.\n");
     out.push_str("- **dbt macros / `dbt_packages/`** — Rocky has no Jinja runtime. Hand-port any ");
     out.push_str("logic to plain SQL or to a Rocky AI prompt.\n");
-    out.push_str("- **`{% if %}` / `{% for %}` / `{{ var() }}`** outside of `is_incremental()` — ");
-    out.push_str("the body is emitted verbatim with `# TODO: dbt-jinja-not-translated` comments ");
-    out.push_str("flagging the lines you need to revisit.\n");
+    out.push_str("- **Raw Jinja control flow** — unresolved Jinja that invokes ");
+    out.push_str("`is_incremental()` is refused on every raw import path. ");
+    out.push_str("With `--no-manifest`, ");
+    out.push_str("`{% for %}` / `{% set %}` models are also refused. Other `{% if %}` bodies ");
+    out.push_str("are emitted with ");
+    out.push_str("`# TODO: dbt-jinja-not-translated` comments and must be reviewed.\n");
     if !ctx.unknown_materializations.is_empty() {
         out.push_str("- **Unmapped `materialized` values** (treated as `full_refresh`):\n");
         for name in ctx.unknown_materializations {

--- a/engine/rocky/tests/import_dbt_incremental.rs
+++ b/engine/rocky/tests/import_dbt_incremental.rs
@@ -1,0 +1,63 @@
+//! Regression coverage for unsafe raw dbt incremental guards.
+
+use std::fs;
+use std::process::Command;
+
+#[test]
+fn no_manifest_refuses_unbounded_append_model() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dbt_dir = tmp.path().join("dbt");
+    let models_dir = dbt_dir.join("models");
+    let out_dir = tmp.path().join("out");
+    fs::create_dir_all(&models_dir).expect("create dbt models");
+    fs::write(
+        dbt_dir.join("dbt_project.yml"),
+        "name: incremental_repro\nversion: '1.0'\nprofile: incremental_repro\n",
+    )
+    .expect("write dbt project");
+    fs::write(
+        dbt_dir.join("profiles.yml"),
+        "incremental_repro:\n  target: dev\n  outputs:\n    dev:\n      type: duckdb\n      path: fixture.duckdb\n      schema: main\n",
+    )
+    .expect("write dbt profile");
+    fs::write(
+        models_dir.join("events.sql"),
+        r#"{{ config(materialized='incremental') }}
+SELECT *
+FROM raw.events
+{% if is_incremental() %}
+WHERE event_time > (SELECT MAX(event_time) FROM {{ this }})
+{% endif %}
+"#,
+    )
+    .expect("write incremental model");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rocky"))
+        .args(["--output", "json", "import-dbt", "--dbt-project"])
+        .arg(&dbt_dir)
+        .arg("--output-dir")
+        .arg(&out_dir)
+        .arg("--no-manifest")
+        .env("RUST_LOG", "error")
+        .output()
+        .expect("run import-dbt");
+
+    assert!(
+        output.status.success(),
+        "import-dbt failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let result: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("import-dbt output should be JSON");
+    assert_eq!(result["imported"], 0);
+    assert_eq!(result["failed"], 1);
+    assert_eq!(result["failed_details"][0]["name"], "events");
+    assert!(
+        result["failed_details"][0]["reason"]
+            .as_str()
+            .is_some_and(|reason| reason.contains("is_incremental()"))
+    );
+    assert_eq!(result["emission"]["models_translated_count"], 0);
+    assert!(!out_dir.join("models/events.sql").exists());
+    assert!(!out_dir.join("models/events.toml").exists());
+}


### PR DESCRIPTION
## Summary

Fail closed whenever a raw dbt model still contains Jinja that invokes
`is_incremental()`. Rocky cannot preserve dbt's
false-on-bootstrap/true-on-existing-target distinction from raw SQL, so the
model is now reported under `failed_details` and no model SQL or sidecar is
emitted.

This applies to both append-only models and models with a `unique_key`: a
full-source merge is idempotent by key, but it is not semantically equivalent
to the bounded dbt query.

Closes #1183.

## Root cause

The raw importer called `detect_is_incremental`, which removed the guarded
predicate before conversion. For append-only incremental materialization,
Rocky then reused the remaining unfiltered query for every `INSERT`,
duplicating the full source on each run. That detector only recognized the
exact `{% if is_incremental() %}` spelling; compound conditions could instead
fall through the generic Jinja fallback, which applies conditional bodies
unconditionally.

Allowing the same rewrite for a keyed merge avoids duplicate keys, but still
changes which source rows are evaluated and can rewrite historical rows or
recompute nondeterministic expressions. Raw guards therefore need one
strategy-independent, fail-closed rule.

## Changes

- Refuse any raw Jinja statement or expression that invokes
  `is_incremental()` on both raw SQL paths: `--no-manifest` and manifest nodes
  without `compiled_code`. This covers compound `if` / `elif` conditions,
  whitespace inside the call, and indirect `{% set %}` forms.
- Apply the refusal before strategy inference or Jinja conversion, including
  keyed merge models.
- Add compiler coverage for append and keyed models on both raw paths.
- Add a real-binary regression proving the CLI reports the model failure and
  emits no SQL or sidecar artifacts.
- Correct the migration guide, command reference, changelog, and generated
  migration notes to describe the actual semantics and remediation.

The CLI keeps its existing partial-import contract: individual model failures
are returned in `failed` / `failed_details` while the process exits
successfully. Compiled manifest models are unchanged; users should still verify
that compiled SQL retains the intended predicate and is valid for Rocky's
initial target state.

## Validation

- `cargo test -p rocky-compiler` — 394 unit tests and 22 integration tests
  passed; doc tests passed (1 ignored).
- `cargo test -p rocky --test import_dbt_incremental -- --nocapture` — passed.
- `cargo test -p rocky-cli --test import_dbt_emit -- --nocapture` — passed.
- `cargo fmt --all -- --check` and `git diff --check` — passed.
- `npm run build` in `docs/` — passed; 98 pages built.
- GitHub Actions — all 8 required checks passed.
- Patch-specific Clippy passed:
  - `cargo clippy -p rocky-compiler --all-targets --all-features -- -D warnings -A unused-assignments`
  - `cargo clippy -p rocky --test import_dbt_incremental -- -D warnings -A unused-assignments -A clippy::collapsible-else-if`

The unmodified strict Clippy command is currently blocked locally by
pre-existing Rust 1.93 `unused_assignments` diagnostics from miette-derived
structs and a `collapsible_else_if` diagnostic in
`rocky-cli/src/commands/list.rs`; none are in this diff.
