### PR TITLE
feat(engine/rocky-cli): add --verbose to rocky estimate

### DIFF
--- a/engine/crates/rocky-cli/src/commands/estimate.rs
+++ b/engine/crates/rocky-cli/src/commands/estimate.rs
@@ -19,12 +19,16 @@ use crate::output::{EstimateOutput, ModelEstimate, print_json};
 use crate::registry::{self, AdapterRegistry};
 
 /// Execute `rocky estimate`: compile models, generate SQL, and run EXPLAIN.
+///
+/// `verbose` affects the TEXT output only — the JSON output is byte-identical
+/// either way, so a `--output json` consumer cannot tell the flag was passed.
 pub async fn run_estimate(
     config_path: &Path,
     models_dir: &Path,
     pipeline_name: Option<&str>,
     model_filter: Option<&str>,
     output_json: bool,
+    verbose: bool,
 ) -> Result<()> {
     // 1. Load config + adapter registry.
     let rocky_cfg = rocky_core::config::load_rocky_config(config_path).context(format!(
@@ -36,7 +40,7 @@ pub async fn run_estimate(
     let warehouse_adapter = adapter_registry.warehouse_adapter(pipeline.target_adapter())?;
 
     // Determine warehouse pricing model from the pipeline's target adapter.
-    let pricing = resolve_pricing(&rocky_cfg, pipeline.target_adapter());
+    let (pricing_source, pricing) = resolve_pricing(&rocky_cfg, pipeline.target_adapter());
 
     // 2. Load all models.
     let all_models = load_all_models(models_dir)?;
@@ -64,6 +68,11 @@ pub async fn run_estimate(
 
     // 3. For each model, generate SQL and run EXPLAIN.
     let mut estimates = Vec::new();
+    // Models dropped before EXPLAIN ever ran. Without these the text report's
+    // "Estimated N model(s)" is a count of what SUCCEEDED, not of what was
+    // asked for, and the difference is otherwise only visible at debug log
+    // level. Surfaced under `--verbose` (the default output is unchanged).
+    let mut skipped: Vec<(String, String)> = Vec::new();
     for model in &models_to_estimate {
         let model_ir = model.to_model_ir();
         let dialect = warehouse_adapter.dialect();
@@ -74,6 +83,7 @@ pub async fn run_estimate(
             Ok(stmts) => stmts.join(";\n"),
             Err(e) => {
                 debug!(model = %model.config.name, "skipping estimate — SQL gen error: {e}");
+                skipped.push((model.config.name.clone(), format!("SQL generation: {e}")));
                 continue;
             }
         };
@@ -93,44 +103,102 @@ pub async fn run_estimate(
     if output_json {
         print_json(&EstimateOutput::new(estimates))?;
     } else {
-        println!("Estimated {} model(s):", estimates.len());
-        println!();
-        for est in &estimates {
-            println!("  {}", est.model_name);
-            if let Some(bytes) = est.estimated_bytes_scanned {
-                println!("    Bytes scanned: {bytes}");
-            }
-            if let Some(rows) = est.estimated_rows {
-                println!("    Rows: {rows}");
-            }
-            if let Some(cost) = est.estimated_cost_usd {
-                println!("    Est. cost: ${cost:.6}");
-            }
-            if !est.raw_explain.is_empty() {
+        print!(
+            "{}",
+            render_estimates_text(&estimates, &skipped, pricing_source, &pricing, verbose)
+        );
+    }
+
+    Ok(())
+}
+
+/// Render the text report. Returns the whole report as a string rather than
+/// printing, so the `--verbose` and default shapes are both testable without a
+/// warehouse — including the promise that passing the flag ADDS lines and
+/// changes none of the existing ones.
+fn render_estimates_text(
+    estimates: &[ModelEstimate],
+    skipped: &[(String, String)],
+    pricing_source: &str,
+    pricing: &WarehouseCostModel,
+    verbose: bool,
+) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+
+    // `write!` to a String is infallible; the returned Result is discarded
+    // deliberately rather than propagated to the caller's `Result<()>`.
+    let _ = writeln!(out, "Estimated {} model(s):", estimates.len());
+    let _ = writeln!(out);
+    for est in estimates {
+        let _ = writeln!(out, "  {}", est.model_name);
+        if let Some(bytes) = est.estimated_bytes_scanned {
+            let _ = writeln!(out, "    Bytes scanned: {bytes}");
+        }
+        if let Some(rows) = est.estimated_rows {
+            let _ = writeln!(out, "    Rows: {rows}");
+        }
+        if let Some(cost) = est.estimated_cost_usd {
+            let _ = writeln!(out, "    Est. cost: ${cost:.6}");
+        }
+        if !est.raw_explain.is_empty() {
+            if verbose {
+                // The whole plan — the reason someone reaches for the flag.
+                for line in est.raw_explain.lines() {
+                    let _ = writeln!(out, "    {line}");
+                }
+            } else {
                 // Show first 3 lines of EXPLAIN for human-readable summary.
                 let preview: Vec<&str> = est.raw_explain.lines().take(3).collect();
                 for line in preview {
-                    println!("    {line}");
+                    let _ = writeln!(out, "    {line}");
                 }
                 let total_lines = est.raw_explain.lines().count();
                 if total_lines > 3 {
-                    println!(
-                        "    ... ({} more lines, use --output json for full plan)",
+                    let _ = writeln!(
+                        out,
+                        "    ... ({} more lines, use --verbose or --output json for full plan)",
                         total_lines - 3
                     );
                 }
             }
-            println!();
         }
+        let _ = writeln!(out);
+    }
 
-        // Print total cost if any model had a cost estimate.
-        let total: f64 = estimates.iter().filter_map(|e| e.estimated_cost_usd).sum();
-        if total > 0.0 {
-            println!("  Total estimated cost: ${total:.6}");
+    // Print total cost if any model had a cost estimate.
+    let total: f64 = estimates.iter().filter_map(|e| e.estimated_cost_usd).sum();
+    if total > 0.0 {
+        let _ = writeln!(out, "  Total estimated cost: ${total:.6}");
+    }
+
+    if verbose {
+        // The two rates that actually enter the arithmetic in `run_explain`.
+        // `per_row_compute_cost` exists on the model but is NOT applied, so
+        // printing it here would suggest the estimate accounts for compute.
+        let _ = writeln!(out);
+        let _ = writeln!(out, "  Pricing model: {pricing_source}");
+        let _ = writeln!(
+            out,
+            "    per row scanned: ${:.3e}",
+            pricing.per_row_scan_cost
+        );
+        let _ = writeln!(
+            out,
+            "    per byte of I/O: ${:.3e}",
+            pricing.per_byte_io_cost
+        );
+
+        if !skipped.is_empty() {
+            let _ = writeln!(out);
+            let _ = writeln!(out, "  Skipped before EXPLAIN ({}):", skipped.len());
+            for (name, reason) in skipped {
+                let _ = writeln!(out, "    {name} — {reason}");
+            }
         }
     }
 
-    Ok(())
+    out
 }
 
 /// Run EXPLAIN for a single model's SQL and return the estimate.
@@ -174,10 +242,15 @@ fn load_all_models(models_dir: &Path) -> Result<Vec<models::Model>> {
 /// Looks up the specific adapter used by the pipeline (not just the first
 /// adapter in the config) and returns the appropriate pricing model. Falls
 /// back to Databricks pricing when the adapter type is not recognized.
+///
+/// The label and the rates come out of ONE match so `--verbose` cannot name a
+/// pricing model different from the one that produced the numbers. The
+/// fallback is labelled as a fallback: an unrecognized adapter type is priced
+/// at Databricks rates, and a surprising cost is otherwise unexplainable.
 fn resolve_pricing(
     config: &rocky_core::config::RockyConfig,
     target_adapter: &str,
-) -> WarehouseCostModel {
+) -> (&'static str, WarehouseCostModel) {
     let adapter_type = config
         .adapters
         .get(target_adapter)
@@ -185,9 +258,170 @@ fn resolve_pricing(
         .unwrap_or("");
 
     match adapter_type {
-        t if t.contains("snowflake") => WarehouseCostModel::snowflake(),
-        t if t.contains("bigquery") => WarehouseCostModel::bigquery(),
-        t if t.contains("duckdb") => WarehouseCostModel::duckdb(),
-        _ => WarehouseCostModel::databricks(),
+        t if t.contains("snowflake") => ("snowflake", WarehouseCostModel::snowflake()),
+        t if t.contains("bigquery") => ("bigquery", WarehouseCostModel::bigquery()),
+        t if t.contains("duckdb") => ("duckdb", WarehouseCostModel::duckdb()),
+        t if t.contains("databricks") => ("databricks", WarehouseCostModel::databricks()),
+        _ => (
+            "databricks (fallback — adapter type not recognized)",
+            WarehouseCostModel::databricks(),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn est(name: &str, plan_lines: usize, cost: Option<f64>) -> ModelEstimate {
+        ModelEstimate {
+            model_name: name.to_string(),
+            estimated_bytes_scanned: Some(1_024),
+            estimated_rows: Some(7),
+            estimated_cost_usd: cost,
+            raw_explain: (1..=plan_lines)
+                .map(|i| format!("plan line {i}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        }
+    }
+
+    /// #480: the flag is additive. Every line the default report emits is
+    /// still emitted, in order, when `--verbose` is passed — the verbose
+    /// report only APPENDS. Asserted as a subsequence rather than by
+    /// restating the expected text, so a future edit to the default shape
+    /// cannot pass this test while silently dropping a line under verbose.
+    #[test]
+    fn verbose_only_adds_lines_it_never_removes_or_reorders_them() {
+        let estimates = vec![est("orders", 2, Some(0.5))];
+        let pricing = WarehouseCostModel::duckdb();
+        let plain = render_estimates_text(&estimates, &[], "duckdb", &pricing, false);
+        let verbose = render_estimates_text(&estimates, &[], "duckdb", &pricing, true);
+
+        let mut v = verbose.lines();
+        for line in plain.lines() {
+            assert!(
+                v.any(|candidate| candidate == line),
+                "verbose report dropped or reordered {line:?}\n--- plain ---\n{plain}\n--- verbose ---\n{verbose}"
+            );
+        }
+        assert!(
+            verbose.lines().count() > plain.lines().count(),
+            "verbose added nothing"
+        );
+    }
+
+    /// #480 acceptance criterion: `rocky estimate` with NO flag is unchanged.
+    /// Pinned as the exact report rather than as spot-checks — a mutation
+    /// that drops one line (say `Rows:`) from the default path passes every
+    /// other test here, including the additive-verbose one, because dropping
+    /// a line from the default keeps it a subsequence of verbose.
+    #[test]
+    fn the_default_report_shape_is_pinned_line_for_line() {
+        let estimates = vec![est("orders", 5, Some(0.5))];
+        let pricing = WarehouseCostModel::duckdb();
+
+        assert_eq!(
+            render_estimates_text(&estimates, &[], "duckdb", &pricing, false),
+            "Estimated 1 model(s):\n\
+             \n\
+             \u{20}\u{20}orders\n\
+             \u{20}\u{20}\u{20}\u{20}Bytes scanned: 1024\n\
+             \u{20}\u{20}\u{20}\u{20}Rows: 7\n\
+             \u{20}\u{20}\u{20}\u{20}Est. cost: $0.500000\n\
+             \u{20}\u{20}\u{20}\u{20}plan line 1\n\
+             \u{20}\u{20}\u{20}\u{20}plan line 2\n\
+             \u{20}\u{20}\u{20}\u{20}plan line 3\n\
+             \u{20}\u{20}\u{20}\u{20}... (2 more lines, use --verbose or --output json for full plan)\n\
+             \n\
+             \u{20}\u{20}Total estimated cost: $0.500000\n"
+        );
+    }
+
+    /// #480: a plan longer than the 3-line preview is truncated by default
+    /// and printed WHOLE under `--verbose`. The truncation hint names the
+    /// flag, so the report's own advice is reachable.
+    #[test]
+    fn verbose_prints_the_whole_plan_where_the_default_truncates() {
+        let estimates = vec![est("orders", 9, None)];
+        let pricing = WarehouseCostModel::duckdb();
+        let plain = render_estimates_text(&estimates, &[], "duckdb", &pricing, false);
+        let verbose = render_estimates_text(&estimates, &[], "duckdb", &pricing, true);
+
+        assert!(plain.contains("plan line 3"), "{plain}");
+        assert!(!plain.contains("plan line 4"), "{plain}");
+        assert!(plain.contains("6 more lines"), "{plain}");
+        assert!(plain.contains("--verbose"), "the hint must name the flag");
+
+        assert!(verbose.contains("plan line 9"), "{verbose}");
+        assert!(
+            !verbose.contains("more lines"),
+            "nothing left to truncate: {verbose}"
+        );
+    }
+
+    /// #480: `--verbose` reports the two rates that actually enter the cost
+    /// arithmetic in `run_explain`, and NOT `per_row_compute_cost`, which the
+    /// model carries but the estimate never applies. Printing it would imply
+    /// the estimate accounts for compute.
+    #[test]
+    fn verbose_reports_only_the_rates_the_estimate_actually_applies() {
+        let pricing = WarehouseCostModel::duckdb();
+        let verbose = render_estimates_text(&[], &[], "duckdb", &pricing, true);
+
+        assert!(verbose.contains("per row scanned"), "{verbose}");
+        assert!(verbose.contains("per byte of I/O"), "{verbose}");
+        assert!(
+            !verbose.contains("compute"),
+            "per_row_compute_cost is not applied by run_explain: {verbose}"
+        );
+    }
+
+    /// #480: models dropped before EXPLAIN are invisible in the default
+    /// report — "Estimated N model(s)" counts successes, not requests — and
+    /// `--verbose` names them with the reason.
+    #[test]
+    fn verbose_names_models_dropped_before_explain_ran() {
+        let skipped = vec![("broken".to_string(), "SQL generation: bad ref".to_string())];
+        let pricing = WarehouseCostModel::duckdb();
+        let plain = render_estimates_text(&[], &skipped, "duckdb", &pricing, false);
+        let verbose = render_estimates_text(&[], &skipped, "duckdb", &pricing, true);
+
+        assert!(
+            !plain.contains("broken"),
+            "default output must be unchanged: {plain}"
+        );
+        assert!(verbose.contains("broken"), "{verbose}");
+        assert!(verbose.contains("SQL generation: bad ref"), "{verbose}");
+    }
+
+    /// The `--verbose` pricing label and the rates come from one match, so a
+    /// genuine Databricks adapter is not labelled a fallback and an
+    /// unrecognized one is — the fallback is the case that makes a surprising
+    /// cost explicable.
+    #[test]
+    fn pricing_label_distinguishes_a_real_databricks_adapter_from_the_fallback() {
+        let cfg: rocky_core::config::RockyConfig = toml::from_str(
+            r#"
+[adapter.dbx]
+type = "databricks"
+host = "example.cloud.databricks.com"
+http_path = "/sql/1.0/warehouses/abc"
+
+[adapter.odd]
+type = "some-future-warehouse"
+"#,
+        )
+        .expect("config");
+
+        let (real, real_rates) = resolve_pricing(&cfg, "dbx");
+        assert_eq!(real, "databricks");
+
+        let (fallback, fallback_rates) = resolve_pricing(&cfg, "odd");
+        assert!(fallback.contains("fallback"), "{fallback}");
+        assert_eq!(
+            real_rates.per_byte_io_cost, fallback_rates.per_byte_io_cost,
+            "the fallback is Databricks pricing — only the label differs"
+        );
     }
 }

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -1824,6 +1824,9 @@ enum Command {
         /// Pipeline name (required if multiple pipelines)
         #[arg(long)]
         pipeline: Option<String>,
+        /// Print extra context for each model (full EXPLAIN plan, pricing rates, models skipped before EXPLAIN).
+        #[arg(long)]
+        verbose: bool,
     },
 
     /// Generate OPTIMIZE/VACUUM SQL for storage compaction, or apply a saved plan.
@@ -4051,6 +4054,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             models,
             model,
             pipeline,
+            verbose,
         } => {
             rocky_cli::commands::run_estimate(
                 &cli.config,
@@ -4058,6 +4062,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                 pipeline.as_deref(),
                 model.as_deref(),
                 json,
+                verbose,
             )
             .await
         }


### PR DESCRIPTION
Closes #480.

`rocky estimate` truncates each model's EXPLAIN plan to three lines and points at `--output json` for the rest — a poor answer for the person actually diagnosing a cost estimate. `--verbose` mirrors the `rocky doctor --verbose` pattern from #21.

## What `--verbose` adds

Text output only. Three things, all already on hand and none of them printed today:

1. **The whole EXPLAIN plan** instead of the three-line preview.
2. **The pricing model that produced the numbers, and the rates that entered the arithmetic.** `per_row_compute_cost` is deliberately *not* printed — `run_explain` never applies it, and showing it would imply the estimate accounts for compute when it doesn't. There's a test asserting the string "compute" does not appear.
3. **Models dropped before EXPLAIN ever ran.** These are invisible today outside `debug!` logs, so `Estimated N model(s)` reads as a count of what was asked for when it's a count of what succeeded.

## Scope guards from the issue

- **JSON output is untouched**; no `*Output` struct changed, so nothing cascades through `just codegen`.
- **`rocky estimate` with no flag is unchanged** — pinned line-for-line by a test rather than spot-checked (see below for why that mattered).

One deliberate exception, called out because it *is* a default-output change: the truncation hint now reads `use --verbose or --output json for full plan`. A hint that omits the better option is a worse hint. Everything the default computes and prints is otherwise byte-identical.

## Two things that changed shape

`resolve_pricing` now returns its label alongside the rates **from one match**, so `--verbose` cannot name a pricing model different from the one that produced the numbers. It also gained an explicit `databricks` arm: previously a real Databricks adapter and an unrecognized one both fell through to the same branch, so labelling that branch "fallback" would have lied about the former — and the fallback is exactly the case that explains a surprising cost.

The text report moved into `render_estimates_text`, which returns the report instead of printing it. That's what makes both shapes testable without a warehouse.

## Tests

Six, all driving `render_estimates_text` / `resolve_pricing` directly. Each was mutation-checked — the production code was broken in the specific way the test claims to catch, and the test failed:

| Mutation | Caught by |
|---|---|
| `--verbose` stops printing the whole plan | `verbose_prints_the_whole_plan_where_the_default_truncates` |
| the unapplied compute rate gets printed | `verbose_reports_only_the_rates_the_estimate_actually_applies` |
| skipped models leak into the default report | `verbose_names_models_dropped_before_explain_ran` |
| the default report drops a line | `the_default_report_shape_is_pinned_line_for_line` |
| `--verbose` drops a line the default emits | `verbose_only_adds_lines_it_never_removes_or_reorders_them` |
| a real Databricks adapter is labelled a fallback | `pricing_label_distinguishes_a_real_databricks_adapter_from_the_fallback` |

The fourth row is the reason the line-for-line pin exists. I wrote the additive-verbose test first and assumed it covered default stability; it doesn't. Dropping a line from the *default* keeps it a subsequence of verbose, so that mutation passed every test I had. The mutation run is what surfaced the gap.

## What I'm least confident about

The `--verbose` layout for the pricing block — rates are printed in scientific notation (`$1.000e-9`), which is precise but not friendly. Plain decimal at these magnitudes reads as `$0.000000`, which is worse. If there's a house style for small currency values I'll match it.

## What I'm most likely missing

Whether SQL-generation failures should stay behind `--verbose` at all. The default already prints `! <model> — explain failed` inline for EXPLAIN failures, so a model that fails *earlier* is treated more quietly than one that fails later — an asymmetry this PR preserves rather than fixes, because the issue's acceptance criteria pin default output. Worth its own issue if you agree it's backwards.
