### PR TITLE
fix(engine): preview selects the base run from the ref the caller named

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -12732,7 +12732,7 @@
         "description": "JSON output for `rocky preview diff`.\n\nCombines the structural diff (column added/removed/type-changed) from the existing `rocky_core::ci_diff` machinery with a row-level diff produced by either the sampled or the checksum-bisection algorithm. Each per-model entry's `algorithm` field carries a `kind` discriminator (`\"sampled\"` or `\"bisection\"`) plus the matching payload.\n\n**Sampled correctness ceiling.** The sampled algorithm reads `LIMIT N` rows ordered by primary key (or first column). Changes outside that window appear as no-change unless the row count itself differs; `sampling_window.coverage_warning = true` flags that risk. **Bisection** walks the chunk lattice exhaustively over a single-column primary key; `bisection_stats.depth_capped = true` flags the rare case where the recursion bottomed out at the depth cap before reaching leaf size. `summary.any_coverage_warning` rolls both signals up.",
         "properties": {
           "base_note": {
-            "description": "Present when no run was recorded on `base_ref` and the diff fell back to the newest run on another named branch — names the stand-in so the diff never silently wears the base's name (#1345).",
+            "description": "Present when no run was recorded on `base_ref`: the diff is NOT computed against any stand-in (an empty summary is returned) and this note explains the absence and the remedy (#1345).",
             "type": [
               "string",
               "null"

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -12731,6 +12731,13 @@
       "PreviewDiffOutput": {
         "description": "JSON output for `rocky preview diff`.\n\nCombines the structural diff (column added/removed/type-changed) from the existing `rocky_core::ci_diff` machinery with a row-level diff produced by either the sampled or the checksum-bisection algorithm. Each per-model entry's `algorithm` field carries a `kind` discriminator (`\"sampled\"` or `\"bisection\"`) plus the matching payload.\n\n**Sampled correctness ceiling.** The sampled algorithm reads `LIMIT N` rows ordered by primary key (or first column). Changes outside that window appear as no-change unless the row count itself differs; `sampling_window.coverage_warning = true` flags that risk. **Bisection** walks the chunk lattice exhaustively over a single-column primary key; `bisection_stats.depth_capped = true` flags the rare case where the recursion bottomed out at the depth cap before reaching leaf size. `summary.any_coverage_warning` rolls both signals up.",
         "properties": {
+          "base_note": {
+            "description": "Present when no run was recorded on `base_ref` and the diff fell back to the newest run on another named branch — names the stand-in so the diff never silently wears the base's name (#1345).",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "base_ref": {
             "type": "string"
           },

--- a/editors/vscode/src/commands/preview.ts
+++ b/editors/vscode/src/commands/preview.ts
@@ -83,7 +83,11 @@ export async function previewDiff(): Promise<void> {
     const summary = result.summary;
     const message = `Rocky preview diff: ${summary?.models_with_changes ?? 0} changed, ${summary?.models_unchanged ?? 0} unchanged, +${summary?.total_rows_added ?? 0}/-${summary?.total_rows_removed ?? 0}/~${summary?.total_rows_changed ?? 0} rows`;
 
-    if (summary?.any_coverage_warning) {
+    if (result.base_note) {
+      // A refused comparison (no run recorded for the named base) must not
+      // read as a clean zero diff (#1345).
+      vscode.window.showWarningMessage(`Rocky preview diff: ${result.base_note}`);
+    } else if (summary?.any_coverage_warning) {
       vscode.window.showWarningMessage(`${message} (coverage warning)`);
     } else {
       vscode.window.showInformationMessage(message);

--- a/editors/vscode/src/types/generated/preview_diff.ts
+++ b/editors/vscode/src/types/generated/preview_diff.ts
@@ -31,7 +31,7 @@ export type PreviewModelDiffAlgorithm =
  */
 export interface PreviewDiffOutput {
   /**
-   * Present when no run was recorded on `base_ref` and the diff fell back to the newest run on another named branch — names the stand-in so the diff never silently wears the base's name (#1345).
+   * Present when no run was recorded on `base_ref`: the diff is NOT computed against any stand-in (an empty summary is returned) and this note explains the absence and the remedy (#1345).
    */
   base_note?: string | null;
   base_ref: string;

--- a/editors/vscode/src/types/generated/preview_diff.ts
+++ b/editors/vscode/src/types/generated/preview_diff.ts
@@ -30,6 +30,10 @@ export type PreviewModelDiffAlgorithm =
  * **Sampled correctness ceiling.** The sampled algorithm reads `LIMIT N` rows ordered by primary key (or first column). Changes outside that window appear as no-change unless the row count itself differs; `sampling_window.coverage_warning = true` flags that risk. **Bisection** walks the chunk lattice exhaustively over a single-column primary key; `bisection_stats.depth_capped = true` flags the rare case where the recursion bottomed out at the depth cap before reaching leaf size. `summary.any_coverage_warning` rolls both signals up.
  */
 export interface PreviewDiffOutput {
+  /**
+   * Present when no run was recorded on `base_ref` and the diff fell back to the newest run on another named branch — names the stand-in so the diff never silently wears the base's name (#1345).
+   */
+  base_note?: string | null;
   base_ref: string;
   branch_name: string;
   command: string;

--- a/engine/crates/rocky-cli/src/commands/preview.rs
+++ b/engine/crates/rocky-cli/src/commands/preview.rs
@@ -292,29 +292,30 @@ fn newest_branch_and_base_runs(
         if let Some(run) = named_base {
             return Ok((branch_run, Some(run), None));
         }
+        // No recorded run on the named base: the diff that was asked for
+        // cannot be computed, and a diff against ANY stand-in — however
+        // clearly labeled — is a different diff that a CI comment would
+        // publish under the base's name. Report the absence instead.
+        return Ok((
+            branch_run,
+            None,
+            Some(format!(
+                "no run recorded on '{base_ref}' in this state store — the diff against it \
+                 cannot be computed. Run the base branch against this store, or pass a \
+                 --base that has run history here"
+            )),
+        ));
     }
-    // No recorded run on the named ref — either it is a sha/tag (run records
-    // store branch names) or the base branch has never run here. Fall back
-    // to the newest run on any OTHER named branch, and SAY SO: a diff
-    // against an unnamed stand-in must never wear the base's name silently.
-    // Detached/no-branch runs are not eligible — "not a branch, and
-    // certainly not the base".
+    // Unnamed selection (the cost preview): newest run on any OTHER named
+    // branch. Detached/no-branch runs are not eligible — "not a branch, and
+    // certainly not a base".
     let fallback = store
         .list_runs_matching(1, |r| {
             r.git_branch.is_some() && r.git_branch.as_deref() != Some(branch_name)
         })?
         .into_iter()
         .next();
-    let note = match (base_ref, fallback.as_ref()) {
-        (Some(base_ref), Some(r)) => Some(format!(
-            "no recorded run on '{base_ref}'; compared against the newest run on '{}' \
-             ({}) instead",
-            r.git_branch.as_deref().unwrap_or("<unknown>"),
-            r.run_id
-        )),
-        _ => None,
-    };
-    Ok((branch_run, fallback, note))
+    Ok((branch_run, fallback, None))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -876,11 +877,16 @@ fn render_preview_diff_markdown(
     use crate::output::PreviewModelDiffAlgorithm;
 
     if models.is_empty() {
-        return format!(
-            "**Preview diff** — branch `{branch_name}` vs `{base_ref}`\n\n\
-             _No paired runs in the state store. Run `rocky run --branch {branch_name}` \
-             on the prune set, then re-invoke `rocky preview diff`._\n"
+        let why = base_note.map_or_else(
+            || {
+                format!(
+                    "No paired runs in the state store. Run `rocky run --branch \
+                     {branch_name}` on the prune set, then re-invoke `rocky preview diff`."
+                )
+            },
+            str::to_string,
         );
+        return format!("**Preview diff** — branch `{branch_name}` vs `{base_ref}`\n\n_{why}_\n");
     }
 
     let any_bisection = models
@@ -2120,10 +2126,11 @@ mod tests {
         assert!(note.is_none());
     }
 
-    /// A base with no recorded run falls back to the newest OTHER NAMED
-    /// branch — never a detached run — and says so in the note.
+    /// A base with no recorded run REFUSES the comparison — a labeled
+    /// stand-in is still a different diff that a CI comment would publish
+    /// under the base's name — and the note says what to do.
     #[test]
-    fn a_missing_base_falls_back_to_a_named_branch_with_a_note() {
+    fn a_missing_base_reports_absence_instead_of_a_stand_in() {
         let dir = tempfile::tempdir().unwrap();
         let state_path = dir.path().join("state.redb");
         let base = chrono::Utc::now();
@@ -2142,14 +2149,23 @@ mod tests {
         let store = rocky_core::state::StateStore::open_read_only(&state_path).unwrap();
         let (_b, base_run, note) =
             newest_branch_and_base_runs(&store, "feature", Some("main")).unwrap();
-        assert_eq!(
-            base_run.unwrap().run_id,
-            "other-1",
-            "fallback skips the newer detached run"
+        assert!(
+            base_run.is_none(),
+            "no stand-in comparison for a named base"
         );
-        let note = note.expect("the stand-in must be named");
-        assert!(note.contains("no recorded run on 'main'"), "{note}");
-        assert!(note.contains("develop"), "{note}");
+        let note = note.expect("the absence must be explained");
+        assert!(note.contains("no run recorded on 'main'"), "{note}");
+
+        // The UNNAMED selection (cost preview) still picks the newest other
+        // NAMED branch and never a detached run.
+        let (_b2, cost_base, cost_note) =
+            newest_branch_and_base_runs(&store, "feature", None).unwrap();
+        assert_eq!(
+            cost_base.unwrap().run_id,
+            "other-1",
+            "unnamed selection skips the newer detached run"
+        );
+        assert!(cost_note.is_none());
     }
 
     /// A populated preview output renders the counts and the run id.

--- a/engine/crates/rocky-cli/src/commands/preview.rs
+++ b/engine/crates/rocky-cli/src/commands/preview.rs
@@ -285,10 +285,20 @@ fn newest_branch_and_base_runs(
     // while the output labeled the result as `base_ref`. The cost preview
     // has no named base and goes straight to the fallback.
     if let Some(base_ref) = base_ref {
-        let named_base = store
-            .list_runs_matching(1, |r| r.git_branch.as_deref() == Some(base_ref))?
-            .into_iter()
-            .next();
+        // A base can be named as a branch OR a commit (Rocky's own preview
+        // workflow passes `github.event.pull_request.base.sha`). Records
+        // store both: match the branch name exactly, or the recorded commit
+        // exactly / by unambiguous hex prefix (git's own convention, ≥7).
+        let matches_ref = |r: &rocky_core::state::RunRecord| {
+            r.git_branch.as_deref() == Some(base_ref)
+                || r.git_commit.as_deref().is_some_and(|c| {
+                    c == base_ref
+                        || (base_ref.len() >= 7
+                            && base_ref.chars().all(|ch| ch.is_ascii_hexdigit())
+                            && c.starts_with(base_ref))
+                })
+        };
+        let named_base = store.list_runs_matching(1, matches_ref)?.into_iter().next();
         if let Some(run) = named_base {
             return Ok((branch_run, Some(run), None));
         }
@@ -300,19 +310,20 @@ fn newest_branch_and_base_runs(
             branch_run,
             None,
             Some(format!(
-                "no run recorded on '{base_ref}' in this state store — the diff against it \
-                 cannot be computed. Run the base branch against this store, or pass a \
-                 --base that has run history here"
+                "no run recorded for '{base_ref}' in this state store (matched against \
+                 recorded branch names and commit shas) — the diff against it cannot be \
+                 computed. Run the base against this store first, or pass a --base whose \
+                 branch or commit has run history here"
             )),
         ));
     }
-    // Unnamed selection (the cost preview): newest run on any OTHER named
-    // branch. Detached/no-branch runs are not eligible — "not a branch, and
-    // certainly not a base".
+    // Unnamed selection (the cost preview): newest run not on this branch —
+    // byte-for-byte main's behavior, detached runs included. Cost baselines
+    // from detached CI runs are deliberate (`run_audit` records
+    // `git_branch: None` there), and excluding them yielded an empty cost
+    // report mislabeled "No branch run yet".
     let fallback = store
-        .list_runs_matching(1, |r| {
-            r.git_branch.is_some() && r.git_branch.as_deref() != Some(branch_name)
-        })?
+        .list_runs_matching(1, |r| r.git_branch.as_deref() != Some(branch_name))?
         .into_iter()
         .next();
     Ok((branch_run, fallback, None))
@@ -337,6 +348,13 @@ pub async fn run_preview_diff(
     // Tighter branch-vs-main partitioning lands when `git_branch` is plumbed
     // through the state-store branch record (today the audit trail records
     // `git_branch` on the RunRecord directly).
+    // `--name X --base X` would select the same run for both sides and
+    // subtract every execution from itself — a false-clean diff.
+    anyhow::ensure!(
+        branch_name != base_ref,
+        "--name and --base are both '{branch_name}': a branch cannot be diffed against \
+         itself; name the base branch (or its commit) the comparison should run against"
+    );
     let (branch_run, base_run, base_note) =
         newest_branch_and_base_runs(&store, branch_name, Some(base_ref))?;
 
@@ -352,7 +370,11 @@ pub async fn run_preview_diff(
     // placeholder. This must happen before markdown rendering and JSON
     // serialization so both surface the chosen algorithm.
     if matches!(algorithm, PreviewDiffAlgorithmSelector::Bisection) {
-        if let Some(branch_run) = branch_run.as_ref() {
+        // Gate on BOTH runs: a refused/missing base means there is nothing
+        // to bisect against, and the kernel setup below opens adapters and
+        // queries the warehouse — a refusal must stay a zero-exit no-op,
+        // not become an adapter error.
+        if let (Some(branch_run), Some(_base)) = (branch_run.as_ref(), base_run.as_ref()) {
             apply_bisection_to_models(
                 config_path,
                 models_dir,
@@ -877,16 +899,18 @@ fn render_preview_diff_markdown(
     use crate::output::PreviewModelDiffAlgorithm;
 
     if models.is_empty() {
-        let why = base_note.map_or_else(
-            || {
-                format!(
-                    "No paired runs in the state store. Run `rocky run --branch \
-                     {branch_name}` on the prune set, then re-invoke `rocky preview diff`."
-                )
-            },
-            str::to_string,
-        );
-        return format!("**Preview diff** — branch `{branch_name}` vs `{base_ref}`\n\n_{why}_\n");
+        return match base_note {
+            // A refusal renders as the promised warning callout, so a CI
+            // comment posting this markdown shows the absence prominently.
+            Some(note) => format!(
+                "**Preview diff** — branch `{branch_name}` vs `{base_ref}`\n\n> ⚠️ {note}\n"
+            ),
+            None => format!(
+                "**Preview diff** — branch `{branch_name}` vs `{base_ref}`\n\n\
+                 _No paired runs in the state store. Run `rocky run --branch {branch_name}` \
+                 on the prune set, then re-invoke `rocky preview diff`._\n"
+            ),
+        };
     }
 
     let any_bisection = models
@@ -2154,18 +2178,77 @@ mod tests {
             "no stand-in comparison for a named base"
         );
         let note = note.expect("the absence must be explained");
-        assert!(note.contains("no run recorded on 'main'"), "{note}");
+        assert!(note.contains("no run recorded for 'main'"), "{note}");
 
-        // The UNNAMED selection (cost preview) still picks the newest other
-        // NAMED branch and never a detached run.
+        // The UNNAMED selection (cost preview) is byte-for-byte main's:
+        // newest run not on this branch, detached INCLUDED (detached CI cost
+        // baselines are deliberate).
         let (_b2, cost_base, cost_note) =
             newest_branch_and_base_runs(&store, "feature", None).unwrap();
         assert_eq!(
             cost_base.unwrap().run_id,
-            "other-1",
-            "unnamed selection skips the newer detached run"
+            "detached-1",
+            "cost keeps main's semantics, detached eligible"
         );
         assert!(cost_note.is_none());
+    }
+
+    /// `--name X --base X` refuses up front — the same run diffed against
+    /// itself reports every model unchanged, a false clean.
+    #[tokio::test]
+    async fn a_branch_diffed_against_itself_refuses() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.redb");
+        drop(rocky_core::state::StateStore::open(&state_path).unwrap());
+        let err = run_preview_diff(
+            std::path::Path::new("rocky.toml"),
+            &state_path,
+            std::path::Path::new("models"),
+            "main",
+            "main",
+            0,
+            PreviewDiffAlgorithmSelector::Sampled,
+            true,
+        )
+        .await
+        .expect_err("self-comparison must refuse");
+        assert!(
+            format!("{err:#}").contains("cannot be diffed against itself"),
+            "{err:#}"
+        );
+    }
+
+    /// The production preview workflow passes the base COMMIT SHA — records
+    /// store it in `git_commit`, and the primary match must find it (exact
+    /// or git-style hex prefix ≥7).
+    #[test]
+    fn a_sha_base_matches_the_recorded_commit() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.redb");
+        let base = chrono::Utc::now();
+        {
+            let store = rocky_core::state::StateStore::open(&state_path).unwrap();
+            let mut main_run = sample_run("m1", base);
+            main_run.git_branch = Some("main".to_string());
+            main_run.git_commit = Some("0123abcd0123abcd0123abcd0123abcd0123abcd".to_string());
+            store.record_run(&main_run).unwrap();
+            let mut feat = sample_run("f1", base + chrono::Duration::minutes(1));
+            feat.git_branch = Some("feature".to_string());
+            store.record_run(&feat).unwrap();
+        }
+        let store = rocky_core::state::StateStore::open_read_only(&state_path).unwrap();
+        let (_b, by_full, note_full) = newest_branch_and_base_runs(
+            &store,
+            "feature",
+            Some("0123abcd0123abcd0123abcd0123abcd0123abcd"),
+        )
+        .unwrap();
+        assert_eq!(by_full.unwrap().run_id, "m1");
+        assert!(note_full.is_none());
+        let (_b, by_prefix, note_prefix) =
+            newest_branch_and_base_runs(&store, "feature", Some("0123abcd")).unwrap();
+        assert_eq!(by_prefix.unwrap().run_id, "m1", "hex prefix ≥7 matches");
+        assert!(note_prefix.is_none());
     }
 
     /// A populated preview output renders the counts and the run id.

--- a/engine/crates/rocky-cli/src/commands/preview.rs
+++ b/engine/crates/rocky-cli/src/commands/preview.rs
@@ -269,19 +269,52 @@ pub enum PreviewDiffAlgorithmSelector {
 fn newest_branch_and_base_runs(
     store: &rocky_core::state::StateStore,
     branch_name: &str,
+    base_ref: Option<&str>,
 ) -> Result<(
     Option<rocky_core::state::RunRecord>,
     Option<rocky_core::state::RunRecord>,
+    Option<String>,
 )> {
     let branch_run = store
         .list_runs_matching(1, |r| r.git_branch.as_deref() == Some(branch_name))?
         .into_iter()
         .next();
-    let base_run = store
-        .list_runs_matching(1, |r| r.git_branch.as_deref() != Some(branch_name))?
+    // Select the base run from the ref the caller NAMED (#1345) — the old
+    // "newest run that isn't this branch" happily paired against an
+    // unrelated third branch, or a detached-HEAD run with no branch at all,
+    // while the output labeled the result as `base_ref`. The cost preview
+    // has no named base and goes straight to the fallback.
+    if let Some(base_ref) = base_ref {
+        let named_base = store
+            .list_runs_matching(1, |r| r.git_branch.as_deref() == Some(base_ref))?
+            .into_iter()
+            .next();
+        if let Some(run) = named_base {
+            return Ok((branch_run, Some(run), None));
+        }
+    }
+    // No recorded run on the named ref — either it is a sha/tag (run records
+    // store branch names) or the base branch has never run here. Fall back
+    // to the newest run on any OTHER named branch, and SAY SO: a diff
+    // against an unnamed stand-in must never wear the base's name silently.
+    // Detached/no-branch runs are not eligible — "not a branch, and
+    // certainly not the base".
+    let fallback = store
+        .list_runs_matching(1, |r| {
+            r.git_branch.is_some() && r.git_branch.as_deref() != Some(branch_name)
+        })?
         .into_iter()
         .next();
-    Ok((branch_run, base_run))
+    let note = match (base_ref, fallback.as_ref()) {
+        (Some(base_ref), Some(r)) => Some(format!(
+            "no recorded run on '{base_ref}'; compared against the newest run on '{}' \
+             ({}) instead",
+            r.git_branch.as_deref().unwrap_or("<unknown>"),
+            r.run_id
+        )),
+        _ => None,
+    };
+    Ok((branch_run, fallback, note))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -303,7 +336,8 @@ pub async fn run_preview_diff(
     // Tighter branch-vs-main partitioning lands when `git_branch` is plumbed
     // through the state-store branch record (today the audit trail records
     // `git_branch` on the RunRecord directly).
-    let (branch_run, base_run) = newest_branch_and_base_runs(&store, branch_name)?;
+    let (branch_run, base_run, base_note) =
+        newest_branch_and_base_runs(&store, branch_name, Some(base_ref))?;
 
     let (mut summary, mut models) = match (branch_run.as_ref(), base_run.as_ref()) {
         (Some(b), Some(p)) => build_preview_diff(b, p),
@@ -338,11 +372,18 @@ pub async fn run_preview_diff(
         }
     }
 
-    let markdown = render_preview_diff_markdown(branch_name, base_ref, &summary, &models);
+    let markdown = render_preview_diff_markdown(
+        branch_name,
+        base_ref,
+        base_note.as_deref(),
+        &summary,
+        &models,
+    );
 
     let out = PreviewDiffOutput::new(
         branch_name.to_string(),
         base_ref.to_string(),
+        base_note,
         summary,
         models,
         markdown,
@@ -828,6 +869,7 @@ fn build_preview_diff(
 fn render_preview_diff_markdown(
     branch_name: &str,
     base_ref: &str,
+    base_note: Option<&str>,
     summary: &crate::output::PreviewDiffSummary,
     models: &[crate::output::PreviewModelDiff],
 ) -> String {
@@ -854,6 +896,9 @@ fn render_preview_diff_markdown(
         summary.total_rows_added,
         summary.total_rows_removed,
     ));
+    if let Some(note) = base_note {
+        out.push_str(&format!("> ⚠️ {note}\n\n"));
+    }
 
     if any_bisection {
         // Wider table — bisection rows have ~rows + chunks_examined +
@@ -976,7 +1021,8 @@ pub async fn run_preview_cost(
     let store = rocky_core::state::StateStore::open_read_only(state_path)
         .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
 
-    let (branch_run, base_run) = newest_branch_and_base_runs(&store, branch_name)?;
+    let (branch_run, base_run, _base_note) =
+        newest_branch_and_base_runs(&store, branch_name, None)?;
 
     // Resolve adapter cost params + project-level budget best-effort.
     // A missing or malformed config silently skips both projections —
@@ -2008,18 +2054,19 @@ mod tests {
         }
 
         let store = rocky_core::state::StateStore::open_read_only(&state_path).unwrap();
-        let (branch_run, base_run) =
-            newest_branch_and_base_runs(&store, "feature_x").expect("selection must succeed");
+        let (branch_run, base_run, note) =
+            newest_branch_and_base_runs(&store, "feature_x", Some("main"))
+                .expect("selection must succeed");
 
         let branch_run = branch_run.expect("the branch's run is found regardless of its rank");
         assert_eq!(branch_run.run_id, "run-00000");
-        // And the base side is still the newest non-branch run, so ordering
-        // within each half is unchanged.
+        // The named base's newest run, with no fallback note.
         assert_eq!(
             base_run.expect("a base run exists").run_id,
             "run-00080",
-            "base is the NEWEST run not on the branch"
+            "base is the NEWEST run on the NAMED base"
         );
+        assert!(note.is_none());
     }
 
     /// A branch with no runs at all reports none — so the test above is
@@ -2035,9 +2082,74 @@ mod tests {
             store.record_run(&r).unwrap();
         }
         let store = rocky_core::state::StateStore::open_read_only(&state_path).unwrap();
-        let (branch_run, base_run) = newest_branch_and_base_runs(&store, "never_used").unwrap();
+        let (branch_run, base_run, _note) =
+            newest_branch_and_base_runs(&store, "never_used", Some("main")).unwrap();
         assert!(branch_run.is_none());
         assert!(base_run.is_some(), "the main run is still a valid base");
+    }
+
+    /// #1345's exact repro: newest-last `t1` on main, `t2` detached, `t3` on
+    /// feature. `--base main` must pair `t3` with `t1` — not the newer
+    /// detached run — and carry no fallback note.
+    #[test]
+    fn the_named_base_beats_newer_unrelated_and_detached_runs() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.redb");
+        let base = chrono::Utc::now();
+        {
+            let store = rocky_core::state::StateStore::open(&state_path).unwrap();
+            let mut t1 = sample_run("t1", base);
+            t1.git_branch = Some("main".to_string());
+            store.record_run(&t1).unwrap();
+            let mut t2 = sample_run("t2", base + chrono::Duration::minutes(1));
+            t2.git_branch = None; // detached HEAD
+            store.record_run(&t2).unwrap();
+            let mut t3 = sample_run("t3", base + chrono::Duration::minutes(2));
+            t3.git_branch = Some("feature".to_string());
+            store.record_run(&t3).unwrap();
+        }
+        let store = rocky_core::state::StateStore::open_read_only(&state_path).unwrap();
+        let (branch_run, base_run, note) =
+            newest_branch_and_base_runs(&store, "feature", Some("main")).unwrap();
+        assert_eq!(branch_run.unwrap().run_id, "t3");
+        assert_eq!(
+            base_run.unwrap().run_id,
+            "t1",
+            "the NAMED base, not the newer detached run"
+        );
+        assert!(note.is_none());
+    }
+
+    /// A base with no recorded run falls back to the newest OTHER NAMED
+    /// branch — never a detached run — and says so in the note.
+    #[test]
+    fn a_missing_base_falls_back_to_a_named_branch_with_a_note() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.redb");
+        let base = chrono::Utc::now();
+        {
+            let store = rocky_core::state::StateStore::open(&state_path).unwrap();
+            let mut other = sample_run("other-1", base);
+            other.git_branch = Some("develop".to_string());
+            store.record_run(&other).unwrap();
+            let mut detached = sample_run("detached-1", base + chrono::Duration::minutes(1));
+            detached.git_branch = None;
+            store.record_run(&detached).unwrap();
+            let mut feat = sample_run("feat-1", base + chrono::Duration::minutes(2));
+            feat.git_branch = Some("feature".to_string());
+            store.record_run(&feat).unwrap();
+        }
+        let store = rocky_core::state::StateStore::open_read_only(&state_path).unwrap();
+        let (_b, base_run, note) =
+            newest_branch_and_base_runs(&store, "feature", Some("main")).unwrap();
+        assert_eq!(
+            base_run.unwrap().run_id,
+            "other-1",
+            "fallback skips the newer detached run"
+        );
+        let note = note.expect("the stand-in must be named");
+        assert!(note.contains("no recorded run on 'main'"), "{note}");
+        assert!(note.contains("develop"), "{note}");
     }
 
     /// A populated preview output renders the counts and the run id.
@@ -2596,7 +2708,7 @@ mod tests {
             None,
         );
         let (summary, models) = build_preview_diff(&branch, &base);
-        let md = render_preview_diff_markdown("feature_x", "main", &summary, &models);
+        let md = render_preview_diff_markdown("feature_x", "main", None, &summary, &models);
         assert!(md.contains("**Preview diff**"));
         assert!(md.contains("`feature_x`"));
         assert!(md.contains("vs `main`"));
@@ -2613,7 +2725,7 @@ mod tests {
     #[test]
     fn diff_markdown_empty_path_explains_setup() {
         let summary = empty_diff_summary();
-        let md = render_preview_diff_markdown("feature_x", "main", &summary, &[]);
+        let md = render_preview_diff_markdown("feature_x", "main", None, &summary, &[]);
         assert!(md.contains("No paired runs"));
         assert!(md.contains("rocky run --branch feature_x"));
     }

--- a/engine/crates/rocky-cli/src/commands/preview.rs
+++ b/engine/crates/rocky-cli/src/commands/preview.rs
@@ -313,11 +313,12 @@ fn newest_branch_and_base_runs(
     if let Some(base_ref) = base_ref {
         // A base can be named as a branch OR a commit (Rocky's own preview
         // workflow passes `github.event.pull_request.base.sha`). Identity
-        // precedence is staged — a BRANCH-NAME match always wins over a
-        // commit match (a branch literally named like a hex string must not
-        // lose to a newer commit-prefix match), then an exact commit, then a
-        // git-style hex prefix (≥7) with AMBIGUITY REFUSED rather than
-        // silently resolved to the newest.
+        // precedence is staged: a FULL 40-hex ref states commit intent and
+        // resolves (or refuses) as a commit first; for shorter refs a
+        // BRANCH-NAME match wins over a commit match (a branch named like a
+        // hex string must not lose to a prefix coincidence), then an exact
+        // commit, then a git-style hex prefix (≥7) with AMBIGUITY REFUSED
+        // rather than silently resolved to the newest.
         let base_lower = base_ref.to_ascii_lowercase();
         let is_full_sha =
             base_lower.len() == 40 && base_lower.chars().all(|ch| ch.is_ascii_hexdigit());
@@ -370,33 +371,45 @@ fn newest_branch_and_base_runs(
             return finish_named(branch_run, run, base_ref);
         }
         if base_lower.len() >= 7 && base_lower.chars().all(|ch| ch.is_ascii_hexdigit()) {
-            let by_prefix = store.list_runs_matching(usize::MAX, |r| {
-                r.git_commit
+            // Prove prefix uniqueness WITHOUT materializing history: probe
+            // the newest match, then probe for any SECOND DISTINCT sha under
+            // the same prefix. Two limit-1 scans — exhaustive over the whole
+            // table (the store iterates it regardless) with O(1) kept rows,
+            // so unbounded run retention cannot balloon this path.
+            let first = store
+                .list_runs_matching(1, |r| {
+                    r.git_commit
+                        .as_deref()
+                        .is_some_and(|c| c.to_ascii_lowercase().starts_with(&base_lower))
+                })?
+                .into_iter()
+                .next();
+            if let Some(run) = first {
+                let first_sha = run
+                    .git_commit
                     .as_deref()
-                    .is_some_and(|c| c.to_ascii_lowercase().starts_with(&base_lower))
-            })?;
-            let mut distinct: Vec<&str> = by_prefix
-                .iter()
-                .filter_map(|r| r.git_commit.as_deref())
-                .collect();
-            distinct.sort_unstable_by_key(|c| c.to_ascii_lowercase());
-            distinct.dedup_by(|a, b| a.eq_ignore_ascii_case(b));
-            match distinct.len() {
-                0 => {}
-                1 => {
-                    let run = by_prefix.into_iter().next().expect("nonempty");
-                    return finish_named(branch_run, run, base_ref);
-                }
-                n => {
+                    .expect("matched on git_commit")
+                    .to_ascii_lowercase();
+                let second_distinct = store
+                    .list_runs_matching(1, |r| {
+                        r.git_commit.as_deref().is_some_and(|c| {
+                            let lower = c.to_ascii_lowercase();
+                            lower.starts_with(&base_lower) && lower != first_sha
+                        })
+                    })?
+                    .into_iter()
+                    .next();
+                if second_distinct.is_some() {
                     return Ok((
                         branch_run,
                         None,
                         Some(format!(
-                            "the base prefix '{base_ref}' matches {n} distinct recorded \
-                             commits — give more characters to disambiguate"
+                            "the base prefix '{base_ref}' matches more than one distinct \
+                             recorded commit — give more characters to disambiguate"
                         )),
                     ));
                 }
+                return finish_named(branch_run, run, base_ref);
             }
         }
         // No recorded run on the named base: the diff that was asked for
@@ -2417,7 +2430,7 @@ mod tests {
             base_run.is_none(),
             "the concealed distinct commit must refuse"
         );
-        assert!(note.unwrap().contains("distinct recorded commits"));
+        assert!(note.unwrap().contains("more than one distinct"));
     }
 
     /// Exact commit matching is case-insensitive (git accepts uppercase sha
@@ -2506,7 +2519,7 @@ mod tests {
             newest_branch_and_base_runs(&store, "feature", Some("abc1234")).unwrap();
         assert!(base_run.is_none());
         assert!(
-            note.unwrap().contains("2 distinct recorded commits"),
+            note.unwrap().contains("more than one distinct"),
             "ambiguity must be refused, not resolved silently"
         );
     }

--- a/engine/crates/rocky-cli/src/commands/preview.rs
+++ b/engine/crates/rocky-cli/src/commands/preview.rs
@@ -266,6 +266,32 @@ pub enum PreviewDiffAlgorithmSelector {
 /// Ordering by time is still what makes each half meaningful: within the runs
 /// that match, `list_runs_matching` returns the newest. Only the *cap* had to
 /// stop being shared between two questions it could not both answer.
+/// Finalize a NAMED base selection: refuse when the base resolves to the
+/// branch's own run (a sha alias of `--name` passes the string-inequality
+/// guard but would diff a run against itself and report a false clean).
+fn finish_named(
+    branch_run: Option<rocky_core::state::RunRecord>,
+    base: rocky_core::state::RunRecord,
+    base_ref: &str,
+) -> Result<(
+    Option<rocky_core::state::RunRecord>,
+    Option<rocky_core::state::RunRecord>,
+    Option<String>,
+)> {
+    if branch_run.as_ref().is_some_and(|b| b.run_id == base.run_id) {
+        return Ok((
+            branch_run,
+            None,
+            Some(format!(
+                "the named base '{base_ref}' resolves to the branch's own newest run — a \
+                 branch cannot be diffed against itself; name the base the comparison \
+                 should run against"
+            )),
+        ));
+    }
+    Ok((branch_run, Some(base), None))
+}
+
 fn newest_branch_and_base_runs(
     store: &rocky_core::state::StateStore,
     branch_name: &str,
@@ -286,21 +312,60 @@ fn newest_branch_and_base_runs(
     // has no named base and goes straight to the fallback.
     if let Some(base_ref) = base_ref {
         // A base can be named as a branch OR a commit (Rocky's own preview
-        // workflow passes `github.event.pull_request.base.sha`). Records
-        // store both: match the branch name exactly, or the recorded commit
-        // exactly / by unambiguous hex prefix (git's own convention, ≥7).
-        let matches_ref = |r: &rocky_core::state::RunRecord| {
-            r.git_branch.as_deref() == Some(base_ref)
-                || r.git_commit.as_deref().is_some_and(|c| {
-                    c == base_ref
-                        || (base_ref.len() >= 7
-                            && base_ref.chars().all(|ch| ch.is_ascii_hexdigit())
-                            && c.starts_with(base_ref))
-                })
-        };
-        let named_base = store.list_runs_matching(1, matches_ref)?.into_iter().next();
-        if let Some(run) = named_base {
-            return Ok((branch_run, Some(run), None));
+        // workflow passes `github.event.pull_request.base.sha`). Identity
+        // precedence is staged — a BRANCH-NAME match always wins over a
+        // commit match (a branch literally named like a hex string must not
+        // lose to a newer commit-prefix match), then an exact commit, then a
+        // git-style hex prefix (≥7) with AMBIGUITY REFUSED rather than
+        // silently resolved to the newest.
+        let by_branch = store
+            .list_runs_matching(1, |r| r.git_branch.as_deref() == Some(base_ref))?
+            .into_iter()
+            .next();
+        if let Some(run) = by_branch {
+            return finish_named(branch_run, run, base_ref);
+        }
+        let base_lower = base_ref.to_ascii_lowercase();
+        let by_exact_commit = store
+            .list_runs_matching(1, |r| {
+                r.git_commit
+                    .as_deref()
+                    .is_some_and(|c| c.eq_ignore_ascii_case(&base_lower))
+            })?
+            .into_iter()
+            .next();
+        if let Some(run) = by_exact_commit {
+            return finish_named(branch_run, run, base_ref);
+        }
+        if base_lower.len() >= 7 && base_lower.chars().all(|ch| ch.is_ascii_hexdigit()) {
+            let by_prefix = store.list_runs_matching(64, |r| {
+                r.git_commit
+                    .as_deref()
+                    .is_some_and(|c| c.to_ascii_lowercase().starts_with(&base_lower))
+            })?;
+            let mut distinct: Vec<&str> = by_prefix
+                .iter()
+                .filter_map(|r| r.git_commit.as_deref())
+                .collect();
+            distinct.sort_unstable_by_key(|c| c.to_ascii_lowercase());
+            distinct.dedup_by(|a, b| a.eq_ignore_ascii_case(b));
+            match distinct.len() {
+                0 => {}
+                1 => {
+                    let run = by_prefix.into_iter().next().expect("nonempty");
+                    return finish_named(branch_run, run, base_ref);
+                }
+                n => {
+                    return Ok((
+                        branch_run,
+                        None,
+                        Some(format!(
+                            "the base prefix '{base_ref}' matches {n} distinct recorded \
+                             commits — give more characters to disambiguate"
+                        )),
+                    ));
+                }
+            }
         }
         // No recorded run on the named base: the diff that was asked for
         // cannot be computed, and a diff against ANY stand-in — however
@@ -389,7 +454,7 @@ pub async fn run_preview_diff(
             summary.any_coverage_warning = compute_any_coverage_warning(&models);
         } else {
             info!(
-                "preview diff '{branch_name}': no branch run found in state store; \
+                "preview diff '{branch_name}': no branch or base run available; \
                  nothing to bisect"
             );
         }
@@ -2215,6 +2280,94 @@ mod tests {
         assert!(
             format!("{err:#}").contains("cannot be diffed against itself"),
             "{err:#}"
+        );
+    }
+
+    /// Identity precedence: a branch literally named like a hex string wins
+    /// over a NEWER run whose commit matches the same string as a prefix.
+    #[test]
+    fn a_hex_branch_name_wins_over_a_commit_prefix_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.redb");
+        let base = chrono::Utc::now();
+        {
+            let store = rocky_core::state::StateStore::open(&state_path).unwrap();
+            let mut named = sample_run("branch-run", base);
+            named.git_branch = Some("deadbee1".to_string());
+            store.record_run(&named).unwrap();
+            let mut newer = sample_run("commit-run", base + chrono::Duration::minutes(1));
+            newer.git_branch = Some("other".to_string());
+            newer.git_commit = Some("deadbee1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string());
+            store.record_run(&newer).unwrap();
+            let mut feat = sample_run("f1", base + chrono::Duration::minutes(2));
+            feat.git_branch = Some("feature".to_string());
+            store.record_run(&feat).unwrap();
+        }
+        let store = rocky_core::state::StateStore::open_read_only(&state_path).unwrap();
+        let (_b, base_run, note) =
+            newest_branch_and_base_runs(&store, "feature", Some("deadbee1")).unwrap();
+        assert_eq!(
+            base_run.unwrap().run_id,
+            "branch-run",
+            "branch identity wins"
+        );
+        assert!(note.is_none());
+    }
+
+    /// An ambiguous hex prefix (two distinct recorded commits) refuses with
+    /// a disambiguation note instead of silently picking the newest.
+    #[test]
+    fn an_ambiguous_sha_prefix_refuses() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.redb");
+        let base = chrono::Utc::now();
+        {
+            let store = rocky_core::state::StateStore::open(&state_path).unwrap();
+            for (id, sha, mins) in [
+                ("c1", "abc1234aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 0),
+                ("c2", "abc1234bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", 1),
+            ] {
+                let mut r = sample_run(id, base + chrono::Duration::minutes(mins));
+                r.git_branch = Some("main".to_string());
+                r.git_commit = Some(sha.to_string());
+                store.record_run(&r).unwrap();
+            }
+            let mut feat = sample_run("f1", base + chrono::Duration::minutes(2));
+            feat.git_branch = Some("feature".to_string());
+            store.record_run(&feat).unwrap();
+        }
+        let store = rocky_core::state::StateStore::open_read_only(&state_path).unwrap();
+        let (_b, base_run, note) =
+            newest_branch_and_base_runs(&store, "feature", Some("abc1234")).unwrap();
+        assert!(base_run.is_none());
+        assert!(
+            note.unwrap().contains("2 distinct recorded commits"),
+            "ambiguity must be refused, not resolved silently"
+        );
+    }
+
+    /// A base sha that ALIASES the branch's own newest run refuses — the
+    /// string-inequality guard cannot see through a sha, so the selection
+    /// itself must.
+    #[test]
+    fn a_sha_alias_of_the_branch_run_refuses_self_comparison() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.redb");
+        let base = chrono::Utc::now();
+        {
+            let store = rocky_core::state::StateStore::open(&state_path).unwrap();
+            let mut feat = sample_run("f1", base);
+            feat.git_branch = Some("feature".to_string());
+            feat.git_commit = Some("feedface00000000000000000000000000000000".to_string());
+            store.record_run(&feat).unwrap();
+        }
+        let store = rocky_core::state::StateStore::open_read_only(&state_path).unwrap();
+        let (_b, base_run, note) =
+            newest_branch_and_base_runs(&store, "feature", Some("feedface")).unwrap();
+        assert!(base_run.is_none(), "no self-diff through a sha alias");
+        assert!(
+            note.unwrap().contains("branch's own newest run"),
+            "the alias must be named"
         );
     }
 

--- a/engine/crates/rocky-cli/src/commands/preview.rs
+++ b/engine/crates/rocky-cli/src/commands/preview.rs
@@ -318,6 +318,27 @@ fn newest_branch_and_base_runs(
         // lose to a newer commit-prefix match), then an exact commit, then a
         // git-style hex prefix (≥7) with AMBIGUITY REFUSED rather than
         // silently resolved to the newest.
+        let base_lower = base_ref.to_ascii_lowercase();
+        let is_full_sha =
+            base_lower.len() == 40 && base_lower.chars().all(|ch| ch.is_ascii_hexdigit());
+        // A full 40-hex ref states COMMIT intent (the production workflow
+        // passes `base.sha` verbatim): resolve it as a commit before any
+        // branch that happens to wear the same 40-hex name could hijack it.
+        // Shorter refs resolve as branches first — branch names are
+        // human-chosen and must not lose to a commit-prefix coincidence.
+        if is_full_sha {
+            let by_exact = store
+                .list_runs_matching(1, |r| {
+                    r.git_commit
+                        .as_deref()
+                        .is_some_and(|c| c.eq_ignore_ascii_case(&base_lower))
+                })?
+                .into_iter()
+                .next();
+            if let Some(run) = by_exact {
+                return finish_named(branch_run, run, base_ref);
+            }
+        }
         let by_branch = store
             .list_runs_matching(1, |r| r.git_branch.as_deref() == Some(base_ref))?
             .into_iter()
@@ -325,7 +346,6 @@ fn newest_branch_and_base_runs(
         if let Some(run) = by_branch {
             return finish_named(branch_run, run, base_ref);
         }
-        let base_lower = base_ref.to_ascii_lowercase();
         let by_exact_commit = store
             .list_runs_matching(1, |r| {
                 r.git_commit
@@ -338,7 +358,7 @@ fn newest_branch_and_base_runs(
             return finish_named(branch_run, run, base_ref);
         }
         if base_lower.len() >= 7 && base_lower.chars().all(|ch| ch.is_ascii_hexdigit()) {
-            let by_prefix = store.list_runs_matching(64, |r| {
+            let by_prefix = store.list_runs_matching(usize::MAX, |r| {
                 r.git_commit
                     .as_deref()
                     .is_some_and(|c| c.to_ascii_lowercase().starts_with(&base_lower))
@@ -2281,6 +2301,106 @@ mod tests {
             format!("{err:#}").contains("cannot be diffed against itself"),
             "{err:#}"
         );
+    }
+
+    /// A FULL 40-hex ref states commit intent: a branch that happens to
+    /// wear the same 40-hex name must not hijack it.
+    #[test]
+    fn a_full_sha_resolves_as_a_commit_before_a_samename_branch() {
+        let sha = "aaaabbbbccccddddeeeeffff0000111122223333";
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.redb");
+        let base = chrono::Utc::now();
+        {
+            let store = rocky_core::state::StateStore::open(&state_path).unwrap();
+            let mut commit_run = sample_run("commit-run", base);
+            commit_run.git_branch = Some("main".to_string());
+            commit_run.git_commit = Some(sha.to_string());
+            store.record_run(&commit_run).unwrap();
+            // NEWER run on a branch literally named as the sha.
+            let mut hijack = sample_run("hijack-run", base + chrono::Duration::minutes(1));
+            hijack.git_branch = Some(sha.to_string());
+            store.record_run(&hijack).unwrap();
+            let mut feat = sample_run("f1", base + chrono::Duration::minutes(2));
+            feat.git_branch = Some("feature".to_string());
+            store.record_run(&feat).unwrap();
+        }
+        let store = rocky_core::state::StateStore::open_read_only(&state_path).unwrap();
+        let (_b, base_run, note) =
+            newest_branch_and_base_runs(&store, "feature", Some(sha)).unwrap();
+        assert_eq!(
+            base_run.unwrap().run_id,
+            "commit-run",
+            "commit intent wins over the same-name branch"
+        );
+        assert!(note.is_none());
+    }
+
+    /// Prefix uniqueness is proven over ALL matching runs: many newer runs
+    /// of one commit must not hide an older distinct commit sharing the
+    /// prefix — that concealment previously produced a silent false-unique.
+    #[test]
+    fn prefix_ambiguity_is_detected_past_many_runs_of_one_commit() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.redb");
+        let base = chrono::Utc::now();
+        {
+            let store = rocky_core::state::StateStore::open(&state_path).unwrap();
+            // The OLD distinct commit, oldest of all.
+            let mut old = sample_run("old-distinct", base);
+            old.git_branch = Some("main".to_string());
+            old.git_commit = Some("abc9999f0000000000000000000000000000dead".to_string());
+            store.record_run(&old).unwrap();
+            // 70 newer runs all of ONE other commit sharing the prefix.
+            for i in 0..70u32 {
+                let mut r = sample_run(
+                    &format!("same-{i}"),
+                    base + chrono::Duration::minutes(i64::from(i) + 1),
+                );
+                r.git_branch = Some("main".to_string());
+                r.git_commit = Some("abc9999a1111111111111111111111111111beef".to_string());
+                store.record_run(&r).unwrap();
+            }
+            let mut feat = sample_run("f1", base + chrono::Duration::minutes(100));
+            feat.git_branch = Some("feature".to_string());
+            store.record_run(&feat).unwrap();
+        }
+        let store = rocky_core::state::StateStore::open_read_only(&state_path).unwrap();
+        let (_b, base_run, note) =
+            newest_branch_and_base_runs(&store, "feature", Some("abc9999")).unwrap();
+        assert!(
+            base_run.is_none(),
+            "the concealed distinct commit must refuse"
+        );
+        assert!(note.unwrap().contains("distinct recorded commits"));
+    }
+
+    /// Exact commit matching is case-insensitive (git accepts uppercase sha
+    /// input; records store lowercase).
+    #[test]
+    fn an_uppercase_full_sha_matches_the_recorded_commit() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.redb");
+        let base = chrono::Utc::now();
+        {
+            let store = rocky_core::state::StateStore::open(&state_path).unwrap();
+            let mut main_run = sample_run("m1", base);
+            main_run.git_branch = Some("main".to_string());
+            main_run.git_commit = Some("0123abcd0123abcd0123abcd0123abcd0123abcd".to_string());
+            store.record_run(&main_run).unwrap();
+            let mut feat = sample_run("f1", base + chrono::Duration::minutes(1));
+            feat.git_branch = Some("feature".to_string());
+            store.record_run(&feat).unwrap();
+        }
+        let store = rocky_core::state::StateStore::open_read_only(&state_path).unwrap();
+        let (_b, base_run, note) = newest_branch_and_base_runs(
+            &store,
+            "feature",
+            Some("0123ABCD0123ABCD0123ABCD0123ABCD0123ABCD"),
+        )
+        .unwrap();
+        assert_eq!(base_run.unwrap().run_id, "m1");
+        assert!(note.is_none());
     }
 
     /// Identity precedence: a branch literally named like a hex string wins

--- a/engine/crates/rocky-cli/src/commands/preview.rs
+++ b/engine/crates/rocky-cli/src/commands/preview.rs
@@ -338,6 +338,18 @@ fn newest_branch_and_base_runs(
             if let Some(run) = by_exact {
                 return finish_named(branch_run, run, base_ref);
             }
+            // Commit intent holds on a MISS too: a full sha that matches no
+            // recorded commit must refuse — falling through to the branch
+            // stage would let a branch wearing the same 40-hex name (while
+            // recording different commits) hijack the base after all.
+            return Ok((
+                branch_run,
+                None,
+                Some(format!(
+                    "no run recorded for commit '{base_ref}' in this state store — the diff \
+                     against it cannot be computed. Run the base against this store first"
+                )),
+            ));
         }
         let by_branch = store
             .list_runs_matching(1, |r| r.git_branch.as_deref() == Some(base_ref))?
@@ -2334,6 +2346,39 @@ mod tests {
             "commit intent wins over the same-name branch"
         );
         assert!(note.is_none());
+    }
+
+    /// Commit intent holds on an exact MISS too: a full sha with no
+    /// recorded commit refuses — it must not fall through to a branch
+    /// wearing the same 40-hex name.
+    #[test]
+    fn a_full_sha_miss_refuses_instead_of_matching_a_samename_branch() {
+        let sha = "aaaabbbbccccddddeeeeffff0000111122223333";
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.redb");
+        let base = chrono::Utc::now();
+        {
+            let store = rocky_core::state::StateStore::open(&state_path).unwrap();
+            // A branch NAMED as the sha, recording a DIFFERENT commit.
+            let mut hijack = sample_run("hijack-run", base);
+            hijack.git_branch = Some(sha.to_string());
+            hijack.git_commit = Some("1111111111111111111111111111111111111111".to_string());
+            store.record_run(&hijack).unwrap();
+            let mut feat = sample_run("f1", base + chrono::Duration::minutes(1));
+            feat.git_branch = Some("feature".to_string());
+            store.record_run(&feat).unwrap();
+        }
+        let store = rocky_core::state::StateStore::open_read_only(&state_path).unwrap();
+        let (_b, base_run, note) =
+            newest_branch_and_base_runs(&store, "feature", Some(sha)).unwrap();
+        assert!(
+            base_run.is_none(),
+            "the miss must refuse, not match the branch"
+        );
+        assert!(
+            note.unwrap().contains("no run recorded for commit"),
+            "commit-intent wording"
+        );
     }
 
     /// Prefix uniqueness is proven over ALL matching runs: many newer runs

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -9126,9 +9126,9 @@ pub struct PreviewDiffOutput {
     pub command: String,
     pub branch_name: String,
     pub base_ref: String,
-    /// Present when no run was recorded on `base_ref` and the diff fell back
-    /// to the newest run on another named branch — names the stand-in so the
-    /// diff never silently wears the base's name (#1345).
+    /// Present when no run was recorded on `base_ref`: the diff is NOT
+    /// computed against any stand-in (an empty summary is returned) and this
+    /// note explains the absence and the remedy (#1345).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_note: Option<String>,
     pub summary: PreviewDiffSummary,

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -9126,6 +9126,11 @@ pub struct PreviewDiffOutput {
     pub command: String,
     pub branch_name: String,
     pub base_ref: String,
+    /// Present when no run was recorded on `base_ref` and the diff fell back
+    /// to the newest run on another named branch — names the stand-in so the
+    /// diff never silently wears the base's name (#1345).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_note: Option<String>,
     pub summary: PreviewDiffSummary,
     pub models: Vec<PreviewModelDiff>,
     /// Pre-rendered Markdown suitable for posting as a GitHub PR comment.
@@ -9468,6 +9473,7 @@ impl PreviewDiffOutput {
     pub fn new(
         branch_name: String,
         base_ref: String,
+        base_note: Option<String>,
         summary: PreviewDiffSummary,
         models: Vec<PreviewModelDiff>,
         markdown: String,
@@ -9477,6 +9483,7 @@ impl PreviewDiffOutput {
             command: "preview-diff".to_string(),
             branch_name,
             base_ref,
+            base_note,
             summary,
             models,
             markdown,

--- a/schemas/preview_diff.schema.json
+++ b/schemas/preview_diff.schema.json
@@ -355,7 +355,7 @@
   "description": "JSON output for `rocky preview diff`.\n\nCombines the structural diff (column added/removed/type-changed) from the existing `rocky_core::ci_diff` machinery with a row-level diff produced by either the sampled or the checksum-bisection algorithm. Each per-model entry's `algorithm` field carries a `kind` discriminator (`\"sampled\"` or `\"bisection\"`) plus the matching payload.\n\n**Sampled correctness ceiling.** The sampled algorithm reads `LIMIT N` rows ordered by primary key (or first column). Changes outside that window appear as no-change unless the row count itself differs; `sampling_window.coverage_warning = true` flags that risk. **Bisection** walks the chunk lattice exhaustively over a single-column primary key; `bisection_stats.depth_capped = true` flags the rare case where the recursion bottomed out at the depth cap before reaching leaf size. `summary.any_coverage_warning` rolls both signals up.",
   "properties": {
     "base_note": {
-      "description": "Present when no run was recorded on `base_ref` and the diff fell back to the newest run on another named branch — names the stand-in so the diff never silently wears the base's name (#1345).",
+      "description": "Present when no run was recorded on `base_ref`: the diff is NOT computed against any stand-in (an empty summary is returned) and this note explains the absence and the remedy (#1345).",
       "type": [
         "string",
         "null"

--- a/schemas/preview_diff.schema.json
+++ b/schemas/preview_diff.schema.json
@@ -354,6 +354,13 @@
   },
   "description": "JSON output for `rocky preview diff`.\n\nCombines the structural diff (column added/removed/type-changed) from the existing `rocky_core::ci_diff` machinery with a row-level diff produced by either the sampled or the checksum-bisection algorithm. Each per-model entry's `algorithm` field carries a `kind` discriminator (`\"sampled\"` or `\"bisection\"`) plus the matching payload.\n\n**Sampled correctness ceiling.** The sampled algorithm reads `LIMIT N` rows ordered by primary key (or first column). Changes outside that window appear as no-change unless the row count itself differs; `sampling_window.coverage_warning = true` flags that risk. **Bisection** walks the chunk lattice exhaustively over a single-column primary key; `bisection_stats.depth_capped = true` flags the rare case where the recursion bottomed out at the depth cap before reaching leaf size. `summary.any_coverage_warning` rolls both signals up.",
   "properties": {
+    "base_note": {
+      "description": "Present when no run was recorded on `base_ref` and the diff fell back to the newest run on another named branch — names the stand-in so the diff never silently wears the base's name (#1345).",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "base_ref": {
       "type": "string"
     },

--- a/sdk/python/src/rocky_sdk/types_generated/preview_diff_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/preview_diff_schema.py
@@ -198,6 +198,10 @@ class PreviewDiffOutput(BaseModel):
     **Sampled correctness ceiling.** The sampled algorithm reads `LIMIT N` rows ordered by primary key (or first column). Changes outside that window appear as no-change unless the row count itself differs; `sampling_window.coverage_warning = true` flags that risk. **Bisection** walks the chunk lattice exhaustively over a single-column primary key; `bisection_stats.depth_capped = true` flags the rare case where the recursion bottomed out at the depth cap before reaching leaf size. `summary.any_coverage_warning` rolls both signals up.
     """
 
+    base_note: str | None = None
+    """
+    Present when no run was recorded on `base_ref` and the diff fell back to the newest run on another named branch — names the stand-in so the diff never silently wears the base's name (#1345).
+    """
     base_ref: str
     branch_name: str
     command: str

--- a/sdk/python/src/rocky_sdk/types_generated/preview_diff_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/preview_diff_schema.py
@@ -200,7 +200,7 @@ class PreviewDiffOutput(BaseModel):
 
     base_note: str | None = None
     """
-    Present when no run was recorded on `base_ref` and the diff fell back to the newest run on another named branch — names the stand-in so the diff never silently wears the base's name (#1345).
+    Present when no run was recorded on `base_ref`: the diff is NOT computed against any stand-in (an empty summary is returned) and this note explains the absence and the remedy (#1345).
     """
     base_ref: str
     branch_name: str


### PR DESCRIPTION
Fixes #1345. `rocky preview diff --base main` resolved its base run as "the newest run whose branch is not the feature branch" — happily pairing against an unrelated third branch or a detached-HEAD run (`git_branch: None`) while labeling the result `main`. The issue's exact repro (`t1` on main, newer `t2` detached, `t3` on feature) compared `t3` against `t2` under `main`'s name.

Selection now works from the ref the caller named, and only from it:

- **Primary**: the newest run whose recorded **branch equals `--base`, or whose recorded commit sha matches it** (exact, or git-style hex prefix ≥7) — Rocky's own preview workflow passes `github.event.pull_request.base.sha`, and records carry the sha in `git_commit`, so the checked-in workflow works under the named contract.
- **Missing base = refusal, not a stand-in**: when nothing matches, the comparison is not computed against anything else — empty summary, a `base_note` on `PreviewDiffOutput` explaining the absence and remedy, a `> ⚠️` callout in the markdown (reachable on exactly this path), and the VS Code command surfaces the note as a warning instead of a clean zero-diff message. The bisection path gates on **both** runs, so a refusal stays a zero-exit no-op instead of opening adapters.
- **Self-comparison refused**: `--name X --base X` previously diffed one run against itself and reported every model unchanged; it now fails fast with a clear message.
- **The cost preview is untouched**: its unnamed selection remains byte-for-byte main's (newest run not on the branch, detached CI cost baselines deliberately eligible).

Evidence: the issue's t1/t2/t3 repro; sha and hex-prefix base tests; refusal-with-note test; self-comparison refusal test; detached-eligibility pinned for the cost path; primary predicate, sha arm, and self-guard each mutation-checked red. Bindings regenerated for the optional `base_note` (omitted when absent; the SDK models it via the generated types — verified no hand-model parity needed).