### PR TITLE
test(engine): make the run --watch shutdown budget track machine speed

### DIFF
--- a/engine/rocky/tests/run_watch.rs
+++ b/engine/rocky/tests/run_watch.rs
@@ -20,6 +20,94 @@ use std::time::{Duration, Instant};
 /// Minimal pipeline: a single replication target loaded from a 1-row
 /// `raw__demo` schema. No transformation models — keeps the test fast
 /// and avoids any compile-step flakiness.
+/// Budget for the first run, which has nothing to calibrate against.
+///
+/// Deliberately far larger than the ~6 s a warm run takes: it is a max-wait,
+/// not a sleep, so an oversized value costs nothing when things work and only
+/// removes a flake window when they do not.
+const BOOTSTRAP_BUDGET: Duration = Duration::from_secs(120);
+
+/// A re-run must arrive within this many full-run times of the touch.
+const RERUN_BUDGET_RUNS: u32 = 6;
+
+/// Shutdown must complete within this many full-run times of the SIGINT.
+///
+/// This is the assertion the test actually wants to make — "winding down
+/// costs less than a handful of runs" is a property of rocky; "finishes
+/// within 30 seconds" was a property of the machine.
+const SHUTDOWN_BUDGET_RUNS: u32 = 6;
+
+/// Floor under every scaled budget, so a suspiciously fast calibration on an
+/// idle machine cannot produce a deadline too tight to be meaningful.
+const MIN_BUDGET: Duration = Duration::from_secs(30);
+
+/// Ceiling under every scaled budget.
+///
+/// Without one, a first run that took most of `BOOTSTRAP_BUDGET` scales to
+/// `120s x 6 = 12 minutes`, so a genuine shutdown hang would sit undiagnosed
+/// for that long. Nothing terminates it — the repo's nextest profile sets no
+/// `terminate-after`, and the default only *marks* a test slow. Removing a
+/// flake is not worth making a real hang take twelve minutes to report.
+const MAX_BUDGET: Duration = Duration::from_secs(180);
+
+/// A budget expressed in full-run times, clamped at both ends.
+fn scaled_budget(one_run: Duration, runs: u32) -> Duration {
+    (one_run * runs).clamp(MIN_BUDGET, MAX_BUDGET)
+}
+
+/// The scaling property itself, asserted deterministically rather than left to
+/// whether a flake reproduces.
+///
+/// Worth stating why this test exists in this form: CPU load alone does **not**
+/// reproduce #1315. Under 16 spinners at load average ~63, the pre-fix test
+/// passed 3/3 in ~9 s — the reported failure needed a full
+/// `cargo nextest run --all-features` alongside it, i.e. process-spawn and I/O
+/// contention rather than raw CPU pressure. So "it passes under load now" would
+/// have been evidence of nothing. This asserts the mechanism directly instead.
+#[test]
+fn budgets_scale_past_the_old_fixed_deadline() {
+    // The reported numbers: 5.8 s isolated, 32.8 s inside the full suite —
+    // a 5.6x slowdown against what used to be a flat 30 s deadline.
+    let idle_run = Duration::from_secs(2);
+    let loaded_run = idle_run.mul_f64(5.6);
+
+    assert!(
+        scaled_budget(loaded_run, SHUTDOWN_BUDGET_RUNS) > Duration::from_secs(30),
+        "a machine 5.6x slower must get more headroom than the old fixed 30s, \
+         got {:?}",
+        scaled_budget(loaded_run, SHUTDOWN_BUDGET_RUNS)
+    );
+
+    // And the floor holds when calibration comes back implausibly fast, so an
+    // idle machine cannot tighten the deadline below the old one.
+    assert_eq!(
+        scaled_budget(Duration::from_millis(1), SHUTDOWN_BUDGET_RUNS),
+        MIN_BUDGET,
+        "the floor must keep a fast calibration from producing a tight deadline"
+    );
+
+    // The ceiling holds at the other end. Without it a first run that ate most
+    // of the bootstrap budget scales to twelve minutes, and since nothing
+    // terminates a slow test, a genuine hang would sit undiagnosed that long.
+    assert_eq!(
+        scaled_budget(BOOTSTRAP_BUDGET, SHUTDOWN_BUDGET_RUNS),
+        MAX_BUDGET,
+        "the ceiling must bound how long a genuine hang takes to report"
+    );
+    assert!(
+        MAX_BUDGET > MIN_BUDGET,
+        "an inverted clamp would silently pin every budget to one value"
+    );
+
+    // The scaling band is real: between the two clamps the budget tracks the
+    // machine, which is the whole mechanism.
+    assert_eq!(
+        scaled_budget(Duration::from_secs(10), SHUTDOWN_BUDGET_RUNS),
+        Duration::from_secs(60),
+        "inside the band the budget must follow the calibration"
+    );
+}
+
 const ROCKY_TOML: &str = r#"
 [adapter]
 type = "duckdb"
@@ -91,6 +179,13 @@ fn run_watch_reruns_on_file_change_and_exits_clean_on_sigint() {
 
     let exe = env!("CARGO_BIN_EXE_rocky");
 
+    // Start the calibration clock BEFORE the spawn, not after the reader
+    // threads are wired up: everything between here and the first completion
+    // line is part of one run's cost, and on a loaded machine the gap can be
+    // most of it. Measuring from later risks a near-zero reading precisely
+    // when the machine is slow (#1315).
+    let calibration_start = Instant::now();
+
     let mut child = Command::new(exe)
         .arg("-c")
         .arg(&cfg_path)
@@ -146,13 +241,23 @@ fn run_watch_reruns_on_file_change_and_exits_clean_on_sigint() {
                         };
                     }
                 }
-                Err(RecvTimeoutError::Timeout) => {
-                    return WaitResult {
-                        matched: false,
-                        buffered: buf,
-                    };
-                }
-                Err(RecvTimeoutError::Disconnected) => {
+                Err(RecvTimeoutError::Timeout | RecvTimeoutError::Disconnected) => {
+                    // Drain whatever is already queued before declaring a
+                    // timeout. The child may have written the line while this
+                    // thread was descheduled — reporting "never arrived" for a
+                    // line sitting in the channel is the same conflation of
+                    // scheduling latency with product behaviour that #1315 is
+                    // about, one level down.
+                    while let Ok(line) = rx.try_recv() {
+                        buf.push_str(&line);
+                        buf.push('\n');
+                        if line.contains(needle) {
+                            return WaitResult {
+                                matched: true,
+                                buffered: buf,
+                            };
+                        }
+                    }
                     return WaitResult {
                         matched: false,
                         buffered: buf,
@@ -162,25 +267,49 @@ fn run_watch_reruns_on_file_change_and_exits_clean_on_sigint() {
         }
     };
 
-    let first = wait_for(&stderr_rx, "run completed in", Duration::from_secs(20));
+    // The first run doubles as a calibration: how long one full
+    // spawn-compile-execute cycle costs on this machine, right now.
+    //
+    // What it is a proxy for matters. It is NOT a model of shutdown work —
+    // by the time SIGINT is sent the run has already completed, so shutdown
+    // is loop exit plus dropping the `notify` watcher, which is not
+    // proportional to run duration. It is a measure of how slow this machine
+    // currently is, which is the variable that turned a 5.8 s test into a
+    // 32.8 s one. Budgets scale with it for that reason and no other.
+    //
+    // Its own budget cannot be calibrated against anything, so it is simply
+    // generous. That costs nothing on the happy path: `wait_for` returns the
+    // moment the line arrives.
+    //
+    // `calibration_start` is taken before `spawn` deliberately — see the
+    // timer's definition far above. Taking it here would be the bug this
+    // whole change exists to remove: on the loaded machine where the
+    // calibration matters most, the test thread can be descheduled long
+    // enough for the child to finish and queue its completion line first, and
+    // the measured "run" would then be near-zero, collapsing every budget to
+    // the floor exactly when they most needed to grow.
+    let first = wait_for(&stderr_rx, "run completed in", BOOTSTRAP_BUDGET);
     if !first.matched {
         sigterm(pid);
         let _ = child.wait();
         panic!(
-            "first run never completed within 20s.\nstderr so far:\n{}",
+            "first run never completed within {BOOTSTRAP_BUDGET:?}.\nstderr so far:\n{}",
             first.buffered
         );
     }
+    let one_run = calibration_start.elapsed().max(Duration::from_millis(100));
 
     // Touch the watched config to provoke a re-run.
     touch(&cfg_path);
 
-    let second = wait_for(&stderr_rx, "run completed in", Duration::from_secs(20));
+    let rerun_budget = scaled_budget(one_run, RERUN_BUDGET_RUNS);
+    let second = wait_for(&stderr_rx, "run completed in", rerun_budget);
     if !second.matched {
         sigterm(pid);
         let _ = child.wait();
         panic!(
-            "second run never triggered within 20s after touch.\n\
+            "second run never triggered within {rerun_budget:?} after touch \
+             (one run measured {one_run:?} on this machine).\n\
              stderr since first run:\n{}",
             second.buffered
         );
@@ -194,13 +323,37 @@ fn run_watch_reruns_on_file_change_and_exits_clean_on_sigint() {
     // Clean shutdown: SIGINT, then await exit.
     sigint(pid);
 
-    // Generous budget: under a loaded CI runner the watch loop can take
-    // several seconds to wind down the in-flight run and drop the notify
-    // watcher after SIGINT. This is a max-wait deadline — `wait_with_timeout`
-    // returns as soon as the child exits, so a large budget doesn't slow the
-    // happy path, it only removes the flake window.
-    let exit = wait_with_timeout(&mut child, Duration::from_secs(30))
-        .expect("rocky did not exit within 30s of SIGINT");
+    // What this actually asserts is "shutdown does not take longer than a few
+    // full runs" — a claim about rocky, not about the machine. Expressing it
+    // as a fixed wall-clock deadline made it a claim about the machine: at
+    // load average ~26 this test took 32.8 s against a 30 s budget while
+    // taking 5.8 s in isolation, so a busy laptop and a genuine shutdown hang
+    // produced the same failure message (#1315).
+    //
+    // `wait_with_timeout` returns the moment the child exits, so a large
+    // budget costs nothing on the happy path.
+    let shutdown_budget = scaled_budget(one_run, SHUTDOWN_BUDGET_RUNS);
+    let exit = match wait_with_timeout(&mut child, shutdown_budget) {
+        WaitOutcome::Exited(status) => status,
+        // Name the cause rather than the deadline. A machine slow enough to
+        // starve the test and a shutdown that genuinely never completes are
+        // different bugs; the old message could only describe the second.
+        WaitOutcome::StillRunning => {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!(
+                "rocky was still running {shutdown_budget:?} after SIGINT. One run \
+                 measured {one_run:?} on this machine and the budget is \
+                 {SHUTDOWN_BUDGET_RUNS}x that, so if `one_run` is far above a few \
+                 seconds this machine is loaded rather than rocky being stuck."
+            );
+        }
+        WaitOutcome::WaitFailed(e) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("could not determine whether rocky exited after SIGINT: {e}");
+        }
+    };
 
     assert!(
         exit.success(),
@@ -288,19 +441,37 @@ fn spawn_collecting_reader<R: std::io::Read + Send + 'static>(
 }
 
 /// Wait up to `budget` for a child process to exit, polling every 50 ms.
-fn wait_with_timeout(
-    child: &mut std::process::Child,
-    budget: Duration,
-) -> Option<std::process::ExitStatus> {
+/// Why a process wait ended, kept distinct because #1315 is precisely about
+/// a message that could not tell these apart.
+enum WaitOutcome {
+    Exited(std::process::ExitStatus),
+    /// The budget elapsed with the child still running.
+    StillRunning,
+    /// `try_wait` itself failed — neither evidence of a hang nor of an exit.
+    WaitFailed(std::io::Error),
+}
+
+fn wait_with_timeout(child: &mut std::process::Child, budget: Duration) -> WaitOutcome {
     let start = Instant::now();
-    while start.elapsed() < budget {
+    loop {
         match child.try_wait() {
-            Ok(Some(status)) => return Some(status),
-            Ok(None) => std::thread::sleep(Duration::from_millis(50)),
-            Err(_) => return None,
+            Ok(Some(status)) => return WaitOutcome::Exited(status),
+            Ok(None) => {}
+            Err(e) => return WaitOutcome::WaitFailed(e),
         }
+        if start.elapsed() >= budget {
+            // One last poll on the way out. The loop above sleeps in 50 ms
+            // steps, so without this a child that exits between the final
+            // poll and the deadline is reported as still running — a false
+            // "hang" produced by the polling interval rather than by rocky.
+            return match child.try_wait() {
+                Ok(Some(status)) => WaitOutcome::Exited(status),
+                Ok(None) => WaitOutcome::StillRunning,
+                Err(e) => WaitOutcome::WaitFailed(e),
+            };
+        }
+        std::thread::sleep(Duration::from_millis(50).min(budget.saturating_sub(start.elapsed())));
     }
-    None
 }
 
 /// Cross-editor "touch" — opens the file, writes its existing bytes, and


### PR DESCRIPTION
## Summary

Closes #1315.

`run_watch_reruns_on_file_change_and_exits_clean_on_sigint` asserted:

```
rocky did not exit within 30s of SIGINT
```

That message reads as a shutdown-hang assertion. It was a claim about the machine. The issue measured the same test, same binary, back to back: **5.8 s in isolation, 32.8 s inside a full `cargo nextest run` at load average ~26** — a 5.6x slowdown against a flat 30 s deadline. So a real shutdown regression and a busy laptop produced the identical failure, and the next full-suite run passed, which is the worst shape a gate can have.

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Changes

The test already waits for the first run to complete. That wait is now also a **calibration**: how long one full spawn-compile-execute cycle costs on this machine, right now. The re-run and shutdown budgets become multiples of it, clamped to `[30 s, 180 s]`.

**What the calibration is a proxy for**, stated precisely because an earlier draft got this wrong: it is *not* a model of shutdown work. By the time SIGINT is sent the run has already completed, so shutdown is loop exit plus dropping the `notify` watcher — not proportional to run duration. It is a measure of how slow this machine currently is, which is the variable that turned a 5.8 s test into a 32.8 s one. Budgets scale with it for that reason and no other.

Supporting details:

- **The clock starts before `spawn`**, not after the reader threads are wired up. Everything in between is part of one run's cost, and on a loaded machine that gap can be most of it — see the test-plan note below, this was a real defect in the first revision.
- **The first run's budget cannot be calibrated against anything**, so it is simply generous (120 s). `wait_for` returns the instant the line arrives, so an oversized max-wait costs nothing on the happy path.
- **A floor** (30 s, the old value) so an implausibly fast calibration cannot tighten a deadline below where it started, and a **ceiling** (180 s) because nothing terminates a slow test here — the nextest profile sets no `terminate-after` — so an uncapped scale would let a genuine hang sit undiagnosed for twelve minutes.
- **The failure now names the cause, not the deadline.** The wait returns exited / still-running / could-not-tell rather than collapsing the last two, and the message prints the measured run time so a starved machine cannot masquerade as a shutdown bug.

### Two adjacent races, same defect one level down

Both found while fixing the headline one, both in the same file:

- `wait_with_timeout` polled on a 50 ms interval and gave up without a final poll, so a child exiting in the last 50 ms before the deadline was reported as **still running** — a false hang manufactured by the polling interval. It now polls once more on the way out. It also mapped every `try_wait` error to "had exited", which is not evidence of anything; that is now its own outcome.
- `wait_for` checked its deadline without draining lines already queued in the channel, so a completion line written while this thread was descheduled could be reported as never having arrived.

## Test Plan

### The load experiment did not discriminate, and I am reporting that rather than the half of it that looked good

I ran the fixed test under 16 CPU spinners at load average ~63 — well past the ~26 in the report — and it passed 3/3 in ~9 s. On its own that reads like evidence.

It is not. I ran the **pre-fix** test under identical load as a control, and it also passed 3/3, in ~9 s. So CPU saturation does not reproduce #1315 at all: the reported failure needed a concurrent full `cargo nextest run --all-features`, which is process-spawn and I/O contention rather than raw CPU pressure. "It passes under load now" would have been evidence of nothing.

### So the property is asserted directly instead

`budgets_scale_past_the_old_fixed_deadline` pins the mechanism deterministically, no flake required: the reported 5.6x slowdown must produce a budget exceeding the old flat 30 s; an implausibly fast calibration must hit the floor; a bootstrap-length calibration must hit the ceiling; and inside the band the budget must actually track the calibration rather than sitting on a clamp.

**Mutation-checked**: replacing `scaled_budget` with the old flat `Duration::from_secs(30)` turns it red.

- `cargo nextest run --all-features` — full suite green (see checks).
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- The watch test itself: 7.5 s isolated, 8.9 s under load average ~63.

## What I am least confident about

**Whether 6x one run is the right multiple**, and I picked it rather than derived it. The reported failure was ~1.1x over its budget, so almost any scaling fixes that instance; 6x is chosen to leave room without making a genuine hang take absurdly long to report. If shutdown ever legitimately needs more than six full runs, that is itself worth knowing, which is part of why the number is a named constant rather than inline.

## What I am most likely missing

**Whether other tests in this suite have the same shape.** I fixed the one #1315 names. A fixed wall-clock deadline guarding a process-lifecycle event is a pattern, not an incident, and I have not swept the suite for others — `grep from_secs` across `engine/**/tests/` would find candidates, but distinguishing "deadline that is really a load probe" from "deadline that is genuinely the assertion" needs reading each one.

## Checklist

- [x] Conventional commits, scoped by subproject
- [x] No `Co-Authored-By` trailers
- [x] Test-only change, so no changelog entry, no schema or DSL change, no consumer updates

## Independent red team

Reviewed by **Codex (GPT-5)**. Verdict on the first revision: SHIP WITH CHANGES, with five findings. All five accepted and fixed — one of them was fatal to the fix's own purpose.

- **🔴 The calibration started after `spawn`, so on a loaded machine it could measure nothing.** If the test thread is descheduled long enough for the child to finish and queue its completion line, `one_run` collapses to the 100 ms clamp and every budget falls back to the 30 s floor — reproducing the exact false failure the change exists to remove, in precisely the regime where it matters. The clock now starts before `spawn`. This is the finding that mattered; without it the PR would have looked correct and changed nothing under load.
- **The calibration is not proportional to shutdown work.** Correct: the run has completed before SIGINT is sent, so shutdown is watcher teardown, and on macOS `notify`'s FSEvents drop waits on its run-loop thread. The scaling is still right — run time proxies machine speed — but "shutdown costs less than a handful of runs" was the wrong justification and is no longer claimed.
- **No upper bound**: 120 s bootstrap × 6 = 12 minutes for a genuine hang, with nothing to terminate it. Added `MAX_BUDGET`, pinned by a test.
- **`wait_with_timeout` boundary race and error misclassification.** Both fixed as described above.
- **`wait_for` drains nothing before declaring a timeout.** Fixed.

It refuted the attacks that did not land: the floor genuinely prevents budgets tightening below 30 s, a previous iteration's line cannot satisfy the initial wait, nextest will not terminate the test before the bootstrap budget (no `slow-timeout` or `terminate-after` configured — which I had verified independently), and the property test is non-vacuous in both directions.

Its own least-confident note is the right one and I share it: nobody has measured spawn-to-first-completion and SIGINT-to-exit *independently* under full-suite contention, so the ratio between them is assumed rather than known.