### PR TITLE
fix(dagster/sdk): run a transformation asset under its own pipeline

### DIFF
--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A transformation asset now materializes under the pipeline that owns it.** `dagster_rocky` passed only the bare model name to `rocky run --model`, and the engine's model-only fallback resolves the target adapter as the *first transformation pipeline declared in `rocky.toml`*. With one transformation pipeline that is always right; with two — the standard silver/gold layering — every asset built into whichever pipeline came first, so `gold`'s models were written into `silver`'s warehouse. The node's `pipeline` is already in the DAG payload and is now passed through; `--models` is unchanged, so the root a node was discovered in stays the root it is built from. A payload with no `pipeline` (an older engine) keeps the previous fallback rather than inventing a name. This fixes adapter routing for pipelines that *share* a models root; pipelines with separate roots are still blocked earlier, in DAG discovery (#1348). (#1292)
+
+  **This also makes `[target.governance] auto_create_schemas` take effect for Dagster materializations, including single-pipeline projects.** Naming a pipeline selects the engine's explicit-pipeline branch, which reads that setting from the pipeline; the unnamed fallback hardcoded it off. So a project configured `auto_create_schemas = true` whose asset targets a missing schema previously failed with "Schema with name X does not exist" and now creates the schema — which is what `rocky run` has always done for the same config, and what the setting asks for. If you do **not** want Dagster creating schemas, set `auto_create_schemas = false` on that pipeline's target. (#1292, #1350)
+
 ## [1.61.1] — 2026-07-19
 
 ### Changed

--- a/integrations/dagster/src/dagster_rocky/dag_assets.py
+++ b/integrations/dagster/src/dagster_rocky/dag_assets.py
@@ -502,9 +502,18 @@ def _make_dag_group_asset(
                 continue
 
             if node.kind == "transformation":
-                context.log.info(f"Executing rocky run --model {node.label}")
+                # Scope the model to its OWNING pipeline. Without `--pipeline`
+                # the engine falls back to the first transformation pipeline
+                # declared in `rocky.toml`, so in a silver/gold project every
+                # asset builds into whichever one happens to come first (#1292).
+                # `pipeline` is always populated for transformation nodes; the
+                # `None` arm is for a payload from an older engine, which keeps
+                # the previous fallback rather than inventing a pipeline name.
+                pipeline_label = f" --pipeline {node.pipeline}" if node.pipeline else ""
+                context.log.info(f"Executing rocky run --model {node.label}{pipeline_label}")
                 result = rocky.run_model(
                     node.label,
+                    pipeline=node.pipeline,
                     **partition_kwargs,  # type: ignore[arg-type]
                 )
                 context.log.info(

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -1240,6 +1240,7 @@ class RockyResource(dg.ConfigurableResource):
         self,
         model_name: str,
         *,
+        pipeline: str | None = None,
         filter: str | None = None,
         partition: str | None = None,
         partition_from: str | None = None,
@@ -1249,10 +1250,16 @@ class RockyResource(dg.ConfigurableResource):
         lookback: int | None = None,
         parallel: int | None = None,
     ) -> RunResult:
-        """Run ``rocky run --model <name>`` for a single compiled model."""
+        """Run ``rocky run --model <name>`` for a single compiled model.
+
+        ``pipeline`` scopes the model to its owning transformation pipeline.
+        ``--models`` is unaffected — see :meth:`rocky_sdk.RockyClient.run_model`
+        for why the discovery root and the execution root have to stay the same.
+        """
         with _translating():
             return self._get_client().run_model(
                 model_name,
+                pipeline=pipeline,
                 filter=filter,
                 partition=partition,
                 partition_from=partition_from,

--- a/integrations/dagster/tests/test_dag_assets.py
+++ b/integrations/dagster/tests/test_dag_assets.py
@@ -524,6 +524,74 @@ def _materialize_dag(dag: DagResult, run_result, translator=None):
     return dg.materialize(assets, raise_on_error=False)
 
 
+def test_transformation_materializes_against_its_own_pipeline():
+    """#1292: each transformation asset must run under the pipeline that owns it.
+
+    `dagster_rocky` passed only the bare model name, and the engine's model-only
+    fallback then resolves the target adapter as the FIRST transformation
+    pipeline in `rocky.toml` (an `IndexMap`, so declaration order). A silver/gold
+    project therefore built *every* model into whichever pipeline came first —
+    `gold`'s models landing in `silver`'s warehouse.
+
+    Two models from two pipelines, materialized together, is what makes this
+    binding: a single-pipeline fixture cannot tell "passes the right pipeline"
+    apart from "passes a constant".
+
+    Mutation that must turn this red: drop `pipeline=node.pipeline` from the
+    `run_model` call in `dag_assets.py`.
+    """
+    dag = _make_dag_result(
+        nodes=[
+            {
+                "id": "transformation:silver_orders",
+                "kind": "transformation",
+                "label": "silver_orders",
+                "pipeline": "silver",
+                "target": {"catalog": "w", "schema": "s", "table": "silver_orders"},
+            },
+            {
+                "id": "transformation:gold_orders",
+                "kind": "transformation",
+                "label": "gold_orders",
+                "pipeline": "gold",
+                "target": {"catalog": "w", "schema": "g", "table": "gold_orders"},
+            },
+        ]
+    )
+    from unittest.mock import MagicMock
+
+    mock_rocky = MagicMock()
+    mock_rocky.run_model.return_value = _dag_run_result()
+    assets = build_dag_multi_assets(dag, rocky=mock_rocky, translator=RockyDagsterTranslator())
+    dg.materialize(assets, raise_on_error=False)
+
+    by_model = {
+        call.args[0]: call.kwargs.get("pipeline") for call in mock_rocky.run_model.call_args_list
+    }
+    assert by_model == {"silver_orders": "silver", "gold_orders": "gold"}
+
+
+def test_transformation_without_a_pipeline_field_still_runs():
+    """The control, and the back-compat guarantee. A DAG payload from an engine
+    that predates the `pipeline` field must still materialize — passing
+    `pipeline=None` keeps the engine's pre-existing fallback rather than
+    inventing a name. Without this, the assertion above could be satisfied by
+    refusing to run anything that lacks a pipeline."""
+    from unittest.mock import MagicMock
+
+    mock_rocky = MagicMock()
+    mock_rocky.run_model.return_value = _dag_run_result()
+    assets = build_dag_multi_assets(
+        _single_transformation_dag(),
+        rocky=mock_rocky,
+        translator=RockyDagsterTranslator(),
+    )
+    result = dg.materialize(assets, raise_on_error=False)
+
+    assert result.success
+    assert mock_rocky.run_model.call_args.kwargs.get("pipeline") is None
+
+
 def test_dag_transformation_failed_model_raises_failure_not_green():
     """A model run that came back with itemised errors (run_model allows
     partial failure) must FAIL the op with the engine's error — not yield the

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -220,7 +220,7 @@ wheels = [
 
 [[package]]
 name = "dagster-rocky"
-version = "1.60.0"
+version = "1.61.1"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },
@@ -910,7 +910,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.8.3"
+version = "0.10.0"
 source = { editable = "../../sdk/python" }
 dependencies = [
     { name = "pydantic" },

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `RockyClient.run_model()` takes `pipeline=`, scoping a model-only run to its owning transformation pipeline. Without it the engine falls back to the first transformation pipeline declared in `rocky.toml`, which is wrong for any project with more than one. `--models` is still sent alongside it: the engine treats an explicit `--models` as an override of the pipeline's own selection, so dropping it would execute from a different root than `dag()` discovered the model in — different SQL for the same node, or a "model not found". Calls that pass no `pipeline` are byte-identical to before. (#1292)
+
 ## [0.10.0] — 2026-07-24
 
 ### Added

--- a/sdk/python/src/rocky_sdk/client.py
+++ b/sdk/python/src/rocky_sdk/client.py
@@ -956,6 +956,7 @@ class RockyClient:
         self,
         model_name: str,
         *,
+        pipeline: str | None = None,
         filter: str | None = None,
         partition: str | None = None,
         partition_from: str | None = None,
@@ -968,8 +969,32 @@ class RockyClient:
         """Run ``rocky run --model <name>`` for a single compiled model.
 
         ``--model`` skips the replication phase and executes only the named model.
+
+        ``pipeline`` names the transformation pipeline that owns the model. Pass
+        it whenever the project has more than one: without it the engine falls
+        back to the *first* transformation pipeline declared in ``rocky.toml``,
+        so a model belonging to any other one is built into the wrong warehouse.
+
+        ``--models`` is still sent alongside it, and that pairing is deliberate.
+        The engine treats an explicit ``--models`` as an override of the named
+        pipeline's own ``models`` selection, so omitting it would execute from a
+        *different* root than the one this client discovered the model in — and
+        the two must agree. :meth:`dag` enumerates nodes from ``models_dir``, so
+        a caller that discovered ``preview_models/orders`` and then executed the
+        pipeline-configured ``models/orders`` would build different SQL than the
+        node it was asked to materialize, or fail "model not found" outright.
+
+        The consequence is that **no** project with two or more transformation
+        pipelines can be served by this client today — not only ones whose
+        pipelines live in separate directories. :meth:`dag` always sends
+        ``--models``, which the engine reads as a whole-project override and
+        clones into every transformation pipeline, so every model ends up
+        claimed more than once and DAG build refuses (#1348). Discovery has to
+        learn per-pipeline roots first; this call must follow it, not lead it.
         """
         args = ["run", "--model", model_name, "--models", self.models_dir]
+        if pipeline is not None:
+            args.extend(["--pipeline", pipeline])
         if filter is not None:
             args.extend(["--filter", filter])
         if partition is not None:

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -104,6 +104,65 @@ def test_build_cmd_uses_state_namespace_when_set():
     assert "--state-path" not in cmd
 
 
+class _ArgvCapturedError(Exception):
+    """Raised by the stub below once it has recorded the argv.
+
+    The assertions here are about the command line the client BUILDS, so the
+    stub short-circuits instead of returning a fake payload. That keeps these
+    tests independent of ``RunResult``'s field set, which has its own drift
+    surface (#924) and would otherwise make an unrelated schema change look
+    like a regression in argv construction.
+    """
+
+    def __init__(self, argv: list[str]) -> None:
+        # NOT `self.args` — that is `BaseException.args`, which coerces to a
+        # tuple and would silently fail every list comparison below.
+        super().__init__()
+        self.argv = argv
+
+
+def _capture_argv(args, allow_partial=False):
+    raise _ArgvCapturedError(args)
+
+
+def _run_model_argv(client, *cargs, **ckwargs) -> list[str]:
+    with patch.object(type(client), "run_cli", staticmethod(_capture_argv)):
+        try:
+            client.run_model(*cargs, **ckwargs)
+        except _ArgvCapturedError as captured:
+            return captured.argv
+    raise AssertionError("run_model did not invoke the CLI")
+
+
+def test_run_model_scopes_to_its_pipeline_without_moving_the_models_root():
+    """#1292: a model-only run must name its owning transformation pipeline.
+
+    Without ``--pipeline`` the engine resolves the target adapter as the FIRST
+    transformation pipeline declared in ``rocky.toml``, so a silver/gold project
+    builds every model into whichever comes first.
+
+    ``--models`` must stay. An earlier revision of this fix dropped it whenever a
+    pipeline was named, reasoning that the pipeline's own configured selection is
+    more correct. That broke a working single-pipeline setup: ``dag()`` discovers
+    nodes from ``models_dir``, so executing from the pipeline's root instead can
+    silently build *different SQL* than the node being materialized, or fail
+    "model not found". The discovery root and the execution root have to agree,
+    and this is the assertion that pins them together.
+    """
+    args = _run_model_argv(_client(models_dir="preview_models"), "gold_orders", pipeline="gold")
+    assert args[:3] == ["run", "--model", "gold_orders"]
+    assert args[3:7] == ["--models", "preview_models", "--pipeline", "gold"]
+
+
+def test_run_model_without_a_pipeline_keeps_the_models_dir():
+    """The control. A single-pipeline project — or a DAG payload from an engine
+    that predates the ``pipeline`` field — is byte-identical to before, so the
+    test above is about the pipeline being added rather than anything moving."""
+    args = _run_model_argv(_client(models_dir="custom_models"), "orders")
+    assert args == ["run", "--model", "orders", "--models", "custom_models"]
+    assert "--pipeline" not in args
+
+
 def test_build_run_args_threads_every_flag():
     client = _client(models_dir="models")
     args = client._build_run_args(


### PR DESCRIPTION
## Summary

Closes #1292.

`dagster_rocky` materialized a transformation asset by passing the **bare model name** to `rocky run --model`, with no `--pipeline`. The engine's model-only fallback then resolves the target adapter as the first transformation pipeline in `config.pipelines` — an `IndexMap` (`config.rs:2486`), so **the first one declared in `rocky.toml`**.

With one transformation pipeline that is always correct. With two sharing a models root, every asset executed against whichever came first, so `gold`'s models were built into `silver`'s warehouse — and reordering `rocky.toml` changed which warehouse a model landed in.

## Subproject(s) touched

- [ ] `engine/` (Rust CLI / crates)
- [x] `integrations/dagster/` (Python package)
- [x] `sdk/python/` (Python SDK)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Changes

The node's `pipeline` is already in the DAG payload and is **always populated** for transformation nodes (`unified_dag.rs:596`), so nothing has to be derived — it is threaded through `RockyResource.run_model` → `RockyClient.run_model` → `--pipeline`.

**No engine change.** `--model` with `--pipeline` is already supported and tested (`models_glob_base.rs:141`); only the caller was missing.

**`--models` is unchanged, and that is now a deliberate assertion rather than an oversight.** An earlier revision of this PR *dropped* `--models` whenever a pipeline was named, reasoning that the pipeline's own configured selection is the more correct root. Review showed that breaks a working configuration — see below. The discovery root and the execution root have to agree, and a test now pins them together.

## ⚠️ Draft: this does not close #1292 on its own, and should not merge alone

Two revisions of this PR made a scope claim that was wrong, each time less wrong than the last. The accurate statement:

**No project with two or more transformation pipelines can reach this code through `RockyComponent` today** — not only ones with separate models roots, which is what I claimed last time.

`RockyClient.dag()` always sends `--models`. The engine reads that as a whole-project override and clones the one loaded model list into **every** transformation pipeline (`dag.rs:141-158`). `reject_models_claimed_twice` then counts pipelines per model name (`unified_dag.rs:326-352`), so with N ≥ 2 transformation pipelines *every* model is claimed N times and DAG build refuses. Sharing a root does not help; it is the cloning that creates the collision, not the directory layout.

So in every configuration reachable today:

- **One transformation pipeline** — the fallback already picked the right pipeline, so `--pipeline` changes no routing. The only observable difference is the `auto_create_schemas` DDL change below.
- **Two or more** — discovery refuses before execution.

That makes this, as it stands, a behaviour change with no compensating benefit. It should land **with or after #1348**, not before.

I am leaving it open as a draft rather than closing it: the change itself is correct and tested, and #1348's fix would otherwise have to carry it.

## Naming a pipeline ships more than the adapter — and one of those things writes DDL

Found by checking my own change rather than by review, and it is the thing a reviewer should look at hardest.

Passing `--pipeline` does not merely select an adapter: it selects the engine's **explicit-pipeline branch**, which differs from the unnamed fallback in a third field.

| | adapter | models glob | `auto_create_schemas` |
|---|---|---|---|
| explicit `--pipeline P` (`run.rs:1458-1462`) | `P`'s | `P`'s | **`P`'s config** |
| fallback (`run.rs:1471-1475`) | first transformation pipeline's | that pipeline's | **hardcoded `false`** |

`auto_create_schemas` issues `CREATE SCHEMA` DDL (`run.rs:7460-7478`). So **every** Dagster deployment — including single-pipeline ones that were never mis-routed — moves from the fallback to the explicit branch. A project configured `auto_create_schemas = true` whose asset targets a missing schema previously failed with "Schema with name X does not exist" and now creates the schema.

I am shipping that rather than suppressing it, for three reasons: the user wrote the setting; `rocky run` has always honoured it for the same config, so this removes a disagreement rather than creating one; and suppressing it from the SDK would mean deliberately ignoring a user's configuration, which is worse than honouring it. It is documented in the dagster changelog with the opt-out (`auto_create_schemas = false`).

But the underlying split is incoherent — the fallback trusts the pipeline it resolved for two fields and ignores it for the third, with no comment either way — so **#1350** files it for a decision in the engine, where it belongs. This PR should not be the thing that settles whether a model-scoped run may emit DDL.

## Test Plan

Four tests, two per layer, each with its own control:

- `test_transformation_materializes_against_its_own_pipeline` — the headline. **Two** models from **two** pipelines materialized together, asserting each `run_model` call carried its own pipeline. A single-pipeline fixture cannot distinguish "passes the right pipeline" from "passes a constant", which is why this one has two.
- `test_transformation_without_a_pipeline_field_still_runs` — back-compat: a payload with no `pipeline` still materializes, passing `pipeline=None`. Without it, the headline test could be satisfied by refusing to run anything unpipelined.
- `test_run_model_scopes_to_its_pipeline_without_moving_the_models_root` — argv: `--pipeline` added, `--models` **still present and unchanged**. This is the regression guard, not a formality.
- `test_run_model_without_a_pipeline_keeps_the_models_dir` — the control: byte-identical argv when no pipeline is named.

The SDK tests assert on the argv the client **builds**, via a stub that records and short-circuits rather than returning a fake payload. That keeps them independent of `RunResult`'s field set, which has its own drift surface (#924) — otherwise an unrelated schema change would surface as an argv regression.

**Mutation-checked**, each reddening exactly one test:

| mutation | fails |
|---|---|
| drop `pipeline=node.pipeline` from the `run_model` call | the two-pipeline routing test only (697 others pass) |
| drop `--models` when a pipeline is named (**the regression review found**) | the argv test only (205 others pass) |

- `pytest` — dagster **698 passed**, sdk **206 passed**.
- `ruff check` + `ruff format --check` — clean in both packages.

## Independent red team

Reviewed by **Codex (GPT-5.6)** with a second independent pass. Verdict on the first revision: **DO NOT SHIP**, and it was right on the finding that mattered most.

- **🔴 Dropping `--models` was a data-integrity regression for a working single-pipeline project.** `dag()` discovers nodes from the client's `models_dir`; my change made execution use the *pipeline's* configured root instead. With `models_dir="preview_models"` and a pipeline configured `models="models/**"`, both containing `orders` with different SQL, the DAG describes preview SQL and materialization silently builds the configured one — or fails "model not found" if the model exists only in the discovery root. Reverted; `--models` stays, and the argv test now pins it.
- **🔴 My reachability claim was wrong.** I wrote that #1261 made this reachable. Discovery refuses first (`dag.rs:141-158`), so it is still blocked. Filed as **#1348**; the PR now says what it does and does not fix.
- **🔴 My "asset keys need no qualification" claim was half wrong.** Node ids *are* safe — `reject_models_claimed_twice` guarantees it. But target triples are **not**: `reject_duplicate_physical_targets` keys on `(adapter, target)`, so the same `c.s.orders` on two different adapters is *deliberately* allowed, and the translator drops the adapter and collapses them into one asset key. I wrote that guard, and still got its guarantee backwards. Filed as **#1349**.
- **Confirmed pre-existing, fails closed:** the legacy `dag_mode=False` derived-model path runs without a pipeline, but `resolve_pipeline(..., None)` loudly rejects a multi-pipeline project (`registry.rs:837-856`). That answers my earlier "probably unreachable" hedge — it is reachable, and it errors rather than mis-routing.
- **Noted, handled:** `DagNodeOutput.pipeline` is `Optional` in the generated type and cached payloads are only Pydantic-validated, so `None` is reachable. The `None` arm keeps the old fallback rather than inventing a name.

Its remaining criticism I am **not** fixing here: the tests inject a `MagicMock` into `build_dag_multi_assets` and so do not exercise `RockyClient.dag()` or the engine producer end to end. That is fair, and the fixture it asks for is the right thing to build — but it belongs with #1348, which is what makes the multi-root path constructible in the first place. Building it here would test a path that cannot yet run.

## What I am least confident about

**Whether `--models` should eventually move to per-pipeline roots on this call.** Keeping it is right *today* because discovery sends it too, so the two agree. It is not right in general — it is why separate-root projects cannot work. I have deliberately made this call follow discovery rather than lead it, and recorded the coupling in #1348, because the previous revision led and broke a working setup.

## What I am most likely missing

**Whether any other `RockyClient` method has the same discovery/execution root split.** I checked `run_model` and `dag`, which are the pair #1292 puts in tension. Nine other methods pass `--models self.models_dir`, and I have not audited whether any of them is a *consumer* of `dag()`'s node identities in the way `run_model` is.

**And whether `auto_create_schemas` is the only field that differs between the two branches.** I compared the three-tuple the two arms return and found one difference. I did not audit what `resolve_pipeline` does beyond returning the config, nor whether anything downstream keys on "was a pipeline named" independently of these three values. `auto_create_catalogs` lives in the same `governance` block and is worth checking — #1350 says so.

## Checklist

- [x] Conventional commits, scoped by subproject
- [x] No `Co-Authored-By` trailers
- [x] Not a CLI JSON schema or DSL syntax change, so no consumer updates required
