### PR TITLE
fix(engine/rocky-cli): report ci-diff rows as warehouse targets

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -6227,7 +6227,7 @@
         "type": "string"
       },
       "DiffResult": {
-        "description": "Diff result for a single model between two pipeline states.",
+        "description": "Diff result for a single warehouse object between two pipeline states.\n\nA row identifies a **target**, not a logical model. A model whose target moves is therefore reported twice — removed at its old target, added at its new one — because that is what happens in the warehouse: nothing drops the abandoned table. [`Self::model_name`] alone cannot distinguish those two rows, so [`Self::resolved_target`] carries the identity they differ on.",
         "properties": {
           "column_changes": {
             "description": "Column-level changes (empty for unchanged models).",
@@ -6237,8 +6237,15 @@
             "type": "array"
           },
           "model_name": {
-            "description": "Fully-qualified model name (e.g. `catalog.schema.table`).",
+            "description": "Logical model name — the sidecar `name`, or the filename stem when the classifier could not resolve a compiled model.\n\nNot unique across a result set: two rows share it when a model's target moved. Key on [`Self::resolved_target`] instead when one is present.",
             "type": "string"
+          },
+          "resolved_target": {
+            "description": "The warehouse object this row describes, as `catalog.schema.table`.\n\n`None` when the classifier fell back to filename matching because a ref did not compile, and for callers that build results without a resolved project (e.g. the row-level comparison in `compare`).",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "row_count_after": {
             "description": "Row count on the incoming (PR) side. `None` for removed models.",

--- a/editors/vscode/src/types/generated/ci_diff.ts
+++ b/editors/vscode/src/types/generated/ci_diff.ts
@@ -186,7 +186,9 @@ export interface BreakingFinding {
   [k: string]: unknown;
 }
 /**
- * Diff result for a single model between two pipeline states.
+ * Diff result for a single warehouse object between two pipeline states.
+ *
+ * A row identifies a **target**, not a logical model. A model whose target moves is therefore reported twice — removed at its old target, added at its new one — because that is what happens in the warehouse: nothing drops the abandoned table. [`Self::model_name`] alone cannot distinguish those two rows, so [`Self::resolved_target`] carries the identity they differ on.
  */
 export interface DiffResult {
   /**
@@ -194,9 +196,17 @@ export interface DiffResult {
    */
   column_changes?: ColumnDiff[];
   /**
-   * Fully-qualified model name (e.g. `catalog.schema.table`).
+   * Logical model name — the sidecar `name`, or the filename stem when the classifier could not resolve a compiled model.
+   *
+   * Not unique across a result set: two rows share it when a model's target moved. Key on [`Self::resolved_target`] instead when one is present.
    */
   model_name: string;
+  /**
+   * The warehouse object this row describes, as `catalog.schema.table`.
+   *
+   * `None` when the classifier fell back to filename matching because a ref did not compile, and for callers that build results without a resolved project (e.g. the row-level comparison in `compare`).
+   */
+  resolved_target?: string | null;
   /**
    * Row count on the incoming (PR) side. `None` for removed models.
    */

--- a/engine/crates/rocky-cli/src/commands/ci_diff.rs
+++ b/engine/crates/rocky-cli/src/commands/ci_diff.rs
@@ -47,6 +47,11 @@ struct ModelChange {
     base_schema_name: Option<String>,
     /// Schema-map key on HEAD.
     head_schema_name: Option<String>,
+    /// Resolved `catalog.schema.table` this change refers to, when both refs
+    /// compiled. The map key can carry a name qualifier to disambiguate two
+    /// models sharing a target; this is the bare warehouse identity, which is
+    /// what the report publishes.
+    resolved_target: Option<String>,
 }
 
 impl ModelChange {
@@ -193,6 +198,31 @@ fn model_file_name<'a>(path: &'a str, models_rel: Option<&str>) -> Option<&'a st
 /// "any descendant", though — a `models/README.md` or a stray CSV cannot change
 /// a compile, and running two compiles for one is pure cost. Used to decide
 /// whether a compile is worth running, never to classify a model.
+/// Whether `path` is shared model configuration — config the compiler reads for
+/// *many* models rather than one.
+///
+/// These files own no model, so the path-matching classifier can never key on
+/// them, yet `groups/*.toml` supplies `schema_template` and `_defaults.toml`
+/// supplies `target.catalog` / `target.schema` — either can move every model
+/// that reads it.
+fn is_shared_model_config(path: &str, models_rel: Option<&str>) -> bool {
+    let Some(root) = models_rel else {
+        return false;
+    };
+    let Ok(relative) = Path::new(path).strip_prefix(root) else {
+        return false;
+    };
+    if relative.extension().and_then(|ext| ext.to_str()) != Some("toml") {
+        return false;
+    }
+    let components: Vec<_> = relative.iter().filter_map(|c| c.to_str()).collect();
+    match components.as_slice() {
+        [file] => matches!(*file, "_defaults.toml" | "test_definitions.toml"),
+        ["groups", _] => true,
+        _ => false,
+    }
+}
+
 fn compiler_input_under_models_root(path: &str, models_rel: Option<&str>) -> bool {
     models_rel.is_some_and(|root| Path::new(path).strip_prefix(root).is_ok())
         && matches!(
@@ -278,9 +308,13 @@ fn record_model_side(
     changes: &mut HashMap<String, ModelChange>,
     key: String,
     model_name: &str,
+    resolved_target: Option<&str>,
     is_base: bool,
 ) {
     let change = changes.entry(key).or_default();
+    if change.resolved_target.is_none() {
+        change.resolved_target = resolved_target.map(str::to_string);
+    }
     if is_base {
         change.base_schema_name = Some(model_name.to_string());
         if change.model_name.is_empty() {
@@ -290,6 +324,24 @@ fn record_model_side(
         change.head_schema_name = Some(model_name.to_string());
         change.model_name = model_name.to_string();
     }
+}
+
+/// Record one compiled model under its target-derived key.
+fn record_resolved_model(
+    changes: &mut HashMap<String, ModelChange>,
+    model: &Model,
+    ambiguous: &HashSet<String>,
+    is_base: bool,
+) {
+    let target = target_identity(model);
+    // A target shared by two models can't identify either of them; fall
+    // back to pairing by name so neither disappears from the report.
+    let key = if ambiguous.contains(&target) {
+        format!("{target}#{}", model.config.name)
+    } else {
+        target.clone()
+    };
+    record_model_side(changes, key, &model.config.name, Some(&target), is_base);
 }
 
 fn record_resolved_side(
@@ -304,15 +356,7 @@ fn record_resolved_side(
         .iter()
         .filter(|model| model_matches_path(model, path, models_rel))
     {
-        let target = target_identity(model);
-        // A target shared by two models can't identify either of them; fall
-        // back to pairing by name so neither disappears from the report.
-        let key = if ambiguous.contains(&target) {
-            format!("{target}#{}", model.config.name)
-        } else {
-            target
-        };
-        record_model_side(changes, key, &model.config.name, is_base);
+        record_resolved_model(changes, model, ambiguous, is_base);
     }
 }
 
@@ -348,6 +392,35 @@ fn classify_model_changes(
                 false,
             );
         }
+
+        // Shared config — `_defaults.toml`, `groups/*.toml`,
+        // `test_definitions.toml` — owns no model file, so nothing above can
+        // key on it. It can still retarget every model that reads it, and a
+        // row here identifies a *target*: N tables abandoned, N created. Pair
+        // the two compiles by logical name and record any pair whose resolved
+        // target moved. Models the shared config did not move contribute
+        // nothing, so this stays proportional to the retargeted set rather
+        // than emitting a row per model in the project.
+        if files
+            .iter()
+            .any(|file| is_shared_model_config(&file.path, models_rel))
+        {
+            let head_by_name: HashMap<&str, &Model> = head
+                .iter()
+                .map(|model| (model.config.name.as_str(), model))
+                .collect();
+            for base_model in base {
+                let Some(head_model) = head_by_name.get(base_model.config.name.as_str()) else {
+                    continue;
+                };
+                if target_identity(base_model) == target_identity(head_model) {
+                    continue;
+                }
+                record_resolved_model(&mut changes, base_model, &ambiguous, true);
+                record_resolved_model(&mut changes, head_model, &ambiguous, false);
+            }
+        }
+
         return changes;
     }
 
@@ -394,6 +467,9 @@ fn classify_model_changes(
                 model_name: name,
                 base_schema_name,
                 head_schema_name,
+                // Filename fallback: the key is a stem, not a warehouse
+                // identity. Publishing it as one would be a lie.
+                resolved_target: None,
             },
         );
     }
@@ -697,6 +773,11 @@ fn build_diff_results(
             let result = DiffResult {
                 model_name: change.model_name.clone(),
                 status,
+                // The change-map key IS the resolved target on the resolved
+                // path. On the fallback path it is a filename stem, which is
+                // not a warehouse identity — leave it unset rather than
+                // publishing a stem as though it were one.
+                resolved_target: change.resolved_target.clone(),
                 row_count_before: None,
                 row_count_after: None,
                 column_changes,
@@ -1098,6 +1179,7 @@ mod tests {
             model_name: name.to_string(),
             base_schema_name,
             head_schema_name,
+            resolved_target: None,
         }
     }
 
@@ -1860,6 +1942,7 @@ mod tests {
                         model_name: "orders".to_string(),
                         base_schema_name: Some(format!("s{i}")),
                         head_schema_name: None,
+                        resolved_target: None,
                     },
                 );
             }
@@ -2232,9 +2315,29 @@ mod tests {
 
         let data = compute_in(dir, &models_dir);
 
-        // No model file changed, so there is nothing structural to report …
-        assert!(data.results.is_empty(), "results: {:?}", data.results);
-        // … but both compiles must be available, or `--semantic` is a no-op.
+        // No model *file* changed, but a row identifies a target and the group
+        // moved this model's: the old table is abandoned, a new one appears.
+        let row = |status: ModelDiffStatus| {
+            data.results
+                .iter()
+                .find(|result| result.status == status)
+                .unwrap_or_else(|| panic!("no {status} row in {:?}", data.results))
+        };
+        assert_eq!(data.results.len(), 2, "results: {:?}", data.results);
+        assert_eq!(
+            row(ModelDiffStatus::Removed).resolved_target.as_deref(),
+            Some("poc.mart_emea.orders")
+        );
+        assert_eq!(
+            row(ModelDiffStatus::Added).resolved_target.as_deref(),
+            Some("poc.mart_emea_v2.orders")
+        );
+        // Both rows name the same model, so the target is the only thing
+        // telling them apart — the reason it is on `DiffResult` at all.
+        assert_eq!(row(ModelDiffStatus::Removed).model_name, "orders");
+        assert_eq!(row(ModelDiffStatus::Added).model_name, "orders");
+
+        // The semantic gate must still fire alongside it.
         assert!(
             data.base_compile.is_some() && data.head_compile.is_some(),
             "shared-config change must not suppress the compiles"
@@ -2245,6 +2348,44 @@ mod tests {
                 .iter()
                 .any(rocky_core::breaking_change::BreakingFinding::is_breaking),
             "retargeting a group must surface a breaking finding, got: {findings:?}"
+        );
+    }
+
+    /// A shared-config edit that moves nothing must stay quiet — the scan is
+    /// proportional to the retargeted set, not to the project.
+    #[test]
+    fn e2e_shared_config_edit_that_moves_nothing_reports_nothing() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let models_dir = init_repo(
+            dir,
+            &[
+                (
+                    "_defaults.toml",
+                    "[target]\ncatalog = \"poc\"\nschema = \"marts\"\n",
+                ),
+                ("orders.sql", "SELECT 1 AS id\n"),
+                (
+                    "orders.toml",
+                    "name = \"orders\"\n\n[strategy]\ntype = \"full_refresh\"\n",
+                ),
+            ],
+        );
+
+        // Touch the shared config without changing any resolved target.
+        fs::write(
+            models_dir.join("_defaults.toml"),
+            "# routing for the marts layer\n[target]\ncatalog = \"poc\"\nschema = \"marts\"\n",
+        )
+        .unwrap();
+        run_git(dir, &["add", "."]);
+        run_git(dir, &["commit", "-q", "-m", "comment only"]);
+
+        let data = compute_in(dir, &models_dir);
+        assert!(
+            data.results.is_empty(),
+            "a no-op shared-config edit must not emit rows: {:?}",
+            data.results
         );
     }
 

--- a/engine/crates/rocky-cli/src/commands/ci_diff.rs
+++ b/engine/crates/rocky-cli/src/commands/ci_diff.rs
@@ -304,6 +304,26 @@ fn target_identity(model: &Model) -> String {
     format!("{}.{}.{}", target.catalog, target.schema, target.table)
 }
 
+/// The model's target identity, but only when every component is a real SQL
+/// identifier.
+///
+/// Target components are not validated at load — that happens later, at SQL
+/// generation, where `format_table_ref` rejects them. `resolved_target` is
+/// published as *the warehouse object this row describes*, so a string that
+/// could never name one must not go out under that contract; such a model
+/// reports `None` and is simply unidentified rather than misidentified.
+///
+/// This also keeps the disambiguating `{target}#{name}` map key injective:
+/// a validated identifier cannot contain `#`, so a qualified key can never
+/// collide with some other model's bare target.
+fn publishable_target(model: &Model) -> Option<String> {
+    let target = &model.config.target;
+    [&target.catalog, &target.schema, &target.table]
+        .iter()
+        .all(|component| rocky_sql::validation::validate_identifier(component).is_ok())
+        .then(|| target_identity(model))
+}
+
 fn record_model_side(
     changes: &mut HashMap<String, ModelChange>,
     key: String,
@@ -341,7 +361,13 @@ fn record_resolved_model(
     } else {
         target.clone()
     };
-    record_model_side(changes, key, &model.config.name, Some(&target), is_base);
+    record_model_side(
+        changes,
+        key,
+        &model.config.name,
+        publishable_target(model).as_deref(),
+        is_base,
+    );
 }
 
 fn record_resolved_side(
@@ -2348,6 +2374,86 @@ mod tests {
                 .iter()
                 .any(rocky_core::breaking_change::BreakingFinding::is_breaking),
             "retargeting a group must surface a breaking finding, got: {findings:?}"
+        );
+    }
+
+    /// `_defaults.toml` supplies `target.schema` to every model in the
+    /// directory, so editing it moves all of them. Same shape as the group
+    /// case, different shared-config file.
+    #[test]
+    fn e2e_defaults_retarget_reports_both_targets() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let models_dir = init_repo(
+            dir,
+            &[
+                (
+                    "_defaults.toml",
+                    "[target]\ncatalog = \"poc\"\nschema = \"marts\"\n",
+                ),
+                ("orders.sql", "SELECT 1 AS id\n"),
+                (
+                    "orders.toml",
+                    "name = \"orders\"\n\n[strategy]\ntype = \"full_refresh\"\n",
+                ),
+            ],
+        );
+
+        fs::write(
+            models_dir.join("_defaults.toml"),
+            "[target]\ncatalog = \"poc\"\nschema = \"marts_v2\"\n",
+        )
+        .unwrap();
+        run_git(dir, &["add", "."]);
+        run_git(dir, &["commit", "-q", "-m", "retarget via _defaults"]);
+
+        let data = compute_in(dir, &models_dir);
+        let target = |status: ModelDiffStatus| {
+            data.results
+                .iter()
+                .find(|r| r.status == status)
+                .and_then(|r| r.resolved_target.as_deref())
+        };
+        assert_eq!(data.results.len(), 2, "results: {:?}", data.results);
+        assert_eq!(target(ModelDiffStatus::Removed), Some("poc.marts.orders"));
+        assert_eq!(target(ModelDiffStatus::Added), Some("poc.marts_v2.orders"));
+    }
+
+    /// A target that could never name a warehouse object must not be published
+    /// as one. Components are not validated at load — only at SQL generation —
+    /// so `ci-diff` has to check before it publishes.
+    #[test]
+    fn unvalidatable_target_is_not_published_as_an_identity() {
+        let sources = source_schema("src_orders", &[("id", rocky_ir::RockyType::Int64)]);
+        let dir = TempDir::new().unwrap();
+        write_model_with_identity(
+            dir.path(),
+            "orders",
+            "orders",
+            "not a valid identifier",
+            "SELECT id FROM src_orders",
+        );
+        let compile = compile_head(dir.path(), sources).expect("compile");
+        let model = &compile.project.models[0];
+        assert!(
+            publishable_target(model).is_none(),
+            "an invalid target must not be published, got {:?}",
+            publishable_target(model)
+        );
+
+        // A well-formed one still is.
+        let ok_dir = TempDir::new().unwrap();
+        write_model_with_identity(
+            ok_dir.path(),
+            "orders",
+            "orders",
+            "orders",
+            "SELECT 1 AS id",
+        );
+        let ok = compile_head(ok_dir.path(), HashMap::new()).expect("compile");
+        assert_eq!(
+            publishable_target(&ok.project.models[0]).as_deref(),
+            Some("c.s.orders")
         );
     }
 

--- a/engine/crates/rocky-cli/src/commands/lineage_diff.rs
+++ b/engine/crates/rocky-cli/src/commands/lineage_diff.rs
@@ -145,7 +145,7 @@ fn format_lineage_diff_markdown(results: &[LineageDiffResult], summary: &DiffSum
     }
 
     out.push_str(&format!(
-        "**{} model(s) changed** ({} modified, {} added, {} removed, {} unchanged)\n\n",
+        "**{} row(s) changed** ({} modified, {} added, {} removed, {} unchanged)\n\n",
         summary.modified + summary.added + summary.removed,
         summary.modified,
         summary.added,

--- a/engine/crates/rocky-cli/src/commands/lineage_diff.rs
+++ b/engine/crates/rocky-cli/src/commands/lineage_diff.rs
@@ -216,6 +216,7 @@ mod tests {
     fn enrich_returns_empty_consumers_when_compile_missing() {
         let diff = vec![DiffResult {
             model_name: "orders".into(),
+            resolved_target: None,
             status: ModelDiffStatus::Modified,
             row_count_before: None,
             row_count_after: None,
@@ -238,6 +239,7 @@ mod tests {
         // available, we don't fall back to base.
         let diff = vec![DiffResult {
             model_name: "orders".into(),
+            resolved_target: None,
             status: ModelDiffStatus::Modified,
             row_count_before: None,
             row_count_after: None,

--- a/engine/crates/rocky-core/src/ci_diff.rs
+++ b/engine/crates/rocky-core/src/ci_diff.rs
@@ -170,11 +170,28 @@ impl DiffSummary {
 // Markdown formatter (GitHub PR comment)
 // ---------------------------------------------------------------------------
 
+/// Escape a value going into a Markdown table cell wrapped in a code span.
+///
+/// Neither `config.name` nor a target component is validated as a SQL
+/// identifier at model load, so either can carry a `|` — which ends the cell —
+/// or a backtick, which closes the code span early.
+fn md_cell(value: &str) -> String {
+    value.replace('|', "\\|").replace('`', "'")
+}
+
+/// Escape a value interpolated into the raw HTML `<summary>` heading.
+fn html_text(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
 /// Produce a markdown summary suitable for a GitHub PR comment.
 ///
-/// The output includes a one-line summary, a table of changed models, and
-/// per-model details (column changes, row count deltas) for non-unchanged
-/// models. Unchanged models are mentioned only in the summary count.
+/// The output includes a one-line summary, a table of changed rows, and
+/// per-row details (column changes, row count deltas) for non-unchanged rows.
+/// A row is a warehouse target, so a retargeted model contributes two.
 pub fn format_diff_markdown(results: &[DiffResult]) -> String {
     let summary = DiffSummary::from_results(results);
     let mut out = String::new();
@@ -189,7 +206,7 @@ pub fn format_diff_markdown(results: &[DiffResult]) -> String {
     }
 
     out.push_str(&format!(
-        "**{} model(s) changed** ({} modified, {} added, {} removed, {} unchanged)\n\n",
+        "**{} row(s) changed** ({} modified, {} added, {} removed, {} unchanged)\n\n",
         summary.modified + summary.added + summary.removed,
         summary.modified,
         summary.added,
@@ -229,8 +246,8 @@ pub fn format_diff_markdown(results: &[DiffResult]) -> String {
         if show_target {
             out.push_str(&format!(
                 "| `{}` | `{}` | {} | {} | {} | {} |\n",
-                r.model_name,
-                r.resolved_target.as_deref().unwrap_or("-"),
+                md_cell(&r.model_name),
+                md_cell(r.resolved_target.as_deref().unwrap_or("-")),
                 status_badge,
                 before,
                 after,
@@ -239,7 +256,11 @@ pub fn format_diff_markdown(results: &[DiffResult]) -> String {
         } else {
             out.push_str(&format!(
                 "| `{}` | {} | {} | {} | {} |\n",
-                r.model_name, status_badge, before, after, delta
+                md_cell(&r.model_name),
+                status_badge,
+                before,
+                after,
+                delta
             ));
         }
     }
@@ -252,8 +273,8 @@ pub fn format_diff_markdown(results: &[DiffResult]) -> String {
         }
         // Disambiguate the <summary> too — two rows can share a model name.
         let heading = match &r.resolved_target {
-            Some(target) => format!("{} — {}", r.model_name, target),
-            None => r.model_name.clone(),
+            Some(target) => format!("{} — {}", html_text(&r.model_name), html_text(target)),
+            None => html_text(&r.model_name),
         };
         out.push_str(&format!(
             "<details>\n<summary><b>{heading}</b> — column changes</summary>\n\n"
@@ -265,7 +286,10 @@ pub fn format_diff_markdown(results: &[DiffResult]) -> String {
             let new = c.new_type.as_deref().unwrap_or("-");
             out.push_str(&format!(
                 "| `{}` | {} | {} | {} |\n",
-                c.column_name, c.change_type, old, new
+                md_cell(&c.column_name),
+                c.change_type,
+                md_cell(old),
+                md_cell(new)
             ));
         }
         out.push_str("\n</details>\n\n");
@@ -287,7 +311,7 @@ pub fn format_diff_table(results: &[DiffResult]) -> String {
 
     // Header line
     out.push_str(&format!(
-        "Diff: {} model(s) total — {} modified, {} added, {} removed, {} unchanged\n\n",
+        "Diff: {} row(s) total — {} modified, {} added, {} removed, {} unchanged\n\n",
         summary.total_models, summary.modified, summary.added, summary.removed, summary.unchanged,
     ));
 
@@ -412,6 +436,115 @@ fn format_row_delta(before: Option<u64>, after: Option<u64>) -> String {
 // ===========================================================================
 // Tests
 // ===========================================================================
+
+#[cfg(test)]
+mod render_escaping_tests {
+    //! `config.name` and target components are not validated as SQL
+    //! identifiers at model load, so both reach the renderers as arbitrary
+    //! text. A `|` ends a Markdown cell, a backtick closes the code span, and
+    //! the `<details>` heading is raw HTML.
+    use super::*;
+
+    fn row(model_name: &str, target: Option<&str>) -> DiffResult {
+        DiffResult {
+            model_name: model_name.to_string(),
+            status: ModelDiffStatus::Removed,
+            resolved_target: target.map(str::to_string),
+            row_count_before: None,
+            row_count_after: None,
+            column_changes: vec![ColumnDiff {
+                column_name: "a|b".to_string(),
+                change_type: ColumnChangeType::Removed,
+                old_type: Some("Int64".to_string()),
+                new_type: None,
+            }],
+            sample_changed_rows: None,
+        }
+    }
+
+    #[test]
+    fn pipes_and_backticks_do_not_split_table_rows() {
+        let md = format_diff_markdown(&[row("or|ders`x", Some("c.s.t|z"))]);
+        let summary_row = md
+            .lines()
+            .find(|l| l.contains("removed") && l.starts_with("| `"))
+            .expect("a summary row");
+        // Six cells => five " | " separators; an unescaped pipe adds more.
+        assert_eq!(
+            summary_row.matches(" | ").count(),
+            5,
+            "row split by an unescaped pipe: {summary_row}"
+        );
+        // Each of the two code spans must open and close cleanly, so the
+        // backtick in the model name has to be gone.
+        assert!(!summary_row.contains("ders`x"), "{summary_row}");
+        assert_eq!(summary_row.matches('`').count(), 4, "{summary_row}");
+
+        let column_row = md
+            .lines()
+            .find(|l| l.contains("a\\|b"))
+            .expect("column cell escaped");
+        assert_eq!(column_row.matches(" | ").count(), 3, "{column_row}");
+    }
+
+    #[test]
+    fn details_heading_is_html_escaped() {
+        let md = format_diff_markdown(&[row("<img src=x>", Some("c.s.<b>"))]);
+        let heading = md
+            .lines()
+            .find(|l| l.starts_with("<summary>"))
+            .expect("a details heading");
+        assert!(
+            !heading.contains("<img src=x>") && !heading.contains("c.s.<b>"),
+            "raw HTML reached the <summary> heading: {heading}"
+        );
+        assert!(heading.contains("&lt;img src=x&gt;"), "{heading}");
+        assert!(heading.contains("&lt;b&gt;"), "{heading}");
+    }
+
+    #[test]
+    fn target_column_appears_only_when_a_row_resolved_one() {
+        let with = format_diff_markdown(&[row("orders", Some("c.s.orders"))]);
+        assert!(with.contains("| Model | Target | Status |"), "{with}");
+
+        let without = format_diff_markdown(&[row("orders", None)]);
+        assert!(
+            without.contains("| Model | Status |") && !without.contains("Target"),
+            "fallback output must be unchanged:\n{without}"
+        );
+    }
+
+    #[test]
+    fn mixed_resolved_and_unresolved_rows_stay_aligned() {
+        let mut resolved = row("a", Some("c.s.a"));
+        resolved.status = ModelDiffStatus::Added;
+        let table = format_diff_table(&[resolved, row("b", None)]);
+        let body: Vec<&str> = table
+            .lines()
+            .filter(|l| l.starts_with("  ") && (l.contains("added") || l.contains("removed")))
+            .collect();
+        assert_eq!(body.len(), 2, "{table}");
+        // The unresolved row still gets a padded placeholder cell, so the
+        // status column starts at the same offset in both rows.
+        let offset = |l: &str| l.find("added").or_else(|| l.find("removed"));
+        assert_eq!(
+            offset(body[0]),
+            offset(body[1]),
+            "columns misaligned:\n{table}"
+        );
+    }
+
+    #[test]
+    fn summary_prose_counts_rows_not_models() {
+        // One retargeted model contributes two rows; calling that "2 models"
+        // would be wrong under the target-row contract.
+        let mut added = row("orders", Some("c.s2.orders"));
+        added.status = ModelDiffStatus::Added;
+        let md = format_diff_markdown(&[row("orders", Some("c.s.orders")), added]);
+        assert!(md.contains("**2 row(s) changed**"), "{md}");
+        assert!(!md.contains("model(s) changed"), "{md}");
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -600,7 +733,7 @@ mod tests {
         let md = format_diff_markdown(&results);
 
         // Summary line
-        assert!(md.contains("**3 model(s) changed**"));
+        assert!(md.contains("**3 row(s) changed**"), "{md}");
         assert!(md.contains("1 modified"));
         assert!(md.contains("1 added"));
         assert!(md.contains("1 removed"));

--- a/engine/crates/rocky-core/src/ci_diff.rs
+++ b/engine/crates/rocky-core/src/ci_diff.rs
@@ -87,13 +87,30 @@ pub struct ColumnDiff {
 // Per-model diff result
 // ---------------------------------------------------------------------------
 
-/// Diff result for a single model between two pipeline states.
+/// Diff result for a single warehouse object between two pipeline states.
+///
+/// A row identifies a **target**, not a logical model. A model whose target
+/// moves is therefore reported twice — removed at its old target, added at its
+/// new one — because that is what happens in the warehouse: nothing drops the
+/// abandoned table. [`Self::model_name`] alone cannot distinguish those two
+/// rows, so [`Self::resolved_target`] carries the identity they differ on.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct DiffResult {
-    /// Fully-qualified model name (e.g. `catalog.schema.table`).
+    /// Logical model name — the sidecar `name`, or the filename stem when the
+    /// classifier could not resolve a compiled model.
+    ///
+    /// Not unique across a result set: two rows share it when a model's target
+    /// moved. Key on [`Self::resolved_target`] instead when one is present.
     pub model_name: String,
     /// High-level status.
     pub status: ModelDiffStatus,
+    /// The warehouse object this row describes, as `catalog.schema.table`.
+    ///
+    /// `None` when the classifier fell back to filename matching because a ref
+    /// did not compile, and for callers that build results without a resolved
+    /// project (e.g. the row-level comparison in `compare`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_target: Option<String>,
     /// Row count on the base (target branch) side. `None` for added models.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub row_count_before: Option<u64>,
@@ -180,9 +197,17 @@ pub fn format_diff_markdown(results: &[DiffResult]) -> String {
         summary.unchanged,
     ));
 
-    // Summary table — only non-unchanged models
-    out.push_str("| Model | Status | Rows (before) | Rows (after) | Delta |\n");
-    out.push_str("|-------|--------|--------------|-------------|-------|\n");
+    // Summary table — only non-unchanged models. The target column earns its
+    // width only when a row actually carries one; the fallback classifier and
+    // the row-level comparison paths leave it unset.
+    let show_target = results.iter().any(|r| r.resolved_target.is_some());
+    if show_target {
+        out.push_str("| Model | Target | Status | Rows (before) | Rows (after) | Delta |\n");
+        out.push_str("|-------|--------|--------|--------------|-------------|-------|\n");
+    } else {
+        out.push_str("| Model | Status | Rows (before) | Rows (after) | Delta |\n");
+        out.push_str("|-------|--------|--------------|-------------|-------|\n");
+    }
 
     for r in results {
         if r.status == ModelDiffStatus::Unchanged {
@@ -201,10 +226,22 @@ pub fn format_diff_markdown(results: &[DiffResult]) -> String {
             ModelDiffStatus::Removed => "removed",
             ModelDiffStatus::Unchanged => unreachable!(),
         };
-        out.push_str(&format!(
-            "| `{}` | {} | {} | {} | {} |\n",
-            r.model_name, status_badge, before, after, delta
-        ));
+        if show_target {
+            out.push_str(&format!(
+                "| `{}` | `{}` | {} | {} | {} | {} |\n",
+                r.model_name,
+                r.resolved_target.as_deref().unwrap_or("-"),
+                status_badge,
+                before,
+                after,
+                delta
+            ));
+        } else {
+            out.push_str(&format!(
+                "| `{}` | {} | {} | {} | {} |\n",
+                r.model_name, status_badge, before, after, delta
+            ));
+        }
     }
     out.push('\n');
 
@@ -213,9 +250,13 @@ pub fn format_diff_markdown(results: &[DiffResult]) -> String {
         if r.column_changes.is_empty() {
             continue;
         }
+        // Disambiguate the <summary> too — two rows can share a model name.
+        let heading = match &r.resolved_target {
+            Some(target) => format!("{} — {}", r.model_name, target),
+            None => r.model_name.clone(),
+        };
         out.push_str(&format!(
-            "<details>\n<summary><b>{}</b> — column changes</summary>\n\n",
-            r.model_name
+            "<details>\n<summary><b>{heading}</b> — column changes</summary>\n\n"
         ));
         out.push_str("| Column | Change | Old Type | New Type |\n");
         out.push_str("|--------|--------|----------|----------|\n");
@@ -269,14 +310,23 @@ pub fn format_diff_table(results: &[DiffResult]) -> String {
         .max(5);
     let status_width = 8; // "modified" is the longest status string
     let num_width = 12;
+    // Two rows can share a model name once a target moves, so show the target
+    // when any row resolved one.
+    let target_width = changed
+        .iter()
+        .filter_map(|r| r.resolved_target.as_deref().map(str::len))
+        .max()
+        .map(|w| w.max(6));
 
     // Table header
+    let header_target = target_width.map_or(String::new(), |w| format!("  {:<w$}", "TARGET"));
+    let rule_target = target_width.map_or(String::new(), |w| format!("  {}", "-".repeat(w)));
     out.push_str(&format!(
-        "  {:<model_width$}  {:<status_width$}  {:>num_width$}  {:>num_width$}  {:>num_width$}\n",
+        "  {:<model_width$}{header_target}  {:<status_width$}  {:>num_width$}  {:>num_width$}  {:>num_width$}\n",
         "MODEL", "STATUS", "BEFORE", "AFTER", "DELTA",
     ));
     out.push_str(&format!(
-        "  {:<model_width$}  {:<status_width$}  {:>num_width$}  {:>num_width$}  {:>num_width$}\n",
+        "  {:<model_width$}{rule_target}  {:<status_width$}  {:>num_width$}  {:>num_width$}  {:>num_width$}\n",
         "-".repeat(model_width),
         "-".repeat(status_width),
         "-".repeat(num_width),
@@ -292,9 +342,12 @@ pub fn format_diff_table(results: &[DiffResult]) -> String {
             .row_count_after
             .map_or(String::from("-"), |n| n.to_string());
         let delta = format_row_delta(r.row_count_before, r.row_count_after);
+        let target_cell = target_width.map_or(String::new(), |w| {
+            format!("  {:<w$}", r.resolved_target.as_deref().unwrap_or("-"))
+        });
 
         out.push_str(&format!(
-            "  {:<model_width$}  {:<status_width$}  {:>num_width$}  {:>num_width$}  {:>num_width$}\n",
+            "  {:<model_width$}{target_cell}  {:<status_width$}  {:>num_width$}  {:>num_width$}  {:>num_width$}\n",
             r.model_name,
             r.status.to_string(),
             before,
@@ -372,6 +425,7 @@ mod tests {
         DiffResult {
             model_name: name.to_string(),
             status: ModelDiffStatus::Unchanged,
+            resolved_target: None,
             row_count_before: Some(rows),
             row_count_after: Some(rows),
             column_changes: vec![],
@@ -388,6 +442,7 @@ mod tests {
         DiffResult {
             model_name: name.to_string(),
             status: ModelDiffStatus::Modified,
+            resolved_target: None,
             row_count_before: Some(before),
             row_count_after: Some(after),
             column_changes,
@@ -399,6 +454,7 @@ mod tests {
         DiffResult {
             model_name: name.to_string(),
             status: ModelDiffStatus::Added,
+            resolved_target: None,
             row_count_before: None,
             row_count_after: Some(rows),
             column_changes: vec![],
@@ -410,6 +466,7 @@ mod tests {
         DiffResult {
             model_name: name.to_string(),
             status: ModelDiffStatus::Removed,
+            resolved_target: None,
             row_count_before: Some(rows),
             row_count_after: None,
             column_changes: vec![],

--- a/schemas/ci_diff.schema.json
+++ b/schemas/ci_diff.schema.json
@@ -581,7 +581,7 @@
       "type": "object"
     },
     "DiffResult": {
-      "description": "Diff result for a single model between two pipeline states.",
+      "description": "Diff result for a single warehouse object between two pipeline states.\n\nA row identifies a **target**, not a logical model. A model whose target moves is therefore reported twice — removed at its old target, added at its new one — because that is what happens in the warehouse: nothing drops the abandoned table. [`Self::model_name`] alone cannot distinguish those two rows, so [`Self::resolved_target`] carries the identity they differ on.",
       "properties": {
         "column_changes": {
           "description": "Column-level changes (empty for unchanged models).",
@@ -591,8 +591,15 @@
           "type": "array"
         },
         "model_name": {
-          "description": "Fully-qualified model name (e.g. `catalog.schema.table`).",
+          "description": "Logical model name — the sidecar `name`, or the filename stem when the classifier could not resolve a compiled model.\n\nNot unique across a result set: two rows share it when a model's target moved. Key on [`Self::resolved_target`] instead when one is present.",
           "type": "string"
+        },
+        "resolved_target": {
+          "description": "The warehouse object this row describes, as `catalog.schema.table`.\n\n`None` when the classifier fell back to filename matching because a ref did not compile, and for callers that build results without a resolved project (e.g. the row-level comparison in `compare`).",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "row_count_after": {
           "description": "Row count on the incoming (PR) side. `None` for removed models.",

--- a/sdk/python/src/rocky_sdk/types_generated/ci_diff_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/ci_diff_schema.py
@@ -406,7 +406,9 @@ class BreakingFinding(BaseModel):
 
 class DiffResult(BaseModel):
     """
-    Diff result for a single model between two pipeline states.
+    Diff result for a single warehouse object between two pipeline states.
+
+    A row identifies a **target**, not a logical model. A model whose target moves is therefore reported twice — removed at its old target, added at its new one — because that is what happens in the warehouse: nothing drops the abandoned table. [`Self::model_name`] alone cannot distinguish those two rows, so [`Self::resolved_target`] carries the identity they differ on.
     """
 
     column_changes: list[ColumnDiff] | None = None
@@ -415,7 +417,15 @@ class DiffResult(BaseModel):
     """
     model_name: str
     """
-    Fully-qualified model name (e.g. `catalog.schema.table`).
+    Logical model name — the sidecar `name`, or the filename stem when the classifier could not resolve a compiled model.
+
+    Not unique across a result set: two rows share it when a model's target moved. Key on [`Self::resolved_target`] instead when one is present.
+    """
+    resolved_target: str | None = None
+    """
+    The warehouse object this row describes, as `catalog.schema.table`.
+
+    `None` when the classifier fell back to filename matching because a ref did not compile, and for callers that build results without a resolved project (e.g. the row-level comparison in `compare`).
     """
     row_count_after: conint(ge=0) | None = None
     """


### PR DESCRIPTION
Fixes #1233.

`DiffResult` was designed to describe a warehouse object — it carries `row_count_before` / `row_count_after`, and `model_name` was documented as `catalog.schema.table`. It never held one, and no field on the row named the target. Two consequences, both surfaced while reviewing #1226:

- A model whose target moved produced **two rows that were indistinguishable** — same `model_name`, nothing to say which table each referred to.
- A shared-config edit that retargeted *every model in the project* produced **no rows at all**, visible only through opt-in `--semantic`.

This adopts the contract the struct already implied — **a row identifies a target** — and makes the output say so. That framing is what `#1225`'s expected output, `breaking_change.rs`'s `ModelRemoved`/`ModelAdded`, and the `row_count_*` fields all already assume; nothing in the run, catalog, or drift paths drops an abandoned target, so a moved model really does leave a stale table behind.

### Changes

**`DiffResult.resolved_target: Option<String>`** — the bare `catalog.schema.table`. Optional, so the JSON stays wire-compatible: generated Pydantic optionals default to `None` and the TypeScript members are optional. Left unset on the filename-fallback path, where the classifier's key is a stem rather than a warehouse identity — publishing that as a target would be a lie.

**Shared-config retargets are reported.** `_defaults.toml`, `groups/*.toml`, and `test_definitions.toml` own no model file, so the path-matching classifier could never key on them, yet a group's `schema_template` or a defaults `target.schema` moves every model that reads it. When one of those changed and both refs compiled, the classifier now also pairs the two compiles by logical name and records the pairs whose resolved target differs — proportional to the retargeted set, not a row per model. A no-op edit to the same files still reports nothing.

**The target is rendered** — a Target column in the Markdown table, a qualified `<details>` heading, and a TARGET column in the terminal table, each only when a row actually resolved one, so fallback output is byte-identical.

**`model_name`'s doc is corrected**: it is the logical name, and it is not unique across a result set.

### Before / after

| case | before | after |
|---|---|---|
| `groups/*.toml` retarget | **0 rows** | `orders` removed `poc.mart_emea.orders` + added `poc.mart_emea_v2.orders` |
| `_defaults.toml` retarget | **0 rows** | same shape |
| per-model retarget | 2 rows, both `orders`, indistinguishable | 2 rows carrying their targets |
| no-op shared-config edit | 0 rows | 0 rows (unchanged) |
| base ref does not compile | fallback | fallback, `resolved_target` unset |

Verified against a rename **and** a group retarget in one commit: the renamed model is caught by the file pass and the untouched sibling by the new scan, with no double-counting.

### Notes

`#[non_exhaustive]` on `DiffResult` was considered and skipped — no crate in this workspace is published, so there are no external Rust consumers for it to protect, and it would cost a setter for every construction site.

`just codegen` re-run (schema + Pydantic + TypeScript + OpenAPI); a freshly exported schema set diffs byte-identical against the committed one. `just regen-fixtures` produces no drift — the dagster corpus captures `ci`, not `ci-diff`. The incidental `package-lock.json` churn `just codegen` produces on macOS is excluded.
