### PR TITLE
fix(engine/rocky-cli): test declarative DSL models

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`rocky test --declarative` now executes sidecar tests for `.rocky` DSL models.** The command's private model loader discovered `.sql` sources only, so DSL models' declared tests were silently skipped and the command exited successfully with `total: 0`. Declarative testing now uses the shared project loader and treats `.sql` and `.rocky` models consistently. (#1425)
+
 - **`rocky compile --model <name>` now reports exactly that model and rejects unknown names.** The selector previously filtered diagnostics and expanded SQL only: counts, execution layers, model details, text execution order, and `has_errors` still described the whole project. A healthy selected model could therefore exit nonzero with no visible diagnostic because an unrelated model was broken, while a misspelled model name exited 0 and returned the whole project. Rocky still compile-checks the full project internally for dependency and type context, but the returned report and exit status now share one exact-model scope; an unknown selector fails with `model not found`. (#1422)
 
 ## [1.70.1] - 2026-08-11

--- a/engine/crates/rocky-cli/src/commands/test.rs
+++ b/engine/crates/rocky-cli/src/commands/test.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use tracing::{debug, info, warn};
 
-use rocky_core::models;
 use rocky_core::tests::{TestSeverity, TestType, generate_test_sql_with_dialect};
 use rocky_core::traits::WarehouseAdapter;
 
@@ -177,22 +176,9 @@ pub fn run_test(
 // Declarative test runner (`rocky test --declarative`)
 // ---------------------------------------------------------------------------
 
-/// Load all models from a directory including one level of subdirectories.
-fn load_all_models(models_dir: &Path) -> Result<Vec<models::Model>> {
-    let mut all = models::load_models_from_dir(models_dir).context(format!(
-        "failed to load models from {}",
-        models_dir.display()
-    ))?;
-
-    if let Ok(entries) = std::fs::read_dir(models_dir) {
-        for entry in entries.flatten() {
-            if entry.path().is_dir()
-                && let Ok(sub) = models::load_models_from_dir(&entry.path())
-            {
-                all.extend(sub);
-            }
-        }
-    }
+/// Load every `.sql` and `.rocky` model beneath the models directory.
+fn load_all_models(models_dir: &Path) -> Result<Vec<rocky_core::models::Model>> {
+    let mut all = crate::models_loader::load_project_models(models_dir)?;
     all.sort_unstable_by(|a, b| a.config.name.cmp(&b.config.name));
     Ok(all)
 }
@@ -517,5 +503,34 @@ fn test_type_label(tt: &TestType) -> &'static str {
         TestType::Composite { .. } => "composite",
         TestType::NotInFuture => "not_in_future",
         TestType::OlderThanNDays { .. } => "older_than_n_days",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::load_all_models;
+
+    #[test]
+    fn declarative_loader_includes_tests_from_rocky_models() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let models = tmp.path().join("models");
+        std::fs::create_dir(&models).expect("create models dir");
+        std::fs::write(
+            models.join("orders.rocky"),
+            "from raw_orders\nselect { id }\n",
+        )
+        .expect("write rocky model");
+        std::fs::write(
+            models.join("orders.toml"),
+            "name = \"orders\"\n\n[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"c\"\nschema = \"s\"\ntable = \"orders\"\n\n[[tests]]\ntype = \"not_null\"\ncolumn = \"id\"\n",
+        )
+        .expect("write model sidecar");
+
+        let loaded = load_all_models(&models).expect("load models");
+
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].config.name, "orders");
+        assert_eq!(loaded[0].config.tests.len(), 1);
+        assert_eq!(loaded[0].config.tests[0].column.as_deref(), Some("id"));
     }
 }


### PR DESCRIPTION
## Summary

`rocky test --declarative` used a private SQL-only model loader. As a result, sidecar tests attached to `.rocky` DSL models were silently skipped and the command could report zero tests with a successful exit.

This change reuses Rocky's shared recursive project loader, which already supports both `.sql` and `.rocky` sources, while preserving deterministic model ordering.

Closes #1425.

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Changes

- replace the declarative runner's duplicate SQL-only loader with `models_loader::load_project_models`
- add a focused regression test proving a `.rocky` model's sidecar test is loaded
- document the fix in the engine changelog

## Test Plan

- [x] `cargo nextest run --all-features --retries 2 --no-fail-fast --status-level fail --final-status-level fail` (6,026 passed; 111 skipped)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo build --all-features`
- [x] End-to-end `.rocky` fixture: `rocky test --declarative` discovers one test and returns the expected failing `not_null` result instead of `total: 0`

## Checklist

- [x] Commit message follows Conventional Commits and is scoped to `engine/rocky-cli`
- [x] No `Co-Authored-By` trailers
- [x] No CLI JSON schema or DSL syntax change; downstream consumer updates are not required

### Engine (`engine/`)

- [x] Full all-feature test suite passes via nextest (6,026 passed; 111 skipped)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo fmt -- --check` passes

## Review notes

- Least confident area: the end-to-end proof uses DuckDB and validates discovery/execution through the CLI, but it does not repeat the fixture against every warehouse adapter.
- Most important missing coverage: there is no dedicated integration fixture that asserts mixed `.sql` and `.rocky` declarative tests together; the shared loader already has broader recursive-loading coverage, while this regression test targets the missing DSL path.
- Independent different-model red-team pass: not performed in the local environment; the change was manually re-reviewed against the command path, shared loader contract, issue/PR search, and full local suite.
