### PR TITLE
fix(engine): propagate DAG model load errors

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
+++ b/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
@@ -177,7 +177,7 @@ pub async fn run_with_dag(
     let config_dir = config_path.parent().unwrap_or(Path::new("."));
     let models_dir = config_dir.join("models");
     let models = if models_dir.is_dir() {
-        super::dag::load_all_models(&models_dir).unwrap_or_default()
+        super::dag::load_all_models(&models_dir)?
     } else {
         Vec::new()
     };

--- a/engine/rocky/tests/run_dag_json_stdout.rs
+++ b/engine/rocky/tests/run_dag_json_stdout.rs
@@ -54,6 +54,18 @@ depends_on = ["ingest"]
 adapter = "default"
 "#;
 
+const TRANSFORMATION_ONLY_ROCKY_TOML: &str = r#"
+[adapter]
+type = "duckdb"
+path = "fixture.duckdb"
+
+[pipeline.transform]
+type = "transformation"
+
+[pipeline.transform.target]
+adapter = "default"
+"#;
+
 const MODEL_SQL: &str = "SELECT order_id, customer_id, amount FROM raw__orders.orders\n";
 
 const MODEL_TOML: &str = r#"
@@ -132,5 +144,39 @@ fn run_dag_json_stdout_is_a_single_json_document() {
     assert!(
         stderr.contains("Copied"),
         "expected the replication summary on stderr, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn run_dag_fails_when_model_loading_fails() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path();
+    fs::write(dir.join("rocky.toml"), TRANSFORMATION_ONLY_ROCKY_TOML).expect("write rocky.toml");
+    let models_dir = dir.join("models");
+    fs::create_dir(&models_dir).expect("mkdir models");
+    fs::write(models_dir.join("broken.sql"), "SELECT 1 AS id\n").expect("write model sql");
+    fs::write(models_dir.join("broken.toml"), "name = [\n").expect("write malformed model toml");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_rocky"))
+        .arg("-c")
+        .arg(dir.join("rocky.toml"))
+        .arg("run")
+        .arg("--dag")
+        .arg("--output")
+        .arg("json")
+        .current_dir(dir)
+        .env("RUST_LOG", "error")
+        .output()
+        .expect("spawn rocky");
+
+    let stdout = String::from_utf8(out.stdout).expect("utf8 stdout");
+    let stderr = String::from_utf8(out.stderr).expect("utf8 stderr");
+    assert!(
+        !out.status.success(),
+        "malformed models must fail the DAG run\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}"
+    );
+    assert!(
+        stderr.contains("failed to load models from"),
+        "expected the model-load error on stderr, got:\n{stderr}"
     );
 }


### PR DESCRIPTION
## Summary

Make `rocky run --dag` fail when top-level model loading fails instead of
silently running an empty transformation DAG and reporting success.

Closes #1243

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Changes

- Propagate `load_all_models` errors from the DAG run path.
- Add a binary regression test proving that a malformed model sidecar exits
  non-zero and reports the loading failure.

## Test Plan

- [x] `cargo test -p rocky --test run_dag_json_stdout`
- [x] `CARGO_BUILD_JOBS=4 cargo nextest run --all-features` (5,721 passed)
- [x] `CARGO_BUILD_JOBS=4 cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `git diff --check`

## Checklist

- [x] Commit message follows conventional commits and is scoped to `engine`.
- [x] No `Co-Authored-By` trailers.
- [x] No CLI JSON schema or DSL syntax changes.
