### PR TITLE
fix(engine): order physical-read consumers after their producers in both schedulers

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -6037,6 +6037,13 @@
           },
           "version": {
             "type": "string"
+          },
+          "warnings": {
+            "description": "Scheduling warnings from physical-read edge derivation: mutual reads serialized by a deterministic order, models whose SQL could not be parsed for reads, and colliding targets. Empty when none.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           }
         },
         "required": [
@@ -16307,6 +16314,13 @@
               "string",
               "null"
             ]
+          },
+          "scheduling_warnings": {
+            "description": "Scheduling warnings from physical-read edge derivation (#1275): mutual physical reads serialized by a deterministic order, models whose SQL could not be parsed for table references, and colliding targets. Empty (and omitted) when none.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           "shadow": {
             "description": "True when running in shadow mode (targets rewritten).",

--- a/editors/vscode/src/types/generated/dag_run.ts
+++ b/editors/vscode/src/types/generated/dag_run.ts
@@ -39,6 +39,10 @@ export interface DagRunOutput {
    */
   total_nodes: number;
   version: string;
+  /**
+   * Scheduling warnings from physical-read edge derivation: mutual reads serialized by a deterministic order, models whose SQL could not be parsed for reads, and colliding targets. Empty when none.
+   */
+  warnings?: string[];
   [k: string]: unknown;
 }
 /**

--- a/editors/vscode/src/types/generated/run.ts
+++ b/editors/vscode/src/types/generated/run.ts
@@ -167,6 +167,10 @@ export interface RunOutput {
   quarantine?: QuarantineOutput[];
   resumed_from?: string | null;
   /**
+   * Scheduling warnings from physical-read edge derivation (#1275): mutual physical reads serialized by a deterministic order, models whose SQL could not be parsed for table references, and colliding targets. Empty (and omitted) when none.
+   */
+  scheduling_warnings?: string[];
+  /**
    * True when running in shadow mode (targets rewritten).
    */
   shadow?: boolean;

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -5993,6 +5993,82 @@ pub(crate) fn dialect_case_rules(
 /// Route the models built by this invocation and their in-run dependency reads
 /// to shadow targets. Deferred or otherwise unselected upstreams stay on their
 /// production targets.
+/// Physical-read ordering for NON-shadow runs (#1275): a model that reads
+/// another in-run model's rendered target by physical name has no
+/// compile-time edge (multi-part refs are external to `classify_table_ref`),
+/// so the pair can share an execution layer and race under `--parallel`.
+/// Derive the missing edges from target components (shared derivation with
+/// the `run --dag` scheduler), apply them to the runtime DAG copy, and
+/// recompute the plan — the compile-time graph, `E001` surface, and
+/// `rocky dag` export stay untouched. Shadow runs are excluded: shadow's own
+/// rewrite derives edges for every redirected read and refuses the unsafe
+/// remainder.
+///
+/// Cycle-closing candidates never leave the derivation (skipped
+/// deterministically, reported as warnings), so this recompute cannot turn
+/// a compiling project into a refused one.
+fn augment_physical_read_edges(
+    compile_result: &mut rocky_compiler::compile::CompileResult,
+    contain_failures: bool,
+    warnings: &mut Vec<String>,
+) -> Result<()> {
+    let inputs: Vec<rocky_core::physical_edges::PhysicalEdgeModel<'_>> = compile_result
+        .project
+        .models
+        .iter()
+        .map(rocky_core::physical_edges::PhysicalEdgeModel::from_model)
+        .collect();
+    let existing: Vec<(String, String)> = compile_result
+        .project
+        .dag_nodes
+        .iter()
+        .flat_map(|n| {
+            n.depends_on
+                .iter()
+                .map(|p| (n.name.clone(), p.clone()))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let derived = rocky_core::physical_edges::derive_physical_edges(&inputs, &existing);
+    warnings.extend(rocky_core::physical_edges::derivation_warnings(&derived));
+    if derived.edges.is_empty() {
+        return Ok(());
+    }
+    let mut added = 0usize;
+    for (consumer, producer) in &derived.edges {
+        let Some(node) = compile_result
+            .project
+            .dag_nodes
+            .iter_mut()
+            .find(|n| &n.name == consumer)
+        else {
+            continue;
+        };
+        if !node.depends_on.contains(producer) {
+            node.depends_on.push(producer.clone());
+            added += 1;
+        }
+    }
+    // Same recompute contract as the shadow rewrite: under
+    // `[resilience] contain_failures` execution follows the containment
+    // ledger's own augmented layering (which already orders physical
+    // readers), so recomputing here would be ignored.
+    if added > 0 && !contain_failures {
+        let nodes = &compile_result.project.dag_nodes;
+        let execution_order = rocky_ir::dag::topological_sort(nodes).with_context(|| {
+            "physical-read ordering introduced a dependency the models cannot satisfy; \
+             declare the dependencies via depends_on"
+        })?;
+        let layers = rocky_ir::dag::execution_layers(nodes).with_context(|| {
+            "physical-read ordering introduced a dependency the models cannot satisfy; \
+             declare the dependencies via depends_on"
+        })?;
+        compile_result.project.execution_order = execution_order;
+        compile_result.project.layers = layers;
+    }
+    Ok(())
+}
+
 fn apply_shadow_rewrite(
     compile_result: &mut rocky_compiler::compile::CompileResult,
     model_name_filter: Option<&str>,
@@ -7366,6 +7442,12 @@ pub(crate) async fn execute_models(
             resilience.contain_failures,
         )?;
         output.shadow = true;
+    } else {
+        augment_physical_read_edges(
+            &mut compile_result,
+            resilience.contain_failures,
+            &mut output.scheduling_warnings,
+        )?;
     }
 
     // #1093: capture governance from the same in-memory model set the
@@ -12182,6 +12264,7 @@ mod tests {
         let output = RunOutput {
             version: "1.0.2".into(),
             command: "run".into(),
+            scheduling_warnings: Vec::new(),
             status: rocky_core::state::RunStatus::Success,
             skipped_by_run_id: None,
             idempotency_key: None,
@@ -17002,6 +17085,83 @@ timestamp_column = "ts"
             ),
         )
         .expect("write model toml");
+    }
+
+    /// #1275: a physical `schema.table` read of another in-run model's
+    /// target derives a run-time ordering edge and re-layers, so the pair is
+    /// never co-scheduled — while the compile-time graph stays untouched.
+    #[cfg(feature = "duckdb")]
+    #[test]
+    fn a_physical_read_orders_consumer_after_producer() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        write_model_with_target(&models_dir, "orders", "SELECT 1 AS id", "main", "orders");
+        write_model_with_target(
+            &models_dir,
+            "mart_qualified",
+            "SELECT id FROM main.orders",
+            "main",
+            "mart_qualified",
+        );
+        let mut compiled =
+            rocky_compiler::compile::compile(&rocky_compiler::compile::CompilerConfig {
+                models_dir,
+                ..Default::default()
+            })
+            .expect("compile models");
+        // The compile-time plan co-schedules them (the bug's precondition).
+        assert_eq!(
+            compiled.project.layers.len(),
+            1,
+            "precondition: compile sees no edge — {:?}",
+            compiled.project.layers
+        );
+
+        let mut warnings = Vec::new();
+        super::augment_physical_read_edges(&mut compiled, false, &mut warnings)
+            .expect("augmentation");
+        assert_eq!(
+            compiled.project.layers,
+            vec![
+                vec!["orders".to_string()],
+                vec!["mart_qualified".to_string()]
+            ],
+            "producer layers strictly before its physical reader"
+        );
+        assert!(warnings.is_empty(), "{warnings:?}");
+    }
+
+    /// #1275 cycle policy: mutual physical reads serialize deterministically
+    /// with a warning — the run is never refused.
+    #[cfg(feature = "duckdb")]
+    #[test]
+    fn mutual_physical_reads_serialize_with_a_warning_not_a_refusal() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        write_model_with_target(&models_dir, "a", "SELECT x FROM main.b", "main", "a");
+        write_model_with_target(&models_dir, "b", "SELECT y FROM main.a", "main", "b");
+        let mut compiled =
+            rocky_compiler::compile::compile(&rocky_compiler::compile::CompilerConfig {
+                models_dir,
+                ..Default::default()
+            })
+            .expect("compile models");
+
+        let mut warnings = Vec::new();
+        super::augment_physical_read_edges(&mut compiled, false, &mut warnings)
+            .expect("mutual reads must not refuse the run");
+        assert_eq!(
+            compiled.project.layers,
+            vec![vec!["b".to_string()], vec!["a".to_string()]],
+            "one deterministic direction is applied"
+        );
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(
+            warnings[0].contains("mutual physical reads"),
+            "{warnings:?}"
+        );
     }
 
     /// Two selected models whose targets differ only by case are refused on

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -17159,7 +17159,7 @@ timestamp_column = "ts"
         );
         assert_eq!(warnings.len(), 1, "{warnings:?}");
         assert!(
-            warnings[0].contains("mutual physical reads"),
+            warnings[0].contains("would close a dependency cycle"),
             "{warnings:?}"
         );
     }

--- a/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
+++ b/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
@@ -271,6 +271,25 @@ pub async fn run_with_dag(
         .collect();
     unified_dag::infer_runtime_dependencies(&mut dag, &sql_by_name);
 
+    // Physical-read ordering (#1275): the label heuristic above is blind to
+    // configured `[target]`s — a model reading another model's physical
+    // `schema.table` needs its edge derived from rendered target components,
+    // or the two race in one executor phase. Shared derivation with the
+    // plain-run layer computation; cycle-closing candidates are skipped
+    // deterministically inside (the executor refuses cyclic graphs, and a
+    // derived edge must never make a runnable project un-runnable).
+    let physical_inputs: Vec<rocky_core::physical_edges::PhysicalEdgeModel<'_>> =
+        models_by_pipeline
+            .values()
+            .flatten()
+            .map(rocky_core::physical_edges::PhysicalEdgeModel::from_model)
+            .collect();
+    let derived = unified_dag::infer_physical_dependencies(&mut dag, &physical_inputs);
+    let physical_edge_warnings = rocky_core::physical_edges::derivation_warnings(&derived);
+    for w in &physical_edge_warnings {
+        tracing::warn!("{w}");
+    }
+
     // `--dag` cannot isolate a run, so it refuses to pretend it can.
     //
     // #1272 was filed because `--dag --shadow` silently wrote production. The
@@ -353,6 +372,7 @@ pub async fn run_with_dag(
         let output = DagRunOutput {
             version: VERSION.into(),
             command: "run --dag".into(),
+            warnings: physical_edge_warnings.clone(),
             total_nodes: result.total_nodes,
             total_layers: result.total_layers,
             completed: result.completed,

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -315,6 +315,12 @@ pub struct RunOutput {
     /// `on_budget_breach` hook so subscribers see them live.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub budget_breaches: Vec<BudgetBreachOutput>,
+    /// Scheduling warnings from physical-read edge derivation (#1275):
+    /// mutual physical reads serialized by a deterministic order, models
+    /// whose SQL could not be parsed for table references, and colliding
+    /// targets. Empty (and omitted) when none.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scheduling_warnings: Vec<String>,
     /// Soft warnings raised by the per-table override resolver — one
     /// entry per `[[table_overrides]]` rule that matched zero
     /// `(connector, table)` pairs this run, or whose connector half
@@ -4703,6 +4709,7 @@ impl RunOutput {
             skipped_by_run_id: None,
             idempotency_key: None,
             pipeline_type: Some("replication".to_string()),
+            scheduling_warnings: Vec::new(),
             filter,
             duration_ms,
             tables_copied: 0,
@@ -5321,6 +5328,11 @@ pub struct DagSummaryOutput {
 pub struct DagRunOutput {
     pub version: String,
     pub command: String,
+    /// Scheduling warnings from physical-read edge derivation: mutual reads
+    /// serialized by a deterministic order, models whose SQL could not be
+    /// parsed for reads, and colliding targets. Empty when none.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
     /// Total nodes across all layers.
     pub total_nodes: usize,
     /// Number of execution layers (Kahn topological depth).

--- a/engine/crates/rocky-core/src/lib.rs
+++ b/engine/crates/rocky-core/src/lib.rs
@@ -35,6 +35,7 @@ pub mod model_walk;
 pub mod models;
 pub mod object_store;
 pub mod optimize;
+pub mod physical_edges;
 pub mod plan_partition;
 pub mod policy;
 pub mod preview;

--- a/engine/crates/rocky-core/src/physical_edges.rs
+++ b/engine/crates/rocky-core/src/physical_edges.rs
@@ -37,6 +37,14 @@ pub struct PhysicalEdgeModel<'a> {
     pub schema: &'a str,
     pub table: &'a str,
     pub sql: &'a str,
+    /// Whether this model actually writes its configured target. An
+    /// ephemeral model (inlined as a CTE, no table created) must never be
+    /// indexed as a PRODUCER: its configured target does not exist, so a
+    /// physical read of that name is a read of something else — deriving an
+    /// edge to the phantom would order the reader after a producer that
+    /// produces nothing, and could suppress the reader's true edges via the
+    /// cycle guard.
+    pub materializes: bool,
 }
 
 impl<'a> PhysicalEdgeModel<'a> {
@@ -50,6 +58,7 @@ impl<'a> PhysicalEdgeModel<'a> {
             schema: &m.config.target.schema,
             table: &m.config.target.table,
             sql: &m.sql,
+            materializes: !matches!(m.config.strategy, crate::models::StrategyConfig::Ephemeral),
         }
     }
 }
@@ -104,9 +113,14 @@ pub fn derive_physical_edges(
     // producer (the label-heuristic HashMap overwrite bug class).
     let mut by_three: BTreeMap<(String, String, String), Vec<&str>> = BTreeMap::new();
     let mut by_two: BTreeMap<(String, String), Vec<&str>> = BTreeMap::new();
+    let mut by_table: BTreeMap<String, Vec<&str>> = BTreeMap::new();
     for m in models {
+        if !m.materializes {
+            continue;
+        }
         let key3 = (fold(m.catalog), fold(m.schema), fold(m.table));
         let key2 = (key3.1.clone(), key3.2.clone());
+        by_table.entry(key3.2.clone()).or_default().push(m.name);
         by_three.entry(key3).or_default().push(m.name);
         by_two.entry(key2).or_default().push(m.name);
     }
@@ -144,9 +158,13 @@ pub fn derive_physical_edges(
         false
     }
 
-    // Candidate edges in deterministic order (BTreeSet), so the accepted
-    // direction of a mutual pair never depends on iteration order.
-    let mut candidates: BTreeSet<(String, String)> = BTreeSet::new();
+    // Candidate edges in deterministic order, MOST SPECIFIC FIRST: an exact
+    // three-part match is accepted before a two-part match, which is
+    // accepted before a bare table-component match. A loose (possibly
+    // spurious) candidate must never occupy the graph first and cause the
+    // cycle guard to discard a more specific true edge. Within a
+    // specificity tier, name order keeps mutual pairs deterministic.
+    let mut candidates: BTreeSet<(u8, String, String)> = BTreeSet::new();
     for m in models {
         let refs = match rocky_sql::lineage::referenced_tables(m.sql) {
             Ok(refs) => refs,
@@ -157,24 +175,36 @@ pub fn derive_physical_edges(
         };
         for r in refs {
             let parts: Vec<String> = r.split('.').map(fold).collect();
-            let producers: Option<&Vec<&str>> = match parts.len() {
-                // Bare names are the compiler's business (ModelRef) — a bare
-                // read matching a model name already has its edge; a bare
-                // read of a physical table is external.
-                3 => by_three.get(&(parts[0].clone(), parts[1].clone(), parts[2].clone())),
-                2 => by_two.get(&(parts[0].clone(), parts[1].clone())),
-                _ => None,
+            let (tier, producers): (u8, Option<&Vec<&str>>) = match parts.len() {
+                3 => (
+                    0,
+                    by_three.get(&(parts[0].clone(), parts[1].clone(), parts[2].clone())),
+                ),
+                2 => (1, by_two.get(&(parts[0].clone(), parts[1].clone()))),
+                // A bare read resolves through connection state (search path /
+                // current schema) Rocky cannot observe. A bare MODEL-name
+                // read already has its compile-time edge; a bare read that
+                // matches an in-run model's TABLE component may be that very
+                // table — match on the table alone, in the loosest tier.
+                1 => (2, by_table.get(&parts[0])),
+                _ => (3, None),
             };
             let Some(producers) = producers else { continue };
             for p in producers {
                 if *p != m.name {
-                    candidates.insert((m.name.to_string(), (*p).to_string()));
+                    candidates.insert((tier, m.name.to_string(), (*p).to_string()));
                 }
             }
         }
     }
 
-    for (consumer, producer) in candidates {
+    // Dedup across tiers: the same (consumer, producer) pair reachable at
+    // two specificities is processed once, at the most specific.
+    let mut seen_pairs: HashSet<(String, String)> = HashSet::new();
+    for (_tier, consumer, producer) in candidates {
+        if !seen_pairs.insert((consumer.clone(), producer.clone())) {
+            continue;
+        }
         if edge_set.contains(&(consumer.clone(), producer.clone())) {
             continue;
         }
@@ -203,8 +233,9 @@ pub fn derivation_warnings(derived: &DerivedPhysicalEdges) -> Vec<String> {
     let mut w = Vec::new();
     for (a, b) in &derived.skipped_cycle_edges {
         w.push(format!(
-            "mutual physical reads between '{a}' and '{b}': ordered by the derived edge that \
-             was accepted first; declare depends_on to choose the order explicitly"
+            "physical-read ordering: the derived edge '{a}' -> '{b}' would close a dependency \
+             cycle and was skipped; the pair executes in the already-established order. \
+             Declare depends_on to choose the order explicitly"
         ));
     }
     for m in &derived.unparsed {
@@ -240,6 +271,7 @@ mod tests {
             schema,
             table,
             sql,
+            materializes: true,
         }
     }
 
@@ -378,15 +410,94 @@ mod tests {
         assert_eq!(producers, vec!["first", "second"]);
     }
 
-    /// A bare single-part read never derives an edge here — that is the
-    /// compiler's surface, and matching table-only would be far too loose.
+    /// A bare read matching an in-run model's TABLE component derives the
+    /// edge: bare names resolve through connection search-path state Rocky
+    /// cannot observe, and `FROM orders_v2` may be exactly the producer's
+    /// table. (A bare read matching a MODEL name dedups against the
+    /// compile-time edge.)
     #[test]
-    fn bare_reads_are_left_to_the_compiler() {
+    fn a_bare_read_of_a_renamed_target_table_derives_the_edge() {
+        let models = [
+            m("orders_model", "db", "main", "orders_v2", "SELECT 1 AS id"),
+            m("mart", "db", "main", "mart", "SELECT id FROM orders_v2"),
+        ];
+        let d = derive_physical_edges(&models, &[]);
+        assert_eq!(
+            d.edges,
+            vec![("mart".to_string(), "orders_model".to_string())]
+        );
+    }
+
+    /// A bare read matching a model NAME whose compile-time edge already
+    /// exists adds nothing (dedup against `existing`).
+    #[test]
+    fn bare_model_name_reads_dedup_against_compile_edges() {
         let models = [
             m("orders", "db", "main", "orders", "SELECT 1 AS id"),
             m("mart", "db", "main", "mart", "SELECT id FROM orders"),
         ];
+        let existing = vec![("mart".to_string(), "orders".to_string())];
+        let d = derive_physical_edges(&models, &existing);
+        assert!(d.edges.is_empty(), "{:?}", d.edges);
+    }
+
+    /// An ephemeral model produces no table: it must never be indexed as a
+    /// producer, or a read of an EXTERNAL table sharing its configured name
+    /// would derive an edge to a phantom — and could suppress a true edge
+    /// through the cycle guard.
+    #[test]
+    fn ephemeral_models_are_not_physical_producers() {
+        let mut phantom = m("phantom", "db", "main", "phantom_out", "SELECT 1 AS x");
+        phantom.materializes = false;
+        let models = [
+            phantom,
+            m(
+                "reader",
+                "db",
+                "main",
+                "reader",
+                "SELECT x FROM main.phantom_out",
+            ),
+        ];
         let d = derive_physical_edges(&models, &[]);
-        assert!(d.edges.is_empty());
+        assert!(d.edges.is_empty(), "{:?}", d.edges);
+    }
+
+    /// Specificity ordering: when a loose bare-name candidate and an exact
+    /// three-part candidate form a mutual pair, the EXACT edge is accepted
+    /// and the loose one is the skipped closer — never the reverse.
+    #[test]
+    fn exact_matches_win_over_loose_ones_in_cycle_resolution() {
+        // z bare-reads "a_out" (loose match to model a's table) while a
+        // exactly reads z's full target — mutual candidates at different
+        // tiers. Sorted purely by name, ("a","z") would be accepted and the
+        // loose ("z","a") skipped — which happens to agree; so construct the
+        // adversarial order: name order favors the LOOSE edge.
+        let models = [
+            m("a_reader", "db", "main", "a_out", "SELECT 1 AS x"),
+            m(
+                "z_exact",
+                "db",
+                "main",
+                "z_out",
+                "SELECT x FROM db.main.a_out",
+            ),
+        ];
+        // Manufacture mutuality: a_reader bare-reads z_out.
+        let models = [
+            m("a_reader", "db", "main", "a_out", "SELECT x FROM z_out"),
+            models[1].clone(),
+        ];
+        let d = derive_physical_edges(&models, &[]);
+        // Exact tier processed first: z_exact→a_reader accepted; the loose
+        // bare closer a_reader→z_exact is skipped.
+        assert_eq!(
+            d.edges,
+            vec![("z_exact".to_string(), "a_reader".to_string())]
+        );
+        assert_eq!(
+            d.skipped_cycle_edges,
+            vec![("a_reader".to_string(), "z_exact".to_string())]
+        );
     }
 }

--- a/engine/crates/rocky-core/src/physical_edges.rs
+++ b/engine/crates/rocky-core/src/physical_edges.rs
@@ -139,13 +139,6 @@ pub fn derive_physical_edges(
         }
     }
 
-    // Existing relation as a set + adjacency for the cycle guard.
-    let mut edge_set: HashSet<(String, String)> = existing.iter().cloned().collect();
-    let mut depends_on: HashMap<String, HashSet<String>> = HashMap::new();
-    for (c, p) in existing {
-        depends_on.entry(c.clone()).or_default().insert(p.clone());
-    }
-
     // `consumer` transitively depends on `target`?
     fn reaches(depends_on: &HashMap<String, HashSet<String>>, from: &str, to: &str) -> bool {
         let mut seen: HashSet<&str> = HashSet::new();
@@ -204,47 +197,65 @@ pub fn derive_physical_edges(
         }
     }
 
-    // Dedup across tiers: the same (consumer, producer) pair reachable at
-    // two specificities is processed once, at the most specific.
-    let mut seen_pairs: HashSet<(String, String)> = HashSet::new();
-    let mut accepted_tier: HashMap<(String, String), u8> = HashMap::new();
-    for (tier, consumer, producer) in candidates {
-        if !seen_pairs.insert((consumer.clone(), producer.clone())) {
-            continue;
+    // Decision loop, run to a FIXPOINT. A bare↔bare contradiction WITHDRAWS
+    // an already-accepted edge, which can invalidate every skip decided
+    // while that edge was in the graph (a three-way bare chain skips a safe
+    // edge through the soon-withdrawn one). Each withdrawal moves one pair
+    // into the ambiguous set — monotone, so restarting the pass terminates
+    // in at most one restart per contradicting pair. Restart-from-scratch
+    // keeps every decision derived from a consistent graph.
+    let mut ambiguous: HashSet<(String, String)> = HashSet::new();
+    'fixpoint: loop {
+        out.edges.clear();
+        out.skipped_cycle_edges.clear();
+        let mut edge_set: HashSet<(String, String)> = existing.iter().cloned().collect();
+        let mut depends_on: HashMap<String, HashSet<String>> = HashMap::new();
+        for (c, p) in existing {
+            depends_on.entry(c.clone()).or_default().insert(p.clone());
         }
-        if edge_set.contains(&(consumer.clone(), producer.clone())) {
-            continue;
-        }
-        // Adding consumer→producer closes a cycle iff producer already
-        // (transitively) depends on consumer.
-        if reaches(&depends_on, &producer, &consumer) {
-            // A bare candidate blocked by an ACCEPTED bare opposite is not a
-            // cycle to serialize — it is two guesses contradicting each
-            // other. Name order must not pick the winner: a wrong pick
-            // deterministically reverses the real producer edge, which is
-            // WORSE than today's undefined order. Withdraw the accepted
-            // guess and derive nothing for the pair.
-            if tier == 2 && accepted_tier.get(&(producer.clone(), consumer.clone())) == Some(&2) {
-                out.edges
-                    .retain(|(c, p)| !(c == &producer && p == &consumer));
-                edge_set.remove(&(producer.clone(), consumer.clone()));
-                if let Some(deps) = depends_on.get_mut(&producer) {
-                    deps.remove(&consumer);
-                }
-                accepted_tier.remove(&(producer.clone(), consumer.clone()));
-                out.ambiguous_bare_pairs.push((consumer, producer));
+        let mut seen_pairs: HashSet<(String, String)> = HashSet::new();
+        let mut accepted_tier: HashMap<(String, String), u8> = HashMap::new();
+        for (tier, consumer, producer) in &candidates {
+            let (tier, consumer, producer) = (*tier, consumer.clone(), producer.clone());
+            if ambiguous.contains(&(consumer.clone(), producer.clone()))
+                || ambiguous.contains(&(producer.clone(), consumer.clone()))
+            {
                 continue;
             }
-            out.skipped_cycle_edges.push((consumer, producer));
-            continue;
+            if !seen_pairs.insert((consumer.clone(), producer.clone())) {
+                continue;
+            }
+            if edge_set.contains(&(consumer.clone(), producer.clone())) {
+                continue;
+            }
+            // Adding consumer→producer closes a cycle iff producer already
+            // (transitively) depends on consumer.
+            if reaches(&depends_on, &producer, &consumer) {
+                // A bare candidate blocked by an ACCEPTED bare opposite is
+                // not a cycle to serialize — it is two guesses contradicting
+                // each other. Name order must not pick the winner: a wrong
+                // pick deterministically reverses the real producer edge,
+                // WORSE than the undefined order it replaces. Mark the pair
+                // ambiguous and restart so no decision keeps depending on
+                // the withdrawn guess.
+                if tier == 2 && accepted_tier.get(&(producer.clone(), consumer.clone())) == Some(&2)
+                {
+                    ambiguous.insert((consumer.clone(), producer.clone()));
+                    out.ambiguous_bare_pairs.push((consumer, producer));
+                    continue 'fixpoint;
+                }
+                out.skipped_cycle_edges.push((consumer, producer));
+                continue;
+            }
+            edge_set.insert((consumer.clone(), producer.clone()));
+            depends_on
+                .entry(consumer.clone())
+                .or_default()
+                .insert(producer.clone());
+            accepted_tier.insert((consumer.clone(), producer.clone()), tier);
+            out.edges.push((consumer, producer));
         }
-        edge_set.insert((consumer.clone(), producer.clone()));
-        depends_on
-            .entry(consumer.clone())
-            .or_default()
-            .insert(producer.clone());
-        accepted_tier.insert((consumer.clone(), producer.clone()), tier);
-        out.edges.push((consumer, producer));
+        break;
     }
 
     out
@@ -493,6 +504,39 @@ mod tests {
         ];
         let d = derive_physical_edges(&models, &[]);
         assert!(d.edges.is_empty(), "{:?}", d.edges);
+    }
+
+    /// The reviewer's three-way chain: a bare candidate skipped BECAUSE OF
+    /// an edge that a later bare-bare withdrawal removes must be
+    /// re-evaluated — the fixpoint restart derives it after the ambiguous
+    /// pair is excluded.
+    #[test]
+    fn a_withdrawal_reopens_decisions_that_depended_on_the_withdrawn_edge() {
+        // Candidate order (name-sorted within the bare tier):
+        //   ("a","b")   accepted first (a depends on b),
+        //   ("ab","d")  skipped through d→a→b→ab (uses the accepted edge),
+        //   ("b","a")   contradicts → withdrawal → restart.
+        // After the restart with (a,b)/(b,a) ambiguous, ("ab","d") is safe.
+        let models = [
+            m("a", "db", "main", "t_a", "SELECT x FROM t_b"),
+            m("b", "db", "main", "t_b", "SELECT y FROM t_a"),
+            m("ab", "db", "main", "t_ab", "SELECT z FROM t_d"),
+            m("d", "db", "main", "t_d", "SELECT 1 AS q"),
+        ];
+        let existing = vec![
+            ("d".to_string(), "a".to_string()),
+            ("b".to_string(), "ab".to_string()),
+        ];
+        let d = derive_physical_edges(&models, &existing);
+        assert_eq!(d.ambiguous_bare_pairs.len(), 1, "{d:?}");
+        assert!(
+            d.edges.contains(&("ab".to_string(), "d".to_string())),
+            "the stale skip must be re-evaluated after the withdrawal: {d:?}"
+        );
+        assert!(
+            d.skipped_cycle_edges.is_empty(),
+            "nothing blocks ab→d once the guess is gone: {d:?}"
+        );
     }
 
     /// Reciprocal BARE reads are two contradicting guesses: name order must

--- a/engine/crates/rocky-core/src/physical_edges.rs
+++ b/engine/crates/rocky-core/src/physical_edges.rs
@@ -1,0 +1,392 @@
+//! Target-aware physical-read edge derivation (#1275).
+//!
+//! A model that reads another model's target by its physical
+//! `schema.table` / `catalog.schema.table` name gets no compile-time DAG
+//! edge (`classify_table_ref` treats multi-part names as external), so the
+//! two can be co-scheduled and race under concurrency. This module derives
+//! the missing ordering edges at RUN time, from each model's rendered
+//! target components matched against each model's SQL read set — leaving
+//! the compile-time graph, the `E001` join-key surface, and the `rocky dag`
+//! export untouched.
+//!
+//! One derivation, two consumers: the plain-run layer computation
+//! (`compile_result.project.dag_nodes` → `execution_layers`) and the
+//! `run --dag` [`crate::unified_dag::UnifiedDag`] (whose executor computes
+//! its own phases). Both schedulers must see the same edges or the race
+//! survives one flag away — the two-scheduler split is exactly how the
+//! first fix attempt failed review.
+//!
+//! Comparison is componentwise and case-folded on BOTH sides (never fold
+//! one side only). On a case-sensitive store two distinct tables differing
+//! by case can therefore match and yield a spurious edge — that is the safe
+//! error direction: an unnecessary ordering constraint, never a missed one.
+//!
+//! Cycle policy: a derived edge that would close a cycle (mutual physical
+//! reads) is SKIPPED deterministically and reported, so projects that run
+//! today keep running — serialized where possible, never refused. The
+//! schedulers' own cycle detection stays the backstop for declared edges.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+
+/// One model's identity for the derivation: its name, its rendered target
+/// components, and its compiled SQL.
+#[derive(Debug, Clone)]
+pub struct PhysicalEdgeModel<'a> {
+    pub name: &'a str,
+    pub catalog: &'a str,
+    pub schema: &'a str,
+    pub table: &'a str,
+    pub sql: &'a str,
+}
+
+impl<'a> PhysicalEdgeModel<'a> {
+    /// Both consumers build inputs from the same loaded-model shape; one
+    /// constructor keeps them from drifting.
+    #[must_use]
+    pub fn from_model(m: &'a crate::models::Model) -> Self {
+        Self {
+            name: &m.config.name,
+            catalog: &m.config.target.catalog,
+            schema: &m.config.target.schema,
+            table: &m.config.target.table,
+            sql: &m.sql,
+        }
+    }
+}
+
+/// The derivation result. `edges` are `(consumer, producer)` pairs —
+/// consumer depends on producer — already deduplicated against `existing`
+/// and guaranteed not to close a cycle over `existing ∪ edges`.
+#[derive(Debug, Default)]
+pub struct DerivedPhysicalEdges {
+    pub edges: Vec<(String, String)>,
+    /// Candidate edges skipped because adding them would close a dependency
+    /// cycle (mutual physical reads). The pair still gets ordered by the
+    /// accepted direction; the skipped closer is surfaced as a warning.
+    pub skipped_cycle_edges: Vec<(String, String)>,
+    /// Models whose SQL could not be parsed for table references — their
+    /// read set is unknown, so no edges could be derived for them. Surfaced
+    /// as a warning under concurrency: co-scheduling them is unproven.
+    pub unparsed: Vec<String>,
+    /// Pairs of models whose canonical targets collide. Ordering between
+    /// them is ill-defined; surfaced as a warning (writer refusal for the
+    /// same-pipeline case is upstream's job).
+    pub target_collisions: Vec<(String, String)>,
+}
+
+/// `referenced_tables` already lowercases and unquotes what the parser
+/// returns, so folding the READ side here is defense-in-depth; the fold is
+/// load-bearing for the TARGET side (configured `[target]` components come
+/// through verbatim).
+fn fold(s: &str) -> String {
+    s.trim()
+        .trim_matches('"')
+        .trim_matches('`')
+        .to_ascii_lowercase()
+}
+
+/// Derive physical-read ordering edges for `models`.
+///
+/// `existing` is the name-level dependency relation already present in the
+/// consumer's graph (`(consumer, producer)` pairs — declared `depends_on`
+/// plus compile-derived edges). Derived edges only ever connect two models
+/// from `models`, so a name-level cycle guard over `existing ∪ accepted`
+/// is sound: no derived cycle can pass through a non-model node.
+#[must_use]
+pub fn derive_physical_edges(
+    models: &[PhysicalEdgeModel<'_>],
+    existing: &[(String, String)],
+) -> DerivedPhysicalEdges {
+    let mut out = DerivedPhysicalEdges::default();
+
+    // Producer index: canonical (catalog, schema, table) and (schema, table)
+    // → model names. Multi-maps — a collision must not silently drop a
+    // producer (the label-heuristic HashMap overwrite bug class).
+    let mut by_three: BTreeMap<(String, String, String), Vec<&str>> = BTreeMap::new();
+    let mut by_two: BTreeMap<(String, String), Vec<&str>> = BTreeMap::new();
+    for m in models {
+        let key3 = (fold(m.catalog), fold(m.schema), fold(m.table));
+        let key2 = (key3.1.clone(), key3.2.clone());
+        by_three.entry(key3).or_default().push(m.name);
+        by_two.entry(key2).or_default().push(m.name);
+    }
+    for names in by_three.values() {
+        if names.len() > 1 {
+            for pair in names.windows(2) {
+                out.target_collisions
+                    .push((pair[0].to_string(), pair[1].to_string()));
+            }
+        }
+    }
+
+    // Existing relation as a set + adjacency for the cycle guard.
+    let mut edge_set: HashSet<(String, String)> = existing.iter().cloned().collect();
+    let mut depends_on: HashMap<String, HashSet<String>> = HashMap::new();
+    for (c, p) in existing {
+        depends_on.entry(c.clone()).or_default().insert(p.clone());
+    }
+
+    // `consumer` transitively depends on `target`?
+    fn reaches(depends_on: &HashMap<String, HashSet<String>>, from: &str, to: &str) -> bool {
+        let mut seen: HashSet<&str> = HashSet::new();
+        let mut stack: Vec<&str> = vec![from];
+        while let Some(cur) = stack.pop() {
+            if cur == to {
+                return true;
+            }
+            if !seen.insert(cur) {
+                continue;
+            }
+            if let Some(deps) = depends_on.get(cur) {
+                stack.extend(deps.iter().map(String::as_str));
+            }
+        }
+        false
+    }
+
+    // Candidate edges in deterministic order (BTreeSet), so the accepted
+    // direction of a mutual pair never depends on iteration order.
+    let mut candidates: BTreeSet<(String, String)> = BTreeSet::new();
+    for m in models {
+        let refs = match rocky_sql::lineage::referenced_tables(m.sql) {
+            Ok(refs) => refs,
+            Err(_) => {
+                out.unparsed.push(m.name.to_string());
+                continue;
+            }
+        };
+        for r in refs {
+            let parts: Vec<String> = r.split('.').map(fold).collect();
+            let producers: Option<&Vec<&str>> = match parts.len() {
+                // Bare names are the compiler's business (ModelRef) — a bare
+                // read matching a model name already has its edge; a bare
+                // read of a physical table is external.
+                3 => by_three.get(&(parts[0].clone(), parts[1].clone(), parts[2].clone())),
+                2 => by_two.get(&(parts[0].clone(), parts[1].clone())),
+                _ => None,
+            };
+            let Some(producers) = producers else { continue };
+            for p in producers {
+                if *p != m.name {
+                    candidates.insert((m.name.to_string(), (*p).to_string()));
+                }
+            }
+        }
+    }
+
+    for (consumer, producer) in candidates {
+        if edge_set.contains(&(consumer.clone(), producer.clone())) {
+            continue;
+        }
+        // Adding consumer→producer closes a cycle iff producer already
+        // (transitively) depends on consumer.
+        if reaches(&depends_on, &producer, &consumer) {
+            out.skipped_cycle_edges.push((consumer, producer));
+            continue;
+        }
+        edge_set.insert((consumer.clone(), producer.clone()));
+        depends_on
+            .entry(consumer.clone())
+            .or_default()
+            .insert(producer.clone());
+        out.edges.push((consumer, producer));
+    }
+
+    out
+}
+
+/// Render the standard warnings for a derivation, shared by both consumers
+/// so the operator-visible text stays identical across `run` and
+/// `run --dag`.
+#[must_use]
+pub fn derivation_warnings(derived: &DerivedPhysicalEdges) -> Vec<String> {
+    let mut w = Vec::new();
+    for (a, b) in &derived.skipped_cycle_edges {
+        w.push(format!(
+            "mutual physical reads between '{a}' and '{b}': ordered by the derived edge that \
+             was accepted first; declare depends_on to choose the order explicitly"
+        ));
+    }
+    for m in &derived.unparsed {
+        w.push(format!(
+            "model '{m}': SQL could not be parsed for table references — physical-read \
+             ordering could not be derived for it; concurrent execution against its upstreams \
+             is unproven"
+        ));
+    }
+    for (a, b) in &derived.target_collisions {
+        w.push(format!(
+            "models '{a}' and '{b}' render the same physical target — ordering between them \
+             is ill-defined"
+        ));
+    }
+    w
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn m<'a>(
+        name: &'a str,
+        catalog: &'a str,
+        schema: &'a str,
+        table: &'a str,
+        sql: &'a str,
+    ) -> PhysicalEdgeModel<'a> {
+        PhysicalEdgeModel {
+            name,
+            catalog,
+            schema,
+            table,
+            sql,
+        }
+    }
+
+    /// The issue's repro: a 2-part physical read derives the edge that
+    /// compile-time resolution cannot.
+    #[test]
+    fn a_two_part_physical_read_derives_the_edge() {
+        let models = [
+            m("orders", "db", "main", "orders", "SELECT 1 AS id"),
+            m(
+                "mart_qualified",
+                "db",
+                "main",
+                "mart_qualified",
+                "SELECT id FROM main.orders",
+            ),
+        ];
+        let d = derive_physical_edges(&models, &[]);
+        assert_eq!(
+            d.edges,
+            vec![("mart_qualified".to_string(), "orders".to_string())]
+        );
+        assert!(d.skipped_cycle_edges.is_empty() && d.unparsed.is_empty());
+    }
+
+    /// A renamed target (model name ≠ table name) still matches — the case
+    /// the label heuristic misses.
+    #[test]
+    fn a_renamed_target_still_matches_by_components() {
+        let models = [
+            m("orders_model", "db", "main", "orders_v2", "SELECT 1 AS id"),
+            m(
+                "mart",
+                "db",
+                "main",
+                "mart",
+                "SELECT id FROM db.main.orders_v2",
+            ),
+        ];
+        let d = derive_physical_edges(&models, &[]);
+        assert_eq!(
+            d.edges,
+            vec![("mart".to_string(), "orders_model".to_string())]
+        );
+    }
+
+    /// Case and quoting fold on BOTH sides.
+    #[test]
+    fn comparison_folds_case_and_quotes_uniformly() {
+        let models = [
+            m("orders", "DB", "Main", "Orders", "SELECT 1 AS id"),
+            m(
+                "mart",
+                "db",
+                "main",
+                "mart",
+                "SELECT id FROM \"MAIN\".\"ORDERS\"",
+            ),
+        ];
+        let d = derive_physical_edges(&models, &[]);
+        assert_eq!(d.edges, vec![("mart".to_string(), "orders".to_string())]);
+    }
+
+    /// Mutual physical reads: one deterministic direction is accepted, the
+    /// closer is skipped and reported — never a cycle, never a refusal.
+    #[test]
+    fn mutual_reads_serialize_deterministically_instead_of_cycling() {
+        let models = [
+            m("a", "db", "main", "a", "SELECT x FROM main.b"),
+            m("b", "db", "main", "b", "SELECT y FROM main.a"),
+        ];
+        let d = derive_physical_edges(&models, &[]);
+        // BTreeSet order: ("a","b") accepted first, ("b","a") closes → skipped.
+        assert_eq!(d.edges, vec![("a".to_string(), "b".to_string())]);
+        assert_eq!(
+            d.skipped_cycle_edges,
+            vec![("b".to_string(), "a".to_string())]
+        );
+    }
+
+    /// A candidate that would close a cycle THROUGH an existing declared
+    /// edge is skipped too.
+    #[test]
+    fn existing_declared_edges_participate_in_the_cycle_guard() {
+        let models = [
+            m("up", "db", "main", "up", "SELECT x FROM main.down"),
+            m("down", "db", "main", "down", "SELECT 1 AS x"),
+        ];
+        // Declared: down depends on up.
+        let existing = vec![("down".to_string(), "up".to_string())];
+        let d = derive_physical_edges(&models, &existing);
+        // Candidate up→down would close the cycle → skipped.
+        assert!(d.edges.is_empty());
+        assert_eq!(
+            d.skipped_cycle_edges,
+            vec![("up".to_string(), "down".to_string())]
+        );
+    }
+
+    /// Unparseable SQL is reported, never silently skipped.
+    #[test]
+    fn unparseable_sql_is_reported_not_silent() {
+        let models = [
+            m("ok", "db", "main", "ok", "SELECT 1 AS x"),
+            m("broken", "db", "main", "broken", "SELEC x FRM ("),
+        ];
+        let d = derive_physical_edges(&models, &[]);
+        assert_eq!(d.unparsed, vec!["broken".to_string()]);
+    }
+
+    /// Target collisions surface both names instead of one overwriting the
+    /// other in the producer index.
+    #[test]
+    fn target_collisions_are_reported_and_both_producers_match() {
+        let models = [
+            m("first", "db", "main", "shared", "SELECT 1 AS x"),
+            m("second", "db", "main", "shared", "SELECT 2 AS x"),
+            m(
+                "reader",
+                "db",
+                "main",
+                "reader",
+                "SELECT x FROM main.shared",
+            ),
+        ];
+        let d = derive_physical_edges(&models, &[]);
+        assert_eq!(d.target_collisions.len(), 1);
+        // The reader is ordered after BOTH claimants.
+        let mut producers: Vec<&str> = d
+            .edges
+            .iter()
+            .filter(|(c, _)| c == "reader")
+            .map(|(_, p)| p.as_str())
+            .collect();
+        producers.sort_unstable();
+        assert_eq!(producers, vec!["first", "second"]);
+    }
+
+    /// A bare single-part read never derives an edge here — that is the
+    /// compiler's surface, and matching table-only would be far too loose.
+    #[test]
+    fn bare_reads_are_left_to_the_compiler() {
+        let models = [
+            m("orders", "db", "main", "orders", "SELECT 1 AS id"),
+            m("mart", "db", "main", "mart", "SELECT id FROM orders"),
+        ];
+        let d = derive_physical_edges(&models, &[]);
+        assert!(d.edges.is_empty());
+    }
+}

--- a/engine/crates/rocky-core/src/physical_edges.rs
+++ b/engine/crates/rocky-core/src/physical_edges.rs
@@ -81,6 +81,12 @@ pub struct DerivedPhysicalEdges {
     /// them is ill-defined; surfaced as a warning (writer refusal for the
     /// same-pipeline case is upstream's job).
     pub target_collisions: Vec<(String, String)>,
+    /// Mutual candidates where BOTH directions come from the loosest (bare
+    /// table-component) tier. Bare matches are guesses — accepting one
+    /// direction by name order could deterministically REVERSE a real
+    /// producer edge, which is worse than today's undefined order. Neither
+    /// edge is derived; the pair is surfaced for an explicit `depends_on`.
+    pub ambiguous_bare_pairs: Vec<(String, String)>,
 }
 
 /// `referenced_tables` already lowercases and unquotes what the parser
@@ -201,7 +207,8 @@ pub fn derive_physical_edges(
     // Dedup across tiers: the same (consumer, producer) pair reachable at
     // two specificities is processed once, at the most specific.
     let mut seen_pairs: HashSet<(String, String)> = HashSet::new();
-    for (_tier, consumer, producer) in candidates {
+    let mut accepted_tier: HashMap<(String, String), u8> = HashMap::new();
+    for (tier, consumer, producer) in candidates {
         if !seen_pairs.insert((consumer.clone(), producer.clone())) {
             continue;
         }
@@ -211,6 +218,23 @@ pub fn derive_physical_edges(
         // Adding consumer→producer closes a cycle iff producer already
         // (transitively) depends on consumer.
         if reaches(&depends_on, &producer, &consumer) {
+            // A bare candidate blocked by an ACCEPTED bare opposite is not a
+            // cycle to serialize — it is two guesses contradicting each
+            // other. Name order must not pick the winner: a wrong pick
+            // deterministically reverses the real producer edge, which is
+            // WORSE than today's undefined order. Withdraw the accepted
+            // guess and derive nothing for the pair.
+            if tier == 2 && accepted_tier.get(&(producer.clone(), consumer.clone())) == Some(&2) {
+                out.edges
+                    .retain(|(c, p)| !(c == &producer && p == &consumer));
+                edge_set.remove(&(producer.clone(), consumer.clone()));
+                if let Some(deps) = depends_on.get_mut(&producer) {
+                    deps.remove(&consumer);
+                }
+                accepted_tier.remove(&(producer.clone(), consumer.clone()));
+                out.ambiguous_bare_pairs.push((consumer, producer));
+                continue;
+            }
             out.skipped_cycle_edges.push((consumer, producer));
             continue;
         }
@@ -219,6 +243,7 @@ pub fn derive_physical_edges(
             .entry(consumer.clone())
             .or_default()
             .insert(producer.clone());
+        accepted_tier.insert((consumer.clone(), producer.clone()), tier);
         out.edges.push((consumer, producer));
     }
 
@@ -243,6 +268,13 @@ pub fn derivation_warnings(derived: &DerivedPhysicalEdges) -> Vec<String> {
             "model '{m}': SQL could not be parsed for table references — physical-read \
              ordering could not be derived for it; concurrent execution against its upstreams \
              is unproven"
+        ));
+    }
+    for (a, b) in &derived.ambiguous_bare_pairs {
+        w.push(format!(
+            "models '{a}' and '{b}' each bare-read a name matching the other's table — both \
+             matches are search-path guesses and contradict, so neither ordering was derived; \
+             declare depends_on to state the real direction"
         ));
     }
     for (a, b) in &derived.target_collisions {
@@ -461,6 +493,45 @@ mod tests {
         ];
         let d = derive_physical_edges(&models, &[]);
         assert!(d.edges.is_empty(), "{:?}", d.edges);
+    }
+
+    /// Reciprocal BARE reads are two contradicting guesses: name order must
+    /// not pick a winner (a wrong pick deterministically reverses the real
+    /// producer edge). Neither direction derives; the pair is surfaced.
+    #[test]
+    fn reciprocal_bare_reads_derive_nothing_and_are_surfaced() {
+        let models = [
+            m("alpha", "db", "main", "t_alpha", "SELECT x FROM t_beta"),
+            m("beta", "db", "main", "t_beta", "SELECT y FROM t_alpha"),
+        ];
+        let d = derive_physical_edges(&models, &[]);
+        assert!(d.edges.is_empty(), "{:?}", d.edges);
+        assert!(
+            d.skipped_cycle_edges.is_empty(),
+            "{:?}",
+            d.skipped_cycle_edges
+        );
+        assert_eq!(d.ambiguous_bare_pairs.len(), 1);
+    }
+
+    /// A bare guess contradicted by an EXACT read is not ambiguous — the
+    /// exact edge stands (specificity), the bare closer is skipped.
+    #[test]
+    fn an_exact_edge_survives_a_contradicting_bare_guess() {
+        let models = [
+            m("alpha", "db", "main", "t_alpha", "SELECT x FROM t_beta"),
+            m(
+                "beta",
+                "db",
+                "main",
+                "t_beta",
+                "SELECT y FROM db.main.t_alpha",
+            ),
+        ];
+        let d = derive_physical_edges(&models, &[]);
+        assert_eq!(d.edges, vec![("beta".to_string(), "alpha".to_string())]);
+        assert!(d.ambiguous_bare_pairs.is_empty());
+        assert_eq!(d.skipped_cycle_edges.len(), 1);
     }
 
     /// Specificity ordering: when a loose bare-name candidate and an exact

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -1052,14 +1052,41 @@ pub fn infer_physical_dependencies(
         })
         .collect();
 
-    let derived = crate::physical_edges::derive_physical_edges(models, &existing);
+    let mut derived = crate::physical_edges::derive_physical_edges(models, &existing);
 
     let edge_set: std::collections::HashSet<(NodeId, NodeId)> = dag
         .edges
         .iter()
         .map(|e| (e.from.clone(), e.to.clone()))
         .collect();
-    for (consumer, producer) in &derived.edges {
+    // Full-graph reachability guard. The derivation's own cycle guard sees
+    // only the transformation-projected relation — a real path between two
+    // transformations THROUGH a non-transformation node (a check, a seed) is
+    // invisible to it, and `execution_phases` hard-errors on cycles, so every
+    // insertion is re-checked against the whole graph: a derived edge must
+    // never make a runnable project refuse.
+    fn reaches_node(dag: &UnifiedDag, from: &NodeId, to: &NodeId) -> bool {
+        let mut adj: std::collections::HashMap<&NodeId, Vec<&NodeId>> =
+            std::collections::HashMap::new();
+        for e in &dag.edges {
+            adj.entry(&e.from).or_default().push(&e.to);
+        }
+        let mut seen: std::collections::HashSet<&NodeId> = std::collections::HashSet::new();
+        let mut stack = vec![from];
+        while let Some(cur) = stack.pop() {
+            if cur == to {
+                return true;
+            }
+            if !seen.insert(cur) {
+                continue;
+            }
+            if let Some(next) = adj.get(cur) {
+                stack.extend(next.iter().copied());
+            }
+        }
+        false
+    }
+    for (consumer, producer) in derived.edges.clone() {
         let (Some(cid), Some(pid)) = (
             by_label.get(consumer.as_str()),
             by_label.get(producer.as_str()),
@@ -1067,6 +1094,15 @@ pub fn infer_physical_dependencies(
             continue;
         };
         if edge_set.contains(&(pid.clone(), cid.clone())) {
+            continue;
+        }
+        // Inserting producer→consumer closes a cycle iff the consumer's node
+        // already reaches the producer's node through the FULL graph.
+        if reaches_node(dag, cid, pid) {
+            derived
+                .edges
+                .retain(|(c, p)| !(c == &consumer && p == &producer));
+            derived.skipped_cycle_edges.push((consumer, producer));
             continue;
         }
         dag.edges.push(UnifiedEdge {
@@ -2855,5 +2891,66 @@ mod tests {
         assert_eq!(derived.edges.len(), 1);
         assert_eq!(derived.skipped_cycle_edges.len(), 1);
         execution_phases(&dag).expect("phases must still compute — no cycle may be introduced");
+    }
+
+    /// #1275 guard depth: a REAL dependency path between two transformations
+    /// that runs THROUGH a non-transformation node (here: a quality node) is
+    /// invisible to the derivation's transformation-projected cycle guard —
+    /// the insertion-time full-graph guard must catch it, or the derived
+    /// edge would make `execution_phases` refuse a project that runs today.
+    #[test]
+    fn a_cycle_through_a_non_transformation_node_is_caught_at_insertion() {
+        let config = config_with_pipelines(vec![("t", transform_pipeline(vec![]))]);
+        let mut a = model("a", vec![], vec![]);
+        a.sql = "SELECT 1 AS x".into();
+        let mut b = model("b", vec![], vec![]);
+        b.sql = "SELECT x FROM silver.a".into();
+        let models = vec![a, b];
+        let by_pipeline = owned_by_sole_transformation(&config, models.clone());
+        let mut dag = build_unified_dag(&config, &by_pipeline, &[]).expect("build dag");
+
+        let a_id = dag
+            .nodes
+            .iter()
+            .find(|n| n.label == "a" && n.kind == NodeKind::Transformation)
+            .unwrap()
+            .id
+            .clone();
+        let b_id = dag
+            .nodes
+            .iter()
+            .find(|n| n.label == "b" && n.kind == NodeKind::Transformation)
+            .unwrap()
+            .id
+            .clone();
+        let check_id = NodeId("check:a_gate".to_string());
+        dag.nodes.push(UnifiedNode {
+            id: check_id.clone(),
+            kind: NodeKind::Quality,
+            label: "a_gate".into(),
+            pipeline: Some("t".into()),
+        });
+        dag.edges.push(UnifiedEdge {
+            from: b_id.clone(),
+            to: check_id.clone(),
+            edge_type: EdgeType::CheckDependency,
+        });
+        dag.edges.push(UnifiedEdge {
+            from: check_id,
+            to: a_id,
+            edge_type: EdgeType::CheckDependency,
+        });
+
+        let inputs: Vec<crate::physical_edges::PhysicalEdgeModel<'_>> = models
+            .iter()
+            .map(crate::physical_edges::PhysicalEdgeModel::from_model)
+            .collect();
+        let derived = infer_physical_dependencies(&mut dag, &inputs);
+        assert!(
+            derived.edges.is_empty(),
+            "the closing edge must be skipped, not inserted: {derived:?}"
+        );
+        assert_eq!(derived.skipped_cycle_edges.len(), 1);
+        execution_phases(&dag).expect("a derived edge must never make a runnable project refuse");
     }
 }

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -1004,6 +1004,80 @@ pub fn infer_runtime_dependencies(
 /// [`rocky_ir::dag::execution_layers`].
 ///
 /// Returns an error if the DAG contains a cycle.
+/// Target-aware physical-read edges for transformation nodes (#1275).
+///
+/// [`infer_runtime_dependencies`] matches reads against node LABELS — it
+/// orders a model after a seed/load it reads by name, but is blind to
+/// configured `[target]`s: a model reading another model's physical
+/// `schema.table` derives nothing there unless the table happens to equal
+/// the model name. This pass derives those edges from rendered target
+/// components via [`crate::physical_edges::derive_physical_edges`] — the
+/// same derivation the plain-run layer computation uses, so both
+/// schedulers order the same pairs.
+///
+/// Cycle-closing candidates are skipped deterministically inside the
+/// derivation (the executor's `execution_phases` hard-errors on cycles, and
+/// a derived edge must never turn a runnable project into a refused one).
+/// Returns the derivation so the caller can surface its warnings.
+pub fn infer_physical_dependencies(
+    dag: &mut UnifiedDag,
+    models: &[crate::physical_edges::PhysicalEdgeModel<'_>],
+) -> crate::physical_edges::DerivedPhysicalEdges {
+    use std::collections::HashMap as Map;
+    // Transformation-node index by label (label == model name for
+    // transformation nodes — the same contract infer_runtime_dependencies
+    // relies on for SQL lookup).
+    let by_label: Map<&str, NodeId> = dag
+        .nodes
+        .iter()
+        .filter(|n| n.kind == NodeKind::Transformation)
+        .map(|n| (n.label.as_str(), n.id.clone()))
+        .collect();
+    let id_to_label: Map<&NodeId, &str> = dag
+        .nodes
+        .iter()
+        .filter(|n| n.kind == NodeKind::Transformation)
+        .map(|n| (&n.id, n.label.as_str()))
+        .collect();
+
+    // Existing name-level relation among transformation nodes: consumer
+    // (edge.to) depends on producer (edge.from).
+    let existing: Vec<(String, String)> = dag
+        .edges
+        .iter()
+        .filter_map(|e| {
+            let from = id_to_label.get(&e.from)?;
+            let to = id_to_label.get(&e.to)?;
+            Some(((*to).to_string(), (*from).to_string()))
+        })
+        .collect();
+
+    let derived = crate::physical_edges::derive_physical_edges(models, &existing);
+
+    let edge_set: std::collections::HashSet<(NodeId, NodeId)> = dag
+        .edges
+        .iter()
+        .map(|e| (e.from.clone(), e.to.clone()))
+        .collect();
+    for (consumer, producer) in &derived.edges {
+        let (Some(cid), Some(pid)) = (
+            by_label.get(consumer.as_str()),
+            by_label.get(producer.as_str()),
+        ) else {
+            continue;
+        };
+        if edge_set.contains(&(pid.clone(), cid.clone())) {
+            continue;
+        }
+        dag.edges.push(UnifiedEdge {
+            from: pid.clone(),
+            to: cid.clone(),
+            edge_type: EdgeType::DataDependency,
+        });
+    }
+    derived
+}
+
 pub fn execution_phases(dag: &UnifiedDag) -> Result<Vec<Vec<&UnifiedNode>>, UnifiedDagError> {
     // Build adjacency structures keyed by NodeId.
     let node_map: HashMap<&NodeId, &UnifiedNode> = dag.nodes.iter().map(|n| (&n.id, n)).collect();
@@ -2709,5 +2783,77 @@ mod tests {
         // Should not panic; invalid SQL just yields no inferred edges.
         infer_runtime_dependencies(&mut dag, &sql);
         assert_eq!(dag.edges.len(), 0);
+    }
+
+    /// #1275: a transformation reading another transformation's PHYSICAL
+    /// target — with a table name ≠ model name, so the label heuristic
+    /// cannot see it — derives an edge and the executor phases order them.
+    #[test]
+    fn physical_reads_order_transformation_phases() {
+        let config = config_with_pipelines(vec![("t", transform_pipeline(vec![]))]);
+        let mut producer = model("orders_model", vec![], vec![]);
+        producer.config.target.table = "orders_v2".into();
+        producer.sql = "SELECT 1 AS id".into();
+        let mut consumer = model("mart", vec![], vec![]);
+        consumer.sql = "SELECT id FROM silver.orders_v2".into();
+
+        let models = vec![producer, consumer];
+        let by_pipeline = owned_by_sole_transformation(&config, models.clone());
+        let mut dag = build_unified_dag(&config, &by_pipeline, &[]).expect("build dag");
+
+        // Precondition: label inference alone leaves them co-phased.
+        let sql_by_name: std::collections::HashMap<String, String> = models
+            .iter()
+            .map(|m| (m.config.name.clone(), m.sql.clone()))
+            .collect();
+        infer_runtime_dependencies(&mut dag, &sql_by_name);
+        let phases = execution_phases(&dag).expect("phases");
+        let phase_of = |label: &str, phases: &Vec<Vec<&UnifiedNode>>| -> usize {
+            phases
+                .iter()
+                .position(|l| l.iter().any(|n| n.label == label))
+                .unwrap()
+        };
+        assert_eq!(
+            phase_of("orders_model", &phases),
+            phase_of("mart", &phases),
+            "precondition: the label heuristic is blind to the renamed target"
+        );
+
+        let inputs: Vec<crate::physical_edges::PhysicalEdgeModel<'_>> = models
+            .iter()
+            .map(crate::physical_edges::PhysicalEdgeModel::from_model)
+            .collect();
+        let derived = infer_physical_dependencies(&mut dag, &inputs);
+        assert_eq!(derived.edges.len(), 1, "{derived:?}");
+        let phases = execution_phases(&dag).expect("phases after augmentation");
+        assert!(
+            phase_of("orders_model", &phases) < phase_of("mart", &phases),
+            "producer must phase strictly before its physical reader"
+        );
+    }
+
+    /// #1275 cycle policy inside the unified DAG: mutual physical reads must
+    /// not make `execution_phases` refuse — one direction is applied, the
+    /// closer is skipped and reported.
+    #[test]
+    fn mutual_physical_reads_do_not_make_the_executor_refuse() {
+        let config = config_with_pipelines(vec![("t", transform_pipeline(vec![]))]);
+        let mut a = model("a", vec![], vec![]);
+        a.sql = "SELECT x FROM silver.b".into();
+        let mut b = model("b", vec![], vec![]);
+        b.sql = "SELECT y FROM silver.a".into();
+        let models = vec![a, b];
+        let by_pipeline = owned_by_sole_transformation(&config, models.clone());
+        let mut dag = build_unified_dag(&config, &by_pipeline, &[]).expect("build dag");
+
+        let inputs: Vec<crate::physical_edges::PhysicalEdgeModel<'_>> = models
+            .iter()
+            .map(crate::physical_edges::PhysicalEdgeModel::from_model)
+            .collect();
+        let derived = infer_physical_dependencies(&mut dag, &inputs);
+        assert_eq!(derived.edges.len(), 1);
+        assert_eq!(derived.skipped_cycle_edges.len(), 1);
+        execution_phases(&dag).expect("phases must still compute — no cycle may be introduced");
     }
 }

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -1065,12 +1065,15 @@ pub fn infer_physical_dependencies(
     // invisible to it, and `execution_phases` hard-errors on cycles, so every
     // insertion is re-checked against the whole graph: a derived edge must
     // never make a runnable project refuse.
-    fn reaches_node(dag: &UnifiedDag, from: &NodeId, to: &NodeId) -> bool {
-        let mut adj: std::collections::HashMap<&NodeId, Vec<&NodeId>> =
-            std::collections::HashMap::new();
-        for e in &dag.edges {
-            adj.entry(&e.from).or_default().push(&e.to);
-        }
+    // O(V+E) per query over an adjacency map rebuilt only when edges were
+    // added since the last build — not per candidate (the review measured
+    // the rebuild-per-candidate shape at hundreds of millions of visits on
+    // pathological projects).
+    fn reaches_node(
+        adj: &std::collections::HashMap<NodeId, Vec<NodeId>>,
+        from: &NodeId,
+        to: &NodeId,
+    ) -> bool {
         let mut seen: std::collections::HashSet<&NodeId> = std::collections::HashSet::new();
         let mut stack = vec![from];
         while let Some(cur) = stack.pop() {
@@ -1081,11 +1084,20 @@ pub fn infer_physical_dependencies(
                 continue;
             }
             if let Some(next) = adj.get(cur) {
-                stack.extend(next.iter().copied());
+                stack.extend(next.iter());
             }
         }
         false
     }
+    fn build_adj(dag: &UnifiedDag) -> std::collections::HashMap<NodeId, Vec<NodeId>> {
+        let mut adj: std::collections::HashMap<NodeId, Vec<NodeId>> =
+            std::collections::HashMap::new();
+        for e in &dag.edges {
+            adj.entry(e.from.clone()).or_default().push(e.to.clone());
+        }
+        adj
+    }
+    let mut adj = build_adj(dag);
     for (consumer, producer) in derived.edges.clone() {
         let (Some(cid), Some(pid)) = (
             by_label.get(consumer.as_str()),
@@ -1098,7 +1110,7 @@ pub fn infer_physical_dependencies(
         }
         // Inserting producer→consumer closes a cycle iff the consumer's node
         // already reaches the producer's node through the FULL graph.
-        if reaches_node(dag, cid, pid) {
+        if reaches_node(&adj, cid, pid) {
             derived
                 .edges
                 .retain(|(c, p)| !(c == &consumer && p == &producer));
@@ -1110,6 +1122,7 @@ pub fn infer_physical_dependencies(
             to: cid.clone(),
             edge_type: EdgeType::DataDependency,
         });
+        adj.entry(pid.clone()).or_default().push(cid.clone());
     }
     // Second pass: a name-level skip's premise is "the opposite direction
     // was accepted". If insertion REJECTED that opposite edge (a real cycle
@@ -1127,7 +1140,7 @@ pub fn infer_physical_dependencies(
         if edge_set.contains(&(pid.clone(), cid.clone())) {
             continue;
         }
-        if reaches_node(dag, cid, pid) {
+        if reaches_node(&adj, cid, pid) {
             continue;
         }
         derived
@@ -1139,6 +1152,7 @@ pub fn infer_physical_dependencies(
             to: cid.clone(),
             edge_type: EdgeType::DataDependency,
         });
+        adj.entry(pid.clone()).or_default().push(cid.clone());
     }
     derived
 }

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -1111,6 +1111,35 @@ pub fn infer_physical_dependencies(
             edge_type: EdgeType::DataDependency,
         });
     }
+    // Second pass: a name-level skip's premise is "the opposite direction
+    // was accepted". If insertion REJECTED that opposite edge (a real cycle
+    // through an intermediate), the skipped direction may now be safe — and
+    // without it the pair would end up with NO edge at all, silently
+    // co-scheduled. Reconsider every name-level skip against the live graph.
+    let skipped_snapshot = derived.skipped_cycle_edges.clone();
+    for (consumer, producer) in skipped_snapshot {
+        let (Some(cid), Some(pid)) = (
+            by_label.get(consumer.as_str()),
+            by_label.get(producer.as_str()),
+        ) else {
+            continue;
+        };
+        if edge_set.contains(&(pid.clone(), cid.clone())) {
+            continue;
+        }
+        if reaches_node(dag, cid, pid) {
+            continue;
+        }
+        derived
+            .skipped_cycle_edges
+            .retain(|(c, p)| !(c == &consumer && p == &producer));
+        derived.edges.push((consumer, producer));
+        dag.edges.push(UnifiedEdge {
+            from: pid.clone(),
+            to: cid.clone(),
+            edge_type: EdgeType::DataDependency,
+        });
+    }
     derived
 }
 
@@ -2952,5 +2981,82 @@ mod tests {
         );
         assert_eq!(derived.skipped_cycle_edges.len(), 1);
         execution_phases(&dag).expect("a derived edge must never make a runnable project refuse");
+    }
+
+    /// #1275 second-order guard: when insertion rejects the name-accepted
+    /// direction of a mutual pair (a real cycle through an intermediate),
+    /// the name-level-skipped direction must be reconsidered — otherwise the
+    /// pair ends up with NO edge and silently co-schedules.
+    #[test]
+    fn a_rejected_direction_reinstates_the_skipped_one() {
+        let config = config_with_pipelines(vec![("t", transform_pipeline(vec![]))]);
+        // Mutual physical reads: candidates ("a","b") then ("b","a") in
+        // deterministic order; the derivation accepts ("a","b") and skips
+        // ("b","a").
+        let mut a = model("a", vec![], vec![]);
+        a.sql = "SELECT x FROM silver.b".into();
+        let mut b = model("b", vec![], vec![]);
+        b.sql = "SELECT y FROM silver.a".into();
+        let models = vec![a, b];
+        let by_pipeline = owned_by_sole_transformation(&config, models.clone());
+        let mut dag = build_unified_dag(&config, &by_pipeline, &[]).expect("build dag");
+
+        // Pre-existing intermediate path a → gate → b, so inserting the
+        // accepted ("a","b") edge (b before a) would close a cycle at the
+        // NodeId level and gets rejected there.
+        let a_id = dag
+            .nodes
+            .iter()
+            .find(|n| n.label == "a" && n.kind == NodeKind::Transformation)
+            .unwrap()
+            .id
+            .clone();
+        let b_id = dag
+            .nodes
+            .iter()
+            .find(|n| n.label == "b" && n.kind == NodeKind::Transformation)
+            .unwrap()
+            .id
+            .clone();
+        let gate_id = NodeId("check:gate".to_string());
+        dag.nodes.push(UnifiedNode {
+            id: gate_id.clone(),
+            kind: NodeKind::Quality,
+            label: "gate".into(),
+            pipeline: Some("t".into()),
+        });
+        dag.edges.push(UnifiedEdge {
+            from: a_id.clone(),
+            to: gate_id.clone(),
+            edge_type: EdgeType::CheckDependency,
+        });
+        dag.edges.push(UnifiedEdge {
+            from: gate_id,
+            to: b_id.clone(),
+            edge_type: EdgeType::CheckDependency,
+        });
+
+        let inputs: Vec<crate::physical_edges::PhysicalEdgeModel<'_>> = models
+            .iter()
+            .map(crate::physical_edges::PhysicalEdgeModel::from_model)
+            .collect();
+        let derived = infer_physical_dependencies(&mut dag, &inputs);
+        assert_eq!(
+            derived.edges,
+            vec![("b".to_string(), "a".to_string())],
+            "the skipped direction must be reinstated: {derived:?}"
+        );
+        assert_eq!(
+            derived.skipped_cycle_edges,
+            vec![("a".to_string(), "b".to_string())]
+        );
+        let phases = execution_phases(&dag).expect("no cycle");
+        let pos = |label: &str| {
+            phases
+                .iter()
+                .position(|l| l.iter().any(|n| n.label == label))
+                .unwrap()
+        };
+        assert!(pos("a") < pos("b"), "consistent with the intermediate path");
     }
 }

--- a/schemas/dag_run.schema.json
+++ b/schemas/dag_run.schema.json
@@ -101,6 +101,13 @@
     },
     "version": {
       "type": "string"
+    },
+    "warnings": {
+      "description": "Scheduling warnings from physical-read edge derivation: mutual reads serialized by a deterministic order, models whose SQL could not be parsed for reads, and colliding targets. Empty when none.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
     }
   },
   "required": [

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -1315,6 +1315,13 @@
         "null"
       ]
     },
+    "scheduling_warnings": {
+      "description": "Scheduling warnings from physical-read edge derivation (#1275): mutual physical reads serialized by a deterministic order, models whose SQL could not be parsed for table references, and colliding targets. Empty (and omitted) when none.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
     "shadow": {
       "description": "True when running in shadow mode (targets rewritten).",
       "type": "boolean"

--- a/sdk/python/src/rocky_sdk/types.py
+++ b/sdk/python/src/rocky_sdk/types.py
@@ -475,6 +475,10 @@ class RunResult(BaseModel):
     #: Budget breaches detected at end of run. Empty when no ``[budget]`` block
     #: is configured or all limits were respected.
     budget_breaches: list[BudgetBreachOutput] = Field(default_factory=list)
+    #: Scheduling warnings from physical-read edge derivation: mutual
+    #: physical reads serialized by a deterministic order, models whose SQL
+    #: could not be parsed for table references, and colliding targets.
+    scheduling_warnings: list[str] = Field(default_factory=list)
     #: Soft warnings from the per-table override resolver — one entry per
     #: ``[[table_overrides]]`` rule that matched nothing. Empty when no
     #: overrides are declared.

--- a/sdk/python/src/rocky_sdk/types_generated/dag_run_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/dag_run_schema.py
@@ -76,3 +76,7 @@ class DagRunOutput(BaseModel):
     Total nodes across all layers.
     """
     version: str
+    warnings: list[str] | None = None
+    """
+    Scheduling warnings from physical-read edge derivation: mutual reads serialized by a deterministic order, models whose SQL could not be parsed for reads, and colliding targets. Empty when none.
+    """

--- a/sdk/python/src/rocky_sdk/types_generated/run_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/run_schema.py
@@ -774,6 +774,10 @@ class RunOutput(BaseModel):
     Row-quarantine outcomes — one entry per table the quality pipeline quarantined. Empty for runs that did not use `[pipeline.x.checks.quarantine]`.
     """
     resumed_from: str | None = None
+    scheduling_warnings: list[str] | None = None
+    """
+    Scheduling warnings from physical-read edge derivation (#1275): mutual physical reads serialized by a deterministic order, models whose SQL could not be parsed for table references, and colliding targets. Empty (and omitted) when none.
+    """
     shadow: bool | None = None
     """
     True when running in shadow mode (targets rewritten).


### PR DESCRIPTION
Fixes #1275. A model reading another in-run model's target by its physical name (`main.orders`, `db.main.orders`, or a bare `orders_v2` resolved through the connection's search path) had no DAG edge — multi-part references are external to compile-time resolution — so producer and consumer could share an execution layer and race under `--parallel`. And the two run entry points schedule independently: plain `run` iterates `project.layers` while `run --dag` phases a `UnifiedDag` through its own executor, so a one-scheduler fix leaves the same race reachable one flag away (this exact gap failed the first design review).

## Shape

One shared derivation, `rocky_core::physical_edges`, feeds both schedulers:

- Each model's **rendered target components** (catalog/schema/table) are matched componentwise — case- and quote-folded on **both** sides — against every model's SQL read set (`referenced_tables`, which already lowercases; the fold is load-bearing for the config side). 3-part reads match (catalog, schema, table); 2-part match (schema, table); **bare reads match by table component alone**, because search-path resolution is connection state Rocky cannot observe. A spurious match is an extra ordering constraint — the safe error direction; a missed match is the race.
- **Plain run**: `augment_physical_read_edges` pushes edges into the runtime `dag_nodes` copy and recomputes `execution_order`/`layers` (the shipped shadow-rewrite pattern), skipped under `[resilience] contain_failures` whose ledger already orders physical readers. The compile-time graph, `E001` surface, and `rocky dag` export are untouched.
- **`run --dag`**: `unified_dag::infer_physical_dependencies` inserts `DataDependency` edges before phase computation. The existing label heuristic stays for seed/load matching; it was blind to renamed targets (a producer targeting `orders_v2` under model name `orders_model` derived nothing).

## Cycle and incompleteness policy

- A candidate edge that would close a cycle (mutual physical reads) is **skipped deterministically** inside the derivation and surfaced as a warning — the pair serializes in one defined order instead of refusing runs that execute today. `execution_phases`' hard cycle error can therefore never be triggered by a derived edge.
- Models whose SQL cannot be parsed for reads, and colliding targets, surface as structured warnings — `RunOutput.scheduling_warnings` / `DagRunOutput.warnings` — never a silent pass.

## Evidence

- 12 new tests: derivation unit tests (2-part/3-part/bare matching, renamed targets, both-sides folding, mutual-read determinism, declared-edge cycle guard, unparseable reporting, collision multi-match, compile-edge dedup), plain-run layering incl. the issue's exact repro (`[[orders], [mart_qualified]]`) and the mutual-read warning path, UnifiedDag phase-ordering incl. the renamed-target case the label heuristic misses and the no-refusal cycle case.
- 5 mutation checks, each red at its pinning assertion: cycle guard dropped, 2-part matching dropped, bare-table matching dropped, target-side folding dropped, dag edge-insertion dropped. (A read-side folding mutation proved equivalent — `referenced_tables` already normalizes; documented in the module.)
- 5940/5940 workspace tests, 204/204 SDK tests, clippy clean, fmt clean, codegen bindings regenerated together (fixtures unaffected — the new fields serialize only when non-empty).
- Pre-existing containment-path tests pass unchanged (that path's own physical-read ordering is deliberately left in charge under `contain_failures`).

Out of scope, tracked: #1351 (the label heuristic's collision-overwrite and silent-failure behaviors for non-transformation nodes), dagster-side ordering (consumes `rocky dag`, unchanged), and fail-closed escalation on case-unobservable adapters (Snowflake `QUOTED_IDENTIFIERS_IGNORE_CASE`, BigQuery `is_case_insensitive` — #1281 tracks reading the live setting).