### PR TITLE
docs(engine): record why the backfill apply arm skips the run-plan shape check

### DIFF
--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -3102,6 +3102,23 @@ async fn run_apply_ai_authored_plan(
 /// ([`crate::commands::run::execute_backfill_set`]) so classified retry (R1)
 /// and failure containment (R2) apply to the rebuild. The closure is never
 /// re-authored — a backfill only re-runs existing recipes over its window.
+///
+/// **Why this arm does not call [`validate_run_plan_execution_shape`]** (#1325).
+/// It is the third kind carrying a `RunPlan` payload, and the other two —
+/// `Run` and `AiAuthored` — do call it. The reason this one is safe is NOT
+/// that a backfill plan cannot carry the rejected `dag && model` shape:
+/// `build_run_plan` hardcodes `dag: false` / `model: None` today, but that is
+/// the argument #1173 already rejected, since the check exists precisely for
+/// plans written by an OLDER binary, and a plan payload is on-disk JSON that
+/// the gc apply path already treats as possibly hand-authored.
+///
+/// It is safe because this arm never READS those fields. It consumes
+/// `models_dir`, `models`, `partition_from`, `partition_to`, and `parallel`,
+/// so the DAG runner is never reached and DAG-precedence cannot widen the
+/// authorized scope. That guarantee is structural, not enforced: routing a
+/// backfill through the shared `execute_run_plan` (as `Run` and `AiAuthored`
+/// already do) would reintroduce the exposure with no test failing. Add the
+/// shape validation here if this arm ever grows a consumer of either field.
 async fn run_apply_backfill_plan(
     root: &Path,
     config_path: &Path,

--- a/engine/crates/rocky-cli/src/commands/backfill.rs
+++ b/engine/crates/rocky-cli/src/commands/backfill.rs
@@ -939,4 +939,32 @@ mod tests {
         assert_eq!(plan.parallel, 1);
         assert!(!plan.run_all);
     }
+
+    /// #1325: a composed backfill never carries the `dag && model` shape that
+    /// `validate_run_plan_execution_shape` rejects (#1173).
+    ///
+    /// The backfill apply arm does NOT call that validation, and is safe only
+    /// because it never reads either field. This pins the plan-time half of
+    /// that argument: if backfill ever becomes DAG-aware or model-scoped at
+    /// compose time, this fails and points at the apply arm's doc comment,
+    /// which says to add the shape check there.
+    ///
+    /// It does not — and cannot cheaply — pin the apply-time half, which stays
+    /// a structural guarantee documented at `run_apply_backfill_plan`.
+    #[test]
+    fn build_run_plan_never_composes_the_shape_apply_does_not_validate() {
+        let plan = build_run_plan(
+            Path::new("models"),
+            &["a".to_string()],
+            &[vec!["a".to_string()]],
+            None,
+            None,
+        );
+        assert!(
+            !(plan.dag && plan.model.is_some()),
+            "a composed backfill carries the contradictory dag+model shape that the \
+             backfill apply arm does not validate — add validate_run_plan_execution_shape \
+             to run_apply_backfill_plan"
+        );
+    }
 }


### PR DESCRIPTION
Refs #1325 — **does not close it**, see "Status" below.

#1325 asks, for each `PlanKind`, whether every plan-build-time invariant is re-established at apply, and that anything structurally safe be written down so the next person adding a plan-time check knows to ask.

I audited the five kinds that had not been looked at — `Gc`, `Restore`, `Backfill`, `Replication`, `AiAuthored` — and found **no gap of the promote class**. The full per-kind table is in the issue; the short version:

- **`Gc`** re-runs the *same* eligibility path against the live store, keys on full identity, refuses fail-closed on hash mismatch, and takes derivability from the fresh candidate — "trust the live candidate, never the plan payload".
- **`Restore`**'s hash-exact check *is* the operation, and it re-derives on the recording engine.
- **`Replication`** re-runs discovery and diffs the persisted snapshot before any SQL is emitted.
- **`AiAuthored`** dispatches the identical `execute_run_plan` as `Run`, so `Run`'s recompile applies.

## The one thing worth recording

Three kinds carry a `RunPlan` payload. `validate_run_plan_execution_shape` — the #1173 defence that rejects `dag && model.is_some()` because letting DAG precedence win "would silently widen the authorized scope" — runs on `Run` (`apply.rs:247`) and `AiAuthored` (`apply.rs:2970`), but **not** on `Backfill`.

That is safe today. But not for the reason it looks like:

- **Not** because a backfill can't carry the shape. `build_run_plan` hardcodes `dag: false` / `model: None` — and "newly-composed plans are fine" is exactly the argument #1173 rejected. The check exists *because* a plan on disk may come from an older binary, and the payload is JSON that the gc apply path already treats as possibly hand-authored.
- **Yes** because the backfill apply arm never *reads* those fields. It consumes `models_dir`, `models`, `partition_from`, `partition_to`, `parallel` — nothing else. The DAG runner is unreachable, so the hazard cannot materialize.

That guarantee rests entirely on `execute_backfill_set` never growing a consumer of either field, and nothing enforced it. `Run` and `AiAuthored` already share `execute_run_plan`; routing backfill through the same generic path is a plausible refactor that would reintroduce the exposure **with no test failing**.

## What this PR does

1. Records the reasoning at the apply seam (`run_apply_backfill_plan`), including the explicit instruction to add the shape check if that arm ever grows a consumer of `dag` or `model`.
2. Pins the plan-time half with a test: composing a backfill that carries `dag && model` now fails, and the assertion message points at the seam comment.

The test was mutation-checked — flipping `build_run_plan` to emit `dag: true` / `model: Some(..)` makes it fail.

## What it deliberately does not do

Pin the apply-time half. That would need a full apply harness (config, state store, review marker, adapter), and there is currently **no** backfill apply test in `apply.rs` to build on. Standing that up is a different PR; asserting the guarantee in a comment while pretending a cheap test covered it would be worse than saying so plainly.

## Status: why #1325 stays open

The "no gap found" conclusions for the five kinds are single-model analysis. Per the standing rule not to self-certify soundness — three prior stop-reviews each caught a grain overclaim — they want an independent pass before being treated as settled, and independent red-team capacity is unavailable until 2026-08-08.

The `Backfill` finding is different in kind: it is a concrete, checkable claim about which fields one function reads, and it does not depend on that review.

Also still outstanding from the issue's acceptance list: the equivalent structural note next to each *other* plan type's definition. I would rather write those once the audit conclusions have been independently checked than commit a confident comment I may have to walk back.

## What I am least confident about

Whether `Gc`'s re-derivation is as complete as it reads. It re-runs `gather_eviction_candidates`, re-checks derivability, and pins hash identity, which covers the invariant the plan is *about* — but I traced the eviction decision, not every consumer of the plan payload downstream of it. A property enforced somewhere between that function and the tombstone write, which I did not read, would not appear in my table.
