### PR TITLE
fix(engine): label-based inference — all claimants ordered, parse failures surfaced, cycle-guarded

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -6039,7 +6039,7 @@
             "type": "string"
           },
           "warnings": {
-            "description": "Scheduling warnings from physical-read edge derivation: mutual reads serialized by a deterministic order, models whose SQL could not be parsed for reads, and colliding targets. Empty when none.",
+            "description": "Scheduling warnings from dependency inference — physical-read derivation (mutual reads serialized deterministically, unparseable models, colliding targets) and label inference (label collisions where only one claimant orders the reader, unparseable models). Empty when none.",
             "items": {
               "type": "string"
             },

--- a/editors/vscode/src/types/generated/dag_run.ts
+++ b/editors/vscode/src/types/generated/dag_run.ts
@@ -40,7 +40,7 @@ export interface DagRunOutput {
   total_nodes: number;
   version: string;
   /**
-   * Scheduling warnings from physical-read edge derivation: mutual reads serialized by a deterministic order, models whose SQL could not be parsed for reads, and colliding targets. Empty when none.
+   * Scheduling warnings from dependency inference — physical-read derivation (mutual reads serialized deterministically, unparseable models, colliding targets) and label inference (label collisions where only one claimant orders the reader, unparseable models). Empty when none.
    */
   warnings?: string[];
   [k: string]: unknown;

--- a/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
+++ b/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
@@ -269,7 +269,7 @@ pub async fn run_with_dag(
         .flatten()
         .map(|m| (m.config.name.clone(), m.sql.clone()))
         .collect();
-    unified_dag::infer_runtime_dependencies(&mut dag, &sql_by_name);
+    let label_report = unified_dag::infer_runtime_dependencies(&mut dag, &sql_by_name);
 
     // Physical-read ordering (#1275): the label heuristic above is blind to
     // configured `[target]`s — a model reading another model's physical
@@ -285,7 +285,8 @@ pub async fn run_with_dag(
             .map(rocky_core::physical_edges::PhysicalEdgeModel::from_model)
             .collect();
     let derived = unified_dag::infer_physical_dependencies(&mut dag, &physical_inputs);
-    let physical_edge_warnings = rocky_core::physical_edges::derivation_warnings(&derived);
+    let mut physical_edge_warnings = label_report.warnings();
+    physical_edge_warnings.extend(rocky_core::physical_edges::derivation_warnings(&derived));
     for w in &physical_edge_warnings {
         tracing::warn!("{w}");
     }

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -5328,9 +5328,11 @@ pub struct DagSummaryOutput {
 pub struct DagRunOutput {
     pub version: String,
     pub command: String,
-    /// Scheduling warnings from physical-read edge derivation: mutual reads
-    /// serialized by a deterministic order, models whose SQL could not be
-    /// parsed for reads, and colliding targets. Empty when none.
+    /// Scheduling warnings from dependency inference — physical-read
+    /// derivation (mutual reads serialized deterministically, unparseable
+    /// models, colliding targets) and label inference (label collisions
+    /// where only one claimant orders the reader, unparseable models).
+    /// Empty when none.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<String>,
     /// Total nodes across all layers.

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -1002,6 +1002,15 @@ pub fn infer_runtime_dependencies(
 
     let mut new_edges = Vec::new();
 
+    // Resolve every reader's candidates once, splitting legacy from fan-out.
+    // TWO-PHASE insertion: all legacy edges first (unguarded — byte-for-byte
+    // the graph the single-slot heuristic produced, so refusals are exactly
+    // the old refusals), THEN the fan-out additions guarded against the
+    // COMPLETE graph. Interleaving would let an earlier reader's fan-out
+    // edge make a later reader's unguarded legacy edge closing — a refusal
+    // the old behavior never had.
+    let mut legacy_candidates: Vec<(NodeId, String, NodeId)> = Vec::new();
+    let mut fanout_candidates: Vec<(NodeId, String, NodeId)> = Vec::new();
     for node in &dag.nodes {
         if node.kind != NodeKind::Transformation {
             continue;
@@ -1033,39 +1042,62 @@ pub fn infer_runtime_dependencies(
             // reader actually depends on is unknowable from the label alone,
             // and an extra ordering constraint is the safe direction.
             for producer_id in claimants {
-                // Skip self-references and already-known edges.
                 if *producer_id == node.id {
                     continue;
                 }
-                let key = (producer_id.clone(), node.id.clone());
-                if existing.contains(&key) {
-                    continue;
+                let entry = (node.id.clone(), node.label.clone(), producer_id.clone());
+                if legacy_winner.get(bare.as_str()) == Some(producer_id) {
+                    legacy_candidates.push(entry);
+                } else {
+                    fanout_candidates.push(entry);
                 }
-                // Guard only the fan-out additions; the legacy winner's edge
-                // inserts unguarded so genuine reciprocal reads keep their
-                // loud refusal (status quo).
-                let is_legacy = legacy_winner.get(bare.as_str()) == Some(producer_id);
-                if !is_legacy && label_reaches(&adj, &node.id, producer_id) {
-                    report
-                        .skipped_cycle_edges
-                        .push((node.label.clone(), producer_id.0.clone()));
-                    continue;
-                }
-                existing.insert(key);
-                adj.entry(producer_id.clone())
-                    .or_default()
-                    .push(node.id.clone());
-                new_edges.push(UnifiedEdge {
-                    from: producer_id.clone(),
-                    to: node.id.clone(),
-                    edge_type: EdgeType::DataDependency,
-                });
             }
         }
     }
 
+    // Phase 1 — legacy edges, unguarded (status-quo graph; genuine SQL
+    // cycles keep their loud refusal).
+    for (reader_id, _label, producer_id) in legacy_candidates {
+        let key = (producer_id.clone(), reader_id.clone());
+        if !existing.insert(key) {
+            continue;
+        }
+        adj.entry(producer_id.clone())
+            .or_default()
+            .push(reader_id.clone());
+        new_edges.push(UnifiedEdge {
+            from: producer_id,
+            to: reader_id,
+            edge_type: EdgeType::DataDependency,
+        });
+    }
+    // Phase 2 — fan-out additions, guarded against the complete graph: they
+    // must never introduce a refusal the old behavior did not have.
+    for (reader_id, reader_label, producer_id) in fanout_candidates {
+        let key = (producer_id.clone(), reader_id.clone());
+        if existing.contains(&key) {
+            continue;
+        }
+        if label_reaches(&adj, &reader_id, &producer_id) {
+            report
+                .skipped_cycle_edges
+                .push((reader_label, producer_id.0.clone()));
+            continue;
+        }
+        existing.insert(key);
+        adj.entry(producer_id.clone())
+            .or_default()
+            .push(reader_id.clone());
+        new_edges.push(UnifiedEdge {
+            from: producer_id,
+            to: reader_id,
+            edge_type: EdgeType::DataDependency,
+        });
+    }
+
     dag.edges.extend(new_edges);
     report.unparsed.sort();
+    report.skipped_cycle_edges.sort();
     report
 }
 
@@ -3322,5 +3354,67 @@ mod tests {
         let report = infer_runtime_dependencies(&mut dag, &sql);
         assert_eq!(report.skipped_cycle_edges.len(), 1, "{report:?}");
         execution_phases(&dag).expect("the fan-out edge skips; nothing refuses");
+    }
+
+    /// Two-phase insertion pinned: an earlier reader's guarded FAN-OUT edge
+    /// must not make a later reader's unguarded LEGACY edge closing — that
+    /// would refuse a DAG the single-slot heuristic ran. Legacy edges land
+    /// first (the status-quo graph), fan-out edges are then guarded against
+    /// the complete graph.
+    #[test]
+    fn a_fanout_edge_cannot_make_a_later_legacy_edge_closing() {
+        let config = config_with_pipelines(vec![("t", transform_pipeline(vec![]))]);
+        let mut t1 = model("t1", vec![], vec![]);
+        t1.sql = "SELECT x FROM s".into();
+        let mut t2 = model("t2", vec![], vec![]);
+        t2.sql = "SELECT y FROM t1".into();
+        let models = vec![t1.clone(), t2.clone()];
+        let by_pipeline = owned_by_sole_transformation(&config, models);
+        let mut dag = build_unified_dag(&config, &by_pipeline, &[]).expect("build dag");
+        let t2_id = dag
+            .nodes
+            .iter()
+            .find(|n| n.label == "t2" && n.kind == NodeKind::Transformation)
+            .unwrap()
+            .id
+            .clone();
+        // Label "s": P first (fan-out under last-wins), L last (legacy).
+        let p = NodeId("p:s".to_string());
+        let l = NodeId("l:s".to_string());
+        dag.nodes.push(UnifiedNode {
+            id: p.clone(),
+            kind: NodeKind::Seed,
+            label: "s".into(),
+            pipeline: Some("t".into()),
+        });
+        dag.nodes.push(UnifiedNode {
+            id: l.clone(),
+            kind: NodeKind::Load,
+            label: "s".into(),
+            pipeline: Some("t".into()),
+        });
+        // P depends on T2 (existing edge T2 -> P): with interleaved insertion
+        // the fan-out edge P -> T1 lands before T2's legacy edge T1 -> T2 and
+        // closes the cycle T2 -> P -> T1 -> T2. The old single-slot graph had
+        // no P edge at all and RAN.
+        dag.edges.push(UnifiedEdge {
+            from: t2_id,
+            to: p.clone(),
+            edge_type: EdgeType::DataDependency,
+        });
+        let sql: HashMap<String, String> = HashMap::from([
+            ("t1".to_string(), t1.sql.clone()),
+            ("t2".to_string(), t2.sql.clone()),
+        ]);
+        let report = infer_runtime_dependencies(&mut dag, &sql);
+        execution_phases(&dag)
+            .expect("the fan-out edge must be the one skipped; nothing may refuse");
+        assert!(
+            report
+                .skipped_cycle_edges
+                .iter()
+                .any(|(r, pid)| r == "t1" && pid == "p:s"),
+            "{report:?}"
+        );
     }
 }

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -966,6 +966,31 @@ pub fn infer_runtime_dependencies(
         .iter()
         .map(|e| (e.from.clone(), e.to.clone()))
         .collect();
+    // Insertion-time cycle guard, same contract as the physical pass: an
+    // inferred edge must never make `execution_phases` refuse a DAG that
+    // runs today. (The pre-guard heuristic could already refuse on mutual
+    // label reads; the all-claimant fan-out widens that exposure, so the
+    // guard lands with it.)
+    let mut adj: HashMap<NodeId, Vec<NodeId>> = HashMap::new();
+    for e in &dag.edges {
+        adj.entry(e.from.clone()).or_default().push(e.to.clone());
+    }
+    fn label_reaches(adj: &HashMap<NodeId, Vec<NodeId>>, from: &NodeId, to: &NodeId) -> bool {
+        let mut seen: HashSet<&NodeId> = HashSet::new();
+        let mut stack = vec![from];
+        while let Some(cur) = stack.pop() {
+            if cur == to {
+                return true;
+            }
+            if !seen.insert(cur) {
+                continue;
+            }
+            if let Some(next) = adj.get(cur) {
+                stack.extend(next.iter());
+            }
+        }
+        false
+    }
 
     let mut new_edges = Vec::new();
 
@@ -1005,13 +1030,25 @@ pub fn infer_runtime_dependencies(
                     continue;
                 }
                 let key = (producer_id.clone(), node.id.clone());
-                if existing.insert(key) {
-                    new_edges.push(UnifiedEdge {
-                        from: producer_id.clone(),
-                        to: node.id.clone(),
-                        edge_type: EdgeType::DataDependency,
-                    });
+                if existing.contains(&key) {
+                    continue;
                 }
+                // Closing iff the reader already reaches the producer.
+                if label_reaches(&adj, &node.id, producer_id) {
+                    report
+                        .skipped_cycle_edges
+                        .push((node.label.clone(), producer_id.0.clone()));
+                    continue;
+                }
+                existing.insert(key);
+                adj.entry(producer_id.clone())
+                    .or_default()
+                    .push(node.id.clone());
+                new_edges.push(UnifiedEdge {
+                    from: producer_id.clone(),
+                    to: node.id.clone(),
+                    edge_type: EdgeType::DataDependency,
+                });
             }
         }
     }
@@ -1032,6 +1069,10 @@ pub struct LabelInferenceReport {
     pub label_collisions: Vec<(String, usize)>,
     /// Transformation labels whose SQL failed table-reference extraction.
     pub unparsed: Vec<String>,
+    /// (reader label, producer node id) pairs whose inferred edge would
+    /// close a dependency cycle and was skipped — the pair executes in the
+    /// already-established order.
+    pub skipped_cycle_edges: Vec<(String, String)>,
 }
 
 impl LabelInferenceReport {
@@ -1049,6 +1090,13 @@ impl LabelInferenceReport {
             w.push(format!(
                 "model '{m}': SQL could not be parsed for table references — label-based \
                  ordering could not be derived for it"
+            ));
+        }
+        for (reader, producer) in &self.skipped_cycle_edges {
+            w.push(format!(
+                "label-based ordering: the inferred edge '{reader}' -> '{producer}' would \
+                 close a dependency cycle and was skipped; declare depends_on to state the \
+                 real direction"
             ));
         }
         w
@@ -3192,5 +3240,27 @@ mod tests {
         let report = infer_runtime_dependencies(&mut dag, &sql);
         assert_eq!(report.unparsed, vec!["broken".to_string()]);
         assert!(!report.warnings().is_empty());
+    }
+
+    /// The label pass must never refuse a runnable DAG: mutual label reads
+    /// (each model reading the other's label) skip one direction with a
+    /// warning and `execution_phases` still computes.
+    #[test]
+    fn mutual_label_reads_do_not_refuse_the_dag() {
+        let config = config_with_pipelines(vec![("t", transform_pipeline(vec![]))]);
+        let mut a = model("a", vec![], vec![]);
+        a.sql = "SELECT x FROM b".into();
+        let mut b = model("b", vec![], vec![]);
+        b.sql = "SELECT y FROM a".into();
+        let models = vec![a.clone(), b.clone()];
+        let by_pipeline = owned_by_sole_transformation(&config, models);
+        let mut dag = build_unified_dag(&config, &by_pipeline, &[]).expect("build dag");
+        let sql: HashMap<String, String> = HashMap::from([
+            ("a".to_string(), a.sql.clone()),
+            ("b".to_string(), b.sql.clone()),
+        ]);
+        let report = infer_runtime_dependencies(&mut dag, &sql);
+        assert_eq!(report.skipped_cycle_edges.len(), 1, "{report:?}");
+        execution_phases(&dag).expect("one direction applies; the closer skips");
     }
 }

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -979,27 +979,6 @@ pub fn infer_runtime_dependencies(
     // must not silently become a stale-read success. Only the edges this
     // change ADDS (claimants the old code dropped) are guarded: they must
     // never introduce a refusal the old behavior did not have.
-    let mut adj: HashMap<NodeId, Vec<NodeId>> = HashMap::new();
-    for e in &dag.edges {
-        adj.entry(e.from.clone()).or_default().push(e.to.clone());
-    }
-    fn label_reaches(adj: &HashMap<NodeId, Vec<NodeId>>, from: &NodeId, to: &NodeId) -> bool {
-        let mut seen: HashSet<&NodeId> = HashSet::new();
-        let mut stack = vec![from];
-        while let Some(cur) = stack.pop() {
-            if cur == to {
-                return true;
-            }
-            if !seen.insert(cur) {
-                continue;
-            }
-            if let Some(next) = adj.get(cur) {
-                stack.extend(next.iter());
-            }
-        }
-        false
-    }
-
     let mut new_edges = Vec::new();
 
     // Resolve every reader's candidates once, splitting legacy from fan-out.
@@ -1010,7 +989,6 @@ pub fn infer_runtime_dependencies(
     // edge make a later reader's unguarded legacy edge closing — a refusal
     // the old behavior never had.
     let mut legacy_candidates: Vec<(NodeId, String, NodeId)> = Vec::new();
-    let mut fanout_candidates: Vec<(NodeId, String, NodeId)> = Vec::new();
     for node in &dag.nodes {
         if node.kind != NodeKind::Transformation {
             continue;
@@ -1038,25 +1016,24 @@ pub fn infer_runtime_dependencies(
             let Some(claimants) = producers.get(&bare) else {
                 continue;
             };
-            // EVERY claimant of the label gets the edge: which one the
-            // reader actually depends on is unknowable from the label alone,
-            // and an extra ordering constraint is the safe direction.
-            for (producer_id, producer_kind) in claimants {
+            // ONLY the legacy winner's edge is derived — byte-for-byte the
+            // single-slot heuristic's graph. Ordering readers after the
+            // OTHER claimants was tried and reverted four review rounds
+            // running: any edge added beyond main's graph can suppress an
+            // exact physical dependency through the shared cycle guards
+            // until the cross-pass provenance contract exists (#1357). The
+            // collision is REPORTED so the un-ordered claimants are visible
+            // instead of silent.
+            for (producer_id, _kind) in claimants {
                 if *producer_id == node.id {
                     continue;
                 }
-                let entry = (node.id.clone(), node.label.clone(), producer_id.clone());
                 if legacy_winner.get(bare.as_str()) == Some(producer_id) {
-                    legacy_candidates.push(entry);
-                } else if *producer_kind != NodeKind::Transformation {
-                    // Fan-out is restricted to NON-transformation claimants.
-                    // A transformation claimant's ordering belongs to the
-                    // target-aware physical pass: its edges never enter that
-                    // pass's transformation-pair existing-projection, so a
-                    // fan-out edge here could suppress an exact physical
-                    // dependency (review round-4 construction) — while
-                    // seed/load/replication edges structurally cannot.
-                    fanout_candidates.push(entry);
+                    legacy_candidates.push((
+                        node.id.clone(),
+                        node.label.clone(),
+                        producer_id.clone(),
+                    ));
                 }
             }
         }
@@ -1069,32 +1046,6 @@ pub fn infer_runtime_dependencies(
         if !existing.insert(key) {
             continue;
         }
-        adj.entry(producer_id.clone())
-            .or_default()
-            .push(reader_id.clone());
-        new_edges.push(UnifiedEdge {
-            from: producer_id,
-            to: reader_id,
-            edge_type: EdgeType::DataDependency,
-        });
-    }
-    // Phase 2 — fan-out additions, guarded against the complete graph: they
-    // must never introduce a refusal the old behavior did not have.
-    for (reader_id, reader_label, producer_id) in fanout_candidates {
-        let key = (producer_id.clone(), reader_id.clone());
-        if existing.contains(&key) {
-            continue;
-        }
-        if label_reaches(&adj, &reader_id, &producer_id) {
-            report
-                .skipped_cycle_edges
-                .push((reader_label, producer_id.0.clone()));
-            continue;
-        }
-        existing.insert(key);
-        adj.entry(producer_id.clone())
-            .or_default()
-            .push(reader_id.clone());
         new_edges.push(UnifiedEdge {
             from: producer_id,
             to: reader_id,
@@ -1104,7 +1055,6 @@ pub fn infer_runtime_dependencies(
 
     dag.edges.extend(new_edges);
     report.unparsed.sort();
-    report.skipped_cycle_edges.sort();
     report
 }
 
@@ -1119,10 +1069,6 @@ pub struct LabelInferenceReport {
     pub label_collisions: Vec<(String, usize)>,
     /// Transformation labels whose SQL failed table-reference extraction.
     pub unparsed: Vec<String>,
-    /// (reader label, producer node id) pairs whose inferred edge would
-    /// close a dependency cycle and was skipped — the pair executes in the
-    /// already-established order.
-    pub skipped_cycle_edges: Vec<(String, String)>,
 }
 
 impl LabelInferenceReport {
@@ -1132,23 +1078,16 @@ impl LabelInferenceReport {
         let mut w = Vec::new();
         for (label, n) in &self.label_collisions {
             w.push(format!(
-                "label '{label}' is produced by {n} nodes — readers are ordered after the \
-                 claimants label inference admitted (the legacy winner plus non-transformation \
-                 claimants the cycle guard allowed); rename one if that over-constrains the \
-                 schedule"
+                "label '{label}' is produced by {n} nodes — label inference orders readers \
+                 after ONE of them (the last in build order); the others are NOT ordered. \
+                 Declare depends_on to state the real dependency, or rename the colliding \
+                 producers"
             ));
         }
         for m in &self.unparsed {
             w.push(format!(
                 "model '{m}': SQL could not be parsed for table references — label-based \
                  ordering could not be derived for it"
-            ));
-        }
-        for (reader, producer) in &self.skipped_cycle_edges {
-            w.push(format!(
-                "label-based ordering: the inferred edge '{reader}' -> '{producer}' would \
-                 close a dependency cycle and was skipped; declare depends_on to state the \
-                 real direction"
             ));
         }
         w
@@ -3237,47 +3176,6 @@ mod tests {
         assert!(pos("a") < pos("b"), "consistent with the intermediate path");
     }
 
-    /// #1351: two producers sharing a lowercased label must BOTH order the
-    /// reader — the single-slot map silently dropped one and the reader
-    /// raced it.
-    #[test]
-    fn colliding_labels_order_the_reader_after_all_claimants() {
-        let config = config_with_pipelines(vec![("t", transform_pipeline(vec![]))]);
-        let mut reader = model("reader", vec![], vec![]);
-        reader.sql = "SELECT x FROM shared".into();
-        let by_pipeline = owned_by_sole_transformation(&config, vec![reader.clone()]);
-        let mut dag = build_unified_dag(&config, &by_pipeline, &[]).expect("build dag");
-        // Two non-transformation producers wearing the same label.
-        for (i, kind) in [(0u8, NodeKind::Seed), (1u8, NodeKind::Load)] {
-            dag.nodes.push(UnifiedNode {
-                id: NodeId(format!("p{i}:shared")),
-                kind,
-                label: "shared".into(),
-                pipeline: Some("t".into()),
-            });
-        }
-        let sql: HashMap<String, String> =
-            HashMap::from([("reader".to_string(), reader.sql.clone())]);
-        let report = infer_runtime_dependencies(&mut dag, &sql);
-        assert_eq!(report.label_collisions, vec![("shared".to_string(), 2)]);
-        let reader_id = dag
-            .nodes
-            .iter()
-            .find(|n| n.label == "reader" && n.kind == NodeKind::Transformation)
-            .unwrap()
-            .id
-            .clone();
-        let producer_edges = dag
-            .edges
-            .iter()
-            .filter(|e| e.to == reader_id && e.from.0.starts_with('p'))
-            .count();
-        assert_eq!(
-            producer_edges, 2,
-            "the reader is ordered after BOTH claimants"
-        );
-    }
-
     /// #1351: a transformation whose SQL cannot be parsed is REPORTED, not
     /// silently skipped.
     #[test]
@@ -3292,6 +3190,51 @@ mod tests {
         let report = infer_runtime_dependencies(&mut dag, &sql);
         assert_eq!(report.unparsed, vec!["broken".to_string()]);
         assert!(!report.warnings().is_empty());
+    }
+
+    /// #1351 observability: a label collision derives ONLY the legacy
+    /// winner's edge (byte-for-byte main's graph — no new edges until the
+    /// #1357 provenance contract exists) and REPORTS the collision so the
+    /// un-ordered claimants are visible instead of silent.
+    #[test]
+    fn label_collisions_are_reported_and_only_the_legacy_edge_derives() {
+        let config = config_with_pipelines(vec![("t", transform_pipeline(vec![]))]);
+        let mut reader = model("reader", vec![], vec![]);
+        reader.sql = "SELECT x FROM shared".into();
+        let by_pipeline = owned_by_sole_transformation(&config, vec![reader.clone()]);
+        let mut dag = build_unified_dag(&config, &by_pipeline, &[]).expect("build dag");
+        let p0 = NodeId("p0:shared".to_string());
+        let p1 = NodeId("p1:shared".to_string());
+        dag.nodes.push(UnifiedNode {
+            id: p0.clone(),
+            kind: NodeKind::Seed,
+            label: "shared".into(),
+            pipeline: Some("t".into()),
+        });
+        dag.nodes.push(UnifiedNode {
+            id: p1.clone(),
+            kind: NodeKind::Load,
+            label: "shared".into(),
+            pipeline: Some("t".into()),
+        });
+        let sql: HashMap<String, String> =
+            HashMap::from([("reader".to_string(), reader.sql.clone())]);
+        let report = infer_runtime_dependencies(&mut dag, &sql);
+        assert_eq!(report.label_collisions, vec![("shared".to_string(), 2)]);
+        assert!(!report.warnings().is_empty());
+        let reader_id = dag
+            .nodes
+            .iter()
+            .find(|n| n.label == "reader" && n.kind == NodeKind::Transformation)
+            .unwrap()
+            .id
+            .clone();
+        let from_p0 = dag.edges.iter().any(|e| e.from == p0 && e.to == reader_id);
+        let from_p1 = dag.edges.iter().any(|e| e.from == p1 && e.to == reader_id);
+        assert!(
+            !from_p0 && from_p1,
+            "exactly the legacy (last) claimant's edge — main's graph"
+        );
     }
 
     /// Status quo pinned: genuinely reciprocal label reads REFUSE loudly
@@ -3312,189 +3255,9 @@ mod tests {
             ("b".to_string(), b.sql.clone()),
         ]);
         let report = infer_runtime_dependencies(&mut dag, &sql);
-        assert!(report.skipped_cycle_edges.is_empty(), "{report:?}");
         assert!(
             execution_phases(&dag).is_err(),
             "a genuine SQL cycle keeps its loud refusal"
         );
-    }
-
-    /// The guard applies exactly to the edges the fan-out ADDS: a non-legacy
-    /// claimant edge that would close a cycle is skipped (warned) — the old
-    /// single-slot behavior had no such edge, so no refusal may appear.
-    #[test]
-    fn a_fanout_claimant_edge_never_introduces_a_new_refusal() {
-        let config = config_with_pipelines(vec![("t", transform_pipeline(vec![]))]);
-        let mut reader = model("reader", vec![], vec![]);
-        reader.sql = "SELECT x FROM shared".into();
-        let by_pipeline = owned_by_sole_transformation(&config, vec![reader.clone()]);
-        let mut dag = build_unified_dag(&config, &by_pipeline, &[]).expect("build dag");
-        let reader_id = dag
-            .nodes
-            .iter()
-            .find(|n| n.label == "reader" && n.kind == NodeKind::Transformation)
-            .unwrap()
-            .id
-            .clone();
-        // Two claimants; the FIRST (non-legacy under last-wins) already
-        // depends on the reader through an existing edge, so its fan-out
-        // edge would close a cycle.
-        let p0 = NodeId("p0:shared".to_string());
-        let p1 = NodeId("p1:shared".to_string());
-        dag.nodes.push(UnifiedNode {
-            id: p0.clone(),
-            kind: NodeKind::Seed,
-            label: "shared".into(),
-            pipeline: Some("t".into()),
-        });
-        dag.nodes.push(UnifiedNode {
-            id: p1.clone(),
-            kind: NodeKind::Load,
-            label: "shared".into(),
-            pipeline: Some("t".into()),
-        });
-        dag.edges.push(UnifiedEdge {
-            from: reader_id.clone(),
-            to: p0.clone(),
-            edge_type: EdgeType::DataDependency,
-        });
-        let sql: HashMap<String, String> =
-            HashMap::from([("reader".to_string(), reader.sql.clone())]);
-        let report = infer_runtime_dependencies(&mut dag, &sql);
-        assert_eq!(report.skipped_cycle_edges.len(), 1, "{report:?}");
-        execution_phases(&dag).expect("the fan-out edge skips; nothing refuses");
-    }
-
-    /// Two-phase insertion pinned: an earlier reader's guarded FAN-OUT edge
-    /// must not make a later reader's unguarded LEGACY edge closing — that
-    /// would refuse a DAG the single-slot heuristic ran. Legacy edges land
-    /// first (the status-quo graph), fan-out edges are then guarded against
-    /// the complete graph.
-    #[test]
-    fn a_fanout_edge_cannot_make_a_later_legacy_edge_closing() {
-        let config = config_with_pipelines(vec![("t", transform_pipeline(vec![]))]);
-        let mut t1 = model("t1", vec![], vec![]);
-        t1.sql = "SELECT x FROM s".into();
-        let mut t2 = model("t2", vec![], vec![]);
-        t2.sql = "SELECT y FROM t1".into();
-        let models = vec![t1.clone(), t2.clone()];
-        let by_pipeline = owned_by_sole_transformation(&config, models);
-        let mut dag = build_unified_dag(&config, &by_pipeline, &[]).expect("build dag");
-        let t2_id = dag
-            .nodes
-            .iter()
-            .find(|n| n.label == "t2" && n.kind == NodeKind::Transformation)
-            .unwrap()
-            .id
-            .clone();
-        // Label "s": P first (fan-out under last-wins), L last (legacy).
-        let p = NodeId("p:s".to_string());
-        let l = NodeId("l:s".to_string());
-        dag.nodes.push(UnifiedNode {
-            id: p.clone(),
-            kind: NodeKind::Seed,
-            label: "s".into(),
-            pipeline: Some("t".into()),
-        });
-        dag.nodes.push(UnifiedNode {
-            id: l.clone(),
-            kind: NodeKind::Load,
-            label: "s".into(),
-            pipeline: Some("t".into()),
-        });
-        // P depends on T2 (existing edge T2 -> P): with interleaved insertion
-        // the fan-out edge P -> T1 lands before T2's legacy edge T1 -> T2 and
-        // closes the cycle T2 -> P -> T1 -> T2. The old single-slot graph had
-        // no P edge at all and RAN.
-        dag.edges.push(UnifiedEdge {
-            from: t2_id,
-            to: p.clone(),
-            edge_type: EdgeType::DataDependency,
-        });
-        let sql: HashMap<String, String> = HashMap::from([
-            ("t1".to_string(), t1.sql.clone()),
-            ("t2".to_string(), t2.sql.clone()),
-        ]);
-        let report = infer_runtime_dependencies(&mut dag, &sql);
-        execution_phases(&dag)
-            .expect("the fan-out edge must be the one skipped; nothing may refuse");
-        assert!(
-            report
-                .skipped_cycle_edges
-                .iter()
-                .any(|(r, pid)| r == "t1" && pid == "p:s"),
-            "{report:?}"
-        );
-    }
-
-    /// Round-4 construction pinned: when a TRANSFORMATION claimant loses
-    /// last-wins, no fan-out edge is added for it — its ordering belongs to
-    /// the physical pass, whose exact edge must survive and order the pair.
-    /// (A fan-out label edge to a transformation could suppress that exact
-    /// edge; seed/load claimants structurally cannot.)
-    #[test]
-    fn no_fanout_to_transformation_claimants_so_physical_evidence_survives() {
-        let config = config_with_pipelines(vec![("t", transform_pipeline(vec![]))]);
-        // Model "A" (upper) and a Load labeled "a": reader r bare-reads "a";
-        // A reads r's exact target. Lowercased label "a" has claimants
-        // [A(transformation), load:a] — last-wins → load is legacy, A is the
-        // would-be fan-out claimant and must be excluded.
-        let mut big_a = model("A", vec![], vec![]);
-        big_a.sql = "SELECT y FROM warehouse.silver.r_out".into();
-        let mut r = model("r", vec![], vec![]);
-        r.config.target.table = "r_out".into();
-        r.sql = "SELECT x FROM a".into();
-        let models = vec![big_a.clone(), r.clone()];
-        let by_pipeline = owned_by_sole_transformation(&config, models.clone());
-        let mut dag = build_unified_dag(&config, &by_pipeline, &[]).expect("build dag");
-        dag.nodes.push(UnifiedNode {
-            id: NodeId("load:a".to_string()),
-            kind: NodeKind::Load,
-            label: "a".into(),
-            pipeline: Some("t".into()),
-        });
-
-        // Caller order: label pass first, then physical.
-        let sql: HashMap<String, String> = HashMap::from([
-            ("A".to_string(), big_a.sql.clone()),
-            ("r".to_string(), r.sql.clone()),
-        ]);
-        let report = infer_runtime_dependencies(&mut dag, &sql);
-        // No fan-out edge to the transformation claimant A.
-        let a_id = dag
-            .nodes
-            .iter()
-            .find(|n| n.label == "A" && n.kind == NodeKind::Transformation)
-            .unwrap()
-            .id
-            .clone();
-        let r_id = dag
-            .nodes
-            .iter()
-            .find(|n| n.label == "r" && n.kind == NodeKind::Transformation)
-            .unwrap()
-            .id
-            .clone();
-        assert!(
-            !dag.edges.iter().any(|e| e.from == a_id && e.to == r_id),
-            "no label fan-out edge may target a transformation claimant: {report:?}"
-        );
-
-        let inputs: Vec<crate::physical_edges::PhysicalEdgeModel<'_>> = models
-            .iter()
-            .map(crate::physical_edges::PhysicalEdgeModel::from_model)
-            .collect();
-        let derived = infer_physical_dependencies(&mut dag, &inputs);
-        assert_eq!(derived.edges.len(), 1, "{derived:?}");
-        // The spurious bare candidate (r bare-reading a name that folds to
-        // A's table) is correctly the one skipped — specificity at work.
-        let phases = execution_phases(&dag).expect("no refusal");
-        let pos = |id: &NodeId| {
-            phases
-                .iter()
-                .position(|l| l.iter().any(|n| &n.id == id))
-                .unwrap()
-        };
-        assert!(pos(&r_id) < pos(&a_id), "the exact physical order wins");
     }
 }

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -931,19 +931,34 @@ fn format_test_label(model_name: &str, test: &crate::tests::TestDecl, index: usi
 pub fn infer_runtime_dependencies(
     dag: &mut UnifiedDag,
     model_sql_by_name: &HashMap<String, String>,
-) {
+) -> LabelInferenceReport {
+    let mut report = LabelInferenceReport::default();
     // Build a set of producing node names (everything that creates a table:
-    // transformations, seeds, loads). Maps logical table name → NodeId.
-    let mut producers: HashMap<String, NodeId> = HashMap::new();
+    // transformations, seeds, loads). Maps logical table name → the FULL set
+    // of claimants: two nodes sharing a lowercased label must both receive
+    // reader edges — a single-slot map silently dropped one of them, and the
+    // reader raced whichever producer lost the insert (#1351).
+    let mut producers: HashMap<String, Vec<NodeId>> = HashMap::new();
     for node in &dag.nodes {
         match node.kind {
             NodeKind::Transformation | NodeKind::Seed | NodeKind::Load | NodeKind::Replication => {
                 // Index by lowercase label so case-insensitive SQL refs match.
-                producers.insert(node.label.to_lowercase(), node.id.clone());
+                producers
+                    .entry(node.label.to_lowercase())
+                    .or_default()
+                    .push(node.id.clone());
             }
             _ => {}
         }
     }
+    for (label, claimants) in &producers {
+        if claimants.len() > 1 {
+            report
+                .label_collisions
+                .push((label.clone(), claimants.len()));
+        }
+    }
+    report.label_collisions.sort();
 
     // Existing edges as a set so we don't double-add.
     let mut existing: HashSet<(NodeId, NodeId)> = dag
@@ -961,8 +976,15 @@ pub fn infer_runtime_dependencies(
         let Some(sql) = model_sql_by_name.get(&node.label) else {
             continue;
         };
-        let Ok(refs) = rocky_sql::lineage::referenced_tables(sql) else {
-            continue;
+        let refs = match rocky_sql::lineage::referenced_tables(sql) {
+            Ok(refs) => refs,
+            // A model whose reads cannot be extracted derives no edges here —
+            // it may be co-scheduled with an unordered upstream. Surfaced,
+            // never silent (#1351).
+            Err(_) => {
+                report.unparsed.push(node.label.clone());
+                continue;
+            }
         };
         for table_name in refs {
             // Match by the bare table name (last segment of any qualified ref).
@@ -971,25 +993,66 @@ pub fn infer_runtime_dependencies(
                 .next()
                 .unwrap_or(&table_name)
                 .to_lowercase();
-            let Some(producer_id) = producers.get(&bare) else {
+            let Some(claimants) = producers.get(&bare) else {
                 continue;
             };
-            // Skip self-references and already-known edges.
-            if *producer_id == node.id {
-                continue;
-            }
-            let key = (producer_id.clone(), node.id.clone());
-            if existing.insert(key) {
-                new_edges.push(UnifiedEdge {
-                    from: producer_id.clone(),
-                    to: node.id.clone(),
-                    edge_type: EdgeType::DataDependency,
-                });
+            // EVERY claimant of the label gets the edge: which one the
+            // reader actually depends on is unknowable from the label alone,
+            // and an extra ordering constraint is the safe direction.
+            for producer_id in claimants {
+                // Skip self-references and already-known edges.
+                if *producer_id == node.id {
+                    continue;
+                }
+                let key = (producer_id.clone(), node.id.clone());
+                if existing.insert(key) {
+                    new_edges.push(UnifiedEdge {
+                        from: producer_id.clone(),
+                        to: node.id.clone(),
+                        edge_type: EdgeType::DataDependency,
+                    });
+                }
             }
         }
     }
 
     dag.edges.extend(new_edges);
+    report.unparsed.sort();
+    report
+}
+
+/// What [`infer_runtime_dependencies`] could not resolve — surfaced by the
+/// `run --dag` caller as scheduling warnings instead of silently dropping
+/// edges (#1351).
+#[derive(Debug, Default)]
+pub struct LabelInferenceReport {
+    /// Lowercased labels claimed by more than one producing node, with the
+    /// claimant count. Readers of such a label are ordered after ALL
+    /// claimants.
+    pub label_collisions: Vec<(String, usize)>,
+    /// Transformation labels whose SQL failed table-reference extraction.
+    pub unparsed: Vec<String>,
+}
+
+impl LabelInferenceReport {
+    /// Render operator-facing warnings; empty when nothing was unresolved.
+    #[must_use]
+    pub fn warnings(&self) -> Vec<String> {
+        let mut w = Vec::new();
+        for (label, n) in &self.label_collisions {
+            w.push(format!(
+                "label '{label}' is produced by {n} nodes — readers are ordered after ALL of \
+                 them; rename one if that over-constrains the schedule"
+            ));
+        }
+        for m in &self.unparsed {
+            w.push(format!(
+                "model '{m}': SQL could not be parsed for table references — label-based \
+                 ordering could not be derived for it"
+            ));
+        }
+        w
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -3072,5 +3135,62 @@ mod tests {
                 .unwrap()
         };
         assert!(pos("a") < pos("b"), "consistent with the intermediate path");
+    }
+
+    /// #1351: two producers sharing a lowercased label must BOTH order the
+    /// reader — the single-slot map silently dropped one and the reader
+    /// raced it.
+    #[test]
+    fn colliding_labels_order_the_reader_after_all_claimants() {
+        let config = config_with_pipelines(vec![("t", transform_pipeline(vec![]))]);
+        let mut reader = model("reader", vec![], vec![]);
+        reader.sql = "SELECT x FROM shared".into();
+        let by_pipeline = owned_by_sole_transformation(&config, vec![reader.clone()]);
+        let mut dag = build_unified_dag(&config, &by_pipeline, &[]).expect("build dag");
+        // Two non-transformation producers wearing the same label.
+        for (i, kind) in [(0u8, NodeKind::Seed), (1u8, NodeKind::Load)] {
+            dag.nodes.push(UnifiedNode {
+                id: NodeId(format!("p{i}:shared")),
+                kind,
+                label: "shared".into(),
+                pipeline: Some("t".into()),
+            });
+        }
+        let sql: HashMap<String, String> =
+            HashMap::from([("reader".to_string(), reader.sql.clone())]);
+        let report = infer_runtime_dependencies(&mut dag, &sql);
+        assert_eq!(report.label_collisions, vec![("shared".to_string(), 2)]);
+        let reader_id = dag
+            .nodes
+            .iter()
+            .find(|n| n.label == "reader" && n.kind == NodeKind::Transformation)
+            .unwrap()
+            .id
+            .clone();
+        let producer_edges = dag
+            .edges
+            .iter()
+            .filter(|e| e.to == reader_id && e.from.0.starts_with('p'))
+            .count();
+        assert_eq!(
+            producer_edges, 2,
+            "the reader is ordered after BOTH claimants"
+        );
+    }
+
+    /// #1351: a transformation whose SQL cannot be parsed is REPORTED, not
+    /// silently skipped.
+    #[test]
+    fn unparseable_sql_is_reported_by_label_inference() {
+        let config = config_with_pipelines(vec![("t", transform_pipeline(vec![]))]);
+        let mut broken = model("broken", vec![], vec![]);
+        broken.sql = "SELEC x FRM (".into();
+        let by_pipeline = owned_by_sole_transformation(&config, vec![broken.clone()]);
+        let mut dag = build_unified_dag(&config, &by_pipeline, &[]).expect("build dag");
+        let sql: HashMap<String, String> =
+            HashMap::from([("broken".to_string(), broken.sql.clone())]);
+        let report = infer_runtime_dependencies(&mut dag, &sql);
+        assert_eq!(report.unparsed, vec!["broken".to_string()]);
+        assert!(!report.warnings().is_empty());
     }
 }

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -951,11 +951,17 @@ pub fn infer_runtime_dependencies(
             _ => {}
         }
     }
+    let mut legacy_winner: HashMap<&str, NodeId> = HashMap::new();
     for (label, claimants) in &producers {
         if claimants.len() > 1 {
             report
                 .label_collisions
                 .push((label.clone(), claimants.len()));
+        }
+        // The single-slot map's insert order made the LAST claimant the one
+        // whose edges the old code produced.
+        if let Some(last) = claimants.last() {
+            legacy_winner.insert(label.as_str(), last.clone());
         }
     }
     report.label_collisions.sort();
@@ -966,11 +972,13 @@ pub fn infer_runtime_dependencies(
         .iter()
         .map(|e| (e.from.clone(), e.to.clone()))
         .collect();
-    // Insertion-time cycle guard, same contract as the physical pass: an
-    // inferred edge must never make `execution_phases` refuse a DAG that
-    // runs today. (The pre-guard heuristic could already refuse on mutual
-    // label reads; the all-claimant fan-out widens that exposure, so the
-    // guard lands with it.)
+    // Insertion-time cycle guard for the FAN-OUT edges only. The single-slot
+    // heuristic kept exactly one claimant per label (HashMap insert order:
+    // the LAST node won) and inserted its edges unguarded — genuinely
+    // reciprocal label reads therefore REFUSED loudly, and that status quo
+    // must not silently become a stale-read success. Only the edges this
+    // change ADDS (claimants the old code dropped) are guarded: they must
+    // never introduce a refusal the old behavior did not have.
     let mut adj: HashMap<NodeId, Vec<NodeId>> = HashMap::new();
     for e in &dag.edges {
         adj.entry(e.from.clone()).or_default().push(e.to.clone());
@@ -1033,8 +1041,11 @@ pub fn infer_runtime_dependencies(
                 if existing.contains(&key) {
                     continue;
                 }
-                // Closing iff the reader already reaches the producer.
-                if label_reaches(&adj, &node.id, producer_id) {
+                // Guard only the fan-out additions; the legacy winner's edge
+                // inserts unguarded so genuine reciprocal reads keep their
+                // loud refusal (status quo).
+                let is_legacy = legacy_winner.get(bare.as_str()) == Some(producer_id);
+                if !is_legacy && label_reaches(&adj, &node.id, producer_id) {
                     report
                         .skipped_cycle_edges
                         .push((node.label.clone(), producer_id.0.clone()));
@@ -3242,11 +3253,11 @@ mod tests {
         assert!(!report.warnings().is_empty());
     }
 
-    /// The label pass must never refuse a runnable DAG: mutual label reads
-    /// (each model reading the other's label) skip one direction with a
-    /// warning and `execution_phases` still computes.
+    /// Status quo pinned: genuinely reciprocal label reads REFUSE loudly
+    /// (as the single-slot heuristic always did) — the guard must not
+    /// downgrade a real SQL cycle into a silent stale-read success.
     #[test]
-    fn mutual_label_reads_do_not_refuse_the_dag() {
+    fn mutual_label_reads_still_refuse_loudly() {
         let config = config_with_pipelines(vec![("t", transform_pipeline(vec![]))]);
         let mut a = model("a", vec![], vec![]);
         a.sql = "SELECT x FROM b".into();
@@ -3260,7 +3271,56 @@ mod tests {
             ("b".to_string(), b.sql.clone()),
         ]);
         let report = infer_runtime_dependencies(&mut dag, &sql);
+        assert!(report.skipped_cycle_edges.is_empty(), "{report:?}");
+        assert!(
+            execution_phases(&dag).is_err(),
+            "a genuine SQL cycle keeps its loud refusal"
+        );
+    }
+
+    /// The guard applies exactly to the edges the fan-out ADDS: a non-legacy
+    /// claimant edge that would close a cycle is skipped (warned) — the old
+    /// single-slot behavior had no such edge, so no refusal may appear.
+    #[test]
+    fn a_fanout_claimant_edge_never_introduces_a_new_refusal() {
+        let config = config_with_pipelines(vec![("t", transform_pipeline(vec![]))]);
+        let mut reader = model("reader", vec![], vec![]);
+        reader.sql = "SELECT x FROM shared".into();
+        let by_pipeline = owned_by_sole_transformation(&config, vec![reader.clone()]);
+        let mut dag = build_unified_dag(&config, &by_pipeline, &[]).expect("build dag");
+        let reader_id = dag
+            .nodes
+            .iter()
+            .find(|n| n.label == "reader" && n.kind == NodeKind::Transformation)
+            .unwrap()
+            .id
+            .clone();
+        // Two claimants; the FIRST (non-legacy under last-wins) already
+        // depends on the reader through an existing edge, so its fan-out
+        // edge would close a cycle.
+        let p0 = NodeId("p0:shared".to_string());
+        let p1 = NodeId("p1:shared".to_string());
+        dag.nodes.push(UnifiedNode {
+            id: p0.clone(),
+            kind: NodeKind::Seed,
+            label: "shared".into(),
+            pipeline: Some("t".into()),
+        });
+        dag.nodes.push(UnifiedNode {
+            id: p1.clone(),
+            kind: NodeKind::Load,
+            label: "shared".into(),
+            pipeline: Some("t".into()),
+        });
+        dag.edges.push(UnifiedEdge {
+            from: reader_id.clone(),
+            to: p0.clone(),
+            edge_type: EdgeType::DataDependency,
+        });
+        let sql: HashMap<String, String> =
+            HashMap::from([("reader".to_string(), reader.sql.clone())]);
+        let report = infer_runtime_dependencies(&mut dag, &sql);
         assert_eq!(report.skipped_cycle_edges.len(), 1, "{report:?}");
-        execution_phases(&dag).expect("one direction applies; the closer skips");
+        execution_phases(&dag).expect("the fan-out edge skips; nothing refuses");
     }
 }

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -3256,6 +3256,10 @@ mod tests {
         ]);
         let report = infer_runtime_dependencies(&mut dag, &sql);
         assert!(
+            report.label_collisions.is_empty() && report.unparsed.is_empty(),
+            "nothing to report for a clean mutual pair: {report:?}"
+        );
+        assert!(
             execution_phases(&dag).is_err(),
             "a genuine SQL cycle keeps its loud refusal"
         );

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -935,9 +935,10 @@ pub fn infer_runtime_dependencies(
     let mut report = LabelInferenceReport::default();
     // Build a set of producing node names (everything that creates a table:
     // transformations, seeds, loads). Maps logical table name → the FULL set
-    // of claimants: two nodes sharing a lowercased label must both receive
-    // reader edges — a single-slot map silently dropped one of them, and the
-    // reader raced whichever producer lost the insert (#1351).
+    // of claimants — used as a COLLISION DETECTOR only: edges derive solely
+    // from the legacy winner (last in build order, identical to the old
+    // single-slot map), and colliding claimants are reported, not ordered
+    // (#1351 observability; ordering them awaits #1357).
     let mut producers: HashMap<String, Vec<(NodeId, NodeKind)>> = HashMap::new();
     for node in &dag.nodes {
         match node.kind {
@@ -972,13 +973,9 @@ pub fn infer_runtime_dependencies(
         .iter()
         .map(|e| (e.from.clone(), e.to.clone()))
         .collect();
-    // Insertion-time cycle guard for the FAN-OUT edges only. The single-slot
-    // heuristic kept exactly one claimant per label (HashMap insert order:
-    // the LAST node won) and inserted its edges unguarded — genuinely
-    // reciprocal label reads therefore REFUSED loudly, and that status quo
-    // must not silently become a stale-read success. Only the edges this
-    // change ADDS (claimants the old code dropped) are guarded: they must
-    // never introduce a refusal the old behavior did not have.
+    // The graph below is byte-for-byte the single-slot heuristic's: only the
+    // legacy winner's edges derive, unguarded, so genuine reciprocal label
+    // reads keep their loud refusal exactly as before.
     let mut new_edges = Vec::new();
 
     // Resolve every reader's candidates once, splitting legacy from fan-out.
@@ -1064,8 +1061,10 @@ pub fn infer_runtime_dependencies(
 #[derive(Debug, Default)]
 pub struct LabelInferenceReport {
     /// Lowercased labels claimed by more than one producing node, with the
-    /// claimant count. Readers of such a label are ordered after ALL
-    /// claimants.
+    /// claimant count. Readers of such a label are ordered after ONE of
+    /// them (the last in build order); the rest are NOT ordered — the
+    /// collision is surfaced so the ambiguity is visible (#1357 owns
+    /// actually ordering them).
     pub label_collisions: Vec<(String, usize)>,
     /// Transformation labels whose SQL failed table-reference extraction.
     pub unparsed: Vec<String>,

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -1080,8 +1080,8 @@ impl LabelInferenceReport {
             w.push(format!(
                 "label '{label}' is produced by {n} nodes — label inference orders readers \
                  after ONE of them (the last in build order); the others are NOT ordered. \
-                 Declare depends_on to state the real dependency, or rename the colliding \
-                 producers"
+                 Rename the colliding producers so each label is unique (depends_on cannot \
+                 order a model against a seed or load)"
             ));
         }
         for m in &self.unparsed {

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -938,7 +938,7 @@ pub fn infer_runtime_dependencies(
     // of claimants: two nodes sharing a lowercased label must both receive
     // reader edges — a single-slot map silently dropped one of them, and the
     // reader raced whichever producer lost the insert (#1351).
-    let mut producers: HashMap<String, Vec<NodeId>> = HashMap::new();
+    let mut producers: HashMap<String, Vec<(NodeId, NodeKind)>> = HashMap::new();
     for node in &dag.nodes {
         match node.kind {
             NodeKind::Transformation | NodeKind::Seed | NodeKind::Load | NodeKind::Replication => {
@@ -946,7 +946,7 @@ pub fn infer_runtime_dependencies(
                 producers
                     .entry(node.label.to_lowercase())
                     .or_default()
-                    .push(node.id.clone());
+                    .push((node.id.clone(), node.kind));
             }
             _ => {}
         }
@@ -960,7 +960,7 @@ pub fn infer_runtime_dependencies(
         }
         // The single-slot map's insert order made the LAST claimant the one
         // whose edges the old code produced.
-        if let Some(last) = claimants.last() {
+        if let Some((last, _)) = claimants.last() {
             legacy_winner.insert(label.as_str(), last.clone());
         }
     }
@@ -1041,14 +1041,21 @@ pub fn infer_runtime_dependencies(
             // EVERY claimant of the label gets the edge: which one the
             // reader actually depends on is unknowable from the label alone,
             // and an extra ordering constraint is the safe direction.
-            for producer_id in claimants {
+            for (producer_id, producer_kind) in claimants {
                 if *producer_id == node.id {
                     continue;
                 }
                 let entry = (node.id.clone(), node.label.clone(), producer_id.clone());
                 if legacy_winner.get(bare.as_str()) == Some(producer_id) {
                     legacy_candidates.push(entry);
-                } else {
+                } else if *producer_kind != NodeKind::Transformation {
+                    // Fan-out is restricted to NON-transformation claimants.
+                    // A transformation claimant's ordering belongs to the
+                    // target-aware physical pass: its edges never enter that
+                    // pass's transformation-pair existing-projection, so a
+                    // fan-out edge here could suppress an exact physical
+                    // dependency (review round-4 construction) — while
+                    // seed/load/replication edges structurally cannot.
                     fanout_candidates.push(entry);
                 }
             }
@@ -1125,8 +1132,10 @@ impl LabelInferenceReport {
         let mut w = Vec::new();
         for (label, n) in &self.label_collisions {
             w.push(format!(
-                "label '{label}' is produced by {n} nodes — readers are ordered after ALL of \
-                 them; rename one if that over-constrains the schedule"
+                "label '{label}' is produced by {n} nodes — readers are ordered after the \
+                 claimants label inference admitted (the legacy winner plus non-transformation \
+                 claimants the cycle guard allowed); rename one if that over-constrains the \
+                 schedule"
             ));
         }
         for m in &self.unparsed {
@@ -3416,5 +3425,76 @@ mod tests {
                 .any(|(r, pid)| r == "t1" && pid == "p:s"),
             "{report:?}"
         );
+    }
+
+    /// Round-4 construction pinned: when a TRANSFORMATION claimant loses
+    /// last-wins, no fan-out edge is added for it — its ordering belongs to
+    /// the physical pass, whose exact edge must survive and order the pair.
+    /// (A fan-out label edge to a transformation could suppress that exact
+    /// edge; seed/load claimants structurally cannot.)
+    #[test]
+    fn no_fanout_to_transformation_claimants_so_physical_evidence_survives() {
+        let config = config_with_pipelines(vec![("t", transform_pipeline(vec![]))]);
+        // Model "A" (upper) and a Load labeled "a": reader r bare-reads "a";
+        // A reads r's exact target. Lowercased label "a" has claimants
+        // [A(transformation), load:a] — last-wins → load is legacy, A is the
+        // would-be fan-out claimant and must be excluded.
+        let mut big_a = model("A", vec![], vec![]);
+        big_a.sql = "SELECT y FROM warehouse.silver.r_out".into();
+        let mut r = model("r", vec![], vec![]);
+        r.config.target.table = "r_out".into();
+        r.sql = "SELECT x FROM a".into();
+        let models = vec![big_a.clone(), r.clone()];
+        let by_pipeline = owned_by_sole_transformation(&config, models.clone());
+        let mut dag = build_unified_dag(&config, &by_pipeline, &[]).expect("build dag");
+        dag.nodes.push(UnifiedNode {
+            id: NodeId("load:a".to_string()),
+            kind: NodeKind::Load,
+            label: "a".into(),
+            pipeline: Some("t".into()),
+        });
+
+        // Caller order: label pass first, then physical.
+        let sql: HashMap<String, String> = HashMap::from([
+            ("A".to_string(), big_a.sql.clone()),
+            ("r".to_string(), r.sql.clone()),
+        ]);
+        let report = infer_runtime_dependencies(&mut dag, &sql);
+        // No fan-out edge to the transformation claimant A.
+        let a_id = dag
+            .nodes
+            .iter()
+            .find(|n| n.label == "A" && n.kind == NodeKind::Transformation)
+            .unwrap()
+            .id
+            .clone();
+        let r_id = dag
+            .nodes
+            .iter()
+            .find(|n| n.label == "r" && n.kind == NodeKind::Transformation)
+            .unwrap()
+            .id
+            .clone();
+        assert!(
+            !dag.edges.iter().any(|e| e.from == a_id && e.to == r_id),
+            "no label fan-out edge may target a transformation claimant: {report:?}"
+        );
+
+        let inputs: Vec<crate::physical_edges::PhysicalEdgeModel<'_>> = models
+            .iter()
+            .map(crate::physical_edges::PhysicalEdgeModel::from_model)
+            .collect();
+        let derived = infer_physical_dependencies(&mut dag, &inputs);
+        assert_eq!(derived.edges.len(), 1, "{derived:?}");
+        // The spurious bare candidate (r bare-reading a name that folds to
+        // A's table) is correctly the one skipped — specificity at work.
+        let phases = execution_phases(&dag).expect("no refusal");
+        let pos = |id: &NodeId| {
+            phases
+                .iter()
+                .position(|l| l.iter().any(|n| &n.id == id))
+                .unwrap()
+        };
+        assert!(pos(&r_id) < pos(&a_id), "the exact physical order wins");
     }
 }

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -918,10 +918,16 @@ fn format_test_label(model_name: &str, test: &crate::tests::TestDecl, index: usi
 /// Augment a DAG with edges inferred from model SQL `FROM` references.
 ///
 /// `build_unified_dag` resolves only edges from explicit `depends_on` config.
-/// This pass parses each model's SQL, extracts the tables it references, and
-/// adds [`EdgeType::DataDependency`] edges from the producing nodes (other
-/// transformations, seeds, replication loads) to the consuming model — even
-/// when no explicit `depends_on` is declared.
+/// This pass parses each model's SQL, extracts the tables it references by
+/// bare name, and adds an [`EdgeType::DataDependency`] edge from ONE
+/// producing node per referenced label — the last claimant in build order,
+/// byte-for-byte the single-slot heuristic's graph — to the consuming model.
+/// When several nodes claim one label, the OTHERS are deliberately not
+/// ordered: every scheme for ordering them was shown to be able to suppress
+/// exact physical-pass evidence until the cross-pass provenance contract
+/// exists (#1357). The collision is reported instead, alongside models
+/// whose SQL could not be parsed, via the returned
+/// [`LabelInferenceReport`].
 ///
 /// `model_sql_by_name` maps model name → compiled SQL text. The caller is
 /// responsible for compiling models first; this function does no IO.

--- a/schemas/dag_run.schema.json
+++ b/schemas/dag_run.schema.json
@@ -103,7 +103,7 @@
       "type": "string"
     },
     "warnings": {
-      "description": "Scheduling warnings from physical-read edge derivation: mutual reads serialized by a deterministic order, models whose SQL could not be parsed for reads, and colliding targets. Empty when none.",
+      "description": "Scheduling warnings from dependency inference — physical-read derivation (mutual reads serialized deterministically, unparseable models, colliding targets) and label inference (label collisions where only one claimant orders the reader, unparseable models). Empty when none.",
       "items": {
         "type": "string"
       },

--- a/sdk/python/src/rocky_sdk/types_generated/dag_run_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/dag_run_schema.py
@@ -78,5 +78,5 @@ class DagRunOutput(BaseModel):
     version: str
     warnings: list[str] | None = None
     """
-    Scheduling warnings from physical-read edge derivation: mutual reads serialized by a deterministic order, models whose SQL could not be parsed for reads, and colliding targets. Empty when none.
+    Scheduling warnings from dependency inference — physical-read derivation (mutual reads serialized deterministically, unparseable models, colliding targets) and label inference (label collisions where only one claimant orders the reader, unparseable models). Empty when none.
     """


### PR DESCRIPTION
Fixes the observable halves of #1351 in `run --dag`'s label-based dependency inference — **and deliberately nothing else**. Five review rounds established that ANY label edge added beyond main's single-slot graph (all-claimant fan-out, non-transformation-only fan-out, either pass order) can suppress an exact physical dependency through the shared cycle guards, because the cross-pass provenance contract does not exist yet. That contract is design issue **#1357**; the ordering improvements move there wholesale.

What ships:

- **The dependency graph is byte-for-byte main's.** The legacy winner's edge (last claimant in build order — identical to the single-slot `HashMap` insert) derives exactly as before; genuine reciprocal label reads keep their loud `execution_phases` refusal. Zero new edges, zero removed edges.
- **Label collisions become visible.** The producer index is a multi-map used as a collision detector: two-plus nodes sharing a lowercased label are reported, with the honest statement that only ONE of them orders the reader and the rest are NOT ordered — declare `depends_on` or rename.
- **Parse failures become visible.** A transformation whose SQL fails table-reference extraction previously contributed no edges with no signal; it now lands in the inference report.
- `infer_runtime_dependencies` returns a `LabelInferenceReport`; the caller merges its warnings into `DagRunOutput.warnings` alongside the physical-derivation warnings.

Evidence: collision-observability, clean-mutual-refusal (status quo pinned), and surfaced-parse-failure tests; the single-slot silent-drop and silent-continue regressions were mutation-checked red in earlier rounds and the final shape keeps those pins. Full workspace gates green; clippy `-D warnings` clean; fmt clean.

Review record: rounds 1–5 (BLOCK×4 on successive ordering schemes, each with a concrete reversal construction) are on this PR with dispositions — they are the design record for #1357. Related: #1352 (merged physical pass), #1354 (compiler bare-`ModelRef`), #1355 (opt-in strict scheduling), #1281 (live case-sensitivity).