### PR TITLE
docs(changelog): record the dependency refresh in the four pending releases

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.37.1] — 2026-08-10
+## [1.37.1] — 2026-08-11
 
 ### Fixed
 
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Regenerated engine bindings: new `state_schedule_hold` and scheduler `brief` types, plus additions to the run, dag, ci-diff, promote-plan, preview-diff, project and tick types. (#1334, #1339, #1352, #1356, #1384, #1385)
 - Dependency refresh: `js-yaml` 4.2.0 → 4.3.1, `undici` 7.28.0 → 7.29.0, and dev-dependency bumps for `fast-uri`, `postcss`, `brace-expansion`, `jsdom`, `@testing-library/jest-dom` and the vscode-minor-patch group. (#1368, #1375, #1376, #1377, #1378, #1392)
+- **`@dagrejs/dagre` 3.0.0 → 3.1.1** — a *runtime* dependency, used for lineage-graph layout in the Inspector canvas, so unlike the bumps above it ships in the extension. Minor release; the lineage view renders unchanged across the extension's 208 unit tests. Alongside it, dev-dependency bumps for `@types/node`, `eslint`, `mocha` and `typescript-eslint`. The `engines.vscode` / `@types/vscode` / `@vscode/test-electron` triangle is deliberately untouched. (#1418, #1420)
 
 ## [1.37.0] — 2026-07-24
 

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.70.1] - 2026-08-10
+## [1.70.1] - 2026-08-11
+
+### Changed
+
+- **Dependency refresh — 146 crates**, including `aws-lc-rs` 1.17 → 1.18 / `aws-lc-sys` 0.41 → 0.44, the `arrow` family 58.3 → 58.4, `clap` 4.6.4 → 4.6.6, `blake3` 1.8.5 → 1.8.6, `rmcp` and `salsa`. No source changes; the full suite passes at 5835 tests with clippy clean under `-D warnings`. (#1420)
+
+  One advisory is knowingly **not** closed by this: `thrift` stays at 0.17.0 (RUSTSEC memory-allocation advisory, patched in 0.23.0) because `parquet` 58.4.0 pins `thrift ^0.17`, so no in-range update reaches it. `parquet` 59.2.0 drops the dependency entirely, but that is an `arrow` 58 → 59 major migration and is tracked separately rather than folded into a patch release.
 
 ### Fixed
 

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.62.0] — 2026-08-10
+## [1.62.0] — 2026-08-11
+
+### Changed
+
+- **The build backend is now bounded: `hatchling>=1.30.1,<1.32`.** Same reason as `rocky-sdk`: hatchling 1.32.0 (2026-08-11) emits `Metadata-Version: 2.5`, which the twine in our pinned publish action rejects at upload. `dagster-release` uses that same action, so it would have failed identically. Runtime dependencies are unaffected — this constrains only how the wheel is built. (#1420)
+
+- Development dependencies refreshed (ruff 0.15.18 → 0.16.2, `tqdm`, `tomlkit`, `pytz`, `tzdata`, `typing-extensions`, `platformdirs`). The `rocky-sdk>=0.9.1` floor is unchanged. (#1420)
 
 ### Fixed
 

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.11.0] — 2026-08-10
+## [0.11.0] — 2026-08-11
 
 ### Added
 
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Regenerated types pick up engine-side additions to the run, dag, ci-diff, promote-plan, preview-diff, project and tick schemas. (#1352, #1356, #1360, #1384, #1385)
+
+- **The build backend is now bounded: `hatchling>=1.30.1,<1.32`.** It was previously unbounded, so each release built against whatever had just been published. hatchling 1.32.0 landed on 2026-08-11 and emits `Metadata-Version: 2.5`, which the twine bundled in our pinned publish action rejects — the wheel built cleanly and failed at upload. The bound is a range rather than a single pin because the transition is not monotonic: 1.30.0 emitted 2.5, 1.30.1 reverted to 2.4, and 1.32.0 re-landed it. Runtime dependencies are unaffected; this constrains only how the wheel is built. (#1420)
+
+- Development dependencies refreshed (ruff 0.15.18 → 0.16.2, `typing-extensions`, `packaging`, `platformdirs`, `typeguard`). (#1420)
 
 ## [0.10.0] — 2026-07-24
 


### PR DESCRIPTION
Changelogs only — no version files, no source. Last step before re-tagging the four pending releases.

The `1.70.1` / `0.11.0` / `1.62.0` / `1.37.1` sections were written in #1417, before the dependency work in #1412, #1418 and #1420 landed. Tagging freezes a changelog, so this records what each release actually contains and moves the dates to the day they are cut.

## Beyond routine bumps

**engine** — states plainly that `thrift` stays at 0.17.0 and why: `parquet` 58.4.0 pins `thrift ^0.17`, so no in-range update reaches it, and `parquet` 59.2.0 (which drops thrift entirely) is an `arrow` 58 → 59 major migration. An open advisory a reader can see beats one they assume was closed by "dependency refresh".

**sdk / dagster** — the `hatchling>=1.30.1,<1.32` bound, including why it is a range rather than a pin: 1.30.0 emitted `Metadata-Version: 2.5`, 1.30.1 reverted to 2.4, and 1.32.0 re-landed it. Noted as build-only, since it does not constrain anything a consumer installs.

**vscode** — `@dagrejs/dagre` 3.0.0 → 3.1.1 called out as a **runtime** dependency that ships in the extension, unlike the four dev-dependency bumps beside it in #1418. Also records that the `engines.vscode` / `@types/vscode` / `@vscode/test-electron` triangle was deliberately left alone.

## After this merges

Re-tag all four at the merge commit, in order `sdk` → `vscode` → `dagster` → `engine`. The existing tags point at `30de33e3`, which predates the hatchling bound — re-running a release from them reproduces today's `sdk-release` failure exactly.