### PR TITLE
feat(engine): scheduler metrics under serve --scheduler

### DIFF
--- a/deploy/observability/grafana/alerting/rocky-alerts.yaml
+++ b/deploy/observability/grafana/alerting/rocky-alerts.yaml
@@ -99,35 +99,147 @@ groups:
                     params: [5]
 
 # ---------------------------------------------------------------------------
-# Scheduler alerts (stub — arrives with the native-scheduler work).
-#
-# Once `rocky serve --scheduler` / `rocky tick` ship their telemetry, a
-# consecutive-failures alert belongs here. Left commented until those metrics
-# exist so provisioning never references a metric that isn't emitted yet.
-#
-#      - uid: rocky-scheduler-consecutive-failures
-#        title: Rocky scheduled pipeline is failing repeatedly
-#        condition: C
-#        for: 0m
-#        labels:
-#          severity: critical
-#        annotations:
-#          summary: "A scheduled Rocky pipeline has failed repeatedly."
-#        data:
-#          - refId: A
-#            relativeTimeRange: { from: 900, to: 0 }
-#            datasourceUid: prometheus
-#            model:
-#              refId: A
-#              editorMode: code
-#              expr: max(rocky_scheduler_consecutive_failures) by (pipeline)
-#              instant: true
-#          - refId: C
-#            datasourceUid: __expr__
-#            model:
-#              refId: C
-#              type: threshold
-#              expression: A
-#              conditions:
-#                - type: query
-#                  evaluator: { type: gt, params: [3] }
+# Scheduler alerts. These reference metrics emitted only by a running
+# `rocky serve --scheduler` (experimental); with no scheduler running the
+# series are absent and noDataState keeps the rules quiet. rocky.scheduler.*
+# counters arrive with add_metric_suffixes off (see alloy/config.alloy), so the
+# Prometheus names carry no _total suffix.
+  - orgId: 1
+    name: rocky-scheduler
+    folder: Rocky
+    interval: 1m
+    rules:
+      # The loop is ticking but not reconciling: config_error or fault every
+      # tick. Excludes permit_held / lock_skipped, which are LEGITIMATE sustained
+      # states — a long API backfill holds the mutation permit across many ticks,
+      # and another reconciler may hold the tick lock — so alerting on
+      # "ticking but zero completed" would false-page a normal long run. A short
+      # rate window ([2m], a few default 15s poll intervals) so a transient bad
+      # edit drops the rate to zero well inside the 5m `for`, while an every-tick
+      # failure keeps it continuously positive; widen [2m] for a long poll
+      # interval. (A genuinely wedged permit, distinct from a long run, is not
+      # separable from these metrics alone — a known gap for the experimental cut.)
+      - uid: rocky-scheduler-tick-errors
+        title: Rocky scheduler is ticking but not reconciling
+        condition: C
+        for: 5m
+        noDataState: OK
+        execErrState: Error
+        labels:
+          severity: critical
+        annotations:
+          summary: "The Rocky scheduler is ticking but failing to reconcile."
+          description: "rocky.scheduler.ticks with outcome=config_error or fault has been continuously non-zero for 5 minutes — the resident loop is alive but cannot reconcile (a bad rocky.toml every tick, or a repeated tick fault), so no scheduled work is running. Fix the config or investigate the fault."
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              refId: A
+              editorMode: code
+              expr: sum(rate(rocky_scheduler_ticks{outcome=~"config_error|fault"}[2m]))
+              instant: true
+              range: false
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: A
+              conditions:
+                - type: query
+                  evaluator:
+                    type: gt
+                    params: [0]
+
+      # A scheduled pipeline has failed 3 or more times in a row. gt [2] on an
+      # integer gauge is "3 or more".
+      - uid: rocky-scheduler-consecutive-failures
+        title: Rocky scheduled pipeline is failing repeatedly
+        condition: C
+        for: 0m
+        noDataState: OK
+        execErrState: Error
+        labels:
+          severity: critical
+        annotations:
+          summary: "A scheduled Rocky pipeline has failed 3+ times in a row."
+          description: "rocky.scheduler.consecutive_failures reached 3 or more for at least one pipeline. The reconciler is backing it off; the count clears only when the pipeline next succeeds. This gauge is in-process — it also resets to zero if the scheduler restarts."
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              refId: A
+              editorMode: code
+              expr: max(rocky_scheduler_consecutive_failures) by (pipeline)
+              instant: true
+              range: false
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: A
+              conditions:
+                - type: query
+                  evaluator:
+                    type: gt
+                    params: [2]
+
+      # Execution lag p95 above 120s (twice the one-minute cron granularity)
+      # for 5 minutes — the loop is running demands well after they came due.
+      # Tune the 120 to twice YOUR shortest cron interval.
+      - uid: rocky-scheduler-lag
+        title: Rocky scheduler is falling behind
+        condition: C
+        for: 5m
+        noDataState: OK
+        execErrState: Error
+        labels:
+          severity: warning
+        annotations:
+          summary: "Rocky scheduler execution lag p95 is above 120s."
+          description: "The p95 of rocky.scheduler.lag_seconds has stayed above 120 seconds for 5 minutes — the reconciler is executing demands well after their logical time. Tune the threshold to twice your shortest cron interval."
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: prometheus
+            model:
+              refId: A
+              editorMode: code
+              expr: histogram_quantile(0.95, sum(rate(rocky_scheduler_lag_seconds_bucket[15m])) by (le))
+              instant: true
+              range: false
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: C
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: A
+              conditions:
+                - type: query
+                  evaluator:
+                    type: gt
+                    params: [120]

--- a/deploy/observability/grafana/dashboards/rocky-scheduler.json
+++ b/deploy/observability/grafana/dashboards/rocky-scheduler.json
@@ -1,0 +1,128 @@
+{
+  "uid": "rocky-scheduler",
+  "title": "Rocky Scheduler",
+  "tags": ["rocky", "scheduler"],
+  "timezone": "",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "10s",
+  "time": { "from": "now-6h", "to": "now" },
+  "templating": { "list": [] },
+  "annotations": { "list": [] },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Ticks per second, by outcome",
+      "description": "rate(rocky_scheduler_ticks) by outcome — reconciliation passes the resident scheduler runs, split by how each ended (completed, config_error, permit_held, lock_skipped, fault). Summed, this is the loop's liveness signal; a flat line at zero means the loop stopped ticking. A stack dominated by config_error or fault is the alive-but-not-reconciling case the tick-errors alert catches. rocky.scheduler.ticks is a true counter (add_metric_suffixes is off in the shipped Alloy config, so it arrives as rocky_scheduler_ticks with no _total), so read it with rate(), not last-value.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "drawStyle": "line", "lineWidth": 2, "pointSize": 6, "showPoints": "auto", "fillOpacity": 10, "spanNulls": false, "stacking": { "mode": "normal", "group": "A" } },
+          "unit": "reqps",
+          "min": 0
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "completed" }, "properties": [ { "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } } ] },
+          { "matcher": { "id": "byName", "options": "config_error" }, "properties": [ { "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } } ] },
+          { "matcher": { "id": "byName", "options": "fault" }, "properties": [ { "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } } ] }
+        ]
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(rate(rocky_scheduler_ticks[5m])) by (outcome)", "legendFormat": "{{outcome}}", "refId": "A" }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Execution lag (seconds)",
+      "description": "Percentiles of rocky.scheduler.lag_seconds — the gap between a demand's logical timestamp and when the tick actually executed it. A rising lag means the loop is falling behind its schedules. Alerts fire when p95 lag exceeds twice the shortest cron interval.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "drawStyle": "line", "lineWidth": 2, "pointSize": 6, "showPoints": "auto", "fillOpacity": 10 },
+          "unit": "s",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "histogram_quantile(0.50, sum(rate(rocky_scheduler_lag_seconds_bucket[5m])) by (le))", "legendFormat": "p50", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "histogram_quantile(0.95, sum(rate(rocky_scheduler_lag_seconds_bucket[5m])) by (le))", "legendFormat": "p95", "refId": "B" }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Due vs executed per second",
+      "description": "rate(rocky_scheduler_due) and rate(rocky_scheduler_executed). Due counts demands that came due each tick; executed counts those that ran to a terminal outcome. A persistent gap between them means demand is being suppressed — see the skipped-by-reason panel for why.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "drawStyle": "line", "lineWidth": 2, "pointSize": 6, "showPoints": "auto", "fillOpacity": 10 },
+          "unit": "reqps",
+          "min": 0
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "due" }, "properties": [ { "id": "color", "value": { "mode": "fixed", "fixedColor": "blue" } } ] },
+          { "matcher": { "id": "byName", "options": "executed" }, "properties": [ { "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } } ] }
+        ]
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(rate(rocky_scheduler_due[5m]))", "legendFormat": "due", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(rate(rocky_scheduler_executed[5m]))", "legendFormat": "executed", "refId": "B" }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Skipped demands per second, by reason",
+      "description": "rate(rocky_scheduler_skipped) split by the reason label (not_due, disabled, in_flight, catchup_skipped, failure_backoff, partial_backoff, dedup, history_unavailable, state_busy). failure_backoff / partial_backoff climbing is the fingerprint of a sick pipeline the loop is deliberately backing off.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "drawStyle": "line", "lineWidth": 2, "pointSize": 6, "showPoints": "auto", "fillOpacity": 10, "stacking": { "mode": "normal", "group": "A" } },
+          "unit": "reqps",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(rate(rocky_scheduler_skipped[5m])) by (reason)", "legendFormat": "{{reason}}", "refId": "A" }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "table",
+      "title": "Consecutive failures by pipeline",
+      "description": "rocky.scheduler.consecutive_failures — the current run of consecutive failed runs for each pipeline, as a gauge. Zero is healthy; a value climbing to 3+ is the consecutive-failures alert's trigger. Kept in-process, so it resets to zero when the scheduler restarts and a pipeline removed from config leaves a stale row.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 16 },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" } },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 3 } ] },
+          "unit": "short"
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "Value" }, "properties": [ { "id": "displayName", "value": "consecutive failures" }, { "id": "custom.cellOptions", "value": { "type": "color-background" } } ] }
+        ]
+      },
+      "options": { "showHeader": true, "sortBy": [ { "displayName": "consecutive failures", "desc": true } ] },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "max(rocky_scheduler_consecutive_failures) by (pipeline)", "format": "table", "instant": true, "refId": "A" }
+      ],
+      "transformations": [
+        { "id": "organize", "options": { "excludeByName": { "Time": true }, "renameByName": { "pipeline": "pipeline", "Value": "consecutive failures" } } }
+      ]
+    }
+  ]
+}

--- a/docs/src/content/docs/guides/observability.mdx
+++ b/docs/src/content/docs/guides/observability.mdx
@@ -30,12 +30,14 @@ Spans are created around the phases of a run, so a trace reads as the shape of t
 | `materialize.table` | model execution | building one model; one span per model, carrying `rocky.model.fqn` and `rocky.model.kind` |
 | `statement.execute` | warehouse adapter | one SQL statement sent to the warehouse |
 | `state.download` / `state.upload` / `state.probe` | object-store state sync | reading and writing remote state, carrying the `backend` and `bucket` |
+| `scheduler.tick` | resident scheduler | one reconciliation pass of `rocky serve --scheduler`, carrying `rocky.scheduler.outcome` and the pass's due/executed/failed/skipped counts (experimental) |
 
 When Rocky drives a warehouse, the `statement.execute` spans nest under the `materialize.table` span for the model being built, so a single model's SQL is grouped under it.
 
 A few honest limits worth knowing:
 
 - **`statement.execute` spans come from the warehouse adapters.** The Databricks, Snowflake, BigQuery, and Trino adapters emit them. The embedded DuckDB engine runs statements in-process and does not, so local DuckDB runs show model-level spans but no per-statement spans. The `rocky.adapter.name`, `rocky.statement.kind`, and `rocky.warehouse.name` attributes are carried by the Databricks, Snowflake, and BigQuery spans; Trino emits a simpler `statement.execute` span (and a separate `statement.execute_arrow` span on its Arrow path).
+- **`scheduler.tick` comes from the resident scheduler, not a run.** It is emitted once per poll interval by `rocky serve --scheduler` (experimental), so it is its own trace root rather than a child of a `run` span. Each pass records its outcome and counts even when nothing ran, so an idle loop and a wedged one stay distinguishable in the trace.
 - **`rocky.query_duration_ms` is populated by the Databricks adapter today.** Other adapters record their statement spans without feeding that metric yet.
 - **`governance_setup` and `batched_checks` are marker spans.** They are declared to delimit the governance and quality-check phases, but they do not currently parent the events emitted during those phases (those events stay at the root of the trace). Treat them as phase markers, not as subtrees.
 
@@ -56,6 +58,21 @@ Metrics are recorded in-process and exported when the run finishes (the recorded
 | `rocky.query_duration_ms` | histogram | per-statement warehouse time, in milliseconds |
 
 Not every metric is populated on every run — instrumentation is adapter- and pipeline-specific today. `rocky.statements_executed` is emitted by the Databricks adapter; the retry counters by the Databricks and BigQuery adapters; and the table counters and durations (`rocky.tables_processed`, `rocky.tables_failed`, `rocky.table_duration_ms`) by replication runs. Other adapters and pipeline types still emit spans and logs, but do not feed these particular counters yet, so a metric you don't see means that path isn't instrumented, not that nothing happened.
+
+#### Resident scheduler metrics
+
+`rocky serve --scheduler` (experimental) is a long-lived process, so its reconciler exports these for the lifetime of the process rather than at the end of a run. Unlike the run metrics above, the counters are true monotonic counters — read them with `rate()`, not last-value. They appear only while the scheduler is running:
+
+| Metric | Type | Meaning |
+|---|---|---|
+| `rocky.scheduler.ticks` | counter | reconciliation passes the loop has run, split by an `outcome` label |
+| `rocky.scheduler.due` | counter | demands that came due, summed across ticks |
+| `rocky.scheduler.executed` | counter | demands that ran to a terminal outcome |
+| `rocky.scheduler.skipped` | counter | demands suppressed, split by a `reason` label |
+| `rocky.scheduler.lag_seconds` | histogram | seconds between a demand's logical time and its execution |
+| `rocky.scheduler.consecutive_failures` | gauge | current run of consecutive failed runs, per `pipeline` |
+
+The `outcome` label on `rocky.scheduler.ticks` is one of `completed`, `config_error`, `permit_held`, `lock_skipped`, or `fault` — summed across outcomes it is the loop's liveness signal, and split by outcome it makes an execution-blocking pass visible: a scheduler that ticks every minute but fails to parse `rocky.toml` shows up as `outcome=config_error` rather than looking identical to a healthy idle loop. The `reason` label on `rocky.scheduler.skipped` is one of a small fixed set (`not_due`, `disabled`, `in_flight`, `catchup_skipped`, `failure_backoff`, `partial_backoff`, `dedup`, `history_unavailable`, `state_busy`), and the `pipeline` label is a configured pipeline name, so no label can grow unbounded. `rocky.scheduler.consecutive_failures` is kept in-process: it resets to zero when the scheduler restarts, and a pipeline removed from config leaves its last value behind as a stale series. Alert on it alongside a freshness check rather than on its own.
 
 ### Structured logs
 
@@ -115,7 +132,7 @@ OTEL_SERVICE_NAME=rocky \
 # 3. Open Grafana at http://localhost:3000.
 ```
 
-In Grafana, open the Tempo data source and search for traces where `service.name` is `rocky`. Pick a recent trace to see the run laid out span by span: the model-level `materialize.table` spans, and the `statement.execute` spans nested under them when the run drives a warehouse. The provisioned dashboard renders the run metrics (tables processed and failed, error rate, and the duration histograms) from Prometheus.
+In Grafana, open the Tempo data source and search for traces where `service.name` is `rocky`. Pick a recent trace to see the run laid out span by span: the model-level `materialize.table` spans, and the `statement.execute` spans nested under them when the run drives a warehouse. The provisioned **Rocky Runs** dashboard renders the run metrics (tables processed and failed, error rate, and the duration histograms) from Prometheus. A second **Rocky Scheduler** dashboard renders the resident scheduler's lag, due/executed/skipped-by-reason, and per-pipeline consecutive failures, and populates once a `rocky serve --scheduler` process is exporting.
 
 Tear the stack down when you are done. The exact commands, ports, and dashboard details live in the `deploy/observability/` README.
 

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`rocky serve --scheduler` now exports resident-scheduler metrics over OTLP (experimental).** When the scheduler is running and `OTEL_EXPORTER_OTLP_ENDPOINT` is set, a process-lifetime meter provider exports six instruments derived from the same per-tick accounting the `scheduler.tick` span and log event already share, so the three surfaces cannot disagree: `rocky.scheduler.ticks` (counter, split by an `outcome` label — `completed`, `config_error`, `permit_held`, `lock_skipped`, `fault` — so a loop that ticks but never reconciles is alertable rather than indistinguishable from a healthy idle one); `.due`, `.executed` (counters); `.skipped` (counter, split by a bounded `reason` label — `not_due`, `disabled`, `in_flight`, `catchup_skipped`, `failure_backoff`, `partial_backoff`, `dedup`, `history_unavailable`, `state_busy`); `.lag_seconds` (histogram of the gap between a demand's logical time and its execution); and `.consecutive_failures` (gauge, labeled by `pipeline`). Every label is drawn from a bounded set, so metric cardinality cannot blow up. The provider installs nothing unless the scheduler is active and an endpoint is configured, and flushes a final scrape on shutdown once the loop has drained. `consecutive_failures` is tracked in-process, so it resets to zero on restart and a pipeline removed from config leaves a stale series — alert on it alongside a freshness check, not on its own. The `deploy/observability/` quickstart gains a **Rocky Scheduler** Grafana dashboard (ticks-by-outcome, lag, due vs executed, skipped-by-reason, per-pipeline consecutive failures) and provisioned alert rules (ticking-but-not-reconciling on sustained `config_error`/`fault`; consecutive failures of three or more; execution-lag p95 above twice the shortest cron interval). Marked experimental while the reconciler soaks.
+
 ## [1.67.0] - 2026-07-24
 
 ### Added

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -63,6 +63,9 @@ async-trait = { workspace = true }
 # harness, provider-override seam) for THIS crate's test targets only — the
 # `rocky` binary build never sees the feature.
 rocky-core = { path = "../rocky-core", features = ["test-support"] }
+# Exposes the in-memory scheduler-metrics harness for the `run_one_tick`
+# emission tests. Test-only; the `rocky` binary build never sees it.
+rocky-observe = { path = "../rocky-observe", features = ["test-support"] }
 criterion = { version = "0.8", features = ["html_reports"] }
 tempfile = "3"
 # Capturing Layer for the `scheduler.tick` span assertions — the span surface

--- a/engine/crates/rocky-cli/src/commands/scheduler/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/scheduler/mod.rs
@@ -29,11 +29,14 @@ pub use spawner::JobsModelSpawner;
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
+use chrono::{DateTime, Utc};
 use rocky_core::config::load_rocky_config;
-use rocky_core::schedule::{Drain, Spawner, TickOptions, TickReport, tick_once};
+use rocky_core::schedule::{
+    Drain, Spawner, TerminalOutcome, TickOptions, TickReport, TickSkipReason, tick_once,
+};
+use rocky_observe::scheduler_metrics::SchedulerMetrics;
 use rocky_observe::span_attrs;
 use rocky_server::state::ServerState;
 
@@ -77,24 +80,21 @@ impl Default for SchedulerConfig {
     }
 }
 
-/// The injected-clock millis of the loop's most recent iteration start, for the
-/// self-watchdog. A wedged loop stops updating this; the supervisor notices.
-fn now_millis(clock: &dyn Clock) -> u64 {
-    clock.now().timestamp_millis().max(0) as u64
-}
-
 /// Spawn the resident reconciler as a background task with the production
 /// [`TokioClock`], returning its handle. The handle resolves when the loop stops
 /// — after `shutdown` is raised and the in-flight tick has drained.
+///
+/// `metrics` is the process-lifetime recording handle; it is a no-op unless
+/// OTLP metrics are configured, so the loop records unconditionally.
 pub fn spawn_scheduler(
     state: Arc<ServerState>,
     config_path: PathBuf,
     sched: SchedulerConfig,
     shutdown: Drain,
     ready: Drain,
+    metrics: SchedulerMetrics,
 ) -> tokio::task::JoinHandle<()> {
     let clock: Arc<dyn Clock> = Arc::new(TokioClock);
-    let heartbeat = Arc::new(AtomicU64::new(now_millis(&*clock)));
     // Runs go through the persisted jobs model; the spawner shares the shutdown
     // signal so a running child drains on shutdown.
     let spawner: Arc<dyn Spawner> = Arc::new(JobsModelSpawner::new(
@@ -109,17 +109,15 @@ pub fn spawn_scheduler(
         clock,
         shutdown,
         ready,
-        heartbeat,
         spawner,
+        metrics,
     ))
 }
 
 /// Run the resident reconciler until `shutdown` is raised.
 ///
-/// `heartbeat` is stamped with the injected-clock time at the top of every
-/// iteration; the self-watchdog reads it to detect a wedged loop. `shutdown` is
-/// shared with the HTTP server's graceful-shutdown future and doubles as the
-/// drain signal handed to `tick_once` and the spawner.
+/// `shutdown` is shared with the HTTP server's graceful-shutdown future and
+/// doubles as the drain signal handed to `tick_once` and the spawner.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_scheduler(
     state: Arc<ServerState>,
@@ -128,8 +126,8 @@ pub async fn run_scheduler(
     clock: Arc<dyn Clock>,
     shutdown: Drain,
     ready: Drain,
-    heartbeat: Arc<AtomicU64>,
     spawner: Arc<dyn Spawner>,
+    metrics: SchedulerMetrics,
 ) {
     // The `.rocky` dir (tick lock; and, in PR 2, the webhook spool) is anchored
     // to the config file's directory — the project root — not the process cwd,
@@ -171,7 +169,6 @@ pub async fn run_scheduler(
         if shutdown.is_signalled() {
             break;
         }
-        heartbeat.store(now_millis(&*clock), Ordering::Relaxed);
 
         let drained = run_one_tick(
             &state,
@@ -181,6 +178,7 @@ pub async fn run_scheduler(
             &*clock,
             &shutdown,
             &*spawner,
+            &metrics,
         )
         .await;
 
@@ -238,7 +236,15 @@ async fn run_one_tick(
     clock: &dyn Clock,
     shutdown: &Drain,
     spawner: &dyn Spawner,
+    metrics: &SchedulerMetrics,
 ) -> bool {
+    // The tick counter is recorded once, at each terminal outcome below (never
+    // up front), so `.ticks` carries the outcome label: an execution-blocking
+    // pass (config error, held permit, fault) is its own alertable series
+    // instead of being metrically identical to a healthy idle tick. Every exit
+    // path from here reaches exactly one `record_outcome`/`record_tick` — keep
+    // it that way, or a pass will go uncounted.
+
     // Re-read config each iteration. A parse error skips THIS iteration only —
     // the loop must never die on a bad edit, and must never run stale demands.
     let config = match load_rocky_config(config_path) {
@@ -249,7 +255,7 @@ async fn run_one_tick(
                 config = %config_path.display(),
                 "scheduler: config error this iteration; skipping (loop stays alive)",
             );
-            record_outcome(TickOutcome::ConfigError);
+            record_outcome(TickOutcome::ConfigError, metrics);
             return false;
         }
     };
@@ -265,7 +271,7 @@ async fn run_one_tick(
                 running_job_id = %holder,
                 "scheduler: a mutating job holds the permit; skipping this tick",
             );
-            record_outcome(TickOutcome::PermitHeld);
+            record_outcome(TickOutcome::PermitHeld, metrics);
             return false;
         }
     };
@@ -293,14 +299,15 @@ async fn run_one_tick(
     match tick_once(&config, state_path, now, spawner, &opts).await {
         Ok(report) => {
             log_tick(&report);
-            record_tick(&report);
+            record_tick(&report, metrics);
+            record_metrics(&report, now, metrics);
             report.drained
         }
         Err(e) => {
             // A tick fault (state I/O, an `after` cycle) fails THIS tick closed;
             // the loop continues and the next tick re-evaluates.
             tracing::error!(error = %e, "scheduler: tick faulted; loop continues");
-            record_outcome(TickOutcome::Fault);
+            record_outcome(TickOutcome::Fault, metrics);
             false
         }
     }
@@ -355,26 +362,28 @@ fn tick_counts(report: &TickReport) -> TickCounts {
     }
 }
 
-fn record_outcome(outcome: TickOutcome) {
+/// Record a tick's terminal outcome onto both the `scheduler.tick` span and the
+/// `.ticks` counter, so the two can never disagree. The span field is always
+/// recorded; the counter call is a no-op when metrics are off.
+fn record_outcome(outcome: TickOutcome, metrics: &SchedulerMetrics) {
     tracing::Span::current().record(span_attrs::SCHEDULER_OUTCOME, outcome.as_str());
+    metrics.record_tick_outcome(outcome.as_str());
 }
 
-/// Record the tick's counts onto the enclosing `scheduler.tick` span.
+/// Record the tick's counts onto the enclosing `scheduler.tick` span and count
+/// the pass on the `.ticks` counter via [`record_outcome`].
 ///
 /// Deliberately separate from [`log_tick`]: span attributes serve trace
-/// correlation, while the event remains the log surface that the metric
-/// instruments will be derived from.
-fn record_tick(report: &TickReport) {
+/// correlation, while the event remains the log surface the metric instruments
+/// are derived from.
+fn record_tick(report: &TickReport, metrics: &SchedulerMetrics) {
     if report.skipped_whole_tick {
-        record_outcome(TickOutcome::LockSkipped);
+        record_outcome(TickOutcome::LockSkipped, metrics);
         return;
     }
+    record_outcome(TickOutcome::Completed, metrics);
     let counts = tick_counts(report);
     let span = tracing::Span::current();
-    span.record(
-        span_attrs::SCHEDULER_OUTCOME,
-        TickOutcome::Completed.as_str(),
-    );
     span.record(span_attrs::SCHEDULER_DUE, counts.due);
     span.record(span_attrs::SCHEDULER_EXECUTED, counts.executed);
     span.record(span_attrs::SCHEDULER_FAILED, counts.failed);
@@ -407,15 +416,64 @@ fn log_tick(report: &TickReport) {
     );
 }
 
+/// Feed a completed tick into the resident-scheduler OTLP instruments.
+///
+/// Reads the same [`tick_counts`] the span and the log event use, so the metric
+/// values can never disagree with them. A whole-tick lock skip records nothing
+/// beyond the tick counter already incremented at the top of the pass — there
+/// are no per-demand outcomes to attribute.
+fn record_metrics(report: &TickReport, now: DateTime<Utc>, metrics: &SchedulerMetrics) {
+    if report.skipped_whole_tick {
+        return;
+    }
+    let counts = tick_counts(report);
+    metrics.record_due(counts.due as u64);
+    metrics.record_executed(counts.executed as u64);
+
+    // Per-demand skips, each attributed to a bounded reason label. The sum
+    // across reasons equals `counts.skipped`, keeping the metric in step with
+    // the span's `rocky.scheduler.skipped`.
+    for skip in &report.skipped {
+        metrics.record_skip(skip_reason_label(&skip.reason));
+    }
+
+    // Per executed demand: its execution lag, and its outcome folded into the
+    // per-pipeline consecutive-failure gauge.
+    for run in &report.executed {
+        let lag_seconds = (now - run.logical_ts).num_seconds().max(0) as f64;
+        metrics.record_lag_seconds(lag_seconds);
+        metrics.record_execution_outcome(&run.pipeline, run.outcome == TerminalOutcome::Success);
+    }
+}
+
+/// Stable, bounded label for a per-demand skip. Every arm returns a value in
+/// [`span_attrs::SCHEDULER_SKIP_REASONS`], pinned by a test below so the
+/// metric's `reason` label can never drift into a free-form string.
+fn skip_reason_label(reason: &TickSkipReason) -> &'static str {
+    match reason {
+        TickSkipReason::NotDue => "not_due",
+        TickSkipReason::Disabled => "disabled",
+        TickSkipReason::InFlight => "in_flight",
+        TickSkipReason::CatchupSkipped { .. } => "catchup_skipped",
+        TickSkipReason::FailureBackoff { .. } => "failure_backoff",
+        TickSkipReason::PartialBackoff { .. } => "partial_backoff",
+        TickSkipReason::Dedup => "dedup",
+        TickSkipReason::HistoryUnavailable => "history_unavailable",
+        TickSkipReason::StateBusy => "state_busy",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     use std::sync::Mutex;
+    use std::sync::atomic::{AtomicU64, Ordering};
 
     use async_trait::async_trait;
     use chrono::{DateTime, Duration as ChronoDuration, TimeZone, Utc};
     use rocky_core::schedule::{CapturingSpawner, RunOutcome, SpawnRequest};
+    use rocky_observe::scheduler_metrics::testing::MetricsHarness;
     use rocky_server::state::ServerState;
     use tokio::sync::Notify;
 
@@ -640,6 +698,7 @@ cron = "* * * * *"
             clock.as_ref(),
             &shutdown,
             spawner.as_ref(),
+            &SchedulerMetrics::disabled(),
         )
         .await;
 
@@ -647,8 +706,12 @@ cron = "* * * * *"
         capture.spans_named("scheduler.tick")
     }
 
-    /// Every `TickOutcome` must be a value `rocky-observe` documents, so the
-    /// enum and the published enumeration cannot drift apart across crates.
+    /// Every `TickOutcome` must be a value `rocky-observe` documents — it is
+    /// both the `scheduler.tick` span's outcome and the `.ticks` counter's
+    /// `outcome` label, so the enum and the published enumeration cannot drift
+    /// apart across crates. The exhaustive `match` (no wildcard) is exercised
+    /// per variant, so a new `TickOutcome` breaks this test's compile until it
+    /// is listed, and the assert then fails unless its value is pinned.
     #[test]
     fn tick_outcome_values_match_the_documented_enumeration() {
         for outcome in [
@@ -658,6 +721,14 @@ cron = "* * * * *"
             TickOutcome::LockSkipped,
             TickOutcome::Fault,
         ] {
+            // Exhaustiveness guard: a new variant fails to compile here.
+            match outcome {
+                TickOutcome::Completed
+                | TickOutcome::ConfigError
+                | TickOutcome::PermitHeld
+                | TickOutcome::LockSkipped
+                | TickOutcome::Fault => {}
+            }
             assert!(
                 span_attrs::SCHEDULER_OUTCOMES.contains(&outcome.as_str()),
                 "{} is not in span_attrs::SCHEDULER_OUTCOMES",
@@ -720,6 +791,178 @@ cron = "* * * * *"
         );
     }
 
+    // ---------------------------------------------------------------------
+    // OTLP scheduler metrics
+    // ---------------------------------------------------------------------
+
+    use rocky_observe::scheduler_metrics::testing::MetricPoint;
+
+    /// Drive `ticks` inline reconciliation passes over a shared state store and
+    /// metrics harness, advancing the clock one minute between passes, and
+    /// return the collected metric points. Inline (not the spawned loop) so the
+    /// harness's instruments are recorded synchronously on the test's runtime.
+    async fn drive_ticks_with_metrics(
+        config: &str,
+        spawner: Arc<dyn Spawner>,
+        ticks: usize,
+    ) -> Vec<MetricPoint> {
+        let (dir, config_path) = temp_project(config);
+        let state = test_state(dir.path());
+        let harness = MetricsHarness::new();
+        let metrics = harness.metrics();
+        let shutdown = Drain::new();
+        let clock = FakeClock::new(at(2026, 5, 2, 3, 0));
+        let state_path = dir.path().join(".rocky-state.redb");
+        let rocky_dir = dir.path().join(".rocky");
+
+        for i in 0..ticks {
+            if i > 0 {
+                clock.advance(60);
+            }
+            run_one_tick(
+                &state,
+                &config_path,
+                &state_path,
+                &rocky_dir,
+                clock.as_ref(),
+                &shutdown,
+                spawner.as_ref(),
+                &metrics,
+            )
+            .await;
+        }
+        harness.collect()
+    }
+
+    fn metric<'a>(points: &'a [MetricPoint], name: &str) -> Option<&'a MetricPoint> {
+        points.iter().find(|p| p.name == name)
+    }
+
+    /// Every skip reason the reconciler can produce must map to a value the
+    /// metric label set pins — otherwise a new reason would ship as an
+    /// unbounded, unpinned label. The exhaustive `match` below (no wildcard) is
+    /// exercised for each reason, so adding a `TickSkipReason` variant breaks
+    /// this test's compile until it is listed here, and the runtime assert then
+    /// fails unless its label is a member of `SCHEDULER_SKIP_REASONS`.
+    #[test]
+    fn skip_reason_labels_are_all_pinned() {
+        let ts = at(2026, 5, 2, 3, 0);
+        let all = [
+            TickSkipReason::NotDue,
+            TickSkipReason::Disabled,
+            TickSkipReason::InFlight,
+            TickSkipReason::CatchupSkipped { missed: 3 },
+            TickSkipReason::FailureBackoff { resume_at: ts },
+            TickSkipReason::PartialBackoff { resume_at: ts },
+            TickSkipReason::Dedup,
+            TickSkipReason::HistoryUnavailable,
+            TickSkipReason::StateBusy,
+        ];
+        for reason in &all {
+            // Exhaustiveness guard: a new variant fails to compile here.
+            match reason {
+                TickSkipReason::NotDue
+                | TickSkipReason::Disabled
+                | TickSkipReason::InFlight
+                | TickSkipReason::CatchupSkipped { .. }
+                | TickSkipReason::FailureBackoff { .. }
+                | TickSkipReason::PartialBackoff { .. }
+                | TickSkipReason::Dedup
+                | TickSkipReason::HistoryUnavailable
+                | TickSkipReason::StateBusy => {}
+            }
+            let label = skip_reason_label(reason);
+            assert!(
+                span_attrs::SCHEDULER_SKIP_REASONS.contains(&label),
+                "{label} is not in span_attrs::SCHEDULER_SKIP_REASONS",
+            );
+        }
+    }
+
+    /// A completed tick that fired one successful occurrence exports two ticks
+    /// (the anchor pass plus the firing pass), one due, one executed, a lag
+    /// observation, and a zero failure streak keyed by the pipeline name.
+    #[tokio::test]
+    async fn completed_tick_emits_the_scheduler_instruments() {
+        let spawner: Arc<dyn Spawner> = Arc::new(CapturingSpawner::new(0));
+        // Tick 1 anchors; tick 2 (clock +60s) fires exactly one occurrence.
+        let points = drive_ticks_with_metrics(CRON_EVERY_MINUTE, spawner, 2).await;
+
+        // Both passes reconcile, so both count under outcome=completed.
+        let ticks = metric(&points, "rocky.scheduler.ticks").unwrap();
+        assert_eq!(ticks.value, 2.0);
+        assert_eq!(ticks.attr("outcome"), Some("completed"));
+        assert_eq!(metric(&points, "rocky.scheduler.due").unwrap().value, 1.0);
+        assert_eq!(
+            metric(&points, "rocky.scheduler.executed").unwrap().value,
+            1.0,
+        );
+        assert_eq!(
+            metric(&points, "rocky.scheduler.lag_seconds")
+                .unwrap()
+                .histogram_count,
+            1,
+            "one executed demand ⇒ one lag observation",
+        );
+
+        // The only `consecutive_failures` series is keyed by the configured
+        // pipeline name — never a free-form string.
+        let failure_gauges: Vec<&MetricPoint> = points
+            .iter()
+            .filter(|p| p.name == "rocky.scheduler.consecutive_failures")
+            .collect();
+        assert_eq!(failure_gauges.len(), 1);
+        assert_eq!(failure_gauges[0].attr("pipeline"), Some("raw"));
+        assert_eq!(
+            failure_gauges[0].value, 0.0,
+            "a success ⇒ zero-length failure streak",
+        );
+    }
+
+    /// A failing run climbs the per-pipeline consecutive-failure gauge — the
+    /// signal the alert rule fires on.
+    #[tokio::test]
+    async fn a_failed_run_climbs_the_consecutive_failure_gauge() {
+        // Exit 1 ⇒ a failed terminal outcome (no retry configured).
+        let spawner: Arc<dyn Spawner> = Arc::new(CapturingSpawner::new(1));
+        let points = drive_ticks_with_metrics(CRON_EVERY_MINUTE, spawner, 2).await;
+
+        assert_eq!(
+            metric(&points, "rocky.scheduler.executed").unwrap().value,
+            1.0,
+        );
+        let streak = points
+            .iter()
+            .find(|p| {
+                p.name == "rocky.scheduler.consecutive_failures"
+                    && p.attr("pipeline") == Some("raw")
+            })
+            .expect("a per-pipeline failure gauge point");
+        assert_eq!(streak.value, 1.0, "one failure ⇒ streak of one");
+    }
+
+    /// An execution-blocking outcome (here: an unparseable config every tick)
+    /// counts under its own `outcome` label, so a loop that ticks but never
+    /// reconciles is alertable rather than indistinguishable from a healthy
+    /// idle scheduler. Nothing executed, so no due/executed/lag is recorded.
+    #[tokio::test]
+    async fn config_error_ticks_count_under_their_outcome() {
+        let spawner: Arc<dyn Spawner> = Arc::new(CapturingSpawner::new(0));
+        let points = drive_ticks_with_metrics("not valid toml {{{", spawner, 2).await;
+
+        let ticks: Vec<&MetricPoint> = points
+            .iter()
+            .filter(|p| p.name == "rocky.scheduler.ticks")
+            .collect();
+        assert_eq!(ticks.len(), 1, "one bounded outcome series");
+        assert_eq!(ticks[0].attr("outcome"), Some("config_error"));
+        assert_eq!(ticks[0].value, 2.0, "both passes hit the config error");
+        assert!(
+            metric(&points, "rocky.scheduler.executed").is_none(),
+            "a config-error tick reconciles nothing, so executes nothing",
+        );
+    }
+
     /// The loop fires a due cron demand once per tick after the first-sight
     /// anchor, with no drift: N iterations ⇒ exactly N−1 fires (the first tick
     /// only anchors), each an occurrence of the every-minute schedule.
@@ -734,7 +977,6 @@ cron = "* * * * *"
         // no startup barrier — hand it a pre-signalled readiness latch.
         let ready = Drain::new();
         ready.signal();
-        let heartbeat = Arc::new(AtomicU64::new(0));
 
         let clock_dyn: Arc<dyn Clock> = clock.clone();
         let spawner: Arc<dyn Spawner> = capture.clone();
@@ -748,8 +990,8 @@ cron = "* * * * *"
             clock_dyn,
             shutdown.clone(),
             ready.clone(),
-            heartbeat,
             spawner,
+            SchedulerMetrics::disabled(),
         ));
 
         // Iteration 1 (now = 03:00): first sight ⇒ anchor, no fire.
@@ -811,7 +1053,6 @@ cron = "* * * * *"
         // no startup barrier — hand it a pre-signalled readiness latch.
         let ready = Drain::new();
         ready.signal();
-        let heartbeat = Arc::new(AtomicU64::new(0));
 
         let spawner = Arc::new(DrainBlockingSpawner {
             drain: shutdown.clone(),
@@ -831,8 +1072,8 @@ cron = "* * * * *"
             clock_dyn,
             shutdown.clone(),
             ready.clone(),
-            heartbeat,
             spawner_dyn,
+            SchedulerMetrics::disabled(),
         ));
 
         // Tick 1 anchors (no fire). Advancing makes tick 2 due; its child then
@@ -872,7 +1113,6 @@ cron = "* * * * *"
         // no startup barrier — hand it a pre-signalled readiness latch.
         let ready = Drain::new();
         ready.signal();
-        let heartbeat = Arc::new(AtomicU64::new(0));
 
         let clock_dyn: Arc<dyn Clock> = clock.clone();
         let spawner: Arc<dyn Spawner> = capture.clone();
@@ -886,8 +1126,8 @@ cron = "* * * * *"
             clock_dyn,
             shutdown.clone(),
             ready.clone(),
-            heartbeat,
             spawner,
+            SchedulerMetrics::disabled(),
         ));
 
         // Tick 1 anchors; tick 2 fires once.
@@ -930,7 +1170,6 @@ cron = "* * * * *"
         // no startup barrier — hand it a pre-signalled readiness latch.
         let ready = Drain::new();
         ready.signal();
-        let heartbeat = Arc::new(AtomicU64::new(0));
 
         let clock_dyn: Arc<dyn Clock> = clock.clone();
         let spawner: Arc<dyn Spawner> = capture.clone();
@@ -944,8 +1183,8 @@ cron = "* * * * *"
             clock_dyn,
             shutdown.clone(),
             ready.clone(),
-            heartbeat,
             spawner,
+            SchedulerMetrics::disabled(),
         ));
 
         // Anchor tick.
@@ -989,7 +1228,6 @@ cron = "* * * * *"
         let capture = Arc::new(CapturingSpawner::new(0));
         let shutdown = Drain::new();
         let ready = Drain::new(); // withheld — the server is not up yet
-        let heartbeat = Arc::new(AtomicU64::new(0));
 
         let clock_dyn: Arc<dyn Clock> = clock.clone();
         let spawner: Arc<dyn Spawner> = capture.clone();
@@ -1003,8 +1241,8 @@ cron = "* * * * *"
             clock_dyn,
             shutdown.clone(),
             ready.clone(),
-            heartbeat,
             spawner,
+            SchedulerMetrics::disabled(),
         ));
 
         // Readiness withheld ⇒ the loop is blocked at the barrier: no first tick,
@@ -1040,7 +1278,6 @@ cron = "* * * * *"
         let capture = Arc::new(CapturingSpawner::new(0));
         let shutdown = Drain::new();
         let ready = Drain::new(); // never signalled
-        let heartbeat = Arc::new(AtomicU64::new(0));
 
         let clock_dyn: Arc<dyn Clock> = clock.clone();
         let spawner: Arc<dyn Spawner> = capture.clone();
@@ -1054,8 +1291,8 @@ cron = "* * * * *"
             clock_dyn,
             shutdown.clone(),
             ready,
-            heartbeat,
             spawner,
+            SchedulerMetrics::disabled(),
         ));
 
         // Shutdown wins the readiness race: the loop exits without ticking.

--- a/engine/crates/rocky-cli/src/commands/serve.rs
+++ b/engine/crates/rocky-cli/src/commands/serve.rs
@@ -82,6 +82,18 @@ pub async fn run_serve(
         });
     }
 
+    // Process-lifetime scheduler metrics. Stood up only under `--scheduler`, and
+    // only actually exporting when `OTEL_EXPORTER_OTLP_ENDPOINT` is set — a no-op
+    // guard otherwise, installing no meter provider. Bound at function scope so
+    // its `Drop` (a final flush + shutdown) runs AFTER the scheduler task is
+    // awaited below, letting the last tick's metrics reach the collector before
+    // the provider closes.
+    let meter_guard = if scheduler {
+        rocky_observe::scheduler_metrics::SchedulerMeterGuard::init_if_enabled()
+    } else {
+        rocky_observe::scheduler_metrics::SchedulerMeterGuard::disabled()
+    };
+
     // Spawn the resident reconciler alongside the server, if requested.
     let scheduler_task = if scheduler {
         let sched_cfg = crate::commands::scheduler::SchedulerConfig {
@@ -103,6 +115,7 @@ pub async fn run_serve(
             sched_cfg,
             shutdown.clone(),
             server_ready.clone(),
+            meter_guard.metrics(),
         ))
     } else {
         None

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -14,6 +14,9 @@ otel = [
     "opentelemetry-otlp",
     "tracing-opentelemetry",
 ]
+# Exposes the in-memory metrics harness used to assert scheduler instrument
+# emission. Test-only: never enabled for a release binary.
+test-support = ["otel", "opentelemetry_sdk/testing"]
 
 [dependencies]
 chrono = { workspace = true }

--- a/engine/crates/rocky-observe/src/lib.rs
+++ b/engine/crates/rocky-observe/src/lib.rs
@@ -2,6 +2,7 @@ pub mod events;
 pub mod metrics;
 #[cfg(feature = "otel")]
 pub mod otel;
+pub mod scheduler_metrics;
 pub mod span_attrs;
 pub mod traces;
 pub mod tracing_setup;

--- a/engine/crates/rocky-observe/src/scheduler_metrics.rs
+++ b/engine/crates/rocky-observe/src/scheduler_metrics.rs
@@ -1,0 +1,772 @@
+//! Process-lifetime OTLP metrics for the resident scheduler.
+//!
+//! `rocky serve --scheduler` is Rocky's first long-lived process, so its
+//! reconciler needs metrics that outlive a single tick. The per-run collector
+//! in [`crate::metrics`] snapshots counters at the end of one CLI invocation;
+//! that shape does not fit a loop that ticks indefinitely and needs labeled,
+//! monotonic counters. This module provides a dedicated meter pipeline instead:
+//!
+//! - [`SchedulerMeterGuard`] stands up an OTLP meter provider that stays
+//!   resident for the process lifetime and flushes a final scrape on drop.
+//! - [`SchedulerMetrics`] is the cheap, cloneable handle the loop records
+//!   through — a counter per tick, per due/executed demand, per skip (by
+//!   reason), a lag histogram, and a per-pipeline consecutive-failure gauge.
+//!
+//! Both are no-ops unless the `otel` feature is compiled **and**
+//! `OTEL_EXPORTER_OTLP_ENDPOINT` is set — mirroring how the tracer initialises
+//! (`init_tracing`). A build without a collector configured installs nothing
+//! and pays nothing: no meter provider, no background reader.
+//!
+//! # Instruments
+//!
+//! | Instrument | Kind | Attributes |
+//! |---|---|---|
+//! | `rocky.scheduler.ticks` | counter | — |
+//! | `rocky.scheduler.due` | counter | — |
+//! | `rocky.scheduler.executed` | counter | — |
+//! | `rocky.scheduler.skipped` | counter | `reason` |
+//! | `rocky.scheduler.lag_seconds` | histogram | — |
+//! | `rocky.scheduler.consecutive_failures` | gauge | `pipeline` |
+//!
+//! The `reason` attribute is drawn from a bounded, config-independent set
+//! ([`crate::span_attrs::SCHEDULER_SKIP_REASONS`]); the `pipeline` attribute is
+//! a configured pipeline name, so both label sets are bounded by construction —
+//! no free-form string (an error message, a user id) ever reaches a label.
+
+#[cfg(feature = "otel")]
+pub use enabled::{SchedulerMeterGuard, SchedulerMetrics};
+
+#[cfg(all(feature = "otel", feature = "test-support"))]
+pub use enabled::testing;
+
+#[cfg(not(feature = "otel"))]
+pub use disabled::{SchedulerMeterGuard, SchedulerMetrics};
+
+#[cfg(feature = "otel")]
+mod enabled {
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    use opentelemetry::KeyValue;
+    use opentelemetry::metrics::{Counter, Gauge, Histogram, Meter, MeterProvider};
+    use opentelemetry_sdk::metrics::SdkMeterProvider;
+
+    /// Meter scope for every scheduler instrument.
+    const METER_NAME: &str = "rocky.scheduler";
+
+    const INSTR_TICKS: &str = "rocky.scheduler.ticks";
+    const INSTR_DUE: &str = "rocky.scheduler.due";
+    const INSTR_EXECUTED: &str = "rocky.scheduler.executed";
+    const INSTR_SKIPPED: &str = "rocky.scheduler.skipped";
+    const INSTR_LAG: &str = "rocky.scheduler.lag_seconds";
+    const INSTR_CONSECUTIVE_FAILURES: &str = "rocky.scheduler.consecutive_failures";
+
+    const ATTR_REASON: &str = "reason";
+    const ATTR_PIPELINE: &str = "pipeline";
+    const ATTR_OUTCOME: &str = "outcome";
+
+    const DEFAULT_ENDPOINT: &str = "http://localhost:4317";
+    const DEFAULT_SERVICE_NAME: &str = "rocky";
+    /// How often the periodic reader pushes to the collector between the
+    /// final on-drop flush.
+    const EXPORT_INTERVAL: Duration = Duration::from_secs(30);
+
+    /// The scheduler's OTel instruments plus the in-process failure-streak map
+    /// backing the `consecutive_failures` gauge.
+    struct Instruments {
+        ticks: Counter<u64>,
+        due: Counter<u64>,
+        executed: Counter<u64>,
+        skipped: Counter<u64>,
+        lag_seconds: Histogram<f64>,
+        consecutive_failures: Gauge<u64>,
+        /// Per-pipeline running count of consecutive failed runs. In-process
+        /// only: resets to zero on restart, and a pipeline removed from config
+        /// leaves its last gauge value as a stale series. Bounded by the
+        /// configured pipeline count, so it can never grow unbounded.
+        streaks: Mutex<HashMap<String, u64>>,
+    }
+
+    impl Instruments {
+        fn new(meter: &Meter) -> Self {
+            Self {
+                ticks: meter
+                    .u64_counter(INSTR_TICKS)
+                    .with_description(
+                        "Reconciliation passes the resident scheduler has run, by outcome.",
+                    )
+                    .build(),
+                due: meter
+                    .u64_counter(INSTR_DUE)
+                    .with_description("Demands that came due, summed across ticks.")
+                    .build(),
+                executed: meter
+                    .u64_counter(INSTR_EXECUTED)
+                    .with_description(
+                        "Demands that ran to a terminal outcome, summed across ticks.",
+                    )
+                    .build(),
+                skipped: meter
+                    .u64_counter(INSTR_SKIPPED)
+                    .with_description(
+                        "Demands suppressed this tick, by reason, summed across ticks.",
+                    )
+                    .build(),
+                lag_seconds: meter
+                    .f64_histogram(INSTR_LAG)
+                    .with_unit("s")
+                    .with_description(
+                        "Seconds between a demand's logical timestamp and its execution.",
+                    )
+                    .build(),
+                consecutive_failures: meter
+                    .u64_gauge(INSTR_CONSECUTIVE_FAILURES)
+                    .with_description("Current run of consecutive failed runs, per pipeline.")
+                    .build(),
+                streaks: Mutex::new(HashMap::new()),
+            }
+        }
+    }
+
+    /// A cheap, cloneable handle the scheduler loop records metrics through.
+    ///
+    /// Cloning shares the underlying instruments (they are internally
+    /// reference-counted). A handle from [`SchedulerMetrics::disabled`] — or
+    /// from a guard with no configured endpoint — drops every call, so the loop
+    /// records unconditionally and pays nothing when metrics are off.
+    #[derive(Clone, Default)]
+    pub struct SchedulerMetrics {
+        inner: Option<Arc<Instruments>>,
+    }
+
+    impl SchedulerMetrics {
+        pub(crate) fn from_meter(meter: &Meter) -> Self {
+            Self {
+                inner: Some(Arc::new(Instruments::new(meter))),
+            }
+        }
+
+        /// A handle that records nothing.
+        #[must_use]
+        pub fn disabled() -> Self {
+            Self { inner: None }
+        }
+
+        /// Whether this handle is backed by a live meter.
+        #[must_use]
+        pub fn is_enabled(&self) -> bool {
+            self.inner.is_some()
+        }
+
+        /// Count one reconciliation pass, attributed to its terminal
+        /// `outcome`. Summed across outcomes this is the loop's liveness
+        /// signal; split by outcome it makes the execution-blocking passes
+        /// (`config_error`, `permit_held`, `fault`, `lock_skipped`) visible and
+        /// alertable rather than metrically identical to a healthy idle tick.
+        /// The caller must pass a value from
+        /// [`crate::span_attrs::SCHEDULER_OUTCOMES`] so the label stays bounded.
+        pub fn record_tick_outcome(&self, outcome: &'static str) {
+            if let Some(i) = &self.inner {
+                i.ticks.add(1, &[KeyValue::new(ATTR_OUTCOME, outcome)]);
+            }
+        }
+
+        /// Add this tick's due count.
+        pub fn record_due(&self, count: u64) {
+            if let Some(i) = &self.inner {
+                i.due.add(count, &[]);
+            }
+        }
+
+        /// Add this tick's executed count.
+        pub fn record_executed(&self, count: u64) {
+            if let Some(i) = &self.inner {
+                i.executed.add(count, &[]);
+            }
+        }
+
+        /// Count one skipped demand, attributed to `reason`. The caller must
+        /// pass a value from [`crate::span_attrs::SCHEDULER_SKIP_REASONS`] so
+        /// the label set stays bounded.
+        pub fn record_skip(&self, reason: &'static str) {
+            if let Some(i) = &self.inner {
+                i.skipped.add(1, &[KeyValue::new(ATTR_REASON, reason)]);
+            }
+        }
+
+        /// Record the execution lag (now − the demand's logical timestamp) for
+        /// one executed demand, in seconds.
+        pub fn record_lag_seconds(&self, seconds: f64) {
+            if let Some(i) = &self.inner {
+                i.lag_seconds.record(seconds, &[]);
+            }
+        }
+
+        /// Update the per-pipeline consecutive-failure streak from one executed
+        /// demand's outcome and emit the resulting gauge value. A success
+        /// resets the streak to zero; any other terminal outcome increments it.
+        pub fn record_execution_outcome(&self, pipeline: &str, succeeded: bool) {
+            let Some(i) = &self.inner else {
+                return;
+            };
+            let streak = {
+                let mut streaks = i
+                    .streaks
+                    .lock()
+                    .expect("scheduler failure-streak map poisoned");
+                let entry = streaks.entry(pipeline.to_string()).or_insert(0);
+                *entry = if succeeded { 0 } else { *entry + 1 };
+                *entry
+            };
+            i.consecutive_failures.record(
+                streak,
+                &[KeyValue::new(ATTR_PIPELINE, pipeline.to_string())],
+            );
+        }
+    }
+
+    /// Owns the process-lifetime meter provider and flushes a final scrape when
+    /// the resident scheduler stops.
+    ///
+    /// Hold this for the lifetime of the `serve --scheduler` process — dropping
+    /// it flushes and shuts the meter provider down, after which recorded
+    /// metrics go nowhere. Drop it **after** the scheduler task has finished so
+    /// the last tick's metrics reach the collector.
+    pub struct SchedulerMeterGuard {
+        provider: Option<SdkMeterProvider>,
+    }
+
+    impl SchedulerMeterGuard {
+        /// Stand up the OTLP meter provider when `OTEL_EXPORTER_OTLP_ENDPOINT`
+        /// is set; otherwise return a guard that installs nothing.
+        ///
+        /// Must be called from within a Tokio runtime — the tonic gRPC
+        /// transport the OTLP exporter uses requires one.
+        #[must_use]
+        pub fn init_if_enabled() -> Self {
+            if std::env::var_os("OTEL_EXPORTER_OTLP_ENDPOINT").is_none() {
+                return Self { provider: None };
+            }
+            match build_provider() {
+                Ok(provider) => {
+                    tracing::info!("scheduler OTLP metrics exporter initialised");
+                    Self {
+                        provider: Some(provider),
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "scheduler OTLP metrics init failed; continuing without metrics export",
+                    );
+                    Self { provider: None }
+                }
+            }
+        }
+
+        /// A guard that installs nothing — used when the scheduler is not
+        /// running, so `serve` without `--scheduler` never stands up a meter.
+        #[must_use]
+        pub fn disabled() -> Self {
+            Self { provider: None }
+        }
+
+        /// A recording handle bound to this guard's meter, or a no-op handle
+        /// when no provider was installed.
+        #[must_use]
+        pub fn metrics(&self) -> SchedulerMetrics {
+            match &self.provider {
+                Some(provider) => SchedulerMetrics::from_meter(&provider.meter(METER_NAME)),
+                None => SchedulerMetrics::disabled(),
+            }
+        }
+    }
+
+    impl Drop for SchedulerMeterGuard {
+        fn drop(&mut self) {
+            let Some(provider) = self.provider.take() else {
+                return;
+            };
+            // `shutdown` flushes the final scrape and then closes the provider,
+            // so a single call exports the last tick's metrics — no separate
+            // `force_flush` (which would be a second export attempt, doubling the
+            // worst-case hang against a black-hole endpoint). The blocking here is
+            // bounded by the OTLP exporter's request timeout
+            // (`OTEL_EXPORTER_OTLP_TIMEOUT`, default 10s), so an unreachable
+            // collector cannot delay process exit indefinitely.
+            if let Err(e) = provider.shutdown() {
+                tracing::warn!(error = %e, "scheduler meter provider shutdown failed");
+            }
+        }
+    }
+
+    fn build_provider() -> Result<SdkMeterProvider, Box<dyn std::error::Error + Send + Sync>> {
+        use opentelemetry_otlp::WithExportConfig;
+        use opentelemetry_sdk::Resource;
+        use opentelemetry_sdk::metrics::PeriodicReader;
+
+        let endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
+            .unwrap_or_else(|_| DEFAULT_ENDPOINT.to_string());
+        let service_name =
+            std::env::var("OTEL_SERVICE_NAME").unwrap_or_else(|_| DEFAULT_SERVICE_NAME.to_string());
+
+        let exporter = opentelemetry_otlp::MetricExporter::builder()
+            .with_tonic()
+            .with_endpoint(&endpoint)
+            .build()?;
+
+        let reader = PeriodicReader::builder(exporter)
+            .with_interval(EXPORT_INTERVAL)
+            .build();
+
+        let resource = Resource::builder().with_service_name(service_name).build();
+
+        Ok(SdkMeterProvider::builder()
+            .with_reader(reader)
+            .with_resource(resource)
+            .build())
+    }
+
+    /// In-memory test harness for asserting instrument emission without a live
+    /// collector. Gated behind `test-support` so it is never compiled into a
+    /// release binary.
+    #[cfg(feature = "test-support")]
+    pub mod testing {
+        use std::collections::BTreeMap;
+
+        use opentelemetry::metrics::MeterProvider;
+        use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
+        use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
+
+        use super::{METER_NAME, SchedulerMetrics};
+
+        /// A single flattened observation, reduced to the fields the tests
+        /// assert on.
+        #[derive(Debug, Clone)]
+        pub struct MetricPoint {
+            /// The instrument name (e.g. `rocky.scheduler.ticks`).
+            pub name: String,
+            /// The data point's attributes, keyed by attribute name.
+            pub attrs: BTreeMap<String, String>,
+            /// Sums and gauges: the point value. Histograms: the observation
+            /// sum.
+            pub value: f64,
+            /// Histograms: the number of recorded observations. Zero for sums
+            /// and gauges.
+            pub histogram_count: u64,
+        }
+
+        impl MetricPoint {
+            /// The value of the named attribute, if present.
+            #[must_use]
+            pub fn attr(&self, key: &str) -> Option<&str> {
+                self.attrs.get(key).map(String::as_str)
+            }
+        }
+
+        /// An in-memory meter pipeline plus the recording handle bound to it.
+        pub struct MetricsHarness {
+            provider: SdkMeterProvider,
+            exporter: InMemoryMetricExporter,
+            metrics: SchedulerMetrics,
+        }
+
+        impl Default for MetricsHarness {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
+        impl MetricsHarness {
+            /// Build a harness backed by an in-memory exporter.
+            #[must_use]
+            pub fn new() -> Self {
+                let exporter = InMemoryMetricExporter::default();
+                let provider = SdkMeterProvider::builder()
+                    .with_periodic_exporter(exporter.clone())
+                    .build();
+                let metrics = SchedulerMetrics::from_meter(&provider.meter(METER_NAME));
+                Self {
+                    provider,
+                    exporter,
+                    metrics,
+                }
+            }
+
+            /// A recording handle sharing this harness's instruments.
+            #[must_use]
+            pub fn metrics(&self) -> SchedulerMetrics {
+                self.metrics.clone()
+            }
+
+            /// Force a periodic flush and return the points from this export.
+            ///
+            /// The exporter is reset afterwards so a subsequent `collect` sees
+            /// only the newest export — a gauge then reads as its current
+            /// value, not a stale one accumulated across flushes.
+            #[must_use]
+            pub fn collect(&self) -> Vec<MetricPoint> {
+                self.provider.force_flush().expect("force_flush");
+                let points = read_points(&self.exporter);
+                self.exporter.reset();
+                points
+            }
+
+            /// Shut the provider down (mirroring the guard's `Drop`) and return
+            /// the points the exporter received — proves the final scrape
+            /// survives shutdown.
+            #[must_use]
+            pub fn shutdown_and_collect(self) -> Vec<MetricPoint> {
+                self.provider.shutdown().expect("shutdown");
+                read_points(&self.exporter)
+            }
+        }
+
+        fn read_points(exporter: &InMemoryMetricExporter) -> Vec<MetricPoint> {
+            let mut out = Vec::new();
+            let resource_metrics = exporter
+                .get_finished_metrics()
+                .expect("finished metrics available");
+            for rm in &resource_metrics {
+                for sm in rm.scope_metrics() {
+                    for metric in sm.metrics() {
+                        let name = metric.name().to_string();
+                        match metric.data() {
+                            AggregatedMetrics::U64(data) => push_u64(&mut out, &name, data),
+                            AggregatedMetrics::F64(data) => push_f64(&mut out, &name, data),
+                            AggregatedMetrics::I64(_) => {}
+                        }
+                    }
+                }
+            }
+            out
+        }
+
+        fn attrs_of<'a>(
+            kvs: impl Iterator<Item = &'a opentelemetry::KeyValue>,
+        ) -> BTreeMap<String, String> {
+            kvs.map(|kv| (kv.key.as_str().to_string(), kv.value.to_string()))
+                .collect()
+        }
+
+        fn push_u64(out: &mut Vec<MetricPoint>, name: &str, data: &MetricData<u64>) {
+            match data {
+                MetricData::Sum(sum) => {
+                    for dp in sum.data_points() {
+                        out.push(MetricPoint {
+                            name: name.to_string(),
+                            attrs: attrs_of(dp.attributes()),
+                            value: dp.value() as f64,
+                            histogram_count: 0,
+                        });
+                    }
+                }
+                MetricData::Gauge(gauge) => {
+                    for dp in gauge.data_points() {
+                        out.push(MetricPoint {
+                            name: name.to_string(),
+                            attrs: attrs_of(dp.attributes()),
+                            value: dp.value() as f64,
+                            histogram_count: 0,
+                        });
+                    }
+                }
+                MetricData::Histogram(hist) => {
+                    for dp in hist.data_points() {
+                        out.push(MetricPoint {
+                            name: name.to_string(),
+                            attrs: attrs_of(dp.attributes()),
+                            value: dp.sum() as f64,
+                            histogram_count: dp.count(),
+                        });
+                    }
+                }
+                MetricData::ExponentialHistogram(_) => {}
+            }
+        }
+
+        fn push_f64(out: &mut Vec<MetricPoint>, name: &str, data: &MetricData<f64>) {
+            match data {
+                MetricData::Sum(sum) => {
+                    for dp in sum.data_points() {
+                        out.push(MetricPoint {
+                            name: name.to_string(),
+                            attrs: attrs_of(dp.attributes()),
+                            value: dp.value(),
+                            histogram_count: 0,
+                        });
+                    }
+                }
+                MetricData::Gauge(gauge) => {
+                    for dp in gauge.data_points() {
+                        out.push(MetricPoint {
+                            name: name.to_string(),
+                            attrs: attrs_of(dp.attributes()),
+                            value: dp.value(),
+                            histogram_count: 0,
+                        });
+                    }
+                }
+                MetricData::Histogram(hist) => {
+                    for dp in hist.data_points() {
+                        out.push(MetricPoint {
+                            name: name.to_string(),
+                            attrs: attrs_of(dp.attributes()),
+                            value: dp.sum(),
+                            histogram_count: dp.count(),
+                        });
+                    }
+                }
+                MetricData::ExponentialHistogram(_) => {}
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::testing::MetricsHarness;
+
+        fn point<'a>(
+            points: &'a [super::testing::MetricPoint],
+            name: &str,
+        ) -> Option<&'a super::testing::MetricPoint> {
+            points.iter().find(|p| p.name == name)
+        }
+
+        /// Serialises the one test that mutates `OTEL_EXPORTER_OTLP_ENDPOINT`
+        /// against any future sibling, so its remove/restore window cannot race
+        /// under a threaded `cargo test` run.
+        fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+            static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+            LOCK.get_or_init(|| std::sync::Mutex::new(()))
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+        }
+
+        /// With no OTLP endpoint configured, `init_if_enabled` installs no meter
+        /// provider and hands back a no-op recording handle. This is the
+        /// "meter leaking on the no-endpoint path" guard, asserted rather than
+        /// only reasoned about.
+        #[test]
+        fn init_without_endpoint_installs_no_meter() {
+            let _serialize = env_lock();
+            let prior = std::env::var_os("OTEL_EXPORTER_OTLP_ENDPOINT");
+            // SAFETY: env mutation is serialised under `env_lock`, and no other
+            // test in this crate mutates this variable.
+            unsafe {
+                std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
+            }
+
+            let meter_guard = super::SchedulerMeterGuard::init_if_enabled();
+            assert!(
+                !meter_guard.metrics().is_enabled(),
+                "no endpoint ⇒ no meter provider, no recording handle",
+            );
+
+            if let Some(v) = prior {
+                // SAFETY: as above — still under `env_lock`.
+                unsafe {
+                    std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", v);
+                }
+            }
+        }
+
+        #[test]
+        fn disabled_handle_records_nothing_and_never_panics() {
+            let metrics = super::SchedulerMetrics::disabled();
+            assert!(!metrics.is_enabled());
+            // None of these may panic or observe anything.
+            metrics.record_tick_outcome("completed");
+            metrics.record_due(3);
+            metrics.record_executed(2);
+            metrics.record_skip("not_due");
+            metrics.record_lag_seconds(1.0);
+            metrics.record_execution_outcome("raw", false);
+        }
+
+        #[test]
+        fn disabled_guard_installs_no_provider() {
+            let guard = super::SchedulerMeterGuard::disabled();
+            assert!(!guard.metrics().is_enabled());
+            // Dropping a no-op guard must not panic.
+            drop(guard);
+        }
+
+        #[test]
+        fn counters_accumulate_across_ticks() {
+            let harness = MetricsHarness::new();
+            let m = harness.metrics();
+            m.record_tick_outcome("completed");
+            m.record_due(2);
+            m.record_executed(1);
+            m.record_tick_outcome("completed");
+            m.record_due(1);
+            m.record_executed(1);
+
+            let points = harness.collect();
+            assert_eq!(point(&points, "rocky.scheduler.ticks").unwrap().value, 2.0);
+            assert_eq!(point(&points, "rocky.scheduler.due").unwrap().value, 3.0);
+            assert_eq!(
+                point(&points, "rocky.scheduler.executed").unwrap().value,
+                2.0
+            );
+        }
+
+        #[test]
+        fn tick_counter_splits_by_outcome_attribute() {
+            let harness = MetricsHarness::new();
+            let m = harness.metrics();
+            m.record_tick_outcome("completed");
+            m.record_tick_outcome("completed");
+            m.record_tick_outcome("config_error");
+
+            let points = harness.collect();
+            let by_outcome: std::collections::BTreeMap<&str, f64> = points
+                .iter()
+                .filter(|p| p.name == "rocky.scheduler.ticks")
+                .map(|p| (p.attr("outcome").expect("outcome attr present"), p.value))
+                .collect();
+            assert_eq!(by_outcome.get("completed"), Some(&2.0));
+            assert_eq!(
+                by_outcome.get("config_error"),
+                Some(&1.0),
+                "an execution-blocking outcome is its own alertable series",
+            );
+        }
+
+        #[test]
+        fn skip_counter_splits_by_reason_attribute() {
+            let harness = MetricsHarness::new();
+            let m = harness.metrics();
+            m.record_skip("not_due");
+            m.record_skip("not_due");
+            m.record_skip("disabled");
+
+            let points = harness.collect();
+            let by_reason: std::collections::BTreeMap<&str, f64> = points
+                .iter()
+                .filter(|p| p.name == "rocky.scheduler.skipped")
+                .map(|p| (p.attr("reason").expect("reason attr present"), p.value))
+                .collect();
+            assert_eq!(by_reason.get("not_due"), Some(&2.0));
+            assert_eq!(by_reason.get("disabled"), Some(&1.0));
+        }
+
+        #[test]
+        fn lag_histogram_records_each_observation() {
+            let harness = MetricsHarness::new();
+            let m = harness.metrics();
+            m.record_lag_seconds(5.0);
+            m.record_lag_seconds(15.0);
+
+            let points = harness.collect();
+            let lag = point(&points, "rocky.scheduler.lag_seconds").unwrap();
+            assert_eq!(lag.histogram_count, 2);
+            assert_eq!(lag.value, 20.0);
+        }
+
+        #[test]
+        fn consecutive_failures_gauge_climbs_then_resets_per_pipeline() {
+            let harness = MetricsHarness::new();
+            let m = harness.metrics();
+            m.record_execution_outcome("raw", false);
+            m.record_execution_outcome("raw", false);
+            m.record_execution_outcome("other", false);
+            let points = harness.collect();
+            let raw = points
+                .iter()
+                .find(|p| {
+                    p.name == "rocky.scheduler.consecutive_failures"
+                        && p.attr("pipeline") == Some("raw")
+                })
+                .unwrap();
+            assert_eq!(raw.value, 2.0, "two consecutive failures ⇒ streak 2");
+
+            // A success resets only `raw`.
+            m.record_execution_outcome("raw", true);
+            let points = harness.collect();
+            let raw = points
+                .iter()
+                .find(|p| {
+                    p.name == "rocky.scheduler.consecutive_failures"
+                        && p.attr("pipeline") == Some("raw")
+                })
+                .unwrap();
+            assert_eq!(raw.value, 0.0, "a success resets the streak to zero");
+        }
+
+        #[test]
+        fn shutdown_exports_the_final_scrape() {
+            let harness = MetricsHarness::new();
+            let m = harness.metrics();
+            m.record_tick_outcome("completed");
+            // No explicit collect(): the shutdown path alone must flush — this
+            // is what the guard's `Drop` relies on to export the last tick.
+            let points = harness.shutdown_and_collect();
+            assert_eq!(point(&points, "rocky.scheduler.ticks").unwrap().value, 1.0);
+        }
+    }
+}
+
+#[cfg(not(feature = "otel"))]
+mod disabled {
+    /// No-op recording handle when the `otel` feature is disabled.
+    #[derive(Clone, Default)]
+    pub struct SchedulerMetrics;
+
+    impl SchedulerMetrics {
+        /// A handle that records nothing.
+        #[must_use]
+        pub fn disabled() -> Self {
+            Self
+        }
+
+        /// Always `false` without the `otel` feature.
+        #[must_use]
+        pub fn is_enabled(&self) -> bool {
+            false
+        }
+
+        /// No-op.
+        pub fn record_tick_outcome(&self, _outcome: &'static str) {}
+
+        /// No-op.
+        pub fn record_due(&self, _count: u64) {}
+
+        /// No-op.
+        pub fn record_executed(&self, _count: u64) {}
+
+        /// No-op.
+        pub fn record_skip(&self, _reason: &'static str) {}
+
+        /// No-op.
+        pub fn record_lag_seconds(&self, _seconds: f64) {}
+
+        /// No-op.
+        pub fn record_execution_outcome(&self, _pipeline: &str, _succeeded: bool) {}
+    }
+
+    /// No-op guard when the `otel` feature is disabled.
+    pub struct SchedulerMeterGuard;
+
+    impl SchedulerMeterGuard {
+        /// No-op: no meter provider exists without the `otel` feature.
+        #[must_use]
+        pub fn init_if_enabled() -> Self {
+            Self
+        }
+
+        /// No-op guard.
+        #[must_use]
+        pub fn disabled() -> Self {
+            Self
+        }
+
+        /// Always a no-op handle without the `otel` feature.
+        #[must_use]
+        pub fn metrics(&self) -> SchedulerMetrics {
+            SchedulerMetrics::disabled()
+        }
+    }
+}

--- a/engine/crates/rocky-observe/src/span_attrs.rs
+++ b/engine/crates/rocky-observe/src/span_attrs.rs
@@ -165,6 +165,25 @@ pub const SCHEDULER_OUTCOMES: &[&str] = &[
     "fault",
 ];
 
+/// Recognised values for the `reason` attribute on the
+/// `rocky.scheduler.skipped` metric — one per way a single demand can be
+/// suppressed on a tick. Bounded and config-independent, so the metric's label
+/// cardinality can never blow up. Kept here (rather than beside the reconciler)
+/// so the metric-recording site and the mapper that produces these strings pin
+/// against one list across crates, exactly as [`SCHEDULER_OUTCOMES`] does for
+/// the tick outcome.
+pub const SCHEDULER_SKIP_REASONS: &[&str] = &[
+    "not_due",
+    "disabled",
+    "in_flight",
+    "catchup_skipped",
+    "failure_backoff",
+    "partial_backoff",
+    "dedup",
+    "history_unavailable",
+    "state_busy",
+];
+
 /// Recognised warehouse-adapter values for [`ADAPTER_NAME`] /
 /// [`WAREHOUSE_NAME`]. Source-side adapters (`airbyte`, `fivetran`)
 /// share the same [`ADAPTER_NAME`] key but live in their own
@@ -248,6 +267,22 @@ mod tests {
             assert!(
                 name.chars().all(|c| c.is_ascii_lowercase()),
                 "{name} must be lower-snake"
+            );
+        }
+    }
+
+    /// The skip-reason label set is a metric label vocabulary — it must stay a
+    /// small, unique, lower-snake set so it can never fragment a dashboard or
+    /// blow up label cardinality.
+    #[test]
+    fn scheduler_skip_reasons_well_formed() {
+        let mut seen = std::collections::HashSet::new();
+        for reason in SCHEDULER_SKIP_REASONS {
+            assert!(!reason.is_empty());
+            assert!(seen.insert(*reason), "duplicate skip reason: {reason}");
+            assert!(
+                reason.chars().all(|c| c.is_ascii_lowercase() || c == '_'),
+                "{reason} must be lower-snake"
             );
         }
     }


### PR DESCRIPTION
## Summary

Stands up a process-lifetime OTLP meter provider for the experimental resident scheduler (`rocky serve --scheduler`). It exports six instruments derived from the **same per-tick accounting** the `scheduler.tick` span and log event already share, so the three surfaces cannot disagree. Also ships a Grafana dashboard and provisioned alerts, and strips dead in-process heartbeat scaffolding.

## What's included

- **Meter provider** bound in `run_serve`, active only under `--scheduler` and only when `OTEL_EXPORTER_OTLP_ENDPOINT` is set — it installs nothing otherwise. It flushes a final scrape on drop, ordered after the scheduler task drains, and the blocking shutdown is bounded by the OTLP exporter request timeout (`OTEL_EXPORTER_OTLP_TIMEOUT`, default 10s) so an unreachable collector cannot delay process exit.
- **Instruments:** `rocky.scheduler.ticks` (bounded `outcome` label), `.due`, `.executed`, `.skipped` (bounded `reason` label), `.lag_seconds` (histogram), `.consecutive_failures` (gauge, per pipeline). Both label sets are bounded by construction and pinned by exhaustive cross-crate tests (a new enum variant fails the test's compile until it is listed).
- The tick counter carries an `outcome` label (`completed` / `config_error` / `permit_held` / `lock_skipped` / `fault`), so an execution-blocking pass (e.g. a bad config edit) is its **own alertable series** rather than being metrically identical to a healthy idle tick.
- **Grafana** `rocky-scheduler.json` dashboard (ticks by outcome, due/executed/skipped-by-reason, lag, consecutive-failures) + provisioned alerts: consecutive failures ≥ 3; lag p95 > 2× the shortest cron interval; and a sustained tick-error rate (`config_error`/`fault`), tuned with a short rate window so a transient edit self-heals without paging.
- Strips a never-read in-process `AtomicU64` heartbeat (dead watchdog scaffolding with no reader). The real cross-process tick-lock heartbeat is untouched.

## Notes

- **Experimental** while the resident reconciler soaks.
- No CLI output schema changed, so no codegen cascade.
- Known, documented limitations: `consecutive_failures` is in-process and resets on restart; a pipeline removed from config leaves a stale gauge series — pair the alert with a freshness check. Sustained `permit_held`/`lock_skipped` are legitimate states (a long backfill holds the mutation permit), so the tick-error alert deliberately excludes them.

## Testing

- `cargo fmt -- --check` and `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo nextest run --all-features`: 5584 passed, 0 failed. New tests assert instrument emission, the per-outcome tick split, the no-endpoint no-op, the guard-drop final scrape, and exhaustive label pinning.
- `just codegen`: zero drift.
