### PR TITLE
docs: give each adapter its own setup page under reference/adapters/

### DIFF
--- a/docs/src/content/docs/guides/connect-a-warehouse.mdx
+++ b/docs/src/content/docs/guides/connect-a-warehouse.mdx
@@ -135,7 +135,7 @@ rocky apply "$plan_id"
 
 Run `rocky doctor` first: it's the credentials and connectivity smoke test, and it tells you which adapter Rocky can reach before you spend any warehouse time. For a replication pipeline, scope the run with `--filter` (for example `rocky plan --filter tenant=acme`).
 
-The full field reference for every adapter is in [Configuration](/reference/configuration/#adaptername); per-adapter auth detail is in [Authentication](/reference/authentication/).
+Each adapter's own fields, authentication, and examples have a dedicated page — [DuckDB](/reference/adapters/duckdb/), [Databricks](/reference/adapters/databricks/), [Snowflake](/reference/adapters/snowflake/), [BigQuery](/reference/adapters/bigquery/), [Fivetran](/reference/adapters/fivetran/). The fields shared by every adapter type are in [Configuration](/reference/configuration/#adaptername), and Databricks auth detail is in [Authentication](/reference/authentication/).
 
 ## Next steps
 

--- a/docs/src/content/docs/reference/adapters/bigquery.md
+++ b/docs/src/content/docs/reference/adapters/bigquery.md
@@ -1,0 +1,39 @@
+---
+title: BigQuery adapter
+description: BigQuery warehouse adapter — project and location fields, and the bearer-token / service-account detection order
+sidebar:
+  order: 4
+---
+
+BigQuery warehouse adapter. Executes SQL through the BigQuery REST API.
+
+## Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `project_id` | string | No | Google Cloud project ID that owns the datasets and is billed for query execution. |
+| `location` | string | No | BigQuery processing location (e.g., `"US"`, `"EU"`, `"us-central1"`). |
+
+```toml
+[adapter.bq]
+type = "bigquery"
+project_id = "${GCP_PROJECT_ID}"
+location = "US"
+```
+
+## Authentication
+
+Credentials come from the environment rather than from `rocky.toml`, and are detected in this order:
+
+1. **`BIGQUERY_TOKEN`** — a pre-obtained OAuth bearer token, used as-is. Checked first, so setting it overrides any service-account key on the same machine.
+2. **`GOOGLE_APPLICATION_CREDENTIALS`** — path to a service-account JSON key. Rocky mints a JWT from the key, exchanges it for an access token at Google's token endpoint, and refreshes it automatically before expiry.
+
+If neither is set, the adapter fails with `no authentication method available — set GOOGLE_APPLICATION_CREDENTIALS or provide a bearer token`.
+
+:::caution[Key file permissions]
+The service-account key holds an RSA private key. On Unix, Rocky emits a warning when the file at `GOOGLE_APPLICATION_CREDENTIALS` is group- or world-readable — `chmod 600` (or `0400`) it.
+:::
+
+## See also
+
+- [`[adapter.NAME]`](/reference/configuration/#adaptername) — fields shared by every adapter type, including the retry policy.

--- a/docs/src/content/docs/reference/adapters/databricks.md
+++ b/docs/src/content/docs/reference/adapters/databricks.md
@@ -1,0 +1,49 @@
+---
+title: Databricks adapter
+description: Databricks SQL warehouse adapter — connection fields, PAT and OAuth M2M auth
+sidebar:
+  order: 2
+---
+
+Databricks SQL warehouse adapter. Executes SQL via the Statement Execution REST API and manages Unity Catalog governance.
+
+## Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `host` | string | Yes | Workspace hostname (e.g., `"workspace.cloud.databricks.com"`). |
+| `http_path` | string | Yes | SQL warehouse HTTP path (e.g., `"/sql/1.0/warehouses/abc123"`). |
+| `token` | string | No | Personal Access Token. Tried first if set. |
+| `client_id` | string | No | OAuth M2M client ID (service principal). Used as fallback when `token` is not set. |
+| `client_secret` | string | No | OAuth M2M client secret. Required if `client_id` is set. |
+| `timeout_secs` | integer | No | Statement execution timeout in seconds (default `120`). Increase for large full-refresh queries. |
+
+```toml
+[adapter.prod]
+type = "databricks"
+host = "${DATABRICKS_HOST}"
+http_path = "${DATABRICKS_HTTP_PATH}"
+token = "${DATABRICKS_TOKEN}"
+```
+
+OAuth M2M instead of PAT:
+
+```toml
+[adapter.prod]
+type = "databricks"
+host = "${DATABRICKS_HOST}"
+http_path = "${DATABRICKS_HTTP_PATH}"
+client_id = "${DATABRICKS_CLIENT_ID}"
+client_secret = "${DATABRICKS_CLIENT_SECRET}"
+```
+
+## Authentication
+
+PAT is tried first; OAuth M2M is the fallback when the PAT token is empty. Both apply to every Databricks API call — SQL Statement Execution, Unity Catalog operations, and workspace bindings.
+
+[Authentication](/reference/authentication/) covers the detection order, token refresh, and validation in full.
+
+## See also
+
+- [`[adapter.NAME]`](/reference/configuration/#adaptername) — fields shared by every adapter type, including the retry policy.
+- [Permissions](/reference/permissions/) — declarative Unity Catalog grants.

--- a/docs/src/content/docs/reference/adapters/duckdb.md
+++ b/docs/src/content/docs/reference/adapters/duckdb.md
@@ -1,0 +1,33 @@
+---
+title: DuckDB adapter
+description: Local in-process execution adapter — config fields and when a persistent path is required
+sidebar:
+  order: 1
+---
+
+Local in-process execution adapter. Use as a warehouse, source, or both: the same adapter instance can handle discovery and execution because they share the same database.
+
+## Fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `path` | string | No | (in-memory) | Path to a persistent DuckDB file. Required when using the same DuckDB adapter for both discovery and execution, so the discovery side sees rows written by the warehouse side. |
+
+```toml
+# In-memory DuckDB
+[adapter.local]
+type = "duckdb"
+
+# Persistent DuckDB file
+[adapter.local]
+type = "duckdb"
+path = "warehouse.duckdb"
+```
+
+## Authentication
+
+None. DuckDB runs in-process.
+
+## See also
+
+- [`[adapter.NAME]`](/reference/configuration/#adaptername) — fields shared by every adapter type, including the retry policy.

--- a/docs/src/content/docs/reference/adapters/fivetran.md
+++ b/docs/src/content/docs/reference/adapters/fivetran.md
@@ -1,0 +1,33 @@
+---
+title: Fivetran adapter
+description: Fivetran source adapter — metadata-only discovery over the Fivetran REST API
+sidebar:
+  order: 5
+---
+
+Fivetran source adapter. Calls the Fivetran REST API to discover connectors and tables. **Metadata only**: Rocky never moves data through this adapter.
+
+## Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `destination_id` | string | Yes | Fivetran destination ID. |
+| `api_key` | string | Yes | Fivetran API key (Basic Auth). |
+| `api_secret` | string | Yes | Fivetran API secret (Basic Auth). |
+
+```toml
+[adapter.fivetran]
+type = "fivetran"
+destination_id = "${FIVETRAN_DESTINATION_ID}"
+api_key = "${FIVETRAN_API_KEY}"
+api_secret = "${FIVETRAN_API_SECRET}"
+```
+
+## Authentication
+
+HTTP Basic Auth using `api_key` and `api_secret`. Source-adapter authentication is separate from warehouse authentication — see [Authentication](/reference/authentication/#source-adapter-authentication).
+
+## See also
+
+- [`[adapter.NAME]`](/reference/configuration/#adaptername) — fields shared by every adapter type, including the retry policy.
+- [Fivetran state cache](/reference/fivetran-state-cache/) — sharing the resolved state envelope across processes.

--- a/docs/src/content/docs/reference/adapters/snowflake.md
+++ b/docs/src/content/docs/reference/adapters/snowflake.md
@@ -1,0 +1,57 @@
+---
+title: Snowflake adapter
+description: Snowflake warehouse adapter — connection fields and the PAT / OAuth / key-pair / password priority order
+sidebar:
+  order: 3
+---
+
+Snowflake warehouse adapter. Supports Programmatic Access Token (PAT), OAuth, key-pair (RS256 JWT), and password authentication.
+
+## Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `account` | string | Yes | Snowflake account identifier (e.g., `"org-account"`). |
+| `warehouse` | string | Yes | Warehouse name for query execution. |
+| `database` | string | No | Default database. |
+| `schema` | string | No | Default schema. |
+| `role` | string | No | Role to assume. |
+| `username` | string | No | Username for key-pair or password auth. |
+| `password` | string | No | Password for password auth. |
+| `private_key_path` | string | No | Path to PKCS#8 PEM private key for key-pair JWT auth. |
+| `oauth_token` | string | No | Pre-supplied OAuth token from an IdP. |
+| `pat` | string | No | Programmatic Access Token (issued via Snowsight User Profile). Sent as a Bearer token with the `PROGRAMMATIC_ACCESS_TOKEN` token-type header, distinct from `oauth_token`. |
+
+## Authentication
+
+Priority order: **PAT** (highest) > **OAuth** > **key-pair JWT** > **password** (lowest).
+
+```toml
+# Programmatic Access Token (PAT) auth — recommended for trial accounts and
+# scripts; issue via Snowsight → User Profile → Personal Access Tokens.
+[adapter.snow]
+type = "snowflake"
+account = "${SNOWFLAKE_ACCOUNT}"
+warehouse = "COMPUTE_WH"
+pat = "${SNOWFLAKE_PAT}"
+
+# Key-pair JWT auth — recommended for production (rotateable, scoped per user).
+[adapter.snow]
+type = "snowflake"
+account = "${SNOWFLAKE_ACCOUNT}"
+warehouse = "COMPUTE_WH"
+username = "${SNOWFLAKE_USER}"
+private_key_path = "${SNOWFLAKE_KEY_PATH}"
+
+# Password auth
+[adapter.snow]
+type = "snowflake"
+account = "${SNOWFLAKE_ACCOUNT}"
+warehouse = "COMPUTE_WH"
+username = "${SNOWFLAKE_USER}"
+password = "${SNOWFLAKE_PASSWORD}"
+```
+
+## See also
+
+- [`[adapter.NAME]`](/reference/configuration/#adaptername) — fields shared by every adapter type, including the retry policy.

--- a/docs/src/content/docs/reference/authentication.md
+++ b/docs/src/content/docs/reference/authentication.md
@@ -59,4 +59,4 @@ Run `rocky validate` to check that at least one authentication method is properl
 
 ## Source Adapter Authentication
 
-Authentication for source adapters is separate from warehouse authentication. Each source adapter is its own `[adapter.NAME]` block. Fivetran uses HTTP Basic Auth with `api_key` and `api_secret` (see [`type = "fivetran"`](/reference/configuration/#type--fivetran) for the full block); DuckDB and `manual` sources require no authentication.
+Authentication for source adapters is separate from warehouse authentication. Each source adapter is its own `[adapter.NAME]` block. Fivetran uses HTTP Basic Auth with `api_key` and `api_secret` (see the [Fivetran adapter](/reference/adapters/fivetran/) for the full block); DuckDB and `manual` sources require no authentication.

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -131,119 +131,18 @@ default_schema = "analytics"
 x_custom_header = "service-account"
 ```
 
-### `type = "duckdb"`
+### Per-adapter setup
 
-Local in-process execution adapter. Use as a warehouse, source, or both: the same adapter instance can handle discovery and execution because they share the same database.
+The connection fields, authentication, and examples for each adapter type live on their own page:
 
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `path` | string | No | (in-memory) | Path to a persistent DuckDB file. Required when using the same DuckDB adapter for both discovery and execution, so the discovery side sees rows written by the warehouse side. |
+- [DuckDB](/reference/adapters/duckdb/) — local in-process execution
+- [Databricks](/reference/adapters/databricks/) — SQL warehouse + Unity Catalog governance
+- [Snowflake](/reference/adapters/snowflake/) — PAT, OAuth, key-pair, and password auth
+- [BigQuery](/reference/adapters/bigquery/) — project/location plus environment-supplied credentials
+- [Fivetran](/reference/adapters/fivetran/) — metadata-only source discovery
 
-```toml
-# In-memory DuckDB
-[adapter.local]
-type = "duckdb"
+`type = "trino"`, `type = "airbyte"`, and `type = "iceberg"` are accepted by the config parser but have no dedicated page yet; configure adapter-specific keys through [`[adapter.NAME.extra]`](#adaptername).
 
-# Persistent DuckDB file
-[adapter.local]
-type = "duckdb"
-path = "warehouse.duckdb"
-```
-
-### `type = "databricks"`
-
-Databricks SQL warehouse adapter. Executes SQL via the Statement Execution REST API and manages Unity Catalog governance.
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `host` | string | Yes | Workspace hostname (e.g., `"workspace.cloud.databricks.com"`). |
-| `http_path` | string | Yes | SQL warehouse HTTP path (e.g., `"/sql/1.0/warehouses/abc123"`). |
-| `token` | string | No | Personal Access Token. Tried first if set. |
-| `client_id` | string | No | OAuth M2M client ID (service principal). Used as fallback when `token` is not set. |
-| `client_secret` | string | No | OAuth M2M client secret. Required if `client_id` is set. |
-| `timeout_secs` | integer | No | Statement execution timeout in seconds (default `120`). Increase for large full-refresh queries. |
-
-```toml
-[adapter.prod]
-type = "databricks"
-host = "${DATABRICKS_HOST}"
-http_path = "${DATABRICKS_HTTP_PATH}"
-token = "${DATABRICKS_TOKEN}"
-```
-
-OAuth M2M instead of PAT:
-
-```toml
-[adapter.prod]
-type = "databricks"
-host = "${DATABRICKS_HOST}"
-http_path = "${DATABRICKS_HTTP_PATH}"
-client_id = "${DATABRICKS_CLIENT_ID}"
-client_secret = "${DATABRICKS_CLIENT_SECRET}"
-```
-
-### `type = "snowflake"`
-
-Snowflake warehouse adapter. Supports Programmatic Access Token (PAT), OAuth, key-pair (RS256 JWT), and password authentication.
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `account` | string | Yes | Snowflake account identifier (e.g., `"org-account"`). |
-| `warehouse` | string | Yes | Warehouse name for query execution. |
-| `database` | string | No | Default database. |
-| `schema` | string | No | Default schema. |
-| `role` | string | No | Role to assume. |
-| `username` | string | No | Username for key-pair or password auth. |
-| `password` | string | No | Password for password auth. |
-| `private_key_path` | string | No | Path to PKCS#8 PEM private key for key-pair JWT auth. |
-| `oauth_token` | string | No | Pre-supplied OAuth token from an IdP. |
-| `pat` | string | No | Programmatic Access Token (issued via Snowsight User Profile). Sent as a Bearer token with the `PROGRAMMATIC_ACCESS_TOKEN` token-type header, distinct from `oauth_token`. |
-
-Authentication priority: PAT (highest) > OAuth > Key-pair JWT > Password (lowest).
-
-```toml
-# Programmatic Access Token (PAT) auth — recommended for trial accounts and
-# scripts; issue via Snowsight → User Profile → Personal Access Tokens.
-[adapter.snow]
-type = "snowflake"
-account = "${SNOWFLAKE_ACCOUNT}"
-warehouse = "COMPUTE_WH"
-pat = "${SNOWFLAKE_PAT}"
-
-# Key-pair JWT auth — recommended for production (rotateable, scoped per user).
-[adapter.snow]
-type = "snowflake"
-account = "${SNOWFLAKE_ACCOUNT}"
-warehouse = "COMPUTE_WH"
-username = "${SNOWFLAKE_USER}"
-private_key_path = "${SNOWFLAKE_KEY_PATH}"
-
-# Password auth
-[adapter.snow]
-type = "snowflake"
-account = "${SNOWFLAKE_ACCOUNT}"
-warehouse = "COMPUTE_WH"
-username = "${SNOWFLAKE_USER}"
-password = "${SNOWFLAKE_PASSWORD}"
-```
-
-### `type = "fivetran"`
-
-Fivetran source adapter. Calls the Fivetran REST API to discover connectors and tables. **Metadata only**: Rocky never moves data through this adapter.
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `destination_id` | string | Yes | Fivetran destination ID. |
-| `api_key` | string | Yes | Fivetran API key (Basic Auth). |
-| `api_secret` | string | Yes | Fivetran API secret (Basic Auth). |
-
-```toml
-[adapter.fivetran]
-type = "fivetran"
-destination_id = "${FIVETRAN_DESTINATION_ID}"
-api_key = "${FIVETRAN_API_KEY}"
-api_secret = "${FIVETRAN_API_SECRET}"
-```
 
 ### `type = "manual"`
 


### PR DESCRIPTION
Closes #478.

`configuration.md` documented every adapter inline, so "how do I set up Snowflake?" meant scanning past four others in a 1400-line page. Each adapter type now has its own page under `reference/adapters/`: [DuckDB](docs/src/content/docs/reference/adapters/duckdb.md), [Databricks](docs/src/content/docs/reference/adapters/databricks.md), [Snowflake](docs/src/content/docs/reference/adapters/snowflake.md), [BigQuery](docs/src/content/docs/reference/adapters/bigquery.md), [Fivetran](docs/src/content/docs/reference/adapters/fivetran.md).

## The split is narrower than "move the adapter section"

`## [adapter.NAME]` and `[adapter.NAME.retry]` **stay** on the overview. They're shared by every adapter type, and roughly 15 pages link into `configuration.md` anchors including `#adaptername` and `#adapternameretry`. Moving only the five per-type `### type = "..."` sections breaks exactly **one** inbound anchor — `authentication.md` → `#type--fivetran` — which this PR repoints at the new Fivetran page.

Sidebar needs no change: `astro.config.mjs` already autogenerates from `reference/`, so the subdirectory becomes a group on its own.

## `bigquery.md` is new content, and that's on purpose

The issue says "no new technical content needs to be authored," but `configuration.md` never had a BigQuery section despite `type = "bigquery"` being an accepted adapter type. Rather than skip the page or invent it, I grounded it in the code:

- `project_id` and `location` come from the adapter config struct in `rocky-core`.
- The credential detection order — `BIGQUERY_TOKEN` first, then `GOOGLE_APPLICATION_CREDENTIALS`, else a hard error — and the group/world-readable key-file warning come from `rocky-bigquery`'s auth module.

So the "missing" page was a real documentation hole this issue happened to surface.

## Two deliberate omissions

- **`type = "manual"` stays inline.** It has no connection fields, no auth, and no capacity settings — a setup page would be empty. `trino` / `airbyte` / `iceberg` parse but have no documented fields, and the overview now says so rather than leaving the reader to infer it from the type list.
- **No capability matrix.** It's explicitly optional in the issue, and every cell would be a per-adapter trait claim requiring verification against the trait default plus each adapter's overrides. A wrong cell in a comparison table is worse than no table.

## Verification

`npm run build` passes — but it resolves *pages*, not *anchor fragments*, so a rotted `#anchor` sails through a green build. That's the exact failure mode this PR could have introduced, so I checked it directly: a script over the built site confirms **all 145 internal anchor links across 113 pages resolve**, zero broken.

The checker was itself mutation-checked — re-injecting the pre-split `#type--fivetran` link makes it report exactly that one break — so its zero isn't a vacuous pass over an empty set.

## What I'm least confident about

Whether `[adapter.NAME.retry]` belongs on the overview or repeated per adapter. I kept it central because it's one shared schema and duplicating it invites drift, but it does mean a reader on `snowflake.md` has to follow a link to find retry behaviour. Each page's "See also" points at it.

## What I'm most likely missing

External inbound links to the moved anchors. I checked the repo and found none outside `docs/`, but a blog post or an old GitHub issue linking `/reference/configuration/#type--snowflake` would now 404 to the top of the configuration page. If that's a concern, Starlight's `redirects` map in `astro.config.mjs` already handles the legacy `/features/*` paths and could take fragment-level entries too — say the word and I'll add them.
