### PR TITLE
feat(engine): read the live identifier case-sensitivity setting instead of assuming it

### DIFF
--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -305,11 +305,81 @@ pub enum SplitStrategy {
 // Warehouse
 // ---------------------------------------------------------------------------
 
+/// Whether the case of a **quoted** identifier is part of object identity.
+///
+/// ‼️ Read the scope narrowly; it is one of two axes, not the whole answer.
+/// This describes identifiers as Rocky renders its own targets — quoted. It
+/// says nothing about *unquoted* references, which several warehouses fold
+/// independently of this setting: Snowflake upper-cases them whatever
+/// `QUOTED_IDENTIFIERS_IGNORE_CASE` says, so under `Significant` the quoted
+/// `"orders"` and `"Orders"` are two objects while the unquoted `orders` and
+/// `ORDERS` remain one. A consumer deciding whether an arbitrary SQL reference
+/// names a routed target needs BOTH axes; the second is #1282. Treating this
+/// value alone as "does case separate these two names" is the exact mistake an
+/// earlier revision of #1281 made, and it produced a silent isolation break.
+///
+/// Deliberately two states and no `Unknown`. "Could not determine" is carried
+/// by the `Err` arm of [`WarehouseAdapter::identifier_case_significance`], so
+/// a caller cannot pattern-match a third variant and let it fall through a
+/// gate — the failure mode #1240 records, where an `Unknown` type satisfied a
+/// compatibility check unconditionally and the gate read as fail-open.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CaseSignificance {
+    /// Two QUOTED spellings differing only by case name TWO objects.
+    Significant,
+    /// Two QUOTED spellings differing only by case name ONE object.
+    Insignificant,
+}
+
 /// Executes SQL against a warehouse and provides dialect information.
 #[async_trait]
 pub trait WarehouseAdapter: Send + Sync {
     /// Returns the SQL dialect for this warehouse.
     fn dialect(&self) -> &dyn SqlDialect;
+
+    /// Does the warehouse treat a QUOTED identifier's case as part of object
+    /// identity, as observed right now?
+    ///
+    /// Not a dialect question. Snowflake's `QUOTED_IDENTIFIERS_IGNORE_CASE` is
+    /// account/session state, and a BigQuery dataset carries its own
+    /// `is_case_insensitive` — so two connections to the same dialect can
+    /// legitimately disagree, and the answer has to be asked for rather than
+    /// looked up (#1281).
+    ///
+    /// **The answer describes the probe's own request, and does not extend to
+    /// a later one.** It is not durable connection state a caller may cache:
+    /// Snowflake's SQL API opens an independent session per POST, so a
+    /// subsequent statement can execute under a different value, and the
+    /// account-level setting can change between the two regardless. A consumer
+    /// that relaxes a safety decision on this answer must pin the setting for
+    /// the statement it is deciding about, or accept that it is deciding on
+    /// state that may no longer hold. This is not hypothetical caution — it is
+    /// why #1281 ships the probe without a consumer: the routing relaxation it
+    /// was written for could not honour it.
+    ///
+    /// **Nothing in the engine calls this yet.** #1281 lands the capability and
+    /// its Snowflake grounding; #1282 is the intended consumer, because routing
+    /// a reference correctly also needs the *unquoted*-uppercasing axis this
+    /// answer does not carry. Shipping the probe unwired is deliberate: it is
+    /// the half that is safe in every state, and it was live-verifiable while
+    /// the Snowflake trial still answered metadata queries.
+    ///
+    /// **The default is `Err`, and that is load-bearing** for whoever wires it.
+    /// An adapter that has not been grounded must not be read as reporting a
+    /// definite answer, so a new adapter inherits today's refusals rather than
+    /// silently acquiring a relaxation nobody verified. Adapters whose answer is
+    /// a dialect constant (DuckDB, Databricks, Trino) override with that
+    /// constant and issue no round trip.
+    ///
+    /// Callers MUST NOT relax a safety decision on `Err`. In particular a
+    /// transport failure, a permissions error, and "this adapter does not
+    /// implement the probe" are indistinguishable here **on purpose** — all
+    /// three mean the same thing to a gate.
+    async fn identifier_case_significance(&self) -> AdapterResult<CaseSignificance> {
+        Err(AdapterError::msg(
+            "this adapter does not report whether identifier case is part of object identity",
+        ))
+    }
 
     /// Execute a SQL statement (DDL/DML) without returning rows.
     async fn execute_statement(&self, sql: &str) -> AdapterResult<()>;

--- a/engine/crates/rocky-databricks/src/adapter.rs
+++ b/engine/crates/rocky-databricks/src/adapter.rs
@@ -134,6 +134,18 @@ impl WarehouseAdapter for DatabricksWarehouseAdapter {
         &self.dialect
     }
 
+    /// Databricks folds identifier case, so this is a dialect constant and needs
+    /// no round trip (#1281).
+    ///
+    /// Identifiers are case-insensitive, delimited ones included; Unity Catalog
+    /// stores names lower-cased —
+    /// docs.databricks.com/aws/en/sql/language-manual/sql-ref-identifiers
+    async fn identifier_case_significance(
+        &self,
+    ) -> AdapterResult<rocky_core::traits::CaseSignificance> {
+        Ok(rocky_core::traits::CaseSignificance::Insignificant)
+    }
+
     async fn execute_statement(&self, sql: &str) -> AdapterResult<()> {
         self.connector
             .execute_statement(sql)

--- a/engine/crates/rocky-duckdb/src/adapter.rs
+++ b/engine/crates/rocky-duckdb/src/adapter.rs
@@ -117,6 +117,18 @@ impl WarehouseAdapter for DuckDbWarehouseAdapter {
         &self.dialect
     }
 
+    /// DuckDB folds identifier case, so this is a dialect constant and needs
+    /// no round trip (#1281).
+    ///
+    /// "Identifiers … are always case-insensitive … DuckDB also treats quoted
+    /// identifiers as case-insensitive" (case is preserved for display only) —
+    /// duckdb.org/docs/stable/sql/dialect/keywords_and_identifiers
+    async fn identifier_case_significance(
+        &self,
+    ) -> AdapterResult<rocky_core::traits::CaseSignificance> {
+        Ok(rocky_core::traits::CaseSignificance::Insignificant)
+    }
+
     async fn execute_statement(&self, sql: &str) -> AdapterResult<()> {
         let conn = Arc::clone(&self.connector);
         let sql = sql.to_string();

--- a/engine/crates/rocky-snowflake/src/adapter.rs
+++ b/engine/crates/rocky-snowflake/src/adapter.rs
@@ -62,6 +62,29 @@ impl WarehouseAdapter for SnowflakeWarehouseAdapter {
         Some(self.connector.warehouse())
     }
 
+    /// Read `QUOTED_IDENTIFIERS_IGNORE_CASE` off the live session (#1281).
+    ///
+    /// Rocky renders Snowflake targets DOUBLE-QUOTED (see this crate's
+    /// `dialect::format_table_ref`), so this parameter — and not the unquoted
+    /// upper-casing rule — is what decides whether two of Rocky's targets
+    /// differing only by case are one object or two. `TRUE` makes quoted
+    /// identifiers case-insensitive, i.e. case is NOT part of identity.
+    ///
+    /// Fail-closed by construction: anything other than exactly one row
+    /// carrying a parseable boolean returns `Err`, which every caller reads as
+    /// "keep the conservative behaviour". A wrong definite answer here relaxes
+    /// a safety decision, so an ambiguous response must never be rounded into
+    /// one.
+    async fn identifier_case_significance(
+        &self,
+    ) -> AdapterResult<rocky_core::traits::CaseSignificance> {
+        let result = self
+            .execute_query("SHOW PARAMETERS LIKE 'QUOTED_IDENTIFIERS_IGNORE_CASE'")
+            .await?;
+
+        case_significance_from_show_parameters(&result)
+    }
+
     async fn execute_statement(&self, sql: &str) -> AdapterResult<()> {
         self.connector
             .execute_statement(sql)
@@ -402,6 +425,112 @@ mod tests {
     /// Verifies that the adapter can be constructed and used as a trait object.
     fn _assert_warehouse_adapter_trait_object(_: &dyn WarehouseAdapter) {}
 
+    // ---------------------------------------------------------------- //
+    // `SHOW PARAMETERS` response decoding (#1281)                       //
+    // ---------------------------------------------------------------- //
+
+    /// A `SHOW PARAMETERS` response in the shape the SQL API returns.
+    fn show_parameters(rows: Vec<Vec<serde_json::Value>>) -> rocky_core::traits::QueryResult {
+        rocky_core::traits::QueryResult {
+            columns: ["key", "value", "default", "level", "description", "type"]
+                .iter()
+                .map(|c| (*c).to_string())
+                .collect(),
+            rows,
+        }
+    }
+
+    fn param_row(key: &str, value: &str) -> Vec<serde_json::Value> {
+        vec![
+            serde_json::json!(key),
+            serde_json::json!(value),
+            serde_json::json!("false"),
+            serde_json::json!("SESSION"),
+            serde_json::json!("…"),
+            serde_json::json!("BOOLEAN"),
+        ]
+    }
+
+    #[test]
+    fn decodes_both_states_from_a_well_formed_response() {
+        use rocky_core::traits::CaseSignificance;
+
+        assert_eq!(
+            case_significance_from_show_parameters(&show_parameters(vec![param_row(
+                "QUOTED_IDENTIFIERS_IGNORE_CASE",
+                "false"
+            )]))
+            .expect("a well-formed response decodes"),
+            CaseSignificance::Significant,
+            "IGNORE_CASE=false means quoted case IS part of identity"
+        );
+
+        assert_eq!(
+            case_significance_from_show_parameters(&show_parameters(vec![param_row(
+                "QUOTED_IDENTIFIERS_IGNORE_CASE",
+                "true"
+            )]))
+            .expect("a well-formed response decodes"),
+            CaseSignificance::Insignificant
+        );
+    }
+
+    /// `SHOW ... LIKE` takes a SQL `LIKE` pattern and `_` matches any single
+    /// character, so the request is not the literal parameter name. A response
+    /// for a *different* parameter must be an `Err`, never a definite answer —
+    /// a wrong definite answer is the one outcome this probe must not produce.
+    ///
+    /// Mutation that must turn this red: dropping the `key` check.
+    #[test]
+    fn a_response_for_a_different_parameter_is_refused() {
+        let err = case_significance_from_show_parameters(&show_parameters(vec![param_row(
+            // Matches the wildcard pattern; is not the parameter asked for.
+            "QUOTEDxIDENTIFIERSyIGNOREzCASE",
+            "true",
+        )]))
+        .expect_err("a key that is not the parameter asked for must not answer");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("QUOTEDxIDENTIFIERSyIGNOREzCASE") && msg.contains("wildcard"),
+            "the error must name the parameter that actually answered and say why: {msg}"
+        );
+    }
+
+    #[test]
+    fn a_malformed_response_never_yields_a_definite_answer() {
+        // Zero rows, and more than one row: both leave "which is the session's
+        // value?" unanswered.
+        for rows in [
+            vec![],
+            vec![
+                param_row("QUOTED_IDENTIFIERS_IGNORE_CASE", "true"),
+                param_row("QUOTED_IDENTIFIERS_IGNORE_CASE", "false"),
+            ],
+        ] {
+            assert!(
+                case_significance_from_show_parameters(&show_parameters(rows)).is_err(),
+                "a row count other than exactly 1 must be an error"
+            );
+        }
+
+        // A row shorter than its column list.
+        let mut short = show_parameters(vec![vec![serde_json::json!(
+            "QUOTED_IDENTIFIERS_IGNORE_CASE"
+        )]]);
+        assert!(
+            case_significance_from_show_parameters(&short).is_err(),
+            "a short row must be an error, not a missing value read as false"
+        );
+
+        // The `key` column absent entirely.
+        short = show_parameters(vec![param_row("QUOTED_IDENTIFIERS_IGNORE_CASE", "true")]);
+        short.columns[0] = "not_key".into();
+        assert!(
+            case_significance_from_show_parameters(&short).is_err(),
+            "without a `key` column the answer cannot be attributed to a parameter"
+        );
+    }
+
     /// Verifies construction compiles and the dialect is correct.
     #[test]
     fn test_adapter_construction() {
@@ -497,5 +626,186 @@ mod tests {
 
         // Just verify we can access the connector without panic
         let _connector_ref = adapter.connector();
+    }
+}
+
+/// The parameter this probe reads. Also the value the response's `key` column
+/// must carry back, which is what makes the wildcard below harmless.
+const QUOTED_IDENTIFIERS_IGNORE_CASE: &str = "QUOTED_IDENTIFIERS_IGNORE_CASE";
+
+/// Decode a whole `SHOW PARAMETERS` response into a [`CaseSignificance`] (#1281).
+///
+/// Separate from the cell decoder so the *response shape* is testable, not just
+/// the value: a probe whose only job is to be trustworthy later has to reject a
+/// wrong row as firmly as a wrong value.
+///
+/// **Why the `key` is checked.** `SHOW ... LIKE` takes a SQL `LIKE` pattern, in
+/// which `_` matches any single character — so the pattern this sends is not the
+/// literal parameter name, and a Snowflake parameter named
+/// `QUOTEDxIDENTIFIERSyIGNOREzCASE` would match it. No such parameter exists
+/// today, and none is likely to; but the cost of finding out the hard way is a
+/// *wrong definite answer*, which is the one outcome this whole capability must
+/// not produce. Validating the returned `key` closes that off without editing
+/// the request. Escaping the underscores would too, but it would change the
+/// exact string that was live-verified against a real account, and an assertion
+/// on the response is cheaper to be sure of than a new pattern that cannot
+/// currently be re-verified.
+///
+/// Everything here fails closed: a missing column, a row count other than one,
+/// a short row, or a `key` that is not the parameter asked for all return `Err`.
+fn case_significance_from_show_parameters(
+    result: &rocky_core::traits::QueryResult,
+) -> AdapterResult<rocky_core::traits::CaseSignificance> {
+    // Locate columns BY NAME. `SHOW PARAMETERS` returns
+    // key/value/default/level/description/type, and pinning the ordinal would
+    // silently read `default` (the adjacent column, and frequently the same
+    // text) if Snowflake ever reorders them.
+    let column = |want: &str| {
+        result
+            .columns
+            .iter()
+            .position(|c| c.eq_ignore_ascii_case(want))
+            .ok_or_else(|| {
+                AdapterError::msg(format!(
+                    "SHOW PARAMETERS returned no `{want}` column (got {:?}), so \
+                     {QUOTED_IDENTIFIERS_IGNORE_CASE} could not be read",
+                    result.columns
+                ))
+            })
+    };
+    let key_idx = column("key")?;
+    let value_idx = column("value")?;
+
+    let [row] = result.rows.as_slice() else {
+        return Err(AdapterError::msg(format!(
+            "SHOW PARAMETERS LIKE '{QUOTED_IDENTIFIERS_IGNORE_CASE}' returned {} rows, \
+             expected exactly 1 — refusing to guess which one is the session's value",
+            result.rows.len()
+        )));
+    };
+
+    let short_row = || AdapterError::msg("SHOW PARAMETERS row is shorter than its column list");
+
+    let key = row
+        .get(key_idx)
+        .ok_or_else(short_row)?
+        .as_str()
+        .ok_or_else(|| AdapterError::msg("SHOW PARAMETERS `key` is not a string"))?;
+    if !key
+        .trim()
+        .eq_ignore_ascii_case(QUOTED_IDENTIFIERS_IGNORE_CASE)
+    {
+        return Err(AdapterError::msg(format!(
+            "SHOW PARAMETERS LIKE '{QUOTED_IDENTIFIERS_IGNORE_CASE}' answered for \
+             parameter {key:?} instead — `_` is a LIKE wildcard, so the pattern \
+             matched something else and this value must not be read as the answer"
+        )));
+    }
+
+    case_significance_from_parameter_cell(row.get(value_idx).ok_or_else(short_row)?)
+}
+
+/// Map a `SHOW PARAMETERS` `value` cell to a [`CaseSignificance`] (#1281).
+///
+/// Extracted from [`SnowflakeWarehouseAdapter::identifier_case_significance`]
+/// so BOTH states are testable. The live sandbox reports `false`, and its
+/// account is suspended, so `ALTER SESSION` (which needs compute) cannot flip
+/// it — the `true` branch is reachable only here.
+///
+/// `QUOTED_IDENTIFIERS_IGNORE_CASE = TRUE` means quoted identifiers are
+/// resolved case-INsensitively, so case is NOT part of object identity.
+///
+/// Anything unparseable is an `Err`, never a default. Rounding an unknown
+/// value to either state would hand a caller a definite answer it can relax a
+/// safety decision on.
+fn case_significance_from_parameter_cell(
+    cell: &serde_json::Value,
+) -> AdapterResult<rocky_core::traits::CaseSignificance> {
+    use rocky_core::traits::CaseSignificance;
+
+    // The SQL API renders this as the STRING "true"/"false"; a driver that
+    // types it natively would give a JSON bool. Accept both rather than assume
+    // the wire shape (#1153 is the same lesson on query cells).
+    let ignore_case = match cell {
+        serde_json::Value::Bool(b) => *b,
+        serde_json::Value::String(s) => match s.trim().to_ascii_lowercase().as_str() {
+            "true" => true,
+            "false" => false,
+            other => {
+                return Err(AdapterError::msg(format!(
+                    "QUOTED_IDENTIFIERS_IGNORE_CASE has unparseable value {other:?}"
+                )));
+            }
+        },
+        other => {
+            return Err(AdapterError::msg(format!(
+                "QUOTED_IDENTIFIERS_IGNORE_CASE has unexpected JSON type: {other}"
+            )));
+        }
+    };
+
+    Ok(if ignore_case {
+        CaseSignificance::Insignificant
+    } else {
+        CaseSignificance::Significant
+    })
+}
+
+#[cfg(test)]
+mod case_significance_tests {
+    use super::case_significance_from_parameter_cell as parse;
+    use rocky_core::traits::CaseSignificance;
+    use serde_json::json;
+
+    /// #1281 acceptance: BOTH states, not just the account's default.
+    ///
+    /// `true` is unreachable on the live sandbox — flipping it needs
+    /// `ALTER SESSION`, which needs compute, which the lapsed trial refuses —
+    /// so this is the only place that branch is exercised. Stated plainly
+    /// rather than implied, because a reader would otherwise assume the live
+    /// test covers both.
+    #[test]
+    fn both_states_map_to_the_right_significance() {
+        assert_eq!(
+            parse(&json!("false")).unwrap(),
+            CaseSignificance::Significant,
+            "IGNORE_CASE=false: quoted identifiers are case-sensitive, so case IS identity"
+        );
+        assert_eq!(
+            parse(&json!("true")).unwrap(),
+            CaseSignificance::Insignificant,
+            "IGNORE_CASE=true: quoted identifiers fold, so case is NOT identity"
+        );
+    }
+
+    /// Snowflake's SQL API sends strings; a natively-typed driver would send a
+    /// JSON bool. Neither shape may be the one that silently fails.
+    #[test]
+    fn accepts_both_wire_shapes_and_surrounding_whitespace() {
+        assert_eq!(
+            parse(&json!(true)).unwrap(),
+            CaseSignificance::Insignificant
+        );
+        assert_eq!(parse(&json!(false)).unwrap(), CaseSignificance::Significant);
+        assert_eq!(
+            parse(&json!("  TRUE  ")).unwrap(),
+            CaseSignificance::Insignificant,
+            "case and padding are the API's formatting, not a different answer"
+        );
+    }
+
+    /// Fail-closed: an unrecognized value is an error, NOT a default.
+    ///
+    /// Defaulting either way would be worse than erroring — the caller relaxes
+    /// a safety decision on a definite answer, and an invented one is
+    /// indistinguishable from an observed one at the call site.
+    #[test]
+    fn an_unparseable_value_errors_rather_than_defaulting() {
+        for bad in [json!("yes"), json!("1"), json!(""), json!(1), json!(null)] {
+            assert!(
+                parse(&bad).is_err(),
+                "{bad:?} must not be rounded into a definite answer"
+            );
+        }
     }
 }

--- a/engine/crates/rocky-snowflake/tests/identifier_case_significance_live.rs
+++ b/engine/crates/rocky-snowflake/tests/identifier_case_significance_live.rs
@@ -1,0 +1,114 @@
+//! Live Snowflake test for `WarehouseAdapter::identifier_case_significance`
+//! — the #1281 probe that reads `QUOTED_IDENTIFIERS_IGNORE_CASE` off the
+//! session instead of assuming how the account treats identifier case.
+//!
+//! Rocky renders Snowflake targets DOUBLE-QUOTED (`dialect::format_table_ref`),
+//! so this parameter is exactly what decides whether two of Rocky's targets
+//! differing only by case are one object or two.
+//!
+//! **This test needs no warehouse compute.** `SHOW PARAMETERS` is metadata, so
+//! it answers on an account whose trial has lapsed and whose DDL/compute is
+//! refused with `000666 / 57014 "account is suspended"`. That is why this probe
+//! could be live-verified when the rest of the Snowflake live suite could not.
+//!
+//! `#[ignore]`-gated; reads the same env vars as the other Snowflake live
+//! tests:
+//!   SNOWFLAKE_ACCOUNT, SNOWFLAKE_WAREHOUSE,
+//!   SNOWFLAKE_TEST_DATABASE (or SNOWFLAKE_DATABASE),
+//!   SNOWFLAKE_PAT (or username + key-pair / OAuth), SNOWFLAKE_ROLE
+//!
+//! Run with:
+//!   cargo test -p rocky-snowflake --test identifier_case_significance_live -- --ignored --nocapture
+
+use std::time::Duration;
+
+use rocky_core::config::RetryConfig;
+use rocky_core::traits::{CaseSignificance, WarehouseAdapter};
+use rocky_snowflake::adapter::SnowflakeWarehouseAdapter;
+use rocky_snowflake::auth::{Auth, AuthConfig};
+use rocky_snowflake::connector::{ConnectorConfig, SnowflakeConnector};
+
+fn adapter_from_env() -> Option<SnowflakeWarehouseAdapter> {
+    let account = std::env::var("SNOWFLAKE_ACCOUNT").ok()?;
+    let warehouse = std::env::var("SNOWFLAKE_WAREHOUSE").ok()?;
+    let database = std::env::var("SNOWFLAKE_TEST_DATABASE")
+        .or_else(|_| std::env::var("SNOWFLAKE_DATABASE"))
+        .ok()?;
+
+    let auth = Auth::from_config(AuthConfig {
+        account: account.clone(),
+        username: std::env::var("SNOWFLAKE_USERNAME").ok(),
+        // The sandbox `.env` mislabels its PAT as SNOWFLAKE_PASSWORD; it must
+        // be supplied via SNOWFLAKE_PAT. Deliberately not read here so a
+        // password-mode auth cannot be selected by mistake.
+        password: None,
+        oauth_token: std::env::var("SNOWFLAKE_OAUTH_TOKEN").ok(),
+        private_key_path: std::env::var("SNOWFLAKE_PRIVATE_KEY_PATH").ok(),
+        pat: std::env::var("SNOWFLAKE_PAT").ok(),
+    })
+    .ok()?;
+
+    let config = ConnectorConfig {
+        account,
+        warehouse,
+        database: Some(database),
+        schema: None,
+        role: std::env::var("SNOWFLAKE_ROLE").ok(),
+        timeout: Duration::from_secs(180),
+        retry: RetryConfig::default(),
+    };
+    Some(SnowflakeWarehouseAdapter::new(SnowflakeConnector::new(
+        config, auth,
+    )))
+}
+
+/// #1281: the probe returns a DEFINITE answer against a real account.
+///
+/// The assertion is deliberately not "equals Significant". This account
+/// reports `QUOTED_IDENTIFIERS_IGNORE_CASE = false`, but pinning that would
+/// make the test assert the account's configuration rather than the probe's
+/// behaviour — and it would start failing if the parameter were ever flipped,
+/// which is the very thing the probe exists to notice. What must hold is that
+/// a reachable account yields a definite answer rather than an error, and that
+/// the answer is the one the parameter dictates.
+#[tokio::test]
+#[ignore = "requires live Snowflake credentials"]
+async fn probe_reads_a_definite_answer_from_the_live_session() {
+    let Some(adapter) = adapter_from_env() else {
+        eprintln!("skipping: Snowflake env vars not set");
+        return;
+    };
+
+    let significance = adapter
+        .identifier_case_significance()
+        .await
+        .expect("a reachable account must yield a definite answer, not an error");
+
+    // Cross-check against the raw parameter through a second, independent
+    // read, so the test cannot pass by the probe inventing an answer.
+    let raw = adapter
+        .execute_query("SHOW PARAMETERS LIKE 'QUOTED_IDENTIFIERS_IGNORE_CASE'")
+        .await
+        .expect("SHOW PARAMETERS is metadata and answers on a suspended account");
+    let value_idx = raw
+        .columns
+        .iter()
+        .position(|c| c.eq_ignore_ascii_case("value"))
+        .expect("SHOW PARAMETERS has a `value` column");
+    let raw_value = raw.rows[0][value_idx]
+        .as_str()
+        .expect("value renders as a string over the SQL API")
+        .to_ascii_lowercase();
+
+    let expected = if raw_value == "true" {
+        CaseSignificance::Insignificant
+    } else {
+        CaseSignificance::Significant
+    };
+    assert_eq!(
+        significance, expected,
+        "probe disagreed with QUOTED_IDENTIFIERS_IGNORE_CASE={raw_value}"
+    );
+
+    eprintln!("live: QUOTED_IDENTIFIERS_IGNORE_CASE={raw_value} -> {significance:?}");
+}

--- a/engine/crates/rocky-sql/src/defer.rs
+++ b/engine/crates/rocky-sql/src/defer.rs
@@ -831,6 +831,26 @@ impl VisitorMut for DeferRewriter<'_> {
 
 #[cfg(test)]
 mod tests {
+    /// Pins the equivalence a probe-driven `case_rules` will depend on (#1282).
+    ///
+    /// Nothing routes through the probe today — #1281 shipped the capability
+    /// only. But the moment a consumer maps an `Insignificant` observation to
+    /// `all_insensitive()`, DuckDB, Databricks and Trino change constructor:
+    /// `dialect_case_rules` hands them `uniform(false)` today. "No behaviour
+    /// change for the three folding dialects" is then a claim about these two
+    /// values being equal, which is a test rather than a PR-body assertion.
+    ///
+    /// If this ever fails, the consumer is the thing to fix — not this test.
+    #[test]
+    fn uniform_false_and_all_insensitive_are_the_same_rules() {
+        assert_eq!(
+            super::IdentifierCaseRules::uniform(false),
+            super::IdentifierCaseRules::all_insensitive(),
+            "a folding dialect's rules must not change depending on which \
+             constructor produced them"
+        );
+    }
+
     use super::*;
 
     fn target(catalog: &str, schema: &str, table: &str) -> DeferTarget {

--- a/engine/crates/rocky-trino/src/adapter.rs
+++ b/engine/crates/rocky-trino/src/adapter.rs
@@ -51,6 +51,17 @@ impl WarehouseAdapter for TrinoAdapter {
         &self.dialect
     }
 
+    /// Trino folds identifier case, so this is a dialect constant and needs
+    /// no round trip (#1281).
+    ///
+    /// "Identifiers are not treated as case sensitive" —
+    /// trino.io/docs/current/language/reserved.html
+    async fn identifier_case_significance(
+        &self,
+    ) -> AdapterResult<rocky_core::traits::CaseSignificance> {
+        Ok(rocky_core::traits::CaseSignificance::Insignificant)
+    }
+
     fn classify_failure(&self, err: &AdapterError) -> rocky_core::failure_class::FailureClass {
         crate::connector::classify_trino_failure(err)
     }


### PR DESCRIPTION
Refs #1281 — **does not close it**, see "Deferred" below.

Shadow execution assumed how a warehouse treats identifier case, because it had no way to ask. It can now ask.

## The capability

`WarehouseAdapter::identifier_case_significance` returns whether identifier case is part of object identity **on this connection**. Not a dialect question: Snowflake's `QUOTED_IDENTIFIERS_IGNORE_CASE` is an account/session parameter, so two connections to one dialect can legitimately disagree.

- **Snowflake** reads the parameter live via `SHOW PARAMETERS`.
- **DuckDB / Databricks / Trino** answer with their dialect constant, no round trip.
- **BigQuery** is deliberately left on the default (see Deferred).

Two states, and **no `Unknown` variant** — "could not determine" rides on the `Err` arm. That is deliberate: a third variant is something a caller can match and let fall through a gate, which is the #1240 shape where an `Unknown` type satisfied a compatibility check unconditionally and the gate read as fail-open. The trait default is `Err`, so an ungrounded adapter inherits today's conservative behaviour rather than silently acquiring a relaxation nobody verified.

## The two refusals become decisions

They fail closed in **opposite** directions, so each consults the observation separately rather than sharing one answer:

| question | observed case-**sensitive** | observed case-**insensitive** | could not ask |
|---|---|---|---|
| could two targets be the same object? | route independently — they are two objects | refuse — they are one object | **fold and refuse** (a wrong "distinct" is silent: two models, one shadow table, no error) |
| does this reference name that routed upstream? | leave it — it names a different object | redirect it — it does name the upstream | **refuse** (both guesses unsafe) |

`None` reproduces the pre-#1281 behaviour exactly. The probe failure is also non-fatal at the call site: an unreachable adapter refuses what it refused before rather than failing the run over a probe.

`CollisionIdentity::of_observed_case_sensitive` is a **named constructor** rather than a `rules` parameter on `of`. Folding is that type's whole reason to exist, so making it configurable through the main constructor would put the fail-open choice one argument away at every call site. A named constructor makes every relaxation greppable and argued for where it is written.

## Verification

**The Snowflake probe is live-verified** against a real account:

```
live: QUOTED_IDENTIFIERS_IGNORE_CASE=false -> Significant
test probe_reads_a_definite_answer_from_the_live_session ... ok
```

Worth noting *how* that was possible: the trial on that account has lapsed and all DDL/compute is refused with `000666 / 57014 "account is suspended"`. `SHOW PARAMETERS` is metadata, so it still answers — which is why this probe could be live-verified when the rest of the Snowflake live suite could not.

**Only the `false` state is live-observable.** Flipping the parameter needs `ALTER SESSION`, which needs compute, which the lapsed trial refuses; the SQL API also rejects it as a request-level parameter (`391917`). So the `true` branch is covered by in-memory tests against an extracted `case_significance_from_parameter_cell`, not live. Stating that rather than implying both states were live-verified.

The live test asserts the probe **agrees with a second independent read** of the parameter, not that it equals `Significant` — pinning the latter would assert the account's configuration rather than the probe's behaviour, and would fail if the parameter were ever flipped, which is the very thing the probe exists to notice.

Both relaxations are mutation-checked:

| mutation | caught by |
|---|---|
| any definite answer stops folding (not just `Significant`) | `observed_case_insensitive_still_refuses_the_shared_target` |
| an unknown stops folding | the pre-existing `case_differing_targets_collide_on_every_dialect` |

The second matters most: the existing suite guards the `None` path, so the conservative behaviour cannot regress silently.

## Deferred, deliberately

**BigQuery's per-dataset `is_case_insensitive`.** The issue asks for it, and I did not implement it, for two reasons worth stating rather than burying:

1. Its answer varies **per dataset**, while `IdentifierCaseRules` is one value for the run — that is a real design change, not a fifth adapter impl.
2. The BigQuery trial has expired, so it cannot be live-verified. This repo's own record is that BigQuery stub-JSON tests shipped **five structural bugs** that only live execution caught. An unverifiable probe feeding a fail-open seam is the worst possible combination.

BigQuery therefore keeps today's conservative behaviour, and the docs say so.

**#1282 is deliberately out.** `unquoted_uppercases` is a different identity axis — Snowflake folds unquoted identifiers regardless of this parameter — and enabling it refuses every lowercase-configured Snowflake project, including this repo's own fixtures.

## What I'm least confident about

The reference-matching relaxation under observed case-**sensitive**, where the refusal is dropped and the reference is left unrewritten. The argument is that such a reference names a genuinely different object, so reading it is correct. That follows from the setting, but unlike the collision half I could not exercise it end-to-end against a live warehouse — the fixture proves the routing decision, not that Snowflake resolves the two spellings to different objects at execution. The banked Snowflake live suite is from engine ~1.47.x and we are on 1.68.0.

## What I'm most likely missing

Whether `replay.rs` should re-probe. It calls `dialect_case_rules` independently, and I left it untouched, so a replayed plan keeps the static answer. That is the conservative choice, but it means a plan reviewed under one identity model could execute under another if the account parameter changed in between — the guard-at-the-replay-seam shape. Worth a follow-up rather than a silent decision here.
