### PR TITLE
fix(engine): format row-count and checksum identifiers with the adapter's dialect

### DIFF
--- a/engine/crates/rocky-cli/src/commands/compact.rs
+++ b/engine/crates/rocky-cli/src/commands/compact.rs
@@ -770,13 +770,22 @@ async fn hash_table(
     table: &TableRef,
     value_columns: &[String],
 ) -> Result<Vec<PartitionChecksum>> {
-    let table_ref_str = table.validated_full_name().map_err(|e| {
-        anyhow!(
-            "rocky compact --measure-dedup could not validate table reference {table} before \
+    // Dialect-formatted, not `validated_full_name()` — this string is
+    // interpolated into the checksum query below, and that helper emits bare
+    // identifiers regardless of dialect (#1396), so on Snowflake a lower or
+    // mixed-case table was checksummed under the upper-cased name. The
+    // dialect's own `format_table_ref` validates each component too, so the
+    // identifier check this error message describes is preserved.
+    let table_ref_str = adapter
+        .dialect()
+        .format_table_ref(&table.catalog, &table.schema, &table.table)
+        .map_err(|e| {
+            anyhow!(
+                "rocky compact --measure-dedup could not validate table reference {table} before \
                  building the checksum query; verify the warehouse returned catalog, schema, and \
                  table names that are valid SQL identifiers: {e}"
-        )
-    })?;
+            )
+        })?;
     let sql = generate_whole_table_checksum_sql(&table_ref_str, value_columns);
     let result = adapter.execute_query(&sql).await.map_err(|e| {
         anyhow!(

--- a/engine/crates/rocky-cli/src/commands/compare.rs
+++ b/engine/crates/rocky-cli/src/commands/compare.rs
@@ -337,8 +337,17 @@ fn read_or_default<T: Default, E: std::fmt::Display>(
 /// integral-float cell shapes adapters return — a bare `as_str()` would drop
 /// numeric cells to `0` and let a real mismatch pass.
 async fn get_row_count(adapter: &dyn WarehouseAdapter, target: &TargetRef) -> Result<u64> {
-    let table_name = target
-        .validated_full_name()
+    // Format through the ADAPTER'S dialect, not `validated_full_name()`.
+    // That helper emits a bare `catalog.schema.table` and never consults a
+    // dialect, so on Snowflake — which folds unquoted identifiers to upper
+    // case while Rocky creates its objects quoted — a lower or mixed-case
+    // target was counted under the WRONG name: either "not found", or a real
+    // row count from a different table. `rocky compare` is the tool used to
+    // verify a shadow run, so a wrong count here is a false verification
+    // rather than a visible error (#1396).
+    let table_name = adapter
+        .dialect()
+        .format_table_ref(&target.catalog, &target.schema, &target.table)
         .map_err(|e| anyhow::anyhow!("{e}"))?;
     let sql = format!("SELECT COUNT(*) FROM {table_name}");
     let result = adapter
@@ -589,6 +598,78 @@ schema_template = "staging__{{source}}"
         assert!(
             error.to_string().contains("1 table(s) failed comparison"),
             "unexpected error: {error:#}"
+        );
+    }
+
+    /// #1396: `get_row_count` formats its identifier with the ADAPTER'S
+    /// dialect, so a quoting warehouse gets a quoted reference.
+    ///
+    /// Calls the real function and captures the SQL it emits. My first attempt
+    /// asserted properties of the dialect instead and was VACUOUS — it passed
+    /// with the fix reverted. Snowflake is used deliberately: DuckDB renders
+    /// bare, so a DuckDB fixture would pass against the broken code too.
+    #[tokio::test]
+    async fn get_row_count_quotes_its_identifier_on_a_quoting_dialect() {
+        use rocky_core::traits::{AdapterResult, QueryResult, SqlDialect, WarehouseAdapter};
+        use std::sync::Mutex;
+
+        struct CapturingAdapter {
+            dialect: rocky_snowflake::dialect::SnowflakeSqlDialect,
+            seen: Mutex<Vec<String>>,
+        }
+        #[async_trait::async_trait]
+        impl WarehouseAdapter for CapturingAdapter {
+            fn dialect(&self) -> &dyn SqlDialect {
+                &self.dialect
+            }
+            async fn execute_statement(&self, _sql: &str) -> AdapterResult<()> {
+                unimplemented!("get_row_count only queries")
+            }
+            async fn execute_query(&self, sql: &str) -> AdapterResult<QueryResult> {
+                self.seen.lock().unwrap().push(sql.to_string());
+                Ok(QueryResult {
+                    columns: vec!["c".into()],
+                    rows: vec![vec![serde_json::json!(7)]],
+                })
+            }
+            async fn describe_table(
+                &self,
+                _t: &rocky_ir::TableRef,
+            ) -> AdapterResult<Vec<rocky_ir::ColumnInfo>> {
+                unimplemented!("get_row_count never describes")
+            }
+        }
+
+        let adapter = CapturingAdapter {
+            dialect: rocky_snowflake::dialect::SnowflakeSqlDialect,
+            seen: Mutex::new(Vec::new()),
+        };
+        let target = rocky_ir::TargetRef {
+            catalog: "cat".into(),
+            schema: "main".into(),
+            table: "orders".into(),
+        };
+
+        let count = super::get_row_count(&adapter, &target)
+            .await
+            .expect("row count");
+        assert_eq!(count, 7);
+
+        let sql = adapter
+            .seen
+            .lock()
+            .unwrap()
+            .first()
+            .cloned()
+            .expect("a query was issued");
+        assert!(
+            sql.contains(r#""orders""#),
+            "Snowflake folds unquoted identifiers to upper case, so the table must be quoted \
+             or the count reads a different object: {sql}"
+        );
+        assert!(
+            !sql.contains("FROM cat.main.orders"),
+            "a bare `catalog.schema.table` is the #1396 defect: {sql}"
         );
     }
 }


### PR DESCRIPTION
Closes #1396.

`TargetRef::validated_full_name()` delegates to `validation::format_table_ref`, which emits a bare `catalog.schema.table` and **never consults a dialect**. Two call sites interpolated that straight into executed SQL.

Snowflake's own `format_table_ref` quotes every component, and its comment states the reason outright:

> Snowflake folds *unquoted* identifiers to UPPERCASE at parse time, so case-preserving (lowercase or mixed-case) names need explicit double-quoting to round-trip. The shared `validation::format_table_ref` emits unquoted identifiers, which silently breaks against any schema / table created with quoted lowercase names.

The dialect layer was fixed. These call sites were not — so for any target configured in lower or mixed case they addressed `CAT.MAIN.ORDERS` while Rocky's object is `"cat"."main"."orders"`. Either a misleading "table not found", or — the bad case — a real answer from a **different table**.

## Two sites, not one

| Site | Query | Why it matters |
|---|---|---|
| `compare.rs` `get_row_count` | `SELECT COUNT(*)` | `rocky compare` is what verifies a shadow run, so a wrong count is a **false verification**, not a visible error |
| `compact.rs` checksum | `--measure-dedup` whole-table checksum | **not in the original report** |

The second was found by reading *every* `validated_full_name()` consumer rather than trusting the call site the issue named. Ten exist; the other eight are deliberately untouched:

- `compact.rs:453`, `:470` — case-folded identity keys for set membership, never SQL
- `compact.rs:511` — a tracing field
- five in `rocky-ir` — tests

The dialect's `format_table_ref` validates each component as well, so the identifier check those error messages describe is preserved.

## The test, and the one I threw away

`get_row_count_quotes_its_identifier_on_a_quoting_dialect` calls the real function with a capturing adapter and asserts the SQL it emits.

My **first** attempt asserted properties of the dialect — that Snowflake quotes, and that `validated_full_name()` differs from the dialect rendering. Both true, both irrelevant: it passed with the fix reverted, so it proved nothing about `get_row_count`. Mutation-checking caught it; the rewrite fails on that same mutation.

Snowflake is used deliberately. DuckDB renders bare, so a DuckDB fixture would pass against the broken code too — the condition only exists on a quoting dialect.

## Verification

`fmt` clean · `clippy --all-targets --all-features -D warnings` clean · `rocky-cli` lib suite **1420 passed, 0 failed**.

## What I'm least confident about

End-to-end proof needs a live Snowflake DDL round trip — create a lower-case table, count it both ways — and the lapsed trial refuses DDL, so this is verified at the SQL-generation boundary rather than against the warehouse. The mechanism itself *is* live-verified: probing the account, `SELECT 1 AS Foo, 2 AS "Bar"` returns column names `['FOO', 'Bar']`.