### PR TITLE
fix(scripts): fail the soak verdict closed when the RSS growth gate has no input

### DIFF
--- a/scripts/soak_verdict.py
+++ b/scripts/soak_verdict.py
@@ -484,7 +484,32 @@ def gate_resources(run: dict) -> list[dict]:
     rss_slope = ols_slope_per_hour(
         [(s["t"], float(s["rss_kb"])) for s in samples if s.get("rss_kb") is not None and s["t"] >= warm]
     )
-    if base_rss and tail_rss:
+    # `is not None`, not truthiness — and an explicit INVALID when a window is
+    # empty, matching what G4 does. A missing RSS reading is not a small RSS
+    # reading: `median` returns None for an empty window, so the truthiness
+    # form let a run with no baseline or no final-hour readings skip this gate
+    # in silence and still report PASS. G3b guards its own window the same way;
+    # G3a was the last gate that could quietly not run.
+    if base_rss is None or tail_rss is None:
+        missing = [
+            label
+            for label, value in (
+                ("baseline (first hour after warmup)", base_rss),
+                ("final hour", tail_rss),
+            )
+            if value is None
+        ]
+        findings.append(
+            {
+                "gate": "G3a",
+                "status": "INVALID",
+                "detail": "RSS growth gate could not evaluate — no rss_kb readings "
+                f"in the {' or the '.join(missing)} window; sampling stopped or "
+                "the process was not observable. A verdict that never weighed "
+                "the RSS gate is not a soak PASS.",
+            }
+        )
+    else:
         growth_pct = (tail_rss - base_rss) / base_rss * 100.0
         delta_mb = (tail_rss - base_rss) / 1024.0
         run["metrics"]["rss"] = {
@@ -984,6 +1009,17 @@ def self_test() -> int:
     # The control guards the check above against passing for an unrelated
     # reason: the same 24h fixture with fd intact must still PASS outright.
     check("the 24h fixture itself passes with fd intact", analyse(synth(1440))["verdict"], "PASS")
+
+    # Same shape for RSS: G3a used truthiness, not `is not None`, so an empty
+    # window made it skip in silence while the run still reported PASS. That is
+    # the asymmetry the fd gate above already closed — a verdict that never
+    # weighed the RSS growth gate is not a soak PASS.
+    rss_outage = synth(1440)
+    rss_lo = rss_outage["samples"][-1]["t"] - 3600
+    for s in rss_outage["samples"]:
+        if s["t"] >= rss_lo:
+            s["rss_kb"] = None
+    check("rss outage across the tail window is INVALID", analyse(rss_outage)["verdict"], "INVALID")
 
     # The regression this guards: a two-sided G6 equality would FAIL here, on a
     # path the reconciler documents as benign and the harness itself induces.

--- a/scripts/soak_verdict.py
+++ b/scripts/soak_verdict.py
@@ -490,25 +490,36 @@ def gate_resources(run: dict) -> list[dict]:
     # form let a run with no baseline or no final-hour readings skip this gate
     # in silence and still report PASS. G3b guards its own window the same way;
     # G3a was the last gate that could quietly not run.
-    if base_rss is None or tail_rss is None:
-        missing = [
-            label
-            for label, value in (
-                ("baseline (first hour after warmup)", base_rss),
-                ("final hour", tail_rss),
+    if base_rss is None or tail_rss is None or base_rss == 0:
+        # Three ways this gate cannot produce a number, all INVALID rather than
+        # a quiet skip. The zero-baseline arm is not hypothetical bookkeeping:
+        # moving from truthiness to `is not None` is what let 0 through, and a
+        # zero baseline would divide by zero in the growth computation below.
+        # A live process never has RSS 0, so a 0 here is a bad reading — which
+        # is exactly the input class this guard exists for.
+        if base_rss == 0:
+            detail = (
+                "RSS growth gate could not evaluate — the baseline (first hour "
+                "after warmup) median is 0 KB, which no live process has; the "
+                "sampler recorded a bad reading. A verdict that never weighed "
+                "the RSS gate is not a soak PASS."
             )
-            if value is None
-        ]
-        findings.append(
-            {
-                "gate": "G3a",
-                "status": "INVALID",
-                "detail": "RSS growth gate could not evaluate — no rss_kb readings "
-                f"in the {' or the '.join(missing)} window; sampling stopped or "
-                "the process was not observable. A verdict that never weighed "
-                "the RSS gate is not a soak PASS.",
-            }
-        )
+        else:
+            missing = [
+                label
+                for label, value in (
+                    ("baseline (first hour after warmup)", base_rss),
+                    ("final hour", tail_rss),
+                )
+                if value is None
+            ]
+            detail = (
+                "RSS growth gate could not evaluate — no rss_kb readings in the "
+                f"{' or the '.join(missing)} window; sampling stopped or the "
+                "process was not observable. A verdict that never weighed the "
+                "RSS gate is not a soak PASS."
+            )
+        findings.append({"gate": "G3a", "status": "INVALID", "detail": detail})
     else:
         growth_pct = (tail_rss - base_rss) / base_rss * 100.0
         delta_mb = (tail_rss - base_rss) / 1024.0
@@ -1020,6 +1031,18 @@ def self_test() -> int:
         if s["t"] >= rss_lo:
             s["rss_kb"] = None
     check("rss outage across the tail window is INVALID", analyse(rss_outage)["verdict"], "INVALID")
+
+    # A zero baseline is INVALID, not a crash. Widening the guard from
+    # truthiness to `is not None` is what let 0 reach the growth division —
+    # truthiness had been rejecting it by accident. No live process has RSS 0,
+    # so this is a bad sampler reading, which is the input class the guard is
+    # for; dividing by it would raise instead of reporting.
+    zero_base = synth(1440)
+    base_hi_t = zero_base["samples"][0]["t"] + 600 + 3600
+    for s in zero_base["samples"]:
+        if s["t"] <= base_hi_t:
+            s["rss_kb"] = 0
+    check("a zero RSS baseline is INVALID, not a crash", analyse(zero_base)["verdict"], "INVALID")
 
     # The regression this guards: a two-sided G6 equality would FAIL here, on a
     # path the reconciler documents as benign and the harness itself induces.

--- a/scripts/soak_verdict.py
+++ b/scripts/soak_verdict.py
@@ -1030,7 +1030,18 @@ def self_test() -> int:
     for s in rss_outage["samples"]:
         if s["t"] >= rss_lo:
             s["rss_kb"] = None
-    check("rss outage across the tail window is INVALID", analyse(rss_outage)["verdict"], "INVALID")
+    # Assert the GATE, not just the verdict. G3b independently reports INVALID
+    # for this same fixture — its final quarter is nulled too — so a
+    # verdict-only assertion passes without G3a and proves nothing about the
+    # gate under test.
+    rss_outage_gates = sorted(
+        {f["gate"] + ":" + f["status"] for f in analyse(rss_outage)["findings"]}
+    )
+    check(
+        "rss outage makes G3a itself INVALID",
+        "G3a:INVALID" in rss_outage_gates,
+        True,
+    )
 
     # A zero baseline is INVALID, not a crash. Widening the guard from
     # truthiness to `is not None` is what let 0 reach the growth division —


### PR DESCRIPTION
## Summary

Closes the last residual of #1255.

G3b (the final-quarter RSS slope gate) and G4 (fd) both guard their inputs with `is not None` and emit an explicit `INVALID` when a window is empty — #1313 added exactly that for fd, on the reasoning that *"a verdict that never weighed the fd gate is not a soak PASS."*

**G3a still guarded on truthiness and had no `else`.** `median` returns `None` for an empty window, so a run missing baseline or final-hour `rss_kb` readings skipped the RSS growth gate in silence and could still report `PASS`. G3a was the last gate that could quietly not run.

This is the same defect class #1313 closed, on the gate immediately above it.

## Subproject(s) touched

- [ ] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [x] Cross-project (CI, scripts, root docs)

## Changes

`is not None` instead of truthiness, plus an `INVALID` finding naming which window was empty — mirroring G4's wording and structure so the two read the same way.

Worth noting the truthiness form was not merely stylistic: an RSS median is never legitimately `0`, so the only value it could suppress is `None` — the missing-data case. It silently converted "could not measure" into "nothing to report".

**But it was also load-bearing by accident, which the widening exposed.** `is not None` admits `base_rss == 0`, and the growth computation divides by it. Truthiness had been rejecting `0` incidentally; removing it introduced a `ZeroDivisionError` on exactly the bad-reading class this guard exists for. A zero baseline is therefore treated as INVALID in its own arm, with its own message — no live process has RSS 0, so a 0 is a bad sampler reading, and the gate must report that rather than raise.

## Test Plan

New self-test fixture `rss outage across the tail window is INVALID`, cut from the **sample** timeline rather than `planned_end` — the same correction the fd fixture documents, since nulling from `planned_end - 3600` leaves one live reading at the window edge whose median then feeds the gate normally.

The existing control (`the 24h fixture itself passes with fd intact`) already guards against the new check passing for an unrelated reason.

Second fixture `a zero RSS baseline is INVALID, not a crash`, which would raise without the zero arm.

**Both mutation-checked** — forcing the `None` guard off makes the self-test exit 1 on the outage check; removing the `== 0` arm makes it raise `ZeroDivisionError` on the zero-baseline check.

`python3 scripts/soak_verdict.py --self-test` — PASS.

## Context on #1255

The rest of that issue is already fixed on `main` and I verified each piece rather than assuming:

- **G3b exists** — final-quarter least-squares RSS slope, evaluated independently of G3a, with a documented calibration block. It is one-sided, which matches the issue's "Flat, not declining: freed entries return to allocator free lists rather than the OS".
- **The report states that a PASS means no gate fired**, which was the issue's closing ask.
- **The window is cut from the sample timeline**, so a run whose readings stop early cannot shrink its own final quarter out of the gate.

With this, I believe #1255 is fully addressed and can close.

## Checklist

- [x] Conventional commits, scoped by subproject
- [x] No `Co-Authored-By` trailers
- [x] Not a CLI JSON schema or DSL syntax change, so no consumer updates required
