### PR TITLE
fix(engine/rocky-cli): load models below the first subdirectory level

### DIFF
--- a/docs/src/content/docs/advanced/troubleshooting.md
+++ b/docs/src/content/docs/advanced/troubleshooting.md
@@ -16,7 +16,7 @@ A model references another model that doesn't exist in the project.
 **Possible causes:**
 - The referenced model file is missing or misnamed
 - The `name` field in the `.toml` sidecar doesn't match the file name
-- The model is in a subdirectory that Rocky isn't scanning
+- The model is in a subdirectory. `rocky list models` and `rocky dag` walk the whole tree under `models/`, but the compiler reads only the models directory itself, so `rocky compile` treats `models/staging/stg_orders.sql` as absent
 
 **Fix:** Check that the referenced model exists in `models/` and its `name` field matches. Rocky auto-discovers dependencies from SQL table references; bare names matching model file names become DAG edges.
 

--- a/docs/src/content/docs/reference/commands/development.md
+++ b/docs/src/content/docs/reference/commands/development.md
@@ -543,7 +543,7 @@ rocky list deps <model>      # What this model depends on
 rocky list consumers <model> # What depends on this model
 ```
 
-All subcommands support `--output json` via `-o json`. Models are discovered from the `models/` directory (and immediate subdirectories for the common `models/{layer}/` layout).
+All subcommands support `--output json` via `-o json`. Models are discovered from the `models/` directory and every directory beneath it, so both `models/{layer}/` and `models/marts/core/` are picked up. Each directory is read on its own, so a per-directory `_defaults.toml` applies to the models beside it. Nesting deeper than 64 levels is reported as an error rather than skipped.
 
 See the [CLI Reference](/reference/cli/#rocky-list) for full examples and JSON output schemas.
 - [`rocky validate`](/reference/commands/core-pipeline/#rocky-validate) -- validate config after registering the adapter

--- a/engine/crates/rocky-cli/src/api.rs
+++ b/engine/crates/rocky-cli/src/api.rs
@@ -1926,7 +1926,7 @@ mod tests {
     /// `--column-lineage` must not fail on the ordinary nested layout: staging
     /// models one level down feeding marts at the root.
     ///
-    /// The model loader reads the root plus one level below; the lineage compile
+    /// The model loader walks the whole tree below the root; the lineage compile
     /// reads only the root. So `fct` is compiled while the `stg` it selects from
     /// is invisible, and the compiler reports `unknown dependency 'stg'`. That
     /// is an artifact of the shallower read, not a defect in the project.

--- a/engine/crates/rocky-cli/src/commands/branch.rs
+++ b/engine/crates/rocky-cli/src/commands/branch.rs
@@ -1068,8 +1068,8 @@ async fn discover_replication_branch_targets(
 
 /// Transformation pipeline path for [`discover_branch_targets`].
 ///
-/// Walks the model files under the pipeline's `models` glob (top-level +
-/// immediate subdirectories — same surface `rocky list models` and the
+/// Walks the model files under the pipeline's `models` glob (the root and
+/// every directory below it — same surface `rocky list models` and the
 /// catalog scope resolver use) and emits one `(prod, branch_source)` pair
 /// per model. Each model's sidecar `[target]` block supplies the production
 /// catalog/schema/table; the branch source rewrites the schema to the
@@ -1133,9 +1133,20 @@ fn discover_transformation_branch_targets(
         );
     }
 
-    // Load the same way `rocky list models` does: top-level files plus
-    // immediate subdirectories (incl. `.rocky` DSL). Keeps behavior consistent
-    // with the rest of the transformation surface (run, plan, list).
+    // Load the same way `rocky list models` does: top-level files plus every
+    // directory below them (incl. `.rocky` DSL). That matches `list` and `dag`,
+    // NOT the compile a plain `run` drives, which reads only the top level.
+    //
+    // **No collision validation runs on this path, at any depth.** Promotion
+    // emits one step per model straight from this list without compiling, so
+    // the E036 two-models-one-physical-table diagnostic never fires here —
+    // not for a subdirectory model, and not for two top-level ones either.
+    // Two models sharing a target therefore promote as two `CREATE OR REPLACE`
+    // against one table, last writer wins. Recursing the loader (#1262) did not
+    // open that hole, but it does hand this path more models, so more
+    // collisions can reach it. Closing it needs a collision check the
+    // destructive consumers of a raw model set share — `gc`, `apply` and this
+    // one — rather than a bespoke one bolted on here.
     let all_models = crate::models_loader::load_project_models(&models_dir)?;
 
     let shadow_cfg = ShadowConfig {

--- a/engine/crates/rocky-cli/src/commands/compliance.rs
+++ b/engine/crates/rocky-cli/src/commands/compliance.rs
@@ -202,7 +202,7 @@ fn strategy_wire_name(s: MaskStrategy) -> &'static str {
     s.as_str()
 }
 
-/// Recursive model loader (top level + one level of subdirectories,
+/// Recursive model loader (the models root and every directory below it,
 /// including `.rocky` DSL files).
 fn load_all_models(models_dir: &Path) -> Result<Vec<Model>> {
     let mut all = crate::models_loader::load_project_models(models_dir)?;

--- a/engine/crates/rocky-cli/src/commands/dag.rs
+++ b/engine/crates/rocky-cli/src/commands/dag.rs
@@ -39,13 +39,13 @@ const DAG_SCHEMA_VERSION: &str = "1";
 /// Three states rather than an `Option`, because "no root" and "several roots"
 /// both lack a single directory to compile but mean opposite things: the first
 /// has no lineage to report, the second has lineage this command cannot see.
-/// Both currently produce an empty list; keeping them apart is what lets #1262
-/// give the second one a real answer without disturbing the first.
+/// Both currently produce an empty list; keeping them apart is what lets a
+/// later fix give the second one a real answer without disturbing the first.
 enum LineageSource {
-    /// Compile this directory. Note this still inherits #1262: the compiler
-    /// reads the directory itself, while the model loader also reads one level
-    /// below it, so a project keeping its models in `<root>/staging/` has models
-    /// in the DAG that the compile cannot see.
+    /// Compile this directory. Note the compiler reads only the directory
+    /// itself, while the model loader walks the whole tree below it, so a
+    /// project keeping its models in `<root>/staging/` has models in the DAG
+    /// that the compile cannot see.
     Root(std::path::PathBuf),
     /// No transformation models exist, so no lineage does either. Empty is the
     /// complete answer.
@@ -464,7 +464,7 @@ fn build_column_lineage_from_models(
     //
     // This tolerance is pre-existing and is deliberately left alone. Propagating
     // these errors looks obviously right and is not: the compiler reads only the
-    // top level of `models_dir` while the model loader also reads one level
+    // top level of `models_dir` while the model loader walks every directory
     // below it, so the ordinary `models/staging/stg.sql` → `models/fct.sql`
     // layout compiles to `unknown dependency 'stg' referenced by 'fct'` — a
     // artifact of the shallower read, not a defect in the project. Surfacing it
@@ -524,7 +524,7 @@ fn union_by_model_name(by_pipeline: &rocky_core::unified_dag::ModelsByPipeline) 
     all
 }
 
-/// Load models from a directory and its immediate subdirectories
+/// Load models from a directory and every directory below it, at any depth
 /// (including `.rocky` DSL files), sorted by name.
 pub(super) fn load_all_models(models_dir: &Path) -> Result<Vec<Model>> {
     let mut all = crate::models_loader::load_project_models(models_dir)?;

--- a/engine/crates/rocky-cli/src/commands/estimate.rs
+++ b/engine/crates/rocky-cli/src/commands/estimate.rs
@@ -161,7 +161,7 @@ async fn run_explain(
     })
 }
 
-/// Load all models from a directory including one level of subdirectories
+/// Load all models from a directory and every directory below it
 /// (including `.rocky` DSL files).
 fn load_all_models(models_dir: &Path) -> Result<Vec<models::Model>> {
     let mut all = crate::models_loader::load_project_models(models_dir)?;

--- a/engine/crates/rocky-cli/src/commands/list.rs
+++ b/engine/crates/rocky-cli/src/commands/list.rs
@@ -125,8 +125,8 @@ pub fn list_models_output(models_dir: &Path) -> Result<ListModelsOutput> {
     Ok(ListModelsOutput::new(build_model_entries(models_dir)?))
 }
 
-/// Build the model-entry rows by loading the models directory (with the
-/// one-level subdirectory scan).
+/// Build the model-entry rows by loading the models directory (walking every
+/// subdirectory below it).
 fn build_model_entries(models_dir: &Path) -> Result<Vec<ListModelEntry>> {
     let models = load_all_models(models_dir)?;
 
@@ -165,9 +165,10 @@ fn build_model_entries(models_dir: &Path) -> Result<Vec<ListModelEntry>> {
 
 /// Execute `rocky list models`.
 ///
-/// Loads models from the given directory and all immediate subdirectories
-/// (handles the common `models/{layer}/*.sql` layout). Each subdirectory
-/// is scanned independently so per-directory `_defaults.toml` files work.
+/// Loads models from the given directory and every directory below it, at any
+/// depth (handles the common `models/{layer}/*.sql` layout, and `models/marts/
+/// core/` too). Each directory is scanned independently so per-directory
+/// `_defaults.toml` files work.
 pub fn list_models(models_dir: &Path, json: bool) -> Result<()> {
     let entries = build_model_entries(models_dir)?;
 
@@ -259,7 +260,8 @@ pub fn list_sources(config_path: &Path, json: bool) -> Result<()> {
     Ok(())
 }
 
-/// Load all models from a directory (with subdirectory scan, incl. `.rocky`).
+/// Load all models from a directory and every directory below it (incl.
+/// `.rocky`).
 fn load_all_models(models_dir: &Path) -> Result<Vec<rocky_core::models::Model>> {
     let mut all = crate::models_loader::load_project_models(models_dir)?;
     all.sort_unstable_by(|a, b| a.config.name.cmp(&b.config.name));

--- a/engine/crates/rocky-cli/src/commands/optimize.rs
+++ b/engine/crates/rocky-cli/src/commands/optimize.rs
@@ -172,7 +172,7 @@ fn load_dag_from_models(models_dir: Option<&Path>) -> Vec<DagNode> {
         return vec![];
     };
 
-    // Top-level + immediate subdirectories, including `.rocky` DSL files.
+    // The models root and every directory below it, including `.rocky` DSL files.
     // Partial: this drives advisory downstream-reference counts, so one broken
     // draft model must not silently collapse every healthy count to zero.
     let (all_models, _load_errors) = crate::models_loader::load_project_models_partial(dir);

--- a/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
+++ b/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
@@ -384,8 +384,11 @@ pub async fn run_with_dag(
 /// nothing and can never fail on a `models/` directory it would not have
 /// executed. Each pipeline's base directory is derived from its `models` setting
 /// exactly the way [`super::run`] derives it, so `--dag` and a plain run agree
-/// on which files are in scope. Note this is a base directory plus one level of
-/// subdirectory, NOT true glob matching — see `crate::models_loader` and #1262.
+/// on the base DIRECTORY. They do not agree on the file set: this walks the
+/// whole tree below that base, while the compile a plain run drives reads only
+/// the base itself. Note also that the base is walked in full, NOT glob-matched:
+/// `models/*.sql` and `models/**` both load everything under `models` — see
+/// `crate::models_loader`.
 ///
 /// A missing directory is not an error here — that matches `run`, which treats
 /// an absent models directory as a no-op rather than a failure.
@@ -437,8 +440,8 @@ pub(super) fn load_transformation_models(
         };
 
         let mut models: Vec<rocky_core::models::Model> = Vec::new();
-        // Names already seen inside THIS pipeline's own tree. The loader reads a
-        // base directory plus one level below it, so one pipeline can reach the
+        // Names already seen inside THIS pipeline's own tree. The loader walks
+        // the whole tree below the base directory, so one pipeline can reach the
         // same name twice (`transforms/orders` and `transforms/staging/orders`)
         // — that is a duplicate no matter how many pipelines exist.
         let mut seen_here: HashMap<String, String> = HashMap::new();
@@ -1703,7 +1706,7 @@ mod tests {
     /// Guards the seam that per-pipeline attribution nearly broke: a duplicate
     /// model name inside ONE pipeline's tree.
     ///
-    /// The loader reads a base directory plus one level below it, so a single
+    /// The loader walks the whole tree below a base directory, so a single
     /// pipeline can reach `orders` at both `transforms/orders` and
     /// `transforms/staging/orders`. Keying the duplicate check on the resolved
     /// DIRECTORY — needed so two pipelines sharing a directory reach

--- a/engine/crates/rocky-cli/src/commands/test.rs
+++ b/engine/crates/rocky-cli/src/commands/test.rs
@@ -178,6 +178,14 @@ pub fn run_test(
 // ---------------------------------------------------------------------------
 
 /// Load all models from a directory including one level of subdirectories.
+///
+/// Deliberately NOT [`crate::models_loader::load_project_models`], which walks
+/// the whole tree, collects `.rocky` DSL models too, and treats a load failure
+/// as an error. Adopting it here would change three things at once for
+/// `--declarative` — which models run, which files are read, and whether a
+/// broken sidecar aborts the command — so the switch belongs in its own change
+/// with its own note. Until then the declarative runner sees strictly less than
+/// `rocky list models` does.
 fn load_all_models(models_dir: &Path) -> Result<Vec<models::Model>> {
     let mut all = models::load_models_from_dir(models_dir).context(format!(
         "failed to load models from {}",

--- a/engine/crates/rocky-cli/src/models_loader.rs
+++ b/engine/crates/rocky-cli/src/models_loader.rs
@@ -1,12 +1,14 @@
 //! Shared model-directory loader for CLI commands.
 //!
-//! The canonical "load every model in the project" path: top-level dir plus
-//! one level of immediate subdirectories, including **both** `.sql` (sidecar
-//! `.toml`) and `.rocky` DSL files. Commands that need the model list (but not
-//! the resolved DAG) should use this instead of
+//! The canonical "load every model in the project" path: the models root and
+//! **every** directory beneath it, at any depth, including **both** `.sql`
+//! (sidecar `.toml`) and `.rocky` DSL files. Commands that need the model list
+//! (but not the resolved DAG) should use this instead of
 //! [`rocky_core::models::load_models_from_dir`], which collects only `.sql`
-//! files and therefore silently drops `.rocky` DSL models.
+//! files in a single directory and therefore silently drops both `.rocky` DSL
+//! models and everything in a subdirectory.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -131,8 +133,8 @@ pub fn resolve_models_dir(models_glob: &str, config_path: &Path) -> Result<Optio
     })
 }
 
-/// Load all models under `models_dir` (top level + immediate subdirectories),
-/// including `.rocky` DSL files.
+/// Load every model under `models_dir`, at any depth, including `.rocky` DSL
+/// files.
 ///
 /// A load failure in **any** of those directories is an error. Subdirectory
 /// failures used to be discarded, so a malformed model one level down simply
@@ -141,11 +143,20 @@ pub fn resolve_models_dir(models_glob: &str, config_path: &Path) -> Result<Optio
 /// nothing for that subtree. That is the same silent-success class as the
 /// top-level load, which stopped being swallowed in #1244.
 ///
-/// **Scope.** This reads the top level plus one level down. A model at
-/// `models/a/b/` is still not loaded at all — not an error, simply absent
-/// (#1262). Propagating subdirectory errors does not close that hole, and a
-/// project nesting models deeper than one level still silently builds nothing
-/// for the deeper subtree.
+/// The walk is fully recursive as of #1262. It previously read the root plus
+/// one level of immediate subdirectories, so a model at `models/a/b/` was not
+/// loaded at all — not an error, simply absent — even though the default
+/// `models/**` glob reads as recursive. A malformed sidecar down there could
+/// not even fail, because the file was never opened.
+///
+/// **Scope: the compile path is still flat.** `rocky run` (without `--dag`)
+/// compiles through [`rocky_compiler::compile`], which loads models with
+/// `Project::load_models_with_db` — a single directory, no descent at all. So
+/// `rocky list models` and `rocky run --dag` now see the whole tree while a
+/// plain `rocky run` still sees only the models sitting directly in the root.
+/// Widening the compile path materializes tables that projects have never had
+/// built, which is the materialization change #1268 deliberately kept out of a
+/// discovery fix; it needs its own change and its own release note.
 pub fn load_project_models(models_dir: &Path) -> Result<Vec<Model>> {
     let (models, mut errors) = load_project_models_partial(models_dir);
     if errors.is_empty() {
@@ -176,46 +187,121 @@ pub fn load_project_models(models_dir: &Path) -> Result<Vec<Model>> {
 pub fn load_project_models_partial(models_dir: &Path) -> (Vec<Model>, Vec<anyhow::Error>) {
     let mut all = Vec::new();
     let mut errors = Vec::new();
+    let mut visited: HashSet<PathBuf> = HashSet::new();
+    visited.insert(visit_key(models_dir));
 
-    match load_one_dir(models_dir) {
-        Ok(models) => all.extend(models),
-        Err(e) => errors.push(e),
-    }
+    // Pre-order depth-first over an explicit stack — not a recursive function,
+    // so a pathologically deep tree cannot overflow the thread stack. Children
+    // are pushed in reverse sorted order so they pop in sorted order, making
+    // both the model order and the "which broken directory is reported first"
+    // answer independent of `read_dir`'s arbitrary ordering.
+    let mut stack: Vec<(PathBuf, usize)> = vec![(models_dir.to_path_buf(), 0)];
 
-    // `load_dir_models` returns no models for a directory that does not exist,
-    // and several callers rely on that (`rocky docs` on a project with no
-    // models, for one). Only descend when there is something to descend into,
-    // so an absent directory stays a non-error rather than failing `read_dir`.
-    if !models_dir.is_dir() {
-        return (all, errors);
-    }
-
-    let entries = match std::fs::read_dir(models_dir) {
-        Ok(entries) => entries,
-        Err(e) => {
-            errors.push(anyhow::Error::new(e).context(format!(
-                "failed to read models directory {}",
-                models_dir.display()
-            )));
-            return (all, errors);
-        }
-    };
-    let mut subdirs: Vec<PathBuf> = entries
-        .flatten()
-        .map(|entry| entry.path())
-        .filter(|path| path.is_dir())
-        .collect();
-    // Deterministic order: with more than one broken subdirectory, the same one
-    // is always reported first.
-    subdirs.sort();
-
-    for subdir in subdirs {
-        match load_one_dir(&subdir) {
+    while let Some((dir, depth)) = stack.pop() {
+        match load_one_dir(&dir) {
             Ok(models) => all.extend(models),
             Err(e) => errors.push(e),
         }
+
+        // `load_dir_models` returns no models for a directory that does not
+        // exist, and several callers rely on that (`rocky docs` on a project
+        // with no models, for one). Only descend when there is something to
+        // descend into, so an absent directory stays a non-error rather than
+        // failing `read_dir`.
+        if !dir.is_dir() {
+            continue;
+        }
+
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(e) => {
+                errors.push(
+                    anyhow::Error::new(e)
+                        .context(format!("failed to read models directory {}", dir.display())),
+                );
+                continue;
+            }
+        };
+        let mut subdirs: Vec<PathBuf> = Vec::new();
+        for entry in entries {
+            // NOT `entries.flatten()`. A per-entry `io::Error` dropped there is
+            // a directory that vanishes with nothing said about it — the silent
+            // drop this walk exists to close, reintroduced one level down.
+            match entry {
+                Ok(entry) if entry.path().is_dir() => subdirs.push(entry.path()),
+                Ok(_) => {}
+                Err(e) => errors.push(anyhow::Error::new(e).context(format!(
+                    "failed to read an entry of models directory {}",
+                    dir.display()
+                ))),
+            }
+        }
+        subdirs.sort();
+
+        // `is_dir` follows symlinks, and always has: a `models/staging`
+        // symlinked at a shared directory loads today and must keep loading.
+        // That is also how a cycle gets in, so each directory is entered at
+        // most once, keyed on its resolved identity. A directory that cannot
+        // be canonicalized falls back to its own path — it is loaded today, so
+        // failing to resolve it must not drop it.
+        //
+        // Selected WITHOUT marking anything visited, so the depth check below
+        // sees only genuinely-unvisited children. Marking first would both
+        // report a ceiling breach for a subtree that is nothing but a cycle
+        // back to an already-loaded directory, and mark directories visited
+        // that are then abandoned — a later, legitimately shallow path to one
+        // of them would be skipped with no error at all. `batch` dedups two
+        // siblings that alias one directory, which the mark-as-you-go form got
+        // for free.
+        let mut batch: HashSet<PathBuf> = HashSet::new();
+        let fresh: Vec<(PathBuf, PathBuf)> = subdirs
+            .into_iter()
+            .filter_map(|subdir| {
+                let key = visit_key(&subdir);
+                (!visited.contains(&key) && batch.insert(key.clone())).then_some((subdir, key))
+            })
+            .collect();
+        if fresh.is_empty() {
+            continue;
+        }
+
+        if depth + 1 > MAX_MODELS_TREE_DEPTH {
+            errors.push(anyhow::anyhow!(
+                "models directory '{}' nests deeper than the {MAX_MODELS_TREE_DEPTH}-level \
+                 limit; models below it were not loaded",
+                dir.display(),
+            ));
+            continue;
+        }
+
+        visited.extend(fresh.iter().map(|(_, key)| key.clone()));
+        stack.extend(
+            fresh
+                .into_iter()
+                .rev()
+                .map(|(subdir, _)| (subdir, depth + 1)),
+        );
     }
     (all, errors)
+}
+
+/// How deep below the models root the walk descends.
+///
+/// Cycles are broken by the visited set, so this is not what makes the walk
+/// terminate — it is a ceiling on nesting no real project reaches. Exceeding it
+/// is an **error**, never a silent stop: quietly truncating the walk is the
+/// exact failure recursing here exists to close (#1262).
+const MAX_MODELS_TREE_DEPTH: usize = 64;
+
+/// The identity a directory is deduplicated on while walking.
+///
+/// Canonical where possible so two paths reaching one directory — a symlink and
+/// its target, or a symlink pointing back at an ancestor — are entered once.
+/// A directory that cannot be resolved keys on its own path rather than being
+/// skipped: it is loaded today, and a probe that cannot answer "have I been
+/// here?" is not a reason to drop a model.
+fn visit_key(dir: &Path) -> PathBuf {
+    dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf())
 }
 
 /// Load one directory's models, naming that directory in the error.
@@ -258,6 +344,215 @@ mod tests {
         let mut names: Vec<&str> = loaded.iter().map(|m| m.config.name.as_str()).collect();
         names.sort_unstable();
         assert_eq!(names, ["stg", "top"]);
+    }
+
+    /// The regression #1262 exists for: the walk stopped after one level, so a
+    /// model at `models/a/b/` was not loaded — not an error, simply absent —
+    /// while the default `models/**` glob reads as recursive.
+    #[test]
+    fn loads_models_at_every_depth() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let models = tmp.path().join("models");
+        write_model(&models, "top");
+        write_model(&models.join("a"), "lvl1");
+        write_model(&models.join("a").join("b"), "lvl2");
+        write_model(&models.join("a").join("b").join("c"), "lvl3");
+
+        let loaded = load_project_models(&models).expect("load");
+        let mut names: Vec<&str> = loaded.iter().map(|m| m.config.name.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(names, ["lvl1", "lvl2", "lvl3", "top"]);
+    }
+
+    /// A malformed sidecar two levels down must fail exactly the way the top
+    /// level fails. This is what proves the file is *read*: before #1262 the
+    /// same broken TOML changed nothing at all, because nothing ever opened it.
+    #[test]
+    fn a_broken_model_below_the_first_subdirectory_level_is_an_error() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let models = tmp.path().join("models");
+        write_model(&models, "top");
+        let deep = models.join("marts").join("core");
+        write(&deep.join("broken.sql"), "SELECT 1\n");
+        write(&deep.join("broken.toml"), "name = [\n");
+
+        let err = load_project_models(&models).expect_err("a depth-2 failure must propagate");
+        let rendered = format!("{err:#}");
+
+        // The same shape the top level produces — `load_one_dir`'s context,
+        // naming the directory that failed.
+        let top_only = tmp.path().join("top-only");
+        write(&top_only.join("broken.sql"), "SELECT 1\n");
+        write(&top_only.join("broken.toml"), "name = [\n");
+        let top_err = load_project_models(&top_only).expect_err("top-level failure");
+        let top_rendered = format!("{top_err:#}");
+        assert_eq!(
+            rendered.replace(&deep.display().to_string(), "<dir>"),
+            top_rendered.replace(&top_only.display().to_string(), "<dir>"),
+            "a deep failure must render identically to the top-level one"
+        );
+        assert!(
+            rendered.contains(&deep.display().to_string()),
+            "the error must name the failing directory, got: {rendered}"
+        );
+    }
+
+    /// Discovery order must not depend on `read_dir`'s arbitrary ordering, or
+    /// every downstream DAG/doc listing churns between runs and machines.
+    ///
+    /// Directories are created in scrambled order and each holds a model whose
+    /// name sorts against the directory order, so the assertion discriminates
+    /// both against an unsorted walk and against globally name-sorting the
+    /// result (which would return `m00..m07`).
+    #[test]
+    fn discovery_order_is_deterministic() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let models = tmp.path().join("models");
+        write_model(&models, "root");
+        for (dir, model) in [
+            ("d05", "m02"),
+            ("d01", "m07"),
+            ("d07", "m00"),
+            ("d03", "m05"),
+            ("d00", "m06"),
+            ("d06", "m01"),
+            ("d02", "m04"),
+            ("d04", "m03"),
+        ] {
+            write_model(&models.join(dir), model);
+        }
+
+        let names: Vec<String> = load_project_models(&models)
+            .expect("load")
+            .iter()
+            .map(|m| m.config.name.clone())
+            .collect();
+        assert_eq!(
+            names,
+            [
+                "root", "m06", "m07", "m04", "m05", "m03", "m02", "m01", "m00"
+            ],
+            "models must come back in directory-sorted order, root first"
+        );
+    }
+
+    /// A symlink pointing back at an ancestor must not spin forever, and the
+    /// models it reaches must not be loaded twice (a duplicate name is a hard
+    /// error downstream in `Project::from_models`).
+    #[test]
+    #[cfg(unix)]
+    fn a_symlink_cycle_terminates_and_loads_each_model_once() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let models = tmp.path().join("models");
+        write_model(&models, "top");
+        write_model(&models.join("staging"), "stg");
+        std::os::unix::fs::symlink(&models, models.join("staging").join("loop")).expect("symlink");
+
+        let loaded = load_project_models(&models).expect("load");
+        let mut names: Vec<&str> = loaded.iter().map(|m| m.config.name.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(names, ["stg", "top"]);
+    }
+
+    /// A symlinked subdirectory is followed — `is_dir()` has always followed
+    /// symlinks, so a project sharing a models subtree that way keeps loading.
+    #[test]
+    #[cfg(unix)]
+    fn a_symlinked_subdirectory_is_followed() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let models = tmp.path().join("models");
+        write_model(&models, "top");
+        let shared = tmp.path().join("shared");
+        write_model(&shared, "shared_model");
+        std::os::unix::fs::symlink(&shared, models.join("linked")).expect("symlink");
+
+        let loaded = load_project_models(&models).expect("load");
+        let mut names: Vec<&str> = loaded.iter().map(|m| m.config.name.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(names, ["shared_model", "top"]);
+    }
+
+    /// Nesting past the ceiling is reported, never silently truncated —
+    /// a quiet stop is the #1262 failure in a new place.
+    #[test]
+    fn nesting_past_the_depth_ceiling_is_an_error() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let models = tmp.path().join("models");
+        let mut deep = models.clone();
+        for i in 0..=MAX_MODELS_TREE_DEPTH {
+            deep = deep.join(format!("d{i}"));
+        }
+        write_model(&deep, "too_deep");
+
+        let err = load_project_models(&models).expect_err("over-deep nesting must be reported");
+        assert!(
+            format!("{err:#}").contains("nests deeper than"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    /// A directory sitting exactly at the ceiling whose only child is a symlink
+    /// back to somewhere already loaded has nothing unseen below it, so the
+    /// ceiling must stay quiet. Reporting a breach there would fail a project
+    /// over a subtree that contains no model the walk has not already read.
+    ///
+    /// Mutation that must turn this red: mark children visited before the
+    /// depth check instead of after.
+    #[test]
+    #[cfg(unix)]
+    fn the_depth_ceiling_ignores_a_cycle_back_to_a_loaded_directory() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let models = tmp.path().join("models");
+        write_model(&models, "top");
+        let mut deepest = models.clone();
+        for i in 0..MAX_MODELS_TREE_DEPTH {
+            deepest = deepest.join(format!("d{i}"));
+        }
+        write_model(&deepest, "deepest");
+        std::os::unix::fs::symlink(&models, deepest.join("loop")).expect("symlink");
+
+        let loaded = load_project_models(&models).expect("a cycle at the ceiling is not a breach");
+        let mut names: Vec<&str> = loaded.iter().map(|m| m.config.name.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(names, ["deepest", "top"]);
+    }
+
+    /// Two siblings symlinked at one directory must load its models once. The
+    /// mark-as-you-go filter got this for free; selecting without marking has
+    /// to dedup within the batch explicitly.
+    #[test]
+    #[cfg(unix)]
+    fn two_siblings_aliasing_one_directory_load_it_once() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let models = tmp.path().join("models");
+        write_model(&models, "top");
+        let shared = tmp.path().join("shared");
+        write_model(&shared, "shared_model");
+        std::os::unix::fs::symlink(&shared, models.join("alias_a")).expect("symlink a");
+        std::os::unix::fs::symlink(&shared, models.join("alias_b")).expect("symlink b");
+
+        let loaded = load_project_models(&models).expect("load");
+        let mut names: Vec<&str> = loaded.iter().map(|m| m.config.name.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(names, ["shared_model", "top"]);
+    }
+
+    /// Everything the loader is willing to walk it walked before too. Hidden
+    /// directories are **not** excluded today — `read_dir` yields them and
+    /// `is_dir()` accepts them — so a model under one loads, and adding an
+    /// exclusion here would be a new silent drop of exactly the #1262 kind.
+    #[test]
+    fn hidden_directories_are_walked_at_every_depth() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let models = tmp.path().join("models");
+        write_model(&models, "top");
+        write_model(&models.join(".hidden"), "hidden_lvl1");
+        write_model(&models.join(".hidden").join("deeper"), "hidden_lvl2");
+
+        let loaded = load_project_models(&models).expect("load");
+        let mut names: Vec<&str> = loaded.iter().map(|m| m.config.name.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(names, ["hidden_lvl1", "hidden_lvl2", "top"]);
     }
 
     /// The regression this change exists for: a malformed sidecar one level down

--- a/engine/crates/rocky-cli/src/scope.rs
+++ b/engine/crates/rocky-cli/src/scope.rs
@@ -179,8 +179,8 @@ pub(crate) fn resolve_transformation_managed_tables(
         );
     }
 
-    // Load all models the same way `rocky list models` does: top-level +
-    // immediate subdirectories, including `.rocky` DSL files.
+    // Load all models the same way `rocky list models` does: the root and
+    // every directory below it, including `.rocky` DSL files.
     let all_models = crate::models_loader::load_project_models(&models_dir)?;
 
     let mut managed = HashSet::new();


### PR DESCRIPTION
fix(engine/rocky-cli): load models below the first subdirectory level

`load_project_models` read the models root plus exactly one level of
immediate subdirectories. A model at `models/a/b/` was never loaded — not
an error, simply absent — even though the default transformation glob is
`models/**`, which reads as fully recursive. Replacing that model's `.toml`
with malformed TOML changed nothing, because the file was never opened and
so could not even fail. Every command on this loader inherited it: `dag`,
`list`, `docs`, `preview`, `compliance`, `estimate`, `tick`, `validate`,
`branch`, `scope`, and `run --dag`, which built nothing for the deeper
subtree and reported success.

The walk is now a pre-order depth-first traversal of the whole tree, over an
explicit stack rather than recursion so a deep tree cannot overflow. It keeps
the per-directory decomposition, so `_defaults.toml`, `groups/` and named
test definitions still resolve beside the models they apply to. Children are
sorted at every level, so discovery order no longer depends on `read_dir`.
Symlinked subdirectories are still followed, as they always were, and a cycle
is broken by entering each directory at most once keyed on its resolved
identity. Nesting past a 64-level ceiling is reported rather than silently
truncated.

Nothing new is excluded: hidden directories were never filtered out and are
not filtered out now — adding an exclusion here would be a fresh silent drop
of exactly the kind this closes.

The compile path stays flat and is left alone deliberately. `rocky run`
without `--dag` loads through `Project::load_models_with_db`, which reads a
single directory, so it still sees only the models sitting directly in the
root while `rocky list models` and `rocky dag` now see the whole tree.
Widening it materializes tables that projects have never had built, which is
a change that deserves its own PR and its own release note. `rocky test
--declarative` keeps its own shallower loader for the same reason.

Canary: all 112 in-repo projects produce identical `list models`, `dag` and
`validate` output before and after, and the credential-free POCs run
end-to-end with identical logs and exit codes. No in-repo project nests
models more than one level.

Closes #1262


---

**Review question worth settling before merge:** this leaves the compile path
flat on purpose, so after it `rocky list models` and `rocky dag` see the whole
tree while `rocky run` without `--dag` still sees only the root. That is a
smaller blast radius, but it means `list models` can show a model `rocky run`
will not build. Either that asymmetry is acceptable and documented, or the
compile path should follow — worth a deliberate call rather than inheriting it.

Closes #1262
