### PR TITLE
fix(ci): publish engine releases atomically to close the install race

### DIFF
--- a/.github/workflows/engine-release.yml
+++ b/.github/workflows/engine-release.yml
@@ -3,6 +3,17 @@ name: engine-release
 # Full cross-platform release matrix. Builds binaries for all supported
 # platforms and attaches them to the GitHub Release created by the tag push.
 #
+# The release is published atomically: `ensure-release` creates it as a
+# **draft**, the matrix and `checksums` attach every artifact, and only then
+# does `publish` flip it to a published release. This matters because
+# `engine/install.sh` resolves "latest" by listing `/releases` (unauthenticated)
+# and taking the highest `engine-v*` tag. Draft releases are omitted from that
+# listing, so the new version becomes resolvable only once its binaries exist.
+# Creating the release up front (as this workflow used to) made the tag
+# resolvable for the ~15-25 min the matrix was still building, so any
+# concurrent `install.sh` — a user's, or another PR's smoke job — resolved
+# `engine-v<new>` and 404'd on the not-yet-uploaded archive.
+#
 # scripts/release.sh remains as a local-build hotfix fallback.
 
 on:
@@ -146,12 +157,24 @@ jobs:
           Compress-Archive -Path target/${{ matrix.target }}/release/rocky.exe -DestinationPath ${{ matrix.archive }}
           Compress-Archive -Path target/${{ matrix.target }}/release/rocky-lsp.exe -DestinationPath ${{ matrix.lsp_archive }}
 
+      # Upload with `gh` rather than a release action: `gh release upload`
+      # touches assets only, so it cannot disturb the draft state that
+      # `publish` is responsible for clearing. (A release action that PATCHes
+      # the release would publish it early and reintroduce the race this
+      # workflow exists to avoid.) Same mechanism the `checksums` job uses.
+      # `shell: bash` so the windows-2022 runner doesn't run this under pwsh;
+      # paths are relative to the workflow-level `working-directory: engine`,
+      # which is where the packaging steps above wrote the archives.
       - name: Attach to GitHub Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
-        with:
-          files: |
-            engine/${{ matrix.archive }}
-            engine/${{ matrix.lsp_archive }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${GITHUB_REF_NAME}" \
+            "${{ matrix.archive }}" \
+            "${{ matrix.lsp_archive }}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --clobber
 
   # Generate checksums.txt from all platform archives and attach to the release.
   # Runs after all build jobs so every archive is present before hashing.
@@ -206,9 +229,48 @@ jobs:
             --repo "${GITHUB_REPOSITORY}" \
             --clobber
 
+  # Publish the draft, making the version resolvable by engine/install.sh.
+  # Depends on `checksums` as well as `build` so checksums.txt is in place
+  # before anyone can resolve the release — install.sh fetches it to verify
+  # the download.
+  #
+  # `--latest` here rather than at creation: the engine binary owns the repo's
+  # "Latest" badge, and asserting it at publish time also settles the ordering
+  # when a coupled release pushes engine/sdk/dagster/vscode tags together.
+  #
+  # Fail-closed by design: if any platform build or the checksums job fails,
+  # this job is skipped and the release stays an unpublished draft rather than
+  # going live half-populated. That leftover draft is the intended outcome, not
+  # a bug — re-run the failed jobs and this publishes it.
+  publish:
+    name: Publish release
+    needs: [ensure-release, build, checksums]
+    runs-on: ubuntu-24.04
+    # Override the workflow-level `working-directory: engine` — this job needs
+    # no checkout, so that directory does not exist here.
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
+    steps:
+      - name: Publish the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit "${GITHUB_REF_NAME}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --draft=false \
+            --latest
+          echo "Published ${GITHUB_REF_NAME}"
+
   # Create the GitHub Release if it doesn't already exist (supports both
   # CI-only releases and the local scripts/release.sh workflow where the
   # release is created before the tag push).
+  #
+  # Created as a draft so it stays out of the public `/releases` listing until
+  # `publish` runs — see the header comment. An existing release (the
+  # scripts/release.sh path) is left exactly as it is: it already carries the
+  # artifacts that path uploaded, so forcing it back to draft would briefly
+  # retract something deliberately published.
   ensure-release:
     name: Ensure GitHub Release exists
     runs-on: ubuntu-24.04
@@ -226,10 +288,10 @@ jobs:
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "Release $TAG already exists (created by scripts/release.sh)"
           else
-            echo "Creating release $TAG"
+            echo "Creating draft release $TAG"
             gh release create "$TAG" \
               --repo "$GITHUB_REPOSITORY" \
               --generate-notes \
-              --latest \
+              --draft \
               --title "$TAG"
           fi

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A new engine release is no longer installable before its binaries exist. `engine-release.yml` created the GitHub Release up front, which made the new tag resolvable by `install.sh` / `install.ps1` (both pick the highest `engine-v*` from the public `/releases` listing) for the ~15-25 minutes the build matrix was still running — so an install started in that window resolved the new version and failed with a 404 on the missing archive. The release is now created as a draft, which is omitted from that listing, and is published only after every platform archive and `checksums.txt` are attached. A failed build now leaves the release unpublished instead of live and half-populated.
+
 ## [1.66.1] - 2026-07-20
 
 ### Fixed


### PR DESCRIPTION
## Summary

An engine release became installable ~15-25 minutes before its binaries existed. `engine-release.yml` created the GitHub Release in `ensure-release`, *before* the build matrix uploaded anything, so the new tag was immediately resolvable while the archives were still building.

Both installers resolve "latest" by listing the public `/releases` endpoint and taking the highest `engine-v*` tag (`install.sh:110-123`, `install.ps1:80-84`). During the build window they resolved the new version and 404'd:

```
Installing Rocky engine-v1.66.1 (x86_64-unknown-linux-gnu)...
curl: (22) The requested URL returned error: 404
```

Observed on #1182 during the `engine-v1.66.1` cut, where it failed that PR's `Example smoke (real binary)` job. **It is not CI-only** — a user running `install.sh` in that window hit the same 404.

## Subproject(s) touched

- [ ] `engine/` (Rust CLI / crates) — changelog only
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [x] Cross-project (CI, scripts, root docs)

## Changes

Publish the release atomically — it becomes visible only once it is complete.

- `ensure-release` creates the release as a **draft**. Draft releases are omitted from the unauthenticated `/releases` listing, so neither installer can resolve the version yet.
- New `publish` job (`needs: [ensure-release, build, checksums]`) flips it with `gh release edit --draft=false --latest` once every archive and `checksums.txt` are attached.
- Build matrix uploads via `gh release upload` instead of `softprops/action-gh-release`. A release action that PATCHes the release could clear the draft flag early and reinstate the race; `gh release upload` touches assets only. This also matches the existing `checksums` job and drops a third-party action from a `contents: write` workflow.
- `--latest` moves from creation to publish, which additionally settles the "Latest" badge ordering when a coupled release pushes engine/sdk/dagster/vscode tags together.

Two deliberate non-changes: an already-existing release (the `scripts/release.sh` fallback path) is left published rather than forced back to draft, and `install.sh` is untouched — adding a fallback there would mask the underlying problem rather than fix it.

**Fail-closed is now intended behavior:** if a platform build or `checksums` fails, `publish` is skipped and the release stays an unpublished draft instead of going live half-populated. Re-running the failed jobs publishes it. This is commented in the workflow so it isn't later mistaken for a bug.

## Test Plan

The draft mechanics are not exercisable without cutting a release, so I verified each one against the live GitHub API using throwaway draft releases (created and deleted; `--latest=false` throughout so the real badge was never touched — GitHub defaults `make_latest` to true on publish). Verified after cleanup: no probe release, no stray tags, `releases/latest` still `engine-v1.66.1`.

- [x] `gh release upload` succeeds against a **draft** release (exit 0) — the mechanism the build matrix now relies on
- [x] `gh release download` succeeds against a **draft** release (exit 0, content intact) — the `checksums` job depends on this
- [x] `gh release view <tag>` resolves a draft by tag (GitHub's get-release-by-tag API excludes drafts; `gh` falls back to a draft listing)
- [x] A draft is **absent** from the unauthenticated `/releases?per_page=30` listing — the exact query both installers run, i.e. the property the fix rests on
- [x] `gh release edit --draft=false` publishes it (`isDraft` → `false`)
- [x] `actionlint .github/workflows/engine-release.yml` clean
- [x] Job graph parses as `ensure-release → build → checksums → publish`
- [x] Credential-containment checker passes on the edited tree (run with the trusted base laid out correctly, since the checker resolves it via `Path(__file__).resolve().parents[2]`)

Residual risk is concentrated in the `gh release upload` swap, which cannot be exercised until the next cut: it is cross-platform (`shell: bash` so windows-2022 doesn't run it under pwsh) and needs `GH_TOKEN` explicitly, where `softprops` consumed `GITHUB_TOKEN` implicitly. Both are handled here; flagging where a latent bug would surface.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/), scoped by subproject when relevant.
- [x] No `Co-Authored-By` trailers.
- [x] No CLI JSON schema or DSL syntax changed.