### PR TITLE
feat(engine/rocky-trino): implement classify_failure for classified retry

### DIFF
--- a/engine/crates/rocky-trino/src/adapter.rs
+++ b/engine/crates/rocky-trino/src/adapter.rs
@@ -51,6 +51,10 @@ impl WarehouseAdapter for TrinoAdapter {
         &self.dialect
     }
 
+    fn classify_failure(&self, err: &AdapterError) -> rocky_core::failure_class::FailureClass {
+        crate::connector::classify_trino_failure(err)
+    }
+
     async fn execute_statement(&self, sql: &str) -> AdapterResult<()> {
         self.client
             .execute(sql)

--- a/engine/crates/rocky-trino/src/connector.rs
+++ b/engine/crates/rocky-trino/src/connector.rs
@@ -27,6 +27,8 @@
 use std::time::Duration;
 
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
+use rocky_core::failure_class::{FailureClass, TransientKind};
+use rocky_core::traits::AdapterError;
 use serde::Deserialize;
 use thiserror::Error;
 use tokio::time::Instant;
@@ -99,6 +101,72 @@ pub enum TrinoError {
 
     #[error("Trino spooled Arrow decode error: {0}")]
     ArrowDecode(String),
+}
+
+/// Trino [`StandardErrorCode`](https://github.com/trinodb/trino/blob/master/core/trino-spi/src/main/java/io/trino/spi/StandardErrorCode.java)
+/// names that are safe to retry: the query hit a cluster-side blip — a worker
+/// went away, the coordinator was starting/stopping, or an internal
+/// page-transport hiccup — not a deterministic user error. Retrying re-plans
+/// the query, typically onto a healthy set of nodes.
+///
+/// Deliberately conservative: everything not listed (SQL/user errors like
+/// `SYNTAX_ERROR` / `TABLE_NOT_FOUND` / `TYPE_MISMATCH`, permission errors,
+/// resource-exhaustion the retry can't fix) is permanent. A missed transient
+/// name just doesn't get retried; it is never unsafe.
+fn is_retryable_error_name(name: &str) -> bool {
+    matches!(
+        name,
+        "NO_NODES_AVAILABLE"
+            | "REMOTE_TASK_ERROR"
+            | "REMOTE_TASK_MISMATCH"
+            | "REMOTE_HOST_GONE"
+            | "PAGE_TRANSPORT_ERROR"
+            | "PAGE_TRANSPORT_TIMEOUT"
+            | "SERVER_STARTING_UP"
+            | "SERVER_SHUTTING_DOWN"
+    )
+}
+
+/// Classify a Trino [`AdapterError`] for the run loop's classified-retry layer,
+/// mirroring the Snowflake/BigQuery adapters.
+///
+/// Downcasts to the typed [`TrinoError`]: a network / 5xx / timeout /
+/// cluster-blip failure ⇒ [`FailureClass::Transient`]; every other recognised
+/// failure (SQL/user errors, auth, the security refusals, decode errors) ⇒
+/// [`FailureClass::Permanent`]; a non-[`TrinoError`] (e.g. the string-only
+/// "table not found" guard) ⇒ [`FailureClass::Unknown`] (fail closed).
+///
+/// Errs toward `Permanent`/`Unknown`: a missed transient simply isn't retried
+/// (no worse than the prior no-op default), and a mis-retried permanent costs
+/// only wasted attempts — never data loss (the non-replacing-CTAS bootstrap
+/// backstop still guards target creation). Only `Transient` is ever retried.
+#[must_use]
+pub(crate) fn classify_trino_failure(err: &AdapterError) -> FailureClass {
+    let Some(trino_err) = err.inner().downcast_ref::<TrinoError>() else {
+        return FailureClass::Unknown;
+    };
+    match trino_err {
+        TrinoError::Timeout { .. } => FailureClass::Transient(TransientKind::Timeout),
+        TrinoError::Http(e) if e.is_timeout() => FailureClass::Transient(TransientKind::Timeout),
+        TrinoError::Http(e) if e.is_connect() => FailureClass::Transient(TransientKind::Network),
+        TrinoError::Http(_) => FailureClass::Permanent,
+        TrinoError::HttpStatus { status: 429, .. } => {
+            FailureClass::Transient(TransientKind::RateLimit)
+        }
+        TrinoError::HttpStatus {
+            status: 502..=504, ..
+        } => FailureClass::Transient(TransientKind::ServerBusy),
+        TrinoError::HttpStatus { .. } => FailureClass::Permanent,
+        TrinoError::QueryFailed { error_name, .. } if is_retryable_error_name(error_name) => {
+            FailureClass::Transient(TransientKind::ServerBusy)
+        }
+        TrinoError::QueryFailed { .. } => FailureClass::Permanent,
+        TrinoError::Auth(_)
+        | TrinoError::MalformedResponse(_)
+        | TrinoError::UntrustedNextUri { .. }
+        | TrinoError::ArrowEncodingUnavailable
+        | TrinoError::ArrowDecode(_) => FailureClass::Permanent,
+    }
 }
 
 /// Returns `true` when `candidate` is on the same scheme + host + port as
@@ -499,6 +567,106 @@ struct QueryError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn query_failed(error_name: &str) -> AdapterError {
+        AdapterError::new(TrinoError::QueryFailed {
+            state: "FAILED".into(),
+            error_code: 0,
+            error_name: error_name.into(),
+            message: format!("{error_name} at line 1:1"),
+        })
+    }
+
+    #[test]
+    fn classify_trino_failure_maps_transient_and_permanent() {
+        // Cluster-side blips → Transient (retryable). These re-plan onto
+        // healthy nodes on retry.
+        for name in [
+            "NO_NODES_AVAILABLE",
+            "REMOTE_TASK_ERROR",
+            "REMOTE_TASK_MISMATCH",
+            "REMOTE_HOST_GONE",
+            "PAGE_TRANSPORT_ERROR",
+            "PAGE_TRANSPORT_TIMEOUT",
+            "SERVER_STARTING_UP",
+            "SERVER_SHUTTING_DOWN",
+        ] {
+            let class = classify_trino_failure(&query_failed(name));
+            assert!(
+                class.is_retryable(),
+                "{name} should classify Transient: {class:?}"
+            );
+        }
+
+        // User/SQL errors → Permanent, never retried (the dangerous direction).
+        for name in [
+            "SYNTAX_ERROR",
+            "TABLE_NOT_FOUND",
+            "COLUMN_NOT_FOUND",
+            "TYPE_MISMATCH",
+            "PERMISSION_DENIED",
+            "DIVISION_BY_ZERO",
+        ] {
+            let class = classify_trino_failure(&query_failed(name));
+            assert_eq!(class, FailureClass::Permanent, "{name} should be Permanent");
+            assert!(!class.is_retryable());
+        }
+
+        // HTTP: 429 / 502 / 503 / 504 transient; other statuses permanent.
+        for status in [429u16, 502, 503, 504] {
+            let err = AdapterError::new(TrinoError::HttpStatus {
+                status,
+                message: String::new(),
+            });
+            assert!(
+                classify_trino_failure(&err).is_retryable(),
+                "HTTP {status} should be Transient"
+            );
+        }
+        for status in [400u16, 401, 403, 404] {
+            let err = AdapterError::new(TrinoError::HttpStatus {
+                status,
+                message: String::new(),
+            });
+            assert_eq!(
+                classify_trino_failure(&err),
+                FailureClass::Permanent,
+                "HTTP {status} should be Permanent"
+            );
+        }
+
+        // A query timeout is transient.
+        assert!(
+            classify_trino_failure(&AdapterError::new(TrinoError::Timeout {
+                timeout_secs: 30,
+                last_state: "RUNNING".into(),
+            }))
+            .is_retryable()
+        );
+
+        // Security refusal / capability / decode → Permanent (retry can't fix).
+        for err in [
+            TrinoError::UntrustedNextUri {
+                coordinator: "https://a".into(),
+                next: "https://b".into(),
+            },
+            TrinoError::ArrowEncodingUnavailable,
+            TrinoError::ArrowDecode("bad ipc".into()),
+            TrinoError::MalformedResponse("no id".into()),
+        ] {
+            assert_eq!(
+                classify_trino_failure(&AdapterError::new(err)),
+                FailureClass::Permanent
+            );
+        }
+
+        // A non-TrinoError (e.g. the describe "table not found" guard is a
+        // type-erased `msg`) → Unknown → not retryable, so callers correctly
+        // treat it as absence rather than a transient blip.
+        let msg = AdapterError::msg("table iceberg.raw.orders not found");
+        assert_eq!(classify_trino_failure(&msg), FailureClass::Unknown);
+        assert!(!classify_trino_failure(&msg).is_retryable());
+    }
 
     #[test]
     fn same_origin_accepts_matching_host_and_scheme() {


### PR DESCRIPTION
Follow-up to #1208. Extends transient-probe-failure propagation to the Trino adapter.

## Scope: Trino only

"Yes do it" named Trino *and* BigQuery, but **BigQuery already implements `classify_failure`** (`connector.rs:903` → `classify_bigquery_failure`) with the correct behavior: a not-found `msg` → downcast miss → `Unknown` → treated as absent → bootstraps; a real 503 → `Transient` → propagates. So the only gap was Trino, which had no `classify_failure` → every failure fell to the trait default `Unknown` (never retried; post-#1208, every transient describe-probe failure treated as target-absence).

## Change

Mirror the Snowflake/BigQuery idiom exactly: downcast to the typed `TrinoError` and classify —

- **Transient** (retried): network connect/timeout (`reqwest` `is_timeout`/`is_connect`), HTTP 429 / 502–504, query timeout, and a conservative set of retryable Trino `StandardErrorCode` names — `NO_NODES_AVAILABLE`, `REMOTE_TASK_ERROR`, `REMOTE_TASK_MISMATCH`, `REMOTE_HOST_GONE`, `PAGE_TRANSPORT_ERROR`, `PAGE_TRANSPORT_TIMEOUT`, `SERVER_STARTING_UP`, `SERVER_SHUTTING_DOWN`.
- **Permanent** (never retried): SQL/user errors (`SYNTAX_ERROR`, `TABLE_NOT_FOUND`, `TYPE_MISMATCH`, …), auth, the security refusals (`UntrustedNextUri`), Arrow capability/decode, malformed responses, other HTTP statuses.
- **Unknown** (fail closed): a non-`TrinoError` (e.g. the string-only "table not found" describe guard).

**Safety by construction:** the load-bearing #1208 property — *a genuine not-found is never classified transient* — holds and is pinned by the test (`TABLE_NOT_FOUND` asserts `!is_retryable()`), so a genuinely-absent Trino target still bootstraps on first run. The classifier errs toward Permanent/Unknown: a missed transient just isn't retried (no worse than the prior default), and `run_model_with_retry`'s idempotency guard means a mis-classified transient can't double-write — never data loss.

## Test evidence

Pure logic over typed errors, fully unit-tested: transient vs permanent error names, HTTP status bands (429/502–504 transient; 400/401/403/404 permanent), timeout, the security/capability/decode variants, and the type-erased not-found guard → `Unknown`. `cargo test -p rocky-trino` green (57 passed); `cargo clippy --all-targets --all-features -D warnings` and `cargo fmt --check` clean.

The `Http(reqwest::Error)` arm's `is_timeout()`/`is_connect()` branches aren't unit-tested (reqwest errors are impractical to construct) — the logic is trivial and mirrors Snowflake's tested pattern.