### PR TITLE
docs(sdk): add worked examples to RockyClient's four core methods, and execute them in CI

### DIFF
--- a/sdk/python/src/rocky_sdk/client.py
+++ b/sdk/python/src/rocky_sdk/client.py
@@ -832,6 +832,30 @@ class RockyClient:
             emit_fivetran_state_to: Optional path to write the canonical Fivetran
                 state envelope to as a side effect (atomic + idempotent). The
                 envelope is delivered only to the file, not in the return value.
+
+        Example:
+
+            List each discovered source and its tables::
+
+                from rocky_sdk import RockyClient
+
+                client = RockyClient(config_path="rocky.toml")
+                result = client.discover(pipeline="bronze")
+
+                for source in result.sources:
+                    print(source.id, source.source_type)
+                    for table in source.tables:
+                        print("  ", table.name, table.row_count)
+
+            :attr:`~rocky_sdk.types.DiscoverResult.failed_sources` is the field
+            to check before acting on absence. A source missing from
+            ``sources`` because its metadata fetch failed is NOT evidence it
+            was removed upstream, so a consumer diffing against a prior run
+            must not delete on that basis::
+
+                if result.failed_sources:
+                    # Unknown state — reconcile later rather than deleting.
+                    raise RuntimeError(f"{len(result.failed_sources)} sources unreadable")
         """
         args = ["discover"]
         if pipeline is not None:
@@ -852,6 +876,30 @@ class RockyClient:
         Every project shape content-addresses a plan and persists it to
         ``.rocky/plans/<plan_id>.json``. Pass the returned ``plan_id`` to
         :meth:`apply` to execute it.
+
+        Example:
+
+            Review the planned statements, then execute the plan::
+
+                from rocky_sdk import RockyClient
+
+                client = RockyClient(config_path="rocky.toml")
+                plan = client.plan("client=acme")
+
+                for statement in plan.statements:
+                    print(statement.purpose, "->", statement.target)
+                    print(statement.sql)
+
+                # `plan_id` is None for replication-only invocations — only a
+                # run that compiled a models/ directory persists a blueprint,
+                # so guard before applying rather than assuming a string.
+                if plan.plan_id is not None:
+                    result = client.apply(plan.plan_id)
+
+            Governance previews (``classification_actions``, ``mask_actions``,
+            ``retention_actions``) are empty on projects without the
+            corresponding config, so an empty list means "not configured", not
+            "nothing to do".
         """
         args = ["plan"]
         if filter is not None:
@@ -872,6 +920,23 @@ class RockyClient:
         ``gc`` plans yield :class:`RestoreApplyOutput` and :class:`GcApplyOutput`,
         respectively; compact / archive / promote plans yield their respective
         outputs. See :func:`_parse_apply`.
+
+        Example:
+
+            Because the return type is a union, narrow before reading
+            kind-specific fields — ``tables_copied`` exists on a run-shaped
+            result and on none of the others::
+
+                from rocky_sdk import RockyClient, RunResult
+
+                client = RockyClient(config_path="rocky.toml")
+                result = client.apply("a1b2c3d4")
+
+                if isinstance(result, RunResult):
+                    print(result.tables_copied, "copied;", result.tables_failed, "failed")
+                else:
+                    # gc / restore / compact / archive / promote plan kinds.
+                    print(type(result).__name__)
         """
         return _parse_apply(self.run_cli(["apply", plan_id], allow_partial=True))
 
@@ -920,6 +985,29 @@ class RockyClient:
                 ``timeout_seconds`` governs this run. A tenant-collapsed run that
                 copies a heavy client's tables in one invocation can pass a larger
                 budget here without relaxing it for every other run.
+
+        Example:
+
+            Run one client's tables and stream progress, then act on partial
+            success — a failed run still reports what DID materialize::
+
+                from rocky_sdk import RockyClient
+
+                client = RockyClient(config_path="rocky.toml")
+                result = client.run("client=acme", log_callback=print)
+
+                print(result.status, result.tables_copied, "copied")
+
+                # Partial success is a normal return, not an exception: check
+                # `errors` rather than assuming a returned result means success.
+                # `asset_key` is the path as a list of segments, not a string.
+                for failure in result.errors:
+                    print("failed:", ".".join(failure.asset_key), failure.error)
+
+            To also execute compiled models in the same invocation, pass
+            ``run_models=True``::
+
+                result = client.run("client=acme", run_models=True)
         """
         _validate_governance_override(governance_override)
         run_args = self._build_run_args(

--- a/sdk/python/tests/test_docstring_examples.py
+++ b/sdk/python/tests/test_docstring_examples.py
@@ -1,0 +1,181 @@
+"""Execute the ``Example:`` snippets in ``RockyClient``'s core docstrings.
+
+Docstring examples are the first thing a new SDK user copies, and nothing else
+checks them: a renamed field or a changed shape leaves the prose compiling
+(it's a string) and wrong. These tests extract the snippets from the live
+docstrings and RUN them with the subprocess layer stubbed, so every attribute
+access resolves against a real parsed model.
+
+Writing this caught two real errors in the examples it documents (#898):
+``TableError`` has no ``.table`` — the field is ``asset_key``, and it is a
+``list[str]`` rather than a string.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import textwrap
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from rocky_sdk import RockyClient
+
+DOCUMENTED_METHODS = ("apply", "discover", "plan", "run")
+
+# Minimal but SCHEMA-VALID engine payloads. Every required field is present —
+# a fixture that fails validation would make these tests fail for a reason
+# that has nothing to do with the examples.
+DISCOVER_PAYLOAD: dict[str, Any] = {
+    "version": "1",
+    "command": "discover",
+    "sources": [
+        {
+            "id": "acme",
+            "components": {"client": "acme"},
+            "source_type": "postgres",
+            "tables": [{"name": "orders", "row_count": 42}],
+        }
+    ],
+    "failed_sources": [],
+}
+
+PLAN_PAYLOAD: dict[str, Any] = {
+    "version": "1",
+    "command": "plan",
+    "filter": "client=acme",
+    "statements": [
+        {
+            "purpose": "create table",
+            "target": "wh.raw.orders",
+            "sql": "CREATE TABLE wh.raw.orders (...)",
+        }
+    ],
+    "plan_id": "a1b2c3d4",
+    "plan_kind": "run",
+}
+
+RUN_PAYLOAD: dict[str, Any] = {
+    "version": "1",
+    "command": "run",
+    "filter": "client=acme",
+    "duration_ms": 10,
+    "tables_copied": 1,
+    "tables_failed": 1,
+    "status": "PartialFailure",
+    "materializations": [],
+    "check_results": [],
+    "permissions": {
+        "grants_added": 0,
+        "grants_revoked": 0,
+        "catalogs_created": 0,
+        "schemas_created": 0,
+    },
+    "drift": {"tables_checked": 0, "tables_drifted": 0, "actions_taken": []},
+    # `asset_key` is a list of path segments, and the run example joins it.
+    "errors": [{"asset_key": ["raw", "orders"], "error": "boom", "failure_kind": "query"}],
+}
+
+# `rocky apply` of a run-shaped plan prints a RunOutput, so it reuses the payload.
+PAYLOADS = {
+    "discover": DISCOVER_PAYLOAD,
+    "plan": PLAN_PAYLOAD,
+    "run": RUN_PAYLOAD,
+    "apply": RUN_PAYLOAD,
+}
+
+# Snippets that continue an earlier one (no `RockyClient(...)` of their own)
+# get the earlier one's bindings rather than being skipped.
+PRELUDE = {
+    "discover": "from rocky_sdk import RockyClient\n"
+    "client = RockyClient()\n"
+    "result = client.discover()\n",
+    "run": "from rocky_sdk import RockyClient\nclient = RockyClient()\n",
+}
+
+
+def _client_source() -> str:
+    import rocky_sdk.client
+
+    return Path(rocky_sdk.client.__file__).read_text(encoding="utf-8")
+
+
+def _docstrings() -> dict[str, str]:
+    tree = ast.parse(_client_source())
+    found = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name in DOCUMENTED_METHODS:
+            doc = ast.get_docstring(node)
+            if doc is not None:
+                found[node.name] = doc
+    return found
+
+
+def _snippets(doc: str) -> list[str]:
+    """Extract the indented code blocks introduced by a reST ``::`` line."""
+    out: list[str] = []
+    cur: list[str] = []
+    base: int | None = None
+    for line in doc.splitlines():
+        if base is None:
+            if line.rstrip().endswith("::"):
+                base = -1  # the next non-blank line sets the indent
+            continue
+        if not line.strip():
+            if cur:
+                cur.append("")
+            continue
+        indent = len(line) - len(line.lstrip())
+        if base == -1:
+            base = indent
+        if indent >= base:
+            cur.append(line[base:])
+        else:
+            if cur:
+                out.append("\n".join(cur).rstrip())
+                cur = []
+            base = -1 if line.rstrip().endswith("::") else None
+    if cur:
+        out.append("\n".join(cur).rstrip())
+    return [s for s in out if s.strip()]
+
+
+def _fake_run_cli(self: RockyClient, args: list[str], **_kwargs: Any) -> str:
+    return json.dumps(PAYLOADS[args[0]])
+
+
+@pytest.mark.parametrize("method", DOCUMENTED_METHODS)
+def test_core_method_has_a_runnable_example(method: str) -> None:
+    """#898: each of the four core methods documents a worked example.
+
+    Asserted separately from execution so deleting an example fails loudly
+    instead of silently reducing what the executing test covers to nothing.
+    """
+    doc = _docstrings().get(method)
+    assert doc is not None, f"{method} has no docstring"
+    assert "Example:" in doc, f"{method} has no Example: block"
+    assert _snippets(doc), f"{method}'s Example: block has no extractable code"
+
+
+@pytest.mark.parametrize("method", DOCUMENTED_METHODS)
+def test_docstring_examples_execute_against_real_models(method: str) -> None:
+    """Run each snippet with IO stubbed — a wrong field name fails here.
+
+    Compiling is not enough: `error.table` parses fine and raises
+    `AttributeError` only when executed, which is exactly the class of mistake
+    a copied example inflicts on a new user.
+    """
+    doc = _docstrings()[method]
+    snippets = _snippets(doc)
+    assert snippets, f"probe bug: nothing extracted for {method}"
+
+    with mock.patch.object(RockyClient, "run_cli", _fake_run_cli):
+        for snippet in snippets:
+            code = textwrap.dedent(snippet)
+            namespace: dict[str, Any] = {"__name__": "__doc_example__"}
+            if "RockyClient(" not in code:
+                exec(PRELUDE.get(method, ""), namespace)  # noqa: S102 - trusted docstring
+            exec(code, namespace)  # noqa: S102 - trusted docstring


### PR DESCRIPTION
Closes #898.

`rocky-sdk` ships on PyPI with **zero** worked examples across ~20 public `RockyClient` methods, so discovering the SDK means reading the source. This adds `Example:` blocks to the four core methods — `discover`, `plan`, `apply`, `run` — in the style #482 established on the Dagster health helpers. No logic or signature changes.

## The examples document the shape callers actually have to handle

Not the happy path only — each one covers the trap a naive example would walk into:

| Method | What the example insists on | Why |
|---|---|---|
| `plan` | guards `if plan.plan_id is not None` | `plan_id` is `str \| None`; replication-only invocations persist no blueprint, so feeding it straight to `apply()` teaches a `TypeError` |
| `apply` | narrows with `isinstance(result, RunResult)` | the return type is a union over six output shapes, and `tables_copied` exists on exactly one |
| `run` | reads `result.errors` rather than treating a returned result as success | partial success is a normal return, not an exception |
| `discover` | points at `failed_sources` | a source missing from `sources` after a failed metadata fetch is **not** evidence it was removed upstream |

## The examples are executed, not just written

`tests/test_docstring_examples.py` extracts the snippets from the live docstrings and **runs** them with the subprocess layer stubbed, so every attribute access resolves against a real parsed model.

This is beyond what the issue asked for, and it earned its place while being written — it caught a straight error in my own example: `error.table`. `TableError` has no `table` field. It's `asset_key`, and it's a `list[str]`, not a string. Compiling the snippet wouldn't have caught either, because a docstring is a string until something executes it. That's the whole failure mode: the examples most likely to be copied are the ones nothing checks.

Two tests, both mutation-checked:

- `test_docstring_examples_execute_against_real_models` — reintroducing `error.table` makes it fail with `AttributeError`.
- `test_core_method_has_a_runnable_example` — deleting an `Example:` block makes it fail. It exists separately so that deleting an example fails loudly rather than silently reducing the executing test's coverage to nothing.

One process note on the probe itself: my first version of the extractor reported "0 snippets, all parse" and exited 0. A pass over an empty set is a probe bug, not evidence, so the committed version asserts a non-zero snippet count per method.

## Gates

`ruff check`, `ruff format --check`, and `pytest` all clean (212 passed) under `sdk/python`.

## What I'm least confident about

The snippet extractor keys on reST `::` blocks and indentation. It works on all six current snippets and fails loudly when it finds nothing, but a future example written with a different reST construct (a `.. code-block::` directive, say) would be silently skipped by the *executing* test while still satisfying the *presence* test. If we add more examples in another style, the extractor needs widening — the presence test is the tripwire, not a guarantee.

## What I'm most likely missing

Whether four is the right stopping point. The issue caps scope at these four deliberately, and I kept to that, but `run_cli`, `compile`, and `state` are plausibly as load-bearing for a new user. Now that examples are executed rather than merely written, extending to more methods is cheap — happy to do a follow-up if you want the next tier.
