### PR TITLE
fix(engine): discover example projects from git, not a filesystem walk

### DIFF
--- a/engine/rocky/tests/examples_models_load.rs
+++ b/engine/rocky/tests/examples_models_load.rs
@@ -7,10 +7,11 @@
 //! documented usage — failed on it. It only surfaced when `run --dag` started
 //! propagating model-load errors (#1244).
 //!
-//! This walks the repository for every `rocky.toml`, and loads the `models/`
-//! directory beside it through the same loader the CLI uses. Discovery is
-//! filesystem-driven rather than a hardcoded list, so a newly added example is
-//! covered the moment it lands.
+//! This finds every tracked `rocky.toml` and loads the `models/` directory
+//! beside it through the same loader the CLI uses. Discovery comes from
+//! `git ls-files` rather than a hardcoded list, so a newly added example is
+//! covered the moment it lands — and so the set of projects checked is
+//! identical locally and in CI.
 //!
 //! Scope note: the loader reads the top level plus one directory down, so a
 //! model at `models/a/b/` is not covered here because it is not loaded at all
@@ -19,69 +20,251 @@
 use std::path::{Path, PathBuf};
 
 /// Repository root: `engine/rocky` → `engine` → repo root.
-fn repo_root() -> PathBuf {
+///
+/// `None` when those ancestors do not exist, which is the case for an exported
+/// or vendored copy of this crate alone.
+fn repo_root() -> Option<PathBuf> {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("..")
         .join("..")
         .canonicalize()
-        .expect("canonicalize repo root")
+        .ok()
 }
 
-/// Every `rocky.toml` in the repo, skipping build and dependency output.
-fn find_project_configs(dir: &Path, out: &mut Vec<PathBuf>) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
+/// Whether `root` is itself the **top level** of a git work tree.
+///
+/// Discovery below shells out to `git`, which is right for a developer checkout
+/// and for CI but not for an exported source tree — a release tarball, a
+/// vendored copy, a `cargo package` verification build. There are no example
+/// projects to assert about there, so the test skips rather than failing.
+///
+/// "Is this the top level" rather than the easier "is this inside a work tree":
+/// an exported copy can sit **inside an unrelated repository**, say
+/// `vendor/rocky-1.67.0/` in someone else's checkout. `--is-inside-work-tree`
+/// answers true there — about the OUTER repository. Discovery would then run
+/// `git ls-files` against that repository and either find nothing, tripping the
+/// vacuity floor with a misleading message, or hand back paths that are relative
+/// to the outer top level and get joined onto `root` to produce nonsense.
+///
+/// Comparing `--show-toplevel` to `root` answers the question actually being
+/// asked, and is the same condition that makes `--full-name` paths safe to join
+/// onto `root`.
+///
+/// Deliberately narrow: a missing `git`, a non-repository, or a nested copy
+/// skips. Once `root` is confirmed to be the top level, every later failure is a
+/// real failure and is reported as one.
+fn is_git_top_level(root: &Path) -> bool {
+    let Ok(out) = std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(root)
+        .output()
+    else {
+        return false;
     };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        let name = entry.file_name();
-        let name = name.to_string_lossy();
-        if path.is_dir() {
-            if matches!(name.as_ref(), "target" | "node_modules" | ".git" | ".venv") {
-                continue;
-            }
-            find_project_configs(&path, out);
-        } else if name == "rocky.toml" {
-            out.push(path);
-        }
+    if !out.status.success() {
+        return false;
     }
+    String::from_utf8(out.stdout)
+        .ok()
+        .and_then(|top| Path::new(top.trim()).canonicalize().ok())
+        .is_some_and(|top| top == root)
+}
+
+/// Every **tracked** project in this checkout that has a **tracked** models
+/// directory, as `(config_path, models_dir)` pairs.
+///
+/// Derived from `git ls-files`, not a filesystem walk. A walk inherits whatever
+/// else happens to be on disk, and there are two sources of that: other
+/// checkouts of this same repository (git worktrees under `.claude/worktrees/`,
+/// vendored clones, scratch trees), and generated-but-uncommitted project output
+/// such as the POC `scaffolded/`, `imported/` and run-produced `models/`
+/// directories.
+///
+/// Both make the local population differ from CI's, which is how the first
+/// version of this test passed on a clean checkout while failing in a developer
+/// tree — walking 128 projects instead of 78 and reporting four copies of a
+/// pre-fix `docs-demo` this repository had already fixed.
+///
+/// Requiring the models directory to be tracked as well as the config matters:
+/// three POCs commit a `rocky.toml` whose `models/` is produced by running them.
+/// Filtering on the config alone still checked those locally and not in CI.
+/// Keying both on tracked files makes the two populations equal by construction,
+/// rather than by a skip list that has to anticipate every kind of stray
+/// directory.
+fn tracked_projects(root: &Path) -> Vec<(PathBuf, PathBuf)> {
+    let out = std::process::Command::new("git")
+        .args(["ls-files", "-z", "--full-name"])
+        .current_dir(root)
+        .output()
+        .expect("run git ls-files");
+    assert!(
+        out.status.success(),
+        "git ls-files failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let listing = String::from_utf8(out.stdout).expect("git ls-files output is utf8");
+    let files: Vec<&str> = listing.split('\0').filter(|s| !s.is_empty()).collect();
+
+    // Repo-relative directories that hold at least one tracked model file, e.g.
+    // "engine/examples/docs-demo/models" from ".../models/stg_customers.rocky".
+    // The FIRST `models` segment is the project's own; anything deeper belongs
+    // to it.
+    let tracked_models_dirs: std::collections::HashSet<&str> = files
+        .iter()
+        .filter_map(|f| {
+            if let Some(rest) = f.strip_prefix("models/") {
+                let _ = rest;
+                Some("models")
+            } else {
+                f.find("/models/").map(|i| &f[..i + "/models".len()])
+            }
+        })
+        .collect();
+
+    files
+        .iter()
+        .filter(|f| {
+            Path::new(f)
+                .file_name()
+                .is_some_and(|n| n == std::ffi::OsStr::new("rocky.toml"))
+        })
+        .filter_map(|config| {
+            let parent = Path::new(config).parent()?.to_string_lossy().into_owned();
+            let models = if parent.is_empty() {
+                "models".to_string()
+            } else {
+                format!("{parent}/models")
+            };
+            tracked_models_dirs
+                .contains(models.as_str())
+                .then(|| (root.join(config), root.join(&models)))
+        })
+        .collect()
 }
 
 #[test]
 fn every_example_models_dir_loads() {
-    let root = repo_root();
-    let mut configs = Vec::new();
-    find_project_configs(&root, &mut configs);
-    configs.sort();
+    // An exported or vendored source tree has neither the sibling directories
+    // nor a git work tree, and carries no example projects to check. Skip
+    // explicitly and say why, rather than failing on a missing `git`.
+    let Some(root) = repo_root() else {
+        eprintln!(
+            "skipping: {} has no repository root above it (exported or vendored source)",
+            env!("CARGO_MANIFEST_DIR")
+        );
+        return;
+    };
+    if !is_git_top_level(&root) {
+        eprintln!(
+            "skipping: {} is not the top level of a git work tree (exported or \
+             vendored source, possibly nested inside another repository)",
+            root.display()
+        );
+        return;
+    }
 
-    let mut checked = 0usize;
+    let mut projects = tracked_projects(&root);
+    projects.sort();
+
     let mut failures = Vec::new();
 
-    for config in &configs {
-        let models_dir = config
-            .parent()
-            .expect("rocky.toml has a parent")
-            .join("models");
-        if !models_dir.is_dir() {
-            continue;
-        }
-        checked += 1;
-        if let Err(e) = rocky_cli::models_loader::load_project_models(&models_dir) {
-            let rel = models_dir.strip_prefix(&root).unwrap_or(&models_dir);
+    for (_config, models_dir) in &projects {
+        if let Err(e) = rocky_cli::models_loader::load_project_models(models_dir) {
+            let rel = models_dir.strip_prefix(&root).unwrap_or(models_dir);
             failures.push(format!("  {}: {e:#}", rel.display()));
         }
     }
 
-    // A walker that silently found nothing would otherwise pass vacuously.
+    // A discovery step that silently found nothing would otherwise pass
+    // vacuously. This count comes from tracked files, so it is the same here and
+    // in CI — a floor that can actually fire.
+    let checked = projects.len();
     assert!(
         checked >= 50,
         "expected to check 50+ project models directories, only found {checked} \
-         (is the repository walk broken?)"
+         (is `git ls-files` discovery broken?)"
     );
     assert!(
         failures.is_empty(),
         "{} of {checked} project models directories failed to load:\n{}",
         failures.len(),
         failures.join("\n")
+    );
+}
+
+/// Whether a `git` binary can be run at all.
+///
+/// Every assertion below that needs to *build* or *interrogate* a repository is
+/// gated on this. An environment with no git is precisely the one
+/// [`is_git_top_level`] exists to handle, so this guard must not itself require
+/// the tool — spawning `git init` unconditionally is how the previous version
+/// reintroduced the dependency this change removes.
+fn git_available() -> bool {
+    std::process::Command::new("git")
+        .arg("--version")
+        .output()
+        .is_ok_and(|out| out.status.success())
+}
+
+/// The skip predicate must be narrow in every direction, or the check above
+/// either stops guarding the examples or reintroduces the git dependency it
+/// exists to avoid.
+///
+/// The no-repository half runs everywhere, git or no git, so the predicate is
+/// never left entirely unpinned. The two repository-backed halves are gated on
+/// `git` being runnable, and the positive one additionally on an independent
+/// signal — a `.git` entry on disk — rather than on the predicate under test.
+#[test]
+fn git_top_level_detection_is_narrow() {
+    // Holds with or without a git binary: a missing binary makes the predicate
+    // false too, which is the answer this environment wants.
+    let outside = tempfile::tempdir().expect("tempdir");
+    assert!(
+        !is_git_top_level(outside.path()),
+        "a directory with no repository above it must not be detected as a git \
+         top level"
+    );
+
+    if !git_available() {
+        eprintln!("skipping the repository-backed halves: no runnable git binary");
+        return;
+    }
+
+    // The case that matters for a vendored copy: a directory INSIDE a work tree
+    // but not its top level. `--is-inside-work-tree` answers true here, which is
+    // why that is the wrong question — discovery would run against the enclosing
+    // repository and hand back paths relative to ITS top level.
+    let nested = tempfile::tempdir().expect("tempdir");
+    let init = std::process::Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(nested.path())
+        .status()
+        .expect("spawn git init after git_available() said git runs");
+    assert!(init.success(), "git init failed");
+    let inner = nested.path().join("vendor").join("rocky-1.0.0");
+    std::fs::create_dir_all(&inner).expect("mkdir nested copy");
+    let inner = inner.canonicalize().expect("canonicalize nested copy");
+    assert!(
+        !is_git_top_level(&inner),
+        "a copy nested inside another repository must not be detected as a git \
+         top level, or discovery runs against the wrong repository"
+    );
+
+    let Some(root) = repo_root() else {
+        return;
+    };
+    // `.git` is a directory in a clone and a file in a worktree, so test for
+    // existence rather than for a directory.
+    if !root.join(".git").exists() {
+        eprintln!(
+            "skipping the positive half: {} has no .git (exported or vendored source)",
+            root.display()
+        );
+        return;
+    }
+    assert!(
+        is_git_top_level(&root),
+        "a checkout with a .git entry must be detected as its top level, or the \
+         example check silently stops running"
     );
 }


### PR DESCRIPTION
## Summary

The repository walk added in #1263 descended into any directory under the repo root, so the set of projects it checked depended on whatever else was on disk. Two things routinely are: other checkouts of this same repository (git worktrees under `.claude/worktrees/`, vendored clones, scratch trees), and generated-but-uncommitted project output.

It stayed invisible until the loader got stricter in #1266:

- clean CI checkout → 78 projects → passes
- developer tree with agent worktrees → **128** → **fails** on four copies of the pre-fix `docs-demo`, an example this repository had already fixed in #1263

Green CI, red locally, over code from a different commit. My mistake in #1263: I validated the walk against a clean worktree and against the main tree's committed projects, and never against a tree with nested checkouts — even though this repo's own convention puts agent worktrees exactly there.

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Changes

Replace the walk with `git ls-files`. A project is checked when **both** its `rocky.toml` and its `models/` directory are tracked.

The second half is not incidental. My first attempt at this fix only skipped nested checkouts, and filtering to tracked *configs* still left three POCs — `10-cost-budgets`, `12-replication-table-overrides`, `13-run-watch-inner-loop` — whose `rocky.toml` is committed but whose `models/` is produced by running them. Those were checked locally and absent in CI: the same asymmetry, one layer down. Keying both on tracked files makes the populations equal **by construction** (78 either way) rather than by a skip list that has to anticipate every kind of stray directory.

## Test Plan

- [x] Reproduced on merged `main` in a tree containing agent worktrees: `4 of 128 project models directories failed to load`, each a `.claude/worktrees/*/engine/examples/docs-demo/models`.
- [x] After the fix, the same tree passes and checks **78** — the clean-checkout number, verified independently against `git ls-files`.
- [x] Mutation check re-run: reverting `docs-demo` to `||` still fails the test with `1 of 78`, naming the file and offset. It binds.
- [x] The `>= 50` floor now counts a stable population, so it can actually fire rather than tracking whatever is on disk.
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`

## Review

Not sent to the independent red team: this is a test-only discovery change, behaviour-neutral for the engine, and it carries its own mutation check (reproduced red, then green, in the tree that was failing).

**Exported and vendored source trees.** Shelling out to `git` would otherwise make this test require a live work tree, so `cargo test` from a release tarball, a vendored copy, or a `cargo package` verification build would fail on a missing repository rather than on anything real.

The guard is `is_git_top_level` — is `root` the **top level** of a work tree — not the easier "is `root` inside one". That distinction is the whole point: an exported copy can sit inside an *unrelated* repository, say `vendor/rocky-1.67.0/` in someone else's checkout, and `--is-inside-work-tree` answers true there, about the outer repo. Discovery would then run `git ls-files` against that repository and either find nothing (tripping the vacuity floor with a misleading message) or hand back paths relative to the outer top level that get joined onto `root` to produce nonsense. Comparing `--show-toplevel` to `root` is also exactly the condition that makes `--full-name` paths safe to join.

Everything past the guard still fails loudly: with the top level confirmed, a failing `ls-files` is a real failure and the vacuity floor still applies.

`git_top_level_detection_is_narrow` pins the predicate without itself requiring git. Its no-repository half runs everywhere — a missing binary makes the predicate false too, which is the right answer there — so the predicate is never left entirely unpinned. The two repository-backed halves (a directory nested inside a work tree but not its top level, built with a real `git init`; and a checkout with a `.git` entry) are gated on `git` being runnable, and the positive one additionally on the on-disk `.git` entry rather than on the predicate under test.

Three rounds of stop-time review shaped this, and every finding was real:

1. The first version asserted the positive half unconditionally, so the guard failed in exactly the environment the skip existed for.
2. The second used `--is-inside-work-tree`, which misses the nested-vendored case above.
3. The third spawned `git init` with `.expect(...)` in the guard, reintroducing the hard git dependency the change removes — an environment with no git panicked there.

Verified in all four environments by building and running there, not by reasoning:

```
# real checkout
test git_top_level_detection_is_narrow ... ok
test every_example_models_dir_loads ... ok          # 78 projects checked

# git archive HEAD -> temp dir, no repository anywhere above
test result: ok. 2 passed; 0 failed

# same export, now nested inside an unrelated `git init` repo
#   --is-inside-work-tree -> true
#   --show-toplevel       -> the OUTER repo, not the export
skipping: .../export is not the top level of a git work tree (exported or
          vendored source, possibly nested inside another repository)
test result: ok. 2 passed; 0 failed

# no git binary reachable at all (PATH emptied)
skipping: ... is not the top level of a git work tree (...)
skipping the repository-backed halves: no runnable git binary
test result: ok. 2 passed; 0 failed
```

Each guard is mutation-checked, not just asserted: removing the `git_available()` gate makes the no-git run panic, and reverting `docs-demo` to `||` still fails the example check with `1 of 78`.

**What I am least confident about:** the skip means the examples go unguarded in an exported tree. That is fine while CI always runs in a real checkout — it does — and the narrowness test is what stops the skip quietly becoming the normal path. If the examples ever needed checking outside a checkout, discovery would have to be committed as data rather than derived from git.

**The most important thing I am missing:** the recurring shape here is that I keep validating a filesystem-reading test in whichever environment I happen to be in. The original walk was validated in a clean worktree and never in a tree with agent worktrees; the first guard in a checkout and never in an export; the second never in an export nested inside another repo. Each fix was right and each verification was too narrow. Nothing in the repository makes "run this test under the environments it claims to support" cheap or routine, so the next such test will likely repeat it.

## Checklist

- [x] Commit messages follow conventional commits, scoped by subproject
- [x] No `Co-Authored-By` trailers
- [x] No CLI JSON schema or DSL syntax changes


