### PR TITLE
fix(sdk): refuse defer on the plan verb instead of building an argv the CLI rejects

### DIFF
--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -1080,8 +1080,11 @@ class RockyResource(dg.ConfigurableResource):
             context: Dagster execution context (required for Pipes injection).
             filter: Component filter (e.g. ``"tenant=acme"``).
             governance_override / run_models / partition / shadow_suffix / …:
-                Same as :meth:`run`. Threaded into the rocky CLI via
-                :meth:`_build_plan_args`.
+                Same as :meth:`run`, with one exception: ``defer`` / ``defer_to``
+                are ``run``-only flags, so supplying them here raises
+                ``ValueError`` -- the plan step builds the ``rocky plan`` verb,
+                which the CLI parses without them (#1404). Threaded into the
+                rocky CLI via :meth:`_build_plan_args`.
             pipes_client: Optional pre-configured ``PipesSubprocessClient``. When
                 supplied, ``asset_key_fn`` / ``include_keys`` are ignored.
             asset_key_fn: Optional transform applied to each Pipes event's asset

--- a/integrations/dagster/tests/test_resource.py
+++ b/integrations/dagster/tests/test_resource.py
@@ -1909,6 +1909,16 @@ def test_build_plan_args_mirrors_build_run_args_flag_surface():
     on the Python side — every flag ``_build_run_args`` emits must also
     appear in ``_build_plan_args``'s output for the same kwargs (only the
     leading verb differs).
+
+    The parity is NOT total, and this test used to assert that it was: it
+    passed ``defer=True`` / ``defer_to=...`` and required byte-identical
+    argv tails. Those two flags are declared on the ``Run`` clap variant
+    only, so the argv it pinned as correct is one ``rocky plan`` rejects at
+    argument parsing (``error: unexpected argument '--defer' found``,
+    exit 2). The test therefore encoded the defect in #1404 as the contract,
+    which is part of why it survived. Parity is now asserted over the flags
+    that genuinely mirror, with the run-only pair excluded and covered by
+    its own refusal test below.
     """
     rocky = RockyResource(models_dir="m")
     kwargs: dict[str, Any] = {
@@ -1924,15 +1934,35 @@ def test_build_plan_args_mirrors_build_run_args_flag_surface():
         "parallel": 2,
         "shadow_suffix": "_pr_42",
         "idempotency_key": "key-1",
-        "defer": True,
-        "defer_to": "prod_main",
     }
     run_args = rocky._build_run_args("tenant=acme", **kwargs)
     plan_args = rocky._build_plan_args("tenant=acme", **kwargs)
-    # Only the verb token differs.
+    # Only the verb token differs, across every flag the two verbs share.
     assert run_args[0] == "run"
     assert plan_args[0] == "plan"
     assert run_args[1:] == plan_args[1:]
+
+
+def test_build_plan_args_refuses_run_only_defer_flags():
+    """``--defer`` / ``--defer-to`` exist on ``rocky run`` only.
+
+    ``run_pipes`` forwards them into its plan-step build kwargs, so before
+    #1404 a Pipes caller passing ``defer=True`` produced ``rocky plan
+    ... --defer`` — rejected by clap before any work happened. Refused in the
+    builder now, so the caller gets a clear error instead of an argument-parse
+    failure from a subprocess.
+    """
+    rocky = RockyResource(models_dir="m")
+    for extra in ({"defer": True}, {"defer_to": "prod_main"}):
+        with pytest.raises(ValueError, match="defer/defer_to are not supported by rocky plan"):
+            rocky._build_plan_args("tenant=acme", governance_override=None, **extra)
+
+    # The run verb keeps both — the fix must not reach it.
+    run_args = rocky._build_run_args(
+        "tenant=acme", governance_override=None, defer=True, defer_to="prod_main"
+    )
+    assert "--defer" in run_args
+    assert run_args[run_args.index("--defer-to") + 1] == "prod_main"
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/python/src/rocky_sdk/client.py
+++ b/sdk/python/src/rocky_sdk/client.py
@@ -519,12 +519,25 @@ class RockyClient:
         defer: bool = False,
         defer_to: str | None = None,
     ) -> list[str]:
-        """Build the argv for ``rocky plan`` — identical flag plumbing to ``run``.
+        """Build the argv for ``rocky plan``.
 
         Used by the two-step plan + apply path (e.g. dagster Pipes) that needs the
         persisted ``plan_id``. ``--watch`` is intentionally omitted (no run-path
         counterpart; orchestrators own the re-run cadence).
+
+        Raises:
+            ValueError: ``defer`` or ``defer_to`` was supplied. Both flags exist
+                on ``rocky run`` only, so the CLI rejects them at argument
+                parsing and the plan never runs. Refused here, before spawning a
+                subprocess, matching how the client already handles ``env`` on
+                ``retention_status`` (#1404).
         """
+        if defer or defer_to is not None:
+            raise ValueError(
+                "defer/defer_to are not supported by rocky plan (the flags are "
+                "declared on `rocky run` only). Use run() for deferred "
+                "resolution, or drop the argument from the plan call."
+            )
         return self._build_run_or_plan_args(
             "plan",
             filter,
@@ -564,8 +577,15 @@ class RockyClient:
         defer: bool,
         defer_to: str | None,
     ) -> list[str]:
-        """Shared flag plumbing for ``run`` and ``plan`` (the engine backfilled
-        every ``run`` flag onto ``plan`` so the only difference is the verb)."""
+        """Shared flag plumbing for ``run`` and ``plan``.
+
+        The engine backfilled MOST ``run`` flags onto ``plan``, but not all:
+        ``--defer`` / ``--defer-to`` are declared on the ``Run`` clap variant
+        only. Callers building the ``plan`` verb must reject them before they
+        reach argv -- see :meth:`_build_plan_args` (#1404). Treating the two
+        verbs as flag-identical is what produced an argv the CLI refuses to
+        parse.
+        """
         args = [verb, "--filter", filter]
         if pipeline is not None:
             args.extend(["--pipeline", pipeline])

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -861,3 +861,42 @@ def test_ai_sync_parses_populated_proposals_without_phantom_field():
     assert len(result.proposals) == 1
     assert result.proposals[0].model == "revenue"
     assert result.proposals[0].proposed_source == "SELECT *, tax FROM raw"
+
+
+def test_build_plan_args_rejects_defer():
+    # ``--defer`` / ``--defer-to`` are declared on the ``Run`` clap variant only,
+    # so the ``plan`` verb rejects them at argument parsing. The shared argv
+    # builder appended them for both verbs on the premise that the engine had
+    # backfilled every ``run`` flag onto ``plan`` -- false for these two (#1404).
+    #
+    # The reachable caller is dagster's ``RockyResource.run_pipes``, which puts
+    # ``defer`` into its build kwargs and calls this builder; the public
+    # ``RockyClient.plan()`` never exposed the argument. Refuse here, where the
+    # argv is assembled, so every route through it is covered.
+    client = _client()
+    for kwargs in ({"defer": True}, {"defer_to": "prod"}, {"defer": True, "defer_to": "prod"}):
+        with pytest.raises(ValueError, match="defer/defer_to are not supported by rocky plan"):
+            client._build_plan_args("x=y", governance_override=None, **kwargs)
+
+
+def test_build_plan_args_without_defer_is_unaffected():
+    # The guard must not disturb the ordinary plan path.
+    argv = _client()._build_plan_args("x=y", governance_override=None, pipeline="bronze")
+    assert argv[0] == "plan"
+    assert "--defer" not in argv and "--defer-to" not in argv
+    assert argv[argv.index("--pipeline") + 1] == "bronze"
+
+
+def test_run_still_accepts_defer():
+    # The flags are legitimate on ``run`` -- the fix must scope to the plan verb
+    # only, or it would break the deferred-resolution workflow it is protecting.
+    client = _client()
+    argv = client._build_run_args(
+        "x=y",
+        governance_override=None,
+        defer=True,
+        defer_to="prod",
+    )
+    assert argv[0] == "run"
+    assert "--defer" in argv
+    assert argv[argv.index("--defer-to") + 1] == "prod"


### PR DESCRIPTION
Closes #1404.

`--defer` / `--defer-to` are declared on the `Run` clap variant **only**, but the SDK's shared argv builder appended them for both verbs — on the stated premise that *"the engine backfilled every run flag onto plan so the only difference is the verb"*. False for exactly these two flags, so a caller passing defer built `rocky plan … --defer`, which the CLI rejects at argument parsing before doing any work.

Refused in `_build_plan_args`, before a subprocess spawns, matching how the client already handles `env` on `retention_status` (`client.py:1442`).

**`run` is untouched.** The flags are legitimate there, and a fix that scoped wider would break the deferred-resolution workflow it is meant to protect — pinned by `test_run_still_accepts_defer`.

## One correction to the issue

The issue lists `RockyClient.plan(...)` as an affected caller. **It is not.** The public signature is `plan(filter, *, pipeline, env)` and never exposed defer — my first test failed with `TypeError: unexpected keyword argument 'defer'`, which is what surfaced it.

The reachable path is **dagster's `RockyResource.run_pipes`**, which puts `defer` into its build kwargs (`resource.py:1122`) and calls the same builder. So the blast radius is the Pipes path, not every plan caller. The guard still sits in the builder rather than in `run_pipes`, so any future route through it is covered.

## Two false comments corrected

Both asserted the premise that caused this:

- the shared builder's docstring ("the engine backfilled **every** run flag onto plan")
- `run_pipes`' claim that its flags are "Same as `run`" — it now names the exception

## Verification

| | |
|---|---|
| `test_build_plan_args_rejects_defer` | all three shapes: `defer`, `defer_to`, both |
| `test_build_plan_args_without_defer_is_unaffected` | ordinary plan argv unchanged |
| `test_run_still_accepts_defer` | the run verb keeps both flags |
| SDK suite | 215 passed |
| ruff check + format | clean on `sdk/python` and `integrations/dagster` |