### PR TITLE
fix(scripts): soak harness runs under jq 1.6; meta write fails loud

### DIFF
--- a/scripts/soak-scheduler.sh
+++ b/scripts/soak-scheduler.sh
@@ -310,18 +310,21 @@ jq -n \
   --arg sha "$(git -C "$REPO" rev-parse HEAD 2>/dev/null)" \
   --arg branch "$(git -C "$REPO" rev-parse --abbrev-ref HEAD 2>/dev/null)" \
   --arg state_path "$STATE_PATH" \
-  --argjson t0 "$T0" --argjson end "$END" --argjson pid "$SERVE_PID" \
+  --argjson t0 "$T0" --argjson end_ts "$END" --argjson pid "$SERVE_PID" \
   --argjson sample "$SAMPLE_SECONDS" --argjson poll "$POLL_SECONDS" \
   --argjson harvest "$HARVEST_SECONDS" \
   --argjson drain "$DRAIN_SECONDS" --argjson port "$PORT" \
   --argjson token_was_set "$TOKEN_WAS_SET" \
   --argjson ulimit "$(ulimit -n)" \
   '{binary:$bin, version:$version, git_sha:$sha, branch:$branch, state_path:$state_path,
-    t0:$t0, planned_end:$end, pid:$pid, sample_interval:$sample, harvest_interval:$harvest,
+    t0:$t0, planned_end:$end_ts, pid:$pid, sample_interval:$sample, harvest_interval:$harvest,
     poll_interval:$poll,
     drain_timeout:$drain, port:$port, cron:"* * * * *", timezone:"UTC", catchup:"latest",
     retry_max:0, serve_token_was_unset:$token_was_set, ulimit_n:$ulimit}' \
-  >"$OUT/meta.json"
+  >"$OUT/meta.json" || die "meta.json write failed (jq)"
+# The verdict hard-depends on meta.json; an empty file must abort the soak
+# NOW, not surface as INVALID after 24 hours.
+[[ -s "$OUT/meta.json" ]] || die "meta.json is empty"
 
 # ---------------------------------------------------------------------------
 # Phase 4 — unified sample + harvest loop.


### PR DESCRIPTION
Two portability defects in `scripts/soak-scheduler.sh`, found by the containerized aarch64-linux preflight arm for the soak report's carried Linux caveat:

1. **The meta.json jq filter breaks under jq 1.6.** It bound a jq variable named `$end` — `end` is a jq keyword; 1.7 (macOS Homebrew) tolerates keyword-named variables, 1.6 (Debian bookworm) rejects the filter at parse time (`syntax error, unexpected end, expecting IDENT`). Renamed to `$end_ts`; the emitted `planned_end` key is unchanged, so `soak_verdict.py` reads the same shape.
2. **The failure was silent.** The redirect had already truncated `meta.json` to zero bytes, the harness soaked the full arm, and only the verdict — 1h (or 24h) later — surfaced INVALID. The write now `die`s immediately on a jq failure or an empty output file: never soak against a broken instrument.

Evidence: the same 1h Linux arm otherwise ran clean end-to-end (preflight checks all OK, 120/120 samples, flat ~38 MB RSS, stable fd counts, zero zombies, DONE sentinel written); the macOS PASS run's `serve.exit` shows the identical `{"exit":127,"expected":true}` shutdown artifact, confirming that part is platform-independent and pre-existing.