### PR TITLE
fix(ci): fail when a fixture-source POC is missing instead of skipping it

### DIFF
--- a/scripts/regen_fixtures.sh
+++ b/scripts/regen_fixtures.sh
@@ -56,6 +56,42 @@ if [[ ! -d "$POC" ]]; then
     exit 1
 fi
 
+# Every POC this script captures from must exist. Each capture section below
+# used to skip silently when its source was missing, and a skipped section
+# never clears its destination under fixtures_generated/ — so deleting a POC
+# left the previously committed fixtures in place, `git diff --exit-code` saw
+# no change, and codegen-drift passed while the fixtures no longer
+# corresponded to any source (#1432).
+#
+# Failing here makes a deliberate removal explicit: delete the POC and this
+# list in the same PR. Checked up front, so the run fails before it has spent
+# minutes capturing, and the message names every missing source at once
+# rather than one per re-run.
+readonly POCS_ROOT_PREFLIGHT="$WORKSPACE_ROOT/examples/playground/pocs"
+_missing_pocs=()
+for _p in \
+    "$PARTITION_POC" \
+    "$POCS_ROOT_PREFLIGHT/02-performance/06-schema-drift-recover" \
+    "$POCS_ROOT_PREFLIGHT/01-quality/01-data-contracts-strict" \
+    "$POCS_ROOT_PREFLIGHT/02-performance/01-incremental-watermark" \
+    "$POCS_ROOT_PREFLIGHT/02-performance/05-optimize-recommendations" \
+    "$POCS_ROOT_PREFLIGHT/06-developer-experience/01-lineage-column-level" \
+    "$POCS_ROOT_PREFLIGHT/06-developer-experience/05-doctor-and-ci" \
+    "$POCS_ROOT_PREFLIGHT/01-quality/03-anomaly-detection"; do
+    [[ -d "$_p" ]] || _missing_pocs+=("$_p")
+done
+if (( ${#_missing_pocs[@]} > 0 )); then
+    echo "Error: ${#_missing_pocs[@]} fixture-source POC(s) missing:" >&2
+    printf '  %s\n' "${_missing_pocs[@]}" >&2
+    echo >&2
+    echo "Fixtures are captured from these POCs. A missing source would be" >&2
+    echo "skipped silently, leaving stale committed fixtures that no source" >&2
+    echo "produces -- and codegen-drift would pass. If a POC was removed on" >&2
+    echo "purpose, drop it from this list and delete its fixtures in the same" >&2
+    echo "change." >&2
+    exit 1
+fi
+
 mkdir -p "$DEST"
 
 # --- Bootstrap the POC: clean state, seed duckdb, run rocky once for state ---


### PR DESCRIPTION
Closes #1432.

Each capture section in `scripts/regen_fixtures.sh` skipped silently when its source POC was absent, and **a skipped section never clears its destination** under `fixtures_generated/`. Deleting a POC therefore left the previously committed fixtures in place, `git diff --exit-code` saw no change, and codegen-drift passed while those fixtures corresponded to no source.

## The issue named one branch; there are eight

The script's own comment says each section *"skips silently if the POC directory is missing"* — and that holds for **partition, drift, contracts, incremental, optimize, lineage, doctor_ci, anomaly**. Fixing only the partition case the issue cites would have left the class open.

All eight are now validated in pre-flight, beside the existing `rocky` binary and `duckdb` checks. That placement matters twice: the run fails before spending minutes capturing, and the error names *every* missing source at once instead of one per re-run.

A deliberate POC removal now updates this list in the same change — which is the point, since the alternative is a silent stale-fixture window.

## Verification

The guard was extracted and driven directly:

| | |
|---|---|
| real workspace, all 8 present | passes |
| one POC path redirected to a nonexistent dir | **exit 1**, naming that path |

Worth recording how that check was reached: a first attempt tested by `sed`-ing the preflight out of the full script and reported *"guard silent — correct"*. The script actually had a syntax error and never ran. The isolated harness is what turned it into evidence — which is the same false-green shape #1428 and this issue are both about.

`bash -n` and `shellcheck -S error` both clean.