### PR TITLE
fix(engine): a shadow replication run must read production, not its own target

### DIFF
--- a/docs/src/content/docs/concepts/shadow-mode.md
+++ b/docs/src/content/docs/concepts/shadow-mode.md
@@ -16,8 +16,9 @@ Shadow mode writes pipeline output to shadow tables instead of (or alongside) pr
 
 :::caution[Where shadow isolation applies]
 Isolation covers a plain `rocky run` over **transformation** pipelines, and
-**replication** pipelines under `--shadow-schema` (or a branch). Everywhere else
-Rocky now refuses the flag instead of running without isolation:
+**replication** pipelines in either mode — `--shadow-suffix` or `--shadow-schema`
+(or a branch). Everywhere else Rocky refuses the flag instead of running without
+isolation:
 
 - **`rocky run --dag`** refuses `--shadow` / `--branch` outright. The DAG runs
   each model as its own sub-run, so a model's reads of an upstream built by the
@@ -25,10 +26,12 @@ Rocky now refuses the flag instead of running without isolation:
   shadow table would be built from production data while the run reported
   success. Run the shadow pipeline without `--dag`.
 - **Snapshot and load** pipelines refuse it: their targets are not rewritten.
-- **Replication in suffix mode** refuses it. The suffix would be applied to the
-  table name that the source read and the target write share, so the run would
-  read `<source_schema>.<table>_rocky_shadow`. Use `--shadow-schema` instead,
-  which moves only the target schema and leaves the source alone.
+Replication supports both shadow modes, and they isolate differently. Under
+`--shadow-suffix` the copy writes `<table><suffix>` **in the pipeline's own
+target schema**, reading the unsuffixed production source. Under
+`--shadow-schema` the whole target schema moves and table names are untouched.
+Prefer the schema override when you want the shadow objects kept away from
+production tables rather than sitting beside them.
 - **Seeds** cause a `--dag` run to be refused along with the rest; `rocky seed`
   itself has no shadow mode and always writes its configured target.
 

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -333,6 +333,44 @@ fn copy_endpoints(task: &TableTask) -> (TableRef, TableRef) {
     )
 }
 
+/// Build the replication [`ModelIr`] the copy statement is generated from.
+///
+/// Extracted from `process_table` so the source/target split is testable at the
+/// seam that actually emits SQL. [`copy_endpoints`] above splits the two names
+/// correctly and has its own test, but **nothing derived from it reaches the
+/// copy statement** — its `source_table` feeds only the change marker, the
+/// describe, and the row-count check. The statement itself is built from this
+/// `ModelIr`, which is where #1280's split has to hold and where it did not.
+fn replication_model_ir(
+    task: &TableTask,
+    strategy: MaterializationStrategy,
+    governance: GovernanceConfig,
+) -> ModelIr {
+    ModelIr::replication(
+        TargetRef {
+            catalog: task.target_catalog.clone(),
+            schema: task.target_schema.clone(),
+            table: task.target_table_name.clone(),
+        },
+        strategy,
+        SourceRef {
+            catalog: task.source_catalog.clone(),
+            schema: task.source_schema.clone(),
+            // The read keeps the PRODUCTION name — see `TableTask::source_table_name`,
+            // whose doc comment specifies exactly this. #1280 split the field for it;
+            // #1383 then applied the split to `copy_endpoints` and to the target above
+            // but left this one on `target_table_name`, so a shadow-suffix run built
+            // `FROM <source_schema>.<table><suffix>`: normally absent, giving a
+            // misleading "table not found", and — where such a table happened to
+            // exist — silently copying it into the shadow target at exit 0.
+            table: task.source_table_name.clone(),
+        },
+        ColumnSelection::All,
+        task.metadata_columns.clone(),
+        governance,
+    )
+}
+
 #[derive(Clone)]
 struct TableTask {
     source_catalog: String,
@@ -10986,20 +11024,9 @@ async fn process_table(
     let resolved_strategy =
         resolve_merge_update_columns(&strategy, &source_cols, &task.metadata_columns);
 
-    let model_ir = ModelIr::replication(
-        TargetRef {
-            catalog: task.target_catalog.clone(),
-            schema: task.target_schema.clone(),
-            table: task.target_table_name.clone(),
-        },
+    let model_ir = replication_model_ir(
+        task,
         resolved_strategy.clone(),
-        SourceRef {
-            catalog: task.source_catalog.clone(),
-            schema: task.source_schema.clone(),
-            table: task.target_table_name.clone(),
-        },
-        ColumnSelection::All,
-        task.metadata_columns.clone(),
         GovernanceConfig {
             permissions_file: None,
             auto_create_catalogs: pipeline.target.governance.auto_create_catalogs,
@@ -13926,6 +13953,108 @@ merge_keys = ["id"]
             source_table.state_key(),
             target_table.state_key(),
             "shadow and production must not share a watermark key"
+        );
+    }
+
+    /// The same split, at the seam that actually EMITS the copy statement.
+    ///
+    /// The sibling test above asserts `copy_endpoints`, and its stated mutation
+    /// does turn it red — but nothing derived from `copy_endpoints` reaches the
+    /// copy SQL. Its `source_table` feeds only the change marker, the describe,
+    /// and the row-count check. The statement is generated from the `ModelIr`
+    /// built by `replication_model_ir`, whose `SourceRef` read
+    /// `target_table_name` from #1383 until this test existed — so the property
+    /// was asserted at one seam and violated at the other, and a test whose own
+    /// comment says "asserting the SOURCE side is the point" passed throughout.
+    ///
+    /// Mutation that must turn this red: `SourceRef.table:
+    /// task.target_table_name.clone()` in `replication_model_ir`. That is the
+    /// state shipped in engine-v1.69.0, where a shadow-suffix replication run
+    /// read `<source_schema>.<table><suffix>` — normally absent, so the run
+    /// failed with a misleading "table not found"; present, so it silently
+    /// copied an unrelated table into the shadow target and exited 0.
+    #[cfg(feature = "duckdb")]
+    #[test]
+    fn shadow_suffix_copy_sql_reads_production_not_the_shadow_target() {
+        use rocky_core::traits::SqlDialect;
+        use rocky_duckdb::dialect::DuckDbSqlDialect;
+
+        let task = TableTask {
+            source_catalog: "cat".into(),
+            source_schema: "raw".into(),
+            target_catalog: "cat".into(),
+            target_schema: "raw".into(),
+            source_table_name: "orders".into(),
+            target_table_name: "orders_rocky_shadow".into(),
+            asset_key_prefix: vec!["test".into()],
+            tenant: None,
+            check_column_match: false,
+            check_row_count: false,
+            check_freshness: false,
+            column_match_exclude: vec![],
+            metadata_columns: vec![],
+            governance_tags: BTreeMap::new(),
+            prefetched_source_cols: None,
+            prefetched_target_cols: None,
+            effective_override: ResolvedTableOverride::default(),
+            auto_apply_gate: None,
+        };
+
+        let model_ir = super::replication_model_ir(
+            &task,
+            MaterializationStrategy::FullRefresh,
+            GovernanceConfig {
+                permissions_file: None,
+                auto_create_catalogs: false,
+                auto_create_schemas: true,
+            },
+        );
+
+        assert_eq!(
+            model_ir
+                .source
+                .as_ref()
+                .expect("a replication IR always carries a source")
+                .table,
+            "orders",
+            "the IR the copy is generated from must READ the production table"
+        );
+        assert_eq!(model_ir.target.table, "orders_rocky_shadow");
+
+        // Bind to the emitted statement, not just the struct: this is the
+        // artifact the warehouse executes, and the bug was invisible in every
+        // assertion that stopped short of it.
+        let dialect = DuckDbSqlDialect;
+        let sql = rocky_core::sql_gen::generate_bootstrap_create_table_as_sql(
+            &model_ir,
+            &dialect as &dyn SqlDialect,
+        )
+        .expect("a full-refresh replication IR generates a bootstrap CTAS");
+
+        // Compare against the dialect's own rendering rather than parsing the
+        // statement. `generate_replication_create_table_as_sql` interpolates
+        // `format!("{select_clause}\nFROM {source_ref}")`, so the read is
+        // exactly `FROM ` + whatever `format_table_ref` produces — no quoting
+        // or whitespace assumption of this test's own can drift from it.
+        let rendered = |table: &str| {
+            dialect
+                .format_table_ref("cat", "raw", table)
+                .expect("the fixture identifiers are valid")
+        };
+        let production_read = format!("FROM {}", rendered("orders"));
+        let shadow_read = format!("FROM {}", rendered("orders_rocky_shadow"));
+
+        assert!(
+            sql.contains(&production_read),
+            "the copy must READ production ({production_read}): {sql}"
+        );
+        assert!(
+            !sql.contains(&shadow_read),
+            "the copy must not read its own shadow target ({shadow_read}): {sql}"
+        );
+        assert!(
+            sql.contains(&rendered("orders_rocky_shadow")),
+            "the shadow target must still be what the statement WRITES: {sql}"
         );
     }
 

--- a/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
+++ b/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
@@ -320,7 +320,7 @@ pub async fn run_with_dag(
     // #1272 was filed because `--dag --shadow` silently wrote production. The
     // obvious repair — thread `shadow_config` into every sub-run — is necessary
     // but NOT sufficient, and shipping it alone would have replaced a visible
-    // wrong with an invisible one. Four independent reasons, each verified:
+    // wrong with an invisible one. Three independent reasons, each verified:
     //
     // 1. **Cross-model reads are not routed.** The DAG dispatches each
     //    transformation model as its own ONE-model sub-run, so
@@ -335,10 +335,15 @@ pub async fn run_with_dag(
     // 2. **Seeds are not routed.** A seed node dispatches to `seed::run_seed`,
     //    which takes no shadow config and DROPs, recreates and repopulates its
     //    CONFIGURED target.
-    // 3. **Replication suffix mode corrupts the SOURCE.** `TableTask` carries one
-    //    `table_name` for both sides and `run()` stores the SUFFIXED name in it,
-    //    so the copy reads `<source_schema>.<table>_rocky_shadow`.
-    // 4. **Snapshot and load are unrouted** and already refuse inside `run()`.
+    // 3. **Snapshot and load are unrouted** and already refuse inside `run()`.
+    //
+    // A fourth reason stood here until the source/target split was finished:
+    // replication suffix mode read `<source_schema>.<table><suffix>`, i.e. its
+    // own shadow target. #1280 split `TableTask` into `source_table_name` /
+    // `target_table_name` and #1383 applied the split, but the replication
+    // `ModelIr`'s `SourceRef` kept the target name until it was fixed, so the
+    // claim outlived the field it described. The three reasons above are
+    // independent of it and the refusal is unchanged.
     //
     // Refusing whole rather than carving out the narrow survivors (a
     // single-model DAG; replication under `schema_override`) is deliberate:
@@ -353,10 +358,9 @@ pub async fn run_with_dag(
              as its own sub-run, so a model's reads of an upstream built by this same run are \
              NOT redirected to that upstream's shadow target — the downstream shadow table would \
              be built from production data and the run would still report success. Seed, \
-             snapshot and load nodes are not routed at all, and replication's suffix mode \
-             rewrites the source it reads. Run the shadow pipeline without `--dag` (a single \
-             `rocky run --shadow` routes every selected model and rewrites the reads between \
-             them), or run the DAG without the flag"
+             snapshot and load nodes are not routed at all. Run the shadow pipeline without \
+             `--dag` (a single `rocky run --shadow` routes every selected model and rewrites \
+             the reads between them), or run the DAG without the flag"
         );
     }
 


### PR DESCRIPTION
## Summary

`ModelIr::replication`'s `SourceRef` was built from `task.target_table_name`, so a shadow-suffix replication run emitted `FROM <source_schema>.<table><suffix>` — it read the table it was about to write.

Normally no such table exists at the source and the run fails with a misleading "table not found". Where one does exist, the run copies **that** table into the shadow target and exits 0 reporting `Success`.

**Shipped in engine-v1.69.0.**

## Reproduction

On the released 1.69.0 binary, replication-only DuckDB project, sources under `raw__acme`:

```
$ rocky run --pipeline bronze --shadow --shadow-suffix _pr
DuckDB error: Catalog Error: Table with name payments_pr does not exist!
  LINE 3: FROM raw__acme.payments_pr
Error: 2 table(s) failed during parallel execution
```

`--shadow-schema` is unaffected, and that split is the proof it is this line rather than a fixture problem: under a schema override `target_table_name == table.name` (`run.rs:3097-3105`), so the wrong field happens to hold the right value. Only suffix mode is broken — exactly what the defect predicts and not something a bad fixture produces.

The row-count check *did* notice — it reads the source through a different, correct seam and reported source 2 vs target 1 — but a failed check does not gate exit status, so the run still returned `Success`.

## Why the existing test did not catch it

`TableTask::source_table_name` exists precisely for this, and its doc comment states the failure verbatim:

> a single shared field made the copy read its own shadow target: normally absent, so the run failed with a misleading "table not found", and if a table by that name did exist it silently copied the wrong one.

#1280 split the field for that reason. #1383 then applied the split to `copy_endpoints` and to this constructor's `TargetRef`, and left the `SourceRef` on the target name — both lines are in the same commit (`063ad15d`).

Its regression test, `shadow_suffix_reads_production_and_writes_the_suffixed_target`, asserts on `copy_endpoints`, and its stated mutation contract ("build `source_table` from `task.target_table_name`") does turn it red. But **nothing derived from `copy_endpoints` reaches the copy statement**: its `source_table` feeds only the change marker, the describe, and the row-count check. The statement is generated from the `ModelIr`.

So the property was asserted at one seam and violated at the other, and a test whose own comment says *"asserting the SOURCE side is the point. A test that only checked the target would have passed throughout the bug's entire lifetime"* passed throughout the bug's entire lifetime.

## Changes

- `SourceRef.table` now uses `task.source_table_name`.
- Extracted `replication_model_ir` so that seam is testable at all — the bug existed because the construction was inline in a large async fn with no unit-level access.
- New test asserts on the **generated SQL**, not on a struct one layer up: the shadow name must appear before `FROM` and must not appear after it. It fails on precisely the mutation that shipped.
- Dropped the now-false clause from the `rocky run --dag --shadow` refusal, which cited "replication's suffix mode rewrites the source it reads" as one of its grounds. That ground disappears with this fix; the refusal stands on its main one.

## Test Plan

- New test `shadow_suffix_copy_sql_reads_production_not_the_shadow_target`, mutation-checked against the exact shipped line.
- Full suite via CI. Local verification was abandoned deliberately: the `rocky-cli` lib-test target OOM-killed this machine twice (swap 4.8G/6.1G, rustc at 0% CPU), which is a laptop limit and not a signal about the change.

## Blast radius

`ModelIr::recipe_hash` covers `source`, so this changes that hash — but only where the two names differ, and they differ **only** under shadow-suffix (`run.rs:3097-3113`). No run that works today changes identity; the only hashes that move belong to runs that currently fail or copy the wrong table. On this path the hash reaches `recipe_identity` on the materialization output — reporting, not a reuse or skip gate.

## Independent red team

Found by a parallel investigation of the plan/apply seam for #1403, then verified independently against `git blame` and a live reproduction before being acted on. Two of the investigating lenses **contradicted each other** on whether the `--dag` refusal's claim was stale: one read #1383 and concluded the split had landed, the other ran the binary and found it had not. The lens that was wrong was the one that trusted the fix commit without executing it.

**What I am least confident about:** whether any deployment depends on the current (broken) behaviour — I cannot see how, since suffix-mode shadow replication either errors or silently copies the wrong table, but the hash change is the observable difference.

**What I am most likely missing:** whether other consumers of the replication `ModelIr` beyond SQL generation and `recipe_identity` care about `source.table`. I traced those two; a third would show up as a test failure rather than silently.

> **ModelIr / contract semantics preserved: yes** — the IR now describes what the run actually does.

Refs #1383
