### PR TITLE
chore: add Rocky Linguist override

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.rocky linguist-language=SQL linguist-detectable=true


### PR DESCRIPTION
## Summary

I added a repository-level Linguist override so `.rocky` files use SQL highlighting and are included in GitHub's language statistics.

## Subproject(s) touched

- [ ] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [x] Cross-project (CI, scripts, root docs)

## Changes

- Added a root `.gitattributes` override for `*.rocky` files.
- Left detection for other file extensions unchanged.

## Test Plan

- `git check-attr linguist-language linguist-detectable -- <sample>.rocky` returns `SQL` and `true`.
- The same attributes remain unspecified for a tracked `.sql` file.
- `git diff --check origin/main...HEAD`

## Checklist

- [x] Commit messages follow conventional commits.
- [x] No `Co-Authored-By` trailers.
- [x] This does not change the Rocky DSL syntax or CLI JSON schemas.

Fixes #19
