### PR TITLE
fix(engine/rocky-cli): execute the apply gate's config snapshot on the --dag path

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.68.0] - 2026-07-31
+### Fixed
+
+- **`rocky apply` of a `--dag` run plan now executes the config its apply gate approved, instead of re-reading `rocky.toml`.** `execute_run_plan` documents on its own `loaded` parameter that it performs no config load of its own — the single fingerprinted snapshot (#1120) is threaded from gate through execution so a `rocky.toml` swap in that window cannot make execution diverge from what was reviewed. The `--dag` branch broke that invariant: it passed only `config_path` onward, and `run_with_dag` loaded and fingerprinted the file again. A write to `rocky.toml` between the gate and DAG execution therefore ran a different adapter, different targets and different governance than the gate approved, while still reporting success against the reviewed plan id — and the plan-identity checks (`config_policy_identity`) had already run against the gate's snapshot, not the reloaded one. The non-DAG apply path threaded the snapshot correctly, so this was the only apply that re-read. `run_with_dag` now takes the snapshot as a **required** parameter rather than an `Option`, so the fallback load is gone entirely and a future caller cannot silently reopen the window — the same shape `run_seed` / `run_load` adopted for #1120. `rocky run --dag`, which has no gate above it, loads the one snapshot in `main.rs` and hands it down. Narrow in practice (it needs a write inside the gate→execute window) but it was a documented invariant the path silently did not hold. (#1289)
 
 ### Added
 

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -656,6 +656,12 @@ async fn execute_run_plan(
         // contract.
         return crate::commands::run_with_dag(
             config_path,
+            // The gate's own snapshot — NOT a re-read (#1289). `execute_run_plan`
+            // documents on its `loaded` parameter that it performs no config load
+            // of its own; this branch used to violate that by handing `run_with_dag`
+            // only a path, which then loaded the file again after the gate had
+            // fingerprinted it.
+            std::sync::Arc::clone(&loaded),
             state_path,
             output_json,
             &partition_opts,
@@ -4056,6 +4062,110 @@ mod tests {
             "the plan's requested partition must be the one that was rebuilt"
         );
         assert_eq!(rows.rows[0][0].as_str(), Some("2020-01-01"));
+    }
+
+    /// #1289: a `--dag` apply executes the snapshot its GATE read, not a fresh
+    /// `rocky.toml`.
+    ///
+    /// `execute_run_plan` documents on its own `loaded` parameter that it
+    /// performs no config load of its own, but the `--dag` branch passed only
+    /// `config_path` onward and `run_with_dag` then re-read the file — so this
+    /// was the one apply path that reopened the gate→execution swap window
+    /// #1120 closed everywhere else.
+    ///
+    /// The drill is the seed-leg drill from `run_dag_exec`, applied one level
+    /// up: capture the snapshot (adapter → warehouse A), overwrite
+    /// `rocky.toml` to point at warehouse B, then apply. Both DuckDB files
+    /// share the STEM `proj`, so `catalog = "proj"` is valid under either
+    /// config and only the physical path differs — the config swap is the sole
+    /// variable.
+    ///
+    /// Non-vacuous by construction, in two directions: pre-fix the reload
+    /// picks up config B, so the rows land in B (failing the row assertion)
+    /// and opening B's adapter creates the file (failing the `!exists`
+    /// assertion). Post-fix nothing re-reads `rocky.toml`, so B is never
+    /// opened and its file is never created. It also expects `Ok`, so an
+    /// earlier gate turning this into an error fails it too — unlike
+    /// `a_stored_dag_shadow_plan_carries_its_shadow_routing_into_execution`,
+    /// whose `Err` arm fires *after* the load and is therefore identical
+    /// before and after this fix.
+    #[tokio::test]
+    async fn a_stored_dag_plan_executes_the_gates_snapshot_not_a_reload() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let models = root.join("models");
+        std::fs::create_dir(&models).unwrap();
+        std::fs::create_dir(root.join("a")).unwrap();
+        std::fs::create_dir(root.join("b")).unwrap();
+
+        let db_a = root.join("a/proj.duckdb");
+        let db_b = root.join("b/proj.duckdb");
+        let config_path = root.join("rocky.toml");
+        let config_for = |db: &std::path::Path| {
+            format!(
+                "[adapter.local]\n\
+                 type = \"duckdb\"\n\
+                 path = \"{}\"\n\n\
+                 [pipeline.silver]\n\
+                 type = \"transformation\"\n\n\
+                 [pipeline.silver.target]\n\
+                 adapter = \"local\"\n\n\
+                 [pipeline.silver.target.governance]\n\
+                 auto_create_catalogs = true\n\
+                 auto_create_schemas = true\n",
+                db.display()
+            )
+        };
+
+        std::fs::write(models.join("orders.sql"), "SELECT 1 AS v\n").unwrap();
+        std::fs::write(
+            models.join("orders.toml"),
+            "depends_on = []\n\n\
+             [strategy]\ntype = \"full_refresh\"\n\n\
+             [target]\ncatalog = \"proj\"\nschema = \"marts\"\ntable = \"orders\"\n",
+        )
+        .unwrap();
+
+        // The gate reads config A and fingerprints it.
+        std::fs::write(&config_path, config_for(&db_a)).unwrap();
+        let loaded = std::sync::Arc::new(
+            rocky_core::config::load_rocky_config_fingerprinted(&config_path).unwrap(),
+        );
+
+        // The swap window: `rocky.toml` now routes to a different warehouse.
+        std::fs::write(&config_path, config_for(&db_b)).unwrap();
+
+        execute_run_plan(
+            &config_path,
+            loaded,
+            "plan-dag-snapshot",
+            RunPlan {
+                dag: true,
+                models: vec![],
+                execution_layers: vec![],
+                ..minimal_run_plan()
+            },
+            &root.join(".rocky-state.redb"),
+            false,
+            "apply-run-id",
+            // A human apply: the governed `--dag` refusal does not apply.
+            None,
+        )
+        .await
+        .expect("a stored --dag plan must apply cleanly");
+
+        assert!(
+            !db_b.exists(),
+            "the swapped-in config must never be read: opening warehouse B would create its file"
+        );
+
+        let adapter = rocky_duckdb::adapter::DuckDbWarehouseAdapter::open(&db_a).unwrap();
+        let conn = adapter.shared_connector();
+        let guard = conn.lock().unwrap();
+        let rows = guard
+            .execute_sql("SELECT v FROM proj.marts.orders")
+            .expect("the gate's snapshot routed the build into warehouse A");
+        assert_eq!(rows.rows.len(), 1, "the model materialized in warehouse A");
     }
 
     fn minimal_run_plan() -> RunPlan {

--- a/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
+++ b/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
@@ -164,6 +164,18 @@ fn models_dir_for_model_scope(
 /// `rocky run` invocation — it must never invent its own `.rocky_state` file.
 pub async fn run_with_dag(
     config_path: &Path,
+    // The caller's ONE fingerprinted config snapshot (#1120). Taken as a
+    // parameter rather than loaded here so a governed `rocky apply` of a
+    // `--dag` plan executes the *same instance* its apply gate read and
+    // fingerprinted: this function performs NO config load of its own, and a
+    // `rocky.toml` swap between the gate and DAG execution can no longer make
+    // the DAG run a different config than the one that was approved (#1289).
+    //
+    // Non-optional on purpose. An `Option` would leave a fallback load in
+    // place, so a future caller could silently reopen the window; requiring
+    // the snapshot enforces "no config read" at compile time, the same shape
+    // `run_seed` / `run_load` adopted for #1120.
+    loaded: std::sync::Arc<rocky_core::config::LoadedConfig>,
     state_path: &Path,
     json: bool,
     // The caller's time-interval partition options. Every sub-run must receive
@@ -197,10 +209,12 @@ pub async fn run_with_dag(
     // (`Arc::clone` per node in the dispatcher), so a `rocky.toml` swap
     // mid-DAG cannot make later nodes execute a different config than the
     // one the DAG was built from.
-    let loaded = std::sync::Arc::new(
-        rocky_core::config::load_rocky_config_fingerprinted(config_path)
-            .with_context(|| format!("failed to load config from {}", config_path.display()))?,
-    );
+    //
+    // It now arrives from the caller (#1289) rather than being loaded here.
+    // Loading it here made this the ONE apply path that re-read `rocky.toml`
+    // after its gate had already read and fingerprinted it, so a swap in that
+    // window executed a config the gate never approved while still reporting
+    // success against the reviewed plan id.
     let cfg = &loaded.config;
 
     // Load models from the model set each transformation pipeline actually
@@ -1092,6 +1106,19 @@ mod tests {
 
     use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
 
+    /// The one config snapshot every [`run_with_dag`] caller must supply
+    /// (#1289). Production callers get theirs from the apply gate; a test that
+    /// is not exercising the gate loads it the same way `rocky run --dag`
+    /// does. Tests that need to prove the snapshot is *honored* build it
+    /// themselves and then mutate `rocky.toml` — see
+    /// `a_stored_dag_plan_executes_the_gates_snapshot_not_a_reload`.
+    fn dag_snapshot(config_path: &Path) -> std::sync::Arc<rocky_core::config::LoadedConfig> {
+        std::sync::Arc::new(
+            rocky_core::config::load_rocky_config_fingerprinted(config_path)
+                .expect("test fixture config must load"),
+        )
+    }
+
     fn cell_i64(v: &serde_json::Value) -> i64 {
         v.as_i64()
             .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
@@ -1262,6 +1289,7 @@ mod tests {
         let state_path = root.join(".rocky-state.redb");
         run_with_dag(
             &config_path,
+            dag_snapshot(&config_path),
             &state_path,
             false,
             &PartitionRunOptions::default(),
@@ -1360,6 +1388,7 @@ mod tests {
         // Establish the production seed table: two rows.
         run_with_dag(
             &config_path,
+            dag_snapshot(&config_path),
             &state_path,
             false,
             &PartitionRunOptions::default(),
@@ -1383,6 +1412,7 @@ mod tests {
         };
         let err = run_with_dag(
             &config_path,
+            dag_snapshot(&config_path),
             &state_path,
             false,
             &PartitionRunOptions::default(),
@@ -1467,6 +1497,7 @@ mod tests {
         let state_path = root.join(".rocky-state.redb");
         run_with_dag(
             &config_path,
+            dag_snapshot(&config_path),
             &state_path,
             false,
             &PartitionRunOptions::default(),
@@ -1487,6 +1518,7 @@ mod tests {
         };
         run_with_dag(
             &config_path,
+            dag_snapshot(&config_path),
             &state_path,
             false,
             &PartitionRunOptions::default(),
@@ -1577,6 +1609,7 @@ mod tests {
         };
         run_with_dag(
             &root.join("rocky.toml"),
+            dag_snapshot(&root.join("rocky.toml")),
             &root.join(".rocky-state.redb"),
             false,
             &partition_opts,
@@ -1759,6 +1792,7 @@ mod tests {
 
         run_with_dag(
             &root.join("rocky.toml"),
+            dag_snapshot(&root.join("rocky.toml")),
             &root.join(".rocky-state.redb"),
             false,
             &PartitionRunOptions::default(),
@@ -1841,6 +1875,7 @@ mod tests {
 
         run_with_dag(
             &root.join("rocky.toml"),
+            dag_snapshot(&root.join("rocky.toml")),
             &root.join(".rocky-state.redb"),
             false,
             &PartitionRunOptions::default(),

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -3369,8 +3369,18 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                 )
                 .await
             } else if dag {
+                // `rocky run --dag` has no apply gate above it, so it loads the
+                // one snapshot itself and hands it down. `run_with_dag` takes it
+                // as a required parameter so that no caller can re-read the file
+                // between a gate and execution (#1289).
+                let loaded = std::sync::Arc::new(
+                    rocky_core::config::load_rocky_config_fingerprinted(&cli.config).with_context(
+                        || format!("failed to load config from {}", cli.config.display()),
+                    )?,
+                );
                 let run_future = rocky_cli::commands::run_with_dag(
                     &cli.config,
+                    loaded,
                     &state_path,
                     json,
                     &partition_opts,


### PR DESCRIPTION
## Summary

Closes #1289.

`rocky apply` of a `--dag` run plan reloaded `rocky.toml` after the apply gate had already read and fingerprinted it, reopening the gate→execution config-swap window that #1120's single-snapshot invariant closed for every other apply path.

`execute_run_plan` documents the invariant on its own `loaded` parameter — "this function performs NO config load of its own (its former `.ok()` re-load was a swap window between the gate and execution)". The `--dag` branch passed only `config_path` onward, and `run_with_dag` then called `load_rocky_config_fingerprinted` again, dropping the caller's snapshot on the floor. The non-DAG path below it threaded the snapshot correctly, so the DAG apply was the only apply that re-read.

A write to `rocky.toml` inside that window made the DAG execute a different adapter, different targets and different governance than the gate approved, while reporting success against the reviewed plan id — and `config_policy_identity` had already run against the gate's snapshot, not the reloaded one.

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Changes

- `run_with_dag` takes the caller's `Arc<LoadedConfig>` and performs no config load of its own. `run_dag_exec.rs` now contains **zero** non-test `load_rocky_config*` calls.
- `execute_run_plan`'s `--dag` branch threads its own `loaded` through, so both apply entrypoints (human and AI-authored — they share `execute_run_plan`) are covered by the one change.
- `rocky run --dag`, which has no gate above it, loads the one snapshot in `main.rs` and hands it down.

### Why the parameter is required rather than `Option`

The issue suggests an optional pre-loaded config. This uses a non-optional one instead, matching the shape the repo's own #1120 remediations chose for `run_seed` / `run_load`: an `Option` leaves the fallback load in place, so a future caller can pass `None` and silently reopen the window, and a regression test could only ever prove that *today's* apply passes `Some`. Requiring the snapshot enforces "no config read" at compile time. `config_path` stays alongside it — `run_with_dag` still needs the path for relative resolution in four other places (`load_transformation_models`, the `seeds` dir, the `CliDispatcher`, and `default_sub_runner`).

## Test Plan

New regression test `a_stored_dag_plan_executes_the_gates_snapshot_not_a_reload`.

**The test named in the issue as a template is vacuous for this purpose.** `a_stored_dag_shadow_plan_carries_its_shadow_routing_into_execution` sets `shadow: true` and asserts an `Err` from the DAG's shadow refusal — which fires *after* the config load, so both the old and new config produce the identical error and nothing is ever materialized. Pre-fix and post-fix outcomes are byte-identical. It is a usable harness but an unusable assertion.

The new test instead composes the harness from `a_stored_dag_partition_plan_rebuilds_that_partition_not_the_latest` (same `execute_run_plan` `--dag` entry, `shadow: false`, expects `Ok` and real rows — so an earlier gate turning it into an error fails it too) with the A/B swap drill from `seed_dispatch_executes_the_captured_snapshot_not_a_reload`: two DuckDB files sharing the stem `proj`, so `catalog = "proj"` is valid under either config and only the physical path differs. Capture the snapshot pointing at warehouse A, overwrite `rocky.toml` to point at B, apply, then assert the rows landed in A **and** that B's file was never created (DuckDB creates the file on open, so opening B at all is observable).

**Mutation-checked, not just green.** Restoring the pre-fix reload inside `run_with_dag` makes the test fail on exactly the intended assertion:

```
panicked at crates/rocky-cli/src/commands/apply.rs:4157:
the swapped-in config must never be read: opening warehouse B would create its file
test result: FAILED. 0 passed; 1 failed
```

Gates:

- `cargo nextest run --all-features` — **5,799 passed**, 0 failed, 108 skipped.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- Verified `run_dag_exec.rs` has no remaining non-test config load.

## Scope

This closes the **config** swap window only. Model files are still read from disk at DAG execute time, and no models-fingerprint gate is in play because a governed `--dag` apply is refused outright (`apply.rs`: "a `--dag` apply is not yet policy-gated"). That refusal is unchanged.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/), scoped by subproject
- [x] No `Co-Authored-By` trailers
- [x] Not a CLI JSON schema or DSL syntax change, so no consumer updates are required

### Engine (`engine/`)
- [x] `cargo test --all-targets` passes (all-features nextest run)
- [x] `cargo clippy --all-targets -- -D warnings` is clean
- [x] `cargo fmt --check` passes
