### PR TITLE
fix(engine/rocky-cli): resolve run --dag models from the pipeline config

### DIFF
--- a/engine/crates/rocky-cli/src/commands/dag.rs
+++ b/engine/crates/rocky-cli/src/commands/dag.rs
@@ -98,9 +98,17 @@ pub fn dag_output(
     // Load models from the models directory (including subdirectories).
     let models = load_all_models(models_dir)?;
 
-    // Load seeds if the directory exists.
+    // Load seeds if the directory exists. A discovery failure is propagated, not
+    // flattened to "no seeds": the seed nodes and the seed→model edges are built
+    // only from this list, so swallowing a malformed sidecar prints a DAG that
+    // is missing both — an answer that looks complete and is not.
+    let discover = |dir: &Path| -> Result<Vec<rocky_core::seeds::SeedFile>> {
+        rocky_core::seeds::discover_seeds(dir)
+            .map_err(|e| anyhow::anyhow!("{e}"))
+            .with_context(|| format!("failed to discover seeds in {}", dir.display()))
+    };
     let seeds = match seeds_dir {
-        Some(dir) if dir.exists() => rocky_core::seeds::discover_seeds(dir).unwrap_or_default(),
+        Some(dir) if dir.exists() => discover(dir)?,
         _ => {
             // Try default "seeds" relative to config dir.
             let default_seeds = config_path
@@ -108,7 +116,7 @@ pub fn dag_output(
                 .unwrap_or_else(|| Path::new("."))
                 .join("seeds");
             if default_seeds.is_dir() {
-                rocky_core::seeds::discover_seeds(&default_seeds).unwrap_or_default()
+                discover(&default_seeds)?
             } else {
                 vec![]
             }

--- a/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
+++ b/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
@@ -72,7 +72,13 @@ fn default_sub_runner() -> SubRunner {
          model_name: Option<String>,
          skip_opts| {
             Box::pin(async move {
-                let models_dir = models_dir_for_model_scope(&config_path, model_name.as_deref());
+                let models_dir = models_dir_for_model_scope(
+                    &config_path,
+                    &loaded.config,
+                    &pipeline_name,
+                    model_name.as_deref(),
+                )
+                .map_err(|e| format!("{e:#}"))?;
                 let partition_opts = super::PartitionRunOptions {
                     partition: None,
                     from: None,
@@ -123,16 +129,32 @@ fn default_sub_runner() -> SubRunner {
     )
 }
 
-/// Returns the conventional models directory only for a model-scoped
+/// Returns the owning pipeline's models directory, only for a model-scoped
 /// transformation sub-run. Supplying it to replication/load sub-runs makes
 /// `run()` execute every transformation model after the pipeline itself.
-fn models_dir_for_model_scope(config_path: &Path, model_name: Option<&str>) -> Option<PathBuf> {
-    model_name.map(|_| {
-        config_path
-            .parent()
-            .unwrap_or(Path::new("."))
-            .join("models")
-    })
+///
+/// This must resolve the pipeline's CONFIGURED directory, not a hardcoded
+/// `models`. The DAG builds a node for every model it discovered, then hands
+/// each node's model name to a sub-run along with the directory to find it in —
+/// so a pipeline declaring `models = "transforms/**"` built a correct node whose
+/// sub-run then died with `models directory '<config>/models' not found
+/// (required for --model)`. Discovery and execution have to agree, which is why
+/// both go through [`crate::models_loader::resolve_models_dir`].
+fn models_dir_for_model_scope(
+    config_path: &Path,
+    cfg: &rocky_core::config::RockyConfig,
+    pipeline_name: &str,
+    model_name: Option<&str>,
+) -> Result<Option<PathBuf>> {
+    use rocky_core::config::PipelineConfig;
+
+    if model_name.is_none() {
+        return Ok(None);
+    }
+    let Some(PipelineConfig::Transformation(t)) = cfg.pipelines.get(pipeline_name) else {
+        return Ok(None);
+    };
+    crate::models_loader::resolve_models_dir(&t.models, config_path)
 }
 
 /// Execute `rocky run --dag`: run every pipeline in dependency order.
@@ -173,18 +195,26 @@ pub async fn run_with_dag(
     );
     let cfg = &loaded.config;
 
-    // Load models from the conventional `models/` directory next to the config.
-    let config_dir = config_path.parent().unwrap_or(Path::new("."));
-    let models_dir = config_dir.join("models");
-    let models = if models_dir.is_dir() {
-        super::dag::load_all_models(&models_dir)?
-    } else {
-        Vec::new()
-    };
+    // Load models from the model set each transformation pipeline actually
+    // declares — NOT a hardcoded `<config_dir>/models`. Hardcoding it was wrong
+    // in both directions: a pipeline with `models = "transforms/**"` loaded
+    // nothing, built zero transformation nodes, and reported success; and a
+    // project with no transformation pipeline at all was still forced to
+    // validate a `models/` directory that only transformation pipelines
+    // consume (`add_transformation_nodes`), so an unrelated broken model there
+    // failed a replication-only run that `rocky run` executes happily.
+    let models = load_transformation_models(config_path, cfg)?;
 
-    let seeds_dir = config_dir.join("seeds");
+    // Seed-discovery errors are NOT recoverable into "no seeds": seed nodes and
+    // the seed→model edges that order a model after the seed it reads are built
+    // only from this list. Swallowing a malformed seed sidecar drops the seed
+    // node, leaves the model unordered, and lets it run against whatever the
+    // previous run left in the table — a green DAG over stale data.
+    let seeds_dir = config_path.parent().unwrap_or(Path::new(".")).join("seeds");
     let seeds = if seeds_dir.is_dir() {
-        rocky_core::seeds::discover_seeds(&seeds_dir).unwrap_or_default()
+        rocky_core::seeds::discover_seeds(&seeds_dir)
+            .map_err(|e| anyhow::anyhow!("{e}"))
+            .with_context(|| format!("failed to discover seeds in {}", seeds_dir.display()))?
     } else {
         Vec::new()
     };
@@ -273,6 +303,74 @@ pub async fn run_with_dag(
         anyhow::bail!("DAG execution had {} failed node(s)", result.failed);
     }
     Ok(())
+}
+
+/// Load the union of every transformation pipeline's declared model set.
+///
+/// Only transformation pipelines consume models, so a project without one loads
+/// nothing and can never fail on a `models/` directory it would not have
+/// executed. The base directory is derived from each pipeline's `models` glob
+/// exactly the way [`super::run`] derives it (the prefix up to the first `**`),
+/// so `--dag` and a plain run agree on which files are in scope.
+///
+/// A missing directory is not an error here — that matches `run`, which treats
+/// an absent models directory as a no-op rather than a failure.
+///
+/// Directories are deduplicated by canonical path, so two pipelines that write
+/// the same directory differently (`models/**` and `./models/**`) load it once
+/// instead of twice.
+///
+/// A model name reached from more than one place is an ERROR, not a silent
+/// pick-the-first. `build_unified_dag` keys a transformation node by model name
+/// alone, so two models sharing a name cannot both be built — today that
+/// surfaces from the executor as `circular dependency detected involving: []`
+/// (#1261), which names nothing. Failing here names both files instead.
+///
+/// Per-pipeline attribution is deliberately not attempted: `build_unified_dag`
+/// takes one flat model list and gives every transformation pipeline the same
+/// nodes, which is the other half of #1261.
+fn load_transformation_models(
+    config_path: &Path,
+    cfg: &rocky_core::config::RockyConfig,
+) -> Result<Vec<rocky_core::models::Model>> {
+    use rocky_core::config::PipelineConfig;
+
+    // (canonical key, path as configured) — the key only deduplicates, the
+    // configured path is what error messages should show.
+    let mut dirs: Vec<(PathBuf, PathBuf)> = Vec::new();
+    for pipeline in cfg.pipelines.values() {
+        let PipelineConfig::Transformation(t) = pipeline else {
+            continue;
+        };
+        let Some(dir) = crate::models_loader::resolve_models_dir(&t.models, config_path)? else {
+            continue;
+        };
+        let key = dir.canonicalize().unwrap_or_else(|_| dir.clone());
+        if !dirs.iter().any(|(seen_key, _)| seen_key == &key) {
+            dirs.push((key, dir));
+        }
+    }
+
+    let mut models: Vec<rocky_core::models::Model> = Vec::new();
+    let mut by_name: HashMap<String, String> = HashMap::new();
+    for (_, dir) in dirs {
+        for model in super::dag::load_all_models(&dir)? {
+            if let Some(first) = by_name.get(&model.config.name) {
+                anyhow::bail!(
+                    "duplicate model name '{}': declared in both {} and {}. A \
+                     transformation node is keyed by model name alone, so two \
+                     models sharing a name cannot both be built — rename one.",
+                    model.config.name,
+                    first,
+                    model.file_path,
+                );
+            }
+            by_name.insert(model.config.name.clone(), model.file_path.clone());
+            models.push(model);
+        }
+    }
+    models.sort_unstable_by(|a, b| a.config.name.cmp(&b.config.name));
+    Ok(models)
 }
 
 fn status_str(s: &NodeStatus) -> &'static str {
@@ -403,7 +501,7 @@ impl NodeDispatcher for CliDispatcher {
 #[cfg(test)]
 mod skip_opts_threading_tests {
     use std::collections::HashMap;
-    use std::path::{Path, PathBuf};
+    use std::path::PathBuf;
     use std::sync::{Arc, Mutex};
 
     use rocky_core::config::LoadedConfig;
@@ -415,15 +513,106 @@ mod skip_opts_threading_tests {
 
     type RecordedSubRun = (Option<String>, SkipRunOptions);
 
+    const DEFAULT_GLOB_CONFIG: &str = r#"
+[adapter]
+type = "duckdb"
+path = "p.duckdb"
+
+[pipeline.silver]
+type = "transformation"
+
+[pipeline.silver.target]
+adapter = "default"
+"#;
+
+    const CUSTOM_GLOB_CONFIG: &str = r#"
+[adapter]
+type = "duckdb"
+path = "p.duckdb"
+
+[pipeline.ingest]
+strategy = "full_refresh"
+timestamp_column = "_updated_at"
+
+[pipeline.ingest.source.discovery]
+adapter = "default"
+
+[pipeline.ingest.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.ingest.target]
+catalog_template = "c"
+schema_template = "s"
+
+[pipeline.silver]
+type = "transformation"
+models = "transforms/**"
+
+[pipeline.silver.target]
+adapter = "default"
+"#;
+
+    /// Write a project on disk whose `rocky.toml` holds `toml_body`, creating
+    /// each named directory. `resolve_models_dir` returns `None` for a directory
+    /// that does not exist, so these have to be real paths.
+    fn project_with(toml_body: &str, dirs: &[&str]) -> (tempfile::TempDir, PathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("rocky.toml");
+        std::fs::write(&path, toml_body).unwrap();
+        for d in dirs {
+            std::fs::create_dir_all(tmp.path().join(d)).unwrap();
+        }
+        (tmp, path)
+    }
+
     #[test]
     fn models_dir_is_only_set_for_model_scoped_sub_runs() {
-        let config_path = Path::new("project/rocky.toml");
+        let (tmp, config_path) = project_with(DEFAULT_GLOB_CONFIG, &["models"]);
+        let loaded =
+            Arc::new(rocky_core::config::load_rocky_config_fingerprinted(&config_path).unwrap());
+        let cfg = &loaded.config;
 
         assert_eq!(
-            models_dir_for_model_scope(config_path, Some("dim_orders")),
-            Some(PathBuf::from("project/models"))
+            models_dir_for_model_scope(&config_path, cfg, "silver", Some("dim_orders")).unwrap(),
+            Some(tmp.path().join("models"))
         );
-        assert_eq!(models_dir_for_model_scope(config_path, None), None);
+        // No model name means the whole pipeline runs, and `run()` must not be
+        // handed a models directory for that.
+        assert_eq!(
+            models_dir_for_model_scope(&config_path, cfg, "silver", None).unwrap(),
+            None
+        );
+    }
+
+    /// The sub-run must be pointed at the pipeline's CONFIGURED directory.
+    /// Handing it a hardcoded `models` made a correctly-discovered node die with
+    /// "models directory not found (required for --model)".
+    #[test]
+    fn models_dir_follows_the_pipelines_configured_glob() {
+        let (tmp, config_path) = project_with(CUSTOM_GLOB_CONFIG, &["transforms", "models"]);
+        let loaded =
+            Arc::new(rocky_core::config::load_rocky_config_fingerprinted(&config_path).unwrap());
+        let cfg = &loaded.config;
+
+        // `transforms`, not the `models` directory that also exists beside it.
+        assert_eq!(
+            models_dir_for_model_scope(&config_path, cfg, "silver", Some("dim_orders")).unwrap(),
+            Some(tmp.path().join("transforms"))
+        );
+        // A replication pipeline owns no models, so nothing is supplied even if a
+        // model name somehow arrives — that would make `run()` execute every
+        // transformation model after the replication itself.
+        assert_eq!(
+            models_dir_for_model_scope(&config_path, cfg, "ingest", Some("dim_orders")).unwrap(),
+            None
+        );
+        // An unknown pipeline resolves to nothing rather than a guessed default.
+        assert_eq!(
+            models_dir_for_model_scope(&config_path, cfg, "nope", Some("dim_orders")).unwrap(),
+            None
+        );
     }
 
     /// A loaded snapshot for dispatcher tests, built through the real

--- a/engine/crates/rocky-cli/src/commands/tick.rs
+++ b/engine/crates/rocky-cli/src/commands/tick.rs
@@ -16,7 +16,7 @@
 //! partial, `1` tick infrastructure error (config invalid, state unopenable).
 
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::time::Instant;
 
 use anyhow::{Context, Result};
@@ -224,7 +224,8 @@ pub(crate) fn build_member_budgets(
 /// block. Models without one inherit the project default, which is already the
 /// reconciler's fallback — so only own-declared budgets count as member lags.
 fn member_max_lags(tx: &TransformationPipelineConfig, config_path: &Path) -> Result<Vec<u64>> {
-    let Some(models_dir) = resolve_models_dir(&tx.models, config_path)? else {
+    let Some(models_dir) = crate::models_loader::resolve_models_dir(&tx.models, config_path)?
+    else {
         return Ok(Vec::new());
     };
     let models = crate::models_loader::load_project_models(&models_dir)?;
@@ -232,47 +233,6 @@ fn member_max_lags(tx: &TransformationPipelineConfig, config_path: &Path) -> Res
         .iter()
         .filter_map(|m| m.config.freshness.as_ref().map(|f| f.max_lag_seconds))
         .collect())
-}
-
-/// Resolve a transformation pipeline's `models` glob to its base directory,
-/// confined to the project root. Returns `None` when the directory does not
-/// exist. Mirrors `scope.rs`'s containment check: a `models = "../../etc"`
-/// escape must never read outside the project tree.
-fn resolve_models_dir(models_glob: &str, config_path: &Path) -> Result<Option<PathBuf>> {
-    // `Path::new("rocky.toml").parent()` is `Some("")`, not `None`, and an empty
-    // path fails to canonicalize — normalize it to the cwd so a relative default
-    // config (the common case) still resolves its models.
-    let project_root = config_path
-        .parent()
-        .filter(|p| !p.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."));
-    let models_base = models_glob
-        .split(&['*', '?', '['][..])
-        .next()
-        .unwrap_or("models");
-    let models_dir = project_root.join(models_base.trim_end_matches('/'));
-    if !models_dir.exists() {
-        return Ok(None);
-    }
-    // Confine to the project root. Both sides canonicalized so intra-project
-    // symlinks resolve before the prefix check (macOS `/tmp` is itself a
-    // symlink, so asymmetric resolution would false-reject).
-    let canonical_root = project_root.canonicalize().with_context(|| {
-        format!(
-            "project root '{}' could not be resolved",
-            project_root.display()
-        )
-    })?;
-    if let Ok(canonical_models) = models_dir.canonicalize()
-        && !canonical_models.starts_with(&canonical_root)
-    {
-        anyhow::bail!(
-            "models directory '{}' resolves outside the project root '{}'",
-            canonical_models.display(),
-            canonical_root.display(),
-        );
-    }
-    Ok(Some(models_dir))
 }
 
 /// Map the reconciler's [`TickReport`] onto the wire [`TickOutput`].

--- a/engine/crates/rocky-cli/src/models_loader.rs
+++ b/engine/crates/rocky-cli/src/models_loader.rs
@@ -7,10 +7,60 @@
 //! [`rocky_core::models::load_models_from_dir`], which collects only `.sql`
 //! files and therefore silently drops `.rocky` DSL models.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use rocky_core::models::Model;
+
+/// Resolve a transformation pipeline's `models` glob to its base directory,
+/// confined to the project root. Returns `None` when the directory does not
+/// exist. Mirrors `scope.rs`'s containment check: a `models = "../../etc"`
+/// escape must never read outside the project tree.
+///
+/// The base is the leading run of characters before the first wildcard, so
+/// `models/**` and `models/*.sql` both resolve to `models`. Splitting on `**`
+/// alone would leave `models/*.sql` intact and then probe it as a literal
+/// directory, which never exists — the pipeline would contribute no models and
+/// the caller would see an empty, apparently-successful result.
+///
+/// Lifted here from `tick`, which already had the hardened version, so every
+/// caller that needs a pipeline's model directory shares one derivation.
+pub fn resolve_models_dir(models_glob: &str, config_path: &Path) -> Result<Option<PathBuf>> {
+    // `Path::new("rocky.toml").parent()` is `Some("")`, not `None`, and an empty
+    // path fails to canonicalize — normalize it to the cwd so a relative default
+    // config (the common case) still resolves its models.
+    let project_root = config_path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let models_base = models_glob
+        .split(&['*', '?', '['][..])
+        .next()
+        .unwrap_or("models");
+    let models_dir = project_root.join(models_base.trim_end_matches('/'));
+    if !models_dir.exists() {
+        return Ok(None);
+    }
+    // Confine to the project root. Both sides canonicalized so intra-project
+    // symlinks resolve before the prefix check (macOS `/tmp` is itself a
+    // symlink, so asymmetric resolution would false-reject).
+    let canonical_root = project_root.canonicalize().with_context(|| {
+        format!(
+            "project root '{}' could not be resolved",
+            project_root.display()
+        )
+    })?;
+    if let Ok(canonical_models) = models_dir.canonicalize()
+        && !canonical_models.starts_with(&canonical_root)
+    {
+        anyhow::bail!(
+            "models directory '{}' resolves outside the project root '{}'",
+            canonical_models.display(),
+            canonical_root.display(),
+        );
+    }
+    Ok(Some(models_dir))
+}
 
 /// Load all models under `models_dir` (top level + immediate subdirectories),
 /// including `.rocky` DSL files. Subdirectory load failures are skipped
@@ -33,4 +83,57 @@ pub fn load_project_models(models_dir: &Path) -> Result<Vec<Model>> {
         }
     }
     Ok(all)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `models` is documented as a glob, not a directory. Deriving the base by
+    /// splitting on `**` alone leaves `models/*.sql` intact, which is then
+    /// probed as a literal directory, never exists, and silently contributes no
+    /// models at all — the exact silent-success shape this work is closing.
+    #[test]
+    fn resolve_models_dir_handles_every_glob_shape() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let config = root.join("rocky.toml");
+        std::fs::write(&config, "").expect("write config");
+        std::fs::create_dir_all(root.join("models").join("staging")).expect("mkdir models/staging");
+        std::fs::create_dir_all(root.join("transforms")).expect("mkdir transforms");
+
+        for (glob, expected) in [
+            ("models/**", Some("models")),
+            ("models/*.sql", Some("models")),
+            ("models/staging/**", Some("models/staging")),
+            ("models", Some("models")),
+            ("transforms/**", Some("transforms")),
+            // An absent directory is not an error: it matches `run`, which
+            // treats a missing models directory as a no-op.
+            ("nope/**", None),
+        ] {
+            assert_eq!(
+                resolve_models_dir(glob, &config).expect("resolve"),
+                expected.map(|e| root.join(e)),
+                "glob {glob:?}"
+            );
+        }
+    }
+
+    /// A glob escaping the project root is refused rather than read.
+    #[test]
+    fn resolve_models_dir_refuses_an_escape() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("project");
+        std::fs::create_dir_all(&root).expect("mkdir project");
+        std::fs::create_dir_all(tmp.path().join("outside")).expect("mkdir outside");
+        let config = root.join("rocky.toml");
+        std::fs::write(&config, "").expect("write config");
+
+        let err = resolve_models_dir("../outside/**", &config).expect_err("escape must be refused");
+        assert!(
+            format!("{err:#}").contains("outside the project root"),
+            "unexpected error: {err:#}"
+        );
+    }
 }

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -3226,6 +3226,19 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                      silently dropped); run without --dag/--watch, or remove --var"
                 );
             }
+            // `--models` is not threaded into the `--dag` dispatch path either.
+            // The unified DAG resolves each transformation pipeline's own
+            // `models` glob from rocky.toml, so an override passed here would be
+            // silently ignored and the DAG built from a different set of files
+            // than the caller asked for. Reject it loudly, the same way `--var`
+            // is rejected above.
+            if models_dir.is_some() && dag {
+                anyhow::bail!(
+                    "--models is not supported with --dag (it would be silently \
+                     dropped); the unified DAG resolves each transformation \
+                     pipeline's own `models` glob from rocky.toml"
+                );
+            }
             // --idempotency-key is mutually exclusive with --resume / --resume-latest:
             // a resume is an explicit override and should never be short-circuited.
             if idempotency_key.is_some() && (resume.is_some() || resume_latest) {

--- a/engine/rocky/tests/run_dag_model_discovery.rs
+++ b/engine/rocky/tests/run_dag_model_discovery.rs
@@ -1,0 +1,328 @@
+//! `rocky run --dag` must discover models from the model set each transformation
+//! pipeline actually declares.
+//!
+//! It used to hardcode `<config_dir>/models`, which was wrong in both
+//! directions. A pipeline declaring `models = "transforms/**"` loaded nothing,
+//! built zero transformation nodes, and exited 0 — the #1243 silent success by a
+//! different route, which #1244's error propagation could never reach because
+//! there was no error, just an absent directory. And a project with no
+//! transformation pipeline at all was still forced to validate a `models/`
+//! directory that only transformation pipelines consume, so a broken model there
+//! failed a replication-only `--dag` run that plain `rocky run` executes happily.
+//!
+//! Seed discovery is covered here too: it shares the failure mode the model load
+//! had, one seam over.
+
+use std::fs;
+use std::process::Command;
+
+const SEED_SQL: &str = r#"
+CREATE SCHEMA IF NOT EXISTS raw__orders;
+CREATE SCHEMA IF NOT EXISTS staging;
+CREATE OR REPLACE TABLE raw__orders.orders AS
+SELECT
+    i AS order_id,
+    1 + (i % 5) AS customer_id,
+    CAST(i AS DOUBLE) AS amount,
+    TIMESTAMP '2026-01-01' + INTERVAL (i) SECOND AS _updated_at
+FROM generate_series(1, 10) AS t(i);
+"#;
+
+/// A transformation pipeline whose models live somewhere other than `models/`.
+const CUSTOM_GLOB_TOML: &str = r#"
+[adapter]
+type = "duckdb"
+path = "fixture.duckdb"
+
+[pipeline.transform]
+type = "transformation"
+models = "transforms/**"
+
+[pipeline.transform.target]
+adapter = "default"
+"#;
+
+/// Replication only — no transformation pipeline, so no model is ever executed.
+const REPLICATION_ONLY_TOML: &str = r#"
+[adapter]
+type = "duckdb"
+path = "fixture.duckdb"
+
+[pipeline.ingest]
+strategy = "full_refresh"
+timestamp_column = "_updated_at"
+
+[pipeline.ingest.source.discovery]
+adapter = "default"
+
+[pipeline.ingest.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.ingest.target]
+catalog_template = "fixture"
+schema_template = "staging__{source}"
+
+[pipeline.ingest.target.governance]
+auto_create_schemas = true
+
+[pipeline.ingest.execution]
+concurrency = 1
+"#;
+
+const MODEL_SQL: &str = "SELECT order_id, customer_id, amount FROM raw__orders.orders\n";
+
+const MODEL_TOML: &str = r#"
+[target]
+catalog = "fixture"
+schema = "staging"
+"#;
+
+/// TOML that cannot parse — an unterminated array.
+const MALFORMED_TOML: &str = "name = [\n";
+
+fn seed_duckdb(dir: &std::path::Path) {
+    let conn = duckdb::Connection::open(dir.join("fixture.duckdb")).expect("open duckdb");
+    conn.execute_batch(SEED_SQL).expect("seed sql");
+}
+
+fn run_dag(dir: &std::path::Path) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_rocky"))
+        .arg("-c")
+        .arg(dir.join("rocky.toml"))
+        .arg("run")
+        .arg("--dag")
+        .arg("--output")
+        .arg("json")
+        .current_dir(dir)
+        .env("RUST_LOG", "error")
+        .output()
+        .expect("spawn rocky")
+}
+
+/// A pipeline pointing at `transforms/**` must produce that model's node AND
+/// execute it. Asserting only the node count is not enough: discovery and
+/// execution resolve the directory separately, and a build that discovers the
+/// model but hands the sub-run a hardcoded `models/` fails the node with
+/// "models directory not found" while still reporting `total_nodes: 1`.
+///
+/// Before the fix this reported `total_nodes: 0` and exited 0.
+#[test]
+fn custom_models_glob_is_honored() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path();
+    seed_duckdb(dir);
+
+    fs::write(dir.join("rocky.toml"), CUSTOM_GLOB_TOML).expect("write rocky.toml");
+    let transforms = dir.join("transforms");
+    fs::create_dir(&transforms).expect("mkdir transforms");
+    fs::write(transforms.join("stg_orders.sql"), MODEL_SQL).expect("write model sql");
+    fs::write(transforms.join("stg_orders.toml"), MODEL_TOML).expect("write model toml");
+
+    let out = run_dag(dir);
+    let stdout = String::from_utf8(out.stdout).expect("utf8 stdout");
+    let stderr = String::from_utf8(out.stderr).expect("utf8 stderr");
+
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!("expected a DagRunOutput on stdout: {e}\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}");
+    });
+    assert_eq!(
+        parsed
+            .get("total_nodes")
+            .and_then(serde_json::Value::as_u64),
+        Some(1),
+        "the transforms/ model must produce exactly one node, got:\n{stdout}"
+    );
+    let labels: Vec<&str> = parsed["nodes"]
+        .as_array()
+        .expect("nodes array")
+        .iter()
+        .filter_map(|n| n.get("label").and_then(serde_json::Value::as_str))
+        .collect();
+    assert!(
+        labels.contains(&"stg_orders"),
+        "expected the stg_orders node, got labels {labels:?}"
+    );
+    // The node must actually run — discovery finding it is only half the job.
+    assert_eq!(
+        parsed.get("failed").and_then(serde_json::Value::as_u64),
+        Some(0),
+        "the transforms/ model must execute, not just be discovered:\n{stdout}"
+    );
+    assert_eq!(
+        parsed.get("completed").and_then(serde_json::Value::as_u64),
+        Some(1),
+        "expected the transforms/ model to complete:\n{stdout}"
+    );
+    assert!(
+        out.status.success(),
+        "the run must succeed\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}"
+    );
+}
+
+/// No transformation pipeline means no model is ever executed, so an unrelated
+/// `models/` directory must not gate the run. Plain `rocky run` does not compile
+/// models for a replication-only project; `--dag` must not either.
+#[test]
+fn replication_only_run_ignores_an_unrelated_models_dir() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path();
+    seed_duckdb(dir);
+
+    fs::write(dir.join("rocky.toml"), REPLICATION_ONLY_TOML).expect("write rocky.toml");
+    let models_dir = dir.join("models");
+    fs::create_dir(&models_dir).expect("mkdir models");
+    fs::write(models_dir.join("broken.sql"), "SELECT 1 AS id\n").expect("write model sql");
+    fs::write(models_dir.join("broken.toml"), MALFORMED_TOML).expect("write malformed sidecar");
+
+    let out = run_dag(dir);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "a replication-only DAG run must not fail on a models dir it never \
+         executes\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}"
+    );
+}
+
+/// A transformation pipeline DOES consume models, so a broken one there is still
+/// fatal — the #1244 guarantee must survive the scoping change.
+#[test]
+fn transformation_run_still_fails_on_a_broken_model() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path();
+    seed_duckdb(dir);
+
+    fs::write(dir.join("rocky.toml"), CUSTOM_GLOB_TOML).expect("write rocky.toml");
+    let transforms = dir.join("transforms");
+    fs::create_dir(&transforms).expect("mkdir transforms");
+    fs::write(transforms.join("broken.sql"), "SELECT 1 AS id\n").expect("write model sql");
+    fs::write(transforms.join("broken.toml"), MALFORMED_TOML).expect("write malformed sidecar");
+
+    let out = run_dag(dir);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "a broken model in the pipeline's own model set must fail the run"
+    );
+    assert!(
+        stderr.contains("failed to load models from"),
+        "expected the model-load error on stderr, got:\n{stderr}"
+    );
+}
+
+/// A malformed seed sidecar must fail the run rather than silently yielding an
+/// empty seed list — which would drop the seed node and its seed→model edge and
+/// let a model run against stale data under a green DAG.
+#[test]
+fn malformed_seed_sidecar_fails_the_run() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path();
+    seed_duckdb(dir);
+
+    fs::write(dir.join("rocky.toml"), REPLICATION_ONLY_TOML).expect("write rocky.toml");
+    let seeds_dir = dir.join("seeds");
+    fs::create_dir(&seeds_dir).expect("mkdir seeds");
+    fs::write(seeds_dir.join("countries.csv"), "code,name\nFR,France\n").expect("write seed csv");
+    fs::write(seeds_dir.join("countries.toml"), MALFORMED_TOML).expect("write malformed sidecar");
+
+    let out = run_dag(dir);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "a malformed seed sidecar must fail the DAG run"
+    );
+    assert!(
+        stderr.contains("failed to discover seeds"),
+        "expected the seed-discovery error on stderr, got:\n{stderr}"
+    );
+}
+
+/// `models` is a glob, not a directory. A non-`**` wildcard must still resolve
+/// to the conventional directory: deriving the base by splitting on `**` alone
+/// leaves `models/*.sql` intact, probes it as a literal directory that never
+/// exists, and yields an empty DAG that exits 0.
+#[test]
+fn a_wildcard_glob_still_resolves_its_directory() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path();
+    seed_duckdb(dir);
+
+    fs::write(
+        dir.join("rocky.toml"),
+        CUSTOM_GLOB_TOML.replace(r#"models = "transforms/**""#, r#"models = "models/*.sql""#),
+    )
+    .expect("write rocky.toml");
+    let models_dir = dir.join("models");
+    fs::create_dir(&models_dir).expect("mkdir models");
+    fs::write(models_dir.join("stg_orders.sql"), MODEL_SQL).expect("write model sql");
+    fs::write(models_dir.join("stg_orders.toml"), MODEL_TOML).expect("write model toml");
+
+    let out = run_dag(dir);
+    let stdout = String::from_utf8(out.stdout).expect("utf8 stdout");
+    let stderr = String::from_utf8(out.stderr).expect("utf8 stderr");
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!("expected a DagRunOutput on stdout: {e}\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}");
+    });
+    assert_eq!(
+        parsed.get("completed").and_then(serde_json::Value::as_u64),
+        Some(1),
+        "a `models/*.sql` glob must resolve to models/ and build it:\n{stdout}"
+    );
+}
+
+/// Two models sharing a name cannot both become nodes — the node id is the
+/// name. Report it here, naming both files, instead of letting the executor
+/// surface `circular dependency detected involving: []` (#1261), which names
+/// nothing.
+#[test]
+fn duplicate_model_names_are_reported_by_file() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path();
+    seed_duckdb(dir);
+
+    fs::write(dir.join("rocky.toml"), CUSTOM_GLOB_TOML).expect("write rocky.toml");
+    let transforms = dir.join("transforms");
+    let nested = transforms.join("staging");
+    fs::create_dir_all(&nested).expect("mkdir transforms/staging");
+    for target in [&transforms, &nested] {
+        fs::write(target.join("orders.sql"), MODEL_SQL).expect("write model sql");
+        fs::write(target.join("orders.toml"), MODEL_TOML).expect("write model toml");
+    }
+
+    let out = run_dag(dir);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "a duplicate model name must fail the run"
+    );
+    assert!(
+        stderr.contains("duplicate model name 'orders'"),
+        "expected the duplicate-name error, got:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("circular dependency"),
+        "the duplicate must be reported by name, not as a phantom cycle:\n{stderr}"
+    );
+}
+
+/// `--models` is not threaded into the DAG path, so passing it alongside `--dag`
+/// must be rejected rather than silently ignored. Mirrors the `--var` guard.
+#[test]
+fn models_flag_with_dag_is_rejected() {
+    let out = Command::new(env!("CARGO_BIN_EXE_rocky"))
+        .args(["run", "--dag", "--models", "transforms"])
+        .output()
+        .expect("spawn rocky");
+    assert!(
+        !out.status.success(),
+        "`run --dag --models` must exit non-zero, got {:?}",
+        out.status
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--models is not supported with --dag"),
+        "expected the --models/--dag guard message, got stderr: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

`run_with_dag` hardcoded `<config_dir>/models`. That was wrong in both directions:

- A transformation pipeline declaring `models = "transforms/**"` loaded nothing, built zero transformation nodes, and exited 0. This is #1243's silent success by a route the error propagation in #1244 could never reach — there was no error, just an absent directory.
- A project with **no** transformation pipeline was still forced to validate a `models/` directory that only transformation pipelines consume (`add_transformation_nodes`). An unrelated broken model there failed a replication-only `--dag` run that plain `rocky run` executes happily, because `run` only enters the compiled-model phase under `run_all || models_dir.is_some()`.

Closes #1258
Closes #1259

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Changes

- Load the union of every transformation pipeline's declared model set, deriving each base directory from its `models` glob exactly the way `run` derives it (the prefix up to the first `**`). Directories and model names are deduplicated, since pipelines commonly share the default `models/**`.
- A project with no transformation pipeline loads nothing, so it can never fail on a directory it would not have executed. This removes the `run` vs `run --dag` asymmetry #1244 introduced.
- Propagate seed-discovery errors instead of `unwrap_or_default()`. Seed nodes and the seed→model edges that order a model after the seed it reads are built only from that list, so swallowing a malformed sidecar dropped the seed node, left the model unordered, and let it run against whatever the previous run left in the table — a green DAG over stale data.
- Point each transformation sub-run at its **own** pipeline's directory. `models_dir_for_model_scope` also hardcoded `models`, so fixing discovery alone was not enough: a pipeline declaring `models = "transforms/**"` built a correct node whose sub-run then died with `models directory '<config>/models' not found (required for --model)`. Discovery and execution have to agree.
- Error on a duplicate model name, naming both files. A transformation node is keyed by model name alone, so two models sharing a name cannot both be built — today that surfaces from the executor as `circular dependency detected involving: []` (#1261), which names nothing. Reproduced on `4f37c1dd` with `models/orders.sql` plus `models/staging/orders.sql`.
- Deduplicate model directories by canonical path, so two pipelines writing the same directory differently (`models/**` and `./models/**`) load it once rather than colliding with themselves.
- Reject `--models` with `--dag` rather than silently ignoring it, mirroring the existing `--var` guard. The DAG resolves each pipeline's own glob, so an override passed here would build the DAG from a different set of files than the caller asked for.

## Deliberately not changed

`build_unified_dag` takes one flat model list and hands every transformation pipeline the same nodes, so per-pipeline attribution is not attempted here. That indirection is its own bug — two transformation pipelines currently make both `dag` and `run --dag` fail with `circular dependency detected involving: []` (#1261) — and fixing it means changing a rocky-core signature that `dag.rs` also calls.

A missing model directory stays a no-op rather than an error, matching `run`'s existing tolerance.

## Test Plan

New `engine/rocky/tests/run_dag_model_discovery.rs`, five cases:

- [x] `custom_models_glob_is_honored` — `models = "transforms/**"` produces the `stg_orders` node **and executes it** (`completed: 1, failed: 0`). The execution assertion is load-bearing: an earlier revision of this PR passed a node-count-only version of this test while every custom-glob node failed at run time, which is how the `models_dir_for_model_scope` half of the bug was found.
- [x] `duplicate_model_names_are_reported_by_file` — the duplicate is named, and the phantom cycle does not appear.
- [x] `replication_only_run_ignores_an_unrelated_models_dir` — a broken sidecar under `models/` no longer fails a replication-only run.
- [x] `transformation_run_still_fails_on_a_broken_model` — #1244's guarantee survives the scoping change.
- [x] `malformed_seed_sidecar_fails_the_run` — seed discovery errors reach the caller.
- [x] `models_flag_with_dag_is_rejected` — the guard message fires.
- [x] Mutation check: with the two source files reverted and the new tests kept, **all five fail**; with the fix, all five pass. Every assertion binds.
- [x] `cargo test -p rocky --test run_dag_json_stdout` — #1244's own tests still pass.
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`

## Review

Red-teamed by OpenAI Codex (`gpt-5.6-sol`, `xhigh` reasoning) together with #1263 and the loader change; findings and their disposition are in a comment below.

**What I am least confident about:** the union-of-directories shape. It is correct when pipelines share a model set, which is every in-repo project, but for genuinely disjoint globs it still hands every pipeline every model — the same flat-list indirection behind #1261. Nothing in this repository exercises that case, so the tests cannot distinguish "correct" from "correct enough until #1261 lands." What would settle it is fixing #1261 first and giving each pipeline its own set; I took the smaller change because #1261 needs a rocky-core signature change.

**The most important thing I am missing:** a missing model directory is still silent. `models = "transfrms/**"` — a typo — resolves to a directory that does not exist, loads nothing, and reports success with `total_nodes: 0`. That is the exact shape of #1243, and this PR does not close it; it only fixes *which* directory gets consulted. Making it fatal would diverge from `run`, which treats an absent models directory as a no-op, so the two need to change together rather than `--dag` alone drifting stricter again.

## Checklist

- [x] Commit messages follow conventional commits, scoped by subproject
- [x] No `Co-Authored-By` trailers
- [x] No CLI JSON schema or DSL syntax changes

