### PR TITLE
fix(dagster): forward pipeline in streaming and pipes

### DIFF
--- a/docs/src/content/docs/dagster/resource.md
+++ b/docs/src/content/docs/dagster/resource.md
@@ -60,7 +60,7 @@ Runs `rocky plan` and returns the planned SQL statements without executing them.
 | `pipeline` | `str \| None` | `None` | Pipeline name (required when multiple pipelines are defined) |
 | `env` | `str \| None` | `None` | Optional environment name |
 
-### `run(filter, governance_override=None, *, run_models=False, partition=None, partition_from=None, partition_to=None, latest=False, missing=False, lookback=None, parallel=None) -> RunResult`
+### `run(filter, governance_override=None, *, pipeline=None, run_models=False, partition=None, partition_from=None, partition_to=None, latest=False, missing=False, lookback=None, parallel=None) -> RunResult`
 
 Runs Rocky in buffered mode (`subprocess.run`) and returns the full execution result including materializations, check results, drift detection, and permission changes.
 
@@ -70,6 +70,7 @@ Runs Rocky in buffered mode (`subprocess.run`) and returns the full execution re
 |---|---|---|---|
 | `filter` | `str` | required | Component filter (e.g. `"tenant=acme"`) |
 | `governance_override` | `dict \| None` | `None` | Per-run governance config (workspace_ids, grants), merged with `rocky.toml` defaults |
+| `pipeline` | `str \| None` | `None` | Pipeline name (required when multiple pipelines are defined) |
 | `run_models` | `bool` | `False` | Also execute compiled models (passes `--models` and `--all`) |
 | `partition` | `str \| None` | `None` | Single partition key (e.g. `"2026-04-07"`) |
 | `partition_from` | `str \| None` | `None` | Lower bound of a partition range (requires `partition_to`) |
@@ -79,7 +80,7 @@ Runs Rocky in buffered mode (`subprocess.run`) and returns the full execution re
 | `lookback` | `int \| None` | `None` | Recompute the previous N partitions in addition to the selected ones |
 | `parallel` | `int \| None` | `None` | Run N partitions concurrently. Left as `None`, the `--parallel` flag is omitted and the engine applies its own default of 4 concurrent partitions (earlier engine versions defaulted to serial). Pass `1` to run one partition at a time — note this does not bound a replication pipeline's table fan-out, which comes from its `[execution] concurrency`. DuckDB runs serially regardless. |
 
-### `run_streaming(context, filter, governance_override=None, *, run_models=False, partition=None, partition_from=None, partition_to=None, latest=False, missing=False, lookback=None, parallel=None) -> RunResult`
+### `run_streaming(context, filter, governance_override=None, *, pipeline=None, run_models=False, partition=None, partition_from=None, partition_to=None, latest=False, missing=False, lookback=None, parallel=None) -> RunResult`
 
 Pipes-style execution with live stderr streaming to `context.log`. Same semantics as `run()` but spawns the binary via `subprocess.Popen` and forwards Rocky's stderr (tracing output) to `context.log.info` line-by-line as the run progresses. Use this from inside a Dagster `@multi_asset` or `@op` for runs longer than a few seconds.
 
@@ -98,7 +99,7 @@ def replicate(context: dg.AssetExecutionContext, rocky: RockyResource):
     return result.tables_copied
 ```
 
-### `run_pipes(context, filter, governance_override=None, *, run_models=False, partition=None, partition_from=None, partition_to=None, latest=False, missing=False, lookback=None, parallel=None, pipes_client=None) -> PipesClientCompletedInvocation`
+### `run_pipes(context, filter, governance_override=None, *, pipeline=None, run_models=False, partition=None, partition_from=None, partition_to=None, latest=False, missing=False, lookback=None, parallel=None, pipes_client=None) -> PipesClientCompletedInvocation`
 
 Full Dagster Pipes execution with structured event streaming. Spawns `rocky plan` followed by `rocky apply <plan-id>` via `PipesSubprocessClient`, which sets the `DAGSTER_PIPES_CONTEXT` / `DAGSTER_PIPES_MESSAGES` env vars on the apply subprocess. The engine emits one Pipes message per materialization, asset check, and log line, so the run viewer gets `MaterializationEvent` and `AssetCheckEvaluation` events in real time. The plan id is attached via `extras={"plan_id": plan_id}`, so Dagster surfaces it as run metadata in the run viewer.
 

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`run_streaming()` and `run_pipes()` can select a pipeline.** Both methods now
+  accept the same `pipeline=` keyword as buffered `run()`. Streaming forwards it
+  to `rocky run --pipeline`; Pipes persists it through `rocky plan --pipeline`.
+  This restores both execution modes for projects with multiple pipelines. (#1401)
+
 - **Two DAG nodes resolving to one Dagster asset key are refused, with a message that names them.** The engine deliberately permits the same `catalog.schema.table` on two different adapters — `reject_duplicate_physical_targets` keys on `(adapter, target)` — while the default translator keys a transformation asset on the target triple alone, and neither `DagNodeOutput` nor `TargetConfig` carries the adapter, so the collision cannot be expressed in an asset key at all. Dagster did catch this, but only at repository build and only because the specs differ (`rocky/node_id` is stamped into each), and its `Received conflicting AssetSpecs with the same key` names neither the models, nor their pipelines, nor the adapters that make the project legal upstream. `build_dag_specs` now refuses as soon as the keys are known, listing each colliding key with its node ids and pipelines. The check runs **after** the translator, keyed on what it returned, so a project that already disambiguates with a custom `get_dag_node_asset_key` is unaffected. (#1349)
 
 ### Fixed

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -860,6 +860,7 @@ class RockyResource(dg.ConfigurableResource):
             filter: Component filter (e.g. ``"client=acme"``).
             governance_override: Optional per-run governance config (workspace_ids,
                 grants), merged additively with ``rocky.toml`` defaults.
+            pipeline: Pipeline name (required when multiple pipelines are defined).
             run_models: If ``True``, also execute compiled models.
             partition / partition_from / partition_to / latest / missing /
                 lookback / parallel: Partition selection flags.
@@ -917,6 +918,7 @@ class RockyResource(dg.ConfigurableResource):
         filter: str,
         governance_override: dict | None = None,
         *,
+        pipeline: str | None = None,
         run_models: bool = False,
         partition: str | None = None,
         partition_from: str | None = None,
@@ -964,6 +966,7 @@ class RockyResource(dg.ConfigurableResource):
             return self._get_client().run(
                 filter,
                 governance_override=resolved.get("governance_override"),
+                pipeline=pipeline,
                 run_models=run_models,
                 partition=partition,
                 partition_from=partition_from,
@@ -1035,6 +1038,7 @@ class RockyResource(dg.ConfigurableResource):
         filter: str,
         governance_override: dict | None = None,
         *,
+        pipeline: str | None = None,
         run_models: bool = False,
         partition: str | None = None,
         partition_from: str | None = None,
@@ -1101,6 +1105,7 @@ class RockyResource(dg.ConfigurableResource):
         _validate_governance_override(resolved.get("governance_override"))
         build_kwargs: dict[str, Any] = {
             "governance_override": resolved.get("governance_override"),
+            "pipeline": pipeline,
             "run_models": run_models,
             "partition": partition,
             "partition_from": partition_from,

--- a/integrations/dagster/tests/test_resource.py
+++ b/integrations/dagster/tests/test_resource.py
@@ -1288,8 +1288,8 @@ def test_run_rocky_buffered_path_hard_kills_hung_binary(tmp_path: Path):
     )
 
 
-def test_run_streaming_threads_partition_flags():
-    """run_streaming accepts the same partition kwargs as run() and
+def test_run_streaming_threads_all_routing_flags():
+    """run_streaming accepts the same routing kwargs as run() and
     threads them onto its single ``rocky run`` spawn."""
     rocky = RockyResource()
     context = _captured_log_context()
@@ -1308,6 +1308,7 @@ def test_run_streaming_threads_partition_flags():
         rocky.run_streaming(
             context,
             filter="tenant=acme",
+            pipeline="bronze",
             partition="2026-04-08",
             lookback=2,
             parallel=4,
@@ -1317,6 +1318,8 @@ def test_run_streaming_threads_partition_flags():
     assert len(captured_cmd) == 1
     run_cmd = captured_cmd[0]
     assert "run" in run_cmd
+    pipeline_idx = run_cmd.index("--pipeline")
+    assert run_cmd[pipeline_idx + 1] == "bronze"
     assert "--partition" in run_cmd
     assert "2026-04-08" in run_cmd
     assert "--lookback" in run_cmd
@@ -1344,7 +1347,15 @@ def test_run_streaming_default_omits_partition_flags():
         rocky.run_streaming(context, filter="tenant=acme")
 
     run_cmd = captured_cmd[0]
-    for flag in ("--partition", "--from", "--to", "--latest", "--missing", "--lookback"):
+    for flag in (
+        "--pipeline",
+        "--partition",
+        "--from",
+        "--to",
+        "--latest",
+        "--missing",
+        "--lookback",
+    ):
         assert flag not in run_cmd
 
 
@@ -1404,8 +1415,8 @@ def test_run_pipes_calls_pipes_client_with_built_command():
     assert call_kwargs.get("extras") == {"plan_id": plan_id}
 
 
-def test_run_pipes_threads_all_partition_flags():
-    """run_pipes() threads partition kwargs through to the plan-phase
+def test_run_pipes_threads_all_routing_flags():
+    """run_pipes() threads routing kwargs through to the plan-phase
     subprocess argv (Phase 5 — apply-phase argv is just ``apply <plan_id>``).
     """
     rocky = RockyResource()
@@ -1423,6 +1434,7 @@ def test_run_pipes_threads_all_partition_flags():
         rocky.run_pipes(
             context,
             filter="tenant=acme",
+            pipeline="bronze",
             partition_from="2026-04-01",
             partition_to="2026-04-08",
             lookback=2,
@@ -1432,6 +1444,8 @@ def test_run_pipes_threads_all_partition_flags():
 
     plan_args = captured_plan_args[0]
     assert "plan" in plan_args
+    pipeline_idx = plan_args.index("--pipeline")
+    assert plan_args[pipeline_idx + 1] == "bronze"
     assert "--from" in plan_args
     assert "2026-04-01" in plan_args
     assert "--to" in plan_args
@@ -1440,6 +1454,24 @@ def test_run_pipes_threads_all_partition_flags():
     assert "2" in plan_args
     assert "--parallel" in plan_args
     assert "4" in plan_args
+
+
+def test_run_pipes_default_omits_pipeline():
+    """pipeline=None preserves the existing unscoped plan argv."""
+    rocky = RockyResource()
+    context = MagicMock(spec=dg.AssetExecutionContext)
+    fake_client = MagicMock(spec=dg.PipesSubprocessClient)
+    fake_client.run = MagicMock(return_value=MagicMock())
+    captured_plan_args: list[list[str]] = []
+
+    def fake_run_rocky(self, args, *, allow_partial=False, timeout_seconds=None):
+        captured_plan_args.append(args)
+        return _plan_json()
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run_rocky):
+        rocky.run_pipes(context, filter="tenant=acme", pipes_client=fake_client)
+
+    assert "--pipeline" not in captured_plan_args[0]
 
 
 def test_run_pipes_constructs_default_client_when_none_passed():


### PR DESCRIPTION
## Summary

Closes #1401.

`RockyResource.run()` already accepts `pipeline=`, but its two context-aware whole-run variants did not. Multi-pipeline callers therefore could not use live stderr streaming or Dagster Pipes: Python rejected the selector, and an unscoped command is rejected by the engine when several pipelines exist.

## Subproject(s) touched

- [x] `integrations/dagster/` (Python package)
- [x] Documentation

## Changes

- Add the optional, keyword-only `pipeline` argument to `run_streaming()` and forward it to `RockyClient.run()`.
- Add the same argument to `run_pipes()` and persist it on the plan-phase argv; apply remains `rocky apply <plan-id>`.
- Pin both positive `--pipeline <name>` paths and the `pipeline=None` compatibility controls.
- Correct all three public resource signatures in the Dagster docs and record the fix in the changelog.

No SDK or engine change is needed: both shared SDK argv builders already accept `pipeline` and omit the flag for `None`.

## Test Plan

- `UV_CACHE_DIR=/tmp/rocky-uv-cache uv run pytest -q` — **711 passed**
- Focused mutation boundary — **4 passed**
- `uv run ruff check src/ tests/` — clean
- `uv run ruff format --check src/ tests/` — 52 files formatted
- `uv build` — wheel and sdist built
- `npm run build` in `docs/` — 103 pages built

## Independent red team

An independent GPT-5.6-terra review traced the streaming and plan/apply paths and returned **Approve, no findings**. It confirmed that component callers do not carry pipeline identity and are outside this public-resource API fix; changing component discovery/grouping semantics would be separate work.

**What I am least confident about:** no real-engine multi-pipeline Pipes fixture was run; the changed seam is covered at the exact argv boundary.

**What's the most important thing I may be missing:** an end-to-end fixture with two replication pipelines through a real `PipesSubprocessClient`. Existing plan persistence plus the new argv assertions cover the behavior changed here.

## Checklist

- [x] Conventional commit, scoped to Dagster
- [x] No `Co-Authored-By` trailer
- [x] Public docs and changelog updated
- [x] No CLI JSON schema or DSL change

> **ModelIr / contract semantics preserved: yes** — this only restores pipeline selection before execution.
