### PR TITLE
fix(engine/rocky-compiler): make decimal AVG inference conservative

### DIFF
--- a/engine/crates/rocky-compiler/src/typecheck.rs
+++ b/engine/crates/rocky-compiler/src/typecheck.rs
@@ -1387,12 +1387,16 @@ fn infer_aggregation_type(func: &str, input_type: &RockyType) -> (RockyType, boo
             (ty, true)
         }
         "AVG" => {
-            // Exact-numeric AVG is dialect-dependent, and this layer has no
-            // adapter context. Avoid a false concrete type (#1238).
-            let ty = if input_type.is_integer() || input_type.is_float() {
-                RockyType::Float64
-            } else {
+            // `AVG` of an exact-numeric input is dialect-dependent and this layer
+            // has no adapter context: DuckDB returns DOUBLE, Databricks returns
+            // DECIMAL(p + 4, s + 4), BigQuery preserves NUMERIC/BIGNUMERIC. Only
+            // `Decimal` degrades to `Unknown` (#1238) — every other input keeps
+            // `Float64`, so an argument Rocky simply failed to resolve does not
+            // silently drop out of contract validation.
+            let ty = if matches!(input_type, RockyType::Decimal { .. }) {
                 RockyType::Unknown
+            } else {
+                RockyType::Float64
             };
             (ty, true)
         }
@@ -2567,6 +2571,50 @@ mod tests {
         );
     }
 
+    /// The `Decimal` carve-out must not widen into "any input Rocky failed to
+    /// resolve". `validate_contract` skips type validation when the inferred
+    /// type is `Unknown`, so an over-broad withhold would turn E011 into
+    /// silence for every `AVG` in a project compiled without source schemas —
+    /// a fail-open at a gate, not conservative inference.
+    #[test]
+    fn test_avg_over_unresolved_input_still_validates_contracts() {
+        let models = vec![make_model(
+            "averages",
+            "SELECT AVG(amount) AS avg_amount FROM source.raw.orders",
+        )];
+        let project = Project::from_models(models).unwrap();
+
+        let mut external = HashMap::new();
+        external.insert("source.raw.orders".to_string(), vec![]);
+        let graph = build_semantic_graph(&project, &external).unwrap();
+
+        // No source schema for the referenced table — the `AVG` argument does
+        // not resolve, exactly as with a cold schema cache or a fresh clone.
+        let sources = HashMap::new();
+        let result = typecheck_project_with_models(&graph, &sources, None, &project.models, None);
+        let columns = &result.typed_models["averages"];
+        let avg_amount = columns.iter().find(|col| col.name == "avg_amount").unwrap();
+        assert_eq!(avg_amount.data_type, RockyType::Float64);
+
+        let contract = CompilerContract {
+            columns: vec![ContractColumn {
+                name: "avg_amount".to_string(),
+                type_name: Some("Boolean".to_string()),
+                nullable: Some(true),
+                description: None,
+            }],
+            rules: ContractRules::default(),
+        };
+        let diagnostics = validate_contract("averages", columns, &contract);
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| &*diagnostic.code == "E011"
+                    && diagnostic.message.contains("avg_amount")),
+            "an unresolved AVG argument must not silence the contract check: {diagnostics:?}"
+        );
+    }
+
     #[test]
     fn test_cast_alias_uses_cast_type_not_source_type() {
         let models = vec![make_model(
@@ -3020,13 +3068,24 @@ mod tests {
     fn test_infer_expr_avg() {
         let mut scope = TypeScope::new();
         let expr = parse_expr("AVG(x)");
-        assert_eq!(infer_expr_type(&expr, &scope).0, RockyType::Unknown);
+
+        // An argument Rocky cannot resolve keeps `Float64`. Degrading it to
+        // `Unknown` would silently disable the column's E011 contract check
+        // (`contracts.rs` skips type validation for `Unknown`), which is a
+        // fail-open at a gate rather than conservative inference.
+        assert_eq!(infer_expr_type(&expr, &scope).0, RockyType::Float64);
 
         scope
             .columns
             .insert(CiKey::owned("x".to_string()), (RockyType::Int64, false));
         assert_eq!(infer_expr_type(&expr, &scope).0, RockyType::Float64);
 
+        scope
+            .columns
+            .insert(CiKey::owned("x".to_string()), (RockyType::Float32, false));
+        assert_eq!(infer_expr_type(&expr, &scope).0, RockyType::Float64);
+
+        // Only an exact-numeric input is dialect-dependent enough to withhold.
         scope.columns.insert(
             CiKey::owned("x".to_string()),
             (
@@ -3280,12 +3339,21 @@ mod tests {
     #[test]
     fn test_infer_window_avg_over() {
         let mut scope = TypeScope::new();
-        scope.columns.insert(
-            CiKey::owned("amount".to_string()),
-            (RockyType::Int64, false),
-        );
         let expr = parse_expr("AVG(amount) OVER (ORDER BY id)");
         assert_eq!(infer_expr_type(&expr, &scope).0, RockyType::Float64);
+
+        // The windowed form routes through the same rule as the aggregate form.
+        scope.columns.insert(
+            CiKey::owned("amount".to_string()),
+            (
+                RockyType::Decimal {
+                    precision: 10,
+                    scale: 2,
+                },
+                false,
+            ),
+        );
+        assert_eq!(infer_expr_type(&expr, &scope).0, RockyType::Unknown);
     }
 
     #[test]

--- a/engine/crates/rocky-compiler/src/typecheck.rs
+++ b/engine/crates/rocky-compiler/src/typecheck.rs
@@ -1386,7 +1386,16 @@ fn infer_aggregation_type(func: &str, input_type: &RockyType) -> (RockyType, boo
             };
             (ty, true)
         }
-        "AVG" => (RockyType::Float64, true),
+        "AVG" => {
+            // Exact-numeric AVG is dialect-dependent, and this layer has no
+            // adapter context. Avoid a false concrete type (#1238).
+            let ty = if input_type.is_integer() || input_type.is_float() {
+                RockyType::Float64
+            } else {
+                RockyType::Unknown
+            };
+            (ty, true)
+        }
         "MIN" | "MAX" => (input_type.clone(), true),
         "COUNT_DISTINCT" => (RockyType::Int64, false),
         _ => (RockyType::Unknown, true),
@@ -1630,7 +1639,10 @@ fn infer_function_type(func: &ast::Function, scope: &TypeScope) -> (RockyType, b
             };
             (result, true)
         }
-        "AVG" => (RockyType::Float64, true),
+        "AVG" => {
+            let arg_type = first_arg_type(func, scope);
+            infer_aggregation_type("AVG", &arg_type)
+        }
         "MIN" | "MAX" => {
             let arg_type = first_arg_type(func, scope);
             (arg_type, true)
@@ -2467,6 +2479,95 @@ mod tests {
     }
 
     #[test]
+    fn test_avg_type_is_conservative_for_dialect_dependent_decimal() {
+        let models = vec![make_model(
+            "averages",
+            "SELECT AVG(amount) AS avg_amount, AVG(quantity) AS avg_quantity \
+             FROM source.raw.orders",
+        )];
+        let project = Project::from_models(models).unwrap();
+
+        let mut external = HashMap::new();
+        external.insert(
+            "source.raw.orders".to_string(),
+            vec![
+                rocky_ir::ColumnInfo {
+                    name: "amount".to_string(),
+                    data_type: "DECIMAL(10,2)".to_string(),
+                    nullable: false,
+                },
+                rocky_ir::ColumnInfo {
+                    name: "quantity".to_string(),
+                    data_type: "BIGINT".to_string(),
+                    nullable: false,
+                },
+            ],
+        );
+        let graph = build_semantic_graph(&project, &external).unwrap();
+
+        let mut sources = HashMap::new();
+        sources.insert(
+            "source.raw.orders".to_string(),
+            source_schema(&[
+                (
+                    "amount",
+                    RockyType::Decimal {
+                        precision: 10,
+                        scale: 2,
+                    },
+                    false,
+                ),
+                ("quantity", RockyType::Int64, false),
+            ]),
+        );
+
+        let result = typecheck_project_with_models(&graph, &sources, None, &project.models, None);
+        let columns = &result.typed_models["averages"];
+        let avg_amount = columns.iter().find(|col| col.name == "avg_amount").unwrap();
+        let avg_quantity = columns
+            .iter()
+            .find(|col| col.name == "avg_quantity")
+            .unwrap();
+
+        assert_eq!(avg_amount.data_type, RockyType::Unknown);
+        assert_eq!(avg_quantity.data_type, RockyType::Float64);
+        assert!(avg_amount.nullable);
+        assert!(avg_quantity.nullable);
+
+        let contract = CompilerContract {
+            columns: vec![
+                ContractColumn {
+                    name: "avg_amount".to_string(),
+                    type_name: Some("Decimal".to_string()),
+                    nullable: Some(true),
+                    description: None,
+                },
+                ContractColumn {
+                    name: "avg_quantity".to_string(),
+                    type_name: Some("Decimal".to_string()),
+                    nullable: Some(true),
+                    description: None,
+                },
+            ],
+            rules: ContractRules::default(),
+        };
+        let diagnostics = validate_contract("averages", columns, &contract);
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| &*diagnostic.code == "E011"
+                    && diagnostic.message.contains("avg_quantity")),
+            "known Float64 AVG should reject a Decimal contract: {diagnostics:?}"
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| !diagnostic.message.contains("avg_amount")),
+            "dialect-dependent Decimal AVG should not produce a false mismatch: {diagnostics:?}"
+        );
+    }
+
+    #[test]
     fn test_cast_alias_uses_cast_type_not_source_type() {
         let models = vec![make_model(
             "cast_id",
@@ -2917,9 +3018,26 @@ mod tests {
 
     #[test]
     fn test_infer_expr_avg() {
-        let scope = TypeScope::new();
+        let mut scope = TypeScope::new();
         let expr = parse_expr("AVG(x)");
+        assert_eq!(infer_expr_type(&expr, &scope).0, RockyType::Unknown);
+
+        scope
+            .columns
+            .insert(CiKey::owned("x".to_string()), (RockyType::Int64, false));
         assert_eq!(infer_expr_type(&expr, &scope).0, RockyType::Float64);
+
+        scope.columns.insert(
+            CiKey::owned("x".to_string()),
+            (
+                RockyType::Decimal {
+                    precision: 10,
+                    scale: 2,
+                },
+                false,
+            ),
+        );
+        assert_eq!(infer_expr_type(&expr, &scope).0, RockyType::Unknown);
     }
 
     #[test]
@@ -3161,7 +3279,11 @@ mod tests {
 
     #[test]
     fn test_infer_window_avg_over() {
-        let scope = TypeScope::new();
+        let mut scope = TypeScope::new();
+        scope.columns.insert(
+            CiKey::owned("amount".to_string()),
+            (RockyType::Int64, false),
+        );
         let expr = parse_expr("AVG(amount) OVER (ORDER BY id)");
         assert_eq!(infer_expr_type(&expr, &scope).0, RockyType::Float64);
     }


### PR DESCRIPTION
## Summary

Make `AVG` type inference conservative for exact-numeric inputs whose result type depends on the target SQL dialect.

Closes #1238.

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Changes

- Infer `AVG` of a `Decimal` input as `Unknown` because the compiler layer has no adapter context and engines disagree: DuckDB returns `DOUBLE`, while Databricks (`DECIMAL(p + 4, s + 4)`) and BigQuery (`NUMERIC`/`BIGNUMERIC`) preserve an exact-numeric family.
- Keep `AVG` of **every other** input — including an argument that does not resolve — inferred as `Float64`.
- Route both aggregation-lineage and parsed-expression inference through the same rule.
- Add normal-pipeline regression coverage for inferred types, nullability, and contract validation, plus focused expression/window tests.

`ModelIr` and public CLI/DSL contracts are unchanged.

## Review update (2026-07-26)

The first revision withheld `Float64` for every input that was not an integer or a float. That `else` branch also caught `RockyType::Unknown` — an argument Rocky failed to resolve — and `validate_contract` (`rocky-compiler/src/contracts.rs:144`) skips type validation when the inferred type is `Unknown`. The withhold therefore widened into **silence at a validation gate**.

Measured before/after through the real gate path (`build_semantic_graph` → `typecheck_project_with_models` → `validate_contract`, which is what `compile.rs` calls), running identical probe code against both revisions:

| `AVG(x)` argument | `main` | first revision | this revision |
|---|---|---|---|
| `Decimal(10,2)` | `Float64` — false **E011** on a Decimal contract (the reported bug) | `Unknown` — all contracts pass | `Unknown` — all contracts pass |
| `Int64` | `Float64` — mismatches rejected | unchanged | unchanged |
| `String` | `Float64` — mismatches rejected | `Unknown` — **all pass** | `Float64` — mismatches rejected |
| unresolved (no source schema) | `Float64` — mismatches rejected | `Unknown` — **all pass** | `Float64` — mismatches rejected |
| downstream `SELECT avg_amount FROM …` | rejected | **silence propagates** | rejected |

The carve-out is now bounded to `RockyType::Decimal`, so the only behavior change versus `main` is the one #1238 reports. `test_avg_over_unresolved_input_still_validates_contracts` pins the boundary.

### Known residual

A `Decimal`-input `AVG` column is no longer contract-checked at all — a `Float64`, `String` or `Boolean` contract on it now passes silently, where `main` rejected it. This is a deliberate, bounded trade of a false reject for a missed check, and it is **not** the end state: the correct outcome is a third gate verdict (`Unverifiable`) rather than silence, which is the `ContractVerdict{Satisfied, Violated, Unverifiable}` + `UNVERIFIABLE_POLICY` design already approved for the decimal-inference work. This column should move onto that verdict when it lands.

`breaking_change.rs` is unaffected: every consumer calls `diff_project_ir(&base_ir, &head_ir)` with both sides compiled by the same binary, and since `main` maps all `AVG` to a single type, there is no type *difference* on `main` that this change can erase.

### Dialect grounding

The `DECIMAL(p + 4, s + 4)` claim is verified against Databricks' primary documentation. Snowflake and Trino are **not** covered: Snowflake's `AVG` reference documents no return type at all, so the "engines disagree" premise is unverified for 2 of Rocky's 5 warehouse adapters, and the `Float64`-for-integers half is unsourced. Settling that needs a live-execute test against the Snowflake sandbox — tracked as follow-up, not a blocker for withdrawing a known-wrong concrete type.

## Test Plan

- `cargo test -p rocky-compiler` — 419 unit tests and 22 integration tests passed; 1 doctest ignored.
- `cargo nextest run --all-features --no-fail-fast` — **5,713 passed, 108 skipped, 0 failed**, run on this branch rebased onto `main` (`89cf525e`). This includes `run_watch_reruns_on_file_change_and_exits_clean_on_sigint`, which failed in the first CI run; that failure did not reproduce and is unrelated to this diff.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean **workspace-wide** on rustc 1.96.0. The earlier note about pre-existing Rust 1.93 lints in generated diagnostics and `rocky-trino/src/test_helpers.rs` does not reproduce; no allow-list narrowing is needed.
- `cargo fmt -- --check` — passed.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/), scoped by subproject when relevant
- [x] No `Co-Authored-By` trailers
- [x] If this is a CLI JSON schema or DSL syntax change, all consumers (`integrations/dagster/`, `editors/vscode/`) are updated in this same PR (not applicable)

### Engine (`engine/`)

- [x] `cargo test --all-targets` passes (covered by the full all-features nextest run above)
- [x] `cargo clippy --all-targets -- -D warnings` is clean
- [x] `cargo fmt --check` passes

### Dagster (`integrations/dagster/`)

- [ ] `uv run pytest` passes
- [ ] `uv run ruff check` is clean
- [ ] `uv run ruff format --check` passes

### VS Code (`editors/vscode/`)

- [ ] `npm run compile` succeeds
- [ ] `npm run test:unit` passes (electron tests run in CI)
- [ ] `npm run lint` is clean
