### PR TITLE
fix(engine): fail-closed bootstrap follow-ups — propagate transient probe failures, executor survival tests, SDK parity

### DIFF
--- a/engine/crates/rocky-adapter-sdk/src/traits.rs
+++ b/engine/crates/rocky-adapter-sdk/src/traits.rs
@@ -20,6 +20,11 @@
 //! subset so SDK-only implementors have the same method surface available.
 //! All mirrored methods have default impls — adapters opt in by overriding.
 //!
+//! `SqlDialect::create_table_as_new` is part of this mirrored surface: it
+//! defaults to a non-replacing `CREATE TABLE … AS` so an out-of-tree dialect
+//! gets the same fail-closed-bootstrap primitive `rocky-core` uses, without
+//! having to re-derive it.
+//!
 //! Known non-additive divergences (defer to a follow-up — they require
 //! cross-crate type or signature changes that this PR deliberately doesn't
 //! land):
@@ -567,6 +572,17 @@ pub trait SqlDialect: Send + Sync {
     /// CREATE TABLE AS SELECT (full refresh).
     fn create_table_as(&self, target: &str, select_sql: &str) -> String;
 
+    /// CREATE TABLE AS SELECT for a target expected not to exist (fail-closed
+    /// bootstrap).
+    ///
+    /// Mirrors `rocky_core::traits::SqlDialect::create_table_as_new`. Unlike
+    /// [`SqlDialect::create_table_as`], this deliberately does not replace an
+    /// existing target, so bootstrap creation fails closed if an existence
+    /// probe was stale or failed for another reason.
+    fn create_table_as_new(&self, target: &str, select_sql: &str) -> String {
+        format!("CREATE TABLE {target} AS\n{select_sql}")
+    }
+
     /// INSERT INTO ... SELECT (incremental append).
     fn insert_into(&self, target: &str, select_sql: &str) -> String;
 
@@ -1080,6 +1096,20 @@ mod tests {
         // Snowflake-style warehouses opt in by overriding; everything
         // else gets None — used by the dialect's `CREATE DYNAMIC TABLE`.
         assert!(MinimalAdapter.warehouse_name().is_none());
+    }
+
+    #[test]
+    fn create_table_as_new_default_is_non_replacing() {
+        // The mirrored fail-closed-bootstrap primitive: a dialect that only
+        // implements the required `create_table_as` inherits a non-replacing
+        // `CREATE TABLE … AS` — never `CREATE OR REPLACE` — so a stale
+        // existence probe fails closed instead of erasing a live target.
+        let sql = StubDialect.create_table_as_new("analytics.mart", "SELECT 1");
+        assert_eq!(sql, "CREATE TABLE analytics.mart AS\nSELECT 1");
+        assert!(
+            !sql.to_uppercase().contains("OR REPLACE"),
+            "create_table_as_new must not emit OR REPLACE: {sql}"
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-cli/src/commands/load.rs
+++ b/engine/crates/rocky-cli/src/commands/load.rs
@@ -710,17 +710,27 @@ async fn load_with_contract_gate(
     // Gate open: promote staging into the target, mirroring the loader's
     // create/truncate semantics but sourced from the staging table.
     let select_from_staging = format!("SELECT * FROM {staging_ref}");
-    let target_exists = warehouse
-        .describe_table(&target_ir)
-        .await
-        .map(|cols| !cols.is_empty())
-        .unwrap_or(false);
+    // Existence probe. A positively-transient failure (lock, timeout, 5xx)
+    // propagates (fail closed) rather than assume absence and promote over a
+    // target that may be live (the conflation behind #1206). Every other
+    // failure, including a genuine "not found", is treated as absent so the
+    // load can create the target; a genuine not-found is never classified
+    // transient, so first-run load stays intact.
+    let target_exists = match warehouse.describe_table(&target_ir).await {
+        Ok(cols) => !cols.is_empty(),
+        Err(e) if warehouse.classify_failure(&e).is_retryable() => {
+            return Err(anyhow::Error::from(e).context(format!(
+                "target existence probe for load target '{target_ref}' failed with a \
+                 retryable error; refusing to assume it is absent"
+            )));
+        }
+        Err(_) => false,
+    };
 
-    // Fail-closed promote: a target `DESCRIBE` failure collapses to
-    // `target_exists = false` above, so a *non-replacing* CREATE must be used —
-    // if the probe missed a live target this fails ("already exists") instead
-    // of erasing it with `CREATE OR REPLACE`. Mirrors the bootstrap fix in
-    // `run.rs` / `sql_gen.rs`.
+    // Second line of defense: even if the probe treated a live target as
+    // absent, the create path uses the *non-replacing* `create_table_as_new`,
+    // so promotion fails ("already exists") instead of erasing it with
+    // `CREATE OR REPLACE`. Mirrors the bootstrap fix in `run.rs` / `sql_gen.rs`.
     let promote_stmts: Vec<String> = if !target_exists && options.create_table {
         vec![dialect.create_table_as_new(&target_ref, &select_from_staging)]
     } else {

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -13079,6 +13079,15 @@ table = "fct_events"
             !rendered.contains("already exists"),
             "must not have attempted a bootstrap over the live target: {rendered}"
         );
+        // The propagated error rides the same run-loop retry path as any other
+        // transient model failure: `classify_anyhow` walks the anyhow chain to
+        // the `AdapterError` and asks the adapter to classify it, so this is
+        // genuinely retried (not merely surfaced).
+        let class = crate::commands::resilience::classify_anyhow(&error, &failing);
+        assert!(
+            class.is_run_retryable(),
+            "a propagated transient probe failure must be run-retryable: {class:?}"
+        );
 
         // The target was never touched — its sentinel row survives.
         let rows = inner
@@ -13188,6 +13197,105 @@ table = "fct_events"
                 vec![serde_json::json!("2")],
                 vec![serde_json::json!("3")],
             ]
+        );
+    }
+
+    /// The fourth 2×2 cell — a *transient* probe failure on a genuinely-*absent*
+    /// target. This is the one case where the inverse design diverges from the
+    /// old collapse-to-absent behavior: rather than bootstrap *through* the blip
+    /// (masking a metadata failure), it fails closed so the run loop retries the
+    /// probe. The target is left uncreated; recovery is a rerun, not a silent
+    /// create on possibly-stale metadata.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn transient_probe_failure_on_absent_target_fails_closed_for_retry() {
+        use std::time::Instant;
+
+        use rocky_core::models::load_model_pair;
+        use rocky_core::traits::WarehouseAdapter;
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+        use rocky_duckdb::dialect::DuckDbSqlDialect;
+
+        let inner = DuckDbWarehouseAdapter::in_memory().unwrap();
+        for ddl in [
+            "CREATE SCHEMA src",
+            "CREATE SCHEMA tgt",
+            "CREATE TABLE src.events (id INTEGER, region VARCHAR)",
+            "INSERT INTO src.events VALUES (1, 'a'), (2, 'b'), (3, 'c')",
+            // tgt.fct_events deliberately absent.
+        ] {
+            inner.execute_statement(ddl).await.unwrap();
+        }
+
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("fct_events.toml"),
+            r#"
+name = "fct_events"
+
+[strategy]
+type = "incremental"
+timestamp_column = "id"
+
+[target]
+catalog = ""
+schema = "tgt"
+table = "fct_events"
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("fct_events.sql"),
+            "SELECT id FROM src.events",
+        )
+        .unwrap();
+        let model = load_model_pair(
+            &dir.path().join("fct_events.sql"),
+            &dir.path().join("fct_events.toml"),
+            None,
+        )
+        .expect("load incremental model");
+
+        let dialect = DuckDbSqlDialect;
+        let typed_models = indexmap::IndexMap::new();
+        let model_timings = std::collections::HashMap::new();
+        let surrogate_keys = std::collections::HashMap::new();
+        let exec_ctx = super::ExecutionContext {
+            typed_models: &typed_models,
+            model_timings: &model_timings,
+            surrogate_keys: &surrogate_keys,
+        };
+
+        let failing = FailTargetDescribe {
+            inner: &inner,
+            inject_msg: "IO Error: Could not set lock on file \"poc.duckdb\": Resource temporarily unavailable",
+        };
+        let error = super::execute_one_plain_model(
+            &model,
+            &failing as &dyn WarehouseAdapter,
+            &dialect as &dyn rocky_core::traits::SqlDialect,
+            "fct_events",
+            Instant::now(),
+            exec_ctx,
+        )
+        .await
+        .expect_err("a transient probe failure must fail closed, not bootstrap through the blip");
+        assert!(
+            crate::commands::resilience::classify_anyhow(&error, &failing).is_run_retryable(),
+            "the fail-closed error must be run-retryable so the run loop reruns the probe"
+        );
+
+        // The target was NOT created — recovery is a rerun, not a silent create.
+        let tables = inner
+            .execute_query(
+                "SELECT table_name FROM information_schema.tables WHERE table_schema = 'tgt'",
+            )
+            .await
+            .unwrap();
+        assert!(
+            tables.rows.is_empty(),
+            "the absent target must not have been created on a transient probe failure: {:?}",
+            tables.rows
         );
     }
 

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -10584,6 +10584,57 @@ mod tests {
     // tests below (env is shared across the test binary's threads).
     static TRIGGER_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+    /// A fault-injecting `WarehouseAdapter` that wraps a real in-memory DuckDB
+    /// adapter but returns `Err` from `describe_table` for the target schema
+    /// (`"tgt"`), delegating every other call to the inner adapter.
+    ///
+    /// Shared by the three executor fail-closed regression tests
+    /// (replication / transformation / time_interval): each proves that when a
+    /// target existence probe misfires, the bootstrap path must fail closed and
+    /// leave a live target untouched rather than replacing it.
+    #[cfg(feature = "duckdb")]
+    struct FailTargetDescribe<'a> {
+        inner: &'a rocky_duckdb::adapter::DuckDbWarehouseAdapter,
+    }
+
+    #[cfg(feature = "duckdb")]
+    #[async_trait::async_trait]
+    impl rocky_core::traits::WarehouseAdapter for FailTargetDescribe<'_> {
+        fn dialect(&self) -> &dyn rocky_core::traits::SqlDialect {
+            self.inner.dialect()
+        }
+
+        async fn execute_statement(&self, sql: &str) -> rocky_core::traits::AdapterResult<()> {
+            self.inner.execute_statement(sql).await
+        }
+
+        async fn execute_statement_with_stats(
+            &self,
+            sql: &str,
+        ) -> rocky_core::traits::AdapterResult<rocky_core::traits::ExecutionStats> {
+            self.inner.execute_statement_with_stats(sql).await
+        }
+
+        async fn execute_query(
+            &self,
+            sql: &str,
+        ) -> rocky_core::traits::AdapterResult<rocky_core::traits::QueryResult> {
+            self.inner.execute_query(sql).await
+        }
+
+        async fn describe_table(
+            &self,
+            table: &rocky_ir::TableRef,
+        ) -> rocky_core::traits::AdapterResult<Vec<rocky_ir::ColumnInfo>> {
+            if table.schema == "tgt" {
+                return Err(rocky_core::traits::AdapterError::msg(
+                    "injected target DESCRIBE failure",
+                ));
+            }
+            self.inner.describe_table(table).await
+        }
+    }
+
     #[test]
     fn run_trigger_from_env_maps_known_values() {
         use rocky_core::state::RunTrigger;
@@ -12563,43 +12614,11 @@ merge_keys = ["id"]
     #[cfg(feature = "duckdb")]
     #[tokio::test]
     async fn target_describe_failure_does_not_replace_existing_replication_target() {
-        use async_trait::async_trait;
         use chrono::TimeZone;
         use rocky_core::state::StateStore;
-        use rocky_core::traits::{
-            AdapterError, AdapterResult, QueryResult, SqlDialect, WarehouseAdapter,
-        };
+        use rocky_core::traits::WarehouseAdapter;
         use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
         use rocky_ir::{TableRef, WatermarkState};
-
-        struct FailTargetDescribe<'a> {
-            inner: &'a DuckDbWarehouseAdapter,
-        }
-
-        #[async_trait]
-        impl WarehouseAdapter for FailTargetDescribe<'_> {
-            fn dialect(&self) -> &dyn SqlDialect {
-                self.inner.dialect()
-            }
-
-            async fn execute_statement(&self, sql: &str) -> AdapterResult<()> {
-                self.inner.execute_statement(sql).await
-            }
-
-            async fn execute_query(&self, sql: &str) -> AdapterResult<QueryResult> {
-                self.inner.execute_query(sql).await
-            }
-
-            async fn describe_table(
-                &self,
-                table: &TableRef,
-            ) -> AdapterResult<Vec<rocky_ir::ColumnInfo>> {
-                if table.schema == "tgt" {
-                    return Err(AdapterError::msg("injected target DESCRIBE failure"));
-                }
-                self.inner.describe_table(table).await
-            }
-        }
 
         let inner = DuckDbWarehouseAdapter::in_memory().unwrap();
         for sql in [
@@ -12667,6 +12686,219 @@ timestamp_column = "ts"
 
         let rows = inner
             .execute_query("SELECT id FROM tgt.events ORDER BY id")
+            .await
+            .unwrap();
+        assert_eq!(rows.rows, vec![vec![serde_json::json!("99")]]);
+    }
+
+    /// Fail-closed bootstrap — transformation path (`execute_one_plain_model`).
+    ///
+    /// Sibling of the replication regression above, for the second of the three
+    /// executor bootstrap paths. A strategy that mutates an existing target
+    /// (here `incremental`) probes the target with `describe_table` and, if it
+    /// reads as absent, bootstraps via the non-replacing
+    /// `generate_transformation_initial_ddl` CTAS. When that probe *misfires*
+    /// against a live target, the bootstrap must fail closed ("already exists")
+    /// and leave the target's rows untouched — never `CREATE OR REPLACE`.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn target_describe_failure_does_not_replace_existing_transformation_target() {
+        use std::time::Instant;
+
+        use rocky_core::models::load_model_pair;
+        use rocky_core::traits::WarehouseAdapter;
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+        use rocky_duckdb::dialect::DuckDbSqlDialect;
+
+        let inner = DuckDbWarehouseAdapter::in_memory().unwrap();
+        for ddl in [
+            "CREATE SCHEMA src",
+            "CREATE SCHEMA tgt",
+            "CREATE TABLE src.events (id INTEGER, region VARCHAR)",
+            "INSERT INTO src.events VALUES (1, 'a'), (2, 'b'), (3, 'c')",
+            // A live incremental target carrying a sentinel row that must survive.
+            "CREATE TABLE tgt.fct_events (id INTEGER)",
+            "INSERT INTO tgt.fct_events VALUES (99)",
+        ] {
+            inner.execute_statement(ddl).await.unwrap();
+        }
+
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("fct_events.toml"),
+            r#"
+name = "fct_events"
+
+[strategy]
+type = "incremental"
+timestamp_column = "id"
+
+[target]
+catalog = ""
+schema = "tgt"
+table = "fct_events"
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("fct_events.sql"),
+            "SELECT id FROM src.events",
+        )
+        .unwrap();
+        let model = load_model_pair(
+            &dir.path().join("fct_events.sql"),
+            &dir.path().join("fct_events.toml"),
+            None,
+        )
+        .expect("load incremental model");
+
+        let dialect = DuckDbSqlDialect;
+        let typed_models = indexmap::IndexMap::new();
+        let model_timings = std::collections::HashMap::new();
+        let surrogate_keys = std::collections::HashMap::new();
+        let exec_ctx = super::ExecutionContext {
+            typed_models: &typed_models,
+            model_timings: &model_timings,
+            surrogate_keys: &surrogate_keys,
+        };
+
+        let failing = FailTargetDescribe { inner: &inner };
+        let error = match super::execute_one_plain_model(
+            &model,
+            &failing as &dyn WarehouseAdapter,
+            &dialect as &dyn rocky_core::traits::SqlDialect,
+            "fct_events",
+            Instant::now(),
+            exec_ctx,
+        )
+        .await
+        {
+            Ok(_) => {
+                panic!("a failed target probe must not replace an existing transformation target")
+            }
+            Err(error) => error,
+        };
+        assert!(
+            format!("{error:#}").contains("already exists"),
+            "bootstrap should fail on the existing target: {error:#}"
+        );
+
+        let rows = inner
+            .execute_query("SELECT id FROM tgt.fct_events ORDER BY id")
+            .await
+            .unwrap();
+        assert_eq!(rows.rows, vec![vec![serde_json::json!("99")]]);
+    }
+
+    /// Fail-closed bootstrap — time_interval path (`execute_time_interval_model`).
+    ///
+    /// Third of the three executor bootstrap paths. The per-partition
+    /// DELETE+INSERT cycle needs the target to exist, so on first run the
+    /// executor probes with `describe_table` and, if absent, materializes an
+    /// empty target via the non-replacing `generate_time_interval_bootstrap_sql`
+    /// CTAS. A misfired probe against a live target must fail closed and leave
+    /// its rows untouched.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn target_describe_failure_does_not_replace_existing_time_interval_target() {
+        use rocky_core::models::load_model_pair;
+        use rocky_core::state::StateStore;
+        use rocky_core::traits::WarehouseAdapter;
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+        use rocky_duckdb::dialect::DuckDbSqlDialect;
+
+        let inner = DuckDbWarehouseAdapter::in_memory().unwrap();
+        for ddl in [
+            "CREATE SCHEMA src",
+            "CREATE SCHEMA tgt",
+            "CREATE TABLE src.events (id INTEGER, order_date DATE)",
+            "INSERT INTO src.events VALUES (1, DATE '2026-04-07')",
+            // A live time_interval target carrying a sentinel row that must survive.
+            "CREATE TABLE tgt.fct_daily (id INTEGER)",
+            "INSERT INTO tgt.fct_daily VALUES (99)",
+        ] {
+            inner.execute_statement(ddl).await.unwrap();
+        }
+
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("fct_daily.toml"),
+            r#"
+name = "fct_daily"
+
+[strategy]
+type = "time_interval"
+time_column = "order_date"
+granularity = "day"
+
+[target]
+catalog = ""
+schema = "tgt"
+table = "fct_daily"
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("fct_daily.sql"),
+            "SELECT id, order_date FROM src.events",
+        )
+        .unwrap();
+        let model = load_model_pair(
+            &dir.path().join("fct_daily.sql"),
+            &dir.path().join("fct_daily.toml"),
+            None,
+        )
+        .expect("load time_interval model");
+
+        let dialect = DuckDbSqlDialect;
+        let dir_state = tempfile::tempdir().unwrap();
+        let state = StateStore::open(&dir_state.path().join("state.redb")).unwrap();
+        // --latest deterministically plans exactly one partition (the current
+        // period), so planning succeeds and control reaches the bootstrap probe.
+        let opts = PartitionRunOptions {
+            partition: None,
+            from: None,
+            to: None,
+            latest: true,
+            missing: false,
+            lookback: None,
+            parallel: 0,
+        };
+        let typed_models = indexmap::IndexMap::new();
+        let model_timings = std::collections::HashMap::new();
+        let surrogate_keys = std::collections::HashMap::new();
+        let exec_ctx = super::ExecutionContext {
+            typed_models: &typed_models,
+            model_timings: &model_timings,
+            surrogate_keys: &surrogate_keys,
+        };
+        let mut output = RunOutput::new(String::new(), 0, 0);
+
+        let failing = FailTargetDescribe { inner: &inner };
+        let error = match super::execute_time_interval_model(
+            &model,
+            &failing as &dyn WarehouseAdapter,
+            &dialect as &dyn rocky_core::traits::SqlDialect,
+            Some(&state),
+            &opts,
+            "test-run",
+            &mut output,
+            &exec_ctx,
+        )
+        .await
+        {
+            Ok(()) => {
+                panic!("a failed target probe must not replace an existing time_interval target")
+            }
+            Err(error) => error,
+        };
+        assert!(
+            format!("{error:#}").contains("already exists"),
+            "bootstrap should fail on the existing target: {error:#}"
+        );
+
+        let rows = inner
+            .execute_query("SELECT id FROM tgt.fct_daily ORDER BY id")
             .await
             .unwrap();
         assert_eq!(rows.rows, vec![vec![serde_json::json!("99")]]);

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -8724,11 +8724,26 @@ async fn execute_one_plain_model(
             schema: model_ir.target.schema.clone(),
             table: model_ir.target.table.clone(),
         };
-        if warehouse
-            .describe_table(&target_table_struct)
-            .await
-            .is_err()
-        {
+        // Existence probe. A positively-*transient* probe failure (lock,
+        // timeout, 5xx, warehouse warm-up) leaves existence unknown *and* is
+        // likely to clear — fail closed (propagate) rather than assume absence
+        // and bootstrap over a target that may be live (the conflation behind
+        // #1206). Every other failure, including a genuine "not found", is
+        // treated as absent and bootstraps; #1207's non-replacing CTAS
+        // backstops it if the target was in fact live. A genuine not-found is
+        // never classified transient, so first-run bootstrap stays intact on
+        // every adapter.
+        let target_absent = match warehouse.describe_table(&target_table_struct).await {
+            Ok(_) => false,
+            Err(e) if warehouse.classify_failure(&e).is_retryable() => {
+                return Err(anyhow::Error::from(e).context(format!(
+                    "target existence probe for model '{model_name}' failed with a \
+                     retryable error; refusing to assume '{target_ref}' is absent"
+                )));
+            }
+            Err(_) => true,
+        };
+        if target_absent {
             let initial_ddls =
                 rocky_core::sql_gen::generate_transformation_initial_ddl(&model_ir, dialect)?;
             info!(
@@ -8978,7 +8993,20 @@ async fn execute_time_interval_model(
         schema: model.config.target.schema.clone(),
         table: model.config.target.table.clone(),
     };
-    let target_exists = warehouse.describe_table(&target_ref_struct).await.is_ok();
+    // Existence probe — see `execute_one_plain_model` for the rationale. A
+    // positively-transient probe failure propagates (fail closed); every other
+    // failure (incl. a genuine "not found") is treated as absent and
+    // bootstraps, backstopped by the non-replacing CTAS.
+    let target_exists = match warehouse.describe_table(&target_ref_struct).await {
+        Ok(_) => true,
+        Err(e) if warehouse.classify_failure(&e).is_retryable() => {
+            return Err(anyhow::Error::from(e).context(format!(
+                "target existence probe for model '{model_name}' failed with a \
+                 retryable error; refusing to assume '{target_table}' is absent"
+            )));
+        }
+        Err(_) => false,
+    };
     if !target_exists {
         let bootstrap_ir = model.to_model_ir();
         let bootstrap_sql = sql_gen::generate_time_interval_bootstrap_sql(&bootstrap_ir, dialect)
@@ -9759,7 +9787,25 @@ async fn process_table(
                 warehouse.describe_table(&source_table),
                 warehouse.describe_table(&target_table),
             );
-            (src.unwrap_or_default(), tgt.unwrap_or_default())
+            // Source: a failed probe collapses to empty columns, which drift
+            // detection iterates as "no additive columns" (a no-op) — left as
+            // tolerable degradation rather than a hard failure. Target: a
+            // positively-transient probe failure propagates (fail closed)
+            // rather than collapse to "absent" and full-refresh a target that
+            // may be live; every other failure is treated as absent (the
+            // non-replacing CTAS backstops it — cf. #1206/#1207).
+            let target_cols = match tgt {
+                Ok(cols) => cols,
+                Err(e) if warehouse.classify_failure(&e).is_retryable() => {
+                    return Err(anyhow::Error::from(e).context(format!(
+                        "target existence probe for '{}' failed with a retryable \
+                         error; refusing to assume it is absent",
+                        target_table.full_name()
+                    )));
+                }
+                Err(_) => Vec::new(),
+            };
+            (src.unwrap_or_default(), target_cols)
         };
     let target_exists = !target_cols.is_empty();
 
@@ -10585,16 +10631,23 @@ mod tests {
     static TRIGGER_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     /// A fault-injecting `WarehouseAdapter` that wraps a real in-memory DuckDB
-    /// adapter but returns `Err` from `describe_table` for the target schema
-    /// (`"tgt"`), delegating every other call to the inner adapter.
+    /// adapter but returns `Err(inject_msg)` from `describe_table` for the
+    /// target schema (`"tgt"`), delegating every other call — including
+    /// `classify_failure` — to the inner adapter.
     ///
-    /// Shared by the three executor fail-closed regression tests
-    /// (replication / transformation / time_interval): each proves that when a
-    /// target existence probe misfires, the bootstrap path must fail closed and
-    /// leave a live target untouched rather than replacing it.
+    /// Shared by the executor fail-closed regression tests (replication /
+    /// transformation / time_interval). Because `classify_failure` delegates to
+    /// real DuckDB, the injected message selects the scenario:
+    /// - a *non-transient* message (the default `"injected target DESCRIBE
+    ///   failure"`) → the caller treats the target as absent and bootstraps,
+    ///   which the non-replacing CTAS backstops against erasing a live target
+    ///   ("already exists");
+    /// - a *transient* message (e.g. a DuckDB lock-contention error) → the
+    ///   caller fails closed and propagates it, never touching the live target.
     #[cfg(feature = "duckdb")]
     struct FailTargetDescribe<'a> {
         inner: &'a rocky_duckdb::adapter::DuckDbWarehouseAdapter,
+        inject_msg: &'static str,
     }
 
     #[cfg(feature = "duckdb")]
@@ -10622,14 +10675,19 @@ mod tests {
             self.inner.execute_query(sql).await
         }
 
+        fn classify_failure(
+            &self,
+            err: &rocky_core::traits::AdapterError,
+        ) -> rocky_core::failure_class::FailureClass {
+            self.inner.classify_failure(err)
+        }
+
         async fn describe_table(
             &self,
             table: &rocky_ir::TableRef,
         ) -> rocky_core::traits::AdapterResult<Vec<rocky_ir::ColumnInfo>> {
             if table.schema == "tgt" {
-                return Err(rocky_core::traits::AdapterError::msg(
-                    "injected target DESCRIBE failure",
-                ));
+                return Err(rocky_core::traits::AdapterError::msg(self.inject_msg));
             }
             self.inner.describe_table(table).await
         }
@@ -12674,7 +12732,13 @@ timestamp_column = "ts"
             auto_apply_gate: None,
         };
 
-        let failing = FailTargetDescribe { inner: &inner };
+        let failing = FailTargetDescribe {
+            inner: &inner,
+            // Non-transient → the caller treats the target as absent and
+            // bootstraps; the non-replacing CTAS then fails closed on the live
+            // target ("already exists") without erasing it.
+            inject_msg: "injected target DESCRIBE failure",
+        };
         let error = match process_table(&failing, &state, &pipeline, &task, false).await {
             Ok(_) => panic!("a failed target probe must not replace an existing table"),
             Err(error) => error,
@@ -12762,7 +12826,13 @@ table = "fct_events"
             surrogate_keys: &surrogate_keys,
         };
 
-        let failing = FailTargetDescribe { inner: &inner };
+        let failing = FailTargetDescribe {
+            inner: &inner,
+            // Non-transient → the caller treats the target as absent and
+            // bootstraps; the non-replacing CTAS then fails closed on the live
+            // target ("already exists") without erasing it.
+            inject_msg: "injected target DESCRIBE failure",
+        };
         let error = match super::execute_one_plain_model(
             &model,
             &failing as &dyn WarehouseAdapter,
@@ -12874,7 +12944,13 @@ table = "fct_daily"
         };
         let mut output = RunOutput::new(String::new(), 0, 0);
 
-        let failing = FailTargetDescribe { inner: &inner };
+        let failing = FailTargetDescribe {
+            inner: &inner,
+            // Non-transient → the caller treats the target as absent and
+            // bootstraps; the non-replacing CTAS then fails closed on the live
+            // target ("already exists") without erasing it.
+            inject_msg: "injected target DESCRIBE failure",
+        };
         let error = match super::execute_time_interval_model(
             &model,
             &failing as &dyn WarehouseAdapter,
@@ -12902,6 +12978,217 @@ table = "fct_daily"
             .await
             .unwrap();
         assert_eq!(rows.rows, vec![vec![serde_json::json!("99")]]);
+    }
+
+    /// Inverse-design property: a *transient* target-probe failure must not be
+    /// mistaken for absence. The caller fails closed and propagates the
+    /// retryable error rather than bootstrapping — so on a live target it never
+    /// even reaches the CTAS backstop, and the target is left completely
+    /// untouched. Mirror of the non-transient survival tests above (which take
+    /// the treat-as-absent → bootstrap → "already exists" backstop path).
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn transient_target_probe_failure_propagates_without_touching_target() {
+        use std::time::Instant;
+
+        use rocky_core::models::load_model_pair;
+        use rocky_core::traits::WarehouseAdapter;
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+        use rocky_duckdb::dialect::DuckDbSqlDialect;
+
+        let inner = DuckDbWarehouseAdapter::in_memory().unwrap();
+        for ddl in [
+            "CREATE SCHEMA src",
+            "CREATE SCHEMA tgt",
+            "CREATE TABLE src.events (id INTEGER, region VARCHAR)",
+            "INSERT INTO src.events VALUES (1, 'a'), (2, 'b'), (3, 'c')",
+            "CREATE TABLE tgt.fct_events (id INTEGER)",
+            "INSERT INTO tgt.fct_events VALUES (99)",
+        ] {
+            inner.execute_statement(ddl).await.unwrap();
+        }
+
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("fct_events.toml"),
+            r#"
+name = "fct_events"
+
+[strategy]
+type = "incremental"
+timestamp_column = "id"
+
+[target]
+catalog = ""
+schema = "tgt"
+table = "fct_events"
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("fct_events.sql"),
+            "SELECT id FROM src.events",
+        )
+        .unwrap();
+        let model = load_model_pair(
+            &dir.path().join("fct_events.sql"),
+            &dir.path().join("fct_events.toml"),
+            None,
+        )
+        .expect("load incremental model");
+
+        let dialect = DuckDbSqlDialect;
+        let typed_models = indexmap::IndexMap::new();
+        let model_timings = std::collections::HashMap::new();
+        let surrogate_keys = std::collections::HashMap::new();
+        let exec_ctx = super::ExecutionContext {
+            typed_models: &typed_models,
+            model_timings: &model_timings,
+            surrogate_keys: &surrogate_keys,
+        };
+
+        // A DuckDB lock-contention message → real `classify_failure` →
+        // `Transient` → the caller propagates instead of assuming absence.
+        let failing = FailTargetDescribe {
+            inner: &inner,
+            inject_msg: "IO Error: Could not set lock on file \"poc.duckdb\": Resource temporarily unavailable",
+        };
+        let error = match super::execute_one_plain_model(
+            &model,
+            &failing as &dyn WarehouseAdapter,
+            &dialect as &dyn rocky_core::traits::SqlDialect,
+            "fct_events",
+            Instant::now(),
+            exec_ctx,
+        )
+        .await
+        {
+            Ok(_) => panic!("a transient probe failure must not be treated as absence"),
+            Err(error) => error,
+        };
+        let rendered = format!("{error:#}");
+        assert!(
+            rendered.contains("Could not set lock"),
+            "should propagate the retryable probe error: {rendered}"
+        );
+        assert!(
+            rendered.contains("retryable error"),
+            "should carry the fail-closed context: {rendered}"
+        );
+        assert!(
+            !rendered.contains("already exists"),
+            "must not have attempted a bootstrap over the live target: {rendered}"
+        );
+
+        // The target was never touched — its sentinel row survives.
+        let rows = inner
+            .execute_query("SELECT id FROM tgt.fct_events ORDER BY id")
+            .await
+            .unwrap();
+        assert_eq!(rows.rows, vec![vec![serde_json::json!("99")]]);
+    }
+
+    /// First-run guard for the inverse design: a *non-transient* probe failure
+    /// on a genuinely-*absent* target must still bootstrap, not hard-fail.
+    ///
+    /// This is the exact property a "propagate on anything-but-NotFound"
+    /// contract would have broken for every adapter whose missing-relation
+    /// error is not a distinct `NotFound` signal (e.g. Snowflake's ambiguous
+    /// `002003`): treating that non-transient error as a hard probe failure
+    /// would refuse to create the target on first run. Because only
+    /// *positively-transient* failures propagate, a non-transient probe error
+    /// is treated as absence and the target is created + loaded.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn non_transient_probe_failure_on_absent_target_still_bootstraps() {
+        use std::time::Instant;
+
+        use rocky_core::models::load_model_pair;
+        use rocky_core::traits::WarehouseAdapter;
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+        use rocky_duckdb::dialect::DuckDbSqlDialect;
+
+        let inner = DuckDbWarehouseAdapter::in_memory().unwrap();
+        for ddl in [
+            "CREATE SCHEMA src",
+            "CREATE SCHEMA tgt",
+            "CREATE TABLE src.events (id INTEGER, region VARCHAR)",
+            "INSERT INTO src.events VALUES (1, 'a'), (2, 'b'), (3, 'c')",
+            // NOTE: tgt.fct_events is deliberately NOT created — the target is
+            // genuinely absent, so first-run bootstrap must create it.
+        ] {
+            inner.execute_statement(ddl).await.unwrap();
+        }
+
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("fct_events.toml"),
+            r#"
+name = "fct_events"
+
+[strategy]
+type = "incremental"
+timestamp_column = "id"
+
+[target]
+catalog = ""
+schema = "tgt"
+table = "fct_events"
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("fct_events.sql"),
+            "SELECT id FROM src.events",
+        )
+        .unwrap();
+        let model = load_model_pair(
+            &dir.path().join("fct_events.sql"),
+            &dir.path().join("fct_events.toml"),
+            None,
+        )
+        .expect("load incremental model");
+
+        let dialect = DuckDbSqlDialect;
+        let typed_models = indexmap::IndexMap::new();
+        let model_timings = std::collections::HashMap::new();
+        let surrogate_keys = std::collections::HashMap::new();
+        let exec_ctx = super::ExecutionContext {
+            typed_models: &typed_models,
+            model_timings: &model_timings,
+            surrogate_keys: &surrogate_keys,
+        };
+
+        // A non-transient probe failure (not a lock/contention message) →
+        // `classify_failure` → not retryable → treated as absence → bootstrap.
+        let failing = FailTargetDescribe {
+            inner: &inner,
+            inject_msg: "injected non-transient probe failure",
+        };
+        super::execute_one_plain_model(
+            &model,
+            &failing as &dyn WarehouseAdapter,
+            &dialect as &dyn rocky_core::traits::SqlDialect,
+            "fct_events",
+            Instant::now(),
+            exec_ctx,
+        )
+        .await
+        .expect("first-run bootstrap must succeed despite a non-transient probe failure");
+
+        // The target was created and loaded from source exactly once.
+        let rows = inner
+            .execute_query("SELECT id FROM tgt.fct_events ORDER BY id")
+            .await
+            .unwrap();
+        assert_eq!(
+            rows.rows,
+            vec![
+                vec![serde_json::json!("1")],
+                vec![serde_json::json!("2")],
+                vec![serde_json::json!("3")],
+            ]
+        );
     }
 
     /// Regression: losing state while an incremental target still exists must


### PR DESCRIPTION
Follow-ups to #1207 (fail-closed bootstrap / #1206). Three cohesive changes, all fully DuckDB-verifiable — no adapter code touched, no schema/codegen surface.

## 1. Propagate transient describe-probe failures instead of assuming absence (`fix(engine/rocky-cli)`)

The root-cause fix. Existence probes collapsed **every** `describe_table` failure into "target absent" (`is_err()` / `is_ok()` / `unwrap_or_default()`), so a transient metadata/permission/connectivity blip on a *live* target was silently treated as absence — the conflation #1207 could only defend against with a non-replacing CTAS.

This removes the conflation at the probe, **reusing the existing `FailureClass` retryability axis** rather than adding a parallel one: a positively-*transient* probe failure (lock, timeout, 5xx, warehouse warm-up — via `WarehouseAdapter::classify_failure`) now **propagates** (fail closed); every other failure, including a genuine "not found", is treated as absent and bootstraps. Applied to all four probe sites: transformation bootstrap, time_interval bootstrap, replication drift/existence (target only — source stays tolerable degradation), and contract-gated load promotion.

**Why this direction, not a `NotFound` error kind** (which an earlier draft of the follow-up plan proposed): because #1207 already makes bootstrap-on-uncertain *data-safe*, the only thing left to fix is mistaking a retryable blip for absence. The load-bearing property is that **a genuine not-found is never classified transient** (verified across all five adapters), so "positively-transient → propagate, else bootstrap" preserves first-run bootstrap for a genuinely-absent target on every adapter, with **zero** per-adapter classification. The inverse ("propagate on anything that isn't `NotFound`") would have broken first run of every new target on adapters whose missing-relation error is not a distinct signal — e.g. Snowflake's `002003`, which is ambiguous with permission-denied — with no backstop.

**Precise behavior** (the 2×2, all pinned by tests):
| probe failure | live target | absent target |
|---|---|---|
| **transient** | propagate, target untouched, **run-loop retries** | fail closed, target uncreated, run-loop retries (the one divergence from `main`, which bootstrapped *through* the blip) |
| **non-transient** | treat as absent → bootstrap → non-replacing CTAS fails closed ("already exists"), rows survive | treat as absent → **bootstraps** (first-run preserved) |

**Retry is real, not hand-waved:** the propagated error is returned from `execute_one_plain_model` as `anyhow::Error::from(e).context(...)`, and `resilience::classify_anyhow` walks the anyhow chain back to the `AdapterError` to classify it — the same path `run_model_with_retry` already uses to recover transient model failures. Tests assert the propagated error is `is_run_retryable()`. (Non-Auth transients retry; Auth transients fail closed with a clear error, since a model rerun won't clear bad credentials.)

**Adapter reach:** the transient-propagation benefit reaches adapters that implement `classify_failure` — DuckDB, Databricks, Snowflake. Trino and BigQuery don't implement it yet, so their describe failures classify `Unknown` → not retryable → treated as absent, i.e. **identical to `main`** (still data-safe via the CTAS backstop). Wiring their `classify_failure` later extends the benefit with no change here.

## 2. Fail-closed E2E tests for transformation + time_interval bootstrap (`test(engine/rocky-cli)`)

#1207 regression-tested only the replication executor. This mirrors the fault-injection test to `execute_one_plain_model` (transformation) and `execute_time_interval_model` (time_interval), and adds the full 2×2 matrix above. The `FailTargetDescribe` fault-injection wrapper is one shared module-level helper (delegating `classify_failure` so the injected message selects the path).

## 3. SDK dialect parity: `create_table_as_new` (`feat(engine/rocky-adapter-sdk)`)

#1207 added `create_table_as_new` to `rocky_core::traits::SqlDialect` but not to its mirror trait in `rocky-adapter-sdk`, whose module doc promises method-surface parity. Adds the same defaulted (non-replacing) method + a `StubDialect` test asserting no `OR REPLACE`, plus a parity note. Consistency change, not a live fix: out-of-process adapters aren't wired into execution today; it becomes load-bearing when they are.

## Scope note

The change is deliberately confined to the four **destructive** bootstrap/promote probe sites. The read-only `describe_table` consumers (compact, profile, preview, compare, ai_contract's `.is_ok()` gates, the load staging probe) still collapse describe failures, but they don't erase data, so they're left unchanged (no regression vs main).

## Test evidence

`cargo test -p rocky-cli --features duckdb` green (1199 passed); `cargo test -p rocky-adapter-sdk` green. `cargo clippy --all-targets --all-features -D warnings` and `cargo fmt --check` clean on both crates.