### PR TITLE
fix(engine/rocky-cli): isolate transformation shadow runs

### DIFF
--- a/docs/src/content/docs/concepts/shadow-mode.md
+++ b/docs/src/content/docs/concepts/shadow-mode.md
@@ -14,11 +14,25 @@ Shadow mode writes pipeline output to shadow tables instead of (or alongside) pr
 3. A comparison engine checks row counts, schemas, and optionally sample data between shadow and production
 4. Results show pass/warn/fail with detailed diffs
 
-Shadow and branch runs currently reject `content_addressed` and `time_interval`
-models. Those strategies also persist object-storage or partition-state
+:::caution[Shadow isolation covers `rocky run` for transformation pipelines only]
+`rocky run --dag`, and the snapshot and load pipeline kinds, still accept
+`--shadow` and `--branch` but write **production** targets. Do not rely on those
+entrypoints for isolation.
+:::
+
+Shadow and branch runs currently reject `content_addressed`, `time_interval` and
+`ephemeral` models. The first two persist object-storage or partition-state
 identities that cannot yet be isolated by rewriting only the warehouse target.
-Rocky also rejects a derived shadow target that matches any configured
-production target or another selected shadow target.
+Ephemeral models are neither materialized nor inlined into their consumers, so a
+consumer would read the production table and no rewrite could redirect it — give
+the model a materialized strategy to shadow it. Rocky also rejects a derived
+shadow target that matches any configured production target or another selected
+shadow target.
+
+Rocky does **not** yet verify that a derived shadow target is unoccupied by an
+object it does not know about. If a table matching the derived name already
+exists and is not a Rocky model target — a source, a seed, or an ad-hoc table —
+a full-refresh model will replace it. Prefer a dedicated shadow schema you own.
 
 A model that reads another selected model's table is routed to that upstream's
 shadow target whether or not it declares the dependency in `depends_on` —

--- a/docs/src/content/docs/concepts/shadow-mode.md
+++ b/docs/src/content/docs/concepts/shadow-mode.md
@@ -20,6 +20,14 @@ identities that cannot yet be isolated by rewriting only the warehouse target.
 Rocky also rejects a derived shadow target that matches any configured
 production target or another selected shadow target.
 
+A model that reads another selected model's table is routed to that upstream's
+shadow target whether or not it declares the dependency in `depends_on` —
+matching is on the upstream's configured `catalog.schema.table`, so a physical
+read is redirected too. When a reference could resolve to more than one
+selected upstream (two models whose targets share a name in different
+catalogs, read as a bare or partially qualified name), Rocky refuses the run
+rather than guess which one to read.
+
 ## Shadow target rewriting
 
 ### Suffix mode (default)

--- a/docs/src/content/docs/concepts/shadow-mode.md
+++ b/docs/src/content/docs/concepts/shadow-mode.md
@@ -14,6 +14,12 @@ Shadow mode writes pipeline output to shadow tables instead of (or alongside) pr
 3. A comparison engine checks row counts, schemas, and optionally sample data between shadow and production
 4. Results show pass/warn/fail with detailed diffs
 
+Shadow and branch runs currently reject `content_addressed` and `time_interval`
+models. Those strategies also persist object-storage or partition-state
+identities that cannot yet be isolated by rewriting only the warehouse target.
+Rocky also rejects a derived shadow target that matches any configured
+production target or another selected shadow target.
+
 ## Shadow target rewriting
 
 ### Suffix mode (default)

--- a/docs/src/content/docs/reference/commands/core-pipeline.md
+++ b/docs/src/content/docs/reference/commands/core-pipeline.md
@@ -424,8 +424,15 @@ contains a `content_addressed`, `time_interval` or `ephemeral` model — the fir
 two require additional storage or partition-state isolation, and an ephemeral
 model is neither materialized nor inlined, so its consumer would read
 production. They also fail closed when the chosen suffix or schema would collide
-with a production target or another selected shadow target, and when two targets
-differ only by case on a dialect that quotes identifiers.
+with a production target or another selected shadow target.
+
+On a dialect that quotes identifiers — Snowflake and Trino — a run routing more
+than one model is refused when a routed target differs only by case from any
+other model's target. Those are two distinct objects to the warehouse, but
+upstream references are matched case-insensitively, so a read of either could be
+redirected to the wrong one. The refusal is deliberate and does not depend on
+whether any model spells such a read today; rename one of the targets, or scope
+the run so it routes only one of them.
 
 `--shadow` and `--branch` isolate `rocky run` for transformation pipelines.
 `rocky run --dag`, and the snapshot and load pipeline kinds, still write

--- a/docs/src/content/docs/reference/commands/core-pipeline.md
+++ b/docs/src/content/docs/reference/commands/core-pipeline.md
@@ -419,6 +419,12 @@ rocky run --filter client=acme --shadow
 rocky compare --filter client=acme
 ```
 
+Shadow and branch runs fail closed when the selected transformation set
+contains a `content_addressed` or `time_interval` model because those
+strategies require additional storage or partition-state isolation. They also
+fail closed when the chosen suffix or schema would collide with a production
+target or another selected shadow target.
+
 Or run against a named branch:
 
 ```bash

--- a/docs/src/content/docs/reference/commands/core-pipeline.md
+++ b/docs/src/content/docs/reference/commands/core-pipeline.md
@@ -420,10 +420,16 @@ rocky compare --filter client=acme
 ```
 
 Shadow and branch runs fail closed when the selected transformation set
-contains a `content_addressed` or `time_interval` model because those
-strategies require additional storage or partition-state isolation. They also
-fail closed when the chosen suffix or schema would collide with a production
-target or another selected shadow target.
+contains a `content_addressed`, `time_interval` or `ephemeral` model — the first
+two require additional storage or partition-state isolation, and an ephemeral
+model is neither materialized nor inlined, so its consumer would read
+production. They also fail closed when the chosen suffix or schema would collide
+with a production target or another selected shadow target, and when two targets
+differ only by case on a dialect that quotes identifiers.
+
+`--shadow` and `--branch` isolate `rocky run` for transformation pipelines.
+`rocky run --dag`, and the snapshot and load pipeline kinds, still write
+production targets despite accepting the flags.
 
 Or run against a named branch:
 

--- a/docs/src/content/docs/reference/commands/core-pipeline.md
+++ b/docs/src/content/docs/reference/commands/core-pipeline.md
@@ -426,13 +426,18 @@ model is neither materialized nor inlined, so its consumer would read
 production. They also fail closed when the chosen suffix or schema would collide
 with a production target or another selected shadow target.
 
-On a dialect that quotes identifiers — Snowflake and Trino — a run routing more
-than one model is refused when a routed target differs only by case from any
-other model's target. Those are two distinct objects to the warehouse, but
-upstream references are matched case-insensitively, so a read of either could be
-redirected to the wrong one. The refusal is deliberate and does not depend on
-whether any model spells such a read today; rename one of the targets, or scope
-the run so it routes only one of them.
+On a dialect where identifier case is part of object identity — Snowflake and
+BigQuery — a run routing more than one model is refused when a routed target
+differs only by case from any other model's target. Those are two distinct
+objects to the warehouse, but upstream references are matched
+case-insensitively, so a read of either could be redirected to the wrong one.
+The refusal is deliberate and does not depend on whether any model spells such a
+read today; rename one of the targets, or scope the run so it routes only one of
+them.
+
+This is not the same as whether the dialect quotes identifiers. Trino renders
+targets double-quoted yet folds identifiers to lower case regardless, so two
+targets differing only by case name one object there and the run proceeds.
 
 `--shadow` and `--branch` isolate `rocky run` for transformation pipelines.
 `rocky run --dag`, and the snapshot and load pipeline kinds, still write

--- a/docs/src/content/docs/reference/commands/core-pipeline.md
+++ b/docs/src/content/docs/reference/commands/core-pipeline.md
@@ -435,9 +435,9 @@ The refusal is deliberate and does not depend on whether any model spells such a
 read today; rename one of the targets, or scope the run so it routes only one of
 them.
 
-This is not the same as whether the dialect quotes identifiers. Trino renders
-targets double-quoted yet folds identifiers to lower case regardless, so two
-targets differing only by case name one object there and the run proceeds.
+This is not the same as whether the dialect quotes identifiers. Rocky renders
+Trino targets double-quoted, yet treats two Trino targets differing only by case
+as one object, so such a run proceeds there.
 
 `--shadow` and `--branch` isolate `rocky run` for transformation pipelines.
 `rocky run --dag`, and the snapshot and load pipeline kinds, still write

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -5758,17 +5758,31 @@ fn rewrite_quote_style(dialect: &dyn rocky_core::traits::SqlDialect) -> Result<O
 /// only where case is part of identity can two targets differing by case be
 /// two different objects that a rewrite could confuse.
 ///
+/// This answers one narrow question: can two configured targets that differ
+/// only by case be two different objects? It is NOT a specification of how a
+/// reference should be compared per component, and must not be used as one.
+/// BigQuery is the counter-example — its dataset and table IDs are
+/// case-sensitive while its project IDs are not — so making
+/// `rewrite_upstream_refs` case-aware needs per-component semantics rather than
+/// this single boolean.
+///
 /// Unknown dialects fail closed.
 fn dialect_case_sensitive_identity(dialect: &dyn rocky_core::traits::SqlDialect) -> Result<bool> {
     match dialect.name() {
         // Identifiers are case-insensitive: `Orders` and `orders` are one
         // object, so no pair of targets can differ by case alone.
         "duckdb" | "databricks" => Ok(false),
+        // Trino normalizes identifiers to lower case whether or not they are
+        // quoted, so `"Orders"` and `orders` name the same table. This is
+        // exactly why quoting cannot stand in for case-sensitivity: Rocky
+        // renders Trino targets double-quoted, yet case is still not part of
+        // identity.
+        "trino" => Ok(false),
         // Dataset and table IDs are case-sensitive.
         "bigquery" => Ok(true),
-        // Rocky renders every component double-quoted, and a quoted identifier
-        // is taken verbatim rather than case-folded.
-        "snowflake" | "trino" => Ok(true),
+        // Rocky renders every component double-quoted, and Snowflake takes a
+        // quoted identifier verbatim instead of folding it to upper case.
+        "snowflake" => Ok(true),
         other => anyhow::bail!(
             "shadow/branch execution does not know whether '{other}' treats identifier case as \
              part of object identity, so it cannot tell whether two targets differing only by \
@@ -16964,42 +16978,56 @@ timestamp_column = "ts"
 
     /// On a dialect where identifiers are case-insensitive, two targets that
     /// differ only by case name the SAME object, so there is nothing to
-    /// disambiguate and the run must proceed. Pins the false branch of the
-    /// case-sensitivity declaration, which quoting alone would not decide.
+    /// disambiguate and the run must proceed.
+    ///
+    /// Covers Trino as well as DuckDB, and Trino is the point: Rocky renders
+    /// its targets double-quoted, yet Trino folds identifiers to lower case
+    /// whether quoted or not. A guard keyed on quoting would refuse this run;
+    /// one keyed on identity does not.
     #[cfg(feature = "duckdb")]
     #[test]
     fn shadow_allows_case_collisions_on_a_case_insensitive_dialect() {
-        let tmp = tempfile::TempDir::new().expect("temp dir");
-        let models_dir = tmp.path().join("models");
-        std::fs::create_dir(&models_dir).expect("mkdir models");
-        write_model_with_target(
-            &models_dir,
-            "driver",
-            "SELECT id FROM main.Orders",
-            "main",
-            "driver",
-        );
-        write_model_with_target(&models_dir, "lower", "SELECT 1 AS id", "main", "orders");
-        write_model_with_target(&models_dir, "upper", "SELECT 2 AS id", "main", "Orders");
-        let mut compiled =
-            rocky_compiler::compile::compile(&rocky_compiler::compile::CompilerConfig {
-                models_dir,
-                ..Default::default()
-            })
-            .expect("compile models");
-        let selected: std::collections::BTreeSet<String> =
-            ["driver".to_string(), "lower".to_string()]
-                .into_iter()
-                .collect();
-        super::apply_shadow_rewrite(
-            &mut compiled,
-            None,
-            Some(&selected),
-            &rocky_core::shadow::ShadowConfig::default(),
-            &rocky_duckdb::dialect::DuckDbSqlDialect,
-            false,
-        )
-        .expect("DuckDB folds identifier case, so there is no ambiguity to refuse");
+        for (name, dialect) in [
+            (
+                "duckdb",
+                &rocky_duckdb::dialect::DuckDbSqlDialect as &dyn rocky_core::traits::SqlDialect,
+            ),
+            ("trino", &rocky_trino::dialect::TrinoDialect),
+        ] {
+            let tmp = tempfile::TempDir::new().expect("temp dir");
+            let models_dir = tmp.path().join("models");
+            std::fs::create_dir(&models_dir).expect("mkdir models");
+            write_model_with_target(
+                &models_dir,
+                "driver",
+                "SELECT id FROM main.Orders",
+                "main",
+                "driver",
+            );
+            write_model_with_target(&models_dir, "lower", "SELECT 1 AS id", "main", "orders");
+            write_model_with_target(&models_dir, "upper", "SELECT 2 AS id", "main", "Orders");
+            let mut compiled =
+                rocky_compiler::compile::compile(&rocky_compiler::compile::CompilerConfig {
+                    models_dir,
+                    ..Default::default()
+                })
+                .expect("compile models");
+            let selected: std::collections::BTreeSet<String> =
+                ["driver".to_string(), "lower".to_string()]
+                    .into_iter()
+                    .collect();
+            super::apply_shadow_rewrite(
+                &mut compiled,
+                None,
+                Some(&selected),
+                &rocky_core::shadow::ShadowConfig::default(),
+                dialect,
+                false,
+            )
+            .unwrap_or_else(|err| {
+                panic!("{name} folds identifier case, so there is no ambiguity to refuse: {err:#}")
+            });
+        }
     }
 
     /// A case collision can sit in the schema or catalog rather than the table.

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -5774,27 +5774,47 @@ fn apply_shadow_rewrite(
     // Target identity is case-folded, and so is the tail match inside
     // `rewrite_upstream_refs`. On a dialect that quotes its targets that is a
     // lossy key: `"Orders"` and `"orders"` are two distinct Snowflake tables
-    // that fold to one identity, and a read of either could be redirected to
-    // the other's shadow. Refuse rather than guess. Checked across every
-    // compiled model, not just the selected ones, because an unselected model
-    // is exactly the case the routing loop below would not otherwise notice.
+    // that fold to one identity, so a read of one could be redirected to the
+    // other's shadow.
+    //
+    // Only a ROUTED model's production identity becomes a rename key, so the
+    // ambiguity exists only when a selected model is one side of the collision.
+    // Two unrelated models that happen to differ only by case are none of this
+    // run's business, and rejecting them would fail a scoped `--model` run that
+    // is provably safe. The other side may be unselected, though: a read of an
+    // unselected `"Orders"` still tail-matches the rename key of a selected
+    // `"orders"`, which is exactly the misdirection being prevented.
     if quote_style.is_some() {
-        let mut folded: HashMap<String, (String, String)> = HashMap::new();
+        let mut folded: HashMap<String, Vec<(String, String)>> = HashMap::new();
         for model in &compile_result.project.models {
             let exact = format!(
                 "{}.{}.{}",
                 model.config.target.catalog, model.config.target.schema, model.config.target.table
             );
-            let key = exact.to_ascii_lowercase();
+            folded
+                .entry(exact.to_ascii_lowercase())
+                .or_default()
+                .push((exact, model.config.name.clone()));
+        }
+        for model in &compile_result.project.models {
+            if !is_selected(&model.config.name) {
+                continue;
+            }
+            let exact = format!(
+                "{}.{}.{}",
+                model.config.target.catalog, model.config.target.schema, model.config.target.table
+            );
+            let Some(group) = folded.get(&exact.to_ascii_lowercase()) else {
+                continue;
+            };
             if let Some((other_exact, other_model)) =
-                folded.insert(key, (exact.clone(), model.config.name.clone()))
-                && other_exact != exact
+                group.iter().find(|(candidate, _)| *candidate != exact)
             {
                 anyhow::bail!(
                     "shadow/branch execution cannot distinguish the targets of models '{}' \
                      ('{}') and '{}' ('{}'): they differ only by case, which this dialect \
                      treats as two different objects. Rename one target so the two differ by \
-                     more than case",
+                     more than case, or scope the run so it does not select either",
                     other_model,
                     other_exact,
                     model.config.name,
@@ -16765,6 +16785,44 @@ timestamp_column = "ts"
                  folds case and names a different object: {sql}"
             );
         }
+    }
+
+    /// The case guard must scope to what the run actually routes. Only a
+    /// selected model's identity becomes a rename key, so a collision between
+    /// two models this run does not touch cannot misdirect anything — and
+    /// rejecting it would fail a scoped `--model` run that is provably safe.
+    #[cfg(feature = "duckdb")]
+    #[test]
+    fn shadow_allows_case_collisions_outside_the_selected_set() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        write_model_with_target(&models_dir, "picked", "SELECT 1 AS id", "main", "picked");
+        // Two models that collide only by case, neither of them selected.
+        write_model_with_target(&models_dir, "lower", "SELECT 1 AS id", "main", "orders");
+        write_model_with_target(&models_dir, "upper", "SELECT 2 AS id", "main", "Orders");
+        let mut compiled =
+            rocky_compiler::compile::compile(&rocky_compiler::compile::CompilerConfig {
+                models_dir,
+                ..Default::default()
+            })
+            .expect("compile models");
+        super::apply_shadow_rewrite(
+            &mut compiled,
+            Some("picked"),
+            None,
+            &rocky_core::shadow::ShadowConfig::default(),
+            &rocky_snowflake::dialect::SnowflakeSqlDialect,
+            false,
+        )
+        .expect("a scoped run must not be rejected for a collision it does not route");
+        let picked = compiled
+            .project
+            .models
+            .iter()
+            .find(|m| m.config.name == "picked")
+            .expect("picked missing");
+        assert_eq!(picked.config.target.table, "picked_rocky_shadow");
     }
 
     /// Two targets differing only by case are one object to the case-folded

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -5744,6 +5744,42 @@ fn rewrite_quote_style(dialect: &dyn rocky_core::traits::SqlDialect) -> Result<O
     }
 }
 
+/// Whether `sql` mentions `token` as an identifier in some spelling other than
+/// `token` itself.
+///
+/// The shadow rename matches table references case-insensitively, so on a
+/// dialect where identifiers are case-sensitive a read spelled `Orders` folds
+/// onto the rename key of a target spelled `orders`. Only such a read can be
+/// misdirected; a mention that already matches the routed spelling exactly is
+/// unambiguous. Bounded on identifier characters so `orders` does not match
+/// `orders_daily`.
+fn mentions_other_casing(sql: &str, token: &str) -> bool {
+    if token.is_empty() {
+        return false;
+    }
+    let haystack = sql.to_ascii_lowercase();
+    let needle = token.to_ascii_lowercase();
+    let is_ident = |c: char| c.is_ascii_alphanumeric() || c == '_';
+    let mut from = 0usize;
+    while let Some(offset) = haystack[from..].find(&needle) {
+        let start = from + offset;
+        let end = start + needle.len();
+        let bounded_left =
+            start == 0 || !haystack[..start].chars().next_back().is_some_and(is_ident);
+        let bounded_right = haystack[end..].chars().next().is_none_or(|c| !is_ident(c));
+        if bounded_left
+            && bounded_right
+            && sql
+                .get(start..end)
+                .is_some_and(|spelling| spelling != token)
+        {
+            return true;
+        }
+        from = end;
+    }
+    false
+}
+
 /// Route the models built by this invocation and their in-run dependency reads
 /// to shadow targets. Deferred or otherwise unselected upstreams stay on their
 /// production targets.
@@ -5953,6 +5989,23 @@ fn apply_shadow_rewrite(
             let Some(group) = folded.get(&exact.to_ascii_lowercase()) else {
                 continue;
             };
+            // Only a read spelled differently from this model's own target can
+            // be folded onto its rename key by mistake. If every mention of the
+            // table across the models being rewritten already matches the
+            // routed spelling exactly, the rewrite is unambiguous and the run is
+            // safe however many other objects share the folded name.
+            let table = model.config.target.table.as_str();
+            let miscased_read = routes.keys().any(|name| {
+                compile_result
+                    .project
+                    .models
+                    .iter()
+                    .find(|candidate| &candidate.config.name == name)
+                    .is_some_and(|candidate| mentions_other_casing(&candidate.sql, table))
+            });
+            if !miscased_read {
+                continue;
+            }
             if let Some((other_exact, other_model)) =
                 group.iter().find(|(candidate, _)| *candidate != exact)
             {
@@ -16798,8 +16851,16 @@ timestamp_column = "ts"
         let tmp = tempfile::TempDir::new().expect("temp dir");
         let models_dir = tmp.path().join("models");
         std::fs::create_dir(&models_dir).expect("mkdir models");
-        write_model_with_target(&models_dir, "lower", "SELECT 1 AS id", "main", "orders");
-        // Same folded identity as the selected model, different spelling.
+        // The one routed model even reads the OTHER spelling. With a single
+        // route there are no renames to apply, so nothing can be redirected and
+        // the read must be left exactly as written.
+        write_model_with_target(
+            &models_dir,
+            "lower",
+            "SELECT id FROM main.Orders",
+            "main",
+            "orders",
+        );
         write_model_with_target(&models_dir, "upper", "SELECT 2 AS id", "main", "Orders");
         let mut compiled =
             rocky_compiler::compile::compile(&rocky_compiler::compile::CompilerConfig {
@@ -16823,6 +16884,11 @@ timestamp_column = "ts"
             .find(|m| m.config.name == "lower")
             .expect("lower missing");
         assert_eq!(lower.config.target.table, "orders_rocky_shadow");
+        assert!(
+            lower.sql.contains("main.Orders") && !lower.sql.contains("rocky_shadow"),
+            "a single-model run applies no renames, so the read stays as written: {}",
+            lower.sql
+        );
         let upper = compiled
             .project
             .models
@@ -16832,6 +16898,58 @@ timestamp_column = "ts"
         assert_eq!(
             upper.config.target.table, "Orders",
             "an unselected model must stay on its production target"
+        );
+    }
+
+    /// A collision is only dangerous if some read is actually spelled the other
+    /// way. Two routed models that never mention the ambiguous table in a
+    /// different casing rewrite nothing ambiguous, so the run is safe even
+    /// though a case-colliding target exists elsewhere in the project.
+    #[cfg(feature = "duckdb")]
+    #[test]
+    fn shadow_allows_a_case_collision_no_model_reads_ambiguously() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        // Reads `lower`'s target in exactly the routed spelling: unambiguous.
+        write_model_with_target(
+            &models_dir,
+            "driver",
+            "SELECT id FROM main.orders",
+            "main",
+            "driver",
+        );
+        write_model_with_target(&models_dir, "lower", "SELECT 1 AS id", "main", "orders");
+        write_model_with_target(&models_dir, "upper", "SELECT 2 AS id", "main", "Orders");
+        let mut compiled =
+            rocky_compiler::compile::compile(&rocky_compiler::compile::CompilerConfig {
+                models_dir,
+                ..Default::default()
+            })
+            .expect("compile models");
+        let selected: std::collections::BTreeSet<String> =
+            ["driver".to_string(), "lower".to_string()]
+                .into_iter()
+                .collect();
+        super::apply_shadow_rewrite(
+            &mut compiled,
+            None,
+            Some(&selected),
+            &rocky_core::shadow::ShadowConfig::default(),
+            &rocky_snowflake::dialect::SnowflakeSqlDialect,
+            false,
+        )
+        .expect("no read is spelled ambiguously, so the run must not be rejected");
+        let driver = compiled
+            .project
+            .models
+            .iter()
+            .find(|m| m.config.name == "driver")
+            .expect("driver missing");
+        assert!(
+            driver.sql.contains("orders_rocky_shadow"),
+            "the unambiguous read must still be routed: {}",
+            driver.sql
         );
     }
 
@@ -16891,7 +17009,16 @@ timestamp_column = "ts"
         let tmp = tempfile::TempDir::new().expect("temp dir");
         let models_dir = tmp.path().join("models");
         std::fs::create_dir(&models_dir).expect("mkdir models");
-        write_model_with_target(&models_dir, "driver", "SELECT 1 AS id", "main", "driver");
+        // Reads the UNSELECTED model's target in its own spelling. That read
+        // folds onto `lower`'s rename key and would be redirected to `lower`'s
+        // shadow — the misdirection this guard exists to catch.
+        write_model_with_target(
+            &models_dir,
+            "driver",
+            "SELECT id FROM main.Orders",
+            "main",
+            "driver",
+        );
         write_model_with_target(&models_dir, "lower", "SELECT 1 AS id", "main", "orders");
         // Not selected, so `shadow_owners` never compares against it.
         write_model_with_target(&models_dir, "upper", "SELECT 2 AS id", "main", "Orders");

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -5852,23 +5852,32 @@ fn apply_shadow_rewrite(
         );
     }
 
-    let dependencies: HashMap<String, Vec<String>> = compile_result
-        .project
-        .dag_nodes
-        .iter()
-        .map(|node| (node.name.clone(), node.depends_on.clone()))
-        .collect();
     for model in &mut compile_result.project.models {
         let Some((_, own_shadow)) = routes.get(&model.config.name) else {
             continue;
         };
 
-        let renames: HashMap<String, rocky_sql::defer::DeferTarget> = dependencies
-            .get(&model.config.name)
-            .into_iter()
-            .flatten()
-            .filter_map(|dependency| routes.get(dependency))
-            .cloned()
+        // Redirect a read of ANY *other* selected model's production target,
+        // not just the models named in this one's `depends_on`. The declared
+        // graph is not a complete read set: `resolve::classify_table_ref`
+        // auto-derives a dependency only from a BARE single-part name that
+        // matches a model name, so a model reading an in-run upstream by its
+        // physical `schema.table` (classified `SourceRef`) or
+        // `catalog.schema.table` (`RawRef`) name gets no edge — and would
+        // otherwise keep reading production while writing its shadow target.
+        // `commands::containment` refuses to trust `dag_nodes` for the same
+        // reason. Keyed by the upstream's production identity, which is what
+        // `rewrite_upstream_refs` tail-matches against.
+        //
+        // A model's OWN identity is excluded: a self-read (an incremental
+        // model's `WHERE ts > (SELECT MAX(ts) FROM <own target>)`) must keep
+        // reading the production watermark. That read is read-only, and
+        // pointing it at the not-yet-populated shadow target would change what
+        // the model computes.
+        let renames: HashMap<String, rocky_sql::defer::DeferTarget> = routes
+            .iter()
+            .filter(|(name, _)| name.as_str() != model.config.name.as_str())
+            .map(|(_, route)| route.clone())
             .collect();
         if !renames.is_empty() {
             let outcome = rocky_sql::defer::rewrite_upstream_refs(&model.sql, &renames)
@@ -16416,6 +16425,89 @@ timestamp_column = "ts"
             ),
         )
         .expect("write model toml");
+    }
+
+    /// An in-run upstream read spelled as a physical `schema.table` name must
+    /// be routed to that upstream's shadow target even when the sidecar
+    /// declares no `depends_on`.
+    ///
+    /// The declared graph is not a complete read set:
+    /// `rocky_compiler::resolve::classify_table_ref` auto-derives a dependency
+    /// only from a BARE single-part name matching a model name, so a two-part
+    /// `main.orders` is classified `SourceRef` and produces no DAG edge.
+    /// Routing off `depends_on` alone therefore left such a model writing its
+    /// shadow target while still reading production — the containment ledger
+    /// refuses to trust `dag_nodes` for exactly this reason.
+    ///
+    /// The bare-name model is the control: it proves the rewrite is reached at
+    /// all, so a failure of the qualified assertion isolates the regression.
+    #[cfg(feature = "duckdb")]
+    #[test]
+    fn shadow_routes_undeclared_physical_upstream_reads() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        write_model_with_target(&models_dir, "orders", "SELECT 1 AS id", "main", "orders");
+        // Control: a bare-name read auto-derives `depends_on = ["orders"]`.
+        write_model_with_target(
+            &models_dir,
+            "mart_bare",
+            "SELECT id FROM orders",
+            "main",
+            "mart_bare",
+        );
+        // Regression: a two-part physical read declares nothing.
+        write_model_with_target(
+            &models_dir,
+            "mart_qualified",
+            "SELECT id FROM main.orders",
+            "main",
+            "mart_qualified",
+        );
+
+        let mut compiled =
+            rocky_compiler::compile::compile(&rocky_compiler::compile::CompilerConfig {
+                models_dir,
+                ..Default::default()
+            })
+            .expect("compile models");
+        assert!(
+            compiled
+                .project
+                .dag_nodes
+                .iter()
+                .any(|n| n.name == "mart_qualified" && n.depends_on.is_empty()),
+            "premise: a two-part physical read must not auto-derive a dependency"
+        );
+
+        let dialect = rocky_duckdb::dialect::DuckDbSqlDialect;
+        super::apply_shadow_rewrite(
+            &mut compiled,
+            None,
+            None,
+            &rocky_core::shadow::ShadowConfig::default(),
+            &dialect,
+        )
+        .expect("shadow rewrite must succeed");
+
+        let sql_of = |name: &str| {
+            compiled
+                .project
+                .models
+                .iter()
+                .find(|m| m.config.name == name)
+                .unwrap_or_else(|| panic!("model {name} missing"))
+                .sql
+                .to_ascii_lowercase()
+        };
+        assert!(
+            sql_of("mart_bare").contains("orders_rocky_shadow"),
+            "control: a declared bare-name upstream read must be routed to the shadow target"
+        );
+        assert!(
+            sql_of("mart_qualified").contains("orders_rocky_shadow"),
+            "an undeclared physical upstream read must not keep reading production"
+        );
     }
 
     #[cfg(feature = "duckdb")]

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -5715,12 +5715,22 @@ fn apply_defer_rewrite(
 /// Identifier quoting a rewritten upstream reference must use so that it names
 /// the same object the producer's DDL creates.
 ///
-/// This has to track `SqlDialect::format_table_ref` exactly. A producer writes
-/// its target through that method; a rewritten read is re-serialized here. Where
-/// the two disagree the read names a different object than the producer created:
-/// on Snowflake and Trino every component is emitted double-quoted and therefore
-/// case-sensitive, so a bare read folds to upper case and either errors or, worse,
-/// resolves to an unrelated table of that name.
+/// This has to track `SqlDialect::format_table_ref` exactly: a producer writes
+/// its target through that method, and a rewritten read is re-serialized here,
+/// so the two must render the same object the same way.
+///
+/// How much rides on that differs by dialect, and quoting is not the same
+/// question as case-sensitivity — see [`dialect_case_sensitive_identity`]:
+///
+/// - Snowflake folds an unquoted identifier to UPPER case and takes a quoted one
+///   verbatim. Rocky quotes its targets, so a bare read would fold and either
+///   error or resolve to an unrelated table. Here the quoting is load-bearing.
+/// - Trino folds identifiers to lower case whether or not they are quoted, so
+///   both spellings resolve alike. Quoting matches the producer's rendering and
+///   is needed for components that are reserved words, but it is not what makes
+///   the read resolve.
+/// - BigQuery needs backticks because project IDs may contain hyphens, which a
+///   bare identifier would parse as subtraction. Nothing to do with case.
 ///
 /// Unknown dialects fail closed. A new adapter that quotes its targets would
 /// otherwise inherit bare rendering silently, which is exactly the defect this
@@ -5732,8 +5742,9 @@ fn rewrite_quote_style(dialect: &dyn rocky_core::traits::SqlDialect) -> Result<O
         // Backticks: BigQuery project IDs may contain hyphens, which a bare
         // identifier would parse as subtraction.
         "bigquery" => Ok(Some('`')),
-        // Double quotes: both dialects quote every component of a target, which
-        // makes the object case-sensitive.
+        // Double quotes: both render every component of a target quoted. For
+        // Snowflake that also decides which object the read names; for Trino it
+        // only keeps the rendering consistent.
         "snowflake" | "trino" => Ok(Some('"')),
         other => anyhow::bail!(
             "cannot rewrite upstream references for dialect '{other}': its identifier quoting \
@@ -16788,11 +16799,15 @@ timestamp_column = "ts"
     /// name. Under shadow that is the production table, and no rewrite can fix
     /// it because there is no shadow object to point the read at. Shadow mode
     /// must therefore refuse the run rather than quietly read production.
-    /// A rewritten upstream read has to name the same object the producer's DDL
-    /// creates. Snowflake and Trino emit every component of a target
-    /// double-quoted, which makes the object case-sensitive, so a bare read
-    /// folds to upper case and names a different table. Nothing else in the
-    /// suite executes against those dialects, so this asserts the serialized
+    /// A rewritten upstream read has to render the same way the producer's DDL
+    /// does. Snowflake and Trino both emit every component of a target
+    /// double-quoted, so the rewritten read must be quoted too.
+    ///
+    /// What that buys differs: on Snowflake a bare read would fold to UPPER case
+    /// and name a different table, so the quoting decides correctness; on Trino
+    /// identifiers fold to lower case either way, so it only keeps the rendering
+    /// consistent and covers components that are reserved words. Nothing else in
+    /// the suite executes against these dialects, so this asserts the serialized
     /// SQL directly.
     #[cfg(feature = "duckdb")]
     #[test]

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1629,6 +1629,7 @@ pub async fn run(
             None,
             &schema_cache_cfg,
             auto_create_schemas,
+            shadow_config,
             defer_opts,
             skip_gate,
             // Reuse is active iff `[reuse]` is enabled AND `--no-reuse` was
@@ -1964,6 +1965,7 @@ pub async fn run(
                 output_json,
                 partition_opts,
                 &schema_cache_cfg,
+                shadow_config,
                 skip_gate,
                 // `--no-reuse` — the force-BUILD escape hatch for the
                 // content-addressed surface (point-to reuse AND the
@@ -4691,7 +4693,8 @@ pub async fn run(
             // fire. Wrap both calls so subscribers see
             // `pipeline_error` before the error reaches the caller.
             // #1093: the block's `Ok` payload is the `GovernanceSnapshot`
-            // `execute_models` captured at the fingerprint gate — threaded out
+            // `execute_models` captured from the fingerprint-gated compile —
+            // after execution-only target routing — and threaded out
             // so the governance reconcile below applies the gated set, never a
             // fresh disk compile.
             let exec_result: Result<GovernanceSnapshot> = async {
@@ -4709,6 +4712,7 @@ pub async fn run(
                     Some(pipeline_name),
                     &schema_cache_cfg,
                     pipeline.target.governance.auto_create_schemas,
+                    shadow_config,
                     // No `--model` selection on the full-pipeline path, so
                     // `apply_defer_rewrite` is a no-op even when `--defer` is
                     // set (a full run builds every model).
@@ -4802,7 +4806,8 @@ pub async fn run(
             // mirroring the `apply_grants` semantics earlier in this path.
             //
             // #1093: the reconcile iterates the `GovernanceSnapshot` that
-            // `execute_models` captured at the fingerprint gate — the fresh
+            // `execute_models` captured from the fingerprint-gated compile —
+            // after execution-only target routing — and the fresh
             // disk compile that used to run here is gone, so a post-execution
             // sidecar edit cannot change what governance is applied. The
             // env-resolved mask mapping is deliberately NOT part of the
@@ -5706,6 +5711,191 @@ fn apply_defer_rewrite(
     Ok(())
 }
 
+/// Route the models built by this invocation and their in-run dependency reads
+/// to shadow targets. Deferred or otherwise unselected upstreams stay on their
+/// production targets.
+fn apply_shadow_rewrite(
+    compile_result: &mut rocky_compiler::compile::CompileResult,
+    model_name_filter: Option<&str>,
+    model_set: Option<&std::collections::BTreeSet<String>>,
+    config: &rocky_core::shadow::ShadowConfig,
+    dialect: &dyn rocky_core::traits::SqlDialect,
+) -> Result<()> {
+    use std::collections::HashMap;
+
+    let is_selected = |name: &str| {
+        model_name_filter.is_none_or(|selected| selected == name)
+            && model_set.is_none_or(|set| set.contains(name))
+    };
+    let target_identity = |catalog: &str, schema: &str, table: &str| {
+        format!("{catalog}.{schema}.{table}").to_ascii_lowercase()
+    };
+
+    let quote_style = (dialect.name() == "bigquery").then_some('`');
+    let mut production_targets: HashMap<String, Vec<String>> = HashMap::new();
+    for model in &compile_result.project.models {
+        production_targets
+            .entry(target_identity(
+                &model.config.target.catalog,
+                &model.config.target.schema,
+                &model.config.target.table,
+            ))
+            .or_default()
+            .push(model.config.name.clone());
+    }
+    let mut shadow_owners: HashMap<String, String> = HashMap::new();
+    let mut routes: HashMap<String, (String, rocky_sql::defer::DeferTarget)> = HashMap::new();
+    for model in &compile_result.project.models {
+        if !is_selected(&model.config.name) {
+            continue;
+        }
+        match &model.config.strategy {
+            rocky_core::models::StrategyConfig::ContentAddressed { .. } => {
+                anyhow::bail!(
+                    "shadow/branch execution is not supported for content-addressed model '{}': \
+                     its object-storage prefix cannot yet be isolated safely",
+                    model.config.name
+                );
+            }
+            rocky_core::models::StrategyConfig::TimeInterval { .. } => {
+                anyhow::bail!(
+                    "shadow/branch execution is not supported for time-interval model '{}': \
+                     its partition state cannot yet be isolated safely",
+                    model.config.name
+                );
+            }
+            rocky_core::models::StrategyConfig::FullRefresh
+            | rocky_core::models::StrategyConfig::Incremental { .. }
+            | rocky_core::models::StrategyConfig::Merge { .. }
+            | rocky_core::models::StrategyConfig::Ephemeral
+            | rocky_core::models::StrategyConfig::DeleteInsert { .. }
+            | rocky_core::models::StrategyConfig::Microbatch { .. }
+            | rocky_core::models::StrategyConfig::View
+            | rocky_core::models::StrategyConfig::MaterializedView
+            | rocky_core::models::StrategyConfig::DynamicTable { .. } => {}
+        }
+
+        let original = rocky_ir::TargetRef {
+            catalog: model.config.target.catalog.clone(),
+            schema: model.config.target.schema.clone(),
+            table: model.config.target.table.clone(),
+        };
+        let shadow = rocky_core::shadow::shadow_target(&original, config);
+        if !shadow.catalog.is_empty() {
+            if quote_style.is_some() {
+                rocky_sql::validation::validate_gcp_project_id(&shadow.catalog).with_context(
+                    || {
+                        format!(
+                            "shadow target for model '{}' has an invalid BigQuery project ID",
+                            model.config.name
+                        )
+                    },
+                )?;
+            } else {
+                rocky_sql::validation::validate_identifier(&shadow.catalog).with_context(|| {
+                    format!(
+                        "shadow target for model '{}' has an invalid catalog identifier",
+                        model.config.name
+                    )
+                })?;
+            }
+        }
+        rocky_sql::validation::validate_identifier(&shadow.schema).with_context(|| {
+            format!(
+                "shadow target for model '{}' has an invalid schema identifier",
+                model.config.name
+            )
+        })?;
+        rocky_sql::validation::validate_identifier(&shadow.table).with_context(|| {
+            format!(
+                "shadow target for model '{}' has an invalid table identifier",
+                model.config.name
+            )
+        })?;
+
+        let original_key = target_identity(&original.catalog, &original.schema, &original.table);
+        let shadow_key = target_identity(&shadow.catalog, &shadow.schema, &shadow.table);
+        if let Some(production_models) = production_targets.get(&shadow_key) {
+            anyhow::bail!(
+                "shadow target '{}.{}.{}' for model '{}' collides with the production target of \
+                 model(s) {}. Choose a non-empty suffix or a dedicated shadow schema that cannot \
+                 overlap a production target",
+                shadow.catalog,
+                shadow.schema,
+                shadow.table,
+                model.config.name,
+                production_models.join(", "),
+            );
+        }
+        if let Some(existing_model) = shadow_owners.insert(shadow_key, model.config.name.clone()) {
+            anyhow::bail!(
+                "shadow target '{}.{}.{}' is shared by selected models '{}' and '{}'. Choose a \
+                 suffix or shadow schema that preserves a distinct target for every model",
+                shadow.catalog,
+                shadow.schema,
+                shadow.table,
+                existing_model,
+                model.config.name,
+            );
+        }
+        routes.insert(
+            model.config.name.clone(),
+            (
+                original_key,
+                rocky_sql::defer::DeferTarget {
+                    catalog: shadow.catalog,
+                    schema: shadow.schema,
+                    table: shadow.table,
+                    quote_style,
+                },
+            ),
+        );
+    }
+
+    let dependencies: HashMap<String, Vec<String>> = compile_result
+        .project
+        .dag_nodes
+        .iter()
+        .map(|node| (node.name.clone(), node.depends_on.clone()))
+        .collect();
+    for model in &mut compile_result.project.models {
+        let Some((_, own_shadow)) = routes.get(&model.config.name) else {
+            continue;
+        };
+
+        let renames: HashMap<String, rocky_sql::defer::DeferTarget> = dependencies
+            .get(&model.config.name)
+            .into_iter()
+            .flatten()
+            .filter_map(|dependency| routes.get(dependency))
+            .cloned()
+            .collect();
+        if !renames.is_empty() {
+            let outcome = rocky_sql::defer::rewrite_upstream_refs(&model.sql, &renames)
+                .with_context(|| {
+                    format!(
+                        "shadow mode could not rewrite upstream references in model '{}'",
+                        model.config.name
+                    )
+                })?;
+            anyhow::ensure!(
+                outcome.ambiguous_refs.is_empty(),
+                "shadow mode cannot safely route ambiguous upstream reference(s) {:?} in model \
+                 '{}'",
+                outcome.ambiguous_refs,
+                model.config.name
+            );
+            model.sql = outcome.sql;
+        }
+
+        model.config.target.catalog = own_shadow.catalog.clone();
+        model.config.target.schema = own_shadow.schema.clone();
+        model.config.target.table = own_shadow.table.clone();
+    }
+
+    Ok(())
+}
+
 /// The model phase completed cleanly: `execute_models` returned `Ok(())` AND it
 /// recorded NO new table failures (`failures_after == failures_before`).
 ///
@@ -5922,6 +6112,7 @@ pub(crate) async fn execute_backfill_set(
             // Target schemas already exist (the closure was built before); do not
             // auto-create, matching the `--model` entry point.
             false,
+            None, // backfills always target production
             &DeferOptions::default(),
             skip_gate,
             reuse_enabled,
@@ -6086,7 +6277,8 @@ pub(crate) struct GovernedModelGovernance {
 }
 
 /// The governance inputs of the exact compiled set [`execute_models`]
-/// executed, captured at the fingerprint-gate position (#1093).
+/// executed, captured from the fingerprint-gated compile after execution-only
+/// target routing (#1093).
 ///
 /// The post-execution reconcile sites (the replication/DAG classification +
 /// masking + retention + tags reconcile, and [`apply_model_governance_tags`]
@@ -6108,7 +6300,8 @@ pub(crate) struct GovernanceSnapshot {
 
 impl GovernanceSnapshot {
     /// Capture the governance inputs of `models` — the compiled set the
-    /// fingerprint gate verified (when governed), before defer mutates SQL.
+    /// fingerprint gate verified (when governed), after execution-only target
+    /// routing so governance follows the physical tables that were written.
     pub(crate) fn capture(models: &[rocky_core::models::Model]) -> Self {
         Self {
             models: models
@@ -6133,7 +6326,7 @@ impl GovernanceSnapshot {
 /// full-replication/DAG path runs after a clean model phase (§1.1 + §1.2).
 ///
 /// #1093: iterates the [`GovernanceSnapshot`] captured inside
-/// [`execute_models`] at the fingerprint gate — never a fresh disk compile —
+/// [`execute_models`] from the fingerprint-gated compile — never a fresh disk compile —
 /// with the SAME adapter calls in the SAME order the recompile-driven loop
 /// made: `apply_column_tags` → `apply_masking_policy` →
 /// `apply_retention_policy` → `set_tags`, per model, in compiled model order.
@@ -6275,6 +6468,10 @@ pub(crate) async fn execute_models(
     // `pipeline.target.governance.auto_create_schemas` here; defaults to
     // `false` for the model-only entry point that has no pipeline context.
     auto_create_schemas: bool,
+    // Physical target routing for `--shadow` / `--branch`. Applied after the
+    // governed fingerprint and `--defer` rewrite, but before schema creation,
+    // execution, state/reuse identity, metadata, and governance capture.
+    shadow_config: Option<&rocky_core::shadow::ShadowConfig>,
     // `--defer` selection state. When enabled (and a `model_name_filter` is
     // set), every project model NOT in the selection is treated as a deferred
     // upstream: the selected models' bare `ref()`s to those upstreams are
@@ -6549,16 +6746,6 @@ pub(crate) async fn execute_models(
         gate.verify(&compile_result.project.models, &extras)?;
     }
 
-    // #1093: capture the governance snapshot HERE — position-keyed to the
-    // fingerprint gate above (the verify runs only on governed paths; this
-    // capture is unconditional at this position) and BEFORE the `--defer`
-    // rewrite below mutates any SQL — so the snapshot reflects the exact
-    // gated, pre-defer compiled set. The post-execution reconcile sites
-    // consume THIS value instead of fresh-compiling from disk, so a
-    // post-execution `.sql`/`.toml` edit cannot change what governance is
-    // applied out from under the fingerprint that gated execution.
-    let governance_snapshot = GovernanceSnapshot::capture(&compile_result.project.models);
-
     // Per-model compile errors are first-class run failures, not silent
     // skips. Each model that fails to type-check (e.g. E020 — a
     // `time_interval` model whose `time_column` is absent from its SELECT
@@ -6616,6 +6803,23 @@ pub(crate) async fn execute_models(
             warehouse.dialect(),
         )?;
     }
+
+    if let Some(config) = shadow_config {
+        apply_shadow_rewrite(
+            &mut compile_result,
+            model_name_filter,
+            model_set,
+            config,
+            warehouse.dialect(),
+        )?;
+        output.shadow = true;
+    }
+
+    // #1093: capture governance from the same in-memory model set the
+    // fingerprint gate verified, after execution-only defer SQL and physical
+    // shadow-target rewrites. No files are re-read, and governance follows the
+    // exact physical targets this run materializes.
+    let governance_snapshot = GovernanceSnapshot::capture(&compile_result.project.models);
 
     // §P2.6 emit: compile_complete — fires once after a successful
     // compile pass, with the model count from the compiled project.
@@ -8437,7 +8641,7 @@ fn transformation_strategy_name(strategy: &MaterializationStrategy) -> &'static 
 /// classification/retention governance posture on the replication path.
 ///
 /// #1093: reads the [`GovernanceSnapshot`] the caller's [`execute_models`]
-/// captured at the fingerprint gate — the internal recompile this function
+/// captured from the fingerprint-gated compile — the internal recompile this function
 /// used to run is gone, so a post-execution sidecar edit cannot change which
 /// tags are applied. The old compile inputs (`models_dir`, the config's
 /// mask/classification/freshness sections, `run_vars`) fed only that deleted
@@ -14798,6 +15002,7 @@ timestamp_column = "ts"
             None,
             &rocky_core::config::SchemaCacheConfig::default(),
             false,
+            None, // shadow_config (test)
             &DeferOptions::default(),
             super::SkipGateConfig::off(),
             false,
@@ -14875,6 +15080,7 @@ timestamp_column = "ts"
             None,
             &rocky_core::config::SchemaCacheConfig::default(),
             true, // auto_create_schemas
+            None, // shadow_config (test)
             &DeferOptions::default(),
             super::SkipGateConfig::off(),
             false,
@@ -14912,6 +15118,7 @@ timestamp_column = "ts"
             None,
             &rocky_core::config::SchemaCacheConfig::default(),
             true,
+            None, // shadow_config (test)
             &DeferOptions::default(),
             super::SkipGateConfig::off(),
             false,
@@ -15099,6 +15306,7 @@ timestamp_column = "ts"
             None,
             &rocky_core::config::SchemaCacheConfig::default(),
             true,
+            None, // shadow_config (test)
             &DeferOptions::default(),
             super::SkipGateConfig::off(),
             false,
@@ -15339,6 +15547,7 @@ timestamp_column = "ts"
             None,
             &rocky_core::config::SchemaCacheConfig::default(),
             true,
+            None, // shadow_config (test)
             &DeferOptions::default(),
             super::SkipGateConfig::off(),
             false,
@@ -15426,6 +15635,7 @@ timestamp_column = "ts"
             None,
             &rocky_core::config::SchemaCacheConfig::default(),
             true,
+            None, // shadow_config (test)
             &DeferOptions::default(),
             super::SkipGateConfig::off(),
             false,
@@ -15482,6 +15692,7 @@ timestamp_column = "ts"
             None,
             &rocky_core::config::SchemaCacheConfig::default(),
             true,
+            None, // shadow_config (test)
             &DeferOptions::default(),
             super::SkipGateConfig::off(),
             false,
@@ -15670,6 +15881,7 @@ timestamp_column = "ts"
             None,
             &rocky_core::config::SchemaCacheConfig::default(),
             false,
+            None, // shadow_config (test)
             &DeferOptions::default(),
             super::SkipGateConfig::off(),
             false,
@@ -15714,6 +15926,7 @@ timestamp_column = "ts"
             None,
             &rocky_core::config::SchemaCacheConfig::default(),
             true, // auto_create_schemas — the fixtures target `marts`
+            None, // shadow_config (test)
             &DeferOptions::default(),
             super::SkipGateConfig::off(),
             false,
@@ -15764,6 +15977,7 @@ timestamp_column = "ts"
             None,
             &rocky_core::config::SchemaCacheConfig::default(),
             false,
+            None, // shadow_config (test)
             &DeferOptions::default(),
             super::SkipGateConfig::off(),
             false,
@@ -16202,6 +16416,139 @@ timestamp_column = "ts"
             ),
         )
         .expect("write model toml");
+    }
+
+    #[cfg(feature = "duckdb")]
+    #[test]
+    fn shadow_rejects_targets_with_unisolated_external_state() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        std::fs::write(models_dir.join("events.sql"), "SELECT 1 AS id\n").expect("write model sql");
+        std::fs::write(
+            models_dir.join("events.toml"),
+            "[strategy]\ntype = \"content_addressed\"\n\
+             storage_prefix = \"s3://bucket/production/events\"\n\n\
+             [target]\ncatalog = \"\"\nschema = \"main\"\ntable = \"events\"\n",
+        )
+        .expect("write model config");
+
+        let mut compiled =
+            rocky_compiler::compile::compile(&rocky_compiler::compile::CompilerConfig {
+                models_dir,
+                ..Default::default()
+            })
+            .expect("compile model");
+        let dialect = rocky_duckdb::dialect::DuckDbSqlDialect;
+        let config = rocky_core::shadow::ShadowConfig::default();
+
+        let content_addressed =
+            super::apply_shadow_rewrite(&mut compiled, None, None, &config, &dialect)
+                .expect_err("content-addressed shadow must fail closed");
+        assert!(
+            content_addressed
+                .to_string()
+                .contains("object-storage prefix cannot yet be isolated safely")
+        );
+
+        compiled.project.models[0].config.strategy =
+            rocky_core::models::StrategyConfig::TimeInterval {
+                time_column: "id".to_string(),
+                granularity: rocky_ir::TimeGrain::Day,
+                lookback: 0,
+                batch_size: std::num::NonZeroU32::new(1).unwrap(),
+                first_partition: Some("2026-01-01".to_string()),
+            };
+        let time_interval =
+            super::apply_shadow_rewrite(&mut compiled, None, None, &config, &dialect)
+                .expect_err("time-interval shadow must fail closed");
+        assert!(
+            time_interval
+                .to_string()
+                .contains("partition state cannot yet be isolated safely")
+        );
+    }
+
+    #[cfg(feature = "duckdb")]
+    #[test]
+    fn shadow_rejects_production_and_cross_model_target_collisions() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        write_model_with_target(&models_dir, "orders", "SELECT 1 AS id", "main", "orders");
+        write_model_with_target(
+            &models_dir,
+            "reserved_shadow",
+            "SELECT 2 AS id",
+            "main",
+            "orders_rocky_shadow",
+        );
+        write_model_with_target(
+            &models_dir,
+            "regional_orders",
+            "SELECT 3 AS id",
+            "regional",
+            "orders",
+        );
+        let compile = || {
+            rocky_compiler::compile::compile(&rocky_compiler::compile::CompilerConfig {
+                models_dir: models_dir.clone(),
+                ..Default::default()
+            })
+            .expect("compile models")
+        };
+        let dialect = rocky_duckdb::dialect::DuckDbSqlDialect;
+
+        let mut compiled = compile();
+        let empty_suffix = rocky_core::shadow::ShadowConfig {
+            suffix: String::new(),
+            cleanup_after: false,
+            schema_override: None,
+        };
+        let err = super::apply_shadow_rewrite(&mut compiled, None, None, &empty_suffix, &dialect)
+            .expect_err("an empty suffix must not route back to production");
+        assert!(
+            err.to_string()
+                .contains("collides with the production target")
+        );
+
+        let mut compiled = compile();
+        let production_schema = rocky_core::shadow::ShadowConfig {
+            schema_override: Some("main".to_string()),
+            cleanup_after: false,
+            ..Default::default()
+        };
+        let err =
+            super::apply_shadow_rewrite(&mut compiled, None, None, &production_schema, &dialect)
+                .expect_err("a production schema override must fail closed");
+        assert!(
+            err.to_string()
+                .contains("collides with the production target")
+        );
+
+        let mut compiled = compile();
+        let err = super::apply_shadow_rewrite(
+            &mut compiled,
+            None,
+            None,
+            &rocky_core::shadow::ShadowConfig::default(),
+            &dialect,
+        )
+        .expect_err("the default suffix must not overwrite another model's production target");
+        assert!(
+            err.to_string()
+                .contains("collides with the production target")
+        );
+
+        let mut compiled = compile();
+        let shared_schema = rocky_core::shadow::ShadowConfig {
+            schema_override: Some("isolated_shadow".to_string()),
+            cleanup_after: false,
+            ..Default::default()
+        };
+        let err = super::apply_shadow_rewrite(&mut compiled, None, None, &shared_schema, &dialect)
+            .expect_err("selected models must not share a derived shadow target");
+        assert!(err.to_string().contains("is shared by selected models"));
     }
 
     /// Finding 1 (physical-table read escapes containment). A raw-SQL model
@@ -16844,6 +17191,7 @@ timestamp_column = "ts"
             None,
             &rocky_core::config::SchemaCacheConfig::default(),
             false,
+            None, // shadow_config (test)
             &DeferOptions::default(),
             super::SkipGateConfig::off(),
             false,
@@ -16952,6 +17300,7 @@ timestamp_column = "ts"
             None,
             &rocky_core::config::SchemaCacheConfig::default(),
             false,
+            None, // shadow_config (test)
             &defer_opts,
             super::SkipGateConfig::off(),
             false,
@@ -17075,6 +17424,7 @@ timestamp_column = "ts"
             None,
             &rocky_core::config::SchemaCacheConfig::default(),
             false,
+            None, // shadow_config (test)
             &DeferOptions::default(),
             super::SkipGateConfig::off(),
             false,
@@ -17359,6 +17709,7 @@ timestamp_column = "ts"
                 None,
                 &rocky_core::config::SchemaCacheConfig::default(),
                 false,
+                None, // shadow_config (test)
                 &DeferOptions::default(),
                 super::SkipGateConfig::off(),
                 false,
@@ -17486,6 +17837,7 @@ timestamp_column = "ts"
             None,
             &rocky_core::config::SchemaCacheConfig::default(),
             false,
+            None, // shadow_config (test)
             &DeferOptions::default(),
             gate,
             false,
@@ -18463,6 +18815,7 @@ timestamp_column = "ts"
                 None,
                 &rocky_core::config::SchemaCacheConfig::default(),
                 false,
+                None, // shadow_config (test)
                 &DeferOptions::default(),
                 active_gate(true, 0),
                 false,

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -5719,18 +5719,11 @@ fn apply_defer_rewrite(
 /// its target through that method, and a rewritten read is re-serialized here,
 /// so the two must render the same object the same way.
 ///
-/// How much rides on that differs by dialect, and quoting is not the same
-/// question as case-sensitivity — see [`dialect_case_sensitive_identity`]:
-///
-/// - Snowflake folds an unquoted identifier to UPPER case and takes a quoted one
-///   verbatim. Rocky quotes its targets, so a bare read would fold and either
-///   error or resolve to an unrelated table. Here the quoting is load-bearing.
-/// - Trino folds identifiers to lower case whether or not they are quoted, so
-///   both spellings resolve alike. Quoting matches the producer's rendering and
-///   is needed for components that are reserved words, but it is not what makes
-///   the read resolve.
-/// - BigQuery needs backticks because project IDs may contain hyphens, which a
-///   bare identifier would parse as subtraction. Nothing to do with case.
+/// Each value below is read off that dialect's `format_table_ref`, which is
+/// in-repo and checkable. This function deliberately does not reason about how
+/// any warehouse folds identifier case — that is a separate question answered by
+/// [`dialect_case_sensitive_identity`], and conflating the two is what made an
+/// earlier revision of this code wrong.
 ///
 /// Unknown dialects fail closed. A new adapter that quotes its targets would
 /// otherwise inherit bare rendering silently, which is exactly the defect this
@@ -5739,12 +5732,10 @@ fn rewrite_quote_style(dialect: &dyn rocky_core::traits::SqlDialect) -> Result<O
     match dialect.name() {
         // `format_table_ref` renders bare identifiers.
         "duckdb" | "databricks" => Ok(None),
-        // Backticks: BigQuery project IDs may contain hyphens, which a bare
-        // identifier would parse as subtraction.
+        // `format_table_ref` renders backticks; its own comment gives the
+        // reason (project IDs may contain hyphens).
         "bigquery" => Ok(Some('`')),
-        // Double quotes: both render every component of a target quoted. For
-        // Snowflake that also decides which object the read names; for Trino it
-        // only keeps the rendering consistent.
+        // `format_table_ref` renders double quotes on both.
         "snowflake" | "trino" => Ok(Some('"')),
         other => anyhow::bail!(
             "cannot rewrite upstream references for dialect '{other}': its identifier quoting \
@@ -5771,29 +5762,28 @@ fn rewrite_quote_style(dialect: &dyn rocky_core::traits::SqlDialect) -> Result<O
 ///
 /// This answers one narrow question: can two configured targets that differ
 /// only by case be two different objects? It is NOT a specification of how a
-/// reference should be compared per component, and must not be used as one.
-/// BigQuery is the counter-example — its dataset and table IDs are
-/// case-sensitive while its project IDs are not — so making
-/// `rewrite_upstream_refs` case-aware needs per-component semantics rather than
-/// this single boolean.
+/// reference should be compared per component, and must not be used as one — a
+/// warehouse may well apply different rules to the catalog than to the schema
+/// and table. Making `rewrite_upstream_refs` case-aware therefore needs
+/// per-component semantics, established per dialect, rather than this boolean.
+///
+/// The values below are a policy table about warehouse identifier rules, and
+/// nothing in this repository proves them. Only Snowflake has in-repo evidence:
+/// `rocky-snowflake`'s `format_table_ref` documents that emitting bare
+/// identifiers "silently breaks against any schema / table created with quoted
+/// lowercase names", which is why its targets are quoted at all. **Confirm each
+/// entry against that warehouse's published identifier rules before relying on
+/// it, and re-confirm when adding one.** Deriving these from how Rocky renders a
+/// target is precisely the mistake that produced the wrong answer here before —
+/// rendering and identity are independent.
 ///
 /// Unknown dialects fail closed.
 fn dialect_case_sensitive_identity(dialect: &dyn rocky_core::traits::SqlDialect) -> Result<bool> {
     match dialect.name() {
-        // Identifiers are case-insensitive: `Orders` and `orders` are one
-        // object, so no pair of targets can differ by case alone.
-        "duckdb" | "databricks" => Ok(false),
-        // Trino normalizes identifiers to lower case whether or not they are
-        // quoted, so `"Orders"` and `orders` name the same table. This is
-        // exactly why quoting cannot stand in for case-sensitivity: Rocky
-        // renders Trino targets double-quoted, yet case is still not part of
-        // identity.
-        "trino" => Ok(false),
-        // Dataset and table IDs are case-sensitive.
-        "bigquery" => Ok(true),
-        // Rocky renders every component double-quoted, and Snowflake takes a
-        // quoted identifier verbatim instead of folding it to upper case.
-        "snowflake" => Ok(true),
+        // Two targets differing only by case name one object.
+        "duckdb" | "databricks" | "trino" => Ok(false),
+        // Two targets differing only by case can name two objects.
+        "bigquery" | "snowflake" => Ok(true),
         other => anyhow::bail!(
             "shadow/branch execution does not know whether '{other}' treats identifier case as \
              part of object identity, so it cannot tell whether two targets differing only by \
@@ -16800,15 +16790,11 @@ timestamp_column = "ts"
     /// it because there is no shadow object to point the read at. Shadow mode
     /// must therefore refuse the run rather than quietly read production.
     /// A rewritten upstream read has to render the same way the producer's DDL
-    /// does. Snowflake and Trino both emit every component of a target
-    /// double-quoted, so the rewritten read must be quoted too.
-    ///
-    /// What that buys differs: on Snowflake a bare read would fold to UPPER case
-    /// and name a different table, so the quoting decides correctness; on Trino
-    /// identifiers fold to lower case either way, so it only keeps the rendering
-    /// consistent and covers components that are reserved words. Nothing else in
-    /// the suite executes against these dialects, so this asserts the serialized
-    /// SQL directly.
+    /// does, because both name the same object. Snowflake and Trino both emit
+    /// every component of a target double-quoted, so the rewritten read must be
+    /// quoted too; DuckDB renders bare. Nothing else in the suite exercises
+    /// these dialects, so this asserts the serialized SQL directly rather than
+    /// reasoning about how each warehouse resolves it.
     #[cfg(feature = "duckdb")]
     #[test]
     fn shadow_rewritten_reads_match_the_producer_quoting_per_dialect() {
@@ -16995,10 +16981,9 @@ timestamp_column = "ts"
     /// differ only by case name the SAME object, so there is nothing to
     /// disambiguate and the run must proceed.
     ///
-    /// Covers Trino as well as DuckDB, and Trino is the point: Rocky renders
-    /// its targets double-quoted, yet Trino folds identifiers to lower case
-    /// whether quoted or not. A guard keyed on quoting would refuse this run;
-    /// one keyed on identity does not.
+    /// Covers Trino as well as DuckDB, and Trino is the point: Rocky renders its
+    /// targets double-quoted, yet it is declared case-insensitive. A guard keyed
+    /// on quoting would refuse this run; one keyed on identity does not.
     #[cfg(feature = "duckdb")]
     #[test]
     fn shadow_allows_case_collisions_on_a_case_insensitive_dialect() {

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -5720,6 +5720,11 @@ fn apply_shadow_rewrite(
     model_set: Option<&std::collections::BTreeSet<String>>,
     config: &rocky_core::shadow::ShadowConfig,
     dialect: &dyn rocky_core::traits::SqlDialect,
+    // `[resilience] contain_failures`. When on, execution follows the
+    // containment ledger's augmented layers, which own both the ordering and
+    // the cyclic-subgraph recovery — so this function must not recompute or
+    // hard-fail the plan.
+    contain_failures: bool,
 ) -> Result<()> {
     use std::collections::HashMap;
 
@@ -5745,6 +5750,9 @@ fn apply_shadow_rewrite(
     }
     let mut shadow_owners: HashMap<String, String> = HashMap::new();
     let mut routes: HashMap<String, (String, rocky_sql::defer::DeferTarget)> = HashMap::new();
+    // Routed models that materialize nothing, so no reader may be redirected to
+    // their shadow target and no ordering edge may point at them.
+    let mut ephemeral_models: std::collections::HashSet<String> = std::collections::HashSet::new();
     for model in &compile_result.project.models {
         if !is_selected(&model.config.name) {
             continue;
@@ -5764,10 +5772,25 @@ fn apply_shadow_rewrite(
                     model.config.name
                 );
             }
+            // Ephemeral models are inlined as CTEs and never materialized —
+            // `sql_gen::generate_transformation_sql` returns no statements for
+            // them — so their configured target is nominal. They are still
+            // ROUTED (their target is rewritten below) because the governance
+            // snapshot is captured from these same models and its reconcile
+            // loops issue adapter calls against `target_*` without checking
+            // strategy or whether anything was materialized. Leaving an
+            // ephemeral target on production would let a shadow run apply that
+            // model's tags / masks / retention to the PRODUCTION table.
+            //
+            // They are excluded from the reader renames and the edge index
+            // below instead: nothing creates their shadow target, so no reader
+            // may be redirected to it and no ordering edge may depend on it.
+            rocky_core::models::StrategyConfig::Ephemeral => {
+                ephemeral_models.insert(model.config.name.clone());
+            }
             rocky_core::models::StrategyConfig::FullRefresh
             | rocky_core::models::StrategyConfig::Incremental { .. }
             | rocky_core::models::StrategyConfig::Merge { .. }
-            | rocky_core::models::StrategyConfig::Ephemeral
             | rocky_core::models::StrategyConfig::DeleteInsert { .. }
             | rocky_core::models::StrategyConfig::Microbatch { .. }
             | rocky_core::models::StrategyConfig::View
@@ -5854,8 +5877,11 @@ fn apply_shadow_rewrite(
 
     // Reverse index of the rename keys, so a key that `rewrite_upstream_refs`
     // reports as rewritten can be mapped back to the model that produces it.
+    // Ephemeral models are absent: they materialize nothing, so they can never
+    // be the producer an ordering edge should wait on.
     let owner_by_key: HashMap<&str, &str> = routes
         .iter()
+        .filter(|(name, _)| !ephemeral_models.contains(name.as_str()))
         .map(|(name, (original_key, _))| (original_key.as_str(), name.as_str()))
         .collect();
     // Edges discovered by the rewrite: `(consumer, producer)`. Collected here
@@ -5884,9 +5910,16 @@ fn apply_shadow_rewrite(
         // reading the production watermark. That read is read-only, and
         // pointing it at the not-yet-populated shadow target would change what
         // the model computes.
+        //
+        // Ephemeral upstreams are excluded too: they are inlined as CTEs and
+        // materialize nothing, so their shadow target is never created and a
+        // redirected read would resolve to a table that does not exist.
         let renames: HashMap<String, rocky_sql::defer::DeferTarget> = routes
             .iter()
-            .filter(|(name, _)| name.as_str() != model.config.name.as_str())
+            .filter(|(name, _)| {
+                name.as_str() != model.config.name.as_str()
+                    && !ephemeral_models.contains(name.as_str())
+            })
             .map(|(_, route)| route.clone())
             .collect();
         if !renames.is_empty() {
@@ -5946,15 +5979,28 @@ fn apply_shadow_rewrite(
                 added += 1;
             }
         }
-        if added > 0 {
+        // With `[resilience] contain_failures`, execution does not follow
+        // `project.layers` at all — it follows
+        // `ContainmentLedger::augmented_layers`, which derives its own ordering
+        // from the full ref-union-physical edge set (so it already orders a
+        // physical reader after its producer) and, on a cycle, CONTAINS the
+        // stuck set while still layering and running the acyclic remainder.
+        // Recomputing here would be ignored, and hard-failing on a cycle would
+        // preempt that documented recovery — turning "contain A and B, run C"
+        // into "run nothing". Leave the plan to the containment path.
+        if added > 0 && !contain_failures {
             let nodes = &compile_result.project.dag_nodes;
             let execution_order = rocky_ir::dag::topological_sort(nodes).with_context(|| {
                 "shadow mode redirected an upstream read that introduces a dependency cycle; \
-                 the models cannot be ordered safely"
+                 the models cannot be ordered safely. Declare the dependencies via depends_on \
+                 and remove the cycle, or enable `[resilience] contain_failures` to contain the \
+                 cyclic models and run the rest"
             })?;
             let layers = rocky_ir::dag::execution_layers(nodes).with_context(|| {
                 "shadow mode redirected an upstream read that introduces a dependency cycle; \
-                 the models cannot be layered safely"
+                 the models cannot be layered safely. Declare the dependencies via depends_on \
+                 and remove the cycle, or enable `[resilience] contain_failures` to contain the \
+                 cyclic models and run the rest"
             })?;
             compile_result.project.execution_order = execution_order;
             compile_result.project.layers = layers;
@@ -6879,6 +6925,7 @@ pub(crate) async fn execute_models(
             model_set,
             config,
             warehouse.dialect(),
+            resilience.contain_failures,
         )?;
         output.shadow = true;
     }
@@ -16546,6 +16593,7 @@ timestamp_column = "ts"
             None,
             &rocky_core::shadow::ShadowConfig::default(),
             &dialect,
+            false,
         )
         .expect("shadow rewrite must succeed");
 
@@ -16566,6 +16614,93 @@ timestamp_column = "ts"
         assert!(
             sql_of("mart_qualified").contains("orders_rocky_shadow"),
             "an undeclared physical upstream read must not keep reading production"
+        );
+    }
+
+    /// An ephemeral model materializes nothing, so no reader may be redirected
+    /// to its shadow target — but its target must still be rewritten off
+    /// production. `GovernanceSnapshot::capture` reads these same models and
+    /// its reconcile loops issue `apply_column_tags` / `apply_masking_policy` /
+    /// `apply_retention_policy` / `set_tags` against `target_*` without
+    /// consulting the strategy, so an ephemeral target left on production would
+    /// let a shadow run mutate PRODUCTION governance metadata.
+    #[cfg(feature = "duckdb")]
+    #[test]
+    fn shadow_routes_ephemeral_target_but_never_redirects_readers_to_it() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        std::fs::write(models_dir.join("eph.sql"), "SELECT 1 AS id\n").expect("write sql");
+        std::fs::write(
+            models_dir.join("eph.toml"),
+            "[strategy]\ntype = \"ephemeral\"\n\n\
+             [target]\ncatalog = \"\"\nschema = \"main\"\ntable = \"eph\"\n",
+        )
+        .expect("write toml");
+        // Reads the ephemeral model's nominal target by physical name.
+        write_model_with_target(
+            &models_dir,
+            "consumer",
+            "SELECT id FROM main.eph",
+            "main",
+            "consumer",
+        );
+
+        let mut compiled =
+            rocky_compiler::compile::compile(&rocky_compiler::compile::CompilerConfig {
+                models_dir,
+                ..Default::default()
+            })
+            .expect("compile models");
+        let dialect = rocky_duckdb::dialect::DuckDbSqlDialect;
+        super::apply_shadow_rewrite(
+            &mut compiled,
+            None,
+            None,
+            &rocky_core::shadow::ShadowConfig::default(),
+            &dialect,
+            false,
+        )
+        .expect("shadow rewrite must succeed");
+
+        let model = |name: &str| {
+            compiled
+                .project
+                .models
+                .iter()
+                .find(|m| m.config.name == name)
+                .unwrap_or_else(|| panic!("model {name} missing"))
+        };
+
+        // The ephemeral target is rewritten, so nothing downstream of the
+        // governance snapshot can address the production table.
+        assert_eq!(
+            model("eph").config.target.table,
+            "eph_rocky_shadow",
+            "an ephemeral target must not stay on production during a shadow run"
+        );
+        // But no reader is pointed at that never-created table.
+        assert!(
+            model("consumer")
+                .sql
+                .to_ascii_lowercase()
+                .contains("main.eph")
+                && !model("consumer")
+                    .sql
+                    .to_ascii_lowercase()
+                    .contains("eph_rocky_shadow"),
+            "a read of an ephemeral model must not be redirected to its shadow target: {:?}",
+            model("consumer").sql
+        );
+        // And no ordering edge waits on a model that materializes nothing.
+        assert!(
+            compiled
+                .project
+                .dag_nodes
+                .iter()
+                .find(|n| n.name == "consumer")
+                .is_some_and(|n| !n.depends_on.iter().any(|d| d == "eph")),
+            "no derived edge may name an ephemeral producer"
         );
     }
 
@@ -16594,7 +16729,7 @@ timestamp_column = "ts"
         let config = rocky_core::shadow::ShadowConfig::default();
 
         let content_addressed =
-            super::apply_shadow_rewrite(&mut compiled, None, None, &config, &dialect)
+            super::apply_shadow_rewrite(&mut compiled, None, None, &config, &dialect, false)
                 .expect_err("content-addressed shadow must fail closed");
         assert!(
             content_addressed
@@ -16611,7 +16746,7 @@ timestamp_column = "ts"
                 first_partition: Some("2026-01-01".to_string()),
             };
         let time_interval =
-            super::apply_shadow_rewrite(&mut compiled, None, None, &config, &dialect)
+            super::apply_shadow_rewrite(&mut compiled, None, None, &config, &dialect, false)
                 .expect_err("time-interval shadow must fail closed");
         assert!(
             time_interval
@@ -16656,8 +16791,9 @@ timestamp_column = "ts"
             cleanup_after: false,
             schema_override: None,
         };
-        let err = super::apply_shadow_rewrite(&mut compiled, None, None, &empty_suffix, &dialect)
-            .expect_err("an empty suffix must not route back to production");
+        let err =
+            super::apply_shadow_rewrite(&mut compiled, None, None, &empty_suffix, &dialect, false)
+                .expect_err("an empty suffix must not route back to production");
         assert!(
             err.to_string()
                 .contains("collides with the production target")
@@ -16669,9 +16805,15 @@ timestamp_column = "ts"
             cleanup_after: false,
             ..Default::default()
         };
-        let err =
-            super::apply_shadow_rewrite(&mut compiled, None, None, &production_schema, &dialect)
-                .expect_err("a production schema override must fail closed");
+        let err = super::apply_shadow_rewrite(
+            &mut compiled,
+            None,
+            None,
+            &production_schema,
+            &dialect,
+            false,
+        )
+        .expect_err("a production schema override must fail closed");
         assert!(
             err.to_string()
                 .contains("collides with the production target")
@@ -16684,6 +16826,7 @@ timestamp_column = "ts"
             None,
             &rocky_core::shadow::ShadowConfig::default(),
             &dialect,
+            false,
         )
         .expect_err("the default suffix must not overwrite another model's production target");
         assert!(
@@ -16697,8 +16840,9 @@ timestamp_column = "ts"
             cleanup_after: false,
             ..Default::default()
         };
-        let err = super::apply_shadow_rewrite(&mut compiled, None, None, &shared_schema, &dialect)
-            .expect_err("selected models must not share a derived shadow target");
+        let err =
+            super::apply_shadow_rewrite(&mut compiled, None, None, &shared_schema, &dialect, false)
+                .expect_err("selected models must not share a derived shadow target");
         assert!(err.to_string().contains("is shared by selected models"));
     }
 

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -5744,6 +5744,40 @@ fn rewrite_quote_style(dialect: &dyn rocky_core::traits::SqlDialect) -> Result<O
     }
 }
 
+/// Whether this dialect treats identifier case as part of object identity.
+///
+/// Deliberately separate from [`rewrite_quote_style`]. Quoting is a rendering
+/// question and case-sensitivity is an identity one, and they do not imply each
+/// other: BigQuery is backtick-quoted because project IDs may contain hyphens,
+/// not because of case, and a dialect could just as well be case-sensitive
+/// without quoting. Reading one off the other risks both a needless refusal on
+/// a quoted-but-case-insensitive dialect and, worse, silence on a
+/// case-sensitive one that renders bare.
+///
+/// This matters because upstream references are matched case-insensitively, so
+/// only where case is part of identity can two targets differing by case be
+/// two different objects that a rewrite could confuse.
+///
+/// Unknown dialects fail closed.
+fn dialect_case_sensitive_identity(dialect: &dyn rocky_core::traits::SqlDialect) -> Result<bool> {
+    match dialect.name() {
+        // Identifiers are case-insensitive: `Orders` and `orders` are one
+        // object, so no pair of targets can differ by case alone.
+        "duckdb" | "databricks" => Ok(false),
+        // Dataset and table IDs are case-sensitive.
+        "bigquery" => Ok(true),
+        // Rocky renders every component double-quoted, and a quoted identifier
+        // is taken verbatim rather than case-folded.
+        "snowflake" | "trino" => Ok(true),
+        other => anyhow::bail!(
+            "shadow/branch execution does not know whether '{other}' treats identifier case as \
+             part of object identity, so it cannot tell whether two targets differing only by \
+             case name one object or two. Add '{other}' to \
+             `dialect_case_sensitive_identity` after checking how it folds identifiers"
+        ),
+    }
+}
+
 /// Route the models built by this invocation and their in-run dependency reads
 /// to shadow targets. Deferred or otherwise unselected upstreams stay on their
 /// production targets.
@@ -5917,10 +5951,13 @@ fn apply_shadow_rewrite(
     }
 
     // Target identity is case-folded, and so is the tail match inside
-    // `rewrite_upstream_refs`. On a dialect that quotes its targets that is a
-    // lossy key: `"Orders"` and `"orders"` are two distinct Snowflake tables
-    // that fold to one identity, so a read of one could be redirected to the
-    // other's shadow.
+    // `rewrite_upstream_refs`. Where the dialect makes case part of object
+    // identity that is a lossy key: `"Orders"` and `"orders"` are two distinct
+    // Snowflake tables that fold to one identity, so a read of one could be
+    // redirected to the other's shadow. Keyed on that declared property rather
+    // than on whether the dialect quotes — the two are independent, and reading
+    // one off the other would go quiet on a case-sensitive dialect that renders
+    // bare identifiers.
     //
     // The risk exists only where a rename is actually applied. A model's own
     // identity is excluded from its rename set, so a run that routes a single
@@ -5930,7 +5967,7 @@ fn apply_shadow_rewrite(
     // entirely. Above it, the trigger is a routed model, while the collision
     // partner is drawn from every compiled model: a read of an unselected
     // `"Orders"` still tail-matches the rename key of a selected `"orders"`.
-    if quote_style.is_some() && routes.len() > 1 {
+    if dialect_case_sensitive_identity(dialect)? && routes.len() > 1 {
         let mut folded: HashMap<String, Vec<(String, String)>> = HashMap::new();
         for model in &compile_result.project.models {
             let exact = format!(
@@ -16923,6 +16960,46 @@ timestamp_column = "ts"
             format!("{err:#}").contains("differ only by case"),
             "error must explain the collision: {err:#}"
         );
+    }
+
+    /// On a dialect where identifiers are case-insensitive, two targets that
+    /// differ only by case name the SAME object, so there is nothing to
+    /// disambiguate and the run must proceed. Pins the false branch of the
+    /// case-sensitivity declaration, which quoting alone would not decide.
+    #[cfg(feature = "duckdb")]
+    #[test]
+    fn shadow_allows_case_collisions_on_a_case_insensitive_dialect() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        write_model_with_target(
+            &models_dir,
+            "driver",
+            "SELECT id FROM main.Orders",
+            "main",
+            "driver",
+        );
+        write_model_with_target(&models_dir, "lower", "SELECT 1 AS id", "main", "orders");
+        write_model_with_target(&models_dir, "upper", "SELECT 2 AS id", "main", "Orders");
+        let mut compiled =
+            rocky_compiler::compile::compile(&rocky_compiler::compile::CompilerConfig {
+                models_dir,
+                ..Default::default()
+            })
+            .expect("compile models");
+        let selected: std::collections::BTreeSet<String> =
+            ["driver".to_string(), "lower".to_string()]
+                .into_iter()
+                .collect();
+        super::apply_shadow_rewrite(
+            &mut compiled,
+            None,
+            Some(&selected),
+            &rocky_core::shadow::ShadowConfig::default(),
+            &rocky_duckdb::dialect::DuckDbSqlDialect,
+            false,
+        )
+        .expect("DuckDB folds identifier case, so there is no ambiguity to refuse");
     }
 
     /// A case collision can sit in the schema or catalog rather than the table.

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -5852,6 +5852,16 @@ fn apply_shadow_rewrite(
         );
     }
 
+    // Reverse index of the rename keys, so a key that `rewrite_upstream_refs`
+    // reports as rewritten can be mapped back to the model that produces it.
+    let owner_by_key: HashMap<&str, &str> = routes
+        .iter()
+        .map(|(name, (original_key, _))| (original_key.as_str(), name.as_str()))
+        .collect();
+    // Edges discovered by the rewrite: `(consumer, producer)`. Collected here
+    // and applied to `dag_nodes` after the loop, which holds `models` mutably.
+    let mut derived_edges: Vec<(String, String)> = Vec::new();
+
     for model in &mut compile_result.project.models {
         let Some((_, own_shadow)) = routes.get(&model.config.name) else {
             continue;
@@ -5894,12 +5904,61 @@ fn apply_shadow_rewrite(
                 outcome.ambiguous_refs,
                 model.config.name
             );
+            // Every reference actually redirected is now a read of a table
+            // THIS run produces, so it is a real dependency regardless of what
+            // the sidecar declared. Record it: without the edge the producer
+            // and consumer can share an execution layer and the consumer reads
+            // a shadow target that has not been written yet.
+            for key in &outcome.rewritten_keys {
+                if let Some(producer) = owner_by_key.get(key.as_str())
+                    && *producer != model.config.name.as_str()
+                {
+                    derived_edges.push((model.config.name.clone(), (*producer).to_string()));
+                }
+            }
             model.sql = outcome.sql;
         }
 
         model.config.target.catalog = own_shadow.catalog.clone();
         model.config.target.schema = own_shadow.schema.clone();
         model.config.target.table = own_shadow.table.clone();
+    }
+
+    // Apply the derived edges and re-derive the execution plan. The compile
+    // pass computed `execution_order` / `layers` from the declared graph
+    // before this rewrite existed, so they must be recomputed or the new
+    // dependencies would not be honored. A rewrite that introduces a cycle
+    // (two models physically reading each other's targets) surfaces here as a
+    // `DagError` and fails the run rather than executing in an arbitrary order.
+    if !derived_edges.is_empty() {
+        let mut added = 0usize;
+        for (consumer, producer) in derived_edges {
+            let Some(node) = compile_result
+                .project
+                .dag_nodes
+                .iter_mut()
+                .find(|n| n.name == consumer)
+            else {
+                continue;
+            };
+            if !node.depends_on.contains(&producer) {
+                node.depends_on.push(producer);
+                added += 1;
+            }
+        }
+        if added > 0 {
+            let nodes = &compile_result.project.dag_nodes;
+            let execution_order = rocky_ir::dag::topological_sort(nodes).with_context(|| {
+                "shadow mode redirected an upstream read that introduces a dependency cycle; \
+                 the models cannot be ordered safely"
+            })?;
+            let layers = rocky_ir::dag::execution_layers(nodes).with_context(|| {
+                "shadow mode redirected an upstream read that introduces a dependency cycle; \
+                 the models cannot be layered safely"
+            })?;
+            compile_result.project.execution_order = execution_order;
+            compile_result.project.layers = layers;
+        }
     }
 
     Ok(())

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -5744,42 +5744,6 @@ fn rewrite_quote_style(dialect: &dyn rocky_core::traits::SqlDialect) -> Result<O
     }
 }
 
-/// Whether `sql` mentions `token` as an identifier in some spelling other than
-/// `token` itself.
-///
-/// The shadow rename matches table references case-insensitively, so on a
-/// dialect where identifiers are case-sensitive a read spelled `Orders` folds
-/// onto the rename key of a target spelled `orders`. Only such a read can be
-/// misdirected; a mention that already matches the routed spelling exactly is
-/// unambiguous. Bounded on identifier characters so `orders` does not match
-/// `orders_daily`.
-fn mentions_other_casing(sql: &str, token: &str) -> bool {
-    if token.is_empty() {
-        return false;
-    }
-    let haystack = sql.to_ascii_lowercase();
-    let needle = token.to_ascii_lowercase();
-    let is_ident = |c: char| c.is_ascii_alphanumeric() || c == '_';
-    let mut from = 0usize;
-    while let Some(offset) = haystack[from..].find(&needle) {
-        let start = from + offset;
-        let end = start + needle.len();
-        let bounded_left =
-            start == 0 || !haystack[..start].chars().next_back().is_some_and(is_ident);
-        let bounded_right = haystack[end..].chars().next().is_none_or(|c| !is_ident(c));
-        if bounded_left
-            && bounded_right
-            && sql
-                .get(start..end)
-                .is_some_and(|spelling| spelling != token)
-        {
-            return true;
-        }
-        from = end;
-    }
-    false
-}
-
 /// Route the models built by this invocation and their in-run dependency reads
 /// to shadow targets. Deferred or otherwise unselected upstreams stay on their
 /// production targets.
@@ -5989,56 +5953,30 @@ fn apply_shadow_rewrite(
             let Some(group) = folded.get(&exact.to_ascii_lowercase()) else {
                 continue;
             };
-            // EVERY colliding spelling, not just the first. A folded name can
-            // be shared by three or more targets, and evidence for one partner
-            // says nothing about another: stopping at the first would skip a
-            // partner whose components a model does read ambiguously.
-            for (other_exact, other_model) in
-                group.iter().filter(|(candidate, _)| *candidate != exact)
+            // Any other spelling of the same folded name is a different object
+            // on this dialect, and the rename matches case-insensitively, so a
+            // read of either could land on this model's shadow. Refuse.
+            //
+            // Deliberately unconditional on whether some model actually spells
+            // such a read today. Earlier revisions tried to require that
+            // evidence and it was wrong four times over — a scan of the SQL text
+            // cannot tell a table reference from a column, alias, literal or
+            // comment of the same name, and reconstructing the matcher's
+            // resolution from outside the matcher is what kept failing. The
+            // durable fix is to make `rewrite_upstream_refs` case-sensitive when
+            // the dialect quotes identifiers, after which this guard can go
+            // entirely; until then this errs toward refusing a run the operator
+            // can unblock by renaming, rather than silently reading the wrong
+            // table.
+            if let Some((other_exact, other_model)) =
+                group.iter().find(|(candidate, _)| *candidate != exact)
             {
-                // Only a read spelled differently from this model's own target
-                // can be folded onto its rename key by mistake. Check exactly
-                // the components that disagree between the two targets: a
-                // collision may sit in the catalog or schema rather than the
-                // table (`Main.orders` against `main.orders` spells the table
-                // identically), and checking components that already agree
-                // would reject on an unrelated mention of a common word.
-                let routed = [
-                    model.config.target.catalog.as_str(),
-                    model.config.target.schema.as_str(),
-                    model.config.target.table.as_str(),
-                ];
-                let other: Vec<&str> = other_exact.split('.').collect();
-                let ambiguous_parts: Vec<&str> = routed
-                    .iter()
-                    .enumerate()
-                    .filter(|(index, part)| {
-                        other
-                            .get(*index)
-                            .is_some_and(|counterpart| counterpart != *part)
-                    })
-                    .map(|(_, part)| *part)
-                    .collect();
-                let miscased_read = routes.keys().any(|name| {
-                    compile_result
-                        .project
-                        .models
-                        .iter()
-                        .find(|candidate| &candidate.config.name == name)
-                        .is_some_and(|candidate| {
-                            ambiguous_parts
-                                .iter()
-                                .any(|part| mentions_other_casing(&candidate.sql, part))
-                        })
-                });
-                if !miscased_read {
-                    continue;
-                }
                 anyhow::bail!(
                     "shadow/branch execution cannot distinguish the targets of models '{}' \
                      ('{}') and '{}' ('{}'): they differ only by case, which this dialect \
-                     treats as two different objects. Rename one target so the two differ by \
-                     more than case, or scope the run so it routes only one of them",
+                     treats as two different objects, while upstream references are matched \
+                     case-insensitively. Rename one target so the two differ by more than \
+                     case, or scope the run so it routes only one of them",
                     other_model,
                     other_exact,
                     model.config.name,
@@ -17029,58 +16967,6 @@ timestamp_column = "ts"
         assert!(
             format!("{err:#}").contains("differ only by case"),
             "error must explain the collision: {err:#}"
-        );
-    }
-
-    /// A collision is only dangerous if some read is actually spelled the other
-    /// way. Two routed models that never mention the ambiguous table in a
-    /// different casing rewrite nothing ambiguous, so the run is safe even
-    /// though a case-colliding target exists elsewhere in the project.
-    #[cfg(feature = "duckdb")]
-    #[test]
-    fn shadow_allows_a_case_collision_no_model_reads_ambiguously() {
-        let tmp = tempfile::TempDir::new().expect("temp dir");
-        let models_dir = tmp.path().join("models");
-        std::fs::create_dir(&models_dir).expect("mkdir models");
-        // Reads `lower`'s target in exactly the routed spelling: unambiguous.
-        write_model_with_target(
-            &models_dir,
-            "driver",
-            "SELECT id FROM main.orders",
-            "main",
-            "driver",
-        );
-        write_model_with_target(&models_dir, "lower", "SELECT 1 AS id", "main", "orders");
-        write_model_with_target(&models_dir, "upper", "SELECT 2 AS id", "main", "Orders");
-        let mut compiled =
-            rocky_compiler::compile::compile(&rocky_compiler::compile::CompilerConfig {
-                models_dir,
-                ..Default::default()
-            })
-            .expect("compile models");
-        let selected: std::collections::BTreeSet<String> =
-            ["driver".to_string(), "lower".to_string()]
-                .into_iter()
-                .collect();
-        super::apply_shadow_rewrite(
-            &mut compiled,
-            None,
-            Some(&selected),
-            &rocky_core::shadow::ShadowConfig::default(),
-            &rocky_snowflake::dialect::SnowflakeSqlDialect,
-            false,
-        )
-        .expect("no read is spelled ambiguously, so the run must not be rejected");
-        let driver = compiled
-            .project
-            .models
-            .iter()
-            .find(|m| m.config.name == "driver")
-            .expect("driver missing");
-        assert!(
-            driver.sql.contains("orders_rocky_shadow"),
-            "the unambiguous read must still be routed: {}",
-            driver.sql
         );
     }
 

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -5767,22 +5767,40 @@ fn rewrite_quote_style(dialect: &dyn rocky_core::traits::SqlDialect) -> Result<O
 /// and table. Making `rewrite_upstream_refs` case-aware therefore needs
 /// per-component semantics, established per dialect, rather than this boolean.
 ///
-/// The values below are a policy table about warehouse identifier rules, and
-/// nothing in this repository proves them. Only Snowflake has in-repo evidence:
-/// `rocky-snowflake`'s `format_table_ref` documents that emitting bare
-/// identifiers "silently breaks against any schema / table created with quoted
-/// lowercase names", which is why its targets are quoted at all. **Confirm each
-/// entry against that warehouse's published identifier rules before relying on
-/// it, and re-confirm when adding one.** Deriving these from how Rocky renders a
-/// target is precisely the mistake that produced the wrong answer here before —
-/// rendering and identity are independent.
+/// Each entry is taken from the warehouse's own documentation, not inferred
+/// from how Rocky renders a target — rendering and identity are independent, and
+/// deriving one from the other is what produced a wrong answer here before.
+/// DuckDB makes the point: it quotes with double quotes yet treats even quoted
+/// identifiers case-insensitively, the opposite of PostgreSQL.
+///
+/// Re-confirm against the vendor when adding a dialect.
 ///
 /// Unknown dialects fail closed.
 fn dialect_case_sensitive_identity(dialect: &dyn rocky_core::traits::SqlDialect) -> Result<bool> {
     match dialect.name() {
         // Two targets differing only by case name one object.
+        //
+        // DuckDB: "Identifiers ... are always case-insensitive ... DuckDB also
+        // treats quoted identifiers as case-insensitive" (case is preserved for
+        // display only) — duckdb.org/docs/stable/sql/dialect/keywords_and_identifiers
+        // Databricks: identifiers are case-insensitive, delimited ones included;
+        // Unity Catalog stores names lower-cased —
+        // docs.databricks.com/aws/en/sql/language-manual/sql-ref-identifiers
+        // Trino: "Identifiers are not treated as case sensitive" —
+        // trino.io/docs/current/language/reserved.html
         "duckdb" | "databricks" | "trino" => Ok(false),
         // Two targets differing only by case can name two objects.
+        //
+        // BigQuery: dataset and table names are case-sensitive by default, so
+        // `mydataset` and `MyDataset` coexist; a dataset may opt out with
+        // `is_case_insensitive` — docs.cloud.google.com/bigquery/docs/datasets
+        // Snowflake: an unquoted identifier is stored and resolved upper-cased,
+        // a double-quoted one "exactly as entered, including case"; an account
+        // may opt out with QUOTED_IDENTIFIERS_IGNORE_CASE —
+        // docs.snowflake.com/en/sql-reference/identifiers-syntax
+        //
+        // Both opt-outs would only ever make a rejected run acceptable, never
+        // the reverse, so assuming the default is the fail-closed choice.
         "bigquery" | "snowflake" => Ok(true),
         other => anyhow::bail!(
             "shadow/branch execution does not know whether '{other}' treats identifier case as \

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -5771,59 +5771,6 @@ fn apply_shadow_rewrite(
 
     let quote_style = rewrite_quote_style(dialect)?;
 
-    // Target identity is case-folded, and so is the tail match inside
-    // `rewrite_upstream_refs`. On a dialect that quotes its targets that is a
-    // lossy key: `"Orders"` and `"orders"` are two distinct Snowflake tables
-    // that fold to one identity, so a read of one could be redirected to the
-    // other's shadow.
-    //
-    // Only a ROUTED model's production identity becomes a rename key, so the
-    // ambiguity exists only when a selected model is one side of the collision.
-    // Two unrelated models that happen to differ only by case are none of this
-    // run's business, and rejecting them would fail a scoped `--model` run that
-    // is provably safe. The other side may be unselected, though: a read of an
-    // unselected `"Orders"` still tail-matches the rename key of a selected
-    // `"orders"`, which is exactly the misdirection being prevented.
-    if quote_style.is_some() {
-        let mut folded: HashMap<String, Vec<(String, String)>> = HashMap::new();
-        for model in &compile_result.project.models {
-            let exact = format!(
-                "{}.{}.{}",
-                model.config.target.catalog, model.config.target.schema, model.config.target.table
-            );
-            folded
-                .entry(exact.to_ascii_lowercase())
-                .or_default()
-                .push((exact, model.config.name.clone()));
-        }
-        for model in &compile_result.project.models {
-            if !is_selected(&model.config.name) {
-                continue;
-            }
-            let exact = format!(
-                "{}.{}.{}",
-                model.config.target.catalog, model.config.target.schema, model.config.target.table
-            );
-            let Some(group) = folded.get(&exact.to_ascii_lowercase()) else {
-                continue;
-            };
-            if let Some((other_exact, other_model)) =
-                group.iter().find(|(candidate, _)| *candidate != exact)
-            {
-                anyhow::bail!(
-                    "shadow/branch execution cannot distinguish the targets of models '{}' \
-                     ('{}') and '{}' ('{}'): they differ only by case, which this dialect \
-                     treats as two different objects. Rename one target so the two differ by \
-                     more than case, or scope the run so it does not select either",
-                    other_model,
-                    other_exact,
-                    model.config.name,
-                    exact,
-                );
-            }
-        }
-    }
-
     let mut production_targets: HashMap<String, Vec<String>> = HashMap::new();
     for model in &compile_result.project.models {
         production_targets
@@ -5967,6 +5914,60 @@ fn apply_shadow_rewrite(
                 },
             ),
         );
+    }
+
+    // Target identity is case-folded, and so is the tail match inside
+    // `rewrite_upstream_refs`. On a dialect that quotes its targets that is a
+    // lossy key: `"Orders"` and `"orders"` are two distinct Snowflake tables
+    // that fold to one identity, so a read of one could be redirected to the
+    // other's shadow.
+    //
+    // The risk exists only where a rename is actually applied. A model's own
+    // identity is excluded from its rename set, so a run that routes a single
+    // model rewrites nothing at all and cannot misdirect anything however its
+    // target is spelled — rejecting that would fail a provably safe
+    // `--model` run. Below two routed models the check is therefore skipped
+    // entirely. Above it, the trigger is a routed model, while the collision
+    // partner is drawn from every compiled model: a read of an unselected
+    // `"Orders"` still tail-matches the rename key of a selected `"orders"`.
+    if quote_style.is_some() && routes.len() > 1 {
+        let mut folded: HashMap<String, Vec<(String, String)>> = HashMap::new();
+        for model in &compile_result.project.models {
+            let exact = format!(
+                "{}.{}.{}",
+                model.config.target.catalog, model.config.target.schema, model.config.target.table
+            );
+            folded
+                .entry(exact.to_ascii_lowercase())
+                .or_default()
+                .push((exact, model.config.name.clone()));
+        }
+        for model in &compile_result.project.models {
+            if !routes.contains_key(&model.config.name) {
+                continue;
+            }
+            let exact = format!(
+                "{}.{}.{}",
+                model.config.target.catalog, model.config.target.schema, model.config.target.table
+            );
+            let Some(group) = folded.get(&exact.to_ascii_lowercase()) else {
+                continue;
+            };
+            if let Some((other_exact, other_model)) =
+                group.iter().find(|(candidate, _)| *candidate != exact)
+            {
+                anyhow::bail!(
+                    "shadow/branch execution cannot distinguish the targets of models '{}' \
+                     ('{}') and '{}' ('{}'): they differ only by case, which this dialect \
+                     treats as two different objects. Rename one target so the two differ by \
+                     more than case, or scope the run so it routes only one of them",
+                    other_model,
+                    other_exact,
+                    model.config.name,
+                    exact,
+                );
+            }
+        }
     }
 
     // Reverse index of the rename keys, so a key that `rewrite_upstream_refs`
@@ -16787,19 +16788,18 @@ timestamp_column = "ts"
         }
     }
 
-    /// The case guard must scope to what the run actually routes. Only a
-    /// selected model's identity becomes a rename key, so a collision between
-    /// two models this run does not touch cannot misdirect anything — and
-    /// rejecting it would fail a scoped `--model` run that is provably safe.
+    /// A run that routes a single model rewrites nothing — a model's own
+    /// identity is excluded from its rename set — so it cannot misdirect a read
+    /// however its target is spelled. Even a collision against the selected
+    /// model's OWN target must not fail it.
     #[cfg(feature = "duckdb")]
     #[test]
-    fn shadow_allows_case_collisions_outside_the_selected_set() {
+    fn shadow_allows_a_single_model_run_whose_own_target_collides_by_case() {
         let tmp = tempfile::TempDir::new().expect("temp dir");
         let models_dir = tmp.path().join("models");
         std::fs::create_dir(&models_dir).expect("mkdir models");
-        write_model_with_target(&models_dir, "picked", "SELECT 1 AS id", "main", "picked");
-        // Two models that collide only by case, neither of them selected.
         write_model_with_target(&models_dir, "lower", "SELECT 1 AS id", "main", "orders");
+        // Same folded identity as the selected model, different spelling.
         write_model_with_target(&models_dir, "upper", "SELECT 2 AS id", "main", "Orders");
         let mut compiled =
             rocky_compiler::compile::compile(&rocky_compiler::compile::CompilerConfig {
@@ -16809,13 +16809,67 @@ timestamp_column = "ts"
             .expect("compile models");
         super::apply_shadow_rewrite(
             &mut compiled,
-            Some("picked"),
+            Some("lower"),
             None,
             &rocky_core::shadow::ShadowConfig::default(),
             &rocky_snowflake::dialect::SnowflakeSqlDialect,
             false,
         )
-        .expect("a scoped run must not be rejected for a collision it does not route");
+        .expect("a single-model run rewrites no reads and must not be rejected");
+        let lower = compiled
+            .project
+            .models
+            .iter()
+            .find(|m| m.config.name == "lower")
+            .expect("lower missing");
+        assert_eq!(lower.config.target.table, "orders_rocky_shadow");
+        let upper = compiled
+            .project
+            .models
+            .iter()
+            .find(|m| m.config.name == "upper")
+            .expect("upper missing");
+        assert_eq!(
+            upper.config.target.table, "Orders",
+            "an unselected model must stay on its production target"
+        );
+    }
+
+    /// The case guard must scope its TRIGGER to routed models. Two models that
+    /// collide only by case and are both outside the selected set can never be
+    /// the destination of a rename, so the run is safe and must not be rejected.
+    /// Uses two routed models so the guard actually runs — with one, the
+    /// no-renames short-circuit would decide the outcome instead.
+    #[cfg(feature = "duckdb")]
+    #[test]
+    fn shadow_allows_case_collisions_outside_the_selected_set() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        write_model_with_target(&models_dir, "picked", "SELECT 1 AS id", "main", "picked");
+        write_model_with_target(&models_dir, "also", "SELECT 1 AS id", "main", "also");
+        // Two models that collide only by case, neither of them selected.
+        write_model_with_target(&models_dir, "lower", "SELECT 1 AS id", "main", "orders");
+        write_model_with_target(&models_dir, "upper", "SELECT 2 AS id", "main", "Orders");
+        let mut compiled =
+            rocky_compiler::compile::compile(&rocky_compiler::compile::CompilerConfig {
+                models_dir,
+                ..Default::default()
+            })
+            .expect("compile models");
+        let selected: std::collections::BTreeSet<String> =
+            ["picked".to_string(), "also".to_string()]
+                .into_iter()
+                .collect();
+        super::apply_shadow_rewrite(
+            &mut compiled,
+            None,
+            Some(&selected),
+            &rocky_core::shadow::ShadowConfig::default(),
+            &rocky_snowflake::dialect::SnowflakeSqlDialect,
+            false,
+        )
+        .expect("a collision the run does not route must not reject it");
         let picked = compiled
             .project
             .models
@@ -16825,16 +16879,21 @@ timestamp_column = "ts"
         assert_eq!(picked.config.target.table, "picked_rocky_shadow");
     }
 
-    /// Two targets differing only by case are one object to the case-folded
-    /// identity key but two objects to a quoting dialect. Refuse rather than
-    /// redirect a read to the wrong one.
+    /// A routed model whose target case-collides with an UNSELECTED model is the
+    /// gap the shadow-owner check cannot see: the unselected model is never
+    /// routed, so no shared shadow target exists, yet a read of its target still
+    /// folds onto the routed model's rename key and would be redirected to that
+    /// model's shadow. Needs two routed models, because a single one applies no
+    /// renames at all.
     #[cfg(feature = "duckdb")]
     #[test]
-    fn shadow_rejects_case_only_target_collisions_on_quoting_dialects() {
+    fn shadow_rejects_case_collision_between_routed_and_unselected_targets() {
         let tmp = tempfile::TempDir::new().expect("temp dir");
         let models_dir = tmp.path().join("models");
         std::fs::create_dir(&models_dir).expect("mkdir models");
+        write_model_with_target(&models_dir, "driver", "SELECT 1 AS id", "main", "driver");
         write_model_with_target(&models_dir, "lower", "SELECT 1 AS id", "main", "orders");
+        // Not selected, so `shadow_owners` never compares against it.
         write_model_with_target(&models_dir, "upper", "SELECT 2 AS id", "main", "Orders");
         let mut compiled =
             rocky_compiler::compile::compile(&rocky_compiler::compile::CompilerConfig {
@@ -16842,15 +16901,19 @@ timestamp_column = "ts"
                 ..Default::default()
             })
             .expect("compile models");
+        let selected: std::collections::BTreeSet<String> =
+            ["driver".to_string(), "lower".to_string()]
+                .into_iter()
+                .collect();
         let err = super::apply_shadow_rewrite(
             &mut compiled,
             None,
-            None,
+            Some(&selected),
             &rocky_core::shadow::ShadowConfig::default(),
             &rocky_snowflake::dialect::SnowflakeSqlDialect,
             false,
         )
-        .expect_err("case-only target collision must be rejected on a quoting dialect");
+        .expect_err("a routed target colliding by case with an unselected one must be rejected");
         assert!(
             format!("{err:#}").contains("differ only by case"),
             "error must explain the collision: {err:#}"

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -5989,8 +5989,12 @@ fn apply_shadow_rewrite(
             let Some(group) = folded.get(&exact.to_ascii_lowercase()) else {
                 continue;
             };
-            if let Some((other_exact, other_model)) =
-                group.iter().find(|(candidate, _)| *candidate != exact)
+            // EVERY colliding spelling, not just the first. A folded name can
+            // be shared by three or more targets, and evidence for one partner
+            // says nothing about another: stopping at the first would skip a
+            // partner whose components a model does read ambiguously.
+            for (other_exact, other_model) in
+                group.iter().filter(|(candidate, _)| *candidate != exact)
             {
                 // Only a read spelled differently from this model's own target
                 // can be folded onto its rename key by mistake. Check exactly
@@ -16919,6 +16923,67 @@ timestamp_column = "ts"
         assert_eq!(
             upper.config.target.table, "Orders",
             "an unselected model must stay on its production target"
+        );
+    }
+
+    /// A folded name can be shared by three or more targets. Evidence for one
+    /// colliding spelling says nothing about another, so the guard has to weigh
+    /// every partner: here the first one it meets has no ambiguous read and the
+    /// second one does.
+    #[cfg(feature = "duckdb")]
+    #[test]
+    fn shadow_rejects_a_later_case_collision_partner() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        // Reads the TABLE variant. Nothing anywhere reads the schema variant.
+        write_model_with_target(
+            &models_dir,
+            "driver",
+            "SELECT id FROM main.Orders",
+            "main",
+            "driver",
+        );
+        write_model_with_target(&models_dir, "lower", "SELECT 1 AS id", "main", "orders");
+        // Two further spellings of the same folded identity. `a_schema_variant`
+        // sorts first, and no model reads `Main`, so a guard that stopped at the
+        // first partner would clear the run.
+        write_model_with_target(
+            &models_dir,
+            "a_schema_variant",
+            "SELECT 2 AS id",
+            "Main",
+            "orders",
+        );
+        write_model_with_target(
+            &models_dir,
+            "z_table_variant",
+            "SELECT 3 AS id",
+            "main",
+            "Orders",
+        );
+        let mut compiled =
+            rocky_compiler::compile::compile(&rocky_compiler::compile::CompilerConfig {
+                models_dir,
+                ..Default::default()
+            })
+            .expect("compile models");
+        let selected: std::collections::BTreeSet<String> =
+            ["driver".to_string(), "lower".to_string()]
+                .into_iter()
+                .collect();
+        let err = super::apply_shadow_rewrite(
+            &mut compiled,
+            None,
+            Some(&selected),
+            &rocky_core::shadow::ShadowConfig::default(),
+            &rocky_snowflake::dialect::SnowflakeSqlDialect,
+            false,
+        )
+        .expect_err("a colliding partner beyond the first must still be rejected");
+        assert!(
+            format!("{err:#}").contains("differ only by case"),
+            "error must explain the collision: {err:#}"
         );
     }
 

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -5989,26 +5989,47 @@ fn apply_shadow_rewrite(
             let Some(group) = folded.get(&exact.to_ascii_lowercase()) else {
                 continue;
             };
-            // Only a read spelled differently from this model's own target can
-            // be folded onto its rename key by mistake. If every mention of the
-            // table across the models being rewritten already matches the
-            // routed spelling exactly, the rewrite is unambiguous and the run is
-            // safe however many other objects share the folded name.
-            let table = model.config.target.table.as_str();
-            let miscased_read = routes.keys().any(|name| {
-                compile_result
-                    .project
-                    .models
-                    .iter()
-                    .find(|candidate| &candidate.config.name == name)
-                    .is_some_and(|candidate| mentions_other_casing(&candidate.sql, table))
-            });
-            if !miscased_read {
-                continue;
-            }
             if let Some((other_exact, other_model)) =
                 group.iter().find(|(candidate, _)| *candidate != exact)
             {
+                // Only a read spelled differently from this model's own target
+                // can be folded onto its rename key by mistake. Check exactly
+                // the components that disagree between the two targets: a
+                // collision may sit in the catalog or schema rather than the
+                // table (`Main.orders` against `main.orders` spells the table
+                // identically), and checking components that already agree
+                // would reject on an unrelated mention of a common word.
+                let routed = [
+                    model.config.target.catalog.as_str(),
+                    model.config.target.schema.as_str(),
+                    model.config.target.table.as_str(),
+                ];
+                let other: Vec<&str> = other_exact.split('.').collect();
+                let ambiguous_parts: Vec<&str> = routed
+                    .iter()
+                    .enumerate()
+                    .filter(|(index, part)| {
+                        other
+                            .get(*index)
+                            .is_some_and(|counterpart| counterpart != *part)
+                    })
+                    .map(|(_, part)| *part)
+                    .collect();
+                let miscased_read = routes.keys().any(|name| {
+                    compile_result
+                        .project
+                        .models
+                        .iter()
+                        .find(|candidate| &candidate.config.name == name)
+                        .is_some_and(|candidate| {
+                            ambiguous_parts
+                                .iter()
+                                .any(|part| mentions_other_casing(&candidate.sql, part))
+                        })
+                });
+                if !miscased_read {
+                    continue;
+                }
                 anyhow::bail!(
                     "shadow/branch execution cannot distinguish the targets of models '{}' \
                      ('{}') and '{}' ('{}'): they differ only by case, which this dialect \
@@ -16898,6 +16919,51 @@ timestamp_column = "ts"
         assert_eq!(
             upper.config.target.table, "Orders",
             "an unselected model must stay on its production target"
+        );
+    }
+
+    /// A case collision can sit in the schema or catalog rather than the table.
+    /// `Main.orders` and `main.orders` spell the table identically, so evidence
+    /// keyed on the table alone would find nothing and let the ambiguous read
+    /// through.
+    #[cfg(feature = "duckdb")]
+    #[test]
+    fn shadow_rejects_case_collision_in_the_schema_component() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        // Reads the unselected model's schema spelling; the table part matches.
+        write_model_with_target(
+            &models_dir,
+            "driver",
+            "SELECT id FROM Main.orders",
+            "main",
+            "driver",
+        );
+        write_model_with_target(&models_dir, "lower", "SELECT 1 AS id", "main", "orders");
+        write_model_with_target(&models_dir, "upper", "SELECT 2 AS id", "Main", "orders");
+        let mut compiled =
+            rocky_compiler::compile::compile(&rocky_compiler::compile::CompilerConfig {
+                models_dir,
+                ..Default::default()
+            })
+            .expect("compile models");
+        let selected: std::collections::BTreeSet<String> =
+            ["driver".to_string(), "lower".to_string()]
+                .into_iter()
+                .collect();
+        let err = super::apply_shadow_rewrite(
+            &mut compiled,
+            None,
+            Some(&selected),
+            &rocky_core::shadow::ShadowConfig::default(),
+            &rocky_snowflake::dialect::SnowflakeSqlDialect,
+            false,
+        )
+        .expect_err("a schema-only case collision must be rejected too");
+        assert!(
+            format!("{err:#}").contains("differ only by case"),
+            "error must explain the collision: {err:#}"
         );
     }
 

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -5613,12 +5613,13 @@ fn apply_defer_rewrite(
     };
 
     // BigQuery is the one shipping dialect whose qualified parts (the project /
-    // catalog) may contain characters bare SQL identifiers reject — hyphens.
-    // For it the catalog is validated with the GCP-project rule and the
-    // rewritten reference is backtick-quoted to match `format_table_ref`; every
-    // other dialect keeps the strict identifier rule and renders bare names.
+    // catalog) may contain characters bare SQL identifiers reject — hyphens, so
+    // only it validates the catalog with the GCP-project rule. Quoting is a
+    // separate question and is answered per dialect: Snowflake and Trino also
+    // quote every component of a target, so a bare rewritten read would fold
+    // case and name a different object.
     let is_bigquery = dialect.name() == "bigquery";
-    let quote_style: Option<char> = if is_bigquery { Some('`') } else { None };
+    let quote_style: Option<char> = rewrite_quote_style(dialect)?;
 
     // Validate the `--defer-to` schema override once up front — it is user
     // input that ends up serialized into SQL. Schemas/datasets never carry
@@ -5711,6 +5712,38 @@ fn apply_defer_rewrite(
     Ok(())
 }
 
+/// Identifier quoting a rewritten upstream reference must use so that it names
+/// the same object the producer's DDL creates.
+///
+/// This has to track `SqlDialect::format_table_ref` exactly. A producer writes
+/// its target through that method; a rewritten read is re-serialized here. Where
+/// the two disagree the read names a different object than the producer created:
+/// on Snowflake and Trino every component is emitted double-quoted and therefore
+/// case-sensitive, so a bare read folds to upper case and either errors or, worse,
+/// resolves to an unrelated table of that name.
+///
+/// Unknown dialects fail closed. A new adapter that quotes its targets would
+/// otherwise inherit bare rendering silently, which is exactly the defect this
+/// function exists to prevent.
+fn rewrite_quote_style(dialect: &dyn rocky_core::traits::SqlDialect) -> Result<Option<char>> {
+    match dialect.name() {
+        // `format_table_ref` renders bare identifiers.
+        "duckdb" | "databricks" => Ok(None),
+        // Backticks: BigQuery project IDs may contain hyphens, which a bare
+        // identifier would parse as subtraction.
+        "bigquery" => Ok(Some('`')),
+        // Double quotes: both dialects quote every component of a target, which
+        // makes the object case-sensitive.
+        "snowflake" | "trino" => Ok(Some('"')),
+        other => anyhow::bail!(
+            "cannot rewrite upstream references for dialect '{other}': its identifier quoting \
+             is unknown, so a rewritten reference could name a different object than the one \
+             the producing model creates. Add '{other}' to `rewrite_quote_style` after \
+             checking how its `format_table_ref` quotes each component"
+        ),
+    }
+}
+
 /// Route the models built by this invocation and their in-run dependency reads
 /// to shadow targets. Deferred or otherwise unselected upstreams stay on their
 /// production targets.
@@ -5736,7 +5769,41 @@ fn apply_shadow_rewrite(
         format!("{catalog}.{schema}.{table}").to_ascii_lowercase()
     };
 
-    let quote_style = (dialect.name() == "bigquery").then_some('`');
+    let quote_style = rewrite_quote_style(dialect)?;
+
+    // Target identity is case-folded, and so is the tail match inside
+    // `rewrite_upstream_refs`. On a dialect that quotes its targets that is a
+    // lossy key: `"Orders"` and `"orders"` are two distinct Snowflake tables
+    // that fold to one identity, and a read of either could be redirected to
+    // the other's shadow. Refuse rather than guess. Checked across every
+    // compiled model, not just the selected ones, because an unselected model
+    // is exactly the case the routing loop below would not otherwise notice.
+    if quote_style.is_some() {
+        let mut folded: HashMap<String, (String, String)> = HashMap::new();
+        for model in &compile_result.project.models {
+            let exact = format!(
+                "{}.{}.{}",
+                model.config.target.catalog, model.config.target.schema, model.config.target.table
+            );
+            let key = exact.to_ascii_lowercase();
+            if let Some((other_exact, other_model)) =
+                folded.insert(key, (exact.clone(), model.config.name.clone()))
+                && other_exact != exact
+            {
+                anyhow::bail!(
+                    "shadow/branch execution cannot distinguish the targets of models '{}' \
+                     ('{}') and '{}' ('{}'): they differ only by case, which this dialect \
+                     treats as two different objects. Rename one target so the two differ by \
+                     more than case",
+                    other_model,
+                    other_exact,
+                    model.config.name,
+                    exact,
+                );
+            }
+        }
+    }
+
     let mut production_targets: HashMap<String, Vec<String>> = HashMap::new();
     for model in &compile_result.project.models {
         production_targets
@@ -5750,9 +5817,6 @@ fn apply_shadow_rewrite(
     }
     let mut shadow_owners: HashMap<String, String> = HashMap::new();
     let mut routes: HashMap<String, (String, rocky_sql::defer::DeferTarget)> = HashMap::new();
-    // Routed models that materialize nothing, so no reader may be redirected to
-    // their shadow target and no ordering edge may point at them.
-    let mut ephemeral_models: std::collections::HashSet<String> = std::collections::HashSet::new();
     for model in &compile_result.project.models {
         if !is_selected(&model.config.name) {
             continue;
@@ -5772,21 +5836,28 @@ fn apply_shadow_rewrite(
                     model.config.name
                 );
             }
-            // Ephemeral models are inlined as CTEs and never materialized —
-            // `sql_gen::generate_transformation_sql` returns no statements for
-            // them — so their configured target is nominal. They are still
-            // ROUTED (their target is rewritten below) because the governance
-            // snapshot is captured from these same models and its reconcile
-            // loops issue adapter calls against `target_*` without checking
-            // strategy or whether anything was materialized. Leaving an
-            // ephemeral target on production would let a shadow run apply that
-            // model's tags / masks / retention to the PRODUCTION table.
+            // Ephemeral models emit no statements
+            // (`sql_gen::generate_transformation_sql` returns an empty vec), and
+            // the comments throughout this codebase describe them as "inlined as
+            // CTEs in downstream queries". No such inlining exists: nothing in
+            // `rocky-compiler` or `rocky-sql` rewrites a consumer's `FROM eph`
+            // into a CTE, and the dbt importer states outright that
+            // `materialized='ephemeral'` has no Rocky equivalent.
             //
-            // They are excluded from the reader renames and the edge index
-            // below instead: nothing creates their shadow target, so no reader
-            // may be redirected to it and no ordering edge may depend on it.
+            // So a consumer of an ephemeral model reads whatever physical table
+            // happens to carry that name. Under shadow that is the PRODUCTION
+            // table — the one thing this routing exists to prevent — and no
+            // rewrite here can fix it, because there is no shadow object to
+            // point the read at. Fail closed until inlining is real, the same
+            // way the two strategies above do.
             rocky_core::models::StrategyConfig::Ephemeral => {
-                ephemeral_models.insert(model.config.name.clone());
+                anyhow::bail!(
+                    "shadow/branch execution is not supported for ephemeral model '{}': \
+                     ephemeral models are not materialized and are not inlined into their \
+                     consumers, so a consumer would read the production table instead of an \
+                     isolated one. Give the model a materialized strategy to shadow it",
+                    model.config.name
+                );
             }
             rocky_core::models::StrategyConfig::FullRefresh
             | rocky_core::models::StrategyConfig::Incremental { .. }
@@ -5805,7 +5876,10 @@ fn apply_shadow_rewrite(
         };
         let shadow = rocky_core::shadow::shadow_target(&original, config);
         if !shadow.catalog.is_empty() {
-            if quote_style.is_some() {
+            // BigQuery specifically, not "any quoted dialect": Snowflake and
+            // Trino quote their targets too but their catalogs still follow the
+            // strict identifier rule, so the GCP project rule must not apply.
+            if dialect.name() == "bigquery" {
                 rocky_sql::validation::validate_gcp_project_id(&shadow.catalog).with_context(
                     || {
                         format!(
@@ -5877,11 +5951,10 @@ fn apply_shadow_rewrite(
 
     // Reverse index of the rename keys, so a key that `rewrite_upstream_refs`
     // reports as rewritten can be mapped back to the model that produces it.
-    // Ephemeral models are absent: they materialize nothing, so they can never
-    // be the producer an ordering edge should wait on.
+    // Every routed model materializes something: strategies that do not are
+    // rejected above.
     let owner_by_key: HashMap<&str, &str> = routes
         .iter()
-        .filter(|(name, _)| !ephemeral_models.contains(name.as_str()))
         .map(|(name, (original_key, _))| (original_key.as_str(), name.as_str()))
         .collect();
     // Edges discovered by the rewrite: `(consumer, producer)`. Collected here
@@ -5911,15 +5984,9 @@ fn apply_shadow_rewrite(
         // pointing it at the not-yet-populated shadow target would change what
         // the model computes.
         //
-        // Ephemeral upstreams are excluded too: they are inlined as CTEs and
-        // materialize nothing, so their shadow target is never created and a
-        // redirected read would resolve to a table that does not exist.
         let renames: HashMap<String, rocky_sql::defer::DeferTarget> = routes
             .iter()
-            .filter(|(name, _)| {
-                name.as_str() != model.config.name.as_str()
-                    && !ephemeral_models.contains(name.as_str())
-            })
+            .filter(|(name, _)| name.as_str() != model.config.name.as_str())
             .map(|(_, route)| route.clone())
             .collect();
         if !renames.is_empty() {
@@ -7023,6 +7090,16 @@ pub(crate) async fn execute_models(
         let mut targets: std::collections::BTreeSet<(String, String)> =
             std::collections::BTreeSet::new();
         for model in &compile_result.project.models {
+            // Only models this invocation will actually build. Pre-creating a
+            // schema for a model that is filtered out is wasted work in an
+            // ordinary run, and under `--shadow` it is an isolation break: the
+            // unselected model still carries its PRODUCTION target, so a shadow
+            // run would create production schemas.
+            if model_name_filter.is_some_and(|selected| selected != model.config.name)
+                || model_set.is_some_and(|set| !set.contains(&model.config.name))
+            {
+                continue;
+            }
             targets.insert((
                 model.config.target.catalog.clone(),
                 model.config.target.schema.clone(),
@@ -16617,16 +16694,114 @@ timestamp_column = "ts"
         );
     }
 
-    /// An ephemeral model materializes nothing, so no reader may be redirected
-    /// to its shadow target — but its target must still be rewritten off
-    /// production. `GovernanceSnapshot::capture` reads these same models and
-    /// its reconcile loops issue `apply_column_tags` / `apply_masking_policy` /
-    /// `apply_retention_policy` / `set_tags` against `target_*` without
-    /// consulting the strategy, so an ephemeral target left on production would
-    /// let a shadow run mutate PRODUCTION governance metadata.
+    /// An ephemeral model materializes nothing and — despite what the comments
+    /// around `sql_gen` claim — is never inlined into its consumers, so a
+    /// consumer's `FROM eph` resolves to whatever physical table carries that
+    /// name. Under shadow that is the production table, and no rewrite can fix
+    /// it because there is no shadow object to point the read at. Shadow mode
+    /// must therefore refuse the run rather than quietly read production.
+    /// A rewritten upstream read has to name the same object the producer's DDL
+    /// creates. Snowflake and Trino emit every component of a target
+    /// double-quoted, which makes the object case-sensitive, so a bare read
+    /// folds to upper case and names a different table. Nothing else in the
+    /// suite executes against those dialects, so this asserts the serialized
+    /// SQL directly.
     #[cfg(feature = "duckdb")]
     #[test]
-    fn shadow_routes_ephemeral_target_but_never_redirects_readers_to_it() {
+    fn shadow_rewritten_reads_match_the_producer_quoting_per_dialect() {
+        fn rewritten_sql(dialect: &dyn rocky_core::traits::SqlDialect) -> String {
+            let tmp = tempfile::TempDir::new().expect("temp dir");
+            let models_dir = tmp.path().join("models");
+            std::fs::create_dir(&models_dir).expect("mkdir models");
+            write_model_with_target(&models_dir, "orders", "SELECT 1 AS id", "main", "orders");
+            write_model_with_target(
+                &models_dir,
+                "mart",
+                "SELECT id FROM main.orders",
+                "main",
+                "mart",
+            );
+            let mut compiled =
+                rocky_compiler::compile::compile(&rocky_compiler::compile::CompilerConfig {
+                    models_dir,
+                    ..Default::default()
+                })
+                .expect("compile models");
+            super::apply_shadow_rewrite(
+                &mut compiled,
+                None,
+                None,
+                &rocky_core::shadow::ShadowConfig::default(),
+                dialect,
+                false,
+            )
+            .expect("shadow rewrite must succeed");
+            compiled
+                .project
+                .models
+                .iter()
+                .find(|m| m.config.name == "mart")
+                .expect("mart missing")
+                .sql
+                .clone()
+        }
+
+        let duck = rewritten_sql(&rocky_duckdb::dialect::DuckDbSqlDialect);
+        assert!(
+            duck.contains("orders_rocky_shadow") && !duck.contains('"'),
+            "DuckDB renders bare identifiers: {duck}"
+        );
+
+        for (name, sql) in [
+            (
+                "snowflake",
+                rewritten_sql(&rocky_snowflake::dialect::SnowflakeSqlDialect),
+            ),
+            ("trino", rewritten_sql(&rocky_trino::dialect::TrinoDialect)),
+        ] {
+            assert!(
+                sql.contains("\"orders_rocky_shadow\""),
+                "{name} quotes its targets, so the rewritten read must be quoted too or it \
+                 folds case and names a different object: {sql}"
+            );
+        }
+    }
+
+    /// Two targets differing only by case are one object to the case-folded
+    /// identity key but two objects to a quoting dialect. Refuse rather than
+    /// redirect a read to the wrong one.
+    #[cfg(feature = "duckdb")]
+    #[test]
+    fn shadow_rejects_case_only_target_collisions_on_quoting_dialects() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        write_model_with_target(&models_dir, "lower", "SELECT 1 AS id", "main", "orders");
+        write_model_with_target(&models_dir, "upper", "SELECT 2 AS id", "main", "Orders");
+        let mut compiled =
+            rocky_compiler::compile::compile(&rocky_compiler::compile::CompilerConfig {
+                models_dir,
+                ..Default::default()
+            })
+            .expect("compile models");
+        let err = super::apply_shadow_rewrite(
+            &mut compiled,
+            None,
+            None,
+            &rocky_core::shadow::ShadowConfig::default(),
+            &rocky_snowflake::dialect::SnowflakeSqlDialect,
+            false,
+        )
+        .expect_err("case-only target collision must be rejected on a quoting dialect");
+        assert!(
+            format!("{err:#}").contains("differ only by case"),
+            "error must explain the collision: {err:#}"
+        );
+    }
+
+    #[cfg(feature = "duckdb")]
+    #[test]
+    fn shadow_rejects_ephemeral_models() {
         let tmp = tempfile::TempDir::new().expect("temp dir");
         let models_dir = tmp.path().join("models");
         std::fs::create_dir(&models_dir).expect("mkdir models");
@@ -16637,7 +16812,8 @@ timestamp_column = "ts"
              [target]\ncatalog = \"\"\nschema = \"main\"\ntable = \"eph\"\n",
         )
         .expect("write toml");
-        // Reads the ephemeral model's nominal target by physical name.
+        // Reads the ephemeral model's nominal target by physical name. Nothing
+        // inlines that read, so under shadow it would resolve to production.
         write_model_with_target(
             &models_dir,
             "consumer",
@@ -16653,7 +16829,7 @@ timestamp_column = "ts"
             })
             .expect("compile models");
         let dialect = rocky_duckdb::dialect::DuckDbSqlDialect;
-        super::apply_shadow_rewrite(
+        let err = super::apply_shadow_rewrite(
             &mut compiled,
             None,
             None,
@@ -16661,46 +16837,11 @@ timestamp_column = "ts"
             &dialect,
             false,
         )
-        .expect("shadow rewrite must succeed");
-
-        let model = |name: &str| {
-            compiled
-                .project
-                .models
-                .iter()
-                .find(|m| m.config.name == name)
-                .unwrap_or_else(|| panic!("model {name} missing"))
-        };
-
-        // The ephemeral target is rewritten, so nothing downstream of the
-        // governance snapshot can address the production table.
-        assert_eq!(
-            model("eph").config.target.table,
-            "eph_rocky_shadow",
-            "an ephemeral target must not stay on production during a shadow run"
-        );
-        // But no reader is pointed at that never-created table.
+        .expect_err("an ephemeral model must be rejected, not silently left on production");
+        let message = format!("{err:#}");
         assert!(
-            model("consumer")
-                .sql
-                .to_ascii_lowercase()
-                .contains("main.eph")
-                && !model("consumer")
-                    .sql
-                    .to_ascii_lowercase()
-                    .contains("eph_rocky_shadow"),
-            "a read of an ephemeral model must not be redirected to its shadow target: {:?}",
-            model("consumer").sql
-        );
-        // And no ordering edge waits on a model that materializes nothing.
-        assert!(
-            compiled
-                .project
-                .dag_nodes
-                .iter()
-                .find(|n| n.name == "consumer")
-                .is_some_and(|n| !n.depends_on.iter().any(|d| d == "eph")),
-            "no derived edge may name an ephemeral producer"
+            message.contains("ephemeral model 'eph'") && message.contains("not inlined"),
+            "error must name the model and why it cannot be shadowed: {message}"
         );
     }
 

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -1508,6 +1508,77 @@ auto_create_schemas = true
         );
     }
 
+    /// Routing an undeclared physical upstream read to the producer's shadow
+    /// target creates a real dependency, so execution must order the producer
+    /// first even though the sidecar declares no `depends_on`. Without the
+    /// derived edge the two models share an execution layer and the consumer
+    /// reads a shadow table its producer has not written yet.
+    #[tokio::test]
+    async fn transformation_shadow_orders_undeclared_physical_upstream() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+        let models_dir = dir.join("models");
+        std::fs::create_dir(&models_dir).unwrap();
+        let db = dir.join("t.duckdb");
+        let state_path = dir.join(".rocky-state.redb");
+
+        write_model(
+            &models_dir,
+            "orders",
+            "SELECT * FROM (VALUES (1)) AS t(id)",
+            &[],
+        );
+        // Seed production with the dependency declared. A project whose
+        // physical read is undeclared cannot build on a FRESH warehouse at all
+        // — the producer and consumer share a layer and the consumer runs
+        // first — which is the separate, pre-existing ordering gap. Declaring
+        // it here establishes the steady state this test is about: production
+        // tables already exist, so the shadow run is the only thing under test.
+        write_model(
+            &models_dir,
+            "mart",
+            "SELECT id FROM main.orders",
+            &["orders"],
+        );
+        write_config(dir, &db, "");
+        let config_path = dir.join("rocky.toml");
+
+        run_full_dag(&config_path, &state_path, false, None, None).await;
+        assert_eq!(count_rows(&db, "orders").await, 1);
+        assert_eq!(count_rows(&db, "mart").await, 1);
+
+        // Now drop the declaration: the read is physical and undeclared.
+        write_model(&models_dir, "mart", "SELECT id FROM main.orders", &[]);
+        write_model(
+            &models_dir,
+            "orders",
+            "SELECT * FROM (VALUES (1), (2)) AS t(id)",
+            &[],
+        );
+        let shadow = rocky_core::shadow::ShadowConfig {
+            cleanup_after: false,
+            ..Default::default()
+        };
+        run_full_dag(&config_path, &state_path, false, Some(&shadow), None).await;
+
+        assert_eq!(
+            count_rows(&db, "orders").await,
+            1,
+            "shadow must not overwrite production"
+        );
+        assert_eq!(
+            count_rows(&db, "orders_rocky_shadow").await,
+            2,
+            "producer must materialize its shadow target"
+        );
+        assert_eq!(
+            count_rows(&db, "mart_rocky_shadow").await,
+            2,
+            "consumer must read the producer's shadow target, which requires the producer to \
+             have run first"
+        );
+    }
+
     /// A transformation shadow run must materialize the rewritten physical
     /// target and leave the production table untouched. Exercise both CLI
     /// routing modes: the default suffix and branch-style schema override.

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -65,6 +65,8 @@ pub async fn run_transformation(
     // `with_ttl_override` so the override propagates consistently
     // across replication and transformation paths.
     schema_cache_cfg: &rocky_core::config::SchemaCacheConfig,
+    // Resolved `--shadow` / `--branch` physical-target routing.
+    shadow_config: Option<&rocky_core::shadow::ShadowConfig>,
     // Fully-resolved model-skip gate (default-off unless `--skip-unchanged`
     // / `[run] skip_unchanged` is set). Passed straight through to
     // `execute_models`.
@@ -164,6 +166,7 @@ pub async fn run_transformation(
                 None,
                 schema_cache_cfg,
                 pipeline.target.governance.auto_create_schemas,
+                shadow_config,
                 // run_local has no `--model` selection; defer is a no-op here.
                 &super::run::DeferOptions::default(),
                 skip_gate,
@@ -1172,17 +1175,21 @@ mod tests {
             .unwrap();
     }
 
-    /// Count rows in `main.<table>`.
-    async fn count_rows(db: &Path, table: &str) -> i64 {
+    async fn count_rows_in_schema(db: &Path, schema: &str, table: &str) -> i64 {
         let a = DuckDbWarehouseAdapter::open(db).expect("count open");
         let r = a
-            .execute_query(&format!("SELECT COUNT(*) FROM main.{table}"))
+            .execute_query(&format!("SELECT COUNT(*) FROM {schema}.{table}"))
             .await
             .unwrap();
         r.rows[0][0]
             .as_i64()
             .or_else(|| r.rows[0][0].as_str().and_then(|s| s.parse().ok()))
             .unwrap()
+    }
+
+    /// Count rows in `main.<table>`.
+    async fn count_rows(db: &Path, table: &str) -> i64 {
+        count_rows_in_schema(db, "main", table).await
     }
 
     /// Write a `full_refresh` SQL model (`name.sql` + `name.toml`) into the
@@ -1210,10 +1217,17 @@ mod tests {
     }
 
     /// Drive `super::super::run::run()` end-to-end against the given config +
-    /// canonical `state_path`, exercising the full transformation dispatch
-    /// (`run() → run_transformation`). `skip_unchanged` toggles the gate.
-    async fn run_full_dag(config_path: &Path, state_path: &Path, skip_unchanged: bool) {
+    /// canonical `state_path`, exercising both the full transformation
+    /// dispatch and its model-only entry point.
+    async fn run_full_dag(
+        config_path: &Path,
+        state_path: &Path,
+        skip_unchanged: bool,
+        shadow_config: Option<&rocky_core::shadow::ShadowConfig>,
+        model_name_filter: Option<&str>,
+    ) {
         let opts = PartitionRunOptions::default();
+        let models_dir = config_path.parent().unwrap().join("models");
         let skip_opts = SkipRunOptions {
             skip_unchanged,
             force_rebuild: false,
@@ -1230,13 +1244,13 @@ mod tests {
             state_path,
             None,  // governance_override
             false, // output_json
-            None,  // models_dir override — take from config
+            model_name_filter.map(|_| models_dir.as_path()),
             false, // run_all
             None,  // resume_run_id
             false, // resume_latest
-            None,  // shadow_config
+            shadow_config,
             &opts,
-            None, // model_name_filter
+            model_name_filter,
             None, // cache_ttl_override
             None, // idempotency_key
             None, // env
@@ -1310,7 +1324,7 @@ auto_create_schemas = true
         let config_path = dir.join("rocky.toml");
 
         // ---- Run 1: fresh state ⇒ both models build. -------------------
-        run_full_dag(&config_path, &state_path, true).await;
+        run_full_dag(&config_path, &state_path, true, None, None).await;
         assert_eq!(count_rows(&db, "stg").await, 3, "run 1 builds stg");
         assert_eq!(count_rows(&db, "mart").await, 3, "run 1 builds mart");
 
@@ -1347,7 +1361,7 @@ auto_create_schemas = true
         assert_eq!(count_rows(&db, "mart").await, 4);
 
         // ---- Run 2: byte-identical ⇒ both SKIP (sentinels survive). ----
-        run_full_dag(&config_path, &state_path, true).await;
+        run_full_dag(&config_path, &state_path, true, None, None).await;
         assert_eq!(
             count_rows(&db, "stg").await,
             4,
@@ -1367,7 +1381,7 @@ auto_create_schemas = true
             "SELECT id FROM main.stg WHERE id > 1",
             &["stg"],
         );
-        run_full_dag(&config_path, &state_path, true).await;
+        run_full_dag(&config_path, &state_path, true, None, None).await;
         assert_eq!(
             count_rows(&db, "stg").await,
             4,
@@ -1481,17 +1495,115 @@ auto_create_schemas = true
         write_config(dir, &db, "");
         let config_path = dir.join("rocky.toml");
 
-        run_full_dag(&config_path, &state_path, false).await;
+        run_full_dag(&config_path, &state_path, false, None, None).await;
         insert_sentinel(&db, "stg", 999).await;
         assert_eq!(count_rows(&db, "stg").await, 4);
 
         // Gate off ⇒ run 2 rebuilds unconditionally ⇒ sentinel dropped.
-        run_full_dag(&config_path, &state_path, false).await;
+        run_full_dag(&config_path, &state_path, false, None, None).await;
         assert_eq!(
             count_rows(&db, "stg").await,
             3,
             "default-off must rebuild every run — sentinel dropped"
         );
+    }
+
+    /// A transformation shadow run must materialize the rewritten physical
+    /// target and leave the production table untouched. Exercise both CLI
+    /// routing modes: the default suffix and branch-style schema override.
+    #[tokio::test]
+    async fn transformation_shadow_routes_targets_without_overwriting_production() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+        let models_dir = dir.join("models");
+        std::fs::create_dir(&models_dir).unwrap();
+        let db = dir.join("t.duckdb");
+        let state_path = dir.join(".rocky-state.redb");
+
+        write_model(
+            &models_dir,
+            "orders",
+            "SELECT * FROM (VALUES (1)) AS t(id)",
+            &[],
+        );
+        write_model(
+            &models_dir,
+            "mart",
+            "SELECT id FROM main.orders",
+            &["orders"],
+        );
+        write_config(dir, &db, "");
+        let config_path = dir.join("rocky.toml");
+
+        run_full_dag(&config_path, &state_path, false, None, None).await;
+        assert_eq!(count_rows(&db, "orders").await, 1);
+        assert_eq!(count_rows(&db, "mart").await, 1);
+
+        write_model(
+            &models_dir,
+            "orders",
+            "SELECT * FROM (VALUES (1), (2)) AS t(id)",
+            &[],
+        );
+        let suffix_shadow = rocky_core::shadow::ShadowConfig {
+            cleanup_after: false,
+            ..Default::default()
+        };
+        run_full_dag(
+            &config_path,
+            &state_path,
+            false,
+            Some(&suffix_shadow),
+            Some("orders"),
+        )
+        .await;
+        assert_eq!(
+            count_rows(&db, "orders").await,
+            1,
+            "suffix shadow must not overwrite the production target"
+        );
+        assert_eq!(
+            count_rows(&db, "orders_rocky_shadow").await,
+            2,
+            "suffix shadow must materialize the rewritten table"
+        );
+
+        run_full_dag(&config_path, &state_path, false, Some(&suffix_shadow), None).await;
+        assert_eq!(
+            count_rows(&db, "mart_rocky_shadow").await,
+            2,
+            "downstream suffix shadow must read the shadow upstream"
+        );
+
+        write_model(
+            &models_dir,
+            "orders",
+            "SELECT * FROM (VALUES (1), (2), (3)) AS t(id)",
+            &[],
+        );
+        let branch_shadow = rocky_core::shadow::ShadowConfig {
+            schema_override: Some("branch_fix_1269".to_string()),
+            cleanup_after: false,
+            ..Default::default()
+        };
+        run_full_dag(&config_path, &state_path, false, Some(&branch_shadow), None).await;
+        assert_eq!(
+            count_rows(&db, "orders").await,
+            1,
+            "branch shadow must not overwrite the production target"
+        );
+        assert_eq!(
+            count_rows_in_schema(&db, "branch_fix_1269", "orders").await,
+            3,
+            "branch shadow must materialize in its isolated schema"
+        );
+        assert_eq!(
+            count_rows_in_schema(&db, "branch_fix_1269", "mart").await,
+            3,
+            "downstream branch model must read the branch upstream"
+        );
+        assert_eq!(count_rows(&db, "orders").await, 1);
+        assert_eq!(count_rows(&db, "mart").await, 1);
     }
 
     /// Reached-ness guard for per-model `[governance.tags]` application.
@@ -1528,7 +1640,7 @@ auto_create_schemas = true
 
         // The run must succeed: the governance.tags apply block runs (no-op on
         // DuckDB) without aborting the transformation.
-        run_full_dag(&config_path, &state_path, false).await;
+        run_full_dag(&config_path, &state_path, false, None, None).await;
 
         // The view materialized and is queryable.
         let a = DuckDbWarehouseAdapter::open(&db).expect("open db");
@@ -1785,6 +1897,7 @@ auto_create_schemas = true
             false, // output_json
             &PartitionRunOptions::default(),
             &rocky_core::config::SchemaCacheConfig::default(),
+            None, // shadow_config (test)
             super::super::run::SkipGateConfig::off(),
             false, // no_reuse
             &state_path,


### PR DESCRIPTION
## Summary

Prevent transformation `--shadow` and `--branch` runs from writing production targets or reading production versions of selected in-run upstream models.

Refs #1269 — this closes the direct transformation and model-only paths. #1269 stays open
until #1272 lands: `rocky run --dag`, and the snapshot and load pipeline kinds, still accept
`--shadow` / `--branch` and write production targets.

Follow-ups opened from review: #1272 (remaining shadow-writes-production entrypoints),
#1273 (shadow object ownership + lifecycle), #1274 (`rocky compare` for transformation
pipelines), #1275 (physical reads produce no DAG edge, so producer and consumer are
co-scheduled).

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Changes

- Thread the resolved `ShadowConfig` through transformation and model-only execution.
- Rewrite selected model targets and declared in-run dependency reads to their physical shadow targets before schema creation, execution, state/reuse identity, metadata, and governance capture.
- Preserve production reads for unselected/deferred upstreams.
- Reject derived targets that overlap any configured production target or another selected model's shadow target.
- Fail closed for `content_addressed` and `time_interval` shadow runs until their external storage and partition-state identities can be isolated safely.
- Add DuckDB regression coverage for model-only, two-model suffix-shadow, branch-schema routing, unchanged production tables, unsupported strategies, and unsafe target collisions.
- Document shadow routing, collision rejection, and the current fail-closed strategy limitation.

## Test Plan

- [x] `cargo test -p rocky-cli --features duckdb shadow_` (5 passed)
- [x] `cargo nextest run --all-features` (5,741 passed; 108 skipped)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `npm ci && npm run build` in `docs/` (98 pages; 0 dependency vulnerabilities)
- [ ] `cargo test --all-targets` (all test targets passed in the earlier full run, then the Criterion `binary_startup` benchmark self-deadlocked because it launches a nested `cargo run` against the outer Cargo target lock; the repository's canonical all-feature nextest command is green above)
- [ ] `bash scripts/lint-adapter-boundary.sh` from the repository root (fails on existing imports in unrelated `output.rs`, `compact.rs`, `discover.rs`, `export_schemas.rs`, `restore.rs`, `archive.rs`, `replay.rs`, and `run_content_addressed.rs`; this PR adds no violations, and the workflow's adapter-boundary check is green)

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/), scoped by subproject when relevant.
- [x] No `Co-Authored-By` trailers
- [x] If this is a CLI JSON schema or DSL syntax change, all consumers and golden fixtures are updated in the same PR (not applicable: no schema or DSL syntax change).

### Engine (`engine/`)

- [x] The canonical all-feature nextest suite passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo fmt --check` passes

