### PR TITLE
fix(engine/rocky-sql): parse SELECT * EXCEPT (…)

### DIFF
--- a/engine/crates/rocky-compiler/src/resolve.rs
+++ b/engine/crates/rocky-compiler/src/resolve.rs
@@ -275,12 +275,17 @@ mod tests {
     /// fixes one, recompiles, and meets the next.
     #[test]
     fn every_unparseable_model_is_reported_not_just_the_first() {
-        // `SELECT * EXCEPT (...)` is the construct #1224 is about; any SQL the
-        // parser rejects exercises the same path.
+        // Deliberately malformed SQL, not a merely-unsupported construct.
+        //
+        // This fixture used to be `SELECT * EXCEPT (...)`, which the parser
+        // rejected — until #1224 enabled `supports_select_wildcard_except` and
+        // it started parsing, silently emptying this test. A test that proves
+        // "every failure is reported" must not rest on a syntax gap someone
+        // will eventually close; unbalanced parens cannot become valid.
         let models = vec![
-            make_model("a", "SELECT * EXCEPT (x) FROM raw.t"),
+            make_model("a", "SELECT ((( FROM raw.t"),
             make_model("ok", "SELECT 1 AS id"),
-            make_model("b", "SELECT * EXCEPT (y) FROM raw.t"),
+            make_model("b", "SELECT )))"),
         ];
 
         let err = resolve_dependencies(&models).expect_err("unparseable SQL must fail resolution");

--- a/engine/crates/rocky-sql/src/dialect.rs
+++ b/engine/crates/rocky-sql/src/dialect.rs
@@ -27,11 +27,90 @@ impl Dialect for DatabricksDialect {
     fn supports_named_fn_args_with_eq_operator(&self) -> bool {
         true
     }
+
+    /// `SELECT * EXCEPT (a, b)` — star-exclusion.
+    ///
+    /// Databricks SQL and BigQuery both accept it, and sqlparser's own
+    /// `DatabricksDialect` enables it; this hand-rolled dialect simply never
+    /// overrode the trait default of `false`. Measured against a real analytics
+    /// corpus, that one omission accounted for **245 of 249** parse failures —
+    /// 15.8% of models unparseable and 12.3% of join sites invisible to any
+    /// AST-based analysis (#1224).
+    ///
+    /// `* REPLACE (…)` is deliberately NOT enabled alongside it. sqlparser
+    /// gates that separately (`supports_select_wildcard_replace`) and its
+    /// Databricks dialect leaves it off, enabling it only for BigQuery,
+    /// Snowflake, DuckDB and ClickHouse. Since `parse_sql` uses this one
+    /// dialect for every target warehouse, turning it on here would accept
+    /// `REPLACE` for Databricks models too — a widening this issue has no
+    /// evidence for. If a BigQuery corpus needs it, that is a per-target
+    /// dialect question rather than a flag to flip here.
+    fn supports_select_wildcard_except(&self) -> bool {
+        true
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #1224: `SELECT * EXCEPT (…)` is the single construct that accounted for
+    /// 245 of 249 parse failures across a 1553-model real-world corpus.
+    ///
+    /// The failure mode is what makes it expensive: an unparseable model does
+    /// not error, it simply contributes nothing to any AST-driven analysis, so
+    /// lineage and grain checks report clean results over a corpus they only
+    /// partly read.
+    ///
+    /// Mutation that must turn this red: drop
+    /// `supports_select_wildcard_except` from the dialect.
+    #[test]
+    fn star_exclusion_parses() {
+        for sql in [
+            // The issue's repro.
+            "SELECT * EXCEPT (updated_at, _loaded_at) FROM stg_orders",
+            // Single exclusion, and a qualified star.
+            "SELECT * EXCEPT (id) FROM t",
+            "SELECT t.* EXCEPT (id) FROM t",
+            // Alongside other select items, and in a CTE.
+            "SELECT a, t.* EXCEPT (b) FROM t",
+            "WITH c AS (SELECT * EXCEPT (x) FROM t) SELECT * FROM c",
+        ] {
+            crate::parser::parse_sql(sql).unwrap_or_else(|e| panic!("{sql:?} must parse: {e}"));
+        }
+    }
+
+    /// The point of parsing it is that downstream analysis can now SEE it.
+    ///
+    /// A parse failure is silent — the model contributes nothing to lineage
+    /// rather than raising — so "it parses" is necessary but not sufficient.
+    /// This asserts the read actually reaches the lineage extractor, which is
+    /// what the 12.3%-of-join-sites figure in #1224 is about.
+    #[test]
+    fn star_exclusion_reaches_lineage_extraction() {
+        let lin =
+            crate::lineage::extract_lineage("SELECT * EXCEPT (updated_at) FROM main.stg_orders")
+                .expect("lineage over a star-exclusion query");
+        let refs: Vec<String> = lin
+            .source_tables
+            .iter()
+            .map(|t| format!("{t:?}").to_lowercase())
+            .collect();
+        assert!(
+            refs.iter().any(|r| r.contains("stg_orders")),
+            "the FROM relation must be visible to lineage: {refs:?}"
+        );
+    }
+
+    /// The control: ordinary stars keep working, so the test above is not
+    /// passing because the dialect became permissive about everything.
+    #[test]
+    fn a_plain_star_still_parses_and_a_bare_except_is_still_a_set_operator() {
+        crate::parser::parse_sql("SELECT * FROM t").expect("plain star");
+        // `EXCEPT` as a set operator must not be shadowed by the star form.
+        crate::parser::parse_sql("SELECT a FROM t EXCEPT SELECT a FROM u")
+            .expect("set-operator EXCEPT");
+    }
 
     #[test]
     fn test_identifier_rules() {


### PR DESCRIPTION
## Summary

Fixes #1224.

`SELECT * EXCEPT (col, …)` did not parse. Measured against a real 1553-model analytics corpus, that **one construct** accounted for **245 of 249** parse failures: 15.8% of models unparseable, and 12.3% of join sites invisible to any AST-based analysis.

The failure mode is what makes it expensive. An unparseable model does not error — it simply contributes nothing, so lineage and grain checks report clean results over a corpus they only partly read.

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## The cause was a missing override, not a missing feature

sqlparser-rs has supported this since well before the version pinned here. It sits behind `Dialect::supports_select_wildcard_except()`, which the trait defaults to `false` — and **sqlparser's own `DatabricksDialect` enables it**. This crate hand-rolls a dialect of the same name (`rocky-sql/src/dialect.rs`) that overrides four methods and never touched this one.

So the construct was one trait method away from working, and the 16% figure is the cost of a default nobody revisited.

## `* REPLACE (…)` is deliberately not enabled

The issue suggested considering it "while in the same code". I did, and left it off.

sqlparser gates it separately (`supports_select_wildcard_replace`) and its Databricks dialect leaves it **off**, enabling it only for BigQuery, Snowflake, DuckDB and ClickHouse. Meanwhile `parse_sql` uses this one dialect for *every* target warehouse — so flipping it here would accept `REPLACE` for Databricks models too.

That is a widening with no evidence behind it in this issue, and following upstream's per-dialect judgement is the more defensible default. If a BigQuery corpus needs it, that is a per-target dialect question rather than a flag to flip.

## One unrelated test needed a new fixture — worth seeing stated

`rocky-compiler`'s `every_unparseable_model_is_reported_not_just_the_first` used `SELECT * EXCEPT (...)` as its example of invalid SQL, with a comment citing this very issue. Making it parse **silently emptied that test** — it still passed structurally while no longer exercising the multi-failure path.

The fixture is now unbalanced parens. The test's intent (report every parse failure, not just the first) is unchanged and still valuable; what changed is that it no longer rests on a syntax gap someone will eventually close.

Only the full workspace suite caught this. The targeted `rocky-sql` run was green.

## Test Plan

- `star_exclusion_parses` — the issue's repro plus four shapes: single exclusion, qualified `t.* EXCEPT (…)`, mixed with other select items, and inside a CTE.
- `star_exclusion_reaches_lineage_extraction` — **the one that matters**. Parsing is necessary but not sufficient: the whole point is that downstream analysis can now see these models. Asserts the `FROM` relation reaches `extract_lineage`, which is what the 12.3%-of-join-sites figure is about.
- `a_plain_star_still_parses_and_a_bare_except_is_still_a_set_operator` — the control. Ordinary `SELECT *` keeps working and `EXCEPT` as a set operator is not shadowed by the star form, so the tests above are not passing because the dialect became permissive about everything.

**Mutation-checked:** flipping `supports_select_wildcard_except` back to `false` reddens `star_exclusion_parses` and nothing else.

- `cargo nextest run --all-features` — **5,992 passed**.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.

## What I am least confident about

**Whether the silent-skip half of the issue is also worth fixing here.** #1224's third bullet asks whether a parse failure surfaces anywhere a user would see it, and says that if models are skipped silently it is worth fixing independently. I have not changed that: `resolve_dependencies` does return `LineageExtractionMany` listing every failure, so the compiler path is not silent — but I did not audit every AST-driven consumer for whether *it* surfaces the gap. Since this PR removes the overwhelming majority of failures, the remaining silence is less pressing, which is an argument for doing it separately rather than an argument that it is fine.

## The column-lineage question, settled

I initially listed "does column lineage subtract the `EXCEPT` list, or ignore it and over-report columns?" as unverified. Probing it answers cleanly: **the two forms are treated identically, and neither enumerates columns.**

```
sql="SELECT * EXCEPT (updated_at) FROM main.stg_orders"  has_star=true  columns=[]
sql="SELECT * FROM main.stg_orders"                      has_star=true  columns=[]
```

`extract_lineage` does not expand a star against an upstream schema, so there is no column set for an `EXCEPT` list to be subtracted from — the star is recorded as a *partiality flag* instead. Consumers act on that flag rather than on enumerated columns: `catalog.rs`'s `regrade_star_edges` drops any edge whose target has a star to `EdgeConfidence::Medium`, and the catalog summary counts `assets_with_star`.

So there is no over-reporting to worry about, and no subtraction to implement here. What this PR delivers is exactly what #1224 measured — the models become *visible* to `source_tables` and join-site analysis, at the same confidence any other `SELECT *` model gets.

If star expansion against a resolved schema is added later, that is where the `EXCEPT` list would need to be honoured, and it would be a new capability rather than a regression of this one.

## What I am most likely missing

**Whether the parser now accepts `EXCEPT` in positions Databricks itself would reject.** The flag is dialect-wide, so it enables the star-exclusion form wherever sqlparser offers it. I tested the shapes in the Test Plan and the set-operator control, but I did not enumerate every position sqlparser will now permit against Databricks' actual grammar. Being more permissive than the warehouse means Rocky parses something the warehouse would reject at execution — a worse error location, not wrong results, and strictly better than today's "parses nothing".

## Checklist

- [x] Conventional commits, scoped by subproject
- [x] No `Co-Authored-By` trailers
- [x] Not a CLI JSON schema or DSL syntax change, so no consumer updates required
