### PR TITLE
feat(engine/rocky-mcp): read-only scheduler surface — schedule_status + a history trigger filter

### DIFF
--- a/engine/crates/rocky-cli/src/commands/history.rs
+++ b/engine/crates/rocky-cli/src/commands/history.rs
@@ -141,10 +141,32 @@ pub fn history_runs_output(
     since: Option<&str>,
     audit: bool,
 ) -> Result<HistoryOutput> {
+    history_runs_output_filtered(state_path, since, audit, None)
+}
+
+/// [`history_runs_output`] restricted to runs whose `trigger` matches.
+///
+/// The filter applies BELOW the 50-run recency cap (#1304): filtering the
+/// capped result instead would let a busy project's manual runs crowd every
+/// scheduler run out of the window, reporting "no matching runs" over a
+/// project full of them.
+pub fn history_runs_output_filtered(
+    state_path: &Path,
+    since: Option<&str>,
+    audit: bool,
+    trigger: Option<&str>,
+) -> Result<HistoryOutput> {
     let store = StateStore::open_read_only(state_path)?;
     let since_ts = parse_since(since)?;
 
-    let runs = store.list_runs(50)?;
+    let runs = match trigger {
+        Some(trigger) => {
+            // Match on the same Debug form the output serializes (`"Schedule"`,
+            // `"Webhook"`, ...) so the filter vocabulary IS the wire vocabulary.
+            store.list_runs_matching(50, |run| format!("{:?}", run.trigger) == trigger)?
+        }
+        None => store.list_runs(50)?,
+    };
     let filtered: Vec<_> = if let Some(ts) = since_ts {
         runs.into_iter().filter(|r| r.started_at >= ts).collect()
     } else {

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -130,7 +130,10 @@ pub use export_openapi::export_openapi;
 pub use export_schemas::{export_schemas, schemas_hash};
 pub use fmt::run_fmt;
 pub use gc::{run_gc_derivable, run_gc_plan};
-pub use history::{history_runs_output, model_history_output, recipe_history_output, run_history};
+pub use history::{
+    history_runs_output, history_runs_output_filtered, model_history_output, recipe_history_output,
+    run_history,
+};
 pub use hooks::{run_hooks_list, run_hooks_test};
 pub use import_dbt::run_import_dbt;
 pub use imports_update::run_imports_update;

--- a/engine/crates/rocky-cli/src/commands/schedule_status.rs
+++ b/engine/crates/rocky-cli/src/commands/schedule_status.rs
@@ -60,13 +60,19 @@ pub fn schedule_status_output(
     // An ABSENT state file is normal (no tick has run yet) and yields empty
     // cursors; a file that EXISTS but cannot be opened is a real fault and must
     // not be flattened into "nothing scheduled has ever run".
-    let store = match StateStore::open_read_only(state_path) {
-        Ok(store) => Some(store),
-        Err(e) => {
-            if state_path.exists() {
-                return Err(ScheduleStatusError::State(e.into()));
-            }
-            None
+    //
+    // The existence check runs BEFORE the open, not in its error branch:
+    // redb's read-only open still goes through `Database::create`, so opening
+    // an absent path MATERIALIZES the state file — a status read that writes,
+    // on the one endpoint documented side-effect free. (The check-then-open
+    // race is benign: a run starting concurrently creates the real file and
+    // the next status call reads it.)
+    let store = if !state_path.exists() {
+        None
+    } else {
+        match StateStore::open_read_only(state_path) {
+            Ok(store) => Some(store),
+            Err(e) => return Err(ScheduleStatusError::State(e.into())),
         }
     };
 
@@ -359,5 +365,37 @@ mod tests {
         // No last attempt → Throttle::Clear even though it is standing.
         let fresh = ScheduleStateRecord::default();
         assert!(reportable_throttle(&schedule(vec!["upstream"], false), &fresh, now).is_none());
+    }
+}
+
+#[cfg(test)]
+mod side_effect_free_tests {
+    use super::*;
+
+    /// The #1330 review's confirmed defect: redb's read-only open goes through
+    /// `Database::create`, so a status read of a FRESH project materialized
+    /// the state file — a write, on the one endpoint documented side-effect
+    /// free. The existence guard must keep the read genuinely read-only.
+    #[test]
+    fn a_status_read_of_a_fresh_project_creates_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join("rocky.toml");
+        std::fs::write(
+            &config_path,
+            "[adapter]\ntype = \"duckdb\"\npath = \"x.duckdb\"\n\n\
+             [pipeline.p]\ntype = \"transformation\"\nmodels = \"models/**\"\n\n\
+             [pipeline.p.target.governance]\nauto_create_schemas = true\n",
+        )
+        .unwrap();
+        let state_path = tmp.path().join("state.redb");
+        let rocky_dir = tmp.path().join(".rocky");
+
+        let out = schedule_status_output(&config_path, &state_path, &rocky_dir, chrono::Utc::now())
+            .expect("a fresh project must yield an empty snapshot");
+        assert!(
+            !state_path.exists(),
+            "the read-only status must not materialize the state file"
+        );
+        drop(out);
     }
 }

--- a/engine/crates/rocky-cli/src/commands/scheduler/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/scheduler/mod.rs
@@ -50,7 +50,7 @@ pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(15);
 /// root, not the process cwd) joined with `.rocky`. The single derivation shared
 /// by the reconciler loop, the schedule-status endpoint, and the webhook-ingress
 /// accept path, so all three agree on the tick lock and the demand spool.
-pub(crate) fn rocky_dir_for_config(config_path: &Path) -> PathBuf {
+pub fn rocky_dir_for_config(config_path: &Path) -> PathBuf {
     config_path
         .parent()
         .filter(|p| !p.as_os_str().is_empty())

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -2267,13 +2267,29 @@ impl StateStore {
 
     /// List recent runs (newest first).
     pub fn list_runs(&self, limit: usize) -> Result<Vec<RunRecord>, StateError> {
+        self.list_runs_matching(limit, |_| true)
+    }
+
+    /// List the `limit` most recent runs (newest first) satisfying `keep`.
+    ///
+    /// The predicate applies BEFORE the recency cap — the point of this
+    /// variant (#1304): filtering the capped result instead lets a busy
+    /// project's non-matching runs crowd every match out of the window, and
+    /// the caller reads "no matching runs" off a project full of them.
+    pub fn list_runs_matching(
+        &self,
+        limit: usize,
+        keep: impl Fn(&RunRecord) -> bool,
+    ) -> Result<Vec<RunRecord>, StateError> {
         let txn = self.db.begin_read()?;
         let table = txn.open_table(RUN_HISTORY)?;
         let mut runs = Vec::new();
         for entry in table.iter()? {
             let (_, value) = entry?;
             let run: RunRecord = serde_json::from_slice(value.value())?;
-            runs.push(run);
+            if keep(&run) {
+                runs.push(run);
+            }
         }
         // Sort by started_at descending
         runs.sort_by_key(|run| std::cmp::Reverse(run.started_at));
@@ -7983,6 +7999,41 @@ mod tests {
         r.started_at = started_at;
         r.finished_at = started_at;
         r
+    }
+
+    /// The #1304 filter-below-the-cap contract: a matching run older than 50
+    /// non-matching ones is still returned, where filtering the capped result
+    /// would report "no matching runs" over a project full of them.
+    #[test]
+    fn list_runs_matching_filters_below_the_recency_cap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = StateStore::open(&tmp.path().join("s.redb")).unwrap();
+        let base = chrono::Utc::now();
+        let mut old_schedule = run_at("run-schedule", base - chrono::Duration::hours(100));
+        old_schedule.trigger = RunTrigger::Schedule;
+        store.record_run(&old_schedule).unwrap();
+        for i in 0..55 {
+            let mut r = run_at(
+                &format!("run-manual-{i}"),
+                base - chrono::Duration::hours(i),
+            );
+            r.trigger = RunTrigger::Manual;
+            store.record_run(&r).unwrap();
+        }
+
+        let capped = store.list_runs(50).unwrap();
+        assert!(
+            capped
+                .iter()
+                .all(|r| !matches!(r.trigger, RunTrigger::Schedule)),
+            "precondition: the schedule run is outside the 50 newest"
+        );
+
+        let matched = store
+            .list_runs_matching(50, |r| matches!(r.trigger, RunTrigger::Schedule))
+            .unwrap();
+        assert_eq!(matched.len(), 1, "the filter must reach below the cap");
+        assert_eq!(matched[0].run_id, "run-schedule");
     }
 
     fn dag_snapshot_at(timestamp: chrono::DateTime<Utc>, hash: &str) -> DagSnapshot {

--- a/engine/crates/rocky-mcp/src/result_types.rs
+++ b/engine/crates/rocky-mcp/src/result_types.rs
@@ -473,7 +473,8 @@ pub struct RunHistoryLite {
     pub started_at: String,
     /// `"Success"`, `"Failed"`, `"Partial"`, etc.
     pub status: String,
-    /// `"Manual"`, `"Scheduled"`, etc.
+    /// `"Manual"`, `"Schedule"`, `"Webhook"`, etc. — the run trigger's wire
+    /// vocabulary, exactly as `history.trigger` filters on it.
     pub trigger: String,
     /// Number of models executed in the run.
     pub models_executed: usize,

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -2643,7 +2643,9 @@ impl RockyMcpServer {
          last submission and outcome, consecutive failures, active claims, and tick-lock state. \
          Reports stored state only — it does NOT evaluate demand (side-effect free; \
          `rocky tick --dry-run` is the evaluation). `next_fire_at` in the past means an overdue \
-         pipeline, not a future promise."
+         pipeline, not a future promise. Reads the project's canonical state path: a scheduler \
+         started with an explicit `--state-path` override is not visible here — query that \
+         server's GET /api/v1/schedule instead."
     )]
     async fn schedule_status(
         &self,
@@ -2672,10 +2674,11 @@ impl RockyMcpServer {
         })?
         .map_err(|e| {
             ToolError::internal(
-                format!("{e:#}"),
-                "Could not read the schedule state; ensure the project config parses and the \
-                 state store is readable. A project with no [schedule] blocks returns an empty \
-                 snapshot, not an error.",
+                // Top-level message only — the alternate chain carries absolute
+                // project paths, which do not belong on the wire.
+                format!("could not read the schedule state: {e}"),
+                "Ensure the project config parses and the state store is readable. A project \
+                 with no [schedule] blocks returns an empty snapshot, not an error.",
             )
         })?;
         let value = serde_json::to_value(&output).map_err(|e| {

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -162,6 +162,12 @@ pub struct HistoryArgs {
     /// project-level run summary.
     #[serde(default)]
     pub model: Option<String>,
+    /// When set (project-level form only), return only runs whose trigger
+    /// matches — e.g. `"Schedule"` for scheduler-submitted runs. The filter
+    /// applies BEFORE the recency cap, so a busy project's manual runs cannot
+    /// crowd scheduler runs out of the window.
+    #[serde(default)]
+    pub trigger: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -882,7 +888,13 @@ impl RockyMcpServer {
                 }))
             }
             None => {
-                let out = commands::history_runs_output(&state_path, None, false).map_err(|e| {
+                let out = commands::history_runs_output_filtered(
+                    &state_path,
+                    None,
+                    false,
+                    params.0.trigger.as_deref(),
+                )
+                .map_err(|e| {
                     ToolError::internal(
                         format!("{e:#}"),
                         "Could not read the run history from the state store; ensure the \
@@ -2620,6 +2632,55 @@ impl RockyMcpServer {
         let value = serde_json::to_value(&output).map_err(|e| {
             ToolError::internal(
                 format!("failed to serialize the estate brief: {e}"),
+                "Retry; if it persists this is an internal serialization bug.",
+            )
+        })?;
+        Ok(Json(value))
+    }
+
+    #[tool(
+        description = "Read-only scheduler snapshot: per-pipeline cron/after/freshness cursors, \
+         last submission and outcome, consecutive failures, active claims, and tick-lock state. \
+         Reports stored state only — it does NOT evaluate demand (side-effect free; \
+         `rocky tick --dry-run` is the evaluation). `next_fire_at` in the past means an overdue \
+         pipeline, not a future promise."
+    )]
+    async fn schedule_status(
+        &self,
+        Parameters(_args): Parameters<NoArgs>,
+    ) -> ToolResult<serde_json::Value> {
+        let config_path = self.config_path.clone();
+        let state_path = self.state_path();
+        // The SAME `.rocky` derivation the API route and the reconciler use,
+        // so this snapshot reports against the tick lock a `serve --scheduler`
+        // or a cron `rocky tick` actually holds.
+        let rocky_dir = commands::scheduler::rocky_dir_for_config(&config_path);
+        let output = tokio::task::spawn_blocking(move || {
+            commands::schedule_status::schedule_status_output(
+                &config_path,
+                &state_path,
+                &rocky_dir,
+                chrono::Utc::now(),
+            )
+        })
+        .await
+        .map_err(|e| {
+            ToolError::internal(
+                format!("schedule status task failed: {e}"),
+                "Retry; if it persists this is an internal join error.",
+            )
+        })?
+        .map_err(|e| {
+            ToolError::internal(
+                format!("{e:#}"),
+                "Could not read the schedule state; ensure the project config parses and the \
+                 state store is readable. A project with no [schedule] blocks returns an empty \
+                 snapshot, not an error.",
+            )
+        })?;
+        let value = serde_json::to_value(&output).map_err(|e| {
+            ToolError::internal(
+                format!("failed to serialize the schedule snapshot: {e}"),
                 "Retry; if it persists this is an internal serialization bug.",
             )
         })?;

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -103,6 +103,7 @@ async fn tools_list_returns_expected_set() {
             "propose",
             "review_queue",
             "sample_rows",
+            "schedule_status",
             "scorecard",
             "suggest_freshness_block",
             "test",


### PR DESCRIPTION
The first slice of the scheduler agent-operations surface, **deliberately read-only**: the mutating half (`trigger_pipeline`/`resume`) needs a policy-capability vocabulary decision that stays deferred until real demand shows; `pause` rides separately (it carries a cross-crate skip-reason ripple).

## What ships

- **`schedule_status`** — the `GET /api/v1/schedule` projection as an MCP tool, through the **same non-printing core and the same `.rocky` derivation** the API route and the reconciler use, so the snapshot reports against the tick lock a `serve --scheduler` or a cron `rocky tick` actually holds. Stored state only — it does not evaluate demand (side-effect free), and the tool description says so, plus what a past `next_fire_at` means (an overdue pipeline, not a future promise).
- **`history` gains an optional `trigger` argument** (`"Schedule"`, `"Webhook"`, … — the wire vocabulary), applied **below the 50-run recency cap** via a new `StateStore::list_runs_matching`. Filtering the capped result instead lets a busy project's manual runs crowd every scheduler run out of the window — the exact lie-by-omission called out on #1304, whose cheap half this is.

## Evidence

- Below-the-cap contract pinned: a matching run older than **55** non-matching ones is still returned (and a precondition assert proves it sits outside the plain cap).
- MCP tool list + schemas re-pinned (29 tools); roundtrip suite 66/66.
- Full workspace **5873/5873** · clippy `-D warnings` clean · fmt clean.
- **No codegen cascade**: `HistoryOutput`'s shape is untouched (the filter narrows rows, not fields) and `ScheduleStatusOutput` is reused as-is.

## Scope notes

`rocky_dir_for_config` widened `pub(crate)`→`pub` so the MCP layer shares the exact lock-path derivation instead of re-deriving it. The deferred mutating surface and its `PolicyCapability` question, incident bundles, and the brief section remain tracked in the P4 plan; #1304's real half (the `list_runs` full-scan) is unchanged.

Independent red-team pass dispatched; merge held for it plus green CI.