### PR TITLE
fix(engine): stop validate false-greening unloadable configs; warn on unprotected remote state

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -5206,7 +5206,7 @@
         ]
       },
       "ConcurrencyControl": {
-        "description": "Concurrency control for remote `[state]` object writes.\n\nGuards the cross-pod lost update where two runs sharing one `[state]` prefix race: one downloads the state, the other commits, and the first's end-of-run upload silently overwrites the second (last-writer-wins). See [`StateConfig::concurrency_control`].",
+        "description": "Concurrency control for remote `[state]` object writes.\n\nGuards the cross-process lost update where two writers sharing one `[state]` location race: one reads the state, the other commits, and the first's upload silently overwrites the second (last-writer-wins). See [`StateConfig::concurrency_control`].\n\n**Scope:** `docs/adr/ADR-CONCURRENCY.md` governs — compare-and-swap applies to *every* remote state write, split by writer class (runs refuse on conflict; single-record ledger seams retry). Only the run half is implemented today: the ledger-seam writers reached through `RemoteStateSession::upload_only_fail_closed` (`rocky gc`, `rocky policy`, `rocky apply`) still upload unconditionally on every backend, so `cas` does not yet make a deployment fully safe against lost updates. Issue #1228 tracks closing that half; `rocky doctor --check state_concurrency` reports the residual exposure in the meantime.",
         "oneOf": [
           {
             "description": "Unconditional last-writer-wins upload (default) — byte-identical to the pre-CAS behaviour. Correct for single-writer-per-prefix deployments (one run at a time, orchestrator-serialized).",

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -295,6 +295,7 @@ rocky doctor
 | Pipelines | `pipelines` | Validates schema patterns, templates, and governance config |
 | State Sync | `state_sync` | Inspects the configured remote state backend (type only) |
 | State RW | `state_rw` | Round-trips a marker object against the configured backend (put → get → delete). Surfaces IAM and reachability problems at cold start instead of end-of-run upload. No-op for `local`; tiered probes both legs. |
+| State Concurrency | `state_concurrency` | Reports lost-update exposure of a remote `[state]` backend. Every remote configuration warns today, with distinct messages for the three situations: `concurrency_control = "off"` (not enabled), `"cas"` on a backend that performs no compare-and-swap write (enabled but silently downgraded to an unconditional upload), and `"cas"` where it does take effect (runs protected, but `rocky gc` / `rocky policy` / `rocky apply` still write state unconditionally — see issue #1228). Silent for `local`. |
 | Auth | `auth`, `auth/<adapter>` | Pings each warehouse and discovery adapter to verify credentials and connectivity |
 
 **JSON output:**

--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -700,7 +700,7 @@
       ]
     },
     "ConcurrencyControl": {
-      "description": "Concurrency control for remote `[state]` object writes.\n\nGuards the cross-pod lost update where two runs sharing one `[state]` prefix race: one downloads the state, the other commits, and the first's end-of-run upload silently overwrites the second (last-writer-wins). See [`StateConfig::concurrency_control`].",
+      "description": "Concurrency control for remote `[state]` object writes.\n\nGuards the cross-process lost update where two writers sharing one `[state]` location race: one reads the state, the other commits, and the first's upload silently overwrites the second (last-writer-wins). See [`StateConfig::concurrency_control`].\n\n**Scope:** `docs/adr/ADR-CONCURRENCY.md` governs — compare-and-swap applies to *every* remote state write, split by writer class (runs refuse on conflict; single-record ledger seams retry). Only the run half is implemented today: the ledger-seam writers reached through `RemoteStateSession::upload_only_fail_closed` (`rocky gc`, `rocky policy`, `rocky apply`) still upload unconditionally on every backend, so `cas` does not yet make a deployment fully safe against lost updates. Issue #1228 tracks closing that half; `rocky doctor --check state_concurrency` reports the residual exposure in the meantime.",
       "oneOf": [
         {
           "description": "Unconditional last-writer-wins upload (default) — byte-identical to the pre-CAS behaviour. Correct for single-writer-per-prefix deployments (one run at a time, orchestrator-serialized).",

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -349,7 +349,9 @@ export type StateBackend = "local" | "s3" | "gcs" | "valkey" | "tiered";
 /**
  * Concurrency control for remote `[state]` object writes.
  *
- * Guards the cross-pod lost update where two runs sharing one `[state]` prefix race: one downloads the state, the other commits, and the first's end-of-run upload silently overwrites the second (last-writer-wins). See [`StateConfig::concurrency_control`].
+ * Guards the cross-process lost update where two writers sharing one `[state]` location race: one reads the state, the other commits, and the first's upload silently overwrites the second (last-writer-wins). See [`StateConfig::concurrency_control`].
+ *
+ * **Scope:** `docs/adr/ADR-CONCURRENCY.md` governs — compare-and-swap applies to *every* remote state write, split by writer class (runs refuse on conflict; single-record ledger seams retry). Only the run half is implemented today: the ledger-seam writers reached through `RemoteStateSession::upload_only_fail_closed` (`rocky gc`, `rocky policy`, `rocky apply`) still upload unconditionally on every backend, so `cas` does not yet make a deployment fully safe against lost updates. Issue #1228 tracks closing that half; `rocky doctor --check state_concurrency` reports the residual exposure in the meantime.
  */
 export type ConcurrencyControl = "off" | "cas";
 /**

--- a/engine/crates/rocky-cli/src/commands/doctor.rs
+++ b/engine/crates/rocky-cli/src/commands/doctor.rs
@@ -462,7 +462,15 @@ async fn collect_health_checks(
         }
     }
 
-    // 7. Auth — construct adapters and ping each warehouse
+    // 7. Lost-update exposure of the configured remote state backend.
+    //    Silent on `local` — the check simply isn't emitted.
+    if should_run("state_concurrency", check_filter)
+        && let Some(check) = state_concurrency_check(config_path, verbose, &mut suggestions)
+    {
+        checks.push(check);
+    }
+
+    // 8. Auth — construct adapters and ping each warehouse
     if should_run("auth", check_filter) {
         let start = Instant::now();
         match rocky_core::config::load_rocky_config(config_path) {
@@ -608,6 +616,203 @@ async fn collect_health_checks(
     }
 
     (checks, suggestions)
+}
+
+/// Lost-update exposure of the configured `[state]` backend: can two runs
+/// sharing this state silently overwrite each other's committed watermarks?
+///
+/// Returns `None` (silent) for [`StateBackend::Local`] — a local state file has
+/// a single writer by construction, so `concurrency_control = "off"` is correct
+/// there and warning about it would be noise.
+///
+/// Offline: config only, no warehouse and no state-backend I/O.
+///
+/// Capability is **derived**, never re-listed here: the check asks
+/// [`cas_supported_on`][rocky_core::state_sync::cas_supported_on], the same
+/// predicate `RemoteStateSession` gates its write path on. A backend that gains
+/// compare-and-swap support therefore changes the runtime and this diagnostic in
+/// one commit — hardcoding the backend list is how a check ends up warning that
+/// a protected deployment is unprotected, which pushes an operator off a correct
+/// configuration.
+///
+/// A remote backend never reports Healthy today — see *No remote deployment is
+/// fully protected yet* below. The three Warnings are worded apart so an
+/// operator can tell them apart from the message alone:
+///
+/// - `concurrency_control = "off"` on a backend that **would** honour `cas` —
+///   you have not enabled it. Names the setting as the fix.
+/// - `concurrency_control = "cas"` on a backend that **cannot** honour it — you
+///   enabled it and the engine silently downgrades to an unconditional upload,
+///   so the config claims a protection the deployment does not have.
+/// - `concurrency_control = "cas"` on a backend that **does** honour it — runs
+///   are compare-and-swap protected, but the ledger-seam writers still are not.
+///
+/// # No remote deployment is fully protected yet
+///
+/// `docs/adr/ADR-CONCURRENCY.md` is normative: compare-and-swap applies to
+/// *every* remote state write, split by writer class. Only the run half is
+/// implemented. The ledger-seam writers — `rocky gc`, `rocky policy`, and
+/// `rocky apply`, which commit through
+/// `RemoteStateSession::upload_only_fail_closed` — still call the
+/// unconditional [`upload_state`][rocky_core::state_sync::upload_state] on
+/// **every** backend, so a concurrent maintenance or governance command can
+/// silently erase a run's just-committed state.
+///
+/// That exposure is backend-independent, which is why `cas` on a
+/// conditional-write backend earns a Warning rather than a Healthy: a green
+/// verdict there would overclaim exactly as much as it would anywhere else.
+/// Issue #1228 tracks closing the seam half; when it lands, this arm is the one
+/// that becomes Healthy.
+fn state_concurrency_check(
+    config_path: &Path,
+    verbose: bool,
+    suggestions: &mut Vec<String>,
+) -> Option<HealthCheck> {
+    use rocky_core::config::{ConcurrencyControl, StateBackend};
+
+    let start = Instant::now();
+    // A config we cannot READ is not the same as a project on `local`.
+    // Swallowing the error here would emit no check at all, so `rocky doctor
+    // --check state_concurrency` on a broken `rocky.toml` would report
+    // `overall: healthy` with exit 0 over a deployment whose protection nobody
+    // could confirm. Fail loudly, as the other config-dependent checks do.
+    let config = match rocky_core::config::load_rocky_config(config_path) {
+        Ok(config) => config,
+        Err(e) => {
+            return Some(config_load_failed(
+                "state_concurrency",
+                &e,
+                start,
+                suggestions,
+            ));
+        }
+    };
+
+    let backend = config.state.backend;
+    // Exhaustive by design: a backend added later must decide explicitly
+    // whether it is the single-writer local store (this check stays silent) or
+    // a shared location the check has to speak about.
+    let single_writer_local = match backend {
+        StateBackend::Local => true,
+        StateBackend::S3 | StateBackend::Gcs | StateBackend::Valkey | StateBackend::Tiered => false,
+    };
+    if single_writer_local {
+        return None;
+    }
+
+    // DERIVED, never re-listed here: `cas_supported_on` is the engine's own
+    // capability predicate, the one `RemoteStateSession` gates its write path
+    // on. A backend that gains conditional writes flips this check in the same
+    // commit, so the diagnostic can neither vouch for absent protection nor
+    // warn about a deployment that is in fact protected.
+    let cas_supported = rocky_core::state_sync::cas_supported_on(backend);
+
+    let (status, message) = match (config.state.concurrency_control, cas_supported) {
+        // The best configuration available today, and still not Healthy: the
+        // ledger-seam writers bypass CAS on every backend, so a green here
+        // would certify a protection no deployment currently has. This is the
+        // arm that flips to Healthy once the seam half lands.
+        (ConcurrencyControl::Cas, true) => {
+            suggestions.push(
+                "state_concurrency: end-of-run uploads are compare-and-swap protected, but \
+                 `rocky gc`, `rocky policy`, and `rocky apply` still write state \
+                 unconditionally — until issue #1228 lands, do not run maintenance or \
+                 governance commands concurrently with a pipeline run"
+                    .into(),
+            );
+            (
+                HealthStatus::Warning,
+                format!(
+                    "[state] concurrency_control = \"cas\" protects this writer's end-of-run \
+                     upload on the '{backend}' backend, but ledger-seam writers (`rocky gc`, \
+                     `rocky policy`, `rocky apply`) still upload state unconditionally on every \
+                     backend — a concurrent maintenance or governance command can silently \
+                     overwrite a run's committed state. Avoid running them alongside a pipeline \
+                     run; tracked in issue #1228"
+                ),
+            )
+        }
+        // Requested but unsupported. Distinct from the `off` cases on purpose:
+        // the operator has already made the right decision and the engine is
+        // silently not honouring it, so the wording must not read as "you
+        // forgot to turn it on".
+        (ConcurrencyControl::Cas, false) => {
+            suggestions.push(format!(
+                "state_concurrency: concurrency_control = \"cas\" cannot take effect on the \
+                 '{backend}' backend — move [state] to a backend that performs compare-and-swap \
+                 writes, or serialize runs so only one writes this state at a time"
+            ));
+            (
+                HealthStatus::Warning,
+                format!(
+                    "[state] concurrency_control = \"cas\" is a no-op on the '{backend}' backend: \
+                     Rocky performs no compare-and-swap state write there, so each run falls back \
+                     to an unconditional upload. This deployment has asked for lost-update \
+                     protection and is not getting it — concurrent runs sharing this state can \
+                     still silently overwrite each other's committed state"
+                ),
+            )
+        }
+        // Simply not enabled, on a backend that would honour it.
+        (ConcurrencyControl::Off, true) => {
+            suggestions.push(
+                "state_concurrency: set [state] concurrency_control = \"cas\" so a run that loses a \
+                 write race fails instead of overwriting the winner's committed state"
+                    .into(),
+            );
+            (
+                HealthStatus::Warning,
+                format!(
+                    "[state] backend = \"{backend}\" runs with concurrency_control = \"off\": the \
+                     end-of-run upload is unconditional, so concurrent runs sharing this state can \
+                     silently overwrite each other's committed state (last writer wins). This \
+                     backend performs compare-and-swap writes — set concurrency_control = \"cas\""
+                ),
+            )
+        }
+        // Not enabled, and enabling it would not help on this backend either.
+        (ConcurrencyControl::Off, false) => {
+            suggestions.push(format!(
+                "state_concurrency: no concurrency_control setting protects the '{backend}' \
+                 backend — move [state] to a backend that performs compare-and-swap writes, or \
+                 serialize runs so only one writes this state at a time"
+            ));
+            (
+                HealthStatus::Warning,
+                format!(
+                    "[state] backend = \"{backend}\" runs with concurrency_control = \"off\", and \
+                     Rocky performs no compare-and-swap state write on it, so setting \"cas\" would \
+                     not help either: concurrent runs sharing this state can silently overwrite \
+                     each other's committed state (last writer wins)"
+                ),
+            )
+        }
+    };
+
+    let details = if verbose {
+        vec![
+            ("backend".into(), backend.to_string()),
+            (
+                "concurrency_control".into(),
+                config.state.concurrency_control.to_string(),
+            ),
+            ("cas_supported".into(), cas_supported.to_string()),
+            (
+                "cas_effective".into(),
+                rocky_core::state_sync::cas_effective(&config.state).to_string(),
+            ),
+        ]
+    } else {
+        Vec::new()
+    };
+
+    Some(HealthCheck {
+        name: "state_concurrency".into(),
+        status,
+        message,
+        duration_ms: start.elapsed().as_millis() as u64,
+        details,
+    })
 }
 
 /// Health of native orchestration: is a reconciler wedged, and is the timer
@@ -923,6 +1128,296 @@ mod tests {
                 .iter()
                 .any(|c| matches!(c.status, HealthStatus::Critical)),
             "doctor must report at least one Critical so it exits non-zero"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // state_concurrency — lost-update exposure of the remote state backend
+    // -----------------------------------------------------------------------
+
+    /// Write a `rocky.toml` with the given `[state]` body and collect the
+    /// `state_concurrency` check for it.
+    async fn state_concurrency_checks(state_block: &str) -> Vec<HealthCheck> {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("rocky.toml");
+        std::fs::write(
+            &config_path,
+            format!(
+                "[adapter.db]\ntype = \"duckdb\"\n\
+                 [pipeline.raw]\ntype = \"transformation\"\n\
+                 [pipeline.raw.target]\nadapter = \"db\"\n\
+                 [state]\n{state_block}"
+            ),
+        )
+        .unwrap();
+        let state_path = dir.path().join("state.redb");
+        collect_health_checks(&config_path, &state_path, Some("state_concurrency"), false)
+            .await
+            .0
+    }
+
+    /// A local state file has one writer by construction, so `off` is correct
+    /// and warning about it would be noise.
+    #[tokio::test]
+    async fn state_concurrency_is_silent_on_the_local_backend() {
+        let checks = state_concurrency_checks("backend = \"local\"\n").await;
+        assert!(
+            !checks.iter().any(|c| c.name == "state_concurrency"),
+            "local ⇒ the check stays silent, got {checks:?}",
+        );
+    }
+
+    /// The dangerous direction the engine never surfaced: a remote backend
+    /// running last-writer-wins.
+    #[tokio::test]
+    async fn remote_backend_without_concurrency_control_warns() {
+        let checks = state_concurrency_checks("backend = \"s3\"\ns3_bucket = \"example\"\n").await;
+        let check = checks
+            .iter()
+            .find(|c| c.name == "state_concurrency")
+            .expect("a remote backend must emit the check");
+        assert!(
+            matches!(check.status, HealthStatus::Warning),
+            "remote + off is a lost-update exposure, got {:?}",
+            check.status,
+        );
+        assert!(
+            check.message.contains("concurrency_control = \"cas\""),
+            "the warning must name the fix: {}",
+            check.message,
+        );
+    }
+
+    /// The sharper case: the operator asked for protection on a backend that
+    /// cannot provide it, so the request silently downgrades. The message must
+    /// say CAS is *unavailable*, not merely unconfigured.
+    ///
+    /// Deliberately pinned to a backend the engine reports as unsupported via
+    /// `cas_supported_on` rather than a hardcoded name — see
+    /// `cas_verdict_tracks_the_engine_capability_predicate`, which covers every
+    /// backend so this stays honest when one gains support.
+    #[tokio::test]
+    async fn cas_on_a_backend_without_conditional_writes_warns() {
+        assert!(
+            !rocky_core::state_sync::cas_supported_on(rocky_core::config::StateBackend::Valkey),
+            "fixture assumes valkey performs no compare-and-swap write",
+        );
+        let checks = state_concurrency_checks(
+            "backend = \"valkey\"\nconcurrency_control = \"cas\"\nvalkey_url = \"redis://example\"\n",
+        )
+        .await;
+        let check = checks
+            .iter()
+            .find(|c| c.name == "state_concurrency")
+            .expect("a remote backend must emit the check");
+        assert!(
+            matches!(check.status, HealthStatus::Warning),
+            "cas that cannot take effect is not healthy, got {:?}",
+            check.status,
+        );
+        assert!(
+            check.message.contains("no-op") && check.message.contains("unconditional upload"),
+            "the message must say the setting cannot take effect: {}",
+            check.message,
+        );
+    }
+
+    /// `cas` on a conditional-write backend is the best configuration available
+    /// today and still must not report Healthy: the ledger-seam writers bypass
+    /// compare-and-swap on every backend, so a green here would certify a
+    /// protection no deployment currently has.
+    #[tokio::test]
+    async fn cas_on_an_object_store_backend_warns_about_the_seam_writers() {
+        let checks = state_concurrency_checks(
+            "backend = \"s3\"\nconcurrency_control = \"cas\"\ns3_bucket = \"example\"\n",
+        )
+        .await;
+        let check = checks
+            .iter()
+            .find(|c| c.name == "state_concurrency")
+            .expect("a remote backend must emit the check");
+        assert!(
+            matches!(check.status, HealthStatus::Warning),
+            "seam writers bypass CAS, so this must not be Healthy, got {:?}",
+            check.status,
+        );
+        assert!(
+            check.message.contains("end-of-run"),
+            "the message must say what IS protected: {}",
+            check.message,
+        );
+        assert!(
+            check.message.contains("rocky gc") && check.message.contains("unconditionally"),
+            "the message must name the seam writers that bypass CAS: {}",
+            check.message,
+        );
+        assert!(
+            check.message.contains("#1228"),
+            "the message must point at the tracking issue: {}",
+            check.message,
+        );
+    }
+
+    /// Every remote combination is a Warning today, and each of the four is
+    /// distinguishable from its message alone — an operator has to be able to
+    /// tell "not enabled" from "cannot be honoured" from "runs protected, seams
+    /// are not" without reading the source.
+    #[tokio::test]
+    async fn every_remote_warning_is_distinguishable_from_its_message() {
+        let cases = [
+            // (state block, a phrase unique to this case)
+            (
+                "backend = \"s3\"\ns3_bucket = \"example\"\n",
+                "set concurrency_control = \"cas\"",
+            ),
+            (
+                "backend = \"valkey\"\nvalkey_url = \"redis://example\"\n",
+                "would not help either",
+            ),
+            (
+                "backend = \"valkey\"\nvalkey_url = \"redis://example\"\nconcurrency_control = \"cas\"\n",
+                "is a no-op",
+            ),
+            (
+                "backend = \"s3\"\ns3_bucket = \"example\"\nconcurrency_control = \"cas\"\n",
+                "#1228",
+            ),
+        ];
+
+        let mut seen: Vec<String> = Vec::new();
+        for (block, marker) in cases {
+            let checks = state_concurrency_checks(block).await;
+            let check = checks
+                .iter()
+                .find(|c| c.name == "state_concurrency")
+                .expect("a remote backend must emit the check");
+            assert!(
+                matches!(check.status, HealthStatus::Warning),
+                "no remote configuration is fully protected yet, got {:?} for {block}",
+                check.status,
+            );
+            assert!(
+                check.message.contains(marker),
+                "message for {block} must contain {marker:?}: {}",
+                check.message,
+            );
+            assert!(
+                !seen.contains(&check.message),
+                "two cases produced the identical message, so an operator cannot tell them \
+                 apart: {}",
+                check.message,
+            );
+            seen.push(check.message.clone());
+        }
+    }
+
+    /// The verdict must be *derived* from the engine's capability predicate,
+    /// never from a backend list copied into the check. Asserted across every
+    /// remote backend and both settings: the check reports `cas` as taking
+    /// effect exactly when `cas_effective` says compare-and-swap really happens.
+    ///
+    /// Status alone can no longer carry this property — every remote case is a
+    /// Warning until the seam writers stop bypassing CAS — so the assertion is
+    /// on which *message class* is emitted. This is what keeps the check correct
+    /// when a backend gains compare-and-swap support: a stale hardcoded list
+    /// would tell an operator their `cas` setting is a no-op when it is in fact
+    /// working, pushing them off a correct configuration.
+    #[tokio::test]
+    async fn cas_verdict_tracks_the_engine_capability_predicate() {
+        use rocky_core::config::{ConcurrencyControl, StateBackend, StateConfig};
+
+        let remote = [
+            (
+                StateBackend::S3,
+                "backend = \"s3\"\ns3_bucket = \"example\"\n",
+            ),
+            (
+                StateBackend::Gcs,
+                "backend = \"gcs\"\ngcs_bucket = \"example\"\n",
+            ),
+            (
+                StateBackend::Valkey,
+                "backend = \"valkey\"\nvalkey_url = \"redis://example\"\n",
+            ),
+            (
+                StateBackend::Tiered,
+                "backend = \"tiered\"\ns3_bucket = \"example\"\nvalkey_url = \"redis://example\"\n",
+            ),
+        ];
+
+        for (backend, base) in remote {
+            for control in [ConcurrencyControl::Off, ConcurrencyControl::Cas] {
+                let block = match control {
+                    ConcurrencyControl::Off => base.to_string(),
+                    ConcurrencyControl::Cas => {
+                        format!("{base}concurrency_control = \"cas\"\n")
+                    }
+                };
+                let checks = state_concurrency_checks(&block).await;
+                let check = checks
+                    .iter()
+                    .find(|c| c.name == "state_concurrency")
+                    .unwrap_or_else(|| panic!("{backend} must emit the check"));
+
+                // Nothing is fully protected until the seam writers stop
+                // bypassing compare-and-swap.
+                assert!(
+                    matches!(check.status, HealthStatus::Warning),
+                    "{backend} + {control}: every remote case warns today, got {:?}",
+                    check.status,
+                );
+
+                let effective = rocky_core::state_sync::cas_effective(&StateConfig {
+                    backend,
+                    concurrency_control: control,
+                    ..StateConfig::default()
+                });
+                // "is a no-op" is the phrase reserved for a `cas` request the
+                // backend cannot honour. It must appear exactly when the engine
+                // says compare-and-swap does NOT take effect — that equivalence
+                // is what proves the check reads the engine's predicate rather
+                // than a copied backend list.
+                let says_no_op = check.message.contains("is a no-op");
+                assert_eq!(
+                    says_no_op,
+                    control == ConcurrencyControl::Cas && !effective,
+                    "{backend} + {control}: the no-op wording must track cas_effective \
+                     (effective={effective}) — {}",
+                    check.message,
+                );
+                if effective {
+                    assert!(
+                        check.message.contains("#1228"),
+                        "{backend} + {control}: an effective-CAS writer must be told what is \
+                         still unprotected — {}",
+                        check.message,
+                    );
+                }
+            }
+        }
+    }
+
+    /// Fail-closed: a config we cannot read is not evidence of a `local`
+    /// backend, and must not let `--check state_concurrency` exit 0 green.
+    #[tokio::test]
+    async fn state_concurrency_fails_loudly_on_unreadable_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("rocky.toml");
+        std::fs::write(&config_path, "this is not valid toml : : :").unwrap();
+        let state_path = dir.path().join("state.redb");
+
+        let (checks, _) =
+            collect_health_checks(&config_path, &state_path, Some("state_concurrency"), false)
+                .await;
+
+        let check = checks
+            .iter()
+            .find(|c| c.name == "state_concurrency")
+            .expect("an unreadable config must still emit the check");
+        assert!(
+            matches!(check.status, HealthStatus::Critical),
+            "a config we cannot read must not report healthy, got {:?}",
+            check.status,
         );
     }
 

--- a/engine/crates/rocky-cli/src/commands/validate.rs
+++ b/engine/crates/rocky-cli/src/commands/validate.rs
@@ -59,11 +59,18 @@ fn validate_inner(config_path: &Path) -> Result<ValidateOutput> {
         }
     };
 
-    // Emit a structured diagnostic for every adapter-kind / pipeline-role
-    // issue. V032 covers `[adapter.*]` `kind` invariants; V033 covers
-    // `source.adapter` / `source.discovery.adapter` role mismatches.
-    for err in rocky_core::config::validate_adapter_kinds(&cfg) {
-        out.push(kind_diagnostic(&err, config_path));
+    // Emit a structured diagnostic for every issue the shared post-parse
+    // validation chain finds — the same chain `load_rocky_config` runs, so
+    // `rocky validate` and the executing paths agree on what is loadable.
+    // Validating only adapter kinds here let a config that every `rocky run`
+    // rejects (e.g. `[state] freeze_marker_writes` on a backend with no
+    // durable object tier) report "valid" with exit 0.
+    //
+    // V032 covers `[adapter.*]` `kind` invariants, V033 the
+    // `source.adapter` / `source.discovery.adapter` role mismatches, and
+    // V046 the rest of the chain.
+    for err in rocky_core::config::collect_loaded_config_errors(&cfg) {
+        out.push(config_error_diagnostic(&err, config_path));
     }
 
     // Validate adapters
@@ -252,12 +259,23 @@ fn validate_inner(config_path: &Path) -> Result<ValidateOutput> {
     Ok(out)
 }
 
-/// Converts a `kind`-validation error into a `ValidateMessage` with a
-/// structured V-code and a `field` path that points an IDE at the
-/// offending key in `rocky.toml`.
-fn kind_diagnostic(err: &rocky_core::config::ConfigError, config_path: &Path) -> ValidateMessage {
+/// Converts one error from the shared post-parse validation chain into a
+/// `ValidateMessage` with a structured V-code and a `field` path that points
+/// an IDE at the offending key in `rocky.toml`.
+///
+/// Codes are a public contract, so the two pre-existing ones keep their exact
+/// meaning — V032 for `[adapter.*]` `kind` invariants, V033 for pipeline
+/// adapter-role mismatches — and everything else the chain rejects lands on
+/// V046 rather than the V001 parse code, which already carries both the "Config
+/// syntax valid" ok message and the "Failed to parse config" error.
+fn config_error_diagnostic(
+    err: &rocky_core::config::ConfigError,
+    config_path: &Path,
+) -> ValidateMessage {
     use rocky_core::config::ConfigError;
 
+    // `ConfigError` carries every read/parse/env variant too; only the ones
+    // the validation chain can actually produce are worth a `field` path.
     let (code, field) = match err {
         ConfigError::AdapterMissingDiscoveryKind { name, .. }
         | ConfigError::AdapterKindUnsupported { name, .. } => {
@@ -270,7 +288,47 @@ fn kind_diagnostic(err: &rocky_core::config::ConfigError, config_path: &Path) ->
             "V033",
             Some(format!("pipeline.{pipeline}.source.discovery.adapter")),
         ),
-        _ => ("V001", None),
+        ConfigError::ReplicationMergeMissingKeys { pipeline } => {
+            ("V046", Some(format!("pipeline.{pipeline}.merge_keys")))
+        }
+        ConfigError::TableOverrideEmptyMatch { pipeline, .. }
+        | ConfigError::TableOverrideDuplicate { pipeline, .. }
+        | ConfigError::TableOverrideInvalidGlob { pipeline, .. }
+        | ConfigError::TableOverrideMergeMissingKeys { pipeline, .. } => {
+            ("V046", Some(format!("pipeline.{pipeline}.table_overrides")))
+        }
+        ConfigError::SchemaPatternReservedComponent { pipeline, .. } => (
+            "V046",
+            Some(format!(
+                "pipeline.{pipeline}.source.schema_pattern.components"
+            )),
+        ),
+        ConfigError::FivetranCacheMissingField { adapter, .. } => {
+            ("V046", Some(format!("adapter.{adapter}.cache")))
+        }
+        ConfigError::FivetranRatelimitMissingField { adapter, .. } => {
+            ("V046", Some(format!("adapter.{adapter}.ratelimit")))
+        }
+        ConfigError::FivetranStampedeMissingField { adapter, .. } => {
+            ("V046", Some(format!("adapter.{adapter}.stampede")))
+        }
+        ConfigError::FivetranCircuitBreakerMissingField { adapter, .. } => {
+            ("V046", Some(format!("adapter.{adapter}.circuit_breaker")))
+        }
+        ConfigError::PolicyUnsupportedVersion { .. } => ("V046", Some("policy.version".into())),
+        ConfigError::PolicyScopeAnyConflict { rule_index }
+        | ConfigError::PolicyScopeEmpty { rule_index } => {
+            ("V046", Some(format!("policy.rules[{rule_index}].scope")))
+        }
+        ConfigError::PolicyBudgetInvalidWindow { rule_index, .. }
+        | ConfigError::PolicyBudgetZeroFailures { rule_index, .. } => (
+            "V046",
+            Some(format!("policy.rules[{rule_index}].autonomy_budget")),
+        ),
+        ConfigError::StateFreezeMarkerWritesUnsupportedBackend { .. } => {
+            ("V046", Some("state.freeze_marker_writes".into()))
+        }
+        _ => ("V046", None),
     };
 
     ValidateMessage {
@@ -1320,6 +1378,130 @@ mod tests {
         let mut f = NamedTempFile::new().unwrap();
         f.write_all(toml_str.as_bytes()).unwrap();
         validate_inner(f.path()).unwrap()
+    }
+
+    /// Write a config, then return both what `rocky validate` reports and
+    /// whether the executing paths (`load_rocky_config`) accept it.
+    ///
+    /// The pair is the point: `validate` must not green-light a config that
+    /// cannot run, and must not reject one that can.
+    fn validate_and_load(toml_str: &str) -> (ValidateOutput, bool) {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(toml_str.as_bytes()).unwrap();
+        let out = validate_inner(f.path()).unwrap();
+        let loadable = rocky_core::config::load_rocky_config(f.path()).is_ok();
+        (out, loadable)
+    }
+
+    /// `rocky validate` ran only the adapter-kind validator, so a config the
+    /// shared validation chain rejects — here `[state] freeze_marker_writes`
+    /// on a backend with no durable object tier — reported "Config syntax
+    /// valid" and exit 0 while every `rocky run` hard-errored on it.
+    #[test]
+    fn freeze_marker_writes_on_local_backend_is_rejected_v046() {
+        let (out, loadable) = validate_and_load(
+            r#"
+[adapter.db]
+type = "duckdb"
+[pipeline.raw]
+type = "transformation"
+[pipeline.raw.target]
+adapter = "db"
+[state]
+backend = "local"
+freeze_marker_writes = true
+"#,
+        );
+
+        assert!(
+            !out.valid,
+            "a config no run can load must not validate: {:?}",
+            out.messages
+        );
+        let v046: Vec<_> = out
+            .messages
+            .iter()
+            .filter(|m| m.code == "V046" && m.severity == "error")
+            .collect();
+        assert_eq!(v046.len(), 1, "expected one V046: {:?}", out.messages);
+        assert_eq!(
+            v046[0].field.as_deref(),
+            Some("state.freeze_marker_writes"),
+            "the diagnostic must point at the offending key",
+        );
+        assert!(
+            !loadable,
+            "the config validate now rejects must be one load_rocky_config already rejected — \
+             otherwise this is a new rule, not a bug fix",
+        );
+    }
+
+    /// A config carrying both an adapter-kind issue and a later-chain issue
+    /// surfaces both. The kind diagnostic keeps its V032 code and is emitted
+    /// exactly once — the chain now includes the kind validator, so a
+    /// leftover separate pass over it would double-report.
+    #[test]
+    fn kind_and_state_errors_both_surface_exactly_once() {
+        let out = validate_toml(
+            r#"
+[adapter.db]
+type = "duckdb"
+[adapter.ft]
+type = "fivetran"
+[pipeline.raw]
+type = "transformation"
+[pipeline.raw.target]
+adapter = "db"
+[state]
+backend = "local"
+freeze_marker_writes = true
+"#,
+        );
+
+        let v032: Vec<_> = out.messages.iter().filter(|m| m.code == "V032").collect();
+        assert_eq!(
+            v032.len(),
+            1,
+            "the kind diagnostic must be emitted exactly once: {:?}",
+            out.messages
+        );
+        assert_eq!(v032[0].field.as_deref(), Some("adapter.ft.kind"));
+        assert!(
+            out.messages.iter().any(|m| m.code == "V046"),
+            "the later-chain error must surface alongside the kind error: {:?}",
+            out.messages
+        );
+        assert!(!out.valid);
+    }
+
+    /// The chain must not fire on a config the executing paths accept.
+    #[test]
+    fn a_loadable_config_emits_no_chain_errors() {
+        let (out, loadable) = validate_and_load(
+            r#"
+[adapter.db]
+type = "duckdb"
+[pipeline.raw]
+type = "transformation"
+[pipeline.raw.target]
+adapter = "db"
+[state]
+backend = "s3"
+freeze_marker_writes = true
+"#,
+        );
+
+        assert!(
+            loadable,
+            "fixture must be loadable for this test to mean anything"
+        );
+        assert!(
+            !out.messages
+                .iter()
+                .any(|m| ["V032", "V033", "V046"].contains(&m.code.as_str())),
+            "no chain diagnostic may fire on a loadable config: {:?}",
+            out.messages
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -509,7 +509,7 @@ fn default_table_retries() -> u32 {
 }
 
 /// State storage backend variants.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum StateBackend {
     /// State stored on local disk (default). No sync needed.
@@ -539,10 +539,24 @@ impl std::fmt::Display for StateBackend {
 
 /// Concurrency control for remote `[state]` object writes.
 ///
-/// Guards the cross-pod lost update where two runs sharing one `[state]` prefix
-/// race: one downloads the state, the other commits, and the first's end-of-run
+/// Guards the cross-process lost update where two writers sharing one `[state]`
+/// location race: one reads the state, the other commits, and the first's
 /// upload silently overwrites the second (last-writer-wins). See
 /// [`StateConfig::concurrency_control`].
+///
+/// **Scope:** `docs/adr/ADR-CONCURRENCY.md` governs — compare-and-swap applies
+/// to *every* remote state write, split by writer class (runs refuse on
+/// conflict; single-record ledger seams retry). Only the run half is
+/// implemented today: the ledger-seam writers reached through
+/// `RemoteStateSession::upload_only_fail_closed` (`rocky gc`, `rocky policy`,
+/// `rocky apply`) still upload unconditionally on every backend, so `cas` does
+/// not yet make a deployment fully safe against lost updates. Issue #1228
+/// tracks closing that half; `rocky doctor --check state_concurrency` reports
+/// the residual exposure in the meantime.
+//
+// Kept free of rustdoc intra-doc links on purpose: `schemars` exports this
+// comment verbatim as the JSON Schema `description`, which surfaces in editor
+// tooltips and the OpenAPI document, where `[text][path]` renders as noise.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum ConcurrencyControl {
@@ -5820,48 +5834,79 @@ fn apply_single_adapter_discovery_default(config: &mut RockyConfig) {
 /// deprecation warnings programmatically (e.g., `rocky doctor`, `rocky
 /// validate`) can use [`check_config_deprecations`] on the raw TOML string.
 ///
-/// Also validates adapter `kind` fields and pipeline adapter references —
-/// see [`validate_adapter_kinds`]. Fails fast on the first such issue;
-/// `rocky validate` uses [`parse_rocky_config`] + [`validate_adapter_kinds`]
-/// directly so it can emit every issue as its own diagnostic.
+/// Also runs the whole [`CONFIG_VALIDATORS`] chain — adapter `kind` fields,
+/// pipeline adapter references, replication strategies and overrides,
+/// Fivetran cache/resilience blocks, `[policy]`, and `[state]` marker
+/// writes. Fails fast on the first issue; `rocky validate` uses
+/// [`parse_rocky_config`] + [`collect_loaded_config_errors`] over the same
+/// chain so it can emit every issue as its own diagnostic.
 pub fn load_rocky_config(path: &Path) -> Result<RockyConfig, ConfigError> {
     let config = parse_rocky_config(path)?;
     validate_loaded_config(&config)?;
     Ok(config)
 }
 
+/// A validator in the [`CONFIG_VALIDATORS`] chain: pure, panic-free, and
+/// independent of every other validator's outcome.
+type ConfigValidator = fn(&RockyConfig) -> Vec<ConfigError>;
+
+/// The ordered post-parse validation chain, in one place so the fail-fast
+/// consumer ([`validate_loaded_config`], behind `rocky run` and every other
+/// executing path) and the collect-all consumer
+/// ([`collect_loaded_config_errors`], behind `rocky validate`) can never
+/// disagree about which rules a config has to satisfy.
+///
+/// Sharing the list is the point: `rocky validate` used to run only
+/// [`validate_adapter_kinds`], so a config rejected by a later validator —
+/// e.g. `[state] freeze_marker_writes` on a backend with no durable object
+/// tier — reported "valid" and exit 0 while every `rocky run` hard-errored.
+///
+/// Every entry must stay pure and panic-free: the collect-all consumer runs
+/// each one even when an earlier validator already found problems, so a
+/// validator that assumed a predecessor had passed would fault on input the
+/// fail-fast consumer never reaches.
+const CONFIG_VALIDATORS: &[ConfigValidator] = &[
+    validate_adapter_kinds,
+    validate_replication_strategies,
+    validate_schema_pattern_reserved_components,
+    validate_replication_overrides,
+    validate_fivetran_cache,
+    validate_fivetran_resilience,
+    validate_policy,
+    validate_freeze_marker_writes,
+];
+
 /// The fail-fast validation chain shared by [`load_rocky_config`] and
 /// [`load_rocky_config_fingerprinted`]. Returns the first issue, matching
-/// `load_rocky_config`'s historical behavior.
+/// `load_rocky_config`'s historical behavior: validators run in
+/// [`CONFIG_VALIDATORS`] order and the chain stops at the first one that
+/// reports anything.
 fn validate_loaded_config(config: &RockyConfig) -> Result<(), ConfigError> {
-    if let Some(first) = validate_adapter_kinds(config).into_iter().next() {
-        return Err(first);
-    }
-    if let Some(first) = validate_replication_strategies(config).into_iter().next() {
-        return Err(first);
-    }
-    if let Some(first) = validate_schema_pattern_reserved_components(config)
-        .into_iter()
-        .next()
-    {
-        return Err(first);
-    }
-    if let Some(first) = validate_replication_overrides(config).into_iter().next() {
-        return Err(first);
-    }
-    if let Some(first) = validate_fivetran_cache(config).into_iter().next() {
-        return Err(first);
-    }
-    if let Some(first) = validate_fivetran_resilience(config).into_iter().next() {
-        return Err(first);
-    }
-    if let Some(first) = validate_policy(config).into_iter().next() {
-        return Err(first);
-    }
-    if let Some(first) = validate_freeze_marker_writes(config).into_iter().next() {
-        return Err(first);
+    for validate in CONFIG_VALIDATORS {
+        if let Some(first) = validate(config).into_iter().next() {
+            return Err(first);
+        }
     }
     Ok(())
+}
+
+/// Runs the whole [`CONFIG_VALIDATORS`] chain and returns **every** issue,
+/// in chain order, instead of stopping at the first.
+///
+/// The diagnostic counterpart to [`validate_loaded_config`]: `rocky validate`
+/// reports all of a config's problems in one pass rather than making the
+/// author fix them one run at a time. A parsed config that yields an empty
+/// `Vec` here is exactly a config [`load_rocky_config`] accepts, so `rocky
+/// validate` and the executing paths agree on what is loadable.
+///
+/// Callers that need to *load* a config should use [`load_rocky_config`] —
+/// this function neither reads nor parses, and returning `Vec` rather than
+/// `Result` makes it unusable as a gate by accident.
+pub fn collect_loaded_config_errors(config: &RockyConfig) -> Vec<ConfigError> {
+    CONFIG_VALIDATORS
+        .iter()
+        .flat_map(|validate| validate(config))
+        .collect()
 }
 
 /// A parsed [`RockyConfig`] paired with the fingerprint of the exact raw

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -554,6 +554,44 @@ pub struct RemoteStateSession {
     base: Option<Generation>,
 }
 
+/// Whether Rocky performs compare-and-swap state writes on `backend` at all.
+///
+/// The single source of truth for CAS backend capability. The runtime write
+/// path gates on it through [`cas_effective`], and `rocky doctor`'s
+/// `state_concurrency` check derives its verdict from the same call, so a
+/// backend that gains or loses conditional-write support changes both together.
+/// Re-deriving this list anywhere else is how a diagnostic ends up vouching for
+/// protection that is not there — or, just as harmful, warning about a
+/// deployment that is in fact protected.
+///
+/// `local` is `false` because it performs no remote write to condition; callers
+/// that care about the single-writer-local case handle it before asking.
+#[must_use]
+pub fn cas_supported_on(backend: StateBackend) -> bool {
+    match backend {
+        // A conditional-write object tier the upload can compare against.
+        StateBackend::S3 | StateBackend::Gcs => true,
+        // No generation to condition on: `cas` falls back to an unconditional
+        // upload (and warns once at `acquire`).
+        StateBackend::Valkey | StateBackend::Tiered => false,
+        // No remote write at all — the on-disk file IS the state.
+        StateBackend::Local => false,
+    }
+}
+
+/// Whether this `[state]` configuration *actually* performs compare-and-swap
+/// state writes: `concurrency_control = "cas"` requested AND
+/// [`cas_supported_on`] the configured backend.
+///
+/// "Effective" rather than "configured" is the distinction that matters — a
+/// `cas` request on a backend without conditional writes silently downgrades to
+/// an unconditional upload, so the request alone proves nothing about whether
+/// the deployment is protected.
+#[must_use]
+pub fn cas_effective(cfg: &StateConfig) -> bool {
+    cfg.concurrency_control == ConcurrencyControl::Cas && cas_supported_on(cfg.backend)
+}
+
 impl RemoteStateSession {
     /// Build a session over an owned snapshot of `cfg` for the ledger at
     /// `state_path`. Performs no I/O; call [`acquire`][Self::acquire] before
@@ -574,13 +612,11 @@ impl RemoteStateSession {
         }
     }
 
-    /// Whether this session performs compare-and-swap state writes: configured
-    /// `concurrency_control = "cas"` AND a backend with a conditional-write
-    /// object tier (`s3` / `gcs`). On other backends `cas` auto-downgrades to
-    /// an unconditional upload.
+    /// Whether this session performs compare-and-swap state writes — see
+    /// [`cas_effective`], which this delegates to so the write path and the
+    /// `rocky doctor` diagnostic cannot disagree.
     fn cas_enabled(&self) -> bool {
-        self.cfg.concurrency_control == ConcurrencyControl::Cas
-            && matches!(self.cfg.backend, StateBackend::S3 | StateBackend::Gcs)
+        cas_effective(&self.cfg)
     }
 
     /// Download-before-read: resolve, record, and return the ledger's

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -699,7 +699,7 @@
       ]
     },
     "ConcurrencyControl": {
-      "description": "Concurrency control for remote `[state]` object writes.\n\nGuards the cross-pod lost update where two runs sharing one `[state]` prefix race: one downloads the state, the other commits, and the first's end-of-run upload silently overwrites the second (last-writer-wins). See [`StateConfig::concurrency_control`].",
+      "description": "Concurrency control for remote `[state]` object writes.\n\nGuards the cross-process lost update where two writers sharing one `[state]` location race: one reads the state, the other commits, and the first's upload silently overwrites the second (last-writer-wins). See [`StateConfig::concurrency_control`].\n\n**Scope:** `docs/adr/ADR-CONCURRENCY.md` governs — compare-and-swap applies to *every* remote state write, split by writer class (runs refuse on conflict; single-record ledger seams retry). Only the run half is implemented today: the ledger-seam writers reached through `RemoteStateSession::upload_only_fail_closed` (`rocky gc`, `rocky policy`, `rocky apply`) still upload unconditionally on every backend, so `cas` does not yet make a deployment fully safe against lost updates. Issue #1228 tracks closing that half; `rocky doctor --check state_concurrency` reports the residual exposure in the meantime.",
       "oneOf": [
         {
           "description": "Unconditional last-writer-wins upload (default) — byte-identical to the pre-CAS behaviour. Correct for single-writer-per-prefix deployments (one run at a time, orchestrator-serialized).",


### PR DESCRIPTION
## Summary

Two related state-configuration safety gaps: `rocky validate` accepted configs that `rocky run` refuses to load, and nothing warned an operator whose remote-backed deployment had no lost-update protection.

## 1. `validate` no longer false-greens a config that cannot run

`[state] freeze_marker_writes = true` on a `local` backend reported `"valid": true` and exit 0 from `rocky validate`, while `plan` and `doctor --check config` hard-errored on the same file. `validate` did not run the post-parse validators that `load_rocky_config` applies.

The eight post-parse validators are now a single list with two consumers: `load_rocky_config` keeps its exact short-circuit semantics, and `validate` runs the whole chain to collect every error. This is a **structural** guarantee rather than a patched case — `validate` cannot reject what `load_rocky_config` accepts, and a test asserts that pairing.

New diagnostic code `V046` carries these errors with field paths. Verified against the 117 `rocky.toml` files in this repo, base vs new: **zero verdict changes**, so the weekly parse/validate sweep is unaffected.

## 2. New `doctor` check: `state_concurrency`

Warns when a remote-backed deployment has no effective lost-update protection. Capability is **derived** from the engine's own predicate (`cas_supported_on` / `cas_effective` in `rocky-core`, which `cas_enabled` now delegates to) rather than restating a list of backends, so the check cannot drift as backend support changes.

| config | verdict |
|---|---|
| `local`, or no `[state]` | silent — single writer by construction |
| `s3` / `gcs` + `off` | warning — names the fix |
| `s3` / `gcs` + `cas` | warning — end-of-run upload is protected, ledger seams are not (#1228) |
| `valkey` / `tiered` + `off` | warning — and `cas` would not help on this backend |
| `valkey` / `tiered` + `cas` | warning — asked for protection, not getting it |
| unreadable config | **critical** — fail-closed |

All four remote messages are distinct, asserted pairwise, so an operator can tell the situations apart without reading source.

**No deployment reports healthy today, and that is deliberate.** Per ADR-CONCURRENCY D1, compare-and-swap must cover every remote state write split by writer class; only the run half is implemented. The single-record ledger seams (`rocky gc`, `rocky policy`, `rocky apply`) still upload unconditionally on **every** backend, so a concurrent maintenance or governance command can silently overwrite a run's committed state — tracked as #1228. Reporting healthy while that is true would be the same false-green this PR exists to remove.

## Notes

- `ConcurrencyControl`'s doc comment claimed compare-and-swap covered only the end-of-run upload, contradicting D1. Corrected to state D1's scope and that only the run half is implemented. `schemars` exports that comment as the JSON Schema `description`, so the regenerated schema/OpenAPI/editor artifacts are committed alongside — description text only, no structural change.
- `StateBackend` gains `Copy` (fieldless enum, additive).
- The ADR is untouched.

## Testing

`cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean · `cargo nextest run --all-features` **5635 passed** · `just codegen` committed with the change.
