### PR TITLE
feat(engine): [run] strict_scheduling refuses unresolved physical-read ordering

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -15751,7 +15751,8 @@
             "default": {
               "lag_tolerance_seconds": 0,
               "skip_rowcount_fallback": false,
-              "skip_unchanged": false
+              "skip_unchanged": false,
+              "strict_scheduling": false
             },
             "description": "Opt-in run-execution tuning for the `--skip-unchanged` model-skip gate. Default-OFF: an absent `[run]` block (or one that leaves every field at its default) keeps `rocky run`'s behavior byte-identical to before the gate existed. See [`RunConfig`]."
           },
@@ -15974,6 +15975,11 @@
           "skip_unchanged": {
             "default": false,
             "description": "Master switch for the model-skip gate. `false` (default) ⇒ every selected model always builds, exactly as before. The `--skip-unchanged` CLI flag turns the gate on for a single invocation regardless of this value.",
+            "type": "boolean"
+          },
+          "strict_scheduling": {
+            "default": false,
+            "description": "Turn physical-read scheduling warnings into a run refusal.\n\n`false` (default) keeps today's behaviour: #1352 derives ordering edges from physical `schema.table` reads and reports what it could NOT safely resolve — contradicting bare-read pairs, models whose reference extraction failed, colliding targets — as advisory warnings, and the run still exits 0. A consumer that ignores them can read a stale physical target and report success.\n\n`true` refuses instead, for estates that want fail-closed ordering. Opt in rather than default, because making warnings fatal changes run semantics for every existing project (#1355).\n\nLives on `[run]` rather than `[execution]` deliberately: `[execution]` is per-pipeline, and `rocky run --dag` derives ordering ACROSS pipelines, so a per-pipeline switch would have no single answer on the path that most needs one.",
             "type": "boolean"
           }
         },

--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -3403,6 +3403,11 @@
           "default": false,
           "description": "Master switch for the model-skip gate. `false` (default) ⇒ every selected model always builds, exactly as before. The `--skip-unchanged` CLI flag turns the gate on for a single invocation regardless of this value.",
           "type": "boolean"
+        },
+        "strict_scheduling": {
+          "default": false,
+          "description": "Turn physical-read scheduling warnings into a run refusal.\n\n`false` (default) keeps today's behaviour: #1352 derives ordering edges from physical `schema.table` reads and reports what it could NOT safely resolve — contradicting bare-read pairs, models whose reference extraction failed, colliding targets — as advisory warnings, and the run still exits 0. A consumer that ignores them can read a stale physical target and report success.\n\n`true` refuses instead, for estates that want fail-closed ordering. Opt in rather than default, because making warnings fatal changes run semantics for every existing project (#1355).\n\nLives on `[run]` rather than `[execution]` deliberately: `[execution]` is per-pipeline, and `rocky run --dag` derives ordering ACROSS pipelines, so a per-pipeline switch would have no single answer on the path that most needs one.",
+          "type": "boolean"
         }
       },
       "type": "object"
@@ -4658,7 +4663,8 @@
       "default": {
         "lag_tolerance_seconds": 0,
         "skip_rowcount_fallback": false,
-        "skip_unchanged": false
+        "skip_unchanged": false,
+        "strict_scheduling": false
       },
       "description": "Opt-in run-execution tuning for the `--skip-unchanged` model-skip gate. Default-OFF: an absent `[run]` block (or one that leaves every field at its default) keeps `rocky run`'s behavior byte-identical to before the gate existed. See [`RunConfig`]."
     },

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -2181,6 +2181,16 @@ export interface RunConfig {
    * Master switch for the model-skip gate. `false` (default) ⇒ every selected model always builds, exactly as before. The `--skip-unchanged` CLI flag turns the gate on for a single invocation regardless of this value.
    */
   skip_unchanged?: boolean;
+  /**
+   * Turn physical-read scheduling warnings into a run refusal.
+   *
+   * `false` (default) keeps today's behaviour: #1352 derives ordering edges from physical `schema.table` reads and reports what it could NOT safely resolve — contradicting bare-read pairs, models whose reference extraction failed, colliding targets — as advisory warnings, and the run still exits 0. A consumer that ignores them can read a stale physical target and report success.
+   *
+   * `true` refuses instead, for estates that want fail-closed ordering. Opt in rather than default, because making warnings fatal changes run semantics for every existing project (#1355).
+   *
+   * Lives on `[run]` rather than `[execution]` deliberately: `[execution]` is per-pipeline, and `rocky run --dag` derives ordering ACROSS pipelines, so a per-pipeline switch would have no single answer on the path that most needs one.
+   */
+  strict_scheduling?: boolean;
 }
 /**
  * Project-level schedule defaults (`[schedule]`).

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`[run] strict_scheduling` refuses a run whose physical-read ordering could not be fully resolved.** #1352 derives ordering edges from physical `schema.table` reads and reports what it cannot safely resolve — contradicting bare-read pairs, models whose reference extraction failed, colliding targets — as advisory warnings, and the run still exits 0. A consumer that ignores them can read a stale physical target and report success. Setting `strict_scheduling = true` turns any such warning into a refusal that names every unresolved pair and says how to fix it (declare the upstream in `depends_on`) or opt out.
+
+  Default `false`, because making warnings fatal changes run semantics for every existing project. It lives on `[run]` rather than `[execution]` deliberately: `[execution]` is per-pipeline and `rocky run --dag` derives ordering *across* pipelines, so a per-pipeline switch would have no single answer on the path that most needs one. Both the plain and `--dag` paths call the same refusal function, so "strict" cannot come to mean two different things depending on how the run was started — the divergence `--parallel` had before #1288. (#1355)
+
 ### Fixed
 
 - **`rocky run --shadow` (suffix mode) works for replication pipelines.** `TableTask` carried a single `table_name` used for both sides of a copy, and the connector loop stored the shadow-*suffixed* name in it — so a copy of `raw.orders` READ `raw.orders_rocky_shadow`. Normally that table is absent and the run failed with a misleading "table not found"; where such a table existed it silently copied the wrong one. Replication shadow-suffix runs were refused outright rather than allowed to do either. The field is now split into `source_table_name` and `target_table_name`, and only the source read keeps the production name.

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -290,6 +290,34 @@ fn arm_hard_exit_on_second_signal() {
 /// A named function rather than two inline literals so a test can assert the
 /// *production* mapping instead of restating it — a test that rebuilds the
 /// refs itself passes no matter which field `process_table` actually uses.
+/// Refuse a run whose physical-read ordering could not be fully resolved.
+///
+/// #1352 derives ordering edges from physical `schema.table` reads and reports
+/// what it could not safely resolve as advisory warnings — the run still exits
+/// 0, so a consumer that ignores them can read a stale target and report
+/// success. `[run] strict_scheduling` (or `--strict-scheduling`) turns that into
+/// a refusal for estates that want fail-closed ordering (#1355).
+///
+/// Shared by the plain and `--dag` paths deliberately. Two copies would let
+/// "strict" come to mean different things depending on how the run was started,
+/// which is exactly the divergence `--parallel` had before #1288.
+pub(crate) fn refuse_on_scheduling_warnings(strict: bool, warnings: &[String]) -> Result<()> {
+    if !strict || warnings.is_empty() {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "strict scheduling is on and this run's physical-read ordering could not be fully \
+         resolved, so execution order is not guaranteed:\n{}\n\nDeclare each upstream in \
+         `depends_on` to resolve it, or unset `[run] strict_scheduling` / omit \
+         `--strict-scheduling` to run with these as advisory warnings.",
+        warnings
+            .iter()
+            .map(|w| format!("  - {w}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    )
+}
+
 fn copy_endpoints(task: &TableTask) -> (TableRef, TableRef) {
     (
         TableRef {
@@ -1705,6 +1733,7 @@ pub async fn run(
             rocky_cfg.reuse.column_level && !skip_opts.no_reuse,
             run_vars,
             rocky_cfg.resilience.clone(),
+            rocky_cfg.run.strict_scheduling,
             super::resilience::retry_policy_allows(rocky_cfg),
             exec_fp_gate.as_ref(),
             Some(&freeze_fence),
@@ -4838,6 +4867,7 @@ pub async fn run(
                     rocky_cfg.reuse.column_level && !skip_opts.no_reuse,
                     run_vars,
                     rocky_cfg.resilience.clone(),
+            rocky_cfg.run.strict_scheduling,
                     super::resilience::retry_policy_allows(rocky_cfg),
                     exec_fp_gate.as_ref(),
                     Some(&freeze_fence),
@@ -6776,6 +6806,7 @@ pub(crate) async fn execute_backfill_set(
             column_level_enabled,
             &run_vars,
             rocky_cfg.resilience.clone(),
+            rocky_cfg.run.strict_scheduling,
             super::resilience::retry_policy_allows(rocky_cfg),
             exec_fp_gate,
             freeze_fence,
@@ -7171,6 +7202,9 @@ pub(crate) async fn execute_models(
     // retries. Passed by value (cheap `Clone`) so call sites don't juggle a
     // borrow of the `RockyConfig`.
     resilience: rocky_core::config::ResilienceConfig,
+    // `[run] strict_scheduling`, resolved by the caller the same way `skip_gate`
+    // is. Turns unresolved physical-read ordering into a refusal (#1355).
+    strict_scheduling: bool,
     // Whether the agent-policy plane permits the `retry` capability for this
     // run (allow-by-default; only an explicit `capability = "retry"` policy rule
     // gates it). Resolved once by the caller from `[policy]`.
@@ -7521,6 +7555,7 @@ pub(crate) async fn execute_models(
             resilience.contain_failures,
             &mut output.scheduling_warnings,
         )?;
+        refuse_on_scheduling_warnings(strict_scheduling, &output.scheduling_warnings)?;
     }
 
     // #1093: capture governance from the same in-memory model set the
@@ -13754,6 +13789,51 @@ merge_keys = ["id"]
     /// replacement. Plain CREATE should reject the existing target and leave
     /// its rows untouched.
     #[cfg(feature = "duckdb")]
+    /// #1355: `[run] strict_scheduling` turns unresolved physical-read ordering
+    /// into a refusal instead of an advisory warning.
+    ///
+    /// #1352 derives ordering edges from physical reads and reports what it
+    /// cannot safely resolve — contradicting bare-read pairs, extraction
+    /// failures, colliding targets — while still exiting 0. A consumer that
+    /// ignores those warnings can read a stale target and report success.
+    ///
+    /// Mutation that must turn this red: `if !strict || warnings.is_empty()`
+    /// → `if true`.
+    #[test]
+    fn strict_scheduling_refuses_a_run_with_unresolved_ordering() {
+        let warnings = vec![
+            "two models claim main.orders; ordering between them is a guess".to_string(),
+            "reference extraction failed for 'mart'".to_string(),
+        ];
+
+        let err = super::refuse_on_scheduling_warnings(true, &warnings)
+            .expect_err("strict mode must refuse a run it cannot order");
+        let msg = err.to_string();
+
+        // Every warning must reach the operator. A refusal that says "ordering
+        // is not guaranteed" without saying WHICH pairs sends them to the logs
+        // of a run that already refused.
+        assert!(msg.contains("main.orders"), "{msg}");
+        assert!(msg.contains("mart"), "{msg}");
+        // And it must say how to resolve or opt out.
+        assert!(msg.contains("depends_on"), "{msg}");
+        assert!(msg.contains("strict_scheduling"), "{msg}");
+    }
+
+    /// Two controls, because "refuses" must not become "refuses everything".
+    ///
+    /// Default-off is the whole reason this is opt-in: making warnings fatal
+    /// changes run semantics for every existing project.
+    #[test]
+    fn scheduling_warnings_are_advisory_unless_strict_and_present() {
+        let warnings = vec!["ordering between a and b is a guess".to_string()];
+
+        super::refuse_on_scheduling_warnings(false, &warnings)
+            .expect("default (opt-out) must keep warnings advisory");
+        super::refuse_on_scheduling_warnings(true, &[])
+            .expect("strict with a fully-resolved graph must not refuse");
+    }
+
     /// #1280: a shadow SUFFIX run reads production and writes the suffixed
     /// target — the two names are no longer one field.
     ///
@@ -15791,6 +15871,7 @@ timestamp_column = "ts"
             false,
             &rocky_core::run_vars::RunVars::new(),
             rocky_core::config::ResilienceConfig::default(),
+            false, // strict_scheduling (#1355)
             true,
             None, // exec_fp_gate (test)
             None, // freeze_fence (test)
@@ -15870,6 +15951,7 @@ timestamp_column = "ts"
             false,
             &rocky_core::run_vars::RunVars::new(),
             rocky_core::config::ResilienceConfig::default(),
+            false, // strict_scheduling (#1355)
             true,
             Some(&gate),
             None, // freeze_fence (test)
@@ -15909,6 +15991,7 @@ timestamp_column = "ts"
             false,
             &rocky_core::run_vars::RunVars::new(),
             rocky_core::config::ResilienceConfig::default(),
+            false, // strict_scheduling (#1355)
             true,
             Some(&gate),
             None, // freeze_fence (test)
@@ -16098,6 +16181,7 @@ timestamp_column = "ts"
             false,
             &rocky_core::run_vars::RunVars::new(),
             rocky_core::config::ResilienceConfig::default(),
+            false, // strict_scheduling (#1355)
             true,
             Some(&gate),
             None, // freeze_fence (test)
@@ -16340,6 +16424,7 @@ timestamp_column = "ts"
             false,
             &rocky_core::run_vars::RunVars::new(),
             rocky_core::config::ResilienceConfig::default(),
+            false, // strict_scheduling (#1355)
             true,
             Some(&gate),
             None, // freeze_fence (test)
@@ -16429,6 +16514,7 @@ timestamp_column = "ts"
             false,
             &rocky_core::run_vars::RunVars::new(),
             rocky_core::config::ResilienceConfig::default(),
+            false, // strict_scheduling (#1355)
             true,
             Some(&gate),
             None, // freeze_fence (test)
@@ -16487,6 +16573,7 @@ timestamp_column = "ts"
             false,
             &rocky_core::run_vars::RunVars::new(),
             rocky_core::config::ResilienceConfig::default(),
+            false, // strict_scheduling (#1355)
             true,
             Some(&gate),
             None, // freeze_fence (test)
@@ -16677,6 +16764,7 @@ timestamp_column = "ts"
             false,
             &rocky_core::run_vars::RunVars::new(),
             resilience,
+            false, // strict_scheduling (#1355)
             true,
             None, // exec_fp_gate (test)
             None, // freeze_fence (test)
@@ -16723,6 +16811,7 @@ timestamp_column = "ts"
             false,
             &rocky_core::run_vars::RunVars::new(),
             resilience,
+            false, // strict_scheduling (#1355)
             true,
             None, // exec_fp_gate (test)
             None, // freeze_fence (test)
@@ -16775,6 +16864,7 @@ timestamp_column = "ts"
             false,
             &rocky_core::run_vars::RunVars::new(),
             resilience,
+            false, // strict_scheduling (#1355)
             true,
             None, // exec_fp_gate (test)
             None, // freeze_fence (test)
@@ -18866,6 +18956,7 @@ timestamp_column = "ts"
             false,
             &run_vars,
             rocky_core::config::ResilienceConfig::default(),
+            false, // strict_scheduling (#1355)
             true,
             None, // exec_fp_gate (test)
             None, // freeze_fence (test)
@@ -18976,6 +19067,7 @@ timestamp_column = "ts"
             false,
             &rocky_core::run_vars::RunVars::new(),
             rocky_core::config::ResilienceConfig::default(),
+            false, // strict_scheduling (#1355)
             true,
             None, // exec_fp_gate (test)
             None, // freeze_fence (test)
@@ -19101,6 +19193,7 @@ timestamp_column = "ts"
             false,
             &rocky_core::run_vars::RunVars::new(),
             rocky_core::config::ResilienceConfig::default(),
+            false, // strict_scheduling (#1355)
             true,
             None, // exec_fp_gate (test)
             None, // freeze_fence (test)
@@ -19387,6 +19480,7 @@ timestamp_column = "ts"
                 false,
                 &rocky_core::run_vars::RunVars::new(),
                 rocky_core::config::ResilienceConfig::default(),
+                false, // strict_scheduling (#1355)
                 true,
                 None, // exec_fp_gate (test)
                 None, // freeze_fence (test)
@@ -19516,6 +19610,7 @@ timestamp_column = "ts"
             false,
             &rocky_core::run_vars::RunVars::new(),
             rocky_core::config::ResilienceConfig::default(),
+            false, // strict_scheduling (#1355)
             true,
             None, // exec_fp_gate (test)
             None, // freeze_fence (test)
@@ -20495,6 +20590,7 @@ timestamp_column = "ts"
                 false,
                 &rocky_core::run_vars::RunVars::new(),
                 rocky_core::config::ResilienceConfig::default(),
+                false, // strict_scheduling (#1355)
                 true,
                 None, // exec_fp_gate (test)
                 None, // freeze_fence (test)

--- a/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
+++ b/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
@@ -309,6 +309,11 @@ pub async fn run_with_dag(
     for w in &physical_edge_warnings {
         tracing::warn!("{w}");
     }
+    // Same refusal the plain path applies, through the same function — "strict"
+    // must not mean two different things depending on how the run started
+    // (#1355). Placed before the executor is built, so a refused run dispatches
+    // no nodes.
+    super::run::refuse_on_scheduling_warnings(cfg.run.strict_scheduling, &physical_edge_warnings)?;
 
     // `--dag` cannot isolate a run, so it refuses to pretend it can.
     //

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -183,6 +183,7 @@ pub async fn run_transformation(
                 rocky_cfg.reuse.column_level && !no_reuse,
                 run_vars,
                 rocky_cfg.resilience.clone(),
+                rocky_cfg.run.strict_scheduling,
                 super::resilience::retry_policy_allows(rocky_cfg),
                 exec_fp_gate,
                 freeze_fence,

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -2693,6 +2693,26 @@ pub struct RunConfig {
     #[serde(default)]
     pub skip_rowcount_fallback: bool,
 
+    /// Turn physical-read scheduling warnings into a run refusal.
+    ///
+    /// `false` (default) keeps today's behaviour: #1352 derives ordering edges
+    /// from physical `schema.table` reads and reports what it could NOT safely
+    /// resolve — contradicting bare-read pairs, models whose reference
+    /// extraction failed, colliding targets — as advisory warnings, and the run
+    /// still exits 0. A consumer that ignores them can read a stale physical
+    /// target and report success.
+    ///
+    /// `true` refuses instead, for estates that want fail-closed ordering. Opt
+    /// in rather than default, because making warnings fatal changes run
+    /// semantics for every existing project (#1355).
+    ///
+    /// Lives on `[run]` rather than `[execution]` deliberately: `[execution]`
+    /// is per-pipeline, and `rocky run --dag` derives ordering ACROSS pipelines,
+    /// so a per-pipeline switch would have no single answer on the path that
+    /// most needs one.
+    #[serde(default)]
+    pub strict_scheduling: bool,
+
     /// Treat an upstream `MAX(ts)` that moved by fewer than this many seconds
     /// as unchanged for the B3 freshness comparison — the late-arriving-but-
     /// irrelevant micro-update analog of a freshness SLA threshold. Default

--- a/integrations/dagster/tests/fixtures_generated/plan.json
+++ b/integrations/dagster/tests/fixtures_generated/plan.json
@@ -14,7 +14,7 @@
       "sql": "CREATE OR REPLACE TABLE staging__orders.orders AS\nSELECT *\nFROM raw__orders.orders"
     }
   ],
-  "plan_id": "7c3a7623f01f273e5961b22cbde3ae7a20671a5446fd6cb851f56a8214bea6e8",
+  "plan_id": "a44c8485d91a4a8b7fe5060d3b1320aac389de6cb3ddc8a958162c850cfe3fca",
   "plan_kind": "run",
   "created_at": "2000-01-01T00:00:00Z",
   "models": [

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -3402,6 +3402,11 @@
           "default": false,
           "description": "Master switch for the model-skip gate. `false` (default) ⇒ every selected model always builds, exactly as before. The `--skip-unchanged` CLI flag turns the gate on for a single invocation regardless of this value.",
           "type": "boolean"
+        },
+        "strict_scheduling": {
+          "default": false,
+          "description": "Turn physical-read scheduling warnings into a run refusal.\n\n`false` (default) keeps today's behaviour: #1352 derives ordering edges from physical `schema.table` reads and reports what it could NOT safely resolve — contradicting bare-read pairs, models whose reference extraction failed, colliding targets — as advisory warnings, and the run still exits 0. A consumer that ignores them can read a stale physical target and report success.\n\n`true` refuses instead, for estates that want fail-closed ordering. Opt in rather than default, because making warnings fatal changes run semantics for every existing project (#1355).\n\nLives on `[run]` rather than `[execution]` deliberately: `[execution]` is per-pipeline, and `rocky run --dag` derives ordering ACROSS pipelines, so a per-pipeline switch would have no single answer on the path that most needs one.",
+          "type": "boolean"
         }
       },
       "type": "object"
@@ -4657,7 +4662,8 @@
       "default": {
         "lag_tolerance_seconds": 0,
         "skip_rowcount_fallback": false,
-        "skip_unchanged": false
+        "skip_unchanged": false,
+        "strict_scheduling": false
       },
       "description": "Opt-in run-execution tuning for the `--skip-unchanged` model-skip gate. Default-OFF: an absent `[run]` block (or one that leaves every field at its default) keeps `rocky run`'s behavior byte-identical to before the gate existed. See [`RunConfig`]."
     },

--- a/sdk/python/src/rocky_sdk/types_generated/rocky_project_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/rocky_project_schema.py
@@ -1459,6 +1459,16 @@ class RunConfig(BaseModel):
     """
     Master switch for the model-skip gate. `false` (default) ⇒ every selected model always builds, exactly as before. The `--skip-unchanged` CLI flag turns the gate on for a single invocation regardless of this value.
     """
+    strict_scheduling: bool | None = False
+    """
+    Turn physical-read scheduling warnings into a run refusal.
+
+    `false` (default) keeps today's behaviour: #1352 derives ordering edges from physical `schema.table` reads and reports what it could NOT safely resolve — contradicting bare-read pairs, models whose reference extraction failed, colliding targets — as advisory warnings, and the run still exits 0. A consumer that ignores them can read a stale physical target and report success.
+
+    `true` refuses instead, for estates that want fail-closed ordering. Opt in rather than default, because making warnings fatal changes run semantics for every existing project (#1355).
+
+    Lives on `[run]` rather than `[execution]` deliberately: `[execution]` is per-pipeline, and `rocky run --dag` derives ordering ACROSS pipelines, so a per-pipeline switch would have no single answer on the path that most needs one.
+    """
 
 
 class RunRetryConfig(BaseModel):
@@ -3886,6 +3896,7 @@ class RockyConfig(BaseModel):
             "lag_tolerance_seconds": 0,
             "skip_rowcount_fallback": False,
             "skip_unchanged": False,
+            "strict_scheduling": False,
         },
         validate_default=True,
     )


### PR DESCRIPTION
## Summary

Fixes #1355.

#1352 derives ordering edges from physical `schema.table` reads and reports what it **cannot** safely resolve — contradicting bare-read pairs, models whose reference extraction failed, colliding targets — as advisory warnings. The run still exits 0, so a consumer that ignores them can read a stale physical target and report success.

`[run] strict_scheduling = true` turns any such warning into a refusal.

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` · [ ] `editors/vscode/` · [ ] `schemas/` · [ ] Cross-project

## Three decisions worth reviewing

**`[run]`, not `[execution]`.** The issue offers `[execution] strict_scheduling`, which does not work: `ExecutionConfig` is **per-pipeline**, and `rocky run --dag` derives ordering *across* pipelines — so a per-pipeline switch has no single answer on the path that most needs one. `RunConfig` is project-level and already hosts this exact shape (`skip_unchanged`).

**One refusal function, both paths.** The plain path receives the resolved flag as a parameter — the same way `skip_gate` is resolved by the caller from CLI options plus `[run]` — and `--dag` has the config in scope and calls it *before* the executor is built, so a refused run dispatches no nodes. Two copies would let "strict" come to mean different things depending on how the run was started, which is precisely the divergence `--parallel` had before #1288.

**Config-only, no CLI flag.** The issue offers either. A flag would cascade through `run()`'s already-large signature and gains nothing a config key does not already give an estate-level policy. Easy to add later if one-off strict checks turn out to be wanted.

## Test Plan

- `strict_scheduling_refuses_a_run_with_unresolved_ordering` — asserts **every** warning reaches the message, plus both the fix (`depends_on`) and the opt-out. A refusal saying "ordering is not guaranteed" without naming the pairs sends an operator to the logs of a run that already refused.
- `scheduling_warnings_are_advisory_unless_strict_and_present` — two controls in one: default-off keeps warnings advisory, and strict with a fully-resolved graph does not refuse.

**Mutation-checked, each binding to a different test:**

| mutation | fails |
|---|---|
| never refuse (`if true`) | the refusal test only |
| refuse regardless of the flag (drop `!strict`) | the advisory control only |

The second is the one that matters — it is what catches strictness silently becoming the default, which is the change the issue explicitly did *not* want.

- `cargo nextest run --all-features` — **5,995 passed**.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.

Gated twice, deliberately: an earlier identical run passed at 5,993 on a previous base, but `main` then gained #1382 and #1383 — and #1383 touched `run.rs` heavily, the same file this changes. Green on a stale base is not evidence.

## This changes `plan_id` hashes

Worth knowing before merge, and not something I anticipated: `plan_id` is content-addressed over the config fingerprint, so adding a `[run]` field moves it. The dagster fixture shows it exactly:

```
-  "plan_id": "7c3a7623f01f273e5961b22cbde3ae7a20671a5446fd6cb851f56a8214bea6e8"
+  "plan_id": "a44c8485d91a4a8b7fe5060d3b1320aac389de6cb3ddc8a958162c850cfe3fca"
```

Nothing breaks: a persisted plan keeps the id it was written with, and applying it is unaffected. What changes is that **re-planning the same project after this lands produces a different id than it did before** — so anything comparing "would re-planning yield this id?" as a drift signal sees a difference once, at upgrade.

This is the same effect I cited in #1288 as the reason *not* to add `parallel` to the stored plan. It applies to any new `[run]` field, and it is the cost of putting the switch in config rather than behind a CLI-only flag. I still think config is right for an estate-level policy, but the trade should be explicit rather than discovered.

It also took two passes to surface: `just codegen` and `just regen-fixtures` are **separate** drift surfaces, and only the second catches fixture hashes.

## What I am least confident about

**Whether refusing is the right response to *every* warning class, or only some.** `scheduling_warnings` currently mixes three kinds: a contradicting bare-read pair (ordering is a genuine guess), a reference-extraction failure (Rocky could not read the SQL at all), and a colliding target. All three mean "ordering is not guaranteed", so refusing on all three is defensible — but an estate might reasonably want to fail on extraction failures while tolerating a known-benign collision. That would need warnings to carry a class rather than being strings, which is a larger change than this issue asks for and which #1357 may want anyway.

## What I am most likely missing

**Whether `--dag`'s warning set is exactly the plain path's.** The two paths collect from different sources — `augment_physical_read_edges` versus `label_report.warnings()` plus `derivation_warnings` — and I wired the same refusal to both without proving the sets are equivalent. If `--dag` surfaces a warning class the plain path does not, `strict_scheduling` is stricter under `--dag` than without it, which is not obviously wrong but is not something I verified.

## Checklist

- [x] Conventional commits, scoped by subproject
- [x] No `Co-Authored-By` trailers
- [x] Not a CLI JSON schema or DSL syntax change, so no consumer updates required
