### PR TITLE
fix(engine): Snowflake and Databricks statement-kind strippers handle block comments

### DIFF
--- a/engine/crates/rocky-bigquery/src/connector.rs
+++ b/engine/crates/rocky-bigquery/src/connector.rs
@@ -2210,7 +2210,9 @@ mod tests {
 /// (#897). Divergence, on purpose: this stripper also handles BigQuery's
 /// `#` line comments; all three handle `/* */` blocks, and only the
 /// Databricks stripper tracks nesting depth (Spark SQL block comments
-/// nest; here and on Snowflake a nested opener is a syntax error).
+/// nest; here and on Snowflake the scan is flat — the comment ends at
+/// the first `*/` and an inner `/*` is inert text, live-verified on
+/// both, so this flat find matches the server's own lexer).
 fn classify_statement_kind(sql: &str) -> &'static str {
     let sql = strip_leading_sql_comments_and_whitespace(sql);
     let keyword = sql

--- a/engine/crates/rocky-bigquery/src/connector.rs
+++ b/engine/crates/rocky-bigquery/src/connector.rs
@@ -2208,9 +2208,9 @@ mod tests {
 /// `query` / `dml` / `ddl` / `other`. Mirrors the Snowflake and Databricks
 /// connectors' matcher so dashboards filter uniformly across adapters
 /// (#897). Divergence, on purpose: this stripper also handles BigQuery's
-/// `#` line comments and `/* */` blocks; the sibling strippers handle only
-/// `--` and share the `/* */` gap — tracked separately so the parity story
-/// stays explicit rather than silently uneven.
+/// `#` line comments; all three handle `/* */` blocks, and only the
+/// Databricks stripper tracks nesting depth (Spark SQL block comments
+/// nest; here and on Snowflake a nested opener is a syntax error).
 fn classify_statement_kind(sql: &str) -> &'static str {
     let sql = strip_leading_sql_comments_and_whitespace(sql);
     let keyword = sql

--- a/engine/crates/rocky-databricks/src/connector.rs
+++ b/engine/crates/rocky-databricks/src/connector.rs
@@ -1366,10 +1366,12 @@ fn strip_leading_sql_comments_and_whitespace(mut sql: &str) -> &str {
             continue;
         }
         if let Some(body) = trimmed.strip_prefix("/*") {
-            // Spark SQL block comments NEST (unlike Snowflake's and
-            // BigQuery's, where a nested opener is a syntax error) — track
-            // depth so `/* outer /* inner */ still-comment */ SELECT 1`
-            // classifies by its real first keyword.
+            // Spark SQL block comments NEST. Snowflake and BigQuery scan
+            // flat instead — there the comment ends at the FIRST `*/` and
+            // an inner `/*` is inert text (live-verified on both: the
+            // nested probe errors "unexpected 'still'", and
+            // `/* a /* b */ SELECT 1` parses clean) — so track depth here
+            // and only here.
             // Single pass over bytes, O(n): a rescan-from-start loop is
             // quadratic on adversarial comment content, and generated SQL
             // can be large enough for that to stall before submission.

--- a/engine/crates/rocky-databricks/src/connector.rs
+++ b/engine/crates/rocky-databricks/src/connector.rs
@@ -1432,6 +1432,12 @@ mod statement_kind_tests {
             classify_statement_kind("/* outer /* unterminated inner */"),
             "other"
         );
+        // Inner block closes, outer never does: the trailing SELECT is
+        // still inside the comment — fail closed, not "query".
+        assert_eq!(
+            classify_statement_kind("/* outer /* inner */ SELECT 1"),
+            "other"
+        );
     }
 }
 

--- a/engine/crates/rocky-databricks/src/connector.rs
+++ b/engine/crates/rocky-databricks/src/connector.rs
@@ -1354,14 +1354,53 @@ fn classify_statement_kind(sql: &str) -> &'static str {
 fn strip_leading_sql_comments_and_whitespace(mut sql: &str) -> &str {
     loop {
         let trimmed = sql.trim_start();
-        let Some(comment_body) = trimmed.strip_prefix("--") else {
-            return trimmed;
-        };
+        // `--` line comments AND `/* … */` block comments — a statement led
+        // by either must still classify by its first keyword (#1363; the
+        // BigQuery connector strips the same forms plus its dialect-specific
+        // `#`).
+        if let Some(body) = trimmed.strip_prefix("--") {
+            sql = match body.find('\n') {
+                Some(line_end) => &body[line_end + 1..],
+                None => "",
+            };
+            continue;
+        }
+        if let Some(body) = trimmed.strip_prefix("/*") {
+            sql = match body.find("*/") {
+                Some(end) => &body[end + 2..],
+                // Unterminated block comment: nothing classifiable follows.
+                None => "",
+            };
+            continue;
+        }
+        return trimmed;
+    }
+}
 
-        sql = match comment_body.find('\n') {
-            Some(line_end) => &comment_body[line_end + 1..],
-            None => "",
-        };
+#[cfg(test)]
+mod statement_kind_tests {
+    use super::classify_statement_kind;
+
+    #[test]
+    fn classifies_and_strips_both_comment_forms() {
+        assert_eq!(classify_statement_kind("SELECT 1"), "query");
+        assert_eq!(
+            classify_statement_kind("MERGE INTO t USING s ON 1=1"),
+            "dml"
+        );
+        assert_eq!(
+            classify_statement_kind("-- generated\nCREATE TABLE t (id INT)"),
+            "ddl"
+        );
+        assert_eq!(
+            classify_statement_kind("/* multi\nline */ SELECT 1"),
+            "query"
+        );
+        assert_eq!(
+            classify_statement_kind("/* a */ -- b\nINSERT INTO t VALUES (1)"),
+            "dml"
+        );
+        assert_eq!(classify_statement_kind("/* unterminated"), "other");
     }
 }
 

--- a/engine/crates/rocky-databricks/src/connector.rs
+++ b/engine/crates/rocky-databricks/src/connector.rs
@@ -1440,6 +1440,14 @@ mod statement_kind_tests {
             classify_statement_kind("/* outer /* inner */ SELECT 1"),
             "other"
         );
+        // Overlap pins: each delimiter consumes BOTH its bytes. If the
+        // opener consumed one, `/*/` would double as open+close and the
+        // outer block would look terminated (→ "query"); if the closer
+        // consumed one, its trailing `/` would fuse with the next `*`
+        // into a phantom opener and the run of closers would look
+        // unterminated (→ "other").
+        assert_eq!(classify_statement_kind("/* /*/ */ SELECT 1"), "other");
+        assert_eq!(classify_statement_kind("/* /* */*/ SELECT 1"), "query");
     }
 }
 

--- a/engine/crates/rocky-databricks/src/connector.rs
+++ b/engine/crates/rocky-databricks/src/connector.rs
@@ -1366,11 +1366,35 @@ fn strip_leading_sql_comments_and_whitespace(mut sql: &str) -> &str {
             continue;
         }
         if let Some(body) = trimmed.strip_prefix("/*") {
-            sql = match body.find("*/") {
-                Some(end) => &body[end + 2..],
-                // Unterminated block comment: nothing classifiable follows.
-                None => "",
-            };
+            // Spark SQL block comments NEST (unlike Snowflake's and
+            // BigQuery's, where a nested opener is a syntax error) — track
+            // depth so `/* outer /* inner */ still-comment */ SELECT 1`
+            // classifies by its real first keyword.
+            let mut depth: usize = 1;
+            let mut rest = body;
+            loop {
+                let next_close = rest.find("*/");
+                let next_open = rest.find("/*");
+                match (next_open, next_close) {
+                    (Some(o), Some(c)) if o < c => {
+                        depth += 1;
+                        rest = &rest[o + 2..];
+                    }
+                    (_, Some(c)) => {
+                        depth -= 1;
+                        rest = &rest[c + 2..];
+                        if depth == 0 {
+                            break;
+                        }
+                    }
+                    // Unterminated at some depth: nothing classifiable.
+                    (_, None) => {
+                        rest = "";
+                        break;
+                    }
+                }
+            }
+            sql = rest;
             continue;
         }
         return trimmed;
@@ -1401,6 +1425,15 @@ mod statement_kind_tests {
             "dml"
         );
         assert_eq!(classify_statement_kind("/* unterminated"), "other");
+        // Spark SQL nests block comments.
+        assert_eq!(
+            classify_statement_kind("/* outer /* inner */ still-comment */ SELECT 1"),
+            "query"
+        );
+        assert_eq!(
+            classify_statement_kind("/* outer /* unterminated inner */"),
+            "other"
+        );
     }
 }
 

--- a/engine/crates/rocky-databricks/src/connector.rs
+++ b/engine/crates/rocky-databricks/src/connector.rs
@@ -1370,31 +1370,29 @@ fn strip_leading_sql_comments_and_whitespace(mut sql: &str) -> &str {
             // BigQuery's, where a nested opener is a syntax error) — track
             // depth so `/* outer /* inner */ still-comment */ SELECT 1`
             // classifies by its real first keyword.
+            // Single pass over bytes, O(n): a rescan-from-start loop is
+            // quadratic on adversarial comment content, and generated SQL
+            // can be large enough for that to stall before submission.
+            let bytes = body.as_bytes();
             let mut depth: usize = 1;
-            let mut rest = body;
-            loop {
-                let next_close = rest.find("*/");
-                let next_open = rest.find("/*");
-                match (next_open, next_close) {
-                    (Some(o), Some(c)) if o < c => {
+            let mut i = 0usize;
+            while i + 1 < bytes.len() {
+                match &bytes[i..i + 2] {
+                    b"/*" => {
                         depth += 1;
-                        rest = &rest[o + 2..];
+                        i += 2;
                     }
-                    (_, Some(c)) => {
+                    b"*/" => {
                         depth -= 1;
-                        rest = &rest[c + 2..];
+                        i += 2;
                         if depth == 0 {
                             break;
                         }
                     }
-                    // Unterminated at some depth: nothing classifiable.
-                    (_, None) => {
-                        rest = "";
-                        break;
-                    }
+                    _ => i += 1,
                 }
             }
-            sql = rest;
+            sql = if depth == 0 { &body[i..] } else { "" };
             continue;
         }
         return trimmed;

--- a/engine/crates/rocky-snowflake/src/connector.rs
+++ b/engine/crates/rocky-snowflake/src/connector.rs
@@ -640,14 +640,26 @@ fn classify_statement_kind(sql: &str) -> &'static str {
 fn strip_leading_sql_comments_and_whitespace(mut sql: &str) -> &str {
     loop {
         let trimmed = sql.trim_start();
-        let Some(comment_body) = trimmed.strip_prefix("--") else {
-            return trimmed;
-        };
-
-        sql = match comment_body.find('\n') {
-            Some(line_end) => &comment_body[line_end + 1..],
-            None => "",
-        };
+        // `--` line comments AND `/* … */` block comments — a statement led
+        // by either must still classify by its first keyword (#1363; the
+        // BigQuery connector strips the same forms plus its dialect-specific
+        // `#`).
+        if let Some(body) = trimmed.strip_prefix("--") {
+            sql = match body.find('\n') {
+                Some(line_end) => &body[line_end + 1..],
+                None => "",
+            };
+            continue;
+        }
+        if let Some(body) = trimmed.strip_prefix("/*") {
+            sql = match body.find("*/") {
+                Some(end) => &body[end + 2..],
+                // Unterminated block comment: nothing classifiable follows.
+                None => "",
+            };
+            continue;
+        }
+        return trimmed;
     }
 }
 
@@ -965,6 +977,19 @@ mod tests {
             ),
             "ddl"
         );
+    }
+
+    #[test]
+    fn test_classify_statement_kind_skips_block_comments() {
+        assert_eq!(
+            classify_statement_kind("/* multi\nline */ SELECT 1"),
+            "query"
+        );
+        assert_eq!(
+            classify_statement_kind("/* a */ -- b\nINSERT INTO t VALUES (1)"),
+            "dml"
+        );
+        assert_eq!(classify_statement_kind("/* unterminated"), "other");
     }
 
     #[test]


### PR DESCRIPTION
Closes #1363 (filed from #1362's review). A statement led by a `/* ... */` block comment classified `other` on the Snowflake and Databricks `statement.execute` spans while the BigQuery matcher (#1362) stripped it — the three adapters' matchers now agree on the shared comment forms (`--` and block; BigQuery's `#` form stays dialect-specific, as documented on its matcher). Unterminated blocks classify `other`, same as BigQuery.

Per-form tests on both connectors (Databricks previously had no classifier tests at all); the block-comment arm is mutation-checked red on Snowflake. Same evidence shape as #1362: the classifier is bound by tests, the span wiring is the pre-existing call sites, unchanged.