### PR TITLE
fix(engine/rocky-compiler): point the migration guide at rocky-data.dev

### DIFF
--- a/engine/crates/rocky-compiler/src/import/emit.rs
+++ b/engine/crates/rocky-compiler/src/import/emit.rs
@@ -1015,7 +1015,12 @@ fn write_migration_notes(path: &Path, ctx: &MigrationContext<'_>) -> Result<(), 
         "2. Run `rocky compile` from the output directory to type-check the translated models.\n",
     );
     out.push_str("3. Run `rocky test` to exercise any seed data.\n");
-    out.push_str("4. See the [migration guide](https://rocky-data.github.io/rocky/guides/migrate-from-dbt/) for the long tail.\n");
+    // Host is `rocky-data.dev` (docs/astro.config.mjs), not the old GitHub
+    // Pages address. This string is compiled into the binary and written to a
+    // user's disk as MIGRATION-NOTES.md, so a docs-side redirect cannot fix an
+    // already-emitted note — and the `guides/migrate-from-dbt/` path must stay
+    // stable for the same reason (#1433).
+    out.push_str("4. See the [migration guide](https://rocky-data.dev/guides/migrate-from-dbt/) for the long tail.\n");
 
     std::fs::write(path, out).map_err(|e| format!("failed to write {}: {e}", path.display()))
 }


### PR DESCRIPTION
Closes #1433.

`rocky import-dbt` writes `MIGRATION-NOTES.md` next to the imported project, linking to the migration guide on `rocky-data.github.io/rocky`. The docs site is `rocky-data.dev` (`docs/astro.config.mjs`), and whether the old host resolves depends on a GitHub Pages redirect this repo does not own.

The string is **compiled into the binary**, so no docs-side change can reach it, and every note already written to a user's disk carries the stale link.

## Scope

One occurrence repo-wide — `rg 'rocky-data\.github\.io'` over `engine/` returns exactly this line, and nothing outside `engine/` carries it either.

**No committed artifact needed updating.** The issue cites `examples/.../19-import-dbt-unit-tests/imported/MIGRATION-NOTES.md:44` as committed evidence, but that directory is produced by the POC's `run.sh` — `git ls-files` tracks zero `MIGRATION-NOTES.md`. The fix is complete at one line.

## Note added alongside

A comment recording *why* the `guides/migrate-from-dbt/` path has to stay stable: the binary hardcodes it, so renaming that docs page later silently breaks notes files already on users' disks. The in-flight docs sweep preserved that path deliberately; this makes the constraint visible at the site that depends on it.