### PR TITLE
chore: release engine 1.70.1, rocky-sdk 0.11.0, dagster-rocky 1.62.0, vscode 1.37.1

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.37.1] — 2026-08-10
+
+### Fixed
+
+- **Preview selects the base run from the ref the caller named.** The command resolved the base run independently of the ref it was given, so a preview against an explicitly named ref could diff against a different run than the one requested. (#1360)
+
+### Changed
+
+- Regenerated engine bindings: new `state_schedule_hold` and scheduler `brief` types, plus additions to the run, dag, ci-diff, promote-plan, preview-diff, project and tick types. (#1334, #1339, #1352, #1356, #1384, #1385)
+- Dependency refresh: `js-yaml` 4.2.0 → 4.3.1, `undici` 7.28.0 → 7.29.0, and dev-dependency bumps for `fast-uri`, `postcss`, `brace-expansion`, `jsdom`, `@testing-library/jest-dom` and the vscode-minor-patch group. (#1368, #1375, #1376, #1377, #1378, #1392)
+
 ## [1.37.0] — 2026-07-24
 
 ### Added

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocky",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocky",
-      "version": "1.37.0",
+      "version": "1.37.1",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^10.1.0"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.70.1] - 2026-08-10
+
 ### Fixed
 
 - **`fail_fast` recovery no longer duplicates a successful incremental table's last delta.** Warehouse writes commit independently per table, but a sibling failure previously suppressed every deferred watermark in the run. Recovery then read the successful table's old watermark and appended its already-committed rows again. Successful table watermarks now advance after the fan-out drains; failed tables retain their prior state. (#1410)

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.70.0"
+version = "1.70.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3904,7 +3904,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.70.0"
+version = "1.70.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3917,7 +3917,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.70.0"
+version = "1.70.1"
 dependencies = [
  "indexmap",
  "reqwest 0.12.28",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.70.0"
+version = "1.70.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3955,7 +3955,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.70.0"
+version = "1.70.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3983,7 +3983,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.70.0"
+version = "1.70.1"
 dependencies = [
  "redis",
  "serde",
@@ -3995,7 +3995,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.70.0"
+version = "1.70.1"
 dependencies = [
  "async-trait",
  "serde",
@@ -4006,7 +4006,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.70.0"
+version = "1.70.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4065,7 +4065,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.70.0"
+version = "1.70.1"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.70.0"
+version = "1.70.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4146,7 +4146,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.70.0"
+version = "1.70.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4173,7 +4173,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.70.0"
+version = "1.70.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4192,7 +4192,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.70.0"
+version = "1.70.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4210,7 +4210,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.70.0"
+version = "1.70.1"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4241,7 +4241,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.70.0"
+version = "1.70.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4266,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.70.0"
+version = "1.70.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -4279,7 +4279,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.70.0"
+version = "1.70.1"
 dependencies = [
  "logos",
  "miette",
@@ -4291,7 +4291,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.70.0"
+version = "1.70.1"
 dependencies = [
  "rocky-server",
  "rustls",
@@ -4300,7 +4300,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.70.0"
+version = "1.70.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4326,7 +4326,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.70.0"
+version = "1.70.1"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4344,7 +4344,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.70.0"
+version = "1.70.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -4373,7 +4373,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.70.0"
+version = "1.70.1"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -4400,7 +4400,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.70.0"
+version = "1.70.1"
 dependencies = [
  "miette",
  "regex",
@@ -4413,7 +4413,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.70.0"
+version = "1.70.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.70.0"
+version = "1.70.1"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.70.0"
+version = "1.70.1"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.70.0"
+version = "1.70.1"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.70.0"
+version = "1.70.1"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.70.0"
+version = "1.70.1"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.70.0"
+version = "1.70.1"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.70.0"
+version = "1.70.1"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.70.0"
+version = "1.70.1"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.70.0"
+version = "1.70.1"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.70.0"
+version = "1.70.1"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.70.0"
+version = "1.70.1"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.70.0"
+version = "1.70.1"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.70.0"
+version = "1.70.1"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.70.0"
+version = "1.70.1"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.70.0"
+version = "1.70.1"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.70.0"
+version = "1.70.1"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.70.0"
+version = "1.70.1"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.70.0"
+version = "1.70.1"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.70.0"
+version = "1.70.1"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.70.0"
+version = "1.70.1"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.70.0"
+version = "1.70.1"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.70.0"
+version = "1.70.1"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.70.0"
+version = "1.70.1"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.70.0"
+version = "1.70.1"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.70.0"
+version = "1.70.1"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.70.0"
+version = "1.70.1"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.62.0] — 2026-08-10
+
 ### Fixed
 
 - **`run_streaming()` and `run_pipes()` can select a pipeline.** Both methods now
@@ -15,8 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This restores both execution modes for projects with multiple pipelines. (#1401)
 
 - **Two DAG nodes resolving to one Dagster asset key are refused, with a message that names them.** The engine deliberately permits the same `catalog.schema.table` on two different adapters — `reject_duplicate_physical_targets` keys on `(adapter, target)` — while the default translator keys a transformation asset on the target triple alone, and neither `DagNodeOutput` nor `TargetConfig` carries the adapter, so the collision cannot be expressed in an asset key at all. Dagster did catch this, but only at repository build and only because the specs differ (`rocky/node_id` is stamped into each), and its `Received conflicting AssetSpecs with the same key` names neither the models, nor their pipelines, nor the adapters that make the project legal upstream. `build_dag_specs` now refuses as soon as the keys are known, listing each colliding key with its node ids and pipelines. The check runs **after** the translator, keyed on what it returned, so a project that already disambiguates with a custom `get_dag_node_asset_key` is unaffected. (#1349)
-
-### Fixed
 
 - **A failing `rocky dag` no longer loads the legacy graph in its place.** `_dag_payload` caught every exception and omitted the DAG slot, and the loader read a missing slot as "this cache predates DAG mode" and fell back to the discover-based graph. That fallback is not a degraded version of the real graph — it has different assets and different dependencies — so a project whose DAG could not be built got a code location that loaded, looked plausible, and materialized a plan the project does not describe, behind a log warning.
 

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.61.1"
+version = "1.62.0"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -220,7 +220,7 @@ wheels = [
 
 [[package]]
 name = "dagster-rocky"
-version = "1.61.1"
+version = "1.62.0"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },
@@ -910,7 +910,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "../../sdk/python" }
 dependencies = [
     { name = "pydantic" },

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] — 2026-08-10
+
+### Added
+
+- **New generated result models.** `state_schedule_hold_schema` covers the runtime schedule pause/resume surface, and `brief_schema` gains the scheduler section. Both are additive — no existing model changed shape — but they are new public types, which is why this is a minor rather than a patch. (#1334, #1339)
+
+- **Worked examples on `RockyClient`'s four core methods, executed in CI.** `run()`, `plan()`, `apply()` and `dag()` carry runnable docstring examples, and a new test module executes them so the documentation cannot drift from the client's actual signatures. (#1387)
+
+### Changed
+
+- Regenerated types pick up engine-side additions to the run, dag, ci-diff, promote-plan, preview-diff, project and tick schemas. (#1352, #1356, #1360, #1384, #1385)
+
 ## [0.10.0] — 2026-07-24
 
 ### Added

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rocky-sdk"
-version = "0.10.0"
+version = "0.11.0"
 description = "Typed Python client for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Quad-cut. Version bumps and changelogs only; no source changes. One PR per the release convention.

| Artifact | From → To | Why that level |
|---|---|---|
| engine | 1.70.0 → **1.70.1** | patch — one fix, #1411 |
| rocky-sdk | 0.10.0 → **0.11.0** | **minor** — `state_schedule_hold` and `brief` are *new* generated models, so this is additive public API, not a patch |
| dagster-rocky | 1.61.1 → **1.62.0** | **minor** — #1401 restores pipeline selection; #1341 and #1349 add refusals that change load behavior |
| vscode | 1.37.0 → **1.37.1** | patch — #1360 preview fix, regenerated bindings, dependency refresh |

## Contents

**engine** — #1411, the `fail_fast` watermark fix: a sibling failure no longer withholds a successful incremental table's watermark, which had made recovery append its already-committed delta a second time.

**rocky-sdk** — #1387 worked docstring examples executed in CI, plus the new generated models and regenerated types.

**dagster-rocky** — #1401 (`run_streaming`/`run_pipes` accept `pipeline=`), #1349 (two DAG nodes resolving to one asset key are refused by name), #1341 (a failed `rocky dag` refuses instead of silently loading the legacy graph). Also merges a duplicate `### Fixed` heading that had appeared in the changelog's Unreleased section.

**vscode** — #1360 preview base-run fix, regenerated bindings, and the accumulated dependency bumps including `js-yaml` 4.2.0 → 4.3.1.

## Dependency floor

`rocky-sdk>=0.9.1` in `dagster-rocky` is **unchanged and correct**: dagster imports `types_generated` as a module and names none of the new schemas, so nothing in this cut requires a raised floor. The bump still resolves.

## Verification

Lock coherence was proven without compiling, which is the failure mode a version bump actually has:

- `cargo metadata --locked --no-deps` — **exit 0**, so the lockfile matches all 25 bumped manifests
- `uv lock --check` — clean for both `sdk/python` and `integrations/dagster`
- `package.json`, `package-lock.json` `.version` and `.packages[""].version` all agree at 1.37.1

Before each rewrite the lockfile entries at the old version were enumerated to confirm no third-party package shared it. That check earned its keep: `integrations/dagster/uv.lock` carries `tabulate 0.10.0`, which a blind global rewrite of `0.10.0` would have corrupted.

Full test suites are left to CI.

## Tag order after merge

`sdk-v0.11.0` → `vscode-v1.37.1` → `dagster-v1.62.0` → `engine-v1.70.1`

SDK first so the PyPI index has it before `dagster-rocky` publishes against the floor; engine last so it takes GitHub Latest without a race.