### PR TITLE
feat(engine/rocky-bigquery): classify statement.kind on execute spans

### DIFF
--- a/engine/crates/rocky-bigquery/src/connector.rs
+++ b/engine/crates/rocky-bigquery/src/connector.rs
@@ -2207,7 +2207,10 @@ mod tests {
 /// Classify a SQL statement for the `statement.kind` span attribute —
 /// `query` / `dml` / `ddl` / `other`. Mirrors the Snowflake and Databricks
 /// connectors' matcher so dashboards filter uniformly across adapters
-/// (#897).
+/// (#897). Divergence, on purpose: this stripper also handles BigQuery's
+/// `#` line comments and `/* */` blocks; the sibling strippers handle only
+/// `--` and share the `/* */` gap — tracked separately so the parity story
+/// stays explicit rather than silently uneven.
 fn classify_statement_kind(sql: &str) -> &'static str {
     let sql = strip_leading_sql_comments_and_whitespace(sql);
     let keyword = sql

--- a/engine/crates/rocky-bigquery/src/connector.rs
+++ b/engine/crates/rocky-bigquery/src/connector.rs
@@ -2226,14 +2226,28 @@ fn classify_statement_kind(sql: &str) -> &'static str {
 fn strip_leading_sql_comments_and_whitespace(mut sql: &str) -> &str {
     loop {
         let trimmed = sql.trim_start();
-        let Some(comment_body) = trimmed.strip_prefix("--") else {
-            return trimmed;
-        };
-
-        sql = match comment_body.find('\n') {
-            Some(line_end) => &comment_body[line_end + 1..],
-            None => "",
-        };
+        // BigQuery accepts `--` AND `#` line comments plus `/* … */` blocks
+        // (GoogleSQL lexical rules) — a statement led by any of them must
+        // still classify by its first keyword.
+        if let Some(body) = trimmed
+            .strip_prefix("--")
+            .or_else(|| trimmed.strip_prefix('#'))
+        {
+            sql = match body.find('\n') {
+                Some(line_end) => &body[line_end + 1..],
+                None => "",
+            };
+            continue;
+        }
+        if let Some(body) = trimmed.strip_prefix("/*") {
+            sql = match body.find("*/") {
+                Some(end) => &body[end + 2..],
+                // Unterminated block comment: nothing classifiable follows.
+                None => "",
+            };
+            continue;
+        }
+        return trimmed;
     }
 }
 
@@ -2265,6 +2279,20 @@ mod statement_kind_tests {
             classify_statement_kind("-- provisioning\n-- second line\nCREATE TABLE t (id INT64)"),
             "ddl"
         );
+        // BigQuery-specific `#` line comments and `/* */` blocks.
+        assert_eq!(
+            classify_statement_kind("# provisioning\nINSERT INTO t VALUES (1)"),
+            "dml"
+        );
+        assert_eq!(
+            classify_statement_kind("/* multi\nline */ SELECT 1"),
+            "query"
+        );
+        assert_eq!(
+            classify_statement_kind("/* a */ -- b\n# c\nDROP TABLE t"),
+            "ddl"
+        );
         assert_eq!(classify_statement_kind("-- only a comment"), "other");
+        assert_eq!(classify_statement_kind("/* unterminated"), "other");
     }
 }

--- a/engine/crates/rocky-bigquery/src/connector.rs
+++ b/engine/crates/rocky-bigquery/src/connector.rs
@@ -282,11 +282,11 @@ impl BigQueryAdapter {
     /// adapter-tagged child span when traced. Mirrors the OTel
     /// `<verb>.<resource>` shape used by the `materialize.table` parent.
     async fn run_query(&self, sql: &str) -> Result<BigQueryResponse, BigQueryError> {
-        // `statement.kind = "query"` is a best-effort default — BigQuery
-        // routes DDL, DML, and SELECT through the same `jobs.query`
-        // endpoint and the wire request doesn't surface the parsed
-        // statement kind. TODO: classify via `rocky-sql` if downstream
-        // consumers need to filter ddl/dml from query traffic.
+        // BigQuery routes DDL, DML, and SELECT through the same
+        // `jobs.query` endpoint, so the kind is classified from the SQL
+        // text — the same keyword matcher the Snowflake and Databricks
+        // connectors use (#897), keeping `statement.kind` filterable
+        // uniformly across every warehouse adapter.
         //
         // Span attribute schema unification: emit the canonical
         // `rocky.*` keys alongside the bespoke `adapter` /
@@ -295,12 +295,13 @@ impl BigQueryAdapter {
         // aliases. `rocky.warehouse.query_id` starts empty and is
         // filled by `Span::record` once BigQuery returns the
         // `JobReference.job_id`. See `rocky_observe::span_attrs`.
+        let kind = classify_statement_kind(sql);
         let span = info_span!(
             "statement.execute",
             adapter = "bigquery",
-            statement.kind = "query",
+            statement.kind = kind,
             "rocky.adapter.name" = "bigquery",
-            "rocky.statement.kind" = "query",
+            "rocky.statement.kind" = kind,
             "rocky.warehouse.name" = %self.project_id,
             "rocky.warehouse.query_id" = field::Empty,
             "rocky.warehouse.bytes_scanned" = field::Empty,
@@ -2200,5 +2201,70 @@ mod tests {
 
         let unknown = classify_bigquery_failure(&AdapterError::msg("not a bigquery error"));
         assert_eq!(unknown, FailureClass::Unknown);
+    }
+}
+
+/// Classify a SQL statement for the `statement.kind` span attribute —
+/// `query` / `dml` / `ddl` / `other`. Mirrors the Snowflake and Databricks
+/// connectors' matcher so dashboards filter uniformly across adapters
+/// (#897).
+fn classify_statement_kind(sql: &str) -> &'static str {
+    let sql = strip_leading_sql_comments_and_whitespace(sql);
+    let keyword = sql
+        .split(|ch: char| !ch.is_ascii_alphabetic())
+        .next()
+        .unwrap_or("");
+
+    match keyword.to_ascii_uppercase().as_str() {
+        "SELECT" | "WITH" | "SHOW" | "DESCRIBE" | "EXPLAIN" => "query",
+        "INSERT" | "UPDATE" | "DELETE" | "MERGE" | "COPY" | "TRUNCATE" => "dml",
+        "CREATE" | "ALTER" | "DROP" | "GRANT" | "REVOKE" => "ddl",
+        _ => "other",
+    }
+}
+
+fn strip_leading_sql_comments_and_whitespace(mut sql: &str) -> &str {
+    loop {
+        let trimmed = sql.trim_start();
+        let Some(comment_body) = trimmed.strip_prefix("--") else {
+            return trimmed;
+        };
+
+        sql = match comment_body.find('\n') {
+            Some(line_end) => &comment_body[line_end + 1..],
+            None => "",
+        };
+    }
+}
+
+#[cfg(test)]
+mod statement_kind_tests {
+    use super::classify_statement_kind;
+
+    #[test]
+    fn classifies_query_dml_ddl_and_other() {
+        for (sql, expected) in [
+            ("SELECT 1", "query"),
+            ("  with cte AS (SELECT 1) SELECT * FROM cte", "query"),
+            ("EXPLAIN SELECT 1", "query"),
+            ("INSERT INTO t VALUES (1)", "dml"),
+            ("merge INTO t USING s ON t.id = s.id", "dml"),
+            ("TRUNCATE TABLE t", "dml"),
+            ("CREATE TABLE t (id INT64)", "ddl"),
+            ("alter table t ADD COLUMN c STRING", "ddl"),
+            ("DROP SCHEMA s", "ddl"),
+            ("VACUUM t", "other"),
+        ] {
+            assert_eq!(classify_statement_kind(sql), expected, "{sql}");
+        }
+    }
+
+    #[test]
+    fn leading_comments_do_not_hide_the_keyword() {
+        assert_eq!(
+            classify_statement_kind("-- provisioning\n-- second line\nCREATE TABLE t (id INT64)"),
+            "ddl"
+        );
+        assert_eq!(classify_statement_kind("-- only a comment"), "other");
     }
 }

--- a/engine/crates/rocky-observe/src/span_attrs.rs
+++ b/engine/crates/rocky-observe/src/span_attrs.rs
@@ -101,9 +101,9 @@ pub const WAREHOUSE_TABLE_REF: &str = "rocky.warehouse.table_ref";
 
 /// Statement classification (`ddl`, `dml`, `query`, `merge`, ...).
 /// Adapters classify via `rocky_sql` where possible; BigQuery's
-/// `jobs.query` endpoint routes every kind through the same path and
-/// today emits the literal `"query"` until upstream classification
-/// lands.
+/// `jobs.query` endpoint routes every kind through the same path, so
+/// the BigQuery connector classifies the kind from the SQL text — the
+/// same keyword matcher Snowflake and Databricks use (#897).
 ///
 /// **Canonical replacement** for the bespoke `statement.kind`
 /// attribute emitted pre-unification.


### PR DESCRIPTION
Closes #897. BigQuery was the lone warehouse adapter hardcoding `statement.kind = "query"` on its `statement.execute` spans (its `jobs.query` endpoint takes DDL/DML/SELECT alike, so the kind must come from the SQL text — the old TODO said as much). This ports the same keyword matcher the Snowflake (#540, the issue's stated template) and Databricks connectors use, applied to both the bespoke `statement.kind` and canonical `rocky.statement.kind` attributes, so dashboards filter ddl/dml/query traffic uniformly across every adapter.

Tests mirror the Snowflake suite (query/dml/ddl/other + leading-comment stripping), exactly the issue's acceptance bar. Evidence note, stated plainly: the tests bind the **classifier**; the two-line span wiring (`let kind = classify_statement_kind(sql)` into the two attributes) is not exercised by a tracing-capture harness — the same evidence shape as the merged Snowflake template. `cargo test -p rocky-bigquery` green; clippy `-D warnings` clean.