### PR TITLE
fix(engine/rocky-cli): scope compile model output

### DIFF
--- a/docs/src/content/docs/reference/commands/modeling.md
+++ b/docs/src/content/docs/reference/commands/modeling.md
@@ -23,7 +23,7 @@ rocky compile [flags]
 |------|------|---------|-------------|
 | `--models <PATH>` | `PathBuf` | `models` | Directory containing `.sql` and `.toml` model files. |
 | `--contracts <PATH>` | `PathBuf` | | Directory containing data contract definitions. |
-| `--model <NAME>` | `string` | | Filter compilation to a single model by name. |
+| `--model <NAME>` | `string` | | Restrict the reported result and exit status to one exact model name. The full project is still compile-checked for dependency and type context. |
 | `--expand-macros` | `bool` | `false` | Expand macros from `macros/` and include the expanded SQL in the output. |
 | `--target-dialect <DIALECT>` | `dbx` \| `sf` \| `bq` \| `duckdb` | | Run the **P001 dialect-portability lint** against the chosen target. Non-portable constructs emit `error`-severity diagnostics. Precedence: flag > `[portability] target_dialect` in `rocky.toml` > unset. See [Portability linting](/concepts/linters/). |
 | `--with-seed` | `bool` | `false` | Execute `data/seed.sql` against an in-memory DuckDB and use its `information_schema` as the source-of-truth for raw source schemas. Turns leaf `.sql` models from `Unknown` columns into concrete types. Requires the `duckdb` feature (enabled by default in the shipped binary). |
@@ -100,6 +100,11 @@ rocky compile --model fct_revenue --contracts contracts/
   "compile_timings": { "load_ms": 5, "resolve_ms": 1, "typecheck_ms": 12 }
 }
 ```
+
+Model selection is exact: an unknown name is an error. Rocky still loads and
+compile-checks the full project internally so the selected model has dependency
+and type context, but the visible counts, layers, model details, diagnostics,
+and failure state describe only the selected model.
 
 Every diagnostic carries a severity (`"error"`, `"warning"`, `"info"`), a code (`E###` errors, `W###` warnings, `P###` portability lints, or `V###` validation), the owning model, and (when the compiler can locate it) a `span` and `suggestion`.
 

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`rocky compile --model <name>` now reports exactly that model and rejects unknown names.** The selector previously filtered diagnostics and expanded SQL only: counts, execution layers, model details, text execution order, and `has_errors` still described the whole project. A healthy selected model could therefore exit nonzero with no visible diagnostic because an unrelated model was broken, while a misspelled model name exited 0 and returned the whole project. Rocky still compile-checks the full project internally for dependency and type context, but the returned report and exit status now share one exact-model scope; an unknown selector fails with `model not found`. (#1422)
+
 ## [1.70.1] - 2026-08-11
 
 ### Changed

--- a/engine/crates/rocky-cli/src/commands/compile.rs
+++ b/engine/crates/rocky-cli/src/commands/compile.rs
@@ -18,6 +18,8 @@ use rocky_sql::transpile::Dialect;
 
 use crate::output::{CompileOutput, CostHint, ModelDetail, print_json};
 
+use super::ModelNotFound;
+
 /// Execute `rocky compile`.
 ///
 /// `cache_ttl_override`: optional CLI flag value from the binary's
@@ -145,6 +147,13 @@ fn compile_inner(
 
     let mut result = compile::compile(&config)?;
 
+    if let Some(filter) = model_filter
+        && result.project.model(filter).is_none()
+    {
+        return Err(anyhow::Error::new(ModelNotFound(filter.to_string())));
+    }
+    let in_scope = |name: &str| model_filter.is_none_or(|filter| name == filter);
+
     // Portability lint. Effective target_dialect = CLI flag > [portability]
     // config > unset. Project-wide allow list and per-model `-- rocky-allow:`
     // pragmas suppress matching constructs before they become diagnostics.
@@ -199,9 +208,7 @@ fn compile_inner(
 
         let mut expanded = HashMap::new();
         for model in &result.project.models {
-            if let Some(filter) = model_filter
-                && model.config.name != filter
-            {
+            if !in_scope(&model.config.name) {
                 continue;
             }
             let sql = expand_macros(&model.sql, &macro_defs)?;
@@ -264,21 +271,18 @@ fn compile_inner(
     }
 
     // Re-apply model filter to diagnostics (may now include E027).
-    let diagnostics: Vec<_> = if let Some(filter) = model_filter {
-        result
-            .diagnostics
-            .iter()
-            .filter(|d| d.model == filter)
-            .cloned()
-            .collect()
-    } else {
-        result.diagnostics.clone()
-    };
+    let diagnostics: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| in_scope(&d.model))
+        .cloned()
+        .collect();
 
     let models_detail: Vec<ModelDetail> = result
         .project
         .models
         .iter()
+        .filter(|model| in_scope(&model.config.name))
         .map(|model| {
             let typed_cols = result
                 .type_check
@@ -320,26 +324,50 @@ fn compile_inner(
     // not carried on `CompileOutput`: execution order, per-model typed-column
     // counts, and the file_path -> SQL source map (for miette spans).
     let text_data = CompileTextData {
-        execution_order: result.project.execution_order.clone(),
+        execution_order: result
+            .project
+            .execution_order
+            .iter()
+            .filter(|name| in_scope(name))
+            .cloned()
+            .collect(),
         typed_column_counts: result
             .type_check
             .typed_models
             .iter()
+            .filter(|(name, _)| in_scope(name))
             .map(|(name, cols)| (name.clone(), cols.len()))
             .collect(),
         source_map: result
             .project
             .models
             .iter()
+            .filter(|model| in_scope(&model.config.name))
             .map(|m| (m.file_path.clone(), m.sql.clone()))
             .collect(),
     };
 
+    let execution_layers = if model_filter.is_some() {
+        result
+            .project
+            .layers
+            .iter()
+            .filter(|layer| layer.iter().any(|name| in_scope(name)))
+            .count()
+    } else {
+        result.project.layers.len()
+    };
+    let has_errors = if model_filter.is_some() {
+        diagnostics.iter().any(|d| d.severity == Severity::Error)
+    } else {
+        result.has_errors
+    };
+
     let output = CompileOutput::new(
-        result.project.model_count(),
-        result.project.layers.len(),
+        models_detail.len(),
+        execution_layers,
         diagnostics,
-        result.has_errors,
+        has_errors,
         result.timings.clone(),
     )
     .with_models_detail(models_detail)

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -48,8 +48,8 @@ pub struct RockyMcpServer {
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct CompileArgs {
-    /// Optional single-model filter; compile-checks the whole project either
-    /// way but scopes the returned diagnostics to this model when set.
+    /// Optional single-model filter; compile-checks the whole project for type
+    /// context but scopes the returned result to this model when set.
     #[serde(default)]
     pub model: Option<String>,
     /// Optional portability target dialect — one of `"databricks"`,
@@ -539,7 +539,10 @@ impl RockyMcpServer {
             with_seed,
             None,
         )
-        .map_err(|e| ToolError::compile_failed(format!("{e:#}")))?;
+        .map_err(|e| match e.downcast_ref::<commands::ModelNotFound>() {
+            Some(commands::ModelNotFound(name)) => ToolError::model_not_found(name),
+            None => ToolError::compile_failed(format!("{e:#}")),
+        })?;
         Ok(Json(project_compile_result(&output)))
     }
 
@@ -4165,6 +4168,39 @@ mod tests {
             "message should name the model: {:?}",
             err.0
         );
+    }
+
+    #[tokio::test]
+    async fn compile_unknown_model_is_model_not_found() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        std::fs::write(
+            root.join("rocky.toml"),
+            "[adapter.default]\ntype = \"duckdb\"\ndatabase = \":memory:\"\n",
+        )
+        .expect("write config");
+        let models = root.join("models");
+        std::fs::create_dir(&models).expect("create models");
+        std::fs::write(models.join("known.sql"), "SELECT 1 AS id").expect("write sql");
+        std::fs::write(
+            models.join("known.toml"),
+            "name = \"known\"\n\n[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"c\"\nschema = \"s\"\ntable = \"known\"\n",
+        )
+        .expect("write sidecar");
+
+        let server = RockyMcpServer::new(root.join("rocky.toml"));
+        let err = match server
+            .compile(Parameters(CompileArgs {
+                model: Some("missing".into()),
+                target_dialect: None,
+            }))
+            .await
+        {
+            Ok(_) => panic!("unknown model must error"),
+            Err(e) => e,
+        };
+        assert_eq!(err.0.code, crate::error::ToolErrorCode::ModelNotFound);
+        assert!(err.0.message.contains("missing"));
     }
 
     #[test]

--- a/engine/rocky/tests/compile_model_scope.rs
+++ b/engine/rocky/tests/compile_model_scope.rs
@@ -1,0 +1,147 @@
+//! End-to-end coverage for `rocky compile --model` reporting scope.
+
+use std::fs;
+use std::process::{Command, Output};
+
+fn write_model(dir: &std::path::Path, name: &str, sql: &str, depends_on: &[&str]) {
+    fs::write(dir.join(format!("{name}.sql")), sql).expect("write model sql");
+    let dependencies = depends_on
+        .iter()
+        .map(|name| format!("\"{name}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    fs::write(
+        dir.join(format!("{name}.toml")),
+        format!(
+            "name = \"{name}\"\ndepends_on = [{dependencies}]\n\n[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"c\"\nschema = \"s\"\ntable = \"{name}\"\n"
+        ),
+    )
+    .expect("write model sidecar");
+}
+
+fn compile(models: &std::path::Path, model: Option<&str>, output: &str, portable: bool) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_rocky"));
+    command
+        .arg("compile")
+        .arg("--models")
+        .arg(models)
+        .arg("--output")
+        .arg(output)
+        .env("RUST_LOG", "error");
+    if let Some(model) = model {
+        command.arg("--model").arg(model);
+    }
+    if portable {
+        command.arg("--target-dialect").arg("bq");
+    }
+    command.output().expect("spawn rocky compile")
+}
+
+fn parse_json(output: &Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(stdout.trim()).unwrap_or_else(|error| {
+        panic!(
+            "stdout is not JSON: {error}\nstdout: {stdout}\nstderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+#[test]
+fn selected_model_scopes_json_and_text_output() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let models = tmp.path().join("models");
+    fs::create_dir(&models).expect("create models");
+    write_model(&models, "upstream", "SELECT 1 AS id", &[]);
+    write_model(&models, "selected", "SELECT 2 AS id", &["upstream"]);
+
+    let json_output = compile(&models, Some("selected"), "json", false);
+    assert!(json_output.status.success());
+    let json = parse_json(&json_output);
+    assert_eq!(json["models"], 1);
+    assert_eq!(json["execution_layers"], 1);
+    assert_eq!(json["has_errors"], false);
+    assert_eq!(json["models_detail"].as_array().unwrap().len(), 1);
+    assert_eq!(json["models_detail"][0]["name"], "selected");
+
+    let text_output = compile(&models, Some("selected"), "table", false);
+    assert!(text_output.status.success());
+    let text = String::from_utf8(text_output.stdout).expect("utf8 stdout");
+    assert!(text.contains("selected"), "selected model is shown: {text}");
+    assert!(
+        !text.contains("upstream"),
+        "unselected model is hidden: {text}"
+    );
+    assert!(text.contains("Compiled: 1 models, 0 errors, 0 warnings"));
+}
+
+#[test]
+fn unknown_model_is_an_error() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let models = tmp.path().join("models");
+    fs::create_dir(&models).expect("create models");
+    write_model(&models, "known", "SELECT 1 AS id", &[]);
+
+    let output = compile(&models, Some("missing"), "json", false);
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("model 'missing' not found (no transformation model with that name)")
+    );
+}
+
+#[test]
+fn unrelated_model_error_does_not_fail_selected_model() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let models = tmp.path().join("models");
+    fs::create_dir(&models).expect("create models");
+    write_model(&models, "selected", "SELECT 1 AS id", &[]);
+    write_model(&models, "broken", "SELECT NVL(a, b) AS value FROM t", &[]);
+
+    let output = compile(&models, Some("selected"), "json", true);
+    assert!(output.status.success());
+    let json = parse_json(&output);
+    assert_eq!(json["has_errors"], false);
+    assert!(json["diagnostics"].as_array().unwrap().is_empty());
+    assert_eq!(json["models_detail"][0]["name"], "selected");
+}
+
+#[test]
+fn selected_model_error_is_visible_and_fails() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let models = tmp.path().join("models");
+    fs::create_dir(&models).expect("create models");
+    write_model(&models, "clean", "SELECT 1 AS id", &[]);
+    write_model(&models, "broken", "SELECT NVL(a, b) AS value FROM t", &[]);
+
+    let output = compile(&models, Some("broken"), "json", true);
+    assert!(!output.status.success());
+    let json = parse_json(&output);
+    assert_eq!(json["has_errors"], true);
+    assert_eq!(json["models"], 1);
+    assert!(
+        json["diagnostics"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|diagnostic| diagnostic["code"] == "P001" && diagnostic["model"] == "broken")
+    );
+}
+
+#[test]
+fn no_selector_still_reports_the_whole_project() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let models = tmp.path().join("models");
+    fs::create_dir(&models).expect("create models");
+    write_model(&models, "upstream", "SELECT 1 AS id", &[]);
+    write_model(&models, "downstream", "SELECT 2 AS id", &["upstream"]);
+
+    let output = compile(&models, None, "json", false);
+    assert!(output.status.success());
+    let json = parse_json(&output);
+    assert_eq!(json["models"], 2);
+    assert_eq!(json["execution_layers"], 2);
+    assert_eq!(json["models_detail"].as_array().unwrap().len(), 2);
+    assert_eq!(json["has_errors"], false);
+}


### PR DESCRIPTION
## Summary

Closes #1422.

Make `rocky compile --model <name>` return one self-consistent selected-model
view instead of mixing filtered diagnostics with project-wide counts, details,
execution order, layers, and failure state. Unknown model names now fail
explicitly rather than returning the whole project with exit 0.

This continues the model-selector correctness work from #1160 (`run --model`
rejects unknown names) and #1166 (`plan --model` previews the scope that apply
executes), both authored by @mattfaltyn.

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [x] Cross-project (reference docs)

## Changes

- Validate a supplied selector against the compiled transformation project and
  return the existing typed `ModelNotFound` error when it is absent.
- Derive diagnostics, `has_errors`, model/layer counts, `models_detail`, expanded
  SQL, text execution order, typed-column counts, and source mappings from one
  exact-model reporting scope.
- Keep full-project compilation internally for dependency and type context, and
  preserve the no-selector path's existing project-wide behavior.
- Map the newly surfaced typed error to MCP's existing `model_not_found` code
  instead of flattening it to `compile_failed`.
- Add real-binary regressions for selected JSON/text output, unknown selectors,
  unrelated and selected errors, and no-selector compatibility, plus an MCP
  taxonomy regression.
- Document the exact-selector reporting contract in the CLI reference and
  unreleased engine changelog.

No CLI JSON field shape, DSL syntax, generated binding, dependency, or persisted
IR contract changes.

## Duplicate coverage check

Before filing #1422 and again immediately before opening this PR, GitHub issue
and PR searches covered `compile --model`, unknown model handling,
`has_errors`, and `execution_layers`. No existing issue or open PR covers this
engine CLI defect. #1124/#1125 concern the Python SDK's server-mode filter, and
#1165/#1166 concern plan/apply preview fidelity; neither fixes `rocky compile`.

## Test Plan

- `cargo test -p rocky-cli -p rocky-mcp -p rocky --all-features --no-run` — passed.
- Ad-hoc-signed focused CLI integration target before the final compatibility
  case was added — 4 passed, 0 failed (selected JSON/text scope, unknown model,
  unrelated error, selected error).
- Ad-hoc-signed `rocky-mcp` focused test
  `compile_unknown_model_is_model_not_found` — 1 passed, 0 failed.
- Updated five-case `compile_model_scope` target — compiled successfully; both
  the test executable and child `rocky` binary pass strict code-signature
  verification. Execution from Codex remained parked in macOS `_dyld_start`,
  so the added no-selector case was compile/clippy verified locally; the final
  target passed in the all-feature Linux Nextest job below.
- A second full local Nextest attempt through macOS Terminal reached
  `cargo-nextest`, then macOS blocked its `cargo metadata` child from reading
  the repository on the external volume. No security controls or target paths
  were bypassed; the exact Linux all-feature suite is covered by CI.
- `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- `cargo clippy -p rocky --test compile_model_scope -- -D warnings` after the
  final compatibility test — passed.
- `cargo fmt -- --check` — passed.
- `git diff --check` — passed.
- `npm run build` in `docs/` — passed (103 pages built).
- `bash scripts/lint-adapter-boundary.sh` from the repository root — fails on
  existing imports in unchanged `output.rs`, `compact.rs`, `discover.rs`,
  `export_schemas.rs`, `restore.rs`, `archive.rs`, `replay.rs`, and
  `run_content_addressed.rs`; this change adds no adapter import.
- GitHub `engine-ci / Test` (`cargo nextest run --all-features`) — passed on the
  final head, including the five-case integration target.
- All final-head GitHub checks passed: Test, Clippy, Format, adapter boundary,
  release smoke, codegen drift, both credential-containment checks, and the
  credential-free agent error-contract harness.

## Independent red team

An independent GPT-5.6-terra review inspected the complete diff, issue contract,
CLI/MCP callers, diagnostic producers, and no-selector behavior. It returned
**no P0-P2 findings**. The reviewer identified explicit no-selector compatibility
as the most important missing proof; that regression was added before commit.

**What I am least confident about:** whether maintainers intend `--model` to
report only the exact model or its dependency closure. This implements exact
model scope: it matches the public “single model” contract and Rocky's established
selected-run behavior, while still compiling the whole project internally for
dependency/type context.

**What's the most important thing I may be missing:** execution of the complete
five-case integration target on this macOS host. The final target compiles and
lints, its first four behavioral cases passed in the prior signed build, and the
complete target passes in Linux all-feature CI; macOS Terminal currently lacks
permission to read this external-volume worktree for the final local run.

**ModelIr / contract semantics preserved: yes** — this changes command reporting
and selector validation only; compiler IR construction, types, contracts, and SQL
generation are unchanged.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/), scoped by subproject when relevant (e.g. `feat(engine/rocky-databricks): ...`, `fix(dagster): ...`)
- [x] No `Co-Authored-By` trailers
- [x] If this is a CLI JSON schema or DSL syntax change, all consumers (`integrations/dagster/`, `editors/vscode/`) are updated in this same PR (not applicable; no schema or syntax change)

### Engine (`engine/`)

- [x] `cargo test --all-targets` passes (repository-standard all-feature Nextest job)
- [x] `cargo clippy --all-targets -- -D warnings` is clean (also passed with `--all-features`)
- [x] `cargo fmt --check` passes

### Dagster (`integrations/dagster/`)

- [ ] `uv run pytest` passes (not touched)
- [ ] `uv run ruff check` is clean (not touched)
- [ ] `uv run ruff format --check` passes (not touched)

### VS Code (`editors/vscode/`)

- [ ] `npm run compile` succeeds (not touched)
- [ ] `npm run test:unit` passes (not touched)
- [ ] `npm run lint` is clean (not touched)
