### PR TITLE
fix(engine/rocky-cli): persist successful watermarks on partial failure

### DIFF
--- a/docs/src/content/docs/concepts/execution-flow.md
+++ b/docs/src/content/docs/concepts/execution-flow.md
@@ -168,13 +168,13 @@ Each check runs a `SELECT` against the freshly written target table. Failed chec
 
 ### 6g. Defer watermark write
 
-Rocky does **not** immediately write the watermark to the state store after a model succeeds. Instead, it queues the write. Only when the entire layer completes successfully does Rocky commit all watermarks in that layer in a single transaction.
+Rocky does **not** immediately write the watermark to the state store after a model succeeds. Instead, it queues the write. After the layer drains, Rocky commits the watermarks for every successfully written model in a single transaction; failed models never enqueue one.
 
-If any model in the layer fails, no watermarks are committed for that layer. This means a partial layer failure is fully safe to re-run: every model in the layer will start from its previous watermark.
+Successful model watermarks are committed even when a sibling fails. Warehouse writes commit independently per model, so advancing each survivor's table-specific watermark keeps state aligned with data that is already durable and prevents a retry from appending the same incremental delta again.
 
 ## Step 7: Batch-commit watermarks
 
-After a layer completes (all models succeeded, or the run is in partial mode), Rocky commits the deferred watermarks in one redb transaction. Atomic: all-or-nothing.
+After a layer completes, Rocky commits all successful deferred watermarks in one redb transaction. The state update is atomic across those successful models; failed models retain their prior watermarks.
 
 ## Step 8: Fire post-run hooks
 

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`fail_fast` recovery no longer duplicates a successful incremental table's last delta.** Warehouse writes commit independently per table, but a sibling failure previously suppressed every deferred watermark in the run. Recovery then read the successful table's old watermark and appended its already-committed rows again. Successful table watermarks now advance after the fan-out drains; failed tables retain their prior state. (#1410)
+
 ## [1.70.0] - 2026-08-10
 
 ### Fixed

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -4144,50 +4144,41 @@ pub async fn run(
 
     // --- Batch watermark updates (no lock contention — sequential post-run) ---
     //
-    // Under `fail_fast = true` semantics, any table failure should prevent
-    // the surviving tables from advancing their watermarks — otherwise the
-    // next run resumes from a point that implies siblings succeeded. Under
-    // `fail_fast = false` (the default, partial-success semantics), commit
-    // whatever completed cleanly so forward progress isn't lost.
-    let skip_watermarks_due_to_failure = fail_fast && !table_errors.is_empty();
-    if skip_watermarks_due_to_failure {
-        tracing::warn!(
-            deferred = deferred_watermarks.len(),
-            failed_tables = table_errors.len(),
-            "fail_fast + partial failure: skipping {} pending watermark commits so the next run starts from the same baseline",
-            deferred_watermarks.len(),
-        );
-    } else {
-        // §P1.6: single redb transaction for every deferred watermark, run on
-        // the blocking pool so the commit fsync doesn't stall the async task.
-        let store = Arc::clone(&shared_state);
-        let owned: Vec<(String, WatermarkState)> = deferred_watermarks
-            .iter()
-            .map(|wm| {
-                (
-                    wm.state_key.clone(),
-                    WatermarkState {
-                        last_value: wm.timestamp,
-                        updated_at: wm.timestamp,
-                    },
-                )
-            })
-            .collect();
-        let count = owned.len();
-        let res = tokio::task::spawn_blocking(move || {
-            let entries: Vec<(&str, &WatermarkState)> =
-                owned.iter().map(|(k, v)| (k.as_str(), v)).collect();
-            store.batch_set_watermarks(&entries)
+    // Successful table writes have already committed independently in the
+    // warehouse. Always advance their table-specific watermarks, even if a
+    // sibling failed under `fail_fast`; failed tables never enqueue one.
+    // Withholding a survivor's watermark makes recovery append its delta twice.
+    // §P1.6: single redb transaction for every deferred watermark, run on the
+    // blocking pool so the commit fsync doesn't stall the async task.
+    let store = Arc::clone(&shared_state);
+    let owned: Vec<(String, WatermarkState)> = deferred_watermarks
+        .iter()
+        .map(|wm| {
+            (
+                wm.state_key.clone(),
+                WatermarkState {
+                    last_value: wm.timestamp,
+                    updated_at: wm.timestamp,
+                },
+            )
         })
-        .await;
-        match res {
-            // `batch_set_watermarks` returns the count written; ignore it here.
-            Ok(Ok(_)) => {}
-            Ok(Err(e)) => {
-                tracing::warn!(error = %e, count, "failed to persist watermarks for run")
-            }
-            Err(e) => tracing::warn!(error = %e, "watermark flush task panicked"),
+        .collect();
+    let count = owned.len();
+    let res = tokio::task::spawn_blocking(move || {
+        let entries: Vec<(&str, &WatermarkState)> = owned
+            .iter()
+            .map(|(k, v)| (k.as_str(), v))
+            .collect();
+        store.batch_set_watermarks(&entries)
+    })
+    .await;
+    match res {
+        // `batch_set_watermarks` returns the count written; ignore it here.
+        Ok(Ok(_)) => {}
+        Ok(Err(e)) => {
+            tracing::warn!(error = %e, count, "failed to persist watermarks for run")
         }
+        Err(e) => tracing::warn!(error = %e, "watermark flush task panicked"),
     }
 
     // --- Batch table tagging (concurrent, outside the main processing loop) ---
@@ -15042,6 +15033,180 @@ timestamp_column = "ts"
             vec![1, 2, 3],
             "the appended row (id=3) must not be skipped"
         );
+    }
+
+    /// Regression for #1410: a sibling failure under `fail_fast` must not
+    /// withhold the watermark of an incremental table whose warehouse write
+    /// already committed. Otherwise the recovery run appends that delta twice.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn fail_fast_partial_failure_commits_successful_watermark() {
+        use rocky_core::state::StateStore;
+        use rocky_core::traits::WarehouseAdapter;
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+        use rocky_ir::TableRef;
+
+        async fn run_pipeline(
+            config_path: &std::path::Path,
+            state_path: &std::path::Path,
+            run_id: &str,
+        ) -> anyhow::Result<()> {
+            super::run(
+                config_path,
+                Arc::new(rocky_core::config::load_rocky_config_fingerprinted(config_path).unwrap()),
+                None,
+                Some("repro"),
+                state_path,
+                None,
+                true,
+                None,
+                false,
+                None,
+                false,
+                None,
+                &PartitionRunOptions::default(),
+                None,
+                None,
+                None,
+                None,
+                &DeferOptions::default(),
+                &SkipRunOptions::default(),
+                &rocky_core::run_vars::RunVars::new(),
+                Some(run_id),
+                None,
+                false,
+            )
+            .await
+        }
+
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let db_path = tmp.path().join("repro.duckdb");
+        let config_path = tmp.path().join("rocky.toml");
+        let state_path = tmp.path().join("state.redb");
+        std::fs::write(
+            &config_path,
+            format!(
+                r#"
+[adapter]
+type = "duckdb"
+path = "{}"
+
+[pipeline.repro]
+strategy = "incremental"
+timestamp_column = "ts"
+
+[pipeline.repro.source.discovery]
+adapter = "default"
+
+[pipeline.repro.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.repro.target]
+catalog_template = "repro"
+schema_template = "staging__{{source}}"
+
+[pipeline.repro.target.governance]
+auto_create_schemas = true
+
+[pipeline.repro.checks]
+row_count = false
+column_match = false
+
+[pipeline.repro.execution]
+concurrency = 1
+fail_fast = true
+
+[state]
+backend = "local"
+"#,
+                db_path.display()
+            ),
+        )
+        .expect("write rocky.toml");
+
+        {
+            let db = DuckDbWarehouseAdapter::open(&db_path).expect("seed duckdb");
+            for sql in [
+                "CREATE SCHEMA raw__orders",
+                "CREATE TABLE raw__orders.a_good (id INTEGER, ts TIMESTAMP)",
+                "INSERT INTO raw__orders.a_good VALUES (1, TIMESTAMP '2026-01-01')",
+                "CREATE TABLE raw__orders.z_bad (id INTEGER, ts TIMESTAMP)",
+                "INSERT INTO raw__orders.z_bad VALUES (1, TIMESTAMP '2026-01-01')",
+            ] {
+                db.execute_statement(sql).await.unwrap();
+            }
+        }
+        run_pipeline(&config_path, &state_path, "bootstrap")
+            .await
+            .expect("bootstrap run");
+
+        {
+            let db = DuckDbWarehouseAdapter::open(&db_path).expect("mutate duckdb");
+            db.execute_statement(
+                "INSERT INTO raw__orders.a_good VALUES (2, TIMESTAMP '2026-01-02')",
+            )
+            .await
+            .unwrap();
+            db.execute_statement("ALTER TABLE raw__orders.z_bad DROP COLUMN ts")
+                .await
+                .unwrap();
+        }
+        let err = run_pipeline(&config_path, &state_path, "partial")
+            .await
+            .expect_err("the sibling table should fail");
+        assert!(
+            err.downcast_ref::<PartialFailure>().is_some(),
+            "one success plus one failure must be partial: {err:#}"
+        );
+
+        let key = TableRef {
+            catalog: "repro".into(),
+            schema: "staging__orders".into(),
+            table: "a_good".into(),
+        }
+        .state_key();
+        let watermark = StateStore::open(&state_path)
+            .expect("open state")
+            .get_watermark(&key)
+            .expect("read watermark")
+            .expect("successful table watermark");
+        assert_eq!(
+            watermark.last_value.to_rfc3339(),
+            "2026-01-02T00:00:00+00:00",
+            "state must match the already-committed successful table write"
+        );
+
+        {
+            let db = DuckDbWarehouseAdapter::open(&db_path).expect("repair duckdb");
+            db.execute_statement("ALTER TABLE raw__orders.z_bad ADD COLUMN ts TIMESTAMP")
+                .await
+                .unwrap();
+            db.execute_statement("UPDATE raw__orders.z_bad SET ts = TIMESTAMP '2026-01-01'")
+                .await
+                .unwrap();
+            db.execute_statement(
+                "INSERT INTO raw__orders.z_bad VALUES (2, TIMESTAMP '2026-01-02')",
+            )
+            .await
+            .unwrap();
+        }
+        run_pipeline(&config_path, &state_path, "recovery")
+            .await
+            .expect("recovery run");
+
+        let db = DuckDbWarehouseAdapter::open(&db_path).expect("verify duckdb");
+        let counts = db
+            .execute_query(
+                "SELECT COUNT(*), COUNT(DISTINCT id), COUNT(*) FILTER (WHERE id = 2) \
+                 FROM repro.staging__orders.a_good",
+            )
+            .await
+            .unwrap();
+        assert_eq!(counts.rows[0][0], "2", "recovery must not add a third row");
+        assert_eq!(counts.rows[0][1], "2", "both ids must remain distinct");
+        assert_eq!(counts.rows[0][2], "1", "the delta row must appear once");
     }
 
     /// Bad identifier rejected before any warehouse query is issued —


### PR DESCRIPTION
## Summary

Closes #1410.

Persist table-specific watermarks for successful incremental writes even when a sibling table fails under `fail_fast`. This keeps redb state aligned with warehouse data that has already committed and prevents the recovery run from appending the survivor's last delta twice.

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [x] Cross-project (CI, scripts, root docs)

## Changes

- Remove the `fail_fast` gate that discarded every deferred watermark after a partial table failure. Failed tables already enqueue no watermark, so the existing batch contains only successful durable writes.
- Add a DuckDB regression covering bootstrap, one successful incremental write plus one sibling failure, state inspection, repair, and recovery without duplicate rows.
- Correct the execution-flow documentation and record the fix in the engine changelog.

## Test Plan

- Mutation proof: the new regression failed before the production change because `a_good` remained at `2026-01-01T00:00:00+00:00` instead of advancing to `2026-01-02T00:00:00+00:00`; it passes with the fix.
- `cargo test -p rocky-cli --lib watermark -- --nocapture` — 6 passed, 0 failed.
- `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- `cargo fmt -- --check` — passed.
- `npm run build` in `docs/` — passed; 103 pages built.
- `git diff --check` — passed.
- `cargo test --all-targets` — all completed targets passed, but the unrelated existing `run_watch_reruns_on_file_change_and_exits_clean_on_sigint` test exceeded its configured phase budgets and then blocked in cleanup locally; the run was interrupted and no child process remained.
- `cargo nextest run --all-features` — the entire all-feature test profile compiled successfully; local `cargo-nextest` then remained idle without launching child tests on two attempts, so the harness was interrupted.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/), scoped by subproject when relevant (e.g. `feat(engine/rocky-databricks): ...`, `fix(dagster): ...`)
- [x] No `Co-Authored-By` trailers
- [x] If this is a CLI JSON schema or DSL syntax change, all consumers (`integrations/dagster/`, `editors/vscode/`) are updated in this same PR (not applicable; no schema or DSL change)

### Engine (`engine/`)
- [ ] `cargo test --all-targets` passes (see unrelated local watch-test limitation above)
- [x] `cargo clippy --all-targets -- -D warnings` is clean (also passed with `--all-features`)
- [x] `cargo fmt --check` passes

### Dagster (`integrations/dagster/`)
- [ ] `uv run pytest` passes
- [ ] `uv run ruff check` is clean
- [ ] `uv run ruff format --check` passes

### VS Code (`editors/vscode/`)
- [ ] `npm run compile` succeeds
- [ ] `npm run test:unit` passes (electron tests run in CI)
- [ ] `npm run lint` is clean
