### PR TITLE
fix(engine/rocky-cli): propagate subdirectory model-load failures

### DIFF
--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -2375,16 +2375,29 @@ pub(crate) fn resolve_touched_apply_targets(
     // failure just leaves the maps empty and every target falls through as-is.
     let mut fqn_to_name: BTreeMap<String, String> = BTreeMap::new();
     let mut names: BTreeSet<String> = BTreeSet::new();
-    if let Ok(models) = crate::models_loader::load_project_models(&models_dir) {
-        for m in &models {
-            names.insert(m.config.name.clone());
-            let fqn = format!(
-                "{}.{}.{}",
-                m.config.target.catalog, m.config.target.schema, m.config.target.table
-            )
-            .to_lowercase();
-            fqn_to_name.insert(fqn, m.config.name.clone());
-        }
+    // Partial, NOT `load_project_models`: this map is a policy input, so losing
+    // it wholesale because one unrelated subdirectory is malformed is a
+    // fail-open, not a degraded answer. An unresolved FQN is evaluated against
+    // DEFAULT attributes, so a rule scoped to a positive attribute
+    // (`layer = "gold"`) stops matching and the apply can fall through to a
+    // permissive default. Keep every mapping that loaded and warn about the rest
+    // — those specific targets still fall back to defaults, which is exactly the
+    // pre-existing limitation documented above.
+    let (models, load_errors) = crate::models_loader::load_project_models_partial(&models_dir);
+    for e in &load_errors {
+        tracing::warn!(
+            error = %format!("{e:#}"),
+            "some models could not be loaded; policy attributes for their targets fall back to defaults"
+        );
+    }
+    for m in &models {
+        names.insert(m.config.name.clone());
+        let fqn = format!(
+            "{}.{}.{}",
+            m.config.target.catalog, m.config.target.schema, m.config.target.table
+        )
+        .to_lowercase();
+        fqn_to_name.insert(fqn, m.config.name.clone());
     }
 
     let mut touched = BTreeMap::new();
@@ -3758,6 +3771,52 @@ mod tests {
     use super::*;
     use crate::output::{ReplicationTableSnapshot, RunPlan};
     use crate::plan_store::write_plan;
+
+    /// A physical FQN must still resolve to its logical model name when an
+    /// UNRELATED model elsewhere in the tree fails to load.
+    ///
+    /// This map is a policy input: `gate_maintenance_apply` evaluates an
+    /// unresolved target against DEFAULT attributes, so an attribute-scoped rule
+    /// (`layer = "gold"`) stops matching and a destructive compact/archive can
+    /// fall through to a permissive default. Loading models strictly here would
+    /// turn one broken draft into a policy fail-open, which is why this path
+    /// deliberately uses the partial loader.
+    #[test]
+    fn touched_targets_resolve_despite_a_broken_sibling_model() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let config_path = root.join("rocky.toml");
+        std::fs::write(
+            &config_path,
+            "[adapter]\ntype = \"duckdb\"\npath = \"p.duckdb\"\n\n\
+             [pipeline.silver]\ntype = \"transformation\"\n\n\
+             [pipeline.silver.target]\nadapter = \"default\"\n",
+        )
+        .unwrap();
+
+        let models = root.join("models");
+        std::fs::create_dir_all(models.join("staging")).unwrap();
+        // The governed model, valid.
+        std::fs::write(models.join("payments.sql"), "SELECT 1 AS id\n").unwrap();
+        std::fs::write(
+            models.join("payments.toml"),
+            "name = \"payments\"\n[target]\ncatalog = \"wh\"\nschema = \"gold\"\ntable = \"payments\"\n",
+        )
+        .unwrap();
+        // An unrelated broken draft one directory down.
+        std::fs::write(models.join("staging").join("broken.sql"), "SELECT 1\n").unwrap();
+        std::fs::write(models.join("staging").join("broken.toml"), "name = [\n").unwrap();
+
+        let cfg = rocky_core::config::load_rocky_config(&config_path).unwrap();
+        let touched =
+            resolve_touched_apply_targets(&cfg, &config_path, ["wh.gold.payments".to_string()]);
+
+        assert!(
+            touched.contains_key("payments"),
+            "the physical FQN must map to the logical model name so an \
+             attribute-scoped policy rule still fires; got {touched:?}"
+        );
+    }
 
     fn minimal_run_plan() -> RunPlan {
         RunPlan {

--- a/engine/crates/rocky-cli/src/commands/optimize.rs
+++ b/engine/crates/rocky-cli/src/commands/optimize.rs
@@ -173,9 +173,9 @@ fn load_dag_from_models(models_dir: Option<&Path>) -> Vec<DagNode> {
     };
 
     // Top-level + immediate subdirectories, including `.rocky` DSL files.
-    let Ok(all_models) = crate::models_loader::load_project_models(dir) else {
-        return vec![];
-    };
+    // Partial: this drives advisory downstream-reference counts, so one broken
+    // draft model must not silently collapse every healthy count to zero.
+    let (all_models, _load_errors) = crate::models_loader::load_project_models_partial(dir);
 
     all_models
         .iter()

--- a/engine/crates/rocky-cli/src/commands/preview.rs
+++ b/engine/crates/rocky-cli/src/commands/preview.rs
@@ -1003,8 +1003,7 @@ pub async fn run_preview_cost(
     // silently degrades to an empty per-model budget map. Project-level
     // budget projection still runs.
     let model_budgets: BTreeMap<String, rocky_core::config::ModelBudgetConfig> =
-        crate::models_loader::load_project_models(models_dir)
-            .ok()
+        Some(crate::models_loader::load_project_models_partial(models_dir).0)
             .map(|models| {
                 models
                     .into_iter()

--- a/engine/crates/rocky-cli/src/commands/tick.rs
+++ b/engine/crates/rocky-cli/src/commands/tick.rs
@@ -228,7 +228,9 @@ fn member_max_lags(tx: &TransformationPipelineConfig, config_path: &Path) -> Res
     else {
         return Ok(Vec::new());
     };
-    let models = crate::models_loader::load_project_models(&models_dir)?;
+    // Partial: a broken draft in one subdirectory must not drop every healthy
+    // member budget and silently widen this pipeline to the project default.
+    let (models, _load_errors) = crate::models_loader::load_project_models_partial(&models_dir);
     Ok(models
         .iter()
         .filter_map(|m| m.config.freshness.as_ref().map(|f| f.max_lag_seconds))

--- a/engine/crates/rocky-cli/src/models_loader.rs
+++ b/engine/crates/rocky-cli/src/models_loader.rs
@@ -63,31 +63,179 @@ pub fn resolve_models_dir(models_glob: &str, config_path: &Path) -> Result<Optio
 }
 
 /// Load all models under `models_dir` (top level + immediate subdirectories),
-/// including `.rocky` DSL files. Subdirectory load failures are skipped
-/// silently — same tolerance the previous per-command loops had.
+/// including `.rocky` DSL files.
+///
+/// A load failure in **any** of those directories is an error. Subdirectory
+/// failures used to be discarded, so a malformed model one level down simply
+/// vanished from the model list and every command built on this loader carried
+/// on as though it did not exist — `run --dag` reported success having built
+/// nothing for that subtree. That is the same silent-success class as the
+/// top-level load, which stopped being swallowed in #1244.
+///
+/// **Scope.** This reads the top level plus one level down. A model at
+/// `models/a/b/` is still not loaded at all — not an error, simply absent
+/// (#1262). Propagating subdirectory errors does not close that hole, and a
+/// project nesting models deeper than one level still silently builds nothing
+/// for the deeper subtree.
 pub fn load_project_models(models_dir: &Path) -> Result<Vec<Model>> {
-    let mut all = rocky_compiler::project::load_dir_models(models_dir)
-        .map_err(|e| anyhow::anyhow!("{e}"))
-        .context(format!(
-            "failed to load models from {}",
-            models_dir.display()
-        ))?;
+    let (models, mut errors) = load_project_models_partial(models_dir);
+    if errors.is_empty() {
+        Ok(models)
+    } else {
+        Err(errors.remove(0))
+    }
+}
 
-    if let Ok(entries) = std::fs::read_dir(models_dir) {
-        for entry in entries.flatten() {
-            if entry.path().is_dir()
-                && let Ok(sub) = rocky_compiler::project::load_dir_models(&entry.path())
-            {
-                all.extend(sub);
-            }
+/// Load everything that loads, returning the models plus one error per
+/// directory that failed.
+///
+/// For a caller that is deliberately tolerant — it answers a question about the
+/// models that *do* exist — discarding the whole set because one subdirectory is
+/// malformed is worse than the silence it replaces.
+///
+/// The sharp case is [`crate::commands::apply::resolve_touched_apply_targets`],
+/// which maps physical target FQNs back to logical model names so an
+/// attribute-scoped policy rule (`layer = "gold"`, `classifications = ["pii"]`)
+/// still fires on a maintenance apply. An empty map leaves every target
+/// unresolved, and an unresolved target is evaluated against **default**
+/// attributes — so a rule requiring a positive attribute stops matching and a
+/// destructive compact/archive can fall through to a permissive default. Losing
+/// mappings there is a policy fail-open, not a degraded answer.
+///
+/// Strict callers should use [`load_project_models`], which surfaces the first
+/// error instead.
+pub fn load_project_models_partial(models_dir: &Path) -> (Vec<Model>, Vec<anyhow::Error>) {
+    let mut all = Vec::new();
+    let mut errors = Vec::new();
+
+    match load_one_dir(models_dir) {
+        Ok(models) => all.extend(models),
+        Err(e) => errors.push(e),
+    }
+
+    // `load_dir_models` returns no models for a directory that does not exist,
+    // and several callers rely on that (`rocky docs` on a project with no
+    // models, for one). Only descend when there is something to descend into,
+    // so an absent directory stays a non-error rather than failing `read_dir`.
+    if !models_dir.is_dir() {
+        return (all, errors);
+    }
+
+    let entries = match std::fs::read_dir(models_dir) {
+        Ok(entries) => entries,
+        Err(e) => {
+            errors.push(anyhow::Error::new(e).context(format!(
+                "failed to read models directory {}",
+                models_dir.display()
+            )));
+            return (all, errors);
+        }
+    };
+    let mut subdirs: Vec<PathBuf> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.is_dir())
+        .collect();
+    // Deterministic order: with more than one broken subdirectory, the same one
+    // is always reported first.
+    subdirs.sort();
+
+    for subdir in subdirs {
+        match load_one_dir(&subdir) {
+            Ok(models) => all.extend(models),
+            Err(e) => errors.push(e),
         }
     }
-    Ok(all)
+    (all, errors)
+}
+
+/// Load one directory's models, naming that directory in the error.
+fn load_one_dir(dir: &Path) -> Result<Vec<Model>> {
+    rocky_compiler::project::load_dir_models(dir)
+        .map_err(|e| anyhow::anyhow!("{e}"))
+        .with_context(|| format!("failed to load models from {}", dir.display()))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn write(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("mkdir");
+        }
+        std::fs::write(path, contents).expect("write");
+    }
+
+    /// A valid model with a target, so it loads cleanly.
+    fn write_model(dir: &Path, name: &str) {
+        write(&dir.join(format!("{name}.sql")), "SELECT 1 AS id\n");
+        write(
+            &dir.join(format!("{name}.toml")),
+            &format!(
+                "name = \"{name}\"\n[target]\ncatalog = \"w\"\nschema = \"s\"\ntable = \"{name}\"\n"
+            ),
+        );
+    }
+
+    #[test]
+    fn loads_top_level_and_one_subdirectory_level() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let models = tmp.path().join("models");
+        write_model(&models, "top");
+        write_model(&models.join("staging"), "stg");
+
+        let loaded = load_project_models(&models).expect("load");
+        let mut names: Vec<&str> = loaded.iter().map(|m| m.config.name.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(names, ["stg", "top"]);
+    }
+
+    /// The regression this change exists for: a malformed sidecar one level down
+    /// used to be discarded, leaving the caller with a short model list and no
+    /// indication anything was missing.
+    #[test]
+    fn a_broken_model_in_a_subdirectory_is_an_error() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let models = tmp.path().join("models");
+        write_model(&models, "top");
+        write(&models.join("staging").join("broken.sql"), "SELECT 1\n");
+        write(&models.join("staging").join("broken.toml"), "name = [\n");
+
+        let err = load_project_models(&models).expect_err("subdirectory failure must propagate");
+        let rendered = format!("{err:#}");
+        assert!(
+            rendered.contains("failed to load models from"),
+            "expected the load-failure context, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("staging"),
+            "the error must name the failing subdirectory, got: {rendered}"
+        );
+    }
+
+    /// Callers pass directories that may not exist; that must stay a non-error.
+    #[test]
+    fn a_missing_directory_yields_no_models() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let loaded = load_project_models(&tmp.path().join("does-not-exist")).expect("load");
+        assert!(loaded.is_empty());
+    }
+
+    /// Files directly inside the models directory are not descended into, and a
+    /// non-model file in a subdirectory is ignored rather than failing.
+    #[test]
+    fn unrelated_files_do_not_fail_the_load() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let models = tmp.path().join("models");
+        write_model(&models, "top");
+        write(&models.join("README.md"), "# notes\n");
+        write(&models.join("docs").join("notes.md"), "# more notes\n");
+
+        let loaded = load_project_models(&models).expect("load");
+        let names: Vec<&str> = loaded.iter().map(|m| m.config.name.as_str()).collect();
+        assert_eq!(names, ["top"]);
+    }
 
     /// `models` is documented as a glob, not a directory. Deriving the base by
     /// splitting on `**` alone leaves `models/*.sql` intact, which is then


### PR DESCRIPTION
## Summary

`load_project_models` loads the top-level models directory plus one level of immediate subdirectories, but took each subdirectory through `if let Ok(sub)` and discarded the error. A malformed model one level down simply vanished from the model list, and every command built on this loader carried on as though it did not exist.

Through `run --dag` that meant reporting success having built nothing for that subtree — the same silent-success class the top-level load stopped admitting in #1244. Reproduced before this change: a healthy project plus `models/staging/broken.toml` exits 0 with `failed: 0` and never mentions the broken model.

Closes #1257

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Blast radius

This loader is shared by `dag`, `list`, `docs`, `preview`, `compliance`, `estimate`, `test`, `tick`, `validate`, `branch`, `scope` and the maintenance-apply policy gate. **Not all of them should get stricter**, which is the main correction this PR received in review.

Strict (a broken model in a subdirectory now fails the command instead of disappearing): `dag`, `list`, `docs`, `compliance`, `estimate`, `test`, `validate`, `branch`, `scope`. That is the same tolerance change #1244 made at the top level.

Deliberately tolerant, via the new `load_project_models_partial`:

- **`resolve_touched_apply_targets`** — the sharp one. It maps physical target FQNs to logical model names so an attribute-scoped policy rule still fires on a maintenance apply, and it feeds compact's and archive's pre-SQL gates. Emptying that map is a **fail-open**: an unresolved target is evaluated against default attributes, so a `layer = "gold"` rule stops matching and a destructive apply can fall through to a permissive default.
- **`optimize`** — advisory downstream-reference counts must not all collapse to zero.
- **`preview`** — per-model budget projection.
- **`tick`** — member freshness budgets, which would otherwise widen to the project default.

Verified against every project in the repository: **0 of 78** fail, now that #1263 has fixed the one pre-existing breakage.

Verified against every project in the repository: **0 of 78** newly fail. The only failure in the sweep is `engine/examples/docs-demo`, which is broken today for an unrelated reason and is fixed by #1263.

## Changes

- Propagate subdirectory load failures, naming the failing directory.
- Visit subdirectories in sorted order, so a project with several broken ones always reports the same one first.
- Keep an absent models directory a non-error. `load_dir_models` returns no models for a directory that does not exist and several callers rely on that (`rocky docs` on a project with no models, among others), so the descent is skipped rather than failing `read_dir`.

## What this does NOT close

The loader reads the top level plus **one** level down. A model at `models/a/b/` is still not loaded at all — not an error, simply absent (#1262). Verified: `models/a/b/lvl2.sql` never appears in the model list, and corrupting its sidecar changes nothing, because the file is never read.

So this PR narrows the silent-drop surface rather than eliminating it. Making the walk recursive would newly discover `.sql` / `.rocky` files that projects may keep under `models/` deliberately unbuilt — archives, scratch, vendored subtrees — and start materializing tables from them. That is a behavior change deserving its own decision, which is why #1262 is filed separately rather than folded in here.

## Test Plan

Four unit tests in `models_loader.rs`:

- [x] `a_broken_model_in_a_subdirectory_is_an_error` — the regression this exists for; asserts the error names the subdirectory.
- [x] `loads_top_level_and_one_subdirectory_level` — the documented depth still works.
- [x] `a_missing_directory_yields_no_models` — pins the tolerance callers depend on.
- [x] `unrelated_files_do_not_fail_the_load` — a README beside the models is not a model.
- [x] Mutation check: restoring `if let Ok(sub)` fails `a_broken_model_in_a_subdirectory_is_an_error` and only that one, so the assertion binds and the other three are not coupled to it.
- [x] Repository sweep with the built binary: 0 of 78 newly fail.
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`

## Review

Red-teamed by OpenAI Codex (`gpt-5.6-sol`, `xhigh` reasoning) together with #1263 and #1264; findings and their disposition are in a comment below.

**What I am least confident about:** whether eleven commands getting stricter is the right default versus warning on subdirectory failures and continuing. The sweep proves no in-repo project breaks, but it cannot speak for a user mid-edit whose `models/staging/` does not currently parse — `rocky list` and `rocky docs` now fail for them where they used to return the models that *do* parse. Fail-closed is right for `run --dag`, where the consequence is unbuilt tables reported as success; it is more arguable for read-only commands. What would settle it is deciding whether this loader should have one tolerance or two.

**The most important thing I am missing:** #1262 means the fail-closed guarantee this PR appears to establish is not actually established. A reader of this diff could reasonably conclude "subdirectory models can no longer silently vanish," and that is only true for the first level. The honest framing is that the loader now fails loudly for the depth it reads and stays silent about the depth it does not — and the second half is the part that still bites.

## Checklist

- [x] Commit messages follow conventional commits, scoped by subproject
- [x] No `Co-Authored-By` trailers
- [x] No CLI JSON schema or DSL syntax changes

