### PR TITLE
fix(ci): gate release workflow action sources and repair the wasm-pack pin

### DIFF
--- a/.github/SECURITY_ENVIRONMENTS.md
+++ b/.github/SECURITY_ENVIRONMENTS.md
@@ -121,6 +121,28 @@ closed only after these pass on the merged revision:
 Record the run URLs in the remediation ledger. Until these pass on `main`, the
 code is merge-ready but RD-026 stays In review.
 
+## Release and deployment action sources
+
+The containment rules above govern jobs reachable from a pull request. Release,
+publish and deployment workflows are a different trust domain: they run from a
+tag or a push, never execute candidate code, and so none of the pull-request
+rules applied to them. They do hold a write token and the publishing secrets,
+which made an unreviewed action source in one of their steps a direct path into
+the artifacts this project ships — `engine/install.sh` serves exactly those
+binaries.
+
+Every job that is not reachable from a pull request may therefore only run
+actions in `RELEASE_ACTION_SOURCES`, the pinned allowlist in the checker. Parsing
+fails closed: a step whose `uses:` cannot be read as exactly one pinned remote
+source is a violation rather than something to skip, and a repository-local
+action in such a job is rejected outright. Adding a new action to a release
+workflow is a trust-root change and follows the bootstrap procedure below.
+
+Pin provenance is not self-verifying. A pinned commit that shares a long prefix
+with the intended tag but diverges is indistinguishable by eye and simply fails
+to resolve at run time. Confirm any new pin against its upstream tag before
+adding it to the allowlist.
+
 ## Updating frozen trust roots
 
 The credential-containment workflow compares the candidate copies of its

--- a/.github/SECURITY_ENVIRONMENTS.md
+++ b/.github/SECURITY_ENVIRONMENTS.md
@@ -143,6 +143,16 @@ with the intended tag but diverges is indistinguishable by eye and simply fails
 to resolve at run time. Confirm any new pin against its upstream tag before
 adding it to the allowlist.
 
+These jobs must also use the canonical block form the checker understands: block
+mapping jobs, a `steps:` list at six-space indentation, no flow-style `jobs: {...}`,
+no job image, and no reusable-workflow call. A step whose scalar spans several
+lines with a continuation beginning `uses:` is rejected as well. Recognising that
+shape needs a real YAML parser, which this checker forgoes so the same trusted
+file can run in the minimal policy job, so it fails closed and the author
+reformats. The restriction is safe in the other direction: a scalar can never
+conceal an executed step, because step splitting keys off the six-space prefix
+unconditionally.
+
 ## Updating frozen trust roots
 
 The credential-containment workflow compares the candidate copies of its

--- a/.github/scripts/check_credential_containment.py
+++ b/.github/scripts/check_credential_containment.py
@@ -43,6 +43,52 @@ SETUP_UV_SOURCE = "astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9"
 SETUP_NODE_SOURCE = (
     "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020"
 )
+DEPLOY_PAGES_SOURCE = (
+    "actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128"
+)
+UPLOAD_PAGES_ARTIFACT_SOURCE = (
+    "actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9"
+)
+SETUP_NASM_SOURCE = "ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b"
+WASM_PACK_SOURCE = (
+    "jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa"
+)
+SETUP_ZIG_SOURCE = "mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29"
+PYPI_PUBLISH_SOURCE = (
+    "pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247"
+)
+GH_RELEASE_SOURCE = (
+    "softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228"
+)
+TAIKI_INSTALL_SOURCE = (
+    "taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf"
+)
+# Actions a job may run when it is not reachable from a pull request. Release,
+# publish and deployment workflows never execute candidate code, so the
+# containment rules that govern pull-request jobs do not apply to them; what they
+# do hold is a write token and the publishing secrets. That makes an unreviewed
+# action source in one of their steps a direct supply-chain path into the
+# artifacts this project ships, which nothing else in this checker examined.
+RELEASE_ACTION_SOURCES = frozenset(
+    {
+        CHECKOUT_SOURCE,
+        DEPLOY_PAGES_SOURCE,
+        GH_RELEASE_SOURCE,
+        GITHUB_SCRIPT_SOURCE,
+        PYPI_PUBLISH_SOURCE,
+        RUST_CACHE_SOURCE,
+        RUST_TOOLCHAIN_SOURCE,
+        SETUP_NASM_SOURCE,
+        SETUP_NODE_SOURCE,
+        SETUP_UV_SOURCE,
+        SETUP_ZIG_SOURCE,
+        TAIKI_INSTALL_SOURCE,
+        UPLOAD_ARTIFACT_SOURCE,
+        UPLOAD_PAGES_ARTIFACT_SOURCE,
+        WASM_PACK_SOURCE,
+    }
+)
+STEP_USES_RE = re.compile(r"(?m)^\s+(?:-\s+)?uses:\s*([^\s#]+)")
 MODEL_SECRET_RE = re.compile(r"\bANTHROPIC_API_KEY\b", re.IGNORECASE)
 CANDIDATE_JOBS = {
     ("ai-review.yml", "context"),
@@ -1270,6 +1316,31 @@ def _check_unprivileged_job(
     return violations
 
 
+def _check_release_job_sources(job: str) -> list[str]:
+    """Restrict a non-pull-request job to the pinned release action allowlist.
+
+    Parsing fails closed. A step whose `uses:` cannot be read as exactly one
+    pinned remote source is a violation rather than something to skip, because
+    the surrounding job holds credentials and an unreadable step is precisely
+    where an attacker would hide one.
+    """
+
+    violations: list[str] = []
+    for step in _step_blocks(job):
+        declared = STEP_USES_RE.findall(step)
+        if not declared:
+            continue
+        if len(declared) > 1:
+            violations.append("release step declares more than one action source")
+            continue
+        source = declared[0].strip("'\"")
+        if source.startswith("./") or source.startswith("."):
+            violations.append("release step runs a repository-local action")
+        elif source not in RELEASE_ACTION_SOURCES:
+            violations.append("release step action source is not allow-listed")
+    return violations
+
+
 def _check_live_evals(workflow: Workflow, job: str) -> list[str]:
     violations: list[str] = []
     top_level_keys = re.findall(
@@ -1559,6 +1630,8 @@ def check_workflow(workflow: Workflow) -> list[str]:
                     allowed_checkout_maps=CANDIDATE_CHECKOUT_MAPS.get(job_identity),
                 )
             )
+        if not pr_triggered:
+            violations.extend(_check_release_job_sources(job))
         if MODEL_SECRET_RE.search(job) and (workflow.path.name, job_name) not in {
             ("ai-review.yml", "ai-review"),
             ("engine-evals-live.yml", "evals"),

--- a/.github/scripts/check_credential_containment.py
+++ b/.github/scripts/check_credential_containment.py
@@ -1325,9 +1325,15 @@ def _check_release_job_sources(job: str) -> list[str]:
     where an attacker would hide one.
     """
 
+    # Read structure only. A `run:` body is shell, not an action source, and a
+    # heredoc that writes out a workflow file legitimately contains `- uses:`
+    # lines; counting those would reject a valid job. _yaml_structural_text
+    # drops comments and block-scalar bodies, and it cannot hide a real step:
+    # scalar mode ends as soon as indentation returns to the step level.
+    structural = _yaml_structural_text(job)
     violations: list[str] = []
     parsed: list[str] = []
-    for step in _step_blocks(job):
+    for step in _step_blocks(structural):
         declared = STEP_USES_RE.findall(step)
         if not declared:
             continue
@@ -1348,13 +1354,13 @@ def _check_release_job_sources(job: str) -> list[str]:
     # parsed count turns every such shape into a violation instead of a silent
     # gap, which is the difference between this rule binding and merely looking
     # like it does.
-    if len(STEP_USES_RE.findall(job)) != len(parsed):
+    if len(STEP_USES_RE.findall(structural)) != len(parsed):
         violations.append("release job declares an action outside a canonical step")
 
     # A job image runs arbitrary code under the same write token as the steps,
     # so it is an action source in everything but name.
     for key in ("container", "services"):
-        if _key_block(job, key, indent=4) is not None:
+        if _key_block(structural, key, indent=4) is not None:
             violations.append(f"release job declares a {key}")
     return violations
 

--- a/.github/scripts/check_credential_containment.py
+++ b/.github/scripts/check_credential_containment.py
@@ -1326,18 +1326,36 @@ def _check_release_job_sources(job: str) -> list[str]:
     """
 
     violations: list[str] = []
+    parsed: list[str] = []
     for step in _step_blocks(job):
         declared = STEP_USES_RE.findall(step)
         if not declared:
             continue
+        parsed.extend(declared)
         if len(declared) > 1:
             violations.append("release step declares more than one action source")
             continue
         source = declared[0].strip("'\"")
-        if source.startswith("./") or source.startswith("."):
+        if source.startswith("."):
             violations.append("release step runs a repository-local action")
         elif source not in RELEASE_ACTION_SOURCES:
             violations.append("release step action source is not allow-listed")
+
+    # Completeness, not just per-step correctness. _step_blocks only recognises
+    # canonical six-space steps, so anything else -- a job-level `uses:` calling
+    # a reusable workflow, or a step list at a different indentation -- would
+    # otherwise be invisible here and pass. Comparing the raw count against the
+    # parsed count turns every such shape into a violation instead of a silent
+    # gap, which is the difference between this rule binding and merely looking
+    # like it does.
+    if len(STEP_USES_RE.findall(job)) != len(parsed):
+        violations.append("release job declares an action outside a canonical step")
+
+    # A job image runs arbitrary code under the same write token as the steps,
+    # so it is an action source in everything but name.
+    for key in ("container", "services"):
+        if _key_block(job, key, indent=4) is not None:
+            violations.append(f"release job declares a {key}")
     return violations
 
 

--- a/.github/scripts/check_credential_containment.py
+++ b/.github/scripts/check_credential_containment.py
@@ -1333,6 +1333,12 @@ def _check_release_job_sources(job: str) -> list[str]:
     structural = _yaml_structural_text(job)
     violations: list[str] = []
     parsed: list[str] = []
+
+    # A job-level `uses:` is a reusable-workflow call: it replaces the whole job
+    # and never appears as a step, so no step-based rule can see it.
+    if _key_block(structural, "uses", indent=4) is not None:
+        violations.append("release job must not call a reusable workflow")
+
     for step in _step_blocks(structural):
         declared = STEP_USES_RE.findall(step)
         if not declared:
@@ -1354,7 +1360,13 @@ def _check_release_job_sources(job: str) -> list[str]:
     # parsed count turns every such shape into a violation instead of a silent
     # gap, which is the difference between this rule binding and merely looking
     # like it does.
-    if len(STEP_USES_RE.findall(structural)) != len(parsed):
+    # Completeness, not just per-step correctness. _step_blocks only recognises
+    # canonical six-space steps, so a step list at any other indentation would
+    # otherwise be invisible here and pass. Count within the steps block only:
+    # a `uses` key elsewhere in the job -- a matrix dimension named `uses`, say --
+    # is data, not an action, and counting it would reject a valid job.
+    steps_block = _key_block(structural, "steps", indent=4)
+    if steps_block is not None and len(STEP_USES_RE.findall(steps_block)) != len(parsed):
         violations.append("release job declares an action outside a canonical step")
 
     # A job image runs arbitrary code under the same write token as the steps,
@@ -1572,6 +1584,15 @@ def check_workflow(workflow: Workflow) -> list[str]:
         violations.append("PR-triggered jobs must use canonical block form")
     if pr_triggered and any(name.startswith("<unparsed:") for name in jobs):
         violations.append("PR-triggered job definitions must use canonical block form")
+    # The same requirement for workflows a pull request cannot reach. Without it
+    # the release rules below are trivially evaded: a flow-style `jobs: {...}`
+    # is valid to GitHub and to actionlint, but the job parser returns either
+    # nothing or an <unparsed:...> entry, so every per-job rule is skipped and
+    # the workflow passes while running an arbitrary action.
+    if not pr_triggered and ("jobs:" not in workflow.text.splitlines() or not jobs):
+        violations.append("release jobs must use canonical block form")
+    if not pr_triggered and any(name.startswith("<unparsed:") for name in jobs):
+        violations.append("release job definitions must use canonical block form")
     job_names = [
         match.group("bare") or match.group("single") or match.group("double")
         for line in workflow.text.splitlines()
@@ -1654,7 +1675,7 @@ def check_workflow(workflow: Workflow) -> list[str]:
                     allowed_checkout_maps=CANDIDATE_CHECKOUT_MAPS.get(job_identity),
                 )
             )
-        if not pr_triggered:
+        if not pr_triggered and not job_name.startswith("<unparsed:"):
             violations.extend(_check_release_job_sources(job))
         if MODEL_SECRET_RE.search(job) and (workflow.path.name, job_name) not in {
             ("ai-review.yml", "ai-review"),

--- a/.github/tests/test_credential_containment.py
+++ b/.github/tests/test_credential_containment.py
@@ -40,6 +40,7 @@ from normalize_json import (  # noqa: E402
     normalize_preview_json,
 )
 from check_credential_containment import (  # noqa: E402
+    CHECKOUT_SOURCE,
     FROZEN_TRUST_ROOTS,
     RELEASE_ACTION_SOURCES,
     WASM_PACK_SOURCE,
@@ -1636,6 +1637,90 @@ jobs:
                 for item in self.check_fixture("engine-release.yml", ambiguous)
             )
         )
+
+    def test_release_job_cannot_hide_an_action_outside_a_canonical_step(self) -> None:
+        """Per-step correctness is not enough; the step list must be complete.
+
+        _step_blocks only recognises canonical six-space steps, so a job-level
+        `uses:` or a differently indented step list would be parsed as "no steps"
+        and pass a per-step allowlist unchallenged. Each of these shapes is a
+        working release job as far as GitHub is concerned.
+        """
+
+        reusable = """\
+name: engine-release
+on:
+  push:
+    tags: ["engine-v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    uses: attacker/evil-repo/.github/workflows/pwn.yml@main
+    secrets: inherit
+"""
+        self.assertTrue(
+            any(
+                "release job declares an action outside a canonical step" in item
+                for item in self.check_fixture("engine-release.yml", reusable)
+            ),
+            "a reusable workflow call escaped the release allowlist",
+        )
+
+        misindented = """\
+name: engine-release
+on:
+  push:
+    tags: ["engine-v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+        - uses: attacker/evil-action@1111111111111111111111111111111111111111
+"""
+        self.assertTrue(
+            any(
+                "release job declares an action outside a canonical step" in item
+                for item in self.check_fixture("engine-release.yml", misindented)
+            ),
+            "a non-canonical step indentation escaped the release allowlist",
+        )
+
+    def test_release_job_cannot_run_a_container_image(self) -> None:
+        """A job image runs arbitrary code under the same write token as a step."""
+
+        for key, value in (("container", "attacker/evil-image:latest"), ("services", "")):
+            block = f"    {key}: {value}\n" if value else (
+                "    services:\n      db:\n        image: attacker/evil-image:latest\n"
+            )
+            workflow = f"""\
+name: engine-release
+on:
+  push:
+    tags: ["engine-v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+{block}    steps:
+      - uses: {CHECKOUT_SOURCE}
+"""
+            self.assertTrue(
+                any(
+                    f"release job declares a {key}" in item
+                    for item in self.check_fixture("engine-release.yml", workflow)
+                ),
+                f"a hostile {key} escaped the release rules",
+            )
 
     def test_pinned_release_actions_resolve_to_their_commented_versions(self) -> None:
         """Every allow-listed release action must be pinned to a real 40-hex commit.

--- a/.github/tests/test_credential_containment.py
+++ b/.github/tests/test_credential_containment.py
@@ -1822,6 +1822,44 @@ jobs:
                 f"a hostile {key} escaped the release rules",
             )
 
+    def test_release_rules_reject_multiline_scalar_steps_by_design(self) -> None:
+        """A multi-line scalar whose continuation starts with `uses:` is rejected.
+
+        This is a deliberate restriction, not an oversight. Recognising a plain or
+        quoted multi-line scalar needs a real YAML parser, which this checker
+        forgoes on purpose so the same trusted file can run in the minimal policy
+        job. The failure is closed: the continuation is counted as an action the
+        step parser missed, so a workflow using that shape is rejected and the
+        author reformats. A scalar can never hide an executed step in the other
+        direction -- `_step_blocks` splits on the six-space step prefix
+        unconditionally -- which is what makes the restriction safe to keep.
+
+        Pinned here so a future reader sees an intended boundary rather than a bug.
+        """
+
+        workflow = f"""\
+name: engine-release
+on:
+  push:
+    tags: ["engine-v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: a title
+          uses: not/an-action@1111111111111111111111111111111111111111
+      - uses: {CHECKOUT_SOURCE}
+"""
+        violations = self.check_fixture("engine-release.yml", workflow)
+        self.assertTrue(
+            any("release" in item for item in violations),
+            "multi-line scalar steps must fail closed",
+        )
+
     def test_pinned_release_actions_resolve_to_their_commented_versions(self) -> None:
         """Every allow-listed release action must be pinned to a real 40-hex commit.
 

--- a/.github/tests/test_credential_containment.py
+++ b/.github/tests/test_credential_containment.py
@@ -1692,6 +1692,45 @@ jobs:
             "a non-canonical step indentation escaped the release allowlist",
         )
 
+    def test_release_rules_read_structure_not_run_script_bodies(self) -> None:
+        """A `run:` body is shell, not an action source.
+
+        The completeness check counts `uses:` occurrences, so a heredoc that
+        writes out a workflow file - which legitimately contains `- uses:` lines -
+        would be counted as an action the step parser missed and reject a valid
+        job. `_check_unprivileged_job` already reads structural text for the same
+        reason; the release rules must too.
+        """
+
+        workflow = f"""\
+name: engine-release
+on:
+  push:
+    tags: ["engine-v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # uses: attacker/evil-action@1111111111111111111111111111111111111111
+      - name: generate a workflow
+        run: |
+          cat > wf.yml <<'EOF'
+          steps:
+            - uses: someone/else@2222222222222222222222222222222222222222
+          EOF
+      - uses: {CHECKOUT_SOURCE}
+"""
+        violations = [
+            item
+            for item in self.check_fixture("engine-release.yml", workflow)
+            if "release" in item
+        ]
+        self.assertEqual(violations, [], "release rules read a run: body as an action")
+
     def test_release_job_cannot_run_a_container_image(self) -> None:
         """A job image runs arbitrary code under the same write token as a step."""
 

--- a/.github/tests/test_credential_containment.py
+++ b/.github/tests/test_credential_containment.py
@@ -39,7 +39,12 @@ from normalize_json import (  # noqa: E402
     extract_command_object,
     normalize_preview_json,
 )
-from check_credential_containment import FROZEN_TRUST_ROOTS, check_repository  # noqa: E402
+from check_credential_containment import (  # noqa: E402
+    FROZEN_TRUST_ROOTS,
+    RELEASE_ACTION_SOURCES,
+    WASM_PACK_SOURCE,
+    check_repository,
+)
 from preview_comment import (  # noqa: E402
     COMMENT_MARKER,
     MAX_COMMENT_BYTES,
@@ -1081,7 +1086,7 @@ jobs:
   payload:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - run: ./payload/run.sh
@@ -1292,7 +1297,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out exact candidate policy input
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
@@ -1553,6 +1558,102 @@ jobs:
         violations = self.check_fixture("engine-evals.yml", workflow)
         self.assertTrue(any("duplicate top-level" in item for item in violations))
 
+    def test_release_workflow_cannot_run_an_unreviewed_action(self) -> None:
+        workflow = self.read(".github/workflows/engine-release.yml").replace(
+            "      - uses: actions/checkout@"
+            "3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1",
+            "      - uses: attacker/evil-action@"
+            "1111111111111111111111111111111111111111 # v1",
+            1,
+        )
+        violations = self.check_fixture("engine-release.yml", workflow)
+        self.assertTrue(
+            any("release step action source is not allow-listed" in item for item in violations)
+        )
+
+    def test_every_release_workflow_rejects_an_unreviewed_action(self) -> None:
+        """The rule must bind on each credentialed non-pull-request workflow.
+
+        Covering only engine-release.yml would let a sibling release workflow
+        regress silently, which is how this gap existed in the first place.
+        """
+
+        workflows = REPOSITORY_ROOT / ".github" / "workflows"
+        covered = []
+        for path in sorted(workflows.glob("*.yml")):
+            text = path.read_text()
+            if "\n  pull_request:" in text or "\n  pull_request_target:" in text:
+                continue
+            if "\n      - uses: " not in text:
+                continue
+            covered.append(path.name)
+            hostile = text.replace(
+                "\n      - uses: ",
+                "\n      - uses: attacker/evil-action@"
+                "1111111111111111111111111111111111111111\n      - uses: ",
+                1,
+            )
+            violations = self.check_fixture(path.name, hostile)
+            self.assertTrue(
+                any(
+                    "release step action source is not allow-listed" in item
+                    for item in violations
+                ),
+                f"{path.name} did not reject an unreviewed action source",
+            )
+        self.assertIn("engine-release.yml", covered)
+        self.assertIn("engine-wasm-release.yml", covered)
+        self.assertIn("sdk-release.yml", covered)
+        self.assertIn("dagster-release.yml", covered)
+        self.assertIn("vscode-release.yml", covered)
+
+    def test_release_step_local_action_and_ambiguous_uses_fail_closed(self) -> None:
+        base = self.read(".github/workflows/engine-release.yml")
+        local = base.replace(
+            "      - uses: actions/checkout@"
+            "3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1",
+            "      - uses: ./.github/actions/rocky-preview",
+            1,
+        )
+        self.assertTrue(
+            any(
+                "release step runs a repository-local action" in item
+                for item in self.check_fixture("engine-release.yml", local)
+            )
+        )
+        ambiguous = base.replace(
+            "      - uses: actions/checkout@"
+            "3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1",
+            "      - uses: actions/checkout@"
+            "3d3c42e5aac5ba805825da76410c181273ba90b1\n"
+            "        uses: attacker/evil-action@"
+            "1111111111111111111111111111111111111111",
+            1,
+        )
+        self.assertTrue(
+            any(
+                "release step declares more than one action source" in item
+                for item in self.check_fixture("engine-release.yml", ambiguous)
+            )
+        )
+
+    def test_pinned_release_actions_resolve_to_their_commented_versions(self) -> None:
+        """Every allow-listed release action must be pinned to a real 40-hex commit.
+
+        engine-wasm-release.yml shipped a wasm-pack pin that shared a 25-character
+        prefix with the real v0.4.0 commit and then diverged, so the action could
+        never resolve. A malformed pin is indistinguishable from a correct one by
+        eye, so assert the shape here and keep the allowlist the single source.
+        """
+
+        for source in RELEASE_ACTION_SOURCES:
+            owner_repo, _, sha = source.partition("@")
+            self.assertRegex(sha, r"^[0-9a-f]{40}$", f"{owner_repo} is not SHA-pinned")
+            self.assertIn("/", owner_repo)
+
+        workflows = REPOSITORY_ROOT / ".github" / "workflows"
+        wasm = (workflows / "engine-wasm-release.yml").read_text()
+        self.assertIn(WASM_PACK_SOURCE, wasm)
 
 class WorkflowPolicyTests(unittest.TestCase):
     def read(self, relative_path: str) -> str:

--- a/.github/tests/test_credential_containment.py
+++ b/.github/tests/test_credential_containment.py
@@ -1663,7 +1663,7 @@ jobs:
 """
         self.assertTrue(
             any(
-                "release job declares an action outside a canonical step" in item
+                "release job must not call a reusable workflow" in item
                 for item in self.check_fixture("engine-release.yml", reusable)
             ),
             "a reusable workflow call escaped the release allowlist",
@@ -1691,6 +1691,67 @@ jobs:
             ),
             "a non-canonical step indentation escaped the release allowlist",
         )
+
+    def test_release_workflow_must_use_canonical_block_jobs(self) -> None:
+        """Flow-style jobs would otherwise skip every per-job release rule.
+
+        `jobs: {build: {...}}` is valid to GitHub and passes actionlint, but the
+        job parser returns either nothing or an `<unparsed:...>` entry, so the
+        per-job loop never runs the release rules and the workflow passes while
+        executing an arbitrary action. The pull-request side already rejects this
+        shape; workflows a pull request cannot reach must too.
+        """
+
+        header = (
+            "name: engine-release\non:\n  push:\n    tags: [\"engine-v*\"]\n\n"
+            "permissions:\n  contents: write\n\n"
+        )
+        evil = "attacker/evil-action@1111111111111111111111111111111111111111"
+        for label, body in (
+            ("inline jobs mapping", "jobs: {build: {runs-on: ubuntu-latest, steps: [{uses: %s}]}}\n" % evil),
+            ("flow-style job body", "jobs:\n  build: {runs-on: ubuntu-latest, steps: [{uses: %s}]}\n" % evil),
+            ("inline reusable workflow", "jobs: {build: {uses: attacker/evil/.github/workflows/p.yml@main}}\n"),
+        ):
+            violations = self.check_fixture("engine-release.yml", header + body)
+            self.assertTrue(
+                any("must use canonical block form" in item for item in violations),
+                f"{label} escaped the release rules",
+            )
+
+    def test_release_completeness_ignores_non_step_uses_keys(self) -> None:
+        """A `uses` key outside the steps block is data, not an action.
+
+        A matrix dimension named `uses` sits at a deeper indentation than the
+        step parser recognises, so counting `uses:` across the whole job would
+        read it as a missed action and reject a valid workflow.
+        """
+
+        workflow = f"""\
+name: engine-release
+on:
+  push:
+    tags: ["engine-v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - uses: linux
+          - uses: macos
+    steps:
+      - uses: {CHECKOUT_SOURCE}
+"""
+        violations = [
+            item
+            for item in self.check_fixture("engine-release.yml", workflow)
+            if "release" in item
+        ]
+        self.assertEqual(violations, [], "matrix data was read as an action source")
 
     def test_release_rules_read_structure_not_run_script_bodies(self) -> None:
         """A `run:` body is shell, not an action source.

--- a/.github/workflows/engine-wasm-release.yml
+++ b/.github/workflows/engine-wasm-release.yml
@@ -71,7 +71,7 @@ jobs:
       # Prebuilt binary — avoids ~40s of `cargo install wasm-pack --locked`
       # per run and skips a transitive compilation that occasionally trips
       # MSRV / yanked-crate failures.
-      - uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e0cafa345d365d15 # v0.4.0
+      - uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
         with:
           version: 'v0.13.1'
 


### PR DESCRIPTION
Follow-up to #1265 / #1276. **This is a frozen-trust-root change**, so `Credential containment policy` is expected to be red — see the bootstrap procedure in `.github/SECURITY_ENVIRONMENTS.md`.

## The gap

Every substantive action-source rule in `check_credential_containment.py` sits behind a `pr_triggered` guard. Release, publish and deployment workflows are triggered by tag or branch pushes, so they received YAML hygiene checks and nothing else — no action-source validation at all. Those jobs hold `contents: write` and the publishing secrets, which made an unreviewed action source in one of their steps a direct supply-chain path into the binaries `engine/install.sh` serves.

14 jobs across 8 workflows were in that state: `engine-release`, `engine-wasm-release`, `sdk-release`, `dagster-release`, `vscode-release`, `engine-docs`, `engine-evals-live`, `preview-comment`.

Neither did any required status check cover them: the five required contexts are all path-filtered on `engine/**`, so a PR editing only a release workflow triggers none of them.

## The fix

Every job **not reachable from a pull request** may now only run actions in `RELEASE_ACTION_SOURCES`, a pinned allowlist. Parsing fails closed — a step whose `uses:` cannot be read as exactly one pinned remote source is a violation rather than something to skip, and a repository-local action in such a job is rejected outright.

Scoping to *all* non-PR jobs rather than only demonstrably credentialed ones costs nothing: both sets resolve to the same 14 sources, so the broader and simpler invariant is the one enforced.

## A corrupted pin, found while verifying provenance

Every SHA was checked against its upstream tag before being added to the allowlist. One did not resolve:

```
engine-wasm-release.yml pinned:  0d096b08b4e5a7de8c28de67e0cafa345d365d15  # v0.4.0
jetli/wasm-pack-action v0.4.0:   0d096b08b4e5a7de8c28de67e11e945404e9eefa
common prefix:                   0d096b08b4e5a7de8c28de67e  (25 chars, then diverges)
```

`git ls-remote` matches no ref against the pinned value, and the REST API returns `422 No commit found`. The action could never resolve; the pin has been wrong since it was introduced. Corrected, and now asserted from the allowlist so it cannot regress silently.

## Evidence

- `check_credential_containment.py .` → `passed` on the real tree (no false positives)
- `python3 -m unittest discover -s .github/tests` → **104 passed**
- `actionlint` → exit 0
- **Mutation-checked, three cells.** Removing only the two-line enforcement wiring makes 3 of the 4 new tests fail; additionally reverting the wasm pin makes the 4th fail too. The tests bind on what they name rather than passing incidentally.
- `test_every_release_workflow_rejects_an_unreviewed_action` iterates every non-PR workflow rather than hardcoding one, so a sibling release workflow cannot regress silently — which is how this gap arose.