### PR TITLE
docs(engine): describe what `compile --model` actually scopes

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -5145,12 +5145,14 @@
             "$ref": "#/components/schemas/PhaseTimings"
           },
           "diagnostics": {
+            "description": "Diagnostics for the models this result describes. Under `--model`, filtered to those whose owning model name equals the selector exactly — so a diagnostic raised against a different model is absent even when that model is an upstream of the selected one.\n\nAttribution is not always a model you can select: import diagnostics (`E033`, `E034`, `W012`) carry the import name and `W011` carries a contract name, none of which are valid `--model` values. A target collision (`E036`) is attached to every participating model, so one diagnostic can appear under several selectors.",
             "items": {
               "$ref": "#/components/schemas/Diagnostic"
             },
             "type": "array"
           },
           "execution_layers": {
+            "description": "Number of execution layers this result describes.\n\nUnder `--model` only the layers containing the selected model are counted, so this reports `1`. It is not the selected model's depth in the DAG, and not how many layers a rebuild of it would need — treat it as informative only when no selector is passed.",
             "format": "uint",
             "minimum": 0.0,
             "type": "integer"
@@ -5163,9 +5165,11 @@
             "type": "object"
           },
           "has_errors": {
+            "description": "Whether the diagnostics this result describes include error-severity entries — and, for the CLI, whether the command exits non-zero.\n\nUnder `--model` this is computed from the exact-attribution filter above, so it says nothing about whether the selected model's upstreams compile: an error attributed to another model is filtered out and leaves this `false`, even though `rocky run` would classify that model as a compile error and exclude it from execution. A failure that aborts compilation outright rather than emitting a diagnostic — an unparseable model, a semantic-graph or contract-load failure — fails the command before any scoping applies. To learn whether a model can be built, compile without a selector.",
             "type": "boolean"
           },
           "models": {
+            "description": "Number of models this result describes — the whole project, or `1` when `--model` selects one. Not a project-wide total under a selector.",
             "format": "uint",
             "minimum": 0.0,
             "type": "integer"

--- a/docs/src/content/docs/reference/commands/modeling.md
+++ b/docs/src/content/docs/reference/commands/modeling.md
@@ -23,7 +23,7 @@ rocky compile [flags]
 |------|------|---------|-------------|
 | `--models <PATH>` | `PathBuf` | `models` | Directory containing `.sql` and `.toml` model files. |
 | `--contracts <PATH>` | `PathBuf` | | Directory containing data contract definitions. |
-| `--model <NAME>` | `string` | | Restrict the reported result and exit status to one exact model name. The full project is still compile-checked for dependency and type context. |
+| `--model <NAME>` | `string` | | Restrict the reported result and exit status to one exact model name — whether *that model's own source* is valid, not whether its upstreams can be rebuilt. The full project is still loaded and compile-checked internally for dependency and type context. |
 | `--expand-macros` | `bool` | `false` | Expand macros from `macros/` and include the expanded SQL in the output. |
 | `--target-dialect <DIALECT>` | `dbx` \| `sf` \| `bq` \| `duckdb` | | Run the **P001 dialect-portability lint** against the chosen target. Non-portable constructs emit `error`-severity diagnostics. Precedence: flag > `[portability] target_dialect` in `rocky.toml` > unset. See [Portability linting](/concepts/linters/). |
 | `--with-seed` | `bool` | `false` | Execute `data/seed.sql` against an in-memory DuckDB and use its `information_schema` as the source-of-truth for raw source schemas. Turns leaf `.sql` models from `Unknown` columns into concrete types. Requires the `duckdb` feature (enabled by default in the shipped binary). |
@@ -105,6 +105,44 @@ Model selection is exact: an unknown name is an error. Rocky still loads and
 compile-checks the full project internally so the selected model has dependency
 and type context, but the visible counts, layers, model details, diagnostics,
 and failure state describe only the selected model.
+
+**What the exit status does and does not cover.** The selector filters
+diagnostics by **exact attribution** — a diagnostic is reported only when its
+owning model name equals the selector — and the exit status follows that
+filtered set. The dividing line is *how a problem is reported*, not what kind of
+problem it is:
+
+- A **hard compilation failure** — one that aborts compilation rather than
+  emitting a diagnostic, such as a model whose SQL cannot be parsed — fails the
+  command regardless of the selector, because compilation never gets far enough
+  to filter anything. Failures during semantic-graph construction and contract
+  loading behave the same way.
+- An **error diagnostic attributed to another model** is filtered out, so the
+  selected model is reported clean. This holds even though that other model
+  genuinely fails to compile: `rocky run` classifies such a model as a
+  compile error and excludes it from execution. Selecting a model therefore
+  tells you nothing about whether its upstreams compile.
+
+Two consequences worth knowing:
+
+- **Not every diagnostic names a model you can select.** Import-level
+  diagnostics (`E033`, `E034`, `W012`) carry the *import* name, and `W011`
+  carries a contract name that need not correspond to a model at all. Because
+  `--model` requires a real model name, those cannot be surfaced by selecting
+  anything — run without a selector to see them.
+- **A diagnostic can be attributed to more than one model.** A target collision
+  (`E036`) attaches an error to every participating model, so selecting any one
+  of them reports it.
+
+To check whether a model can actually be *built*, compile without a selector.
+`rocky run --model` builds only the selected model and needs `--defer` to
+resolve references to upstreams you did not build; without it the SQL is left
+unchanged and the run succeeds only if the reference already resolves in the
+active namespace.
+
+Note that under `--model`, `execution_layers` counts only the layers containing
+the selected model — so it reports `1`, not the model's depth in the DAG and not
+how many layers rebuilding it would take.
 
 Every diagnostic carries a severity (`"error"`, `"warning"`, `"info"`), a code (`E###` errors, `W###` warnings, `P###` portability lints, or `V###` validation), the owning model, and (when the compiler can locate it) a `span` and `suggestion`.
 

--- a/editors/vscode/src/types/generated/compile.ts
+++ b/editors/vscode/src/types/generated/compile.ts
@@ -127,7 +127,17 @@ export type TimeGrain = "hour" | "day" | "month" | "year";
 export interface CompileOutput {
   command: string;
   compile_timings: PhaseTimings;
+  /**
+   * Diagnostics for the models this result describes. Under `--model`, filtered to those whose owning model name equals the selector exactly — so a diagnostic raised against a different model is absent even when that model is an upstream of the selected one.
+   *
+   * Attribution is not always a model you can select: import diagnostics (`E033`, `E034`, `W012`) carry the import name and `W011` carries a contract name, none of which are valid `--model` values. A target collision (`E036`) is attached to every participating model, so one diagnostic can appear under several selectors.
+   */
   diagnostics: Diagnostic[];
+  /**
+   * Number of execution layers this result describes.
+   *
+   * Under `--model` only the layers containing the selected model are counted, so this reports `1`. It is not the selected model's depth in the DAG, and not how many layers a rebuild of it would need — treat it as informative only when no selector is passed.
+   */
   execution_layers: number;
   /**
    * Expanded SQL for each model after macro substitution. Only populated when `--expand-macros` is passed. Keys are model names, values are the SQL after all `@macro()` calls have been replaced.
@@ -135,7 +145,15 @@ export interface CompileOutput {
   expanded_sql?: {
     [k: string]: string;
   };
+  /**
+   * Whether the diagnostics this result describes include error-severity entries — and, for the CLI, whether the command exits non-zero.
+   *
+   * Under `--model` this is computed from the exact-attribution filter above, so it says nothing about whether the selected model's upstreams compile: an error attributed to another model is filtered out and leaves this `false`, even though `rocky run` would classify that model as a compile error and exclude it from execution. A failure that aborts compilation outright rather than emitting a diagnostic — an unparseable model, a semantic-graph or contract-load failure — fails the command before any scoping applies. To learn whether a model can be built, compile without a selector.
+   */
   has_errors: boolean;
+  /**
+   * Number of models this result describes — the whole project, or `1` when `--model` selects one. Not a project-wide total under a selector.
+   */
   models: number;
   /**
    * Per-model details extracted from each model's TOML frontmatter. Empty when the project has no models. Downstream consumers (`dagster-rocky` to surface per-model freshness policies and partition-keyed assets) iterate this list rather than re-loading model frontmatter themselves.

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -1650,9 +1650,39 @@ pub struct DriftOutput {
 pub struct CompileOutput {
     pub version: String,
     pub command: String,
+    /// Number of models this result describes — the whole project, or `1`
+    /// when `--model` selects one. Not a project-wide total under a selector.
     pub models: usize,
+    /// Number of execution layers this result describes.
+    ///
+    /// Under `--model` only the layers containing the selected model are
+    /// counted, so this reports `1`. It is not the selected model's depth in
+    /// the DAG, and not how many layers a rebuild of it would need — treat it
+    /// as informative only when no selector is passed.
     pub execution_layers: usize,
+    /// Diagnostics for the models this result describes. Under `--model`,
+    /// filtered to those whose owning model name equals the selector exactly —
+    /// so a diagnostic raised against a different model is absent even when
+    /// that model is an upstream of the selected one.
+    ///
+    /// Attribution is not always a model you can select: import diagnostics
+    /// (`E033`, `E034`, `W012`) carry the import name and `W011` carries a
+    /// contract name, none of which are valid `--model` values. A target
+    /// collision (`E036`) is attached to every participating model, so one
+    /// diagnostic can appear under several selectors.
     pub diagnostics: Vec<Diagnostic>,
+    /// Whether the diagnostics this result describes include error-severity
+    /// entries — and, for the CLI, whether the command exits non-zero.
+    ///
+    /// Under `--model` this is computed from the exact-attribution filter
+    /// above, so it says nothing about whether the selected model's upstreams
+    /// compile: an error attributed to another model is filtered out and
+    /// leaves this `false`, even though `rocky run` would classify that model
+    /// as a compile error and exclude it from execution. A failure that aborts
+    /// compilation outright rather than emitting a diagnostic — an unparseable
+    /// model, a semantic-graph or contract-load failure — fails the command
+    /// before any scoping applies. To learn whether a model can be built,
+    /// compile without a selector.
     pub has_errors: bool,
     pub compile_timings: PhaseTimings,
     /// Per-model details extracted from each model's TOML frontmatter.

--- a/engine/crates/rocky-mcp/src/result_types.rs
+++ b/engine/crates/rocky-mcp/src/result_types.rs
@@ -38,7 +38,11 @@ pub struct CompileResult {
     pub error_count: usize,
     /// Count of warning-severity diagnostics.
     pub warning_count: usize,
-    /// Number of models in the project.
+    /// Number of models this result describes — the whole project, or `1`
+    /// when a `model` selector was passed. Not a project-wide total under a
+    /// selector, and `has_errors` / the counts above are scoped the same way:
+    /// they describe the selected model's own validity, not whether its
+    /// upstreams can be rebuilt.
     pub model_count: usize,
     /// All diagnostics (errors + warnings + info).
     pub diagnostics: Vec<DiagnosticLite>,

--- a/engine/rocky/tests/compile_model_scope.rs
+++ b/engine/rocky/tests/compile_model_scope.rs
@@ -145,3 +145,165 @@ fn no_selector_still_reports_the_whole_project() {
     assert_eq!(json["models_detail"].as_array().unwrap().len(), 2);
     assert_eq!(json["has_errors"], false);
 }
+
+/// `execution_layers` is structurally `1` under a selector — a model belongs to
+/// exactly one layer, and only that layer is counted. Asserting `== 1` on a
+/// two-model project passes for the wrong reason, so this pins the claim
+/// against a chain deep enough that "layer count" and "DAG depth" differ: the
+/// deepest model still reports 1 while the unscoped project reports 3.
+///
+/// If `execution_layers` is ever redefined to mean the selected model's depth
+/// or its rebuild closure, this fails — which is the point.
+#[test]
+fn selected_layer_count_is_one_not_the_models_depth() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let models = temp.path().join("models");
+    fs::create_dir_all(&models).expect("models dir");
+    write_model(&models, "a_first", "SELECT 1 AS id", &[]);
+    write_model(&models, "b_second", "SELECT 2 AS id", &["a_first"]);
+    write_model(&models, "c_third", "SELECT 3 AS id", &["b_second"]);
+
+    let whole = compile(&models, None, "json", false);
+    assert!(whole.status.success());
+    let whole_json = parse_json(&whole);
+    assert_eq!(whole_json["models"], 3);
+    assert_eq!(
+        whole_json["execution_layers"], 3,
+        "the unscoped project has three layers, so depth and layer count differ"
+    );
+
+    let selected = compile(&models, Some("c_third"), "json", false);
+    assert!(selected.status.success());
+    let selected_json = parse_json(&selected);
+    assert_eq!(selected_json["models"], 1);
+    assert_eq!(
+        selected_json["execution_layers"], 1,
+        "the deepest model still reports one layer, not its depth of 3"
+    );
+}
+
+/// The documented exit-status contract: `--model` answers "is this model's own
+/// source valid", not "can it be rebuilt right now". An upstream error that
+/// still leaves the project resolvable does not fail the selected model — the
+/// selected model genuinely type-checks, and `rocky run --model` can build it
+/// against an already-materialized upstream.
+///
+/// This is the case a reviewer (me) misread as a fail-open. Pinning it so the
+/// contract is asserted rather than assumed.
+#[test]
+fn upstream_error_does_not_fail_the_selected_model() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let models = temp.path().join("models");
+    fs::create_dir_all(&models).expect("models dir");
+    // `NVL` is a portability error under `--target-dialect bq` (P001).
+    write_model(&models, "upstream", "SELECT NVL(a, b) AS value FROM t", &[]);
+    write_model(&models, "selected", "SELECT 1 AS id", &["upstream"]);
+
+    // The project as a whole fails: the upstream's error is real.
+    let whole = compile(&models, None, "json", true);
+    assert!(
+        !whole.status.success(),
+        "the upstream error fails the project"
+    );
+
+    // Selecting the downstream reports only its own validity.
+    let selected = compile(&models, Some("selected"), "json", true);
+    assert!(
+        selected.status.success(),
+        "an upstream error must not fail the selected model: {}",
+        String::from_utf8_lossy(&selected.stderr)
+    );
+    let json = parse_json(&selected);
+    assert_eq!(json["has_errors"], false);
+    assert!(json["diagnostics"].as_array().unwrap().is_empty());
+}
+
+/// The boundary of the contract above: an upstream failure that stops
+/// dependency resolution outright fails the command *regardless* of the
+/// selector, because the selected model cannot be compiled at all. Without
+/// this, `upstream_error_does_not_fail_the_selected_model` could be read as
+/// "upstream problems are never surfaced under a selector", which is false.
+#[test]
+fn unresolvable_upstream_fails_even_when_another_model_is_selected() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let models = temp.path().join("models");
+    fs::create_dir_all(&models).expect("models dir");
+    write_model(&models, "upstream", "SELECT FROM WHERE (((", &[]);
+    write_model(&models, "selected", "SELECT 1 AS id", &["upstream"]);
+
+    let selected = compile(&models, Some("selected"), "json", false);
+    assert!(
+        !selected.status.success(),
+        "an upstream that cannot be parsed fails the run even under a selector"
+    );
+    let stderr = String::from_utf8_lossy(&selected.stderr);
+    assert!(
+        stderr.contains("failed to parse") || stderr.contains("parser error"),
+        "the failure must be the parse error, not some unrelated non-zero exit: {stderr}"
+    );
+}
+
+/// Writes a `time_interval` model whose declared `time_column` is absent from
+/// its SELECT — the E020 shape, raised by the compiler's typecheck pass.
+fn write_e020_model(dir: &std::path::Path, name: &str) {
+    fs::write(
+        dir.join(format!("{name}.sql")),
+        "SELECT region, SUM(amount) AS revenue FROM raw__sales.orders \
+         WHERE order_at >= @start_date AND order_at < @end_date GROUP BY region",
+    )
+    .expect("write e020 sql");
+    fs::write(
+        dir.join(format!("{name}.toml")),
+        format!(
+            "name = \"{name}\"\ndepends_on = []\n\n\
+             [[sources]]\ncatalog = \"\"\nschema = \"raw__sales\"\ntable = \"orders\"\n\n\
+             [strategy]\ntype = \"time_interval\"\ntime_column = \"order_date\"\n\
+             granularity = \"day\"\nfirst_partition = \"2026-04-04\"\nlookback = 0\n\n\
+             [target]\ncatalog = \"c\"\nschema = \"s\"\ntable = \"{name}\"\n"
+        ),
+    )
+    .expect("write e020 sidecar");
+}
+
+/// Claim-3 regression, on the compiler-raised diagnostic path.
+///
+/// `upstream_error_does_not_fail_the_selected_model` uses P001, which the CLI
+/// appends *after* compilation — so it would stay green if scoping of
+/// compiler-raised diagnostics regressed. E020 comes from the typecheck pass,
+/// which is the path the documented contract actually describes.
+#[test]
+fn compiler_raised_upstream_error_is_scoped_out_of_the_selected_model() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let models = temp.path().join("models");
+    fs::create_dir_all(&models).expect("models dir");
+    write_e020_model(&models, "broken_upstream");
+    write_model(&models, "selected", "SELECT 1 AS id", &["broken_upstream"]);
+
+    // Unscoped: the compiler-raised error is present and fails the project.
+    let whole = compile(&models, None, "json", false);
+    assert!(
+        !whole.status.success(),
+        "the upstream E020 must fail the unscoped project"
+    );
+    let whole_json = parse_json(&whole);
+    assert!(
+        whole_json["diagnostics"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|d| d["code"] == "E020" && d["model"] == "broken_upstream"),
+        "expected E020 attributed to the upstream: {}",
+        whole_json["diagnostics"]
+    );
+
+    // Scoped: filtered out by exact attribution, so the selected model is clean.
+    let selected = compile(&models, Some("selected"), "json", false);
+    assert!(
+        selected.status.success(),
+        "a compiler-raised upstream error must not fail the selected model: {}",
+        String::from_utf8_lossy(&selected.stderr)
+    );
+    let json = parse_json(&selected);
+    assert_eq!(json["has_errors"], false);
+    assert!(json["diagnostics"].as_array().unwrap().is_empty());
+}

--- a/schemas/compile.schema.json
+++ b/schemas/compile.schema.json
@@ -663,12 +663,14 @@
       "$ref": "#/definitions/PhaseTimings"
     },
     "diagnostics": {
+      "description": "Diagnostics for the models this result describes. Under `--model`, filtered to those whose owning model name equals the selector exactly — so a diagnostic raised against a different model is absent even when that model is an upstream of the selected one.\n\nAttribution is not always a model you can select: import diagnostics (`E033`, `E034`, `W012`) carry the import name and `W011` carries a contract name, none of which are valid `--model` values. A target collision (`E036`) is attached to every participating model, so one diagnostic can appear under several selectors.",
       "items": {
         "$ref": "#/definitions/Diagnostic"
       },
       "type": "array"
     },
     "execution_layers": {
+      "description": "Number of execution layers this result describes.\n\nUnder `--model` only the layers containing the selected model are counted, so this reports `1`. It is not the selected model's depth in the DAG, and not how many layers a rebuild of it would need — treat it as informative only when no selector is passed.",
       "format": "uint",
       "minimum": 0.0,
       "type": "integer"
@@ -681,9 +683,11 @@
       "type": "object"
     },
     "has_errors": {
+      "description": "Whether the diagnostics this result describes include error-severity entries — and, for the CLI, whether the command exits non-zero.\n\nUnder `--model` this is computed from the exact-attribution filter above, so it says nothing about whether the selected model's upstreams compile: an error attributed to another model is filtered out and leaves this `false`, even though `rocky run` would classify that model as a compile error and exclude it from execution. A failure that aborts compilation outright rather than emitting a diagnostic — an unparseable model, a semantic-graph or contract-load failure — fails the command before any scoping applies. To learn whether a model can be built, compile without a selector.",
       "type": "boolean"
     },
     "models": {
+      "description": "Number of models this result describes — the whole project, or `1` when `--model` selects one. Not a project-wide total under a selector.",
       "format": "uint",
       "minimum": 0.0,
       "type": "integer"

--- a/sdk/python/src/rocky_sdk/types.py
+++ b/sdk/python/src/rocky_sdk/types.py
@@ -706,13 +706,32 @@ class ModelDetail(BaseModel):
 
 
 class CompileResult(BaseModel):
-    """Output of ``rocky compile --json``."""
+    """Output of ``rocky compile --json``.
+
+    Every count below describes *what the result covers*, which is the whole
+    project or — when ``model_filter`` is passed — the one selected model.
+    """
 
     version: str
     command: str
+    #: Number of models this result describes: the whole project, or ``1``
+    #: under ``model_filter``. Not a project-wide total under a selector.
     models: int
+    #: Number of execution layers this result describes. Under ``model_filter``
+    #: only the layers containing the selected model are counted, so this
+    #: reports ``1`` — not the model's depth in the DAG.
     execution_layers: int
+    #: Under ``model_filter``, filtered to diagnostics whose owning model name
+    #: equals the selector exactly. Note that not every diagnostic names a
+    #: selectable model: import diagnostics (``E033``/``E034``/``W012``) carry
+    #: the import name and ``W011`` a contract name, so those surface only
+    #: without a selector.
     diagnostics: list[Diagnostic]
+    #: Whether ``diagnostics`` includes error-severity entries — and whether
+    #: the CLI exited non-zero. Under ``model_filter`` this says nothing about
+    #: whether the selected model's upstreams compile: an error attributed to
+    #: another model is filtered out and leaves this ``False``. Compile without
+    #: a selector to learn whether a model can actually be built.
     has_errors: bool
     models_detail: list[ModelDetail] = []
     #: Per-phase compile timings. Loose ``dict`` — the nested shape lives on

--- a/sdk/python/src/rocky_sdk/types_generated/compile_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/compile_schema.py
@@ -462,13 +462,31 @@ class CompileOutput(BaseModel):
     command: str
     compile_timings: PhaseTimings
     diagnostics: list[Diagnostic]
+    """
+    Diagnostics for the models this result describes. Under `--model`, filtered to those whose owning model name equals the selector exactly — so a diagnostic raised against a different model is absent even when that model is an upstream of the selected one.
+
+    Attribution is not always a model you can select: import diagnostics (`E033`, `E034`, `W012`) carry the import name and `W011` carries a contract name, none of which are valid `--model` values. A target collision (`E036`) is attached to every participating model, so one diagnostic can appear under several selectors.
+    """
     execution_layers: conint(ge=0)
+    """
+    Number of execution layers this result describes.
+
+    Under `--model` only the layers containing the selected model are counted, so this reports `1`. It is not the selected model's depth in the DAG, and not how many layers a rebuild of it would need — treat it as informative only when no selector is passed.
+    """
     expanded_sql: dict[str, str] | None = None
     """
     Expanded SQL for each model after macro substitution. Only populated when `--expand-macros` is passed. Keys are model names, values are the SQL after all `@macro()` calls have been replaced.
     """
     has_errors: bool
+    """
+    Whether the diagnostics this result describes include error-severity entries — and, for the CLI, whether the command exits non-zero.
+
+    Under `--model` this is computed from the exact-attribution filter above, so it says nothing about whether the selected model's upstreams compile: an error attributed to another model is filtered out and leaves this `false`, even though `rocky run` would classify that model as a compile error and exclude it from execution. A failure that aborts compilation outright rather than emitting a diagnostic — an unparseable model, a semantic-graph or contract-load failure — fails the command before any scoping applies. To learn whether a model can be built, compile without a selector.
+    """
     models: conint(ge=0)
+    """
+    Number of models this result describes — the whole project, or `1` when `--model` selects one. Not a project-wide total under a selector.
+    """
     models_detail: list[ModelDetail] | None = None
     """
     Per-model details extracted from each model's TOML frontmatter. Empty when the project has no models. Downstream consumers (`dagster-rocky` to surface per-model freshness policies and partition-keyed assets) iterate this list rather than re-loading model frontmatter themselves.


### PR DESCRIPTION
Closes #1424. Documentation, generated bindings, and tests — no behaviour change.

## Why this is bigger than the issue

#1424 described one stale MCP string. The real gap was wider: `CompileOutput`'s `models`, `execution_layers`, `diagnostics` and `has_errors` had **no doc comments at all**, and that struct derives `JsonSchema` — so the published schema, `openapi.json`, the SDK and the vscode types described those fields by name only.

## An independent red team refuted most of my first attempt

Worth recording, because the corrections are the substance of this PR. My first draft explained the contract with a story; a Codex review checked each claim against the source and returned **REQUEST CHANGES** on five of seven:

| I wrote | Actually |
|---|---|
| "answers whether the model's own source is valid" | filters by **exact attribution** — `E036` attaches to *every* participating model |
| "stops dependency resolution" | the boundary is **hard `Err` vs emitted diagnostic**; semantic-graph and contract-load failures abort *after* resolution |
| upstream "compiles but fails to materialize" | **E020 is an error-severity compile diagnostic**; `run` classifies such a model as a compile error and excludes it before issuing SQL |
| `run --model` builds against an existing upstream | that generally needs **`--defer`** |
| "select that model to see the diagnostic" | impossible for `E033`/`E034`/`W012` (import name) and `W011` (contract name) — they aren't selectable models |

The docs now describe the mechanism instead.

## Tests

The existing `unrelated_model_error_does_not_fail_selected_model` uses **P001, which the CLI appends *after* compilation** — so it would stay green if scoping of compiler-raised diagnostics regressed. Added:

- `compiler_raised_upstream_error_is_scoped_out_of_the_selected_model` — a real **E020** on the typecheck path; asserts the unscoped project fails *with E020 attributed to the upstream*, and the scoped result is clean.
- `selected_layer_count_is_one_not_the_models_depth` — a 3-model chain where layer count (3) and the selected model's report (1) genuinely differ. The pre-existing `assert_eq!(execution_layers, 1)` on a 2-model project passes under either meaning; this fails if the field is redefined as depth.
- `unresolvable_upstream_fails_even_when_another_model_is_selected` now asserts the **parse-failure class**, not merely a non-zero exit.

**9 passed / 0 failed.**

## Shadow drift

`sdk/python/src/rocky_sdk/types.py`'s `CompileResult` is **hand-written** — codegen does not regenerate it. Without documenting it too, the model Python consumers actually import would have stayed silent while everything around it gained descriptions. That is the #924 trap.

## Verification

- `cargo test -p rocky --test compile_model_scope` — 9/9
- `cargo clippy --all-targets --workspace -- -D warnings` — clean, 0 warnings
- `cargo fmt --check` — clean
- `just codegen` + `just regen-fixtures` — committed; drift is exactly the four generated artifacts (`schemas/compile.schema.json`, `openapi.json`, vscode `compile.ts`, SDK `compile_schema.py`), and I confirmed the descriptions actually land in each rather than trusting a zero exit code
- SDK `ruff check` / `ruff format --check` clean, 212 tests pass