### PR TITLE
fix(scripts): fail the soak verdict closed when the fd gate has no input

### DIFF
--- a/.github/workflows/scripts-ci.yml
+++ b/.github/workflows/scripts-ci.yml
@@ -1,0 +1,53 @@
+# CI for the operational scripts under scripts/ — most importantly the soak
+# harness's verdict logic, whose ~45 self-test assertions otherwise run only
+# when a human remembers to type `just soak-verdict-selftest` (#1311). A silent
+# regression there is discovered 24 hours into the next soak, which is the most
+# expensive possible place to find it.
+name: Scripts CI
+
+on:
+  pull_request:
+    paths:
+      - "scripts/**"
+      - ".github/workflows/scripts-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "scripts/**"
+      - ".github/workflows/scripts-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  soak-verdict-selftest:
+    name: Soak-verdict self-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Run the verdict self-test
+        run: python3 scripts/soak_verdict.py --self-test
+
+  shellcheck:
+    name: Shellcheck scripts
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Shellcheck the soak harness (full severity)
+        # The scripts this workflow exists to protect hold the full bar and
+        # already meet it.
+        run: shellcheck scripts/soak-scheduler.sh
+      - name: Shellcheck everything else (error severity)
+        # Six pre-existing scripts carry SC2155/SC2012/SC2015 warnings today
+        # (release.sh, the vendor_* pair, regen_fixtures.sh, build_rocky_linux.sh).
+        # Cleaning those is a separate, deliberate change — release tooling is
+        # not drive-by territory — so the fleet-wide gate starts at error
+        # severity: real breakage fails, the known warnings do not. Tighten to
+        # full severity once they are cleaned.
+        run: |
+          set -euo pipefail
+          find scripts -name '*.sh' -type f -print0 | sort -z \
+            | xargs -0 shellcheck --severity=error
+          echo "error-severity sweep clean"

--- a/.github/workflows/scripts-ci.yml
+++ b/.github/workflows/scripts-ci.yml
@@ -26,6 +26,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Run the verdict self-test
         run: python3 scripts/soak_verdict.py --self-test
 
@@ -35,6 +37,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Shellcheck the soak harness (full severity)
         # The scripts this workflow exists to protect hold the full bar and
         # already meet it.

--- a/scripts/soak_verdict.py
+++ b/scripts/soak_verdict.py
@@ -95,10 +95,23 @@ def window(samples: list[dict], key: str, lo: float, hi: float) -> list[float]:
 # --------------------------------------------------------------------------
 #
 # G3's percentage-AND-absolute conjunction is a catastrophic-growth trip. It
-# cannot see the leak class this harness exists to hunt: two real 24h runs grew
-# 45.0% / +11.77 MB and 40.45% / +11.16 MB and both cleared it, including the
-# run whose curve was the JobRegistry leak's existence proof. Neither reached
-# the 20 MB floor, so the conjunction never fired.
+# cannot see the growth class this harness exists to hunt: two real 24h runs
+# grew 45.0% / +11.77 MB and 40.45% / +11.16 MB and both cleared it. Neither
+# reached the 20 MB floor, so the conjunction never fired.
+#
+# CAUSAL STORY, corrected after the fact (#1256): the growth in BOTH reference
+# runs was later shown to be ~92-96% OBSERVER-INDUCED — the harness's own 30s
+# `/api/v1/runs` polling against `list_runs`'s whole-table scan (#1304), whose
+# working set tracks a history that grew one run per minute. It was not a
+# product leak, and the job-cache fix it seemed to indict was sound all along.
+# That does NOT loosen this gate: the gate's job is to flag ANY sustained
+# final-quarter slope regardless of origin, and it correctly flagged these —
+# the attribution question is the operator's, not the gate's. Since #1256 the
+# harness harvests every 600s (20x less observer load, <~25 KB/h of induced
+# slope), so a fixed-harness run that trips 200 KB/h is presumptively real.
+# WHEN RE-DERIVING (the instruction below): use a clean-harness reference run,
+# not these two traces, and know that their `+526.9 / +456.0` slopes measure
+# the instrument, not the engine.
 #
 # The discriminating measurement is the FINAL QUARTER. A bounded structure
 # fills once — the job cache reaches its cap around hour 8.5 at one job per
@@ -643,6 +656,32 @@ def gate_resources(run: dict) -> list[dict]:
                     "by_class": classes,
                 }
             )
+    else:
+        # The sharp gate must never be satisfiable by the absence of its input
+        # (#1311). A missing median means lsof produced no readings across an
+        # entire comparison window — an outage G0's 5% whole-run null cap
+        # cannot see when the hole is concentrated (a nulled final hour of a
+        # 24h run is 4.17% of samples). Same rule G3b applies to its quarter:
+        # the window is cut from the sample timeline, never from where
+        # readings happen to exist. Missing input is a re-run, not a pass.
+        missing = [
+            name
+            for name, value in (
+                ("baseline (first hour after warmup)", base_fd),
+                ("final hour", tail_fd),
+            )
+            if value is None
+        ]
+        findings.append(
+            {
+                "gate": "G4",
+                "status": "INVALID",
+                "detail": "fd gate could not evaluate — no fd readings in the "
+                f"{' or the '.join(missing)} window; lsof failed or sampling "
+                "stopped. A verdict that never weighed the fd gate is not a "
+                "soak PASS.",
+            }
+        )
 
     if run["fd_limit_errors"]:
         findings.append(
@@ -927,6 +966,24 @@ def self_test() -> int:
         s["fd_total"] = 42 + i  # monotonic leak
         s["fd_redb"] = 2 + i
     check("fd leak fails", analyse(leak)["verdict"], "FAIL")
+
+    # #1311 — the sharp gate must fail closed when its input vanishes. A nulled
+    # final hour of a 24h run is 120/2880 samples = 4.17%, under G0's 5%
+    # whole-run null cap, so before the fix this run reported PASS with the fd
+    # gate silently skipped — a leaked-fd build could ride an lsof outage
+    # through the gate that exists to catch it.
+    fd_outage = synth(1440)
+    # Cut from the SAMPLE timeline (t_end derives from the last sample, not
+    # planned_end) — nulling from planned_end-3600 leaves one live reading at
+    # the window edge, whose median then feeds the gate normally.
+    outage_lo = fd_outage["samples"][-1]["t"] - 3600
+    for s in fd_outage["samples"]:
+        if s["t"] >= outage_lo:
+            s["fd_total"] = None
+    check("fd outage across the tail window is INVALID", analyse(fd_outage)["verdict"], "INVALID")
+    # The control guards the check above against passing for an unrelated
+    # reason: the same 24h fixture with fd intact must still PASS outright.
+    check("the 24h fixture itself passes with fd intact", analyse(synth(1440))["verdict"], "PASS")
 
     # The regression this guards: a two-sided G6 equality would FAIL here, on a
     # path the reconciler documents as benign and the harness itself induces.


### PR DESCRIPTION
Closes #1311.

G4 — "the sharp one" — silently skipped itself whenever `lsof` produced no readings across a comparison window: no finding, no metrics, a PASS with the fd line simply absent. G0's whole-run 5% null cap can't see a concentrated hole (a nulled final hour of a 24h run is 4.17% of samples). A missing median is now **INVALID**, naming the window — the same cut-from-the-sample-timeline rule G3b already enforces.

**Non-vacuity, proven empirically:** the new fd-outage self-test case grafted onto the pre-fix script reports `PASS` (the defect); the fixed script reports `INVALID`. A same-length intact control pins the fixture itself to PASS so the outage check can't succeed for an unrelated reason.

**Also per #1311:**
- **`scripts-ci.yml`** — the ~47 verdict self-test assertions now run in CI on any `scripts/` change (they previously ran only when a human typed `just soak-verdict-selftest`; zero workflows referenced it). Shellcheck rides along: full severity on the soak harness, error severity fleet-wide — six pre-existing scripts carry SC2155/SC2012/SC2015 warnings, and cleaning release tooling is a deliberate change, not a drive-by; the split is documented in the workflow.
- **G3b calibration comment corrected post-#1256** — the reference runs' slopes measured the instrument (the harness's own `/runs` polling), not the engine; anyone re-deriving the threshold now knows to use a clean-harness reference run.

**Verified:** self-test PASS (both new checks green) · both steps of the new workflow rehearsed locally · both archived reference runs still FAIL G3b · the in-flight clean soak still reads INCOMPLETE with **no** spurious G4 finding.

Scripts + workflow only — will sit BLOCKED on engine-required checks; merging with `--admin` once its own checks are green.