### PR TITLE
fix(engine): a replication plan must persist and replay its shadow routing

### DIFF
--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -3415,6 +3415,55 @@ async fn run_apply_backfill_plan(
 /// the adapter surfaces them) is treated as drift and aborts the apply with
 /// a clear "re-plan and re-apply" error. The check happens BEFORE any SQL
 /// is emitted to the warehouse.
+/// Rebuild the shadow routing a [`ReplicationPlan`] captured (#1403).
+///
+/// Deliberately the same shape as the `RunPlan` arm's reconstruction, branch
+/// lookup included. `--branch` is internally `--shadow --shadow-schema
+/// <branch.schema_prefix>` and clap rejects it alongside the shadow flags, so a
+/// branch plan carries `shadow == false` — consulting only `shadow` would
+/// replay it as a PRODUCTION run.
+///
+/// Extracted rather than inlined so the mapping is testable without standing up
+/// an apply. The defect this fixes was invisible precisely because the decision
+/// lived inside a long async function as a literal `None`.
+///
+/// `state_path` is read ONLY on the branch arm; the other arms never open the
+/// store, so a caller with no branch cannot fail here on an unreadable path.
+fn replication_shadow_config(
+    replication_plan: &ReplicationPlan,
+    state_path: &Path,
+) -> Result<Option<rocky_core::shadow::ShadowConfig>> {
+    // Mirrors the `RunPlan` arm: clap gives `--shadow-suffix` a default, and
+    // the CLI drops it before it reaches a plan unless shadow was requested, so
+    // a `None` here means "not a shadow plan" rather than "defaulted".
+    let suffix = replication_plan
+        .shadow_suffix
+        .clone()
+        .unwrap_or_else(|| "_rocky_shadow".to_string());
+
+    if let Some(ref name) = replication_plan.branch {
+        let store = rocky_core::state::StateStore::open_read_only(state_path)
+            .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
+        let record = store.get_branch(name)?.with_context(|| {
+            format!("branch '{name}' not found — create it with `rocky branch create {name}`")
+        })?;
+        return Ok(Some(rocky_core::shadow::ShadowConfig {
+            suffix,
+            schema_override: Some(record.schema_prefix),
+            cleanup_after: false,
+        }));
+    }
+    Ok(if replication_plan.shadow {
+        Some(rocky_core::shadow::ShadowConfig {
+            suffix,
+            schema_override: replication_plan.shadow_schema.clone(),
+            cleanup_after: false,
+        })
+    } else {
+        None
+    })
+}
+
 async fn run_apply_replication_plan(
     root: &Path,
     config_path: &Path,
@@ -3546,6 +3595,8 @@ async fn run_apply_replication_plan(
     // plan's policy checks.
     let apply_run_id = new_apply_run_id();
 
+    let replication_shadow_config = replication_shadow_config(&replication_plan, state_path)?;
+
     crate::commands::run::run(
         config_path,
         // Execute-from-owned: the SAME snapshot the drift check read (#1120).
@@ -3563,9 +3614,10 @@ async fn run_apply_replication_plan(
         false,
         replication_plan.resume.as_deref(),
         replication_plan.resume_latest,
-        // No shadow config — branch promote and shadow paths are
-        // independent of replication-plan replay.
-        None,
+        // Shadow routing replays, exactly as it does for a `RunPlan` (#1403).
+        // Passing `None` here meant `rocky plan --shadow` was accepted and then
+        // applied against PRODUCTION, reporting Success — the #1272 shape.
+        replication_shadow_config.as_ref(),
         &partition_opts,
         // No model filter — replication runs every discovered table.
         None,
@@ -7347,6 +7399,119 @@ schema_template = "s__{source}"
     // Replication plan (Phase 5b)
     // ------------------------------------------------------------------
 
+    /// #1403: a non-shadow replication plan must serialize exactly as it did
+    /// before the shadow fields existed.
+    ///
+    /// `plan_id` is `blake3({kind, payload})` (`plan_store.rs`), so a field that
+    /// always emits — the shape `RunPlan.shadow` uses — would hand every
+    /// unchanged replication project a brand-new plan id on upgrade, for a
+    /// feature it does not use. `skip_serializing_if` is what prevents that,
+    /// and nothing else in the type system will notice if it is removed.
+    ///
+    /// Mutation that must turn this red: drop `skip_serializing_if` from any of
+    /// the four fields.
+    #[test]
+    fn a_non_shadow_replication_plan_serializes_without_the_shadow_keys() {
+        let value = serde_json::to_value(minimal_replication_plan()).unwrap();
+        let obj = value.as_object().expect("a plan payload is a JSON object");
+        for key in ["shadow", "shadow_suffix", "shadow_schema", "branch"] {
+            assert!(
+                !obj.contains_key(key),
+                "`{key}` must be absent from a non-shadow plan — its presence \
+                 changes plan_id for every existing project: {value}"
+            );
+        }
+    }
+
+    /// #1403: the routing a plan captured is what apply replays.
+    ///
+    /// Mutation that must turn this red: returning `None` unconditionally,
+    /// which is exactly what the replication arm did — `rocky plan --shadow`
+    /// was accepted, discarded, and applied against production at exit 0.
+    #[test]
+    fn a_shadow_replication_plan_replays_its_routing() {
+        let unused = std::path::Path::new("/nonexistent/state.redb");
+
+        let mut plan = minimal_replication_plan();
+        plan.shadow = true;
+        plan.shadow_suffix = Some("_pr".to_string());
+        let cfg = replication_shadow_config(&plan, unused)
+            .expect("no branch means the state store is never opened")
+            .expect("a shadow plan must replay a shadow config");
+        assert_eq!(cfg.suffix, "_pr");
+        assert_eq!(cfg.schema_override, None);
+
+        let mut schema_plan = minimal_replication_plan();
+        schema_plan.shadow = true;
+        schema_plan.shadow_schema = Some("shadow_s".to_string());
+        let cfg = replication_shadow_config(&schema_plan, unused)
+            .unwrap()
+            .expect("a schema-override shadow plan must replay a shadow config");
+        assert_eq!(cfg.schema_override.as_deref(), Some("shadow_s"));
+
+        // The control: a plan that did not ask for shadow must still apply
+        // against production. A fix that turned every replication apply into a
+        // shadow run would be worse than the bug.
+        assert!(
+            replication_shadow_config(&minimal_replication_plan(), unused)
+                .unwrap()
+                .is_none(),
+            "a non-shadow plan must not acquire a shadow config"
+        );
+    }
+
+    /// `--branch` is the case the other tests cannot reach, and the one most
+    /// likely to be got wrong: clap rejects it alongside the shadow flags, so a
+    /// branch plan carries `shadow == false` and looks like a production plan
+    /// to anything that only consults `shadow`.
+    ///
+    /// Needs a real state store because the schema prefix lives in the branch
+    /// record, not the plan — which is why this arm is unreachable from an
+    /// in-memory test, and why it had no coverage until red-team review asked.
+    ///
+    /// Mutations that must turn this red: persisting `branch: None`, or
+    /// returning `None` from the branch arm. Both leave the two tests above
+    /// green while restoring production routing for every branch plan.
+    #[test]
+    fn a_branch_replication_plan_replays_the_branch_schema() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let state_path = dir.path().join("state.redb");
+        {
+            let store = StateStore::open(&state_path).unwrap();
+            store
+                .put_branch(&rocky_core::state::BranchRecord {
+                    name: "feature_x".to_string(),
+                    schema_prefix: "branch__feature_x".to_string(),
+                    created_by: "test".to_string(),
+                    created_at: chrono::Utc::now(),
+                    description: None,
+                })
+                .unwrap();
+        }
+
+        let mut plan = minimal_replication_plan();
+        plan.branch = Some("feature_x".to_string());
+        // A branch plan really does carry `shadow == false` — asserted rather
+        // than assumed, because the whole finding rests on it.
+        assert!(!plan.shadow);
+
+        let cfg = replication_shadow_config(&plan, &state_path)
+            .expect("the branch record exists")
+            .expect("a branch plan must replay as a shadow run, not production");
+        assert_eq!(cfg.schema_override.as_deref(), Some("branch__feature_x"));
+
+        // An unknown branch must fail loudly rather than silently degrade to a
+        // production run — the failure mode this whole PR is about.
+        let mut missing = minimal_replication_plan();
+        missing.branch = Some("no_such_branch".to_string());
+        let err = replication_shadow_config(&missing, &state_path)
+            .expect_err("an unknown branch must not resolve to production routing");
+        assert!(
+            err.to_string().contains("no_such_branch"),
+            "the error must name the branch: {err}"
+        );
+    }
+
     fn minimal_replication_plan() -> ReplicationPlan {
         ReplicationPlan {
             filter: Some("source=orders".to_string()),
@@ -7355,6 +7520,10 @@ schema_template = "s__{source}"
             idempotency_key: None,
             resume: None,
             resume_latest: false,
+            shadow: false,
+            shadow_suffix: None,
+            shadow_schema: None,
+            branch: None,
             governance_override: None,
             config_snapshot: serde_json::json!({"adapter": {"default": {"type": "duckdb"}}}),
             source_state_snapshot: vec![ReplicationConnectorSnapshot {

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -1306,6 +1306,19 @@ pub(crate) fn build_source_state_snapshot(
 /// the project has no `models/` directory or when compile produced
 /// zero models. Discovery has already happened earlier in `plan()`;
 /// this function only canonicalizes the result and persists.
+/// Keep a shadow descriptor only when shadow routing is actually requested.
+///
+/// `--shadow-suffix` / `--shadow-schema` are accepted without `--shadow`, where
+/// they are inert. Returning `None` there keeps a production plan's payload —
+/// and therefore its `plan_id` — exactly as it was before these fields existed.
+fn shadow_descriptor(run_options: &PlanRunOptions, value: Option<&String>) -> Option<String> {
+    if run_options.shadow || run_options.branch.is_some() {
+        value.cloned()
+    } else {
+        None
+    }
+}
+
 fn build_and_persist_replication_plan(
     rocky_cfg: &rocky_core::config::RockyConfig,
     connectors: &[DiscoveredConnector],
@@ -1325,6 +1338,25 @@ fn build_and_persist_replication_plan(
         idempotency_key: run_options.idempotency_key.clone(),
         resume: run_options.resume.clone(),
         resume_latest: run_options.resume_latest,
+        // Shadow routing IS part of a persisted plan's contract — the same
+        // reason the `RunPlan` branch captures it. Dropping it here was #1403:
+        // `rocky plan --shadow` was accepted, silently discarded, and
+        // `rocky apply` then wrote the PRODUCTION targets and reported
+        // Success. That is the #1272 defect shape, one plan kind over.
+        shadow: run_options.shadow,
+        // Only carry the descriptors when the plan is actually a shadow plan.
+        // `--shadow-schema` and `--shadow-suffix` are accepted WITHOUT
+        // `--shadow` (only `--branch` conflicts with them), and such a run is
+        // still a production run. Persisting an inert flag would add a payload
+        // key — and so a new `plan_id` — to a plan whose behaviour is
+        // unchanged. `main.rs` already applies exactly this normalisation to
+        // `shadow_suffix` before it reaches `PlanRunOptions`, and for the same
+        // stated reason; `shadow_schema` is not normalised there, so it is
+        // handled here rather than widening that path and shifting `RunPlan`
+        // ids too.
+        shadow_suffix: shadow_descriptor(run_options, run_options.shadow_suffix.as_ref()),
+        shadow_schema: shadow_descriptor(run_options, run_options.shadow_schema.as_ref()),
+        branch: run_options.branch.clone(),
         governance_override: run_options.governance_override.clone(),
         config_snapshot,
         source_state_snapshot,
@@ -2207,6 +2239,58 @@ mod tests {
 
     use super::*;
     use rocky_ir::MaskStrategy;
+
+    /// #1403: an inert shadow descriptor must not reach the payload.
+    ///
+    /// `--shadow-suffix` / `--shadow-schema` are accepted WITHOUT `--shadow`
+    /// (only `--branch` conflicts with them), and such a run is a production
+    /// run. Persisting the flag anyway adds a payload key to a plan whose
+    /// behaviour is unchanged, and `plan_id` is `blake3({kind, payload})` — so
+    /// an existing project's plan id would move for a flag that does nothing.
+    ///
+    /// Found by red-team review: the first revision of this fix persisted
+    /// `shadow_schema` unconditionally and shifted exactly that id.
+    ///
+    /// Mutation that must turn this red: returning `value.cloned()`
+    /// unconditionally from `shadow_descriptor`.
+    #[test]
+    fn an_inert_shadow_descriptor_is_not_persisted() {
+        let schema = "shadow_s".to_string();
+
+        let inert = PlanRunOptions {
+            shadow: false,
+            branch: None,
+            ..Default::default()
+        };
+        assert_eq!(
+            shadow_descriptor(&inert, Some(&schema)),
+            None,
+            "without --shadow or --branch the descriptor is inert and must not \
+             enter the payload"
+        );
+
+        let shadowed = PlanRunOptions {
+            shadow: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            shadow_descriptor(&shadowed, Some(&schema)).as_deref(),
+            Some("shadow_s"),
+            "under --shadow the descriptor must be persisted"
+        );
+
+        let branched = PlanRunOptions {
+            shadow: false,
+            branch: Some("feature_x".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            shadow_descriptor(&branched, Some(&schema)).as_deref(),
+            Some("shadow_s"),
+            "a branch plan carries shadow == false, so branch must also keep \
+             the descriptor"
+        );
+    }
 
     // ------------------------------------------------------------------
     // replication copy preview — strategy / override fidelity (bug fix:

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -3730,6 +3730,33 @@ pub struct ReplicationPlan {
     /// apply time, like `RunPlan.resume_latest`.
     #[serde(default)]
     pub resume_latest: bool,
+    /// Run in shadow mode (`--shadow`), with `shadow_suffix` / `shadow_schema`
+    /// describing the shadow target — the same contract as [`RunPlan`].
+    ///
+    /// Skipped when `false`, unlike `RunPlan.shadow` which always serializes.
+    /// `plan_id` is `blake3({kind, payload})`, so emitting `"shadow": false`
+    /// would give every unchanged replication project a new plan id purely
+    /// because these fields were added. The asymmetry with `RunPlan` is
+    /// deliberate and costs nothing: a plan that did not request shadow reads
+    /// back identically either way.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub shadow: bool,
+    /// Suffix appended to table names in shadow mode (`--shadow-suffix`).
+    ///
+    /// `None` when shadow was not requested — the CLI normalises clap's
+    /// `_rocky_shadow` default away before it reaches the plan, so this never
+    /// carries a default nobody asked for.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shadow_suffix: Option<String>,
+    /// Override schema for shadow tables (`--shadow-schema`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shadow_schema: Option<String>,
+    /// `--branch <name>`. Internally equivalent to `--shadow --shadow-schema
+    /// <branch.schema_prefix>`, and clap rejects it combined with either, so
+    /// `shadow` is `false` when this is set — persisting it is what stops a
+    /// branch run from replaying as a production run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
     /// Governance override resolved at plan time from
     /// `--governance-override`.
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary

`rocky plan --shadow` on a replication-only project is accepted, silently discarded, and `rocky apply <plan-id>` then writes the **production** targets and reports `"status": "Success"`.

Closes #1403.

## Reproduction (released 1.69.0)

Replication-only DuckDB project, sources under `raw__acme`:

```
$ rocky plan --pipeline bronze --shadow --shadow-suffix _pr --output json
exit=0
$ # .rocky/plans/<id>.json payload keys:
['config_snapshot', 'pipeline', 'resume_latest', 'source_state_snapshot']     # no shadow key at all

$ rocky apply <plan-id> --output json
"status": "Success", "tables_copied": 2
$ # tables matching bronze%:  bronze__acme.orders, bronze__acme.payments      # production
```

The only signal the caller receives is a successful production write.

This is the #1272 shape one plan kind over. `apply.rs` already spells out why the `RunPlan` branch must not do this — *"Dropping it here is the same defect as #1272 one level up — `rocky plan --dag --shadow` followed by `rocky apply` would write production while reporting success"* — and the replication branch did exactly that, via a literal `None`.

## Why persist rather than refuse

Refusing `--shadow` at plan time was the obvious alternative and is wrong on two counts:

- `reject_unsupported_shadow` is the repo's refusal helper for kinds whose targets are not rewritten, and its own doc comment puts replication on the **routed** side: *"Transformation and replication rewrite their targets for a shadow run; snapshot and load do not."*
- The fused path has honoured `--shadow` for replication in both modes since #1280. Refusing here would mean `rocky run --pipeline X --shadow` allowed while `rocky plan --pipeline X --shadow` refused, for the same warehouse effect — the exact asymmetry the isolate-or-refuse rule exists to prevent.

The executor was already shadow-aware end to end (policy gate widened, target schema override, suffix on the target name, freeze fence checking both names). The missing links were the plan fields and the `None`.

## `--branch` is a fourth field, and the same bug

`--branch` is internally `--shadow --shadow-schema <branch.schema_prefix>`, and clap rejects it alongside the shadow flags — so a branch plan carries `shadow == false`. Persisting only the three shadow fields would have left every branch plan replaying against production: the identical defect wearing a different flag. Apply does the branch lookup, mirroring the `RunPlan` arm.

## plan_id stability

`plan_id` is `blake3({kind, payload})`, so a field that always serializes hands every unchanged replication project a new plan id on upgrade for a feature it does not use. `RunPlan.shadow` emits unconditionally; this deliberately does not, using the `skip_serializing_if = "std::ops::Not::not"` idiom already present in `output.rs`. A non-shadow plan's payload is byte-identical to before, and the pre-existing `replication_plan_same_payload_same_plan_id` still passes.

## No codegen cascade — checked, not assumed

`ReplicationPlan` derives `JsonSchema`, which normally implies a published-API change. It is **not** in the exported set: it appears in none of `schemas/`, `docs/public/openapi.json`, the Python SDK types, or the VS Code types. I ran `just codegen` and `just regen-fixtures` anyway; both produced zero drift. The derive being present does not make the type exported.

## Test Plan

The reconstruction is extracted into `replication_shadow_config` rather than left inline. Not tidying — the defect was invisible *because* the decision lived inside a long async function as a literal `None`, unreachable from any test. Same shape as the `SourceRef` fix in #1406.

- `a_non_shadow_replication_plan_serializes_without_the_shadow_keys` — fails if `skip_serializing_if` is dropped from any of the four fields, which nothing else in the type system would catch.
- `a_shadow_replication_plan_replays_its_routing` — fails if the reconstruction returns `None`, i.e. the shipped behaviour. Carries the control that a non-shadow plan must **not** acquire a shadow config: a fix that shadowed every replication apply would be worse than the bug.

Locally: 7/7 in the replication-plan group including the pre-existing `plan_id` tests; `cargo fmt --check` and `cargo check --all-targets` clean. Full suite via CI.

**What I am least confident about:** whether a shadow replication run's objects can later be re-discovered as *sources* on a subsequent plan, if a user's `--shadow-schema` value happens to match the pipeline's `schema_pattern.prefix`. That is a cross-cycle hazard the fused path already has, not something this change introduces, but this makes the plan/apply path reach it too. Untested — I built no fixture for it.

**What I am most likely missing:** whether `env` and the partition flags are dropped by the same function for the same reason. I fixed the field I could demonstrate writing production; I did not audit the rest of `PlanRunOptions` against `ReplicationPlan`.

> **ModelIr / contract semantics preserved: yes** — no IR or contract path changes; this is plan payload plus apply-time routing.
