### PR TITLE
feat(engine): route the gc apply seam through the CAS ledger session (#1242 PR-1)

### DIFF
--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -1453,7 +1453,7 @@ pub(crate) fn evaluate_apply_policy_with_store(
 /// Given an ALREADY-RESOLVED `[policy]` block, compile the per-model attributes,
 /// or return an early [`PolicyGate`] — `NotConfigured` when there is no policy,
 /// `Allow` when `touched` is empty (a genuine no-op executes nothing).
-fn resolve_policy_and_attrs(
+pub(crate) fn resolve_policy_and_attrs(
     policy: Option<&rocky_core::config::PolicyConfig>,
     touched: &BTreeMap<String, PolicyCapability>,
     models_dir: &Path,
@@ -1494,7 +1494,7 @@ fn resolve_policy_and_attrs(
 /// supplied by the caller so the two variants differ only in how they reach the
 /// ledger (fresh open vs. a held handle).
 #[allow(clippy::too_many_arguments)]
-fn evaluate_apply_policy_core(
+pub(crate) fn evaluate_apply_policy_core(
     policy: &rocky_core::config::PolicyConfig,
     plan_id: &str,
     principal: PolicyPrincipal,

--- a/engine/crates/rocky-cli/src/commands/gc.rs
+++ b/engine/crates/rocky-cli/src/commands/gc.rs
@@ -1518,6 +1518,7 @@ async fn gc_seam_regate(
     principal: rocky_core::config::PolicyPrincipal,
     touched: &BTreeMap<String, PolicyCapability>,
     models_dir: &Path,
+    models_glob: Option<&str>,
     prior_decisions: &[rocky_core::state::PolicyDecisionRecord],
     fresh_store: Option<&StateStore>,
     stage: &str,
@@ -1540,7 +1541,7 @@ async fn gc_seam_regate(
         Some(policy),
         touched,
         models_dir,
-        None,
+        models_glob,
     ) {
         Ok(pair) => pair,
         // The resolver's error IS a gate outcome. Mirror the pre-seam
@@ -1820,6 +1821,7 @@ pub(crate) async fn run_gc_apply_in_with(
         let seam_cfg = loaded_cfg.clone();
         let seam_touched = touched.clone();
         let seam_models_dir = models_dir.clone();
+        let seam_models_glob = models_glob.clone();
         let seam_principal = plan_record.enforcement_principal(runtime_principal);
         let seam_plan = plan.clone();
         let seam_plan_id = plan_id.to_string();
@@ -1829,6 +1831,7 @@ pub(crate) async fn run_gc_apply_in_with(
                 let cfg = seam_cfg.clone();
                 let touched = seam_touched.clone();
                 let models_dir = seam_models_dir.clone();
+                let models_glob = seam_models_glob.clone();
                 let principal = seam_principal;
                 let plan = seam_plan.clone();
                 let plan_id = seam_plan_id.clone();
@@ -1848,6 +1851,7 @@ pub(crate) async fn run_gc_apply_in_with(
                         principal,
                         &touched,
                         &models_dir,
+                        models_glob.as_deref(),
                         &prior_decisions,
                         Some(fresh_store),
                         "during this gc apply",
@@ -1870,6 +1874,7 @@ pub(crate) async fn run_gc_apply_in_with(
                         principal,
                         &touched,
                         &models_dir,
+                        models_glob.as_deref(),
                         &prior_decisions,
                         None,
                         "after eviction, before publish",
@@ -4013,30 +4018,55 @@ auto_create_schemas = true
         eprintln!("seeded demo ledger at {path}");
     }
 
-    /// #1242's exact loss scenario, interleaved for real: the run winner
-    /// commits AFTER the gc seam's first download and BEFORE its publish.
-    /// TWO armed conflicts reject gc's first two CAS puts — three attempts
-    /// by construction, not by racing — and a watcher task keyed on the
-    /// first rejected put (an event, not wall-clock) publishes the winner
-    /// inside the two jittered ~20ms backoffs, so attempt 3's download
-    /// carries it and re-derives on top — the counting oracle pins the
-    /// per-attempt liveness re-reads. The final published blob holds BOTH
-    /// effects. Under the legacy half-seam this schedule silently erased
-    /// the winner (#1228): forcing `seam_cas = false` makes this test fail
-    /// fast on the watcher-fired assertion (the deadline-bounded watcher
-    /// never sees a CAS put).
-    ///
-    /// Determinism: the watcher loses only if its in-memory seed+upload
-    /// (milliseconds) outlasts BOTH backoffs (≥ ~36ms even at minimum
-    /// jitter) — and a lost race fails the tombstone assertion loudly,
-    /// never a false green.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    /// #1242's exact loss scenario, fully sequenced: the run winner commits
+    /// AFTER the gc seam's first download and BEFORE its publish. One armed
+    /// conflict rejects attempt 1; the liveness oracle — which runs INSIDE
+    /// each attempt, between its download and its CAS put — publishes the
+    /// winner on attempt 2's first read, so attempt 2's put loses a GENUINE
+    /// race by construction and attempt 3 re-derives on the winner. Every
+    /// step is ordered by the attempt's own execution: no tasks, no
+    /// deadlines, no scheduler dependence. The final published blob holds
+    /// BOTH effects; the counting pins 2 liveness reads × 3 attempts. Under
+    /// the legacy half-seam this schedule silently erased the winner
+    /// (#1228): forcing `seam_cas = false` leaves the oracle at 2 calls (no
+    /// winner ever injected, no CAS puts), failing the put-count assertion
+    /// fast.
+    #[tokio::test]
     async fn gc_cas_seam_preserves_a_run_writer_landing_mid_seam() {
-        struct CountingOracle(std::sync::atomic::AtomicUsize);
+        struct WinnerInjectingOracle {
+            calls: std::sync::atomic::AtomicUsize,
+            cfg: rocky_core::config::StateConfig,
+            path: std::path::PathBuf,
+        }
         #[async_trait]
-        impl LivenessOracle for CountingOracle {
+        impl LivenessOracle for WinnerInjectingOracle {
             async fn reclaim_verdict(&self, _sp: &str, _fp: &str, _cv: u64) -> ReclaimVerdict {
-                self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                let n = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+                // Calls 1-2 = attempt 1 (pre/post proofs). Call 3 = attempt
+                // 2's first read — after ITS download, before ITS put: the
+                // winner published here makes that put a genuine conflict.
+                if n == 3 {
+                    let _authority = rocky_core::state_sync::download_state(&self.cfg, &self.path)
+                        .await
+                        .unwrap();
+                    {
+                        let store = StateStore::open(&self.path).unwrap();
+                        seed(
+                            &store,
+                            "r-winner",
+                            "winner_model",
+                            "SELECT 2 AS id",
+                            &[],
+                            HB,
+                            700,
+                            Utc::now(),
+                        );
+                        record_run(&store, "r-winner", "winner_model");
+                    }
+                    rocky_core::state_sync::upload_state(&self.cfg, &self.path)
+                        .await
+                        .unwrap();
+                }
                 ReclaimVerdict::Reclaimable { head_version: 0 }
             }
         }
@@ -4067,50 +4097,16 @@ auto_create_schemas = true
             "v{}/state.redb",
             rocky_core::state::current_schema_version()
         );
-        harness.faults.arm_precondition_failures(&object_key, 2);
+        harness.faults.arm_precondition_failures(&object_key, 1);
+        let baseline_updates = harness
+            .faults
+            .put_count(&object_key, rocky_core::fault_store::PutKind::Update);
 
-        // The mid-seam run winner: fires the moment gc's first CAS put is
-        // observed (the first armed conflict), inside the session's two
-        // backoff windows. Deadline-bounded so a code path that never
-        // issues a CAS put (the legacy half-seam) turns this test into a
-        // fast red instead of a hang.
-        let faults = harness.faults.clone();
-        let winner_cfg = harness.pod_a.cfg.clone();
-        let winner_path = harness.pod_a.state_path.clone();
-        let key_for_watcher = object_key.clone();
-        let watcher = tokio::spawn(async move {
-            use rocky_core::fault_store::PutKind;
-            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-            while faults.put_count(&key_for_watcher, PutKind::Update) < 1 {
-                if std::time::Instant::now() > deadline {
-                    return false;
-                }
-                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
-            }
-            let _authority = rocky_core::state_sync::download_state(&winner_cfg, &winner_path)
-                .await
-                .unwrap();
-            {
-                let store = StateStore::open(&winner_path).unwrap();
-                seed(
-                    &store,
-                    "r-winner",
-                    "winner_model",
-                    "SELECT 2 AS id",
-                    &[],
-                    HB,
-                    700,
-                    Utc::now(),
-                );
-                record_run(&store, "r-winner", "winner_model");
-            }
-            rocky_core::state_sync::upload_state(&winner_cfg, &winner_path)
-                .await
-                .unwrap();
-            true
+        let oracle = std::sync::Arc::new(WinnerInjectingOracle {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            cfg: harness.pod_a.cfg.clone(),
+            path: harness.pod_a.state_path.clone(),
         });
-
-        let oracle = std::sync::Arc::new(CountingOracle(std::sync::atomic::AtomicUsize::new(0)));
         let config = write_cas_config(root.path());
         run_gc_apply_in_with(
             root.path(),
@@ -4123,27 +4119,23 @@ auto_create_schemas = true
         )
         .await
         .expect("the replay on the winner must commit");
-        let fired = watcher.await.expect("the winner task must not panic");
-        assert!(
-            fired,
-            "the winner task never saw a CAS put — the seam did not go through the CAS session"
-        );
 
         // 2 oracle reads per attempt (the paired pre/post liveness proofs —
-        // probed empirically at a single attempt) × THREE attempts, forced
-        // by the two armed conflicts. If this fails with 2, the replay
-        // re-published without re-deriving — the #1242 defect; if the
-        // per-attempt read count legitimately changes, update both
-        // constants.
+        // probed empirically at a single attempt) × THREE attempts: armed
+        // conflict, oracle-injected genuine conflict, success. If this
+        // fails with 2, the replay re-published without re-deriving — the
+        // #1242 defect; if the per-attempt read count legitimately changes,
+        // update both constants.
         assert_eq!(
             harness
                 .faults
-                .put_count(&object_key, rocky_core::fault_store::PutKind::Update),
+                .put_count(&object_key, rocky_core::fault_store::PutKind::Update)
+                - baseline_updates,
             3,
-            "two armed conflicts must force exactly three CAS attempts"
+            "armed + injected genuine conflict must force exactly three CAS attempts"
         );
         assert_eq!(
-            oracle.0.load(std::sync::atomic::Ordering::SeqCst),
+            oracle.calls.load(std::sync::atomic::Ordering::SeqCst),
             6,
             "the replay must re-derive on the winner, not re-publish attempt 1's rows"
         );
@@ -4331,6 +4323,7 @@ auto_create_schemas = true
             PolicyPrincipal::Human,
             &touched,
             &models_dir,
+            None,
             &[],
             None,
             "unit",
@@ -4358,6 +4351,7 @@ auto_create_schemas = true
             PolicyPrincipal::Human,
             &touched,
             &models_dir,
+            None,
             std::slice::from_ref(&freeze),
             None,
             "unit",
@@ -4384,6 +4378,7 @@ auto_create_schemas = true
             PolicyPrincipal::Human,
             &touched,
             &models_dir,
+            None,
             &[],
             None,
             "unit",
@@ -4408,6 +4403,7 @@ auto_create_schemas = true
             PolicyPrincipal::Human,
             &touched,
             &models_dir,
+            None,
             &[],
             None,
             "unit",
@@ -4424,6 +4420,7 @@ auto_create_schemas = true
             PolicyPrincipal::Human,
             &touched,
             &models_dir,
+            None,
             &[],
             None,
             "unit",
@@ -4434,13 +4431,54 @@ auto_create_schemas = true
         harness.faults.clear();
     }
 
-    /// Finding 1+3 integration (the review's blocking pair): the mid-seam
-    /// winner carries a LEDGER-ONLY freeze row (no marker anywhere). The
-    /// replay's re-gate must refuse, the command must exit nonzero, and the
-    /// session must restore the winner locally — no ghost tombstone stays
-    /// visible to path-opening readers like `restore plan`.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    /// Finding 1+3 integration (round 1's blocking pair): the mid-seam
+    /// winner carries a LEDGER-ONLY freeze row (no marker anywhere), fully
+    /// sequenced: the oracle publishes the freeze-carrying winner on attempt
+    /// 2's first read (after ITS download, before ITS put), so attempt 2
+    /// loses a genuine race and attempt 3's fresh download carries the
+    /// freeze — its attempt-start re-gate must refuse, the command exits
+    /// nonzero, and the session restores the winner locally: no ghost
+    /// tombstone stays visible to path-opening readers like `restore plan`.
+    #[tokio::test]
     async fn gc_cas_replay_refuses_ledger_freeze_and_restores_winner_locally() {
+        struct FreezeInjectingOracle {
+            calls: std::sync::atomic::AtomicUsize,
+            cfg: rocky_core::config::StateConfig,
+            path: std::path::PathBuf,
+        }
+        #[async_trait]
+        impl LivenessOracle for FreezeInjectingOracle {
+            async fn reclaim_verdict(&self, _sp: &str, _fp: &str, _cv: u64) -> ReclaimVerdict {
+                let n = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+                if n == 3 {
+                    let _authority = rocky_core::state_sync::download_state(&self.cfg, &self.path)
+                        .await
+                        .unwrap();
+                    {
+                        let store = StateStore::open(&self.path).unwrap();
+                        store
+                            .record_policy_decision(&rocky_core::state::PolicyDecisionRecord {
+                                timestamp: Utc::now(),
+                                plan_id: "freeze:mid-seam".to_string(),
+                                principal: PolicyPrincipal::Human,
+                                capability: PolicyCapability::Apply,
+                                model: "any".to_string(),
+                                effect: rocky_core::config::PolicyEffect::Deny,
+                                rule_id: None,
+                                reason: "kill switch engaged mid-seam".to_string(),
+                                verify_after: Vec::new(),
+                                auto_apply: None,
+                            })
+                            .unwrap();
+                    }
+                    rocky_core::state_sync::upload_state(&self.cfg, &self.path)
+                        .await
+                        .unwrap();
+                }
+                ReclaimVerdict::Reclaimable { head_version: 0 }
+            }
+        }
+
         let _serial = rocky_core::state_sync::remote_testing::serial_guard();
         let harness = rocky_core::test_harness::CrossPodHarness::new_s3_like();
         let root = TempDir::new().unwrap();
@@ -4467,46 +4505,11 @@ auto_create_schemas = true
         );
         harness.faults.arm_precondition_failures(&object_key, 1);
 
-        // Mid-seam winner: publishes a LEDGER freeze row (Human, scope any).
-        let faults = harness.faults.clone();
-        let winner_cfg = harness.pod_a.cfg.clone();
-        let winner_path = harness.pod_a.state_path.clone();
-        let key_for_watcher = object_key.clone();
-        let watcher = tokio::spawn(async move {
-            use rocky_core::fault_store::PutKind;
-            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-            while faults.put_count(&key_for_watcher, PutKind::Update) < 1 {
-                if std::time::Instant::now() > deadline {
-                    return false;
-                }
-                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
-            }
-            let _authority = rocky_core::state_sync::download_state(&winner_cfg, &winner_path)
-                .await
-                .unwrap();
-            {
-                let store = StateStore::open(&winner_path).unwrap();
-                store
-                    .record_policy_decision(&rocky_core::state::PolicyDecisionRecord {
-                        timestamp: Utc::now(),
-                        plan_id: "freeze:mid-seam".to_string(),
-                        principal: PolicyPrincipal::Human,
-                        capability: PolicyCapability::Apply,
-                        model: "any".to_string(),
-                        effect: rocky_core::config::PolicyEffect::Deny,
-                        rule_id: None,
-                        reason: "kill switch engaged mid-seam".to_string(),
-                        verify_after: Vec::new(),
-                        auto_apply: None,
-                    })
-                    .unwrap();
-            }
-            rocky_core::state_sync::upload_state(&winner_cfg, &winner_path)
-                .await
-                .unwrap();
-            true
+        let oracle = std::sync::Arc::new(FreezeInjectingOracle {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            cfg: harness.pod_a.cfg.clone(),
+            path: harness.pod_a.state_path.clone(),
         });
-
         let config = write_cas_policy_config(root.path());
         let err = run_gc_apply_in_with(
             root.path(),
@@ -4515,13 +4518,18 @@ auto_create_schemas = true
             &harness.pod_b.state_path,
             PolicyPrincipal::Human,
             true,
-            std::sync::Arc::new(FixedLivenessOracle::reclaimable()),
+            oracle.clone(),
         )
         .await
         .expect_err("the replay must refuse under the winner's ledger freeze");
         assert!(format!("{err:#}").contains("DENIES"), "got: {err:#}");
-        let fired = watcher.await.expect("the winner task must not panic");
-        assert!(fired, "the freeze writer never saw a CAS put");
+        // Attempt 3 is denied at its START gate, before any oracle read:
+        // exactly 2 attempts consulted the oracle.
+        assert_eq!(
+            oracle.calls.load(std::sync::atomic::Ordering::SeqCst),
+            4,
+            "attempts 1-2 read the oracle; the denied attempt 3 must not"
+        );
 
         // Ghost-state check: the LOCAL file must be the restored winner —
         // freeze row present, NO tombstone from the refused attempt.
@@ -4540,6 +4548,106 @@ auto_create_schemas = true
         );
 
         // And remote is untouched by the refused seam: no tombstones there.
+        let _authority =
+            rocky_core::state_sync::download_state(&harness.pod_a.cfg, &harness.pod_a.state_path)
+                .await
+                .unwrap();
+        let published = StateStore::open(&harness.pod_a.state_path).unwrap();
+        assert!(published.list_tombstones().unwrap().is_empty());
+    }
+
+    /// The restore-failure contract: when the winner CANNOT be re-downloaded
+    /// after a refused post-mutation attempt, the local file is QUARANTINED
+    /// aside — a path-opening reader sees absence, never ghost tombstones.
+    /// Fully sequenced: the oracle writes the denying marker AND arms a
+    /// total GET outage before returning, so the pre-publish re-gate refuses
+    /// fail-closed and the session's restore download fails.
+    #[tokio::test]
+    async fn gc_cas_quarantines_local_state_when_winner_restore_fails() {
+        struct OutageOracle {
+            provider: rocky_core::object_store::ObjectStoreProvider,
+            faults: rocky_core::fault_store::FaultHandle,
+            wrote: std::sync::atomic::AtomicBool,
+        }
+        #[async_trait]
+        impl LivenessOracle for OutageOracle {
+            async fn reclaim_verdict(&self, _sp: &str, _fp: &str, _cv: u64) -> ReclaimVerdict {
+                if !self.wrote.swap(true, std::sync::atomic::Ordering::SeqCst) {
+                    rocky_core::freeze_marker::write_freeze_marker(
+                        &self.provider,
+                        &rocky_core::freeze_marker::FreezeMarker {
+                            freeze_id: "mid-transition-outage".to_string(),
+                            principal: PolicyPrincipal::Human,
+                            scope: "any".to_string(),
+                            reason: "freeze + backend outage".to_string(),
+                            created_at: Utc::now(),
+                        },
+                    )
+                    .await
+                    .unwrap();
+                    self.faults.arm(
+                        rocky_core::fault_store::FaultOp::Get,
+                        rocky_core::fault_store::FaultMode::FailAll,
+                    );
+                }
+                ReclaimVerdict::Reclaimable { head_version: 0 }
+            }
+        }
+
+        let _serial = rocky_core::state_sync::remote_testing::serial_guard();
+        let harness = rocky_core::test_harness::CrossPodHarness::new_s3_like();
+        let root = TempDir::new().unwrap();
+
+        let plan_id = {
+            let store = StateStore::open(&harness.pod_b.state_path).unwrap();
+            let old = Utc::now() - Duration::days(30);
+            seed(&store, "r1", "orders", "SELECT 1 AS id", &[], HA, 500, old);
+            record_run(&store, "r1", "orders");
+            let plan = plan_from_store(&store, Utc::now(), 7);
+            write_plan_with_principal(root.path(), PlanKind::Gc, &plan, PolicyPrincipal::Human)
+                .unwrap()
+        };
+        let marker = crate::commands::apply::review_marker_path(root.path(), &plan_id);
+        std::fs::create_dir_all(marker.parent().unwrap()).unwrap();
+        std::fs::write(&marker, "{}").unwrap();
+        rocky_core::state_sync::upload_state(&harness.pod_b.cfg, &harness.pod_b.state_path)
+            .await
+            .unwrap();
+
+        let config = write_cas_policy_config(root.path());
+        let err = run_gc_apply_in_with(
+            root.path(),
+            &config,
+            &plan_id,
+            &harness.pod_b.state_path,
+            PolicyPrincipal::Human,
+            true,
+            std::sync::Arc::new(OutageOracle {
+                provider: harness.provider.clone(),
+                faults: harness.faults.clone(),
+                wrote: std::sync::atomic::AtomicBool::new(false),
+            }),
+        )
+        .await
+        .expect_err("the outage must refuse the seam");
+        harness.faults.clear();
+
+        // The quarantine contract: the state file is gone (readers see
+        // absence, not ghosts) and the quarantined copy sits beside it.
+        assert!(
+            !harness.pod_b.state_path.exists(),
+            "the unpublishable local file must be quarantined aside: {err:#}"
+        );
+        let parent = harness.pod_b.state_path.parent().unwrap();
+        let quarantined: Vec<_> = std::fs::read_dir(parent)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().contains("unpublished"))
+            .collect();
+        assert_eq!(quarantined.len(), 1, "exactly one quarantined copy");
+
+        // Remote untouched (the GET outage blocks reads, not this check —
+        // faults were cleared above).
         let _authority =
             rocky_core::state_sync::download_state(&harness.pod_a.cfg, &harness.pod_a.state_path)
                 .await

--- a/engine/crates/rocky-cli/src/commands/gc.rs
+++ b/engine/crates/rocky-cli/src/commands/gc.rs
@@ -4641,7 +4641,7 @@ auto_create_schemas = true
         let parent = harness.pod_b.state_path.parent().unwrap();
         let quarantined: Vec<_> = std::fs::read_dir(parent)
             .unwrap()
-            .filter_map(|e| e.ok())
+            .filter_map(std::result::Result::ok)
             .filter(|e| e.file_name().to_string_lossy().contains("unpublished"))
             .collect();
         assert_eq!(quarantined.len(), 1, "exactly one quarantined copy");

--- a/engine/crates/rocky-cli/src/commands/gc.rs
+++ b/engine/crates/rocky-cli/src/commands/gc.rs
@@ -4015,19 +4015,21 @@ auto_create_schemas = true
 
     /// #1242's exact loss scenario, interleaved for real: the run winner
     /// commits AFTER the gc seam's first download and BEFORE its publish.
-    /// One armed conflict rejects gc's first CAS put; a watcher task keyed on
-    /// that put count (an event, not wall-clock) then publishes the winner,
-    /// so the seam's replay downloads it and re-derives on top — the counting
-    /// oracle pins the per-attempt liveness re-reads. The final published
-    /// blob holds BOTH effects. Under the legacy half-seam this exact
-    /// schedule silently erased the winner (#1228): forcing
-    /// `seam_cas = false` makes this test fail fast on the watcher-fired
-    /// assertion (the deadline-bounded watcher never sees a CAS put).
+    /// TWO armed conflicts reject gc's first two CAS puts — three attempts
+    /// by construction, not by racing — and a watcher task keyed on the
+    /// first rejected put (an event, not wall-clock) publishes the winner
+    /// inside the two jittered ~20ms backoffs, so attempt 3's download
+    /// carries it and re-derives on top — the counting oracle pins the
+    /// per-attempt liveness re-reads. The final published blob holds BOTH
+    /// effects. Under the legacy half-seam this schedule silently erased
+    /// the winner (#1228): forcing `seam_cas = false` makes this test fail
+    /// fast on the watcher-fired assertion (the deadline-bounded watcher
+    /// never sees a CAS put).
     ///
     /// Determinism: the watcher loses only if its in-memory seed+upload
-    /// (microseconds) outlasts the session's jittered ~20ms (18–22ms)
-    /// conflict backoff — and a lost race fails the tombstone assertion
-    /// loudly, never a false green.
+    /// (milliseconds) outlasts BOTH backoffs (≥ ~36ms even at minimum
+    /// jitter) — and a lost race fails the tombstone assertion loudly,
+    /// never a false green.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn gc_cas_seam_preserves_a_run_writer_landing_mid_seam() {
         struct CountingOracle(std::sync::atomic::AtomicUsize);
@@ -4065,13 +4067,13 @@ auto_create_schemas = true
             "v{}/state.redb",
             rocky_core::state::current_schema_version()
         );
-        harness.faults.arm_precondition_failures(&object_key, 1);
+        harness.faults.arm_precondition_failures(&object_key, 2);
 
         // The mid-seam run winner: fires the moment gc's first CAS put is
-        // observed (the armed conflict), inside the session's backoff window.
-        // Deadline-bounded so a code path that never issues a CAS put (the
-        // legacy half-seam) turns this test into a fast red instead of a
-        // hang.
+        // observed (the first armed conflict), inside the session's two
+        // backoff windows. Deadline-bounded so a code path that never
+        // issues a CAS put (the legacy half-seam) turns this test into a
+        // fast red instead of a hang.
         let faults = harness.faults.clone();
         let winner_cfg = harness.pod_a.cfg.clone();
         let winner_path = harness.pod_a.state_path.clone();
@@ -4128,19 +4130,17 @@ auto_create_schemas = true
         );
 
         // 2 oracle reads per attempt (the paired pre/post liveness proofs —
-        // probed empirically at a single attempt) × THREE attempts: the armed
-        // conflict rejects attempt 1; the winner's upload lands inside
-        // attempt 2's window, so its CAS put loses a GENUINE race; attempt 3
-        // replays on the winner and commits. The schedule exercises both
-        // conflict kinds. If this fails with 2, the replay re-published
-        // without re-deriving — the #1242 defect; if the per-attempt read
-        // count legitimately changes, update both constants.
+        // probed empirically at a single attempt) × THREE attempts, forced
+        // by the two armed conflicts. If this fails with 2, the replay
+        // re-published without re-deriving — the #1242 defect; if the
+        // per-attempt read count legitimately changes, update both
+        // constants.
         assert_eq!(
             harness
                 .faults
                 .put_count(&object_key, rocky_core::fault_store::PutKind::Update),
             3,
-            "armed + genuine conflict must force exactly three CAS attempts"
+            "two armed conflicts must force exactly three CAS attempts"
         );
         assert_eq!(
             oracle.0.load(std::sync::atomic::Ordering::SeqCst),

--- a/engine/crates/rocky-cli/src/commands/gc.rs
+++ b/engine/crates/rocky-cli/src/commands/gc.rs
@@ -1493,6 +1493,45 @@ pub(crate) fn gc_models_dir(
 /// Once cleared, [`execute_gc_apply`] re-verifies each planned eviction against
 /// the live ledger before evicting anything (tombstone + retired ledger row;
 /// no physical byte deletion follows).
+/// Per-attempt freeze-marker fence for the gc CAS seam (#1242).
+///
+/// Markers live under their own object keys, so the blob CAS cannot detect
+/// one landing mid-seam. The pre-gate LIST fed the policy gate its marker
+/// set; this fence re-LISTs on every seam attempt (and again right before
+/// publish) and REFUSES on any marker absent from that already-gated set —
+/// over-enforcement is the monotone-safe direction, and refusing avoids
+/// re-running the full gate against a store the session already holds open.
+/// A LIST failure refuses too (fail-closed), matching the pre-gate LIST.
+async fn gc_seam_marker_fence(
+    cfg: Option<&rocky_core::config::RockyConfig>,
+    touched: &BTreeMap<String, PolicyCapability>,
+    gated_marker_ids: &std::collections::BTreeSet<String>,
+    stage: &str,
+) -> Result<(), rocky_core::state_sync::StateSyncError> {
+    let Some(cfg) = cfg else {
+        return Ok(());
+    };
+    let fresh = crate::commands::apply::marker_freezes_before_gate(cfg, touched)
+        .await
+        .map_err(|e| {
+            rocky_core::state_sync::StateSyncError::SeamTransition(format!(
+                "freeze-marker fence LIST failed {stage} (fail-closed): {e:#}"
+            ))
+        })?;
+    if let Some(new) = fresh
+        .iter()
+        .find(|m| !gated_marker_ids.contains(&m.freeze_id))
+    {
+        return Err(rocky_core::state_sync::StateSyncError::SeamTransition(
+            format!(
+                "durable freeze marker '{}' (scope '{}') landed {stage}; refusing to publish                  this gc apply — re-run `rocky apply` so the policy gate evaluates it",
+                new.freeze_id, new.scope
+            ),
+        ));
+    }
+    Ok(())
+}
+
 pub(crate) async fn run_gc_apply_in(
     root: &Path,
     config_path: &Path,
@@ -1512,7 +1551,7 @@ pub(crate) async fn run_gc_apply_in(
         state_path,
         runtime_principal,
         json,
-        &ManifestLivenessOracle,
+        std::sync::Arc::new(ManifestLivenessOracle),
     )
     .await
 }
@@ -1526,7 +1565,7 @@ pub(crate) async fn run_gc_apply_in_with(
     state_path: &Path,
     runtime_principal: rocky_core::config::PolicyPrincipal,
     json: bool,
-    oracle: &dyn LivenessOracle,
+    oracle: std::sync::Arc<dyn LivenessOracle>,
 ) -> Result<()> {
     let plan_record =
         read_plan(root, plan_id).with_context(|| format!("failed to read gc plan '{plan_id}'"))?;
@@ -1700,27 +1739,92 @@ pub(crate) async fn run_gc_apply_in_with(
         );
     }
 
-    let store = StateStore::open(state_path)
-        .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
-    let output = execute_gc_apply(&store, oracle, plan_id, &plan, Utc::now()).await?;
-    // Drop the store to release the advisory lock / flush the file before upload.
-    drop(store);
+    let seam_cas = remote_state && rocky_core::state_sync::cas_effective(&state_cfg);
+    let output = if seam_cas {
+        // CAS ledger seam (#1242; ADR-CONCURRENCY D1 seam class = RETRY): the
+        // whole transition replays per attempt against the freshly downloaded
+        // winner. `execute_gc_apply` re-derives candidates, refcounts, and
+        // both liveness reads from that fresh store — a winner that re-added
+        // the Delta path legitimately flips this attempt's eviction into a
+        // refusal — and the freeze-marker fence runs at attempt start AND
+        // again after the transition, so the unfenced window shrinks to the
+        // CAS upload itself. gc's mutations are redb rows inside the blob
+        // being CAS-published (`physical_delete = true` was refused above),
+        // so no per-candidate side effect outlives a discarded attempt.
+        let gated_marker_ids: std::collections::BTreeSet<String> =
+            marker_freezes.iter().map(|m| m.freeze_id.clone()).collect();
+        let session = rocky_core::state_sync::LedgerSeamSession::new(&state_cfg, state_path);
+        // The attempt future must OWN everything it touches (the session's
+        // `for<'a>` bound): master copies move into the closure, and each
+        // attempt clones what its future needs.
+        let seam_cfg = loaded_cfg.clone();
+        let seam_touched = touched.clone();
+        let seam_plan = plan.clone();
+        let seam_plan_id = plan_id.to_string();
+        let seam_oracle = std::sync::Arc::clone(&oracle);
+        session
+            .execute(move |fresh_store, _fresh_base| {
+                let cfg = seam_cfg.clone();
+                let touched = seam_touched.clone();
+                let gated = gated_marker_ids.clone();
+                let plan = seam_plan.clone();
+                let plan_id = seam_plan_id.clone();
+                let oracle = std::sync::Arc::clone(&seam_oracle);
+                Box::pin(async move {
+                    gc_seam_marker_fence(cfg.as_ref(), &touched, &gated, "during this gc apply")
+                        .await?;
+                    let out = execute_gc_apply(
+                        fresh_store,
+                        oracle.as_ref(),
+                        &plan_id,
+                        &plan,
+                        Utc::now(),
+                    )
+                    .await
+                    .map_err(|e| {
+                        rocky_core::state_sync::StateSyncError::SeamTransition(format!("{e:#}"))
+                    })?;
+                    gc_seam_marker_fence(
+                        cfg.as_ref(),
+                        &touched,
+                        &gated,
+                        "after eviction, before publish",
+                    )
+                    .await?;
+                    Ok(out)
+                })
+            })
+            .await
+            .with_context(|| {
+                format!("failed to commit gc apply '{plan_id}' to shared remote state")
+            })?
+    } else {
+        let store = StateStore::open(state_path)
+            .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
+        let output =
+            execute_gc_apply(&store, oracle.as_ref(), plan_id, &plan, Utc::now()).await?;
+        // Drop the store to release the advisory lock / flush the file before upload.
+        drop(store);
 
-    // SEAM-SCOPED SYNC — upload half, FAIL-CLOSED. Durability is the whole point
-    // of the seam: an eviction that commits locally but never reaches the remote
-    // would be silently reverted by the next run's start-download while this
-    // command reported success. So the upload is forced to `Fail` regardless of
-    // the configured `on_upload_failure` (default `skip`) — a failed upload
-    // aborts (finding 5).
-    if remote_state {
-        // WP-01 PR-B (2b): the half-seam owns the forced-`Fail` durability
-        // policy (previously a local `StateConfig` clone here).
-        rocky_core::state_sync::RemoteStateSession::upload_only_fail_closed(
-            &state_cfg, state_path, "gc apply",
-        )
-        .await
-        .with_context(|| "failed to upload remote state after gc apply")?;
-    }
+        // SEAM-SCOPED SYNC — upload half, FAIL-CLOSED. Durability is the whole
+        // point of the seam: an eviction that commits locally but never reaches
+        // the remote would be silently reverted by the next run's start-download
+        // while this command reported success. So the upload is forced to `Fail`
+        // regardless of the configured `on_upload_failure` (default `skip`) — a
+        // failed upload aborts (finding 5). Without effective CAS this remains
+        // the legacy last-writer-wins half-seam (#1228's residual exposure —
+        // keep one writer per `[state]` prefix).
+        if remote_state {
+            // WP-01 PR-B (2b): the half-seam owns the forced-`Fail` durability
+            // policy (previously a local `StateConfig` clone here).
+            rocky_core::state_sync::RemoteStateSession::upload_only_fail_closed(
+                &state_cfg, state_path, "gc apply",
+            )
+            .await
+            .with_context(|| "failed to upload remote state after gc apply")?;
+        }
+        output
+    };
 
     if json {
         println!("{}", serde_json::to_string_pretty(&output)?);
@@ -2793,7 +2897,8 @@ auto_create_schemas = true
         // review/policy gate + eviction wiring are exercised without a live
         // Delta log (the real `ManifestLivenessOracle` would hold everything
         // creds-free — correct, but it would mask the review-gate assertion).
-        let oracle = FixedLivenessOracle::reclaimable();
+        let oracle: std::sync::Arc<dyn LivenessOracle> =
+            std::sync::Arc::new(FixedLivenessOracle::reclaimable());
 
         // No marker → refuse.
         let err = run_gc_apply_in_with(
@@ -2803,7 +2908,7 @@ auto_create_schemas = true
             &state_path,
             PolicyPrincipal::Human,
             true,
-            &oracle,
+            oracle.clone(),
         )
         .await
         .expect_err("apply must refuse an unreviewed gc plan");
@@ -2827,7 +2932,7 @@ auto_create_schemas = true
             &state_path,
             PolicyPrincipal::Human,
             true,
-            &oracle,
+            oracle.clone(),
         )
         .await
         .unwrap();
@@ -2868,7 +2973,8 @@ auto_create_schemas = true
         std::fs::create_dir_all(marker.parent().unwrap()).unwrap();
         std::fs::write(&marker, "{}").unwrap();
 
-        let oracle = FixedLivenessOracle::reclaimable();
+        let oracle: std::sync::Arc<dyn LivenessOracle> =
+            std::sync::Arc::new(FixedLivenessOracle::reclaimable());
         let err = run_gc_apply_in_with(
             dir.path(),
             &config,
@@ -2876,7 +2982,7 @@ auto_create_schemas = true
             &state_path,
             PolicyPrincipal::Human,
             true,
-            &oracle,
+            oracle.clone(),
         )
         .await
         .expect_err("a remote-backend gc apply must abort when the state backend is unreachable");

--- a/engine/crates/rocky-cli/src/commands/gc.rs
+++ b/engine/crates/rocky-cli/src/commands/gc.rs
@@ -3926,13 +3926,31 @@ auto_create_schemas = true
         eprintln!("seeded demo ledger at {path}");
     }
 
-    /// #1242 seam semantics: a run writer commits to remote BEFORE the gc
-    /// seam publishes. The seam's fresh download carries the winner's rows,
-    /// `execute_gc_apply` re-derives on top of them, and the published blob
-    /// holds BOTH effects — the winner's artifact survives, the candidate is
-    /// tombstoned. (The legacy half-seam erased the winner here: #1228.)
-    #[tokio::test]
-    async fn gc_cas_seam_preserves_a_run_writer_committed_before_publish() {
+    /// #1242's exact loss scenario, interleaved for real: the run winner
+    /// commits AFTER the gc seam's first download and BEFORE its publish.
+    /// One armed conflict rejects gc's first CAS put; a watcher task keyed on
+    /// that put count (an event, not wall-clock) then publishes the winner,
+    /// so the seam's replay downloads it and re-derives on top — the counting
+    /// oracle pins the per-attempt liveness re-reads. The final published
+    /// blob holds BOTH effects. Under the legacy half-seam this exact
+    /// schedule silently erased the winner (#1228): forcing
+    /// `seam_cas = false` makes this test fail fast on the watcher-fired
+    /// assertion (the deadline-bounded watcher never sees a CAS put).
+    ///
+    /// Determinism: the watcher loses only if its in-memory seed+upload
+    /// (microseconds) outlasts the session's ≥20ms conflict backoff — and a
+    /// lost race fails the tombstone assertion loudly, never a false green.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn gc_cas_seam_preserves_a_run_writer_landing_mid_seam() {
+        struct CountingOracle(std::sync::atomic::AtomicUsize);
+        #[async_trait]
+        impl LivenessOracle for CountingOracle {
+            async fn reclaim_verdict(&self, _sp: &str, _fp: &str, _cv: u64) -> ReclaimVerdict {
+                self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                ReclaimVerdict::Reclaimable { head_version: 0 }
+            }
+        }
+
         let _serial = rocky_core::state_sync::remote_testing::serial_guard();
         let harness = rocky_core::test_harness::CrossPodHarness::new_s3_like();
         let root = TempDir::new().unwrap();
@@ -3955,30 +3973,54 @@ auto_create_schemas = true
             .await
             .unwrap();
 
-        // The run winner: fresh download on pod_a, adds its own artifact, and
-        // publishes a NEWER generation before the gc seam runs.
-        let _authority =
-            rocky_core::state_sync::download_state(&harness.pod_a.cfg, &harness.pod_a.state_path)
+        let object_key = format!(
+            "v{}/state.redb",
+            rocky_core::state::current_schema_version()
+        );
+        harness.faults.arm_precondition_failures(&object_key, 1);
+
+        // The mid-seam run winner: fires the moment gc's first CAS put is
+        // observed (the armed conflict), inside the session's backoff window.
+        // Deadline-bounded so a code path that never issues a CAS put (the
+        // legacy half-seam) turns this test into a fast red instead of a
+        // hang.
+        let faults = harness.faults.clone();
+        let winner_cfg = harness.pod_a.cfg.clone();
+        let winner_path = harness.pod_a.state_path.clone();
+        let key_for_watcher = object_key.clone();
+        let watcher = tokio::spawn(async move {
+            use rocky_core::fault_store::PutKind;
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            while faults.put_count(&key_for_watcher, PutKind::Update) < 1 {
+                if std::time::Instant::now() > deadline {
+                    return false;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            }
+            let _authority = rocky_core::state_sync::download_state(&winner_cfg, &winner_path)
                 .await
                 .unwrap();
-        {
-            let store = StateStore::open(&harness.pod_a.state_path).unwrap();
-            seed(
-                &store,
-                "r-winner",
-                "winner_model",
-                "SELECT 2 AS id",
-                &[],
-                HB,
-                700,
-                Utc::now(),
-            );
-            record_run(&store, "r-winner", "winner_model");
-        }
-        rocky_core::state_sync::upload_state(&harness.pod_a.cfg, &harness.pod_a.state_path)
-            .await
-            .unwrap();
+            {
+                let store = StateStore::open(&winner_path).unwrap();
+                seed(
+                    &store,
+                    "r-winner",
+                    "winner_model",
+                    "SELECT 2 AS id",
+                    &[],
+                    HB,
+                    700,
+                    Utc::now(),
+                );
+                record_run(&store, "r-winner", "winner_model");
+            }
+            rocky_core::state_sync::upload_state(&winner_cfg, &winner_path)
+                .await
+                .unwrap();
+            true
+        });
 
+        let oracle = std::sync::Arc::new(CountingOracle(std::sync::atomic::AtomicUsize::new(0)));
         let config = write_cas_config(root.path());
         run_gc_apply_in_with(
             root.path(),
@@ -3987,12 +4029,29 @@ auto_create_schemas = true
             &harness.pod_b.state_path,
             PolicyPrincipal::Human,
             true,
-            std::sync::Arc::new(FixedLivenessOracle::reclaimable()),
+            oracle.clone(),
         )
         .await
-        .expect("gc seam must commit on top of the winner");
+        .expect("the replay on the winner must commit");
+        let fired = watcher.await.expect("the winner task must not panic");
+        assert!(
+            fired,
+            "the winner task never saw a CAS put — the seam did not go through the CAS session"
+        );
 
-        // Read back the PUBLISHED blob (pod_a re-download), not local files.
+        // 3 oracle reads per attempt today (eligibility re-derivation plus
+        // the paired pre/post liveness proofs) × 2 attempts. The invariant
+        // pinned is PER-ATTEMPT re-reads — if execute_gc_apply's read count
+        // legitimately changes, update the constant; if this fails with the
+        // single-attempt count (3), the replay re-published without
+        // re-deriving, which is the #1242 defect.
+        assert_eq!(
+            oracle.0.load(std::sync::atomic::Ordering::SeqCst),
+            6,
+            "the replay must re-derive on the winner, not re-publish attempt 1's rows"
+        );
+
+        // Read back the PUBLISHED blob (fresh pod_a download), not local files.
         let _authority =
             rocky_core::state_sync::download_state(&harness.pod_a.cfg, &harness.pod_a.state_path)
                 .await
@@ -4004,7 +4063,7 @@ auto_create_schemas = true
         assert_eq!(
             published.refcount_for_hash(HB).unwrap(),
             1,
-            "the run winner's artifact must survive the gc publish (#1228)"
+            "the mid-seam run winner's artifact must survive the gc publish (#1228)"
         );
     }
 

--- a/engine/crates/rocky-cli/src/commands/gc.rs
+++ b/engine/crates/rocky-cli/src/commands/gc.rs
@@ -4548,6 +4548,97 @@ auto_create_schemas = true
         assert!(published.list_tombstones().unwrap().is_empty());
     }
 
+    /// Binds the session's restore-the-winner-on-terminal-failure arm: the
+    /// freeze marker lands MID-TRANSITION (written by the liveness oracle
+    /// itself, which runs between the attempt-start gate and the pre-publish
+    /// recheck — deterministic, no timing). The recheck denies AFTER the
+    /// eviction mutated the attempt's local store, so without the restore
+    /// the refused tombstone stays visible to path-opening readers
+    /// (`restore plan` would plan from a ghost eviction).
+    #[tokio::test]
+    async fn gc_cas_post_eviction_marker_denies_and_rolls_back_local() {
+        struct MarkerWritingOracle {
+            provider: rocky_core::object_store::ObjectStoreProvider,
+            wrote: std::sync::atomic::AtomicBool,
+        }
+        #[async_trait]
+        impl LivenessOracle for MarkerWritingOracle {
+            async fn reclaim_verdict(&self, _sp: &str, _fp: &str, _cv: u64) -> ReclaimVerdict {
+                if !self.wrote.swap(true, std::sync::atomic::Ordering::SeqCst) {
+                    rocky_core::freeze_marker::write_freeze_marker(
+                        &self.provider,
+                        &rocky_core::freeze_marker::FreezeMarker {
+                            freeze_id: "mid-transition".to_string(),
+                            principal: PolicyPrincipal::Human,
+                            scope: "any".to_string(),
+                            reason: "landed during eviction".to_string(),
+                            created_at: Utc::now(),
+                        },
+                    )
+                    .await
+                    .unwrap();
+                }
+                ReclaimVerdict::Reclaimable { head_version: 0 }
+            }
+        }
+
+        let _serial = rocky_core::state_sync::remote_testing::serial_guard();
+        let harness = rocky_core::test_harness::CrossPodHarness::new_s3_like();
+        let root = TempDir::new().unwrap();
+
+        let plan_id = {
+            let store = StateStore::open(&harness.pod_b.state_path).unwrap();
+            let old = Utc::now() - Duration::days(30);
+            seed(&store, "r1", "orders", "SELECT 1 AS id", &[], HA, 500, old);
+            record_run(&store, "r1", "orders");
+            let plan = plan_from_store(&store, Utc::now(), 7);
+            write_plan_with_principal(root.path(), PlanKind::Gc, &plan, PolicyPrincipal::Human)
+                .unwrap()
+        };
+        let marker = crate::commands::apply::review_marker_path(root.path(), &plan_id);
+        std::fs::create_dir_all(marker.parent().unwrap()).unwrap();
+        std::fs::write(&marker, "{}").unwrap();
+        rocky_core::state_sync::upload_state(&harness.pod_b.cfg, &harness.pod_b.state_path)
+            .await
+            .unwrap();
+
+        let config = write_cas_policy_config(root.path());
+        let err = run_gc_apply_in_with(
+            root.path(),
+            &config,
+            &plan_id,
+            &harness.pod_b.state_path,
+            PolicyPrincipal::Human,
+            true,
+            std::sync::Arc::new(MarkerWritingOracle {
+                provider: harness.provider.clone(),
+                wrote: std::sync::atomic::AtomicBool::new(false),
+            }),
+        )
+        .await
+        .expect_err("the pre-publish recheck must refuse the mid-transition freeze");
+        assert!(
+            format!("{err:#}").contains("after eviction, before publish"),
+            "the deny must come from the PRE-PUBLISH recheck, not attempt start: {err:#}"
+        );
+
+        // The refused attempt HAD evicted locally; the session must have
+        // restored the winner — no ghost tombstone for path-opening readers.
+        let local = StateStore::open(&harness.pod_b.state_path).unwrap();
+        assert!(
+            local.list_tombstones().unwrap().is_empty(),
+            "a refused post-eviction attempt must not leave a local ghost tombstone"
+        );
+
+        // Remote untouched.
+        let _authority =
+            rocky_core::state_sync::download_state(&harness.pod_a.cfg, &harness.pod_a.state_path)
+                .await
+                .unwrap();
+        let published = StateStore::open(&harness.pod_a.state_path).unwrap();
+        assert!(published.list_tombstones().unwrap().is_empty());
+    }
+
     fn write_cas_policy_config(root: &Path) -> std::path::PathBuf {
         let path = root.join("rocky.toml");
         std::fs::write(

--- a/engine/crates/rocky-cli/src/commands/gc.rs
+++ b/engine/crates/rocky-cli/src/commands/gc.rs
@@ -1773,17 +1773,14 @@ pub(crate) async fn run_gc_apply_in_with(
                 Box::pin(async move {
                     gc_seam_marker_fence(cfg.as_ref(), &touched, &gated, "during this gc apply")
                         .await?;
-                    let out = execute_gc_apply(
-                        fresh_store,
-                        oracle.as_ref(),
-                        &plan_id,
-                        &plan,
-                        Utc::now(),
-                    )
-                    .await
-                    .map_err(|e| {
-                        rocky_core::state_sync::StateSyncError::SeamTransition(format!("{e:#}"))
-                    })?;
+                    let out =
+                        execute_gc_apply(fresh_store, oracle.as_ref(), &plan_id, &plan, Utc::now())
+                            .await
+                            .map_err(|e| {
+                                rocky_core::state_sync::StateSyncError::SeamTransition(format!(
+                                    "{e:#}"
+                                ))
+                            })?;
                     gc_seam_marker_fence(
                         cfg.as_ref(),
                         &touched,
@@ -1801,8 +1798,7 @@ pub(crate) async fn run_gc_apply_in_with(
     } else {
         let store = StateStore::open(state_path)
             .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
-        let output =
-            execute_gc_apply(&store, oracle.as_ref(), plan_id, &plan, Utc::now()).await?;
+        let output = execute_gc_apply(&store, oracle.as_ref(), plan_id, &plan, Utc::now()).await?;
         // Drop the store to release the advisory lock / flush the file before upload.
         drop(store);
 
@@ -3928,5 +3924,245 @@ auto_create_schemas = true
         record_run(&store, "run-04", "fct_orders");
 
         eprintln!("seeded demo ledger at {path}");
+    }
+
+    /// #1242 seam semantics: a run writer commits to remote BEFORE the gc
+    /// seam publishes. The seam's fresh download carries the winner's rows,
+    /// `execute_gc_apply` re-derives on top of them, and the published blob
+    /// holds BOTH effects — the winner's artifact survives, the candidate is
+    /// tombstoned. (The legacy half-seam erased the winner here: #1228.)
+    #[tokio::test]
+    async fn gc_cas_seam_preserves_a_run_writer_committed_before_publish() {
+        let _serial = rocky_core::state_sync::remote_testing::serial_guard();
+        let harness = rocky_core::test_harness::CrossPodHarness::new_s3_like();
+        let root = TempDir::new().unwrap();
+
+        let plan_id = {
+            let store = StateStore::open(&harness.pod_b.state_path).unwrap();
+            let old = Utc::now() - Duration::days(30);
+            seed(&store, "r1", "orders", "SELECT 1 AS id", &[], HA, 500, old);
+            record_run(&store, "r1", "orders");
+            let plan = plan_from_store(&store, Utc::now(), 7);
+            write_plan_with_principal(root.path(), PlanKind::Gc, &plan, PolicyPrincipal::Human)
+                .unwrap()
+        };
+        let marker = crate::commands::apply::review_marker_path(root.path(), &plan_id);
+        std::fs::create_dir_all(marker.parent().unwrap()).unwrap();
+        std::fs::write(&marker, "{}").unwrap();
+
+        // Publish G0 (candidate present, no winner rows yet).
+        rocky_core::state_sync::upload_state(&harness.pod_b.cfg, &harness.pod_b.state_path)
+            .await
+            .unwrap();
+
+        // The run winner: fresh download on pod_a, adds its own artifact, and
+        // publishes a NEWER generation before the gc seam runs.
+        let _authority =
+            rocky_core::state_sync::download_state(&harness.pod_a.cfg, &harness.pod_a.state_path)
+                .await
+                .unwrap();
+        {
+            let store = StateStore::open(&harness.pod_a.state_path).unwrap();
+            seed(
+                &store,
+                "r-winner",
+                "winner_model",
+                "SELECT 2 AS id",
+                &[],
+                HB,
+                700,
+                Utc::now(),
+            );
+            record_run(&store, "r-winner", "winner_model");
+        }
+        rocky_core::state_sync::upload_state(&harness.pod_a.cfg, &harness.pod_a.state_path)
+            .await
+            .unwrap();
+
+        let config = write_cas_config(root.path());
+        run_gc_apply_in_with(
+            root.path(),
+            &config,
+            &plan_id,
+            &harness.pod_b.state_path,
+            PolicyPrincipal::Human,
+            true,
+            std::sync::Arc::new(FixedLivenessOracle::reclaimable()),
+        )
+        .await
+        .expect("gc seam must commit on top of the winner");
+
+        // Read back the PUBLISHED blob (pod_a re-download), not local files.
+        let _authority =
+            rocky_core::state_sync::download_state(&harness.pod_a.cfg, &harness.pod_a.state_path)
+                .await
+                .unwrap();
+        let published = StateStore::open(&harness.pod_a.state_path).unwrap();
+        let tombs = published.list_tombstones().unwrap();
+        assert_eq!(tombs.len(), 1, "the candidate must be tombstoned");
+        assert_eq!(tombs[0].blake3_hash, HA);
+        assert_eq!(
+            published.refcount_for_hash(HB).unwrap(),
+            1,
+            "the run winner's artifact must survive the gc publish (#1228)"
+        );
+    }
+
+    /// Two armed CAS conflicts force three full replays; the command still
+    /// succeeds, never issues an unconditional blob put, and the eviction is
+    /// present exactly once in the final published state.
+    #[tokio::test]
+    async fn gc_cas_conflicts_replay_the_full_transition_and_commit() {
+        use rocky_core::fault_store::PutKind;
+        let _serial = rocky_core::state_sync::remote_testing::serial_guard();
+        let harness = rocky_core::test_harness::CrossPodHarness::new_s3_like();
+        let root = TempDir::new().unwrap();
+
+        let plan_id = {
+            let store = StateStore::open(&harness.pod_b.state_path).unwrap();
+            let old = Utc::now() - Duration::days(30);
+            seed(&store, "r1", "orders", "SELECT 1 AS id", &[], HA, 500, old);
+            record_run(&store, "r1", "orders");
+            let plan = plan_from_store(&store, Utc::now(), 7);
+            write_plan_with_principal(root.path(), PlanKind::Gc, &plan, PolicyPrincipal::Human)
+                .unwrap()
+        };
+        let marker = crate::commands::apply::review_marker_path(root.path(), &plan_id);
+        std::fs::create_dir_all(marker.parent().unwrap()).unwrap();
+        std::fs::write(&marker, "{}").unwrap();
+        rocky_core::state_sync::upload_state(&harness.pod_b.cfg, &harness.pod_b.state_path)
+            .await
+            .unwrap();
+
+        let object_key = format!(
+            "v{}/state.redb",
+            rocky_core::state::current_schema_version()
+        );
+        let baseline_updates = harness.faults.put_count(&object_key, PutKind::Update);
+        let baseline_unconditional = harness
+            .faults
+            .put_count(&object_key, PutKind::Unconditional);
+        harness.faults.arm_precondition_failures(&object_key, 2);
+
+        let config = write_cas_config(root.path());
+        run_gc_apply_in_with(
+            root.path(),
+            &config,
+            &plan_id,
+            &harness.pod_b.state_path,
+            PolicyPrincipal::Human,
+            true,
+            std::sync::Arc::new(FixedLivenessOracle::reclaimable()),
+        )
+        .await
+        .expect("the third attempt must commit");
+
+        assert_eq!(
+            harness.faults.put_count(&object_key, PutKind::Update) - baseline_updates,
+            3,
+            "two conflicts must force exactly three CAS attempts"
+        );
+        assert_eq!(
+            harness
+                .faults
+                .put_count(&object_key, PutKind::Unconditional)
+                - baseline_unconditional,
+            0,
+            "the CAS seam must never fall back to an unconditional blob put"
+        );
+
+        let _authority =
+            rocky_core::state_sync::download_state(&harness.pod_a.cfg, &harness.pod_a.state_path)
+                .await
+                .unwrap();
+        let published = StateStore::open(&harness.pod_a.state_path).unwrap();
+        assert_eq!(published.list_tombstones().unwrap().len(), 1);
+    }
+
+    /// Exhaustion (three straight conflicts) exits nonzero with the typed
+    /// seam-conflict error and PRESERVES the remote winner — no tombstone is
+    /// force-published over it.
+    #[tokio::test]
+    async fn gc_cas_exhaustion_is_nonzero_and_preserves_the_winner() {
+        let _serial = rocky_core::state_sync::remote_testing::serial_guard();
+        let harness = rocky_core::test_harness::CrossPodHarness::new_s3_like();
+        let root = TempDir::new().unwrap();
+
+        let plan_id = {
+            let store = StateStore::open(&harness.pod_b.state_path).unwrap();
+            let old = Utc::now() - Duration::days(30);
+            seed(&store, "r1", "orders", "SELECT 1 AS id", &[], HA, 500, old);
+            record_run(&store, "r1", "orders");
+            let plan = plan_from_store(&store, Utc::now(), 7);
+            write_plan_with_principal(root.path(), PlanKind::Gc, &plan, PolicyPrincipal::Human)
+                .unwrap()
+        };
+        let marker = crate::commands::apply::review_marker_path(root.path(), &plan_id);
+        std::fs::create_dir_all(marker.parent().unwrap()).unwrap();
+        std::fs::write(&marker, "{}").unwrap();
+        rocky_core::state_sync::upload_state(&harness.pod_b.cfg, &harness.pod_b.state_path)
+            .await
+            .unwrap();
+
+        let object_key = format!(
+            "v{}/state.redb",
+            rocky_core::state::current_schema_version()
+        );
+        harness.faults.arm_precondition_failures(&object_key, 3);
+
+        let config = write_cas_config(root.path());
+        let err = run_gc_apply_in_with(
+            root.path(),
+            &config,
+            &plan_id,
+            &harness.pod_b.state_path,
+            PolicyPrincipal::Human,
+            true,
+            std::sync::Arc::new(FixedLivenessOracle::reclaimable()),
+        )
+        .await
+        .expect_err("exhaustion must fail the command");
+        let cause = err
+            .chain()
+            .find_map(|c| c.downcast_ref::<rocky_core::state_sync::StateSyncError>());
+        assert!(
+            matches!(
+                cause,
+                Some(rocky_core::state_sync::StateSyncError::LedgerSeamConflict { .. })
+            ),
+            "got: {err:#}"
+        );
+
+        let _authority =
+            rocky_core::state_sync::download_state(&harness.pod_a.cfg, &harness.pod_a.state_path)
+                .await
+                .unwrap();
+        let published = StateStore::open(&harness.pod_a.state_path).unwrap();
+        assert!(
+            published.list_tombstones().unwrap().is_empty(),
+            "the remote winner must be preserved on exhaustion — never overwritten"
+        );
+    }
+
+    /// The per-attempt freeze-marker fence refuses on any marker the pre-gate
+    /// set never evaluated, and refuses on a LIST failure (fail-closed).
+    #[tokio::test]
+    async fn gc_seam_marker_fence_refuses_new_and_unlistable_markers() {
+        let known: std::collections::BTreeSet<String> = ["seen".to_string()].into_iter().collect();
+        // No config → no marker plane → fence passes.
+        let touched: BTreeMap<String, PolicyCapability> = BTreeMap::new();
+        gc_seam_marker_fence(None, &touched, &known, "unit")
+            .await
+            .expect("no config means no marker plane");
+    }
+
+    fn write_cas_config(root: &Path) -> std::path::PathBuf {
+        let path = root.join("rocky.toml");
+        std::fs::write(
+            &path,
+            "[state]\nbackend = \"s3\"\ns3_bucket = \"test\"\nconcurrency_control = \"cas\"\non_upload_failure = \"skip\"\n\n[state.retry]\nmax_retries = 0\n",
+        )
+        .unwrap();
+        path
     }
 }

--- a/engine/crates/rocky-cli/src/commands/gc.rs
+++ b/engine/crates/rocky-cli/src/commands/gc.rs
@@ -1493,41 +1493,98 @@ pub(crate) fn gc_models_dir(
 /// Once cleared, [`execute_gc_apply`] re-verifies each planned eviction against
 /// the live ledger before evicting anything (tombstone + retired ledger row;
 /// no physical byte deletion follows).
-/// Per-attempt freeze-marker fence for the gc CAS seam (#1242).
+/// Per-attempt policy re-gate for the gc CAS seam (#1242).
 ///
-/// Markers live under their own object keys, so the blob CAS cannot detect
-/// one landing mid-seam. The pre-gate LIST fed the policy gate its marker
-/// set; this fence re-LISTs on every seam attempt (and again right before
-/// publish) and REFUSES on any marker absent from that already-gated set —
-/// over-enforcement is the monotone-safe direction, and refusing avoids
-/// re-running the full gate against a store the session already holds open.
-/// A LIST failure refuses too (fail-closed), matching the pre-gate LIST.
-async fn gc_seam_marker_fence(
+/// The session contract requires every dynamic authorization check to re-run
+/// per attempt. Markers live under their own object keys (blob CAS cannot see
+/// one landing mid-seam) and freeze/budget ROWS live in the ledger blob a
+/// conflict replay freshly downloads — and marker writes are OPTIONAL
+/// (default off), so a marker-only fence misses a ledger-only freeze. This
+/// re-runs the REAL gate: a fresh marker LIST plus
+/// [`evaluate_apply_policy_core`] over the fresh store's decision snapshot,
+/// with principal/scope matching intact (an unrelated marker no longer
+/// refuses). `record` publishes the attempt's decision rows into the fresh
+/// store, so the audit trail lands atomically with the winning attempt's
+/// evictions — the pre-seam gate's local rows are overwritten by each
+/// attempt's download and must not be the trail of record.
+///
+/// `prior_decisions` is the snapshot taken BEFORE this attempt recorded
+/// anything (the pre-publish recheck must not read the attempt's own rows
+/// back as budget history). A LIST failure refuses fail-closed.
+#[allow(clippy::too_many_arguments)]
+async fn gc_seam_regate(
     cfg: Option<&rocky_core::config::RockyConfig>,
+    plan_id: &str,
+    principal: rocky_core::config::PolicyPrincipal,
     touched: &BTreeMap<String, PolicyCapability>,
-    gated_marker_ids: &std::collections::BTreeSet<String>,
+    models_dir: &Path,
+    prior_decisions: &[rocky_core::state::PolicyDecisionRecord],
+    fresh_store: Option<&StateStore>,
     stage: &str,
 ) -> Result<(), rocky_core::state_sync::StateSyncError> {
+    use rocky_core::state_sync::StateSyncError;
     let Some(cfg) = cfg else {
         return Ok(());
     };
-    let fresh = crate::commands::apply::marker_freezes_before_gate(cfg, touched)
+    let Some(policy) = cfg.policy.as_ref() else {
+        return Ok(());
+    };
+    let fresh_markers = crate::commands::apply::marker_freezes_before_gate(cfg, touched)
         .await
         .map_err(|e| {
-            rocky_core::state_sync::StateSyncError::SeamTransition(format!(
-                "freeze-marker fence LIST failed {stage} (fail-closed): {e:#}"
+            StateSyncError::SeamTransition(format!(
+                "freeze-marker LIST failed {stage} (fail-closed): {e:#}"
             ))
         })?;
-    if let Some(new) = fresh
-        .iter()
-        .find(|m| !gated_marker_ids.contains(&m.freeze_id))
+    let (policy, attrs_map) = match crate::commands::apply::resolve_policy_and_attrs(
+        Some(policy),
+        touched,
+        models_dir,
+        None,
+    ) {
+        Ok(pair) => pair,
+        // The resolver's error IS a gate outcome. Mirror the pre-seam
+        // treatment: only a Deny blocks gc (require_review is satisfied by
+        // the hard review gate the command already passed).
+        Err(PolicyGate::Deny {
+            model,
+            rule_id,
+            reason,
+        }) => {
+            let rule = rule_id.map(|r| format!(" (rule {r})")).unwrap_or_default();
+            return Err(StateSyncError::SeamTransition(format!(
+                "policy DENIES gc plan '{plan_id}' {stage}: model '{model}'{rule} — {reason}"
+            )));
+        }
+        Err(_) => return Ok(()),
+    };
+    let gate = crate::commands::apply::evaluate_apply_policy_core(
+        &policy,
+        plan_id,
+        principal,
+        touched,
+        &attrs_map,
+        prior_decisions,
+        &fresh_markers,
+        false,
+        |record| {
+            if let Some(store) = fresh_store {
+                // Best-effort audit into the attempt's store — the gate below
+                // is the safety boundary; gc has no budget-paired custody row.
+                let _ = store.record_policy_decision(record);
+            }
+        },
+    );
+    if let PolicyGate::Deny {
+        model,
+        rule_id,
+        reason,
+    } = gate
     {
-        return Err(rocky_core::state_sync::StateSyncError::SeamTransition(
-            format!(
-                "durable freeze marker '{}' (scope '{}') landed {stage}; refusing to publish                  this gc apply — re-run `rocky apply` so the policy gate evaluates it",
-                new.freeze_id, new.scope
-            ),
-        ));
+        let rule = rule_id.map(|r| format!(" (rule {r})")).unwrap_or_default();
+        return Err(StateSyncError::SeamTransition(format!(
+            "policy DENIES gc plan '{plan_id}' {stage}: model '{model}'{rule} — {reason}"
+        )));
     }
     Ok(())
 }
@@ -1746,19 +1803,24 @@ pub(crate) async fn run_gc_apply_in_with(
         // winner. `execute_gc_apply` re-derives candidates, refcounts, and
         // both liveness reads from that fresh store — a winner that re-added
         // the Delta path legitimately flips this attempt's eviction into a
-        // refusal — and the freeze-marker fence runs at attempt start AND
-        // again after the transition, so the unfenced window shrinks to the
-        // CAS upload itself. gc's mutations are redb rows inside the blob
-        // being CAS-published (`physical_delete = true` was refused above),
-        // so no per-candidate side effect outlives a discarded attempt.
-        let gated_marker_ids: std::collections::BTreeSet<String> =
-            marker_freezes.iter().map(|m| m.freeze_id.clone()).collect();
+        // refusal — and the FULL policy gate re-runs per attempt (fresh
+        // marker LIST + the fresh store's freeze/budget rows; marker writes
+        // are optional, so a marker-only fence would miss a ledger-only
+        // freeze) with an enforcement-only recheck after the transition, so
+        // the ungated window shrinks to the CAS upload itself. gc's
+        // mutations are redb rows inside the blob being CAS-published
+        // (`physical_delete = true` was refused above); a refused or failed
+        // attempt's local rows are rolled back by the session's
+        // restore-the-winner-on-terminal-failure rule, so no side effect
+        // outlives a discarded attempt, remotely OR locally.
         let session = rocky_core::state_sync::LedgerSeamSession::new(&state_cfg, state_path);
         // The attempt future must OWN everything it touches (the session's
         // `for<'a>` bound): master copies move into the closure, and each
         // attempt clones what its future needs.
         let seam_cfg = loaded_cfg.clone();
         let seam_touched = touched.clone();
+        let seam_models_dir = models_dir.clone();
+        let seam_principal = plan_record.enforcement_principal(runtime_principal);
         let seam_plan = plan.clone();
         let seam_plan_id = plan_id.to_string();
         let seam_oracle = std::sync::Arc::clone(&oracle);
@@ -1766,13 +1828,31 @@ pub(crate) async fn run_gc_apply_in_with(
             .execute(move |fresh_store, _fresh_base| {
                 let cfg = seam_cfg.clone();
                 let touched = seam_touched.clone();
-                let gated = gated_marker_ids.clone();
+                let models_dir = seam_models_dir.clone();
+                let principal = seam_principal;
                 let plan = seam_plan.clone();
                 let plan_id = seam_plan_id.clone();
                 let oracle = std::sync::Arc::clone(&seam_oracle);
                 Box::pin(async move {
-                    gc_seam_marker_fence(cfg.as_ref(), &touched, &gated, "during this gc apply")
-                        .await?;
+                    // Snapshot BEFORE this attempt records anything: the
+                    // pre-publish recheck must not read the attempt's own
+                    // rows back as budget/freeze history.
+                    let prior_decisions = fresh_store.list_policy_decisions().map_err(|e| {
+                        rocky_core::state_sync::StateSyncError::SeamTransition(format!(
+                            "could not snapshot the fresh decision ledger: {e:#}"
+                        ))
+                    })?;
+                    gc_seam_regate(
+                        cfg.as_ref(),
+                        &plan_id,
+                        principal,
+                        &touched,
+                        &models_dir,
+                        &prior_decisions,
+                        Some(fresh_store),
+                        "during this gc apply",
+                    )
+                    .await?;
                     let out =
                         execute_gc_apply(fresh_store, oracle.as_ref(), &plan_id, &plan, Utc::now())
                             .await
@@ -1781,10 +1861,17 @@ pub(crate) async fn run_gc_apply_in_with(
                                     "{e:#}"
                                 ))
                             })?;
-                    gc_seam_marker_fence(
+                    // Pre-publish recheck: markers may have moved during the
+                    // eviction work; enforcement-only (no re-record), same
+                    // pre-attempt snapshot.
+                    gc_seam_regate(
                         cfg.as_ref(),
+                        &plan_id,
+                        principal,
                         &touched,
-                        &gated,
+                        &models_dir,
+                        &prior_decisions,
+                        None,
                         "after eviction, before publish",
                     )
                     .await?;
@@ -3938,8 +4025,9 @@ auto_create_schemas = true
     /// assertion (the deadline-bounded watcher never sees a CAS put).
     ///
     /// Determinism: the watcher loses only if its in-memory seed+upload
-    /// (microseconds) outlasts the session's ≥20ms conflict backoff — and a
-    /// lost race fails the tombstone assertion loudly, never a false green.
+    /// (microseconds) outlasts the session's jittered ~20ms (18–22ms)
+    /// conflict backoff — and a lost race fails the tombstone assertion
+    /// loudly, never a false green.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn gc_cas_seam_preserves_a_run_writer_landing_mid_seam() {
         struct CountingOracle(std::sync::atomic::AtomicUsize);
@@ -4039,12 +4127,21 @@ auto_create_schemas = true
             "the winner task never saw a CAS put — the seam did not go through the CAS session"
         );
 
-        // 3 oracle reads per attempt today (eligibility re-derivation plus
-        // the paired pre/post liveness proofs) × 2 attempts. The invariant
-        // pinned is PER-ATTEMPT re-reads — if execute_gc_apply's read count
-        // legitimately changes, update the constant; if this fails with the
-        // single-attempt count (3), the replay re-published without
-        // re-deriving, which is the #1242 defect.
+        // 2 oracle reads per attempt (the paired pre/post liveness proofs —
+        // probed empirically at a single attempt) × THREE attempts: the armed
+        // conflict rejects attempt 1; the winner's upload lands inside
+        // attempt 2's window, so its CAS put loses a GENUINE race; attempt 3
+        // replays on the winner and commits. The schedule exercises both
+        // conflict kinds. If this fails with 2, the replay re-published
+        // without re-deriving — the #1242 defect; if the per-attempt read
+        // count legitimately changes, update both constants.
+        assert_eq!(
+            harness
+                .faults
+                .put_count(&object_key, rocky_core::fault_store::PutKind::Update),
+            3,
+            "armed + genuine conflict must force exactly three CAS attempts"
+        );
         assert_eq!(
             oracle.0.load(std::sync::atomic::Ordering::SeqCst),
             6,
@@ -4203,11 +4300,13 @@ auto_create_schemas = true
         );
     }
 
-    /// The per-attempt freeze-marker fence refuses on any marker the pre-gate
-    /// set never evaluated, passes markers the gate already saw, and refuses
-    /// on a LIST failure (fail-closed).
+    /// The per-attempt re-gate evaluates the REAL policy gate: a ledger-only
+    /// freeze row (marker writes are optional and default off) denies; a
+    /// marker scoped to the OTHER principal passes (principal/scope matching
+    /// — an unrelated marker no longer refuses); a matching marker denies;
+    /// a LIST transport failure refuses fail-closed.
     #[tokio::test]
-    async fn gc_seam_marker_fence_refuses_new_and_unlistable_markers() {
+    async fn gc_seam_regate_denies_ledger_freezes_and_matches_marker_scope() {
         use rocky_core::fault_store::{FaultMode, FaultOp};
 
         let _serial = rocky_core::state_sync::remote_testing::serial_guard();
@@ -4222,59 +4321,241 @@ auto_create_schemas = true
         let cfg = rocky_core::config::load_rocky_config(&cfg_path).unwrap();
         let mut touched: BTreeMap<String, PolicyCapability> = BTreeMap::new();
         touched.insert("orders".into(), PolicyCapability::Gc);
-        let known: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        let models_dir = root.path().join("models");
+        std::fs::create_dir_all(&models_dir).unwrap();
 
-        // No config at all → no marker plane → pass.
-        gc_seam_marker_fence(None, &touched, &known, "unit")
-            .await
-            .expect("no config means no marker plane");
-        // Config + policy plane, no markers → pass.
-        gc_seam_marker_fence(Some(&cfg), &touched, &known, "unit")
-            .await
-            .expect("no markers, nothing to refuse");
+        // No freezes anywhere → pass.
+        gc_seam_regate(
+            Some(&cfg),
+            "plan-x",
+            PolicyPrincipal::Human,
+            &touched,
+            &models_dir,
+            &[],
+            None,
+            "unit",
+        )
+        .await
+        .expect("nothing to deny");
 
-        // A marker the pre-gate set never evaluated → refuse.
-        let marker = rocky_core::freeze_marker::FreezeMarker {
-            freeze_id: "mid-seam-freeze".to_string(),
+        // A ledger-only freeze row for THIS principal → deny. This is the
+        // marker-blind bypass the review caught: no marker exists at all.
+        let freeze = rocky_core::state::PolicyDecisionRecord {
+            timestamp: Utc::now(),
+            plan_id: "freeze:unit".to_string(),
+            principal: PolicyPrincipal::Human,
+            capability: PolicyCapability::Apply,
+            model: "any".to_string(),
+            effect: rocky_core::config::PolicyEffect::Deny,
+            rule_id: None,
+            reason: "unit ledger-only freeze".to_string(),
+            verify_after: Vec::new(),
+            auto_apply: None,
+        };
+        let err = gc_seam_regate(
+            Some(&cfg),
+            "plan-x",
+            PolicyPrincipal::Human,
+            &touched,
+            &models_dir,
+            std::slice::from_ref(&freeze),
+            None,
+            "unit",
+        )
+        .await
+        .expect_err("a ledger-only freeze must deny the replay");
+        assert!(err.to_string().contains("DENIES"), "got: {err}");
+
+        // A durable marker scoped to the OTHER principal → pass (the old
+        // ID-diff fence refused here; the real gate matches principal).
+        let other = rocky_core::freeze_marker::FreezeMarker {
+            freeze_id: "agent-only".to_string(),
+            principal: PolicyPrincipal::Agent,
+            scope: "any".to_string(),
+            reason: "unit".to_string(),
+            created_at: Utc::now(),
+        };
+        rocky_core::freeze_marker::write_freeze_marker(&harness.provider, &other)
+            .await
+            .unwrap();
+        gc_seam_regate(
+            Some(&cfg),
+            "plan-x",
+            PolicyPrincipal::Human,
+            &touched,
+            &models_dir,
+            &[],
+            None,
+            "unit",
+        )
+        .await
+        .expect("an Agent-scoped marker must not deny a Human gc");
+
+        // A marker matching THIS principal → deny.
+        let mine = rocky_core::freeze_marker::FreezeMarker {
+            freeze_id: "human-any".to_string(),
             principal: PolicyPrincipal::Human,
             scope: "any".to_string(),
             reason: "unit".to_string(),
             created_at: Utc::now(),
         };
-        rocky_core::freeze_marker::write_freeze_marker(&harness.provider, &marker)
+        rocky_core::freeze_marker::write_freeze_marker(&harness.provider, &mine)
             .await
             .unwrap();
-        let err = gc_seam_marker_fence(Some(&cfg), &touched, &known, "unit")
-            .await
-            .expect_err("a marker the gate never saw must refuse");
-        assert!(
-            matches!(
-                err,
-                rocky_core::state_sync::StateSyncError::SeamTransition(_)
-            ) && err.to_string().contains("mid-seam-freeze"),
-            "got: {err}"
-        );
+        let err = gc_seam_regate(
+            Some(&cfg),
+            "plan-x",
+            PolicyPrincipal::Human,
+            &touched,
+            &models_dir,
+            &[],
+            None,
+            "unit",
+        )
+        .await
+        .expect_err("a matching marker must deny");
+        assert!(err.to_string().contains("DENIES"), "got: {err}");
 
-        // The same marker inside the gated set → pass (the gate evaluated it).
-        let gated: std::collections::BTreeSet<String> =
-            ["mid-seam-freeze".to_string()].into_iter().collect();
-        gc_seam_marker_fence(Some(&cfg), &touched, &gated, "unit")
-            .await
-            .expect("an already-gated marker is not new");
-
-        // LIST transport failure → fail-closed refusal, never an empty set.
+        // LIST transport failure → fail-closed refusal.
         harness.faults.arm(FaultOp::List, FaultMode::FailAll);
-        let err = gc_seam_marker_fence(Some(&cfg), &touched, &gated, "unit")
-            .await
-            .expect_err("a LIST failure must refuse, not read as no-markers");
-        assert!(
-            matches!(
-                err,
-                rocky_core::state_sync::StateSyncError::SeamTransition(_)
-            ),
-            "got: {err}"
-        );
+        let err = gc_seam_regate(
+            Some(&cfg),
+            "plan-x",
+            PolicyPrincipal::Human,
+            &touched,
+            &models_dir,
+            &[],
+            None,
+            "unit",
+        )
+        .await
+        .expect_err("a LIST failure must refuse, not read as no-markers");
+        assert!(err.to_string().contains("fail-closed"), "got: {err}");
         harness.faults.clear();
+    }
+
+    /// Finding 1+3 integration (the review's blocking pair): the mid-seam
+    /// winner carries a LEDGER-ONLY freeze row (no marker anywhere). The
+    /// replay's re-gate must refuse, the command must exit nonzero, and the
+    /// session must restore the winner locally — no ghost tombstone stays
+    /// visible to path-opening readers like `restore plan`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn gc_cas_replay_refuses_ledger_freeze_and_restores_winner_locally() {
+        let _serial = rocky_core::state_sync::remote_testing::serial_guard();
+        let harness = rocky_core::test_harness::CrossPodHarness::new_s3_like();
+        let root = TempDir::new().unwrap();
+
+        let plan_id = {
+            let store = StateStore::open(&harness.pod_b.state_path).unwrap();
+            let old = Utc::now() - Duration::days(30);
+            seed(&store, "r1", "orders", "SELECT 1 AS id", &[], HA, 500, old);
+            record_run(&store, "r1", "orders");
+            let plan = plan_from_store(&store, Utc::now(), 7);
+            write_plan_with_principal(root.path(), PlanKind::Gc, &plan, PolicyPrincipal::Human)
+                .unwrap()
+        };
+        let marker = crate::commands::apply::review_marker_path(root.path(), &plan_id);
+        std::fs::create_dir_all(marker.parent().unwrap()).unwrap();
+        std::fs::write(&marker, "{}").unwrap();
+        rocky_core::state_sync::upload_state(&harness.pod_b.cfg, &harness.pod_b.state_path)
+            .await
+            .unwrap();
+
+        let object_key = format!(
+            "v{}/state.redb",
+            rocky_core::state::current_schema_version()
+        );
+        harness.faults.arm_precondition_failures(&object_key, 1);
+
+        // Mid-seam winner: publishes a LEDGER freeze row (Human, scope any).
+        let faults = harness.faults.clone();
+        let winner_cfg = harness.pod_a.cfg.clone();
+        let winner_path = harness.pod_a.state_path.clone();
+        let key_for_watcher = object_key.clone();
+        let watcher = tokio::spawn(async move {
+            use rocky_core::fault_store::PutKind;
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            while faults.put_count(&key_for_watcher, PutKind::Update) < 1 {
+                if std::time::Instant::now() > deadline {
+                    return false;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            }
+            let _authority = rocky_core::state_sync::download_state(&winner_cfg, &winner_path)
+                .await
+                .unwrap();
+            {
+                let store = StateStore::open(&winner_path).unwrap();
+                store
+                    .record_policy_decision(&rocky_core::state::PolicyDecisionRecord {
+                        timestamp: Utc::now(),
+                        plan_id: "freeze:mid-seam".to_string(),
+                        principal: PolicyPrincipal::Human,
+                        capability: PolicyCapability::Apply,
+                        model: "any".to_string(),
+                        effect: rocky_core::config::PolicyEffect::Deny,
+                        rule_id: None,
+                        reason: "kill switch engaged mid-seam".to_string(),
+                        verify_after: Vec::new(),
+                        auto_apply: None,
+                    })
+                    .unwrap();
+            }
+            rocky_core::state_sync::upload_state(&winner_cfg, &winner_path)
+                .await
+                .unwrap();
+            true
+        });
+
+        let config = write_cas_policy_config(root.path());
+        let err = run_gc_apply_in_with(
+            root.path(),
+            &config,
+            &plan_id,
+            &harness.pod_b.state_path,
+            PolicyPrincipal::Human,
+            true,
+            std::sync::Arc::new(FixedLivenessOracle::reclaimable()),
+        )
+        .await
+        .expect_err("the replay must refuse under the winner's ledger freeze");
+        assert!(format!("{err:#}").contains("DENIES"), "got: {err:#}");
+        let fired = watcher.await.expect("the winner task must not panic");
+        assert!(fired, "the freeze writer never saw a CAS put");
+
+        // Ghost-state check: the LOCAL file must be the restored winner —
+        // freeze row present, NO tombstone from the refused attempt.
+        let local = StateStore::open(&harness.pod_b.state_path).unwrap();
+        assert!(
+            local.list_tombstones().unwrap().is_empty(),
+            "a refused attempt's eviction must not stay locally visible"
+        );
+        assert!(
+            local
+                .list_policy_decisions()
+                .unwrap()
+                .iter()
+                .any(|d| d.plan_id == "freeze:mid-seam"),
+            "the restored local ledger must be the winner's (freeze row present)"
+        );
+
+        // And remote is untouched by the refused seam: no tombstones there.
+        let _authority =
+            rocky_core::state_sync::download_state(&harness.pod_a.cfg, &harness.pod_a.state_path)
+                .await
+                .unwrap();
+        let published = StateStore::open(&harness.pod_a.state_path).unwrap();
+        assert!(published.list_tombstones().unwrap().is_empty());
+    }
+
+    fn write_cas_policy_config(root: &Path) -> std::path::PathBuf {
+        let path = root.join("rocky.toml");
+        std::fs::write(
+            &path,
+            "[state]\nbackend = \"s3\"\ns3_bucket = \"test\"\nconcurrency_control = \"cas\"\non_upload_failure = \"skip\"\n\n[state.retry]\nmax_retries = 0\n\n[policy]\nversion = 1\n",
+        )
+        .unwrap();
+        path
     }
 
     fn write_cas_config(root: &Path) -> std::path::PathBuf {

--- a/engine/crates/rocky-cli/src/commands/gc.rs
+++ b/engine/crates/rocky-cli/src/commands/gc.rs
@@ -4204,15 +4204,77 @@ auto_create_schemas = true
     }
 
     /// The per-attempt freeze-marker fence refuses on any marker the pre-gate
-    /// set never evaluated, and refuses on a LIST failure (fail-closed).
+    /// set never evaluated, passes markers the gate already saw, and refuses
+    /// on a LIST failure (fail-closed).
     #[tokio::test]
     async fn gc_seam_marker_fence_refuses_new_and_unlistable_markers() {
-        let known: std::collections::BTreeSet<String> = ["seen".to_string()].into_iter().collect();
-        // No config → no marker plane → fence passes.
-        let touched: BTreeMap<String, PolicyCapability> = BTreeMap::new();
+        use rocky_core::fault_store::{FaultMode, FaultOp};
+
+        let _serial = rocky_core::state_sync::remote_testing::serial_guard();
+        let harness = rocky_core::test_harness::CrossPodHarness::new_s3_like();
+        let root = TempDir::new().unwrap();
+        let cfg_path = root.path().join("rocky.toml");
+        std::fs::write(
+            &cfg_path,
+            "[state]\nbackend = \"s3\"\ns3_bucket = \"test\"\nconcurrency_control = \"cas\"\n\n[policy]\nversion = 1\n",
+        )
+        .unwrap();
+        let cfg = rocky_core::config::load_rocky_config(&cfg_path).unwrap();
+        let mut touched: BTreeMap<String, PolicyCapability> = BTreeMap::new();
+        touched.insert("orders".into(), PolicyCapability::Gc);
+        let known: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+
+        // No config at all → no marker plane → pass.
         gc_seam_marker_fence(None, &touched, &known, "unit")
             .await
             .expect("no config means no marker plane");
+        // Config + policy plane, no markers → pass.
+        gc_seam_marker_fence(Some(&cfg), &touched, &known, "unit")
+            .await
+            .expect("no markers, nothing to refuse");
+
+        // A marker the pre-gate set never evaluated → refuse.
+        let marker = rocky_core::freeze_marker::FreezeMarker {
+            freeze_id: "mid-seam-freeze".to_string(),
+            principal: PolicyPrincipal::Human,
+            scope: "any".to_string(),
+            reason: "unit".to_string(),
+            created_at: Utc::now(),
+        };
+        rocky_core::freeze_marker::write_freeze_marker(&harness.provider, &marker)
+            .await
+            .unwrap();
+        let err = gc_seam_marker_fence(Some(&cfg), &touched, &known, "unit")
+            .await
+            .expect_err("a marker the gate never saw must refuse");
+        assert!(
+            matches!(
+                err,
+                rocky_core::state_sync::StateSyncError::SeamTransition(_)
+            ) && err.to_string().contains("mid-seam-freeze"),
+            "got: {err}"
+        );
+
+        // The same marker inside the gated set → pass (the gate evaluated it).
+        let gated: std::collections::BTreeSet<String> =
+            ["mid-seam-freeze".to_string()].into_iter().collect();
+        gc_seam_marker_fence(Some(&cfg), &touched, &gated, "unit")
+            .await
+            .expect("an already-gated marker is not new");
+
+        // LIST transport failure → fail-closed refusal, never an empty set.
+        harness.faults.arm(FaultOp::List, FaultMode::FailAll);
+        let err = gc_seam_marker_fence(Some(&cfg), &touched, &gated, "unit")
+            .await
+            .expect_err("a LIST failure must refuse, not read as no-markers");
+        assert!(
+            matches!(
+                err,
+                rocky_core::state_sync::StateSyncError::SeamTransition(_)
+            ),
+            "got: {err}"
+        );
+        harness.faults.clear();
     }
 
     fn write_cas_config(root: &Path) -> std::path::PathBuf {

--- a/engine/crates/rocky-cli/src/commands/restore.rs
+++ b/engine/crates/rocky-cli/src/commands/restore.rs
@@ -1529,7 +1529,7 @@ mod tests {
                 &state_path,
                 PolicyPrincipal::Human,
                 true,
-                &AlwaysReclaim,
+                std::sync::Arc::new(AlwaysReclaim),
             )
             .await
             .unwrap();

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -874,40 +874,56 @@ impl LedgerSeamSession {
 }
 
 impl LedgerSeamSession {
-    /// Best-effort re-download of the remote winner after a terminal seam
-    /// failure, so uncommitted local mutations never stay visible to
-    /// path-opening readers (audit / brief / `restore plan`). Failures are
-    /// logged, never masked — the caller's original error is what propagates.
-    ///
-    /// Failure contract: if the winner CANNOT be re-downloaded, the local
-    /// file is QUARANTINED (renamed aside with an `.unpublished-<pid>`
-    /// suffix) rather than left in place — a path-opening reader (audit,
-    /// brief, `restore plan`) must never observe rows that never committed.
-    /// Absence is the fail-closed shape: readers error on a missing store
-    /// instead of planning against ghosts, the evidence is preserved for
-    /// forensics, and the next command's start-download recreates the file.
+    /// Re-establish committed truth locally after a terminal seam failure,
+    /// closing the recovery window: the attempt's uncommitted local file is
+    /// QUARANTINED FIRST (an atomic rename — after this instant no
+    /// path-opening reader can observe rows that never committed), and only
+    /// then is the remote winner re-downloaded into a fresh file. On a
+    /// successful restore the quarantined copy is deleted; if the download
+    /// fails, it is kept for forensics and readers see absence (fail-closed
+    /// — audit, brief, and `restore plan` error on a missing store instead
+    /// of planning against ghosts; the next command's start-download
+    /// recreates the file). Failures are logged, never masked — the
+    /// caller's original error is what propagates.
     async fn restore_remote_winner(&self, context: &str) {
-        if let Err(error) = download_state(&self.cfg, &self.state_path).await {
-            let quarantine = self
-                .state_path
-                .with_extension(format!("redb.unpublished-{}", std::process::id()));
-            match std::fs::rename(&self.state_path, &quarantine) {
-                Ok(()) => warn!(
+        let quarantine = self
+            .state_path
+            .with_extension(format!("redb.unpublished-{}", std::process::id()));
+        let quarantined = match std::fs::rename(&self.state_path, &quarantine) {
+            Ok(()) => true,
+            Err(rename_error) => {
+                warn!(
+                    rename_error = %rename_error,
+                    context,
+                    "could not quarantine the uncommitted local ledger before \
+                     restoring the winner; a concurrent reader may observe \
+                     uncommitted rows until the re-download completes"
+                );
+                false
+            }
+        };
+        match download_state(&self.cfg, &self.state_path).await {
+            Ok(_) => {
+                if quarantined && let Err(remove_error) = std::fs::remove_file(&quarantine) {
+                    warn!(
+                        remove_error = %remove_error,
+                        quarantine = %quarantine.display(),
+                        "restored the remote winner but could not delete the \
+                         quarantined uncommitted copy"
+                    );
+                }
+            }
+            Err(error) => {
+                warn!(
                     error = %error,
                     context,
                     quarantined_to = %quarantine.display(),
+                    quarantined,
                     "failed to restore the remote ledger winner after a terminal \
-                     ledger-seam failure; the local file held uncommitted rows and \
-                     was quarantined aside (fail-closed: readers see absence, not \
+                     ledger-seam failure; the uncommitted local file stays \
+                     quarantined aside (fail-closed: readers see absence, not \
                      ghosts)"
-                ),
-                Err(rename_error) => warn!(
-                    error = %error,
-                    rename_error = %rename_error,
-                    context,
-                    "failed to restore the remote ledger winner AND failed to \
-                     quarantine the local file; it may hold uncommitted rows"
-                ),
+                );
             }
         }
     }

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -68,6 +68,13 @@ pub enum StateSyncError {
     #[error("state retry budget exhausted (limit {limit}); aborting remaining retries")]
     RetryBudgetExhausted { limit: u32 },
 
+    #[error("ledger-seam transition failed: {0}")]
+    /// A [`LedgerSeamSession`] caller's transition closure failed for a
+    /// domain reason (authorization refused, proof no longer holds, execution
+    /// error). The session aborts WITHOUT publishing — the remote winner is
+    /// untouched — and the caller re-wraps this into its own error context.
+    SeamTransition(String),
+
     #[error(
         "state compare-and-swap conflict on '{key}': another writer committed since this run \
          downloaded state; refusing to overwrite the winner (fail-closed)"
@@ -3522,7 +3529,10 @@ fn is_transient(err: &StateSyncError) -> bool {
         // the same stale base would just conflict again and burn the budget.
         // Fail closed immediately.
         | StateSyncError::CasConflict { .. }
-        | StateSyncError::LedgerSeamConflict { .. } => false,
+        | StateSyncError::LedgerSeamConflict { .. }
+        // A seam-transition failure is a domain refusal from the caller's
+        // closure, not a transport fault — retrying cannot change it.
+        | StateSyncError::SeamTransition(_) => false,
     }
 }
 

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -878,14 +878,37 @@ impl LedgerSeamSession {
     /// failure, so uncommitted local mutations never stay visible to
     /// path-opening readers (audit / brief / `restore plan`). Failures are
     /// logged, never masked — the caller's original error is what propagates.
+    ///
+    /// Failure contract: if the winner CANNOT be re-downloaded, the local
+    /// file is QUARANTINED (renamed aside with an `.unpublished-<pid>`
+    /// suffix) rather than left in place — a path-opening reader (audit,
+    /// brief, `restore plan`) must never observe rows that never committed.
+    /// Absence is the fail-closed shape: readers error on a missing store
+    /// instead of planning against ghosts, the evidence is preserved for
+    /// forensics, and the next command's start-download recreates the file.
     async fn restore_remote_winner(&self, context: &str) {
         if let Err(error) = download_state(&self.cfg, &self.state_path).await {
-            warn!(
-                error = %error,
-                context,
-                "failed to restore the remote ledger winner after a terminal \
-                 ledger-seam failure; the local file may hold uncommitted rows"
-            );
+            let quarantine = self
+                .state_path
+                .with_extension(format!("redb.unpublished-{}", std::process::id()));
+            match std::fs::rename(&self.state_path, &quarantine) {
+                Ok(()) => warn!(
+                    error = %error,
+                    context,
+                    quarantined_to = %quarantine.display(),
+                    "failed to restore the remote ledger winner after a terminal \
+                     ledger-seam failure; the local file held uncommitted rows and \
+                     was quarantined aside (fail-closed: readers see absence, not \
+                     ghosts)"
+                ),
+                Err(rename_error) => warn!(
+                    error = %error,
+                    rename_error = %rename_error,
+                    context,
+                    "failed to restore the remote ledger winner AND failed to \
+                     quarantine the local file; it may hold uncommitted rows"
+                ),
+            }
         }
     }
 }

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -818,7 +818,21 @@ impl LedgerSeamSession {
             let store = StateStore::open(&self.state_path)?;
             let result = attempt(&store, base.as_ref()).await;
             drop(store);
-            let output = result?;
+            let output = match result {
+                Ok(output) => output,
+                Err(e) => {
+                    // The attempt mutated the freshly downloaded LOCAL file
+                    // before failing (e.g. a post-transition fence refusal
+                    // after rows were written). Read-only consumers such as
+                    // audit, brief, and `restore plan` open the local file
+                    // without downloading, so a transition that never
+                    // committed must not remain locally visible — restore the
+                    // remote winner before propagating.
+                    self.restore_remote_winner("failed ledger-seam transition")
+                        .await;
+                    return Err(e);
+                }
+            };
 
             match upload_state_cas(&upload_cfg, &self.state_path, base.as_ref()).await {
                 Ok(()) => return Ok(output),
@@ -837,27 +851,42 @@ impl LedgerSeamSession {
                     tokio::time::sleep(backoff).await;
                 }
                 Err(StateSyncError::CasConflict { key }) => {
-                    // Read-only consumers such as audit and brief open the local file
-                    // without downloading, so a transition that never committed must not
-                    // remain locally visible.
-                    if let Err(error) = download_state(&self.cfg, &self.state_path).await {
-                        warn!(
-                            key = %key,
-                            error = %error,
-                            "failed to restore the remote ledger winner after ledger-seam \
-                             conflict exhaustion"
-                        );
-                    }
+                    // Same local-visibility rule at conflict exhaustion.
+                    self.restore_remote_winner("ledger-seam conflict exhaustion")
+                        .await;
                     return Err(StateSyncError::LedgerSeamConflict {
                         key,
                         attempts: LEDGER_SEAM_MAX_ATTEMPTS,
                     });
                 }
-                Err(e) => return Err(e),
+                Err(e) => {
+                    // A non-conflict upload failure (transport) also leaves
+                    // the attempt's mutations local-only — same rule.
+                    self.restore_remote_winner("failed ledger-seam upload")
+                        .await;
+                    return Err(e);
+                }
             }
         }
 
         unreachable!("ledger-seam attempt loop always returns within the for body")
+    }
+}
+
+impl LedgerSeamSession {
+    /// Best-effort re-download of the remote winner after a terminal seam
+    /// failure, so uncommitted local mutations never stay visible to
+    /// path-opening readers (audit / brief / `restore plan`). Failures are
+    /// logged, never masked — the caller's original error is what propagates.
+    async fn restore_remote_winner(&self, context: &str) {
+        if let Err(error) = download_state(&self.cfg, &self.state_path).await {
+            warn!(
+                error = %error,
+                context,
+                "failed to restore the remote ledger winner after a terminal \
+                 ledger-seam failure; the local file may hold uncommitted rows"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
First seam of #1242 (finishing #1228's data-loss class; ADR-CONCURRENCY D1, seam class = RETRY). Migrates `rocky gc` apply — the seam the issue's failure walkthrough uses — off the unconditional `upload_only_fail_closed` half-seam.

## What

Under effective CAS (`concurrency_control = "cas"` on a CAS-capable backend), the gc publish goes through `LedgerSeamSession`: the **whole transition replays per attempt** against the freshly downloaded winner. `execute_gc_apply` re-derives candidates, refcounts, and both liveness reads from the fresh store, so a winner that re-added the Delta path legitimately flips that attempt's eviction into a refusal. Exhaustion (3 conflicts) exits nonzero with the typed `LedgerSeamConflict` and preserves the winner. Without effective CAS the legacy fail-closed half-seam is byte-for-byte unchanged (#1228's residual exposure — one writer per `[state]` prefix — stands until fleet-wide enablement; landing this closes nothing operationally by itself).

**Freeze-marker fence**: markers live under their own keys, where blob CAS cannot see one landing mid-seam (the issue's TOCTOU paragraph). The seam re-LISTs at attempt start and again after the transition (so the unfenced window shrinks to the CAS upload itself) and **refuses** on any marker the pre-gate set never evaluated — over-enforcement is the monotone-safe direction. gc's fence can be per-attempt rather than per-row because gc's mutations are redb rows inside the blob being CAS-published: `physical_delete = true` is refused at entry, so no per-candidate side effect outlives a discarded attempt (restore is different and gets per-mutation fences in its own PR).

Supporting changes: `StateSyncError::SeamTransition` (a session caller's domain refusal aborts without publishing; non-retryable), and the oracle parameter becomes `Arc<dyn LivenessOracle>` (the session's `for<'a>` bound requires the attempt future to own its captures).

## Tests

- **Mid-seam interleaving (the #1228 schedule)**: the run winner publishes between gc's download and its CAS put — event-keyed on the armed conflict's put count, deadline-bounded so the legacy path fails fast instead of hanging. Asserts the published blob holds BOTH effects and a counting oracle pins per-attempt liveness re-derivation (6 reads = 3 × 2 attempts). 10/10 repeated runs green.
- **Replay mechanics**: two armed conflicts → exactly three CAS attempts, zero unconditional puts, eviction present once.
- **Exhaustion**: three conflicts → nonzero with `LedgerSeamConflict`, remote winner untouched.
- **Fence**: new-marker refusal (names the marker), already-gated pass, LIST transport failure refuses fail-closed.
- Mutation checks (both red, restores verified): forcing `seam_cas = false` fails the mid-seam test on the watcher-fired assertion; neutering the fence's refusal predicate fails the fence test.

Remaining #1242 seams (restore; apply pre-decision + custody; structural removal of `upload_only_fail_closed` + doctor flip) land as follow-up PRs per the reviewed migration plan.