### PR TITLE
fix(engine/rocky-compiler): detect aliased dbt incrementals

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Raw `rocky import-dbt` paths now refuse bare references to the `is_incremental` macro, including callable aliases assigned with `{% set %}`, instead of missing the indirect call and emitting its guarded predicate unconditionally. (#1194)
 - `rocky import-dbt` now refuses models whose unresolved raw Jinja invokes `is_incremental()` (`--no-manifest` or an uncompiled manifest node), instead of deleting bounded logic and potentially emitting an unbounded transformation. (#1183)
 - A new engine release is no longer installable before its binaries exist. `engine-release.yml` created the GitHub Release up front, which made the new tag resolvable by `install.sh` / `install.ps1` (both pick the highest `engine-v*` from the public `/releases` listing) for the ~15-25 minutes the build matrix was still running — so an install started in that window resolved the new version and failed with a 404 on the missing archive. The release is now created as a draft, which is omitted from that listing, and is published only after every platform archive and `checksums.txt` are attached. A failed build now leaves the release unpublished instead of live and half-populated.
 

--- a/engine/crates/rocky-compiler/src/import/dbt.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt.rs
@@ -33,7 +33,7 @@ use super::dbt_manifest::{
 use super::dbt_project::{self, DbtProjectConfig};
 use super::dbt_sources;
 
-const RAW_INCREMENTAL_ERROR: &str = "contains an unresolved `is_incremental()` guard; \
+const RAW_INCREMENTAL_ERROR: &str = "contains an unresolved reference to dbt's `is_incremental()` macro; \
 the raw SQL importer cannot preserve dbt's false-on-bootstrap, true-on-existing-target semantics \
 without either referencing a missing target during bootstrap or deleting bounded incremental \
 logic. Compile dbt in an incremental context, verify the compiled SQL retains its intended \
@@ -2130,19 +2130,111 @@ fn import_single_model(
 // is_incremental() detection
 // ---------------------------------------------------------------------------
 
-/// Whether a raw Jinja statement or expression invokes dbt's
-/// `is_incremental()` macro.
+/// Whether a raw Jinja statement or expression references dbt's
+/// `is_incremental` macro.
 ///
-/// This includes compound conditions and indirect forms such as assigning the
-/// result with `{% set %}`. Raw import cannot evaluate any of them faithfully.
+/// This includes compound conditions and aliases that capture the callable
+/// without invoking it in the same tag. Raw import cannot evaluate any of them
+/// faithfully.
 fn contains_unresolved_is_incremental(sql: &str) -> bool {
-    let jinja_re = Regex::new(r"(?s)(?:\{%-?(.*?)-?%\}|\{\{-?(.*?)-?\}\})").unwrap();
-    let invocation_re = Regex::new(r"\bis_incremental\s*\(\s*\)").unwrap();
-    jinja_re.captures_iter(sql).any(|caps| {
-        caps.get(1)
-            .or_else(|| caps.get(2))
-            .is_some_and(|body| invocation_re.is_match(body.as_str()))
-    })
+    let mut search_start = 0;
+
+    while search_start < sql.len() {
+        let rest = &sql[search_start..];
+        let statement_start = rest.find("{%");
+        let expression_start = rest.find("{{");
+        let (relative_start, closing_delimiter) = match (statement_start, expression_start) {
+            (Some(statement), Some(expression)) if statement <= expression => (statement, "%}"),
+            (Some(_), Some(expression)) => (expression, "}}"),
+            (Some(statement), None) => (statement, "%}"),
+            (None, Some(expression)) => (expression, "}}"),
+            (None, None) => break,
+        };
+
+        let tag_start = search_start + relative_start;
+        let body_start = tag_start + 2;
+        let Some(relative_end) = find_jinja_tag_end(&sql[body_start..], closing_delimiter) else {
+            // The template is malformed, but keep scanning in case a later
+            // complete tag contains the unsafe reference.
+            search_start = body_start;
+            continue;
+        };
+        let body_end = body_start + relative_end;
+
+        if contains_unquoted_jinja_identifier(&sql[body_start..body_end], "is_incremental") {
+            return true;
+        }
+
+        search_start = body_end + closing_delimiter.len();
+    }
+
+    false
+}
+
+/// Locate a Jinja tag's closing delimiter without treating delimiter text
+/// inside a quoted string as the end of the tag.
+fn find_jinja_tag_end(body: &str, closing_delimiter: &str) -> Option<usize> {
+    let mut chars = body.char_indices();
+    let mut quote = None;
+
+    while let Some((index, ch)) = chars.next() {
+        if let Some(delimiter) = quote {
+            if ch == '\\' {
+                chars.next();
+            } else if ch == delimiter {
+                quote = None;
+            }
+            continue;
+        }
+
+        if ch == '\'' || ch == '"' {
+            quote = Some(ch);
+        } else if body[index..].starts_with(closing_delimiter) {
+            return Some(index);
+        }
+    }
+
+    None
+}
+
+/// Find a standalone Jinja identifier while ignoring quoted string contents.
+/// A string value such as `{% set label = "is_incremental" %}` cannot capture
+/// the macro callable and should not make an otherwise safe model fail.
+fn contains_unquoted_jinja_identifier(body: &str, identifier: &str) -> bool {
+    let mut chars = body.char_indices();
+    let mut quote = None;
+
+    while let Some((index, ch)) = chars.next() {
+        if let Some(delimiter) = quote {
+            if ch == '\\' {
+                chars.next();
+            } else if ch == delimiter {
+                quote = None;
+            }
+            continue;
+        }
+
+        if ch == '\'' || ch == '"' {
+            quote = Some(ch);
+            continue;
+        }
+
+        if body[index..].starts_with(identifier) {
+            let before = body[..index].chars().next_back();
+            let after = body[index + identifier.len()..].chars().next();
+            let standalone = before.is_none_or(|c| !is_jinja_identifier_char(c))
+                && after.is_none_or(|c| !is_jinja_identifier_char(c));
+            if standalone {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+fn is_jinja_identifier_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_'
 }
 
 /// Result of detecting `{% if is_incremental() %}` in SQL.
@@ -2687,7 +2779,19 @@ mod tests {
         assert!(contains_unresolved_is_incremental(
             "{% set incremental = is_incremental() %}"
         ));
+        assert!(contains_unresolved_is_incremental(
+            "{% set incremental_check = is_incremental %}"
+        ));
+        assert!(contains_unresolved_is_incremental(
+            "{% set incremental_check = '%}' and is_incremental %}"
+        ));
         assert!(contains_unresolved_is_incremental("{{ is_incremental() }}"));
+        assert!(!contains_unresolved_is_incremental(
+            "{% set label = 'is_incremental' %}"
+        ));
+        assert!(!contains_unresolved_is_incremental(
+            "{% set is_incrementally = true %}"
+        ));
         assert!(!contains_unresolved_is_incremental(
             "SELECT 'is_incremental()' AS text"
         ));

--- a/engine/crates/rocky-compiler/src/import/emit.rs
+++ b/engine/crates/rocky-compiler/src/import/emit.rs
@@ -954,8 +954,10 @@ fn write_migration_notes(path: &Path, ctx: &MigrationContext<'_>) -> Result<(), 
     out.push_str("- **Singular tests** in `tests/` (custom SQL) — copy and rewrite manually.\n");
     out.push_str("- **dbt macros / `dbt_packages/`** — Rocky has no Jinja runtime. Hand-port any ");
     out.push_str("logic to plain SQL or to a Rocky AI prompt.\n");
-    out.push_str("- **Raw Jinja control flow** — unresolved Jinja that invokes ");
-    out.push_str("`is_incremental()` is refused on every raw import path. ");
+    out.push_str("- **Raw Jinja control flow** — unresolved Jinja that references the ");
+    out.push_str(
+        "`is_incremental` macro, including callable aliases, is refused on every raw import path. ",
+    );
     out.push_str("With `--no-manifest`, ");
     out.push_str("`{% for %}` / `{% set %}` models are also refused. Other `{% if %}` bodies ");
     out.push_str("are emitted with ");

--- a/engine/examples/dbt-migration/README.md
+++ b/engine/examples/dbt-migration/README.md
@@ -33,7 +33,7 @@ rocky-project/
 | Config | `{{ config(materialized='table') }}` in SQL | Separate `.toml` sidecar file |
 | References | `{{ ref('model_name') }}` | Bare name `from stg_customers` |
 | Templating | Jinja2 | None — compiled DSL or plain SQL |
-| Incremental | `{% if is_incremental() %}` blocks | `type = "incremental"` in `.toml` + timestamp column |
+| Incremental | Compile or manually rewrite `{% if is_incremental() %}` blocks; raw imports fail closed | `type = "incremental"` in `.toml` + timestamp column |
 | Schema tests | YAML `schema.yml` files | Contracts (`.contract.toml`) or AI-generated tests |
 | CLI | `dbt run`, `dbt test` | `rocky run`, `rocky plan` |
 

--- a/engine/rocky/tests/import_dbt_incremental.rs
+++ b/engine/rocky/tests/import_dbt_incremental.rs
@@ -1,15 +1,10 @@
 //! Regression coverage for unsafe raw dbt incremental guards.
 
 use std::fs;
+use std::path::Path;
 use std::process::Command;
 
-#[test]
-fn no_manifest_refuses_unbounded_append_model() {
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let dbt_dir = tmp.path().join("dbt");
-    let models_dir = dbt_dir.join("models");
-    let out_dir = tmp.path().join("out");
-    fs::create_dir_all(&models_dir).expect("create dbt models");
+fn write_project_files(dbt_dir: &Path) {
     fs::write(
         dbt_dir.join("dbt_project.yml"),
         "name: incremental_repro\nversion: '1.0'\nprofile: incremental_repro\n",
@@ -20,6 +15,16 @@ fn no_manifest_refuses_unbounded_append_model() {
         "incremental_repro:\n  target: dev\n  outputs:\n    dev:\n      type: duckdb\n      path: fixture.duckdb\n      schema: main\n",
     )
     .expect("write dbt profile");
+}
+
+#[test]
+fn no_manifest_refuses_unbounded_append_model() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dbt_dir = tmp.path().join("dbt");
+    let models_dir = dbt_dir.join("models");
+    let out_dir = tmp.path().join("out");
+    fs::create_dir_all(&models_dir).expect("create dbt models");
+    write_project_files(&dbt_dir);
     fs::write(
         models_dir.join("events.sql"),
         r#"{{ config(materialized='incremental') }}
@@ -49,6 +54,77 @@ WHERE event_time > (SELECT MAX(event_time) FROM {{ this }})
     );
     let result: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("import-dbt output should be JSON");
+    assert_eq!(result["imported"], 0);
+    assert_eq!(result["failed"], 1);
+    assert_eq!(result["failed_details"][0]["name"], "events");
+    assert!(
+        result["failed_details"][0]["reason"]
+            .as_str()
+            .is_some_and(|reason| reason.contains("is_incremental()"))
+    );
+    assert_eq!(result["emission"]["models_translated_count"], 0);
+    assert!(!out_dir.join("models/events.sql").exists());
+    assert!(!out_dir.join("models/events.toml").exists());
+}
+
+#[test]
+fn raw_manifest_refuses_aliased_incremental_macro() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dbt_dir = tmp.path().join("dbt");
+    let target_dir = dbt_dir.join("target");
+    let out_dir = tmp.path().join("out");
+    fs::create_dir_all(&target_dir).expect("create dbt target");
+    write_project_files(&dbt_dir);
+
+    let manifest = serde_json::json!({
+        "metadata": {
+            "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12/manifest.json",
+            "dbt_version": "1.10.0",
+            "project_name": "incremental_repro"
+        },
+        "nodes": {
+            "model.incremental_repro.events": {
+                "unique_id": "model.incremental_repro.events",
+                "name": "events",
+                "resource_type": "model",
+                "raw_code": r#"{% set incremental_check = is_incremental %}
+SELECT * FROM raw.events
+{% if incremental_check() %}
+WHERE event_time > (SELECT MAX(event_time) FROM {{ this }})
+{% endif %}"#,
+                "depends_on": { "nodes": [], "macros": [] },
+                "config": { "materialized": "incremental" },
+                "columns": {},
+                "tags": [],
+                "schema": "main",
+                "database": "fixture"
+            }
+        },
+        "sources": {}
+    });
+    fs::write(
+        target_dir.join("manifest.json"),
+        serde_json::to_vec(&manifest).expect("serialize manifest"),
+    )
+    .expect("write manifest");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rocky"))
+        .args(["--output", "json", "import-dbt", "--dbt-project"])
+        .arg(&dbt_dir)
+        .arg("--output-dir")
+        .arg(&out_dir)
+        .env("RUST_LOG", "error")
+        .output()
+        .expect("run import-dbt");
+
+    assert!(
+        output.status.success(),
+        "import-dbt failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let result: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("import-dbt output should be JSON");
+    assert_eq!(result["import_method"], "Manifest");
     assert_eq!(result["imported"], 0);
     assert_eq!(result["failed"], 1);
     assert_eq!(result["failed_details"][0]["name"], "events");

--- a/examples/playground/pocs/06-developer-experience/14-import-dbt-failure-modes/README.md
+++ b/examples/playground/pocs/06-developer-experience/14-import-dbt-failure-modes/README.md
@@ -8,11 +8,13 @@
 ## What it shows
 
 `rocky import-dbt` is opinionated about what it translates: canonical
-generic tests + `{{ ref }}` / `{{ source }}` / `{{ config }}` /
-`is_incremental()` translate cleanly, a growing set of common dbt
-constructs now **map** to native Rocky equivalents, and a small residue
-of genuinely runtime-only Jinja stays out of scope. This POC throws the
-edge cases at the importer in one go and verifies each is handled
+generic tests + `{{ ref }}` / `{{ source }}` / `{{ config }}` translate
+cleanly, a growing set of common dbt constructs now **map** to native
+Rocky equivalents, and genuinely runtime-only Jinja stays out of scope.
+In particular, every raw import path refuses references to dbt's
+`is_incremental` macro, including callable aliases, because Rocky cannot
+preserve its bootstrap semantics without compiled SQL. This POC throws
+other edge cases at the importer in one go and verifies each is handled
 cleanly — distinguishing the constructs that map from the ones that warn
 or are refused:
 
@@ -117,7 +119,8 @@ before pointing it at a real codebase.
 - **dbt generic tests outside the canonical four** ...
 - **Singular tests** in `tests/` (custom SQL) — copy and rewrite manually.
 - **dbt macros / `dbt_packages/`** — Rocky has no Jinja runtime. ...
-- **`{% if %}` / `{% for %}` / `{{ var() }}`** outside of `is_incremental()` — the body is emitted verbatim with `# TODO: dbt-jinja-not-translated` comments flagging the lines you need to revisit.
+- **Raw Jinja control flow** — unresolved Jinja that references the `is_incremental` macro, including callable aliases, is refused on every raw import path. With `--no-manifest`, `{% for %}` / `{% set %}` models are also refused. Other `{% if %}` bodies are emitted with `# TODO: dbt-jinja-not-translated` comments and must be reviewed.
+
 ## Warnings
 - `stg_variables` — MappedConstruct: {{ var() }} mapped to `@var()` ...
 - `stg_orders` — JinjaControlFlow: ...


### PR DESCRIPTION
## Summary

- fail closed when raw Jinja references the `is_incremental` callable without invoking it in the same tag
- parse Jinja tag boundaries without treating quoted `%}` or `}}` text as a closing delimiter
- add a raw-manifest CLI regression proving `imported: 0`, `failed: 1`, and no emitted model SQL or sidecar
- update migration notes, examples, and the changelog

## Root cause

The raw-manifest guard required `is_incremental` and `()` to appear together in one Jinja tag. Assigning the callable to an alias therefore bypassed the guard, after which generic Jinja lowering made the guarded predicate unconditional.

## Validation

- `cargo test -p rocky-compiler` (394 unit tests, 22 integration tests)
- `cargo test -p rocky --test import_dbt_incremental`
- `cargo clippy -p rocky-compiler -p rocky --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

Closes #1194
