### PR TITLE
fix(engine): make the docs-demo example parse, and pin every example's models dir

### DIFF
--- a/engine/examples/docs-demo/models/stg_customers.rocky
+++ b/engine/examples/docs-demo/models/stg_customers.rocky
@@ -2,7 +2,7 @@
 from raw_customers
 where is_active == true
 derive {
-    full_name: first_name || " " || last_name,
+    full_name: concat(first_name, " ", last_name),
     days_since_signup: current_date - signup_date
 }
 select {

--- a/engine/rocky/tests/examples_models_load.rs
+++ b/engine/rocky/tests/examples_models_load.rs
@@ -1,0 +1,87 @@
+//! Every in-repo example project's models directory must load.
+//!
+//! `engine/examples/docs-demo/models/stg_customers.rocky` shipped from the
+//! initial commit with `||` for string concatenation, which the DSL lexer
+//! tokenizes as two `Pipe` tokens. Nothing caught it: no test loaded the
+//! examples, so the file never parsed and `rocky docs` — the example's own
+//! documented usage — failed on it. It only surfaced when `run --dag` started
+//! propagating model-load errors (#1244).
+//!
+//! This walks the repository for every `rocky.toml`, and loads the `models/`
+//! directory beside it through the same loader the CLI uses. Discovery is
+//! filesystem-driven rather than a hardcoded list, so a newly added example is
+//! covered the moment it lands.
+//!
+//! Scope note: the loader reads the top level plus one directory down, so a
+//! model at `models/a/b/` is not covered here because it is not loaded at all
+//! (tracked separately). This test pins what the loader actually claims to read.
+
+use std::path::{Path, PathBuf};
+
+/// Repository root: `engine/rocky` → `engine` → repo root.
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .canonicalize()
+        .expect("canonicalize repo root")
+}
+
+/// Every `rocky.toml` in the repo, skipping build and dependency output.
+fn find_project_configs(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if path.is_dir() {
+            if matches!(name.as_ref(), "target" | "node_modules" | ".git" | ".venv") {
+                continue;
+            }
+            find_project_configs(&path, out);
+        } else if name == "rocky.toml" {
+            out.push(path);
+        }
+    }
+}
+
+#[test]
+fn every_example_models_dir_loads() {
+    let root = repo_root();
+    let mut configs = Vec::new();
+    find_project_configs(&root, &mut configs);
+    configs.sort();
+
+    let mut checked = 0usize;
+    let mut failures = Vec::new();
+
+    for config in &configs {
+        let models_dir = config
+            .parent()
+            .expect("rocky.toml has a parent")
+            .join("models");
+        if !models_dir.is_dir() {
+            continue;
+        }
+        checked += 1;
+        if let Err(e) = rocky_cli::models_loader::load_project_models(&models_dir) {
+            let rel = models_dir.strip_prefix(&root).unwrap_or(&models_dir);
+            failures.push(format!("  {}: {e:#}", rel.display()));
+        }
+    }
+
+    // A walker that silently found nothing would otherwise pass vacuously.
+    assert!(
+        checked >= 50,
+        "expected to check 50+ project models directories, only found {checked} \
+         (is the repository walk broken?)"
+    );
+    assert!(
+        failures.is_empty(),
+        "{} of {checked} project models directories failed to load:\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}


### PR DESCRIPTION
## Summary

`engine/examples/docs-demo/models/stg_customers.rocky` has never parsed. It uses `||` for string concatenation, which the DSL lexer tokenizes as two `Pipe` tokens — `|` is the pipeline separator and there is no `||` operator. The file dates to the initial commit, so `rocky docs`, the example's own documented usage, has always failed on it.

It surfaced only when `rocky run --dag` started propagating model-load errors (#1244). Nothing caught it because no test loads the examples.

Closes #1260

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Changes

- Rewrite the derived `full_name` column as `concat(first_name, " ", last_name)`. The parser already supports function calls, so this needs no DSL change. The README documents that column, so the model itself was intentional — only the operator was unsupported.
- Add `engine/rocky/tests/examples_models_load.rs`: walk the repository for every `rocky.toml` and load the `models/` directory beside it through the CLI's own loader.

Discovery is filesystem-driven rather than a hardcoded list, so a new example is covered the moment it lands. The test also asserts a floor on how many directories it checked, so a broken repository walk fails loudly instead of passing vacuously over zero projects.

## Test Plan

- [x] `cargo test -p rocky --test examples_models_load` — 78 project models directories load.
- [x] Mutation check: with the example reverted to `||`, the test fails and names the file, the offset, and the `Pipe` token. It binds.
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`

## Scope note

The loader reads the top level plus one directory down, so this test cannot cover a model at `models/a/b/` — that file is not loaded at all today (#1262). The test pins what the loader actually claims to read, not more.

## Review

Red-teamed by OpenAI Codex (`gpt-5.6-sol`, `xhigh` reasoning) together with #1264 and #1266; findings and their disposition are in a comment below.

**What I am least confident about:** whether `concat(...)` is the concatenation form this DSL wants to be idiomatic. It parses and lowers today, but if `||` is meant to be supported, the real fix is the operator and this example goes back to reading naturally. I picked the change that needs no cross-subproject cascade; the operator is a separate decision.

**The most important thing I am missing:** this test only covers projects that have a `models/` directory beside a `rocky.toml`. Example projects are exercised by no other automated check — nothing runs their documented commands — so an example whose `rocky.toml` or README drifts from the CLI still ships broken. Loading models is the cheapest slice of that problem, not the whole of it.

## Checklist

- [x] Commit messages follow conventional commits, scoped by subproject
- [x] No `Co-Authored-By` trailers
- [x] No CLI JSON schema or DSL syntax changes

