### PR TITLE
docs: standing questions + independent red-team rule for analyses and plans

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,17 @@
 
 Single repository for the Rocky data platform — a typed-program layer above the warehouse — and its first-party integrations.
 
+## Always ask when analyzing or planning
+
+Whenever analyzing a problem or planning a change, confront these two questions explicitly, in the output — never just consider them silently:
+
+- What are you least confident about right now?
+- What's the most important thing I'm missing about this situation?
+
+A real answer names the weakest assumption, the stale justification, or the hidden prerequisite — and what would settle it. "Nothing" is acceptable only after an actual search, never as a reflex.
+
+These questions are also red-team bait, deliberately. Give every substantive analysis or plan, plus these two answers, to an independent red team — a genuinely different model, never the authoring model or a same-model agent — because an independent model is better placed than the author to see what's missing. Substantive means it can change behavior, a decision, or standing policy; a small or docs-only diff never exempts a change, only mechanical, behavior-neutral corrections are exempt. Name the reviewer and address or rebut its findings on the record; that disposition closes the loop (the red-team pass itself doesn't recurse). If no independent red team is available, say so in the output rather than skipping silently. Code changes additionally follow the [`AGENT_REVIEW.md`](AGENT_REVIEW.md) adversarial-review profile.
+
 ## Subprojects
 
 | Path | Language | What it is |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,12 @@
 # Rocky monorepo
 
-Canonical agent guidance lives in [`AGENTS.md`](AGENTS.md) (shared across agent tools). Claude Code loads it via the import below; the rest of this file is the Claude Code skills router.
+Canonical agent guidance lives in [`AGENTS.md`](AGENTS.md) (shared across agent tools). Claude Code loads it via the import below; the rest of this file is Claude Code-specific: the red-team mapping and the skills router.
 
 @AGENTS.md
+
+## Red team in Claude Code
+
+The independent red team that [`AGENTS.md`](AGENTS.md) requires for substantive analyses and plans is the **Codex plugin** here (the `codex:codex-rescue` agent). `/code-review` is same-model Claude: strong for code diffs, but it does not satisfy the independence requirement.
 
 ## Claude Code skills
 


### PR DESCRIPTION
## What

- **AGENTS.md**: new "Always ask when analyzing or planning" section. Every analysis or plan must answer two standing questions explicitly, in the output: *What are you least confident about right now?* and *What's the most important thing I'm missing about this situation?* Substantive analyses and plans (impact-based test — can it change behavior, a decision, or standing policy — never file type or diff size) additionally get an independent red team: a genuinely different model, never the authoring model or a same-model agent. The reviewer is named and findings are addressed or rebutted on the record; if no independent model is available, that is stated rather than silently skipped. Code changes additionally follow the existing `AGENT_REVIEW.md` profile.
- **CLAUDE.md**: the Claude Code-specific mapping — the Codex plugin is the independent red team there; `/code-review` remains the code-diff pass but is same-model, so it does not satisfy the independence requirement.

## Why

The two questions are self-assessments, which is exactly where an independent second model outperforms the author's introspection. The rule's wording was itself adversarially reviewed by a second model before landing; that pass caught a same-model example that violated the rule's own independence requirement and a file-type exemption loophole, both fixed here. Keeping the client-specific mapping in CLAUDE.md keeps AGENTS.md vendor-neutral.
