### PR TITLE
docs: plain-language sweep for the subproject READMEs and contributor docs

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -103,7 +103,7 @@ if [[ "${ROCKY_SKIP_CODEGEN_HOOK:-}" != "1" ]]; then
             DIRTY_PATHS=$(
                 git diff --name-only -- \
                     schemas/ \
-                    integrations/dagster/src/dagster_rocky/types_generated/ \
+                    sdk/python/src/rocky_sdk/types_generated/ \
                     editors/vscode/src/types/generated/
             )
             if [[ -n "$DIRTY_PATHS" ]]; then
@@ -114,7 +114,7 @@ The following files were regenerated and are not staged:
 $DIRTY_PATHS
 
 Fix with:
-  git add schemas/ integrations/dagster/src/dagster_rocky/types_generated/ editors/vscode/src/types/generated/
+  git add schemas/ sdk/python/src/rocky_sdk/types_generated/ editors/vscode/src/types/generated/
 EOF
                 FAILED=1
             fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Rocky
 
-Rocky is a monorepo. The five subprojects share one repository, one issue tracker, and one pull-request flow, but each has its own build system.
+Rocky is a monorepo. Every subproject shares one repository, one issue tracker, and one pull-request flow. Each subproject keeps its own build system.
 
 | Subproject | Path | Language | Build |
 |---|---|---|---|
@@ -8,27 +8,38 @@ Rocky is a monorepo. The five subprojects share one repository, one issue tracke
 | Python SDK | `sdk/python/` | Python | `uv` |
 | Dagster integration | `integrations/dagster/` | Python | `uv` |
 | VS Code extension | `editors/vscode/` | TypeScript | `npm` |
-| Sample project | `examples/playground/` | TOML / SQL config | none |
+| Documentation site | `docs/` | Astro | `npm` |
+| POC catalog | `examples/playground/` | TOML / SQL config | none |
 
 ## Getting started
 
-Clone once, work everywhere:
+Clone once, then work anywhere in the tree.
 
 ```bash
 git clone https://github.com/rocky-data/rocky.git
 cd rocky
 ```
 
-Each subproject is built and tested independently. From the repo root, the top-level `justfile` orchestrates common tasks across all of them. Install [`just`](https://github.com/casey/just) and then:
+The top-level `justfile` runs one task across the four code subprojects: the engine, the SDK, the Dagster integration, and the VS Code extension. It does not cover `docs/` or the playground. Install [`just`](https://github.com/casey/just), then:
 
 ```bash
-just build       # build engine + sdk + dagster wheels + vscode extension
-just test        # run all test suites
+just build       # engine, sdk wheel, dagster wheel, vscode extension
+just test        # cargo test, both pytest suites, vscode unit tests
 just lint        # cargo clippy/fmt + ruff + eslint
-just --list      # see all available recipes
+just --list      # every recipe
 ```
 
-You can also build a single subproject directly without `just`; see the per-subproject sections below.
+Two gaps to know about. `just test` runs the VS Code unit tests only; the electron suite has its own recipe, `just test-vscode-electron`. `just build` compiles the extension but does not bundle it, so it does not produce the `dist/extension.js` that debugging needs.
+
+You can also build one subproject directly. The sections below give the commands.
+
+Optional: run `just install-hooks` to point `core.hooksPath` at `.git-hooks/`. Every hook check is conditional. A check runs only when the change touches the subproject it covers.
+
+- **pre-commit:** `cargo fmt --check` for `engine/`, `ruff format --check` for `integrations/dagster/`, eslint for `editors/vscode/`.
+- **pre-commit, codegen drift:** runs only when you stage `output.rs`, `commands/doctor.rs`, or `commands/export_schemas.rs` under `engine/crates/rocky-cli/src/`.
+- **pre-push:** `cargo clippy` for `engine/`, `ruff check` for `integrations/dagster/`.
+
+Neither hook checks `sdk/python/`. A check also skips silently when its tool is not installed, so a missing `uv` turns the ruff check into a pass. The drift check compares fewer paths than `codegen-drift.yml` does, so a commit can pass the hook and still fail CI. Treat the hooks as a fast first pass, not as the gate. Set `ROCKY_SKIP_HOOKS=1` to skip every hook, or `ROCKY_SKIP_CODEGEN_HOOK=1` to skip the drift check alone.
 
 ### Engine (`engine/`)
 
@@ -40,7 +51,9 @@ cargo clippy --all-targets -- -D warnings
 cargo fmt --check
 ```
 
-The engine is a Cargo workspace: the library crates under `engine/crates/` plus the `rocky` and `rocky-lsp` binary crates (Rust edition 2024, MSRV 1.88). Run a single crate's tests with `cargo test -p rocky-core`. End-to-end tests in `crates/rocky-core/tests/e2e.rs` use DuckDB and need no credentials.
+CI is stricter than the `cargo test` and `cargo clippy` lines above. It runs `cargo nextest run --all-features` and `cargo clippy --all-targets --all-features -- -D warnings`. Some adapter code sits behind a Cargo feature, so a default-feature run can pass while CI fails.
+
+The engine is a Cargo workspace: the library crates under `engine/crates/` plus the `rocky` and `rocky-lsp` binary crates. It targets Rust edition 2024 with an MSRV of 1.88. Test one crate with `cargo test -p rocky-core`. The end-to-end tests in `crates/rocky-core/tests/e2e.rs` run against DuckDB and need no credentials.
 
 ### Python SDK (`sdk/python/`)
 
@@ -51,7 +64,7 @@ uv run pytest -v
 uv run ruff check src/ tests/ examples/ && uv run ruff format --check src/ tests/ examples/
 ```
 
-`rocky-sdk` is the standalone typed client (`RockyClient`) that `dagster-rocky` is built on. Unit tests mock the binary and need no credentials; `examples/quickstart.py` runs against a real `rocky` (the `sdk-ci` smoke job installs one). The generated Pydantic models in `src/rocky_sdk/types_generated/` come from `just codegen`; don't hand-edit them.
+`rocky-sdk` is the standalone typed client (`RockyClient`) that `dagster-rocky` builds on. The unit tests patch the subprocess layer, so they need no `rocky` binary and no credentials. `examples/quickstart.py` runs against a real binary, and the `sdk-ci` smoke job installs one. `just codegen` writes the Pydantic models in `src/rocky_sdk/types_generated/`; do not hand-edit them.
 
 ### Dagster integration (`integrations/dagster/`)
 
@@ -62,40 +75,68 @@ uv run pytest -v
 uv run ruff check && uv run ruff format --check
 ```
 
-All tests run without the Rocky binary or credentials; they use JSON fixtures in `tests/fixtures/`.
+Every test runs without the `rocky` binary and without credentials. Hand-written scenario data lives in `tests/scenarios.py` as Python dicts. Captures from a real binary live in `tests/fixtures_generated/`, and `just regen-fixtures` refreshes them.
 
 ### VS Code extension (`editors/vscode/`)
 
 ```bash
 cd editors/vscode
 npm install
-npm run compile
+npm run compile                # tsc, writes out/
+npm run bundle                 # esbuild, writes dist/extension.js
 npm run test:unit              # vitest unit tests (fast)
-npm test                       # full electron integration tests (downloads ~344 MB)
+npm test                       # electron integration tests (~344 MB download)
 ```
 
-For interactive development, open `editors/vscode/` in VS Code and press <kbd>F5</kbd> to launch the Extension Development Host.
+Run `npm run bundle` before you debug. `package.json` loads the extension from `dist/extension.js`, which esbuild produces; `npm run compile` writes only `out/`. Then open `editors/vscode/` in VS Code and press <kbd>F5</kbd> to launch the Extension Development Host.
 
-### Sample project (`examples/playground/`)
+### Documentation site (`docs/`)
 
-A self-contained DuckDB pipeline used as a smoke test for the engine and as a fixture source for the dagster integration. No build step.
+```bash
+cd docs
+npm ci
+npm run dev      # local preview
+npm run build    # the same build CI runs
+```
+
+`docs-build.yml` builds the site on every pull request that touches `docs/`. `engine-docs.yml` deploys it on push to `main`.
+
+### POC catalog (`examples/playground/`)
+
+A catalog of small POCs, one per Rocky feature. Each POC is a complete project you can run through `./run.sh`, and most need only DuckDB and no credentials. The weekly `poc-smoke` job builds a fresh binary and runs the credential-free POCs against it. It skips any POC that needs credentials, Docker, or a Rust toolchain. A second step parse-checks the credential-gated POCs, but that step is `continue-on-error`, so it cannot fail the job. `just regen-fixtures` captures the Dagster test fixtures from specific POCs here. The catalog has no build step.
 
 ## Cross-project changes
 
-The single biggest reason Rocky is a monorepo: changes to the engine's CLI JSON output schema or DSL syntax can be made atomically across all consumers in one PR.
+A change to the engine's CLI JSON output, or to the DSL, reaches every consumer. The monorepo lets you land all of it in one pull request.
 
-**When modifying CLI JSON output** (codegen-driven as of Phase 2):
-1. Edit the typed `*Output` struct in `engine/crates/rocky-cli/src/output.rs` (or `engine/crates/rocky-cli/src/commands/doctor.rs` for the doctor types).
-2. From the repo root, run `just codegen`. This regenerates:
-   - `schemas/<command>.schema.json` (canonical JSON Schema)
-   - `sdk/python/src/rocky_sdk/types_generated/` (Pydantic v2 models)
-   - `editors/vscode/src/types/generated/` (TypeScript interfaces)
-3. Commit the regenerated bindings together with your Rust change.
-4. The `codegen-drift` CI workflow will fail any PR where the committed bindings don't match what the engine produces, so this is enforced.
+**When you change CLI JSON output**, edit the typed `*Output` struct in `engine/crates/rocky-cli/src/output.rs`. The doctor types live in `engine/crates/rocky-cli/src/commands/doctor.rs`. Then run `just codegen` from the repo root.
 
-The generated Pydantic models live in the `rocky-sdk` package. `dagster_rocky.types` (and `dagster_rocky.types_generated`) re-export them from `rocky_sdk`, and `editors/vscode/src/types/rockyJson.ts` is a re-export shim over the generated TypeScript, both providing backward-compat aliases for the renamed class names.
+```
+ engine/crates/rocky-cli/src/output.rs  (the typed *Output structs)
+                 │
+                 │ just codegen — builds the rocky binary, then runs:
+       ┌─────────┴──────────┐
+       │ export-schemas     │ export-openapi
+       ▼                    ▼
+ schemas/*.schema.json   docs/public/openapi.json
+       │
+       ├────────────► Pydantic models       (rocky-sdk)
+       ├────────────► TypeScript interfaces (VS Code)
+       └────────────► project-file schema   (VS Code)
+```
 
-**When modifying Rocky DSL syntax** (`.rocky` files), update in lockstep:
+The OpenAPI document comes straight from the engine's schema registry and its route table, not from the committed schema files. The other three read `schemas/`:
+
+- `sdk/python/src/rocky_sdk/types_generated/` — Pydantic v2 models
+- `editors/vscode/src/types/generated/` — TypeScript interfaces
+- `editors/vscode/schemas/rocky-project.schema.json` — copied from `schemas/rocky_project.schema.json`
+
+Commit everything the cascade writes, `schemas/` included, in the same PR as the Rust change. `codegen-drift.yml` re-runs `just codegen` and `just regen-fixtures` on your PR, then fails it on any diff. Use `just codegen-all` locally when your change also alters the shape of command output; it bundles both steps.
+
+Three shims keep older imports working: `dagster_rocky.types` and `dagster_rocky.types_generated` re-export the Pydantic models from `rocky_sdk`, and `editors/vscode/src/types/rockyJson.ts` re-exports the generated TypeScript under its earlier names.
+
+**When you change Rocky DSL syntax** (`.rocky` files), update all five in lockstep:
+
 1. `engine/crates/rocky-lang/` (parser + lexer)
 2. `engine/crates/rocky-compiler/` (type checking)
 3. `editors/vscode/syntaxes/rocky.tmLanguage.json` (TextMate grammar)
@@ -104,41 +145,86 @@ The generated Pydantic models live in the `rocky-sdk` package. `dagster_rocky.ty
 
 ## Releases
 
-Each artifact is released independently using a tag-namespaced scheme. Releases are **CI-driven**, so land a release PR (version bump + CHANGELOG entry), tag the merged commit, push the tag, and the matching release workflow does the rest:
+Each artifact ships on its own tag prefix. Releases are CI-driven: you land a release PR, then push a tag, and the matching workflow does the rest.
 
-| Artifact | Tag pattern | CI workflow (on tag push) |
-|---|---|---|
-| Rocky CLI binary | `engine-v*` | `engine-release.yml` — full 5-target matrix (macOS ARM64/Intel, Linux x86_64/ARM64, Windows x86_64), all attached to the GitHub Release |
-| rocky-sdk wheel | `sdk-v*` | `sdk-release.yml` — build + PyPI publish via OIDC |
-| dagster-rocky wheel | `dagster-v*` | `dagster-release.yml` — build + PyPI publish via OIDC |
-| Rocky VSIX | `vscode-v*` | `vscode-release.yml` — build + VS Code Marketplace publish |
-
-`dagster-rocky` depends on `rocky-sdk`, so when a `dagster-v*` release raises its `rocky-sdk` floor, publish the `sdk-v*` tag first; the published dagster wheel resolves the SDK from PyPI, not the monorepo path source.
-
-Canonical flow for each artifact:
-
-```bash
-# 1. Bump the version + update the CHANGELOG in a release PR; merge it.
-# 2. Tag the merged commit and push:
-git tag engine-v1.7.0
-git push origin engine-v1.7.0
+```
+  1. release PR        version bump + CHANGELOG entry
+        │
+        │ merge
+        ▼
+  2. commit on main    the commit you will tag
+        │
+        │ tag it <prefix>-v<x.y.z>, then push the tag
+        ▼
+  3. release workflow  builds every artifact for that prefix
+        │
+        │ publish
+        ▼
+  4. GitHub Release, plus PyPI or the Marketplace for three of them
 ```
 
-For convenience, the monorepo exposes `just release-engine <version>`, `just release-sdk <version> [--publish]`, `just release-dagster <version> [--publish]`, and `just release-vscode <version> [--publish]`; these wrap the local-build path below. The `rocky-release` skill (mirrored at `.agents/skills/` and `.claude/skills/`) walks the full checklist.
+Tag the merge commit, then push the tag. Take the version from the release PR. Git refuses a tag that already exists, so a stale version number fails loudly rather than silently.
 
-`scripts/release.sh engine|dagster|vscode <version>` remains as a **local-build fallback** for hotfix scenarios where CI is unavailable. It builds what it can locally (macOS natively, Linux via Docker) and attaches those artifacts to the GitHub Release. Prefer the CI-driven flow for normal releases.
+```bash
+git tag -a engine-v0.2.0 -m "Release engine-v0.2.0"
+git push origin engine-v0.2.0
+```
+
+| Artifact | Tag pattern | Workflow | Also published to |
+|---|---|---|---|
+| Rocky CLI binaries | `engine-v*` | `engine-release.yml` | nothing else |
+| `rocky-sdk` wheel | `sdk-v*` | `sdk-release.yml` | PyPI, via OIDC |
+| `dagster-rocky` wheel | `dagster-v*` | `dagster-release.yml` | PyPI, via OIDC |
+| Rocky VSIX | `vscode-v*` | `vscode-release.yml` | VS Code Marketplace |
+
+Each of these four workflows creates a GitHub Release and attaches what it built. Three of them also publish to a package registry.
+
+A fifth workflow, `engine-wasm-release.yml`, builds the compiler pipeline to WebAssembly on an `engine-wasm-v*` tag. Nothing has shipped from it. `@rocky-data/compiler` is not in the npm registry. The one `engine-wasm-v*` tag has no GitHub Release. The publish step exits early, because the repository has no `NPM_TOKEN` secret. Treat the WebAssembly package as unreleased.
+
+The engine matrix builds five targets: macOS ARM64, macOS Intel, Linux x86_64, Linux ARM64, and Windows x86_64. It attaches a `rocky` archive and a `rocky-lsp` archive for each one.
+
+`dagster-rocky` depends on `rocky-sdk`. When a `dagster-v*` release raises its `rocky-sdk` floor, push the `sdk-v*` tag first. The published dagster wheel resolves the SDK from PyPI, not from the path source in this repository.
+
+`scripts/release.sh engine|sdk|dagster|vscode <version>` is a local-build fallback for a hotfix when CI is unavailable. Run the engine path on an Apple Silicon Mac. It packages the native host build as the macOS ARM64 archive without checking the host architecture, and builds Linux x86_64 in Docker.
+
+Four `just` recipes wrap that same script: `just release-engine <version>`, `just release-sdk <version> [--publish]`, `just release-dagster <version> [--publish]`, and `just release-vscode <version> [--publish]`. Without `--publish`, the sdk, dagster, and vscode paths build the artifact and create the GitHub Release, but never reach PyPI or the Marketplace. `just release-engine` takes no `--publish`, because the engine publishes to GitHub Releases only.
+
+Prefer the tag-driven flow for a normal release. The `rocky-release` skill, mirrored at `.agents/skills/rocky-release/` and `.claude/skills/rocky-release/`, walks the full checklist.
 
 ## Pull requests
 
 - Branch from `main`.
-- One logical change per PR. Cross-project PRs are encouraged when they ship a coordinated change (schema or DSL); otherwise keep changes scoped to one subproject.
-- Conventional commits required: `feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`. Scope by subproject or crate when relevant: `feat(engine/rocky-databricks): add OAuth M2M auth`, `fix(dagster): handle partial-success exit codes`, `docs(vscode): update README screenshots`.
+- One logical change per PR. Cross-project PRs are welcome when they ship a coordinated schema or DSL change; otherwise keep a PR inside one subproject.
+- Conventional commits required: `feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`. Scope by subproject or crate where it helps: `feat(engine/rocky-databricks): add OAuth M2M auth`, `fix(dagster): handle partial-success exit codes`, `docs(vscode): update README screenshots`.
 - **Never** include `Co-Authored-By` trailers in commit messages.
-- CI runs path-filtered workflows for the subprojects you touch. All required checks must pass before merge. Note: benchmarks only run on PRs labeled `perf`; coverage and audit run weekly via `engine-weekly.yml`.
+
+### What CI runs
+
+CI is path-filtered. The paths your PR touches decide which workflows run. Every required check must pass before merge.
+
+| What you touch | Workflow | What it runs |
+|---|---|---|
+| `engine/**` | `engine-ci.yml` | nextest, clippy, `cargo fmt --check`, an adapter-boundary lint, a release-build smoke test |
+| `sdk/python/**` | `sdk-ci.yml` | pytest, ruff, and a smoke job driving the SDK against a real `rocky` |
+| `integrations/dagster/**` | `dagster-ci.yml` | pytest and ruff |
+| `editors/vscode/**` | `vscode-ci.yml` | compile, the electron integration tests, eslint |
+| `docs/**` | `docs-build.yml` | an Astro build of the docs site |
+| `scripts/**` | `scripts-ci.yml` | shellcheck, and a self-test of the soak-verdict script |
+| `.agents/skills/**` or `.claude/skills/**` | `skills-mirror-drift.yml` | diffs the two skill trees and fails unless they are byte-identical |
+| `engine/**`, `schemas/**`, `justfile`, `examples/playground/pocs/**`, or a generated binding | `codegen-drift.yml` | re-runs `just codegen` and `just regen-fixtures`, then fails on any diff |
+| `examples/playground/pocs/**` | `poc-counts-drift.yml` | recounts the POCs and fails on any diff |
+| `engine/evals/**` or `engine/crates/rocky-mcp/**` | `engine-evals.yml` | the eval harness self-test and the structured-error contract |
+| the recipe-manifest surface (`rocky-verify`, `recipe_identity.rs`, `history.rs`, `examples/audit-sample/**`) | `manifest-conformance.yml` | builds `rocky` and `rocky-verify`, then runs the conformance script |
+
+The table covers the common cases, not every path. Each workflow in `.github/workflows/` holds its own exact `paths:` list. Read it there when you need certainty.
+
+Expect more than one workflow on most PRs. Any `engine/**` change triggers at least `engine-ci.yml` and `codegen-drift.yml`, and a narrower engine path can add more. `schemas/**` triggers `engine-ci.yml`, `sdk-ci.yml`, `dagster-ci.yml`, and `vscode-ci.yml`, plus `codegen-drift.yml`. `sdk/python/**` also triggers `dagster-ci.yml`, because the Dagster integration depends on the SDK. The credential-containment policy checks run on every PR, whatever it touches.
+
+Benchmarks run only on a PR labelled `perf` (`engine-bench.yml`). Coverage, the dependency audit, and a POC smoke run happen weekly (`engine-weekly.yml`).
 
 ### Merge strategy
 
-GitHub lets you pick a merge strategy per-PR via the dropdown on the merge button. Rocky's default is **squash and merge**, but choose deliberately; the right choice depends on the PR's shape:
+GitHub offers a merge-strategy dropdown on the merge button. This repository allows squash and rebase, and disables merge commits. Squash is the default. Choose deliberately, because the right choice depends on the PR's shape.
 
 | PR shape | Strategy | Why |
 |---|---|---|
@@ -148,18 +234,16 @@ GitHub lets you pick a merge strategy per-PR via the dropdown on the merge butto
 | Refactor series where intermediate states build meaningfully | **Rebase** | Preserves the step-by-step narrative and keeps `git bisect` granular for debugging future regressions |
 | WIP-heavy branches with "fix typo" / "oops" commits | **Squash** (or clean up via interactive rebase before opening the PR) | Collapses noise into one coherent commit |
 
-**Heuristic**: if every commit in your PR has a distinct meaningful conventional-commit scope, **rebase**: squashing would collapse those scopes into one megacommit and you'd lose the grep-by-crate affordance. Otherwise **squash**.
-
-Avoid the third option (create a merge commit) for normal PRs; it adds a branching structure to trunk-based linear history for no practical benefit in a solo-scale project.
+**Heuristic:** rebase when every commit carries a distinct, meaningful conventional-commit scope. Squashing would collapse those scopes into one commit, and `git log --grep` by crate would stop finding them. Otherwise squash.
 
 ## Code style
 
-Each subproject follows its language's idioms; the linter is the source of truth.
+Each subproject follows its language's idioms. The linter is the source of truth.
 
-- **Rust** (`engine/`): edition 2024, `cargo fmt`, `cargo clippy --all-targets -- -D warnings`. Use `tracing` for logs. Use `thiserror` for library errors and `anyhow` for binary/CLI errors. SQL identifiers must be validated via `rocky-sql/validation.rs` before interpolation.
-- **Python** (`sdk/python/`, `integrations/dagster/`): Python 3.11+, `from __future__ import annotations`, Pydantic for all data structures. Line length 100. Ruff rules: E, F, I, N, UP, B, SIM.
+- **Rust** (`engine/`): edition 2024, `cargo fmt`, `cargo clippy --all-targets -- -D warnings`. Use `tracing` for logs. Use `thiserror` for library errors and `anyhow` for binary and CLI errors. Validate SQL identifiers through `engine/crates/rocky-sql/src/validation.rs` before you interpolate them.
+- **Python** (`sdk/python/`, `integrations/dagster/`): Python 3.11+, `from __future__ import annotations`. Model every parsed Rocky payload with Pydantic; a frozen dataclass is fine for internal value types. Line length 100. Ruff rules: E, F, I, N, UP, B, SIM.
 - **TypeScript** (`editors/vscode/`): ES2022 target, strict mode, `cp.execFile()` (never `cp.exec()`), escape HTML in webview content.
 
 ## Reporting issues
 
-File issues against `rocky-data/rocky` with a label naming the subproject (`engine`, `sdk`, `dagster`, `vscode`, `playground`). Include the subproject's version, your platform, and minimal repro steps.
+File issues against `rocky-data/rocky`. Five labels name a subproject: `engine`, `sdk`, `dagster`, `vscode`, and `playground`. There is no `docs` label, so use the `documentation` label for a documentation issue. Include the subproject's version, your platform, and minimal steps to reproduce.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,32 +2,43 @@
 
 ## Reporting a Vulnerability
 
-We take the security of Rocky and its integrations seriously. If you discover a security vulnerability in any subproject of this repository (`engine/`, `integrations/dagster/`, `editors/vscode/`, `examples/playground/`), please report it through GitHub's private vulnerability reporting:
+**Do not report a security vulnerability through a public GitHub issue.** Use either private channel below. Both reach the maintainers, and either one on its own is enough.
 
-1. Go to the [Security tab](https://github.com/rocky-data/rocky/security/advisories/new) of this repository
-2. Click "Report a vulnerability"
-3. Fill in the details of the vulnerability, including which subproject is affected
+- **The private advisory form.** Open the [private advisory form](https://github.com/rocky-data/rocky/security/advisories/new). The link goes straight to GitHub's "Report a vulnerability" page for this repository.
+- **Email.** Write to **security@rocky-data.dev**.
 
-Alternatively, you can email **security@rocky-data.dev** directly.
+Include these details in whichever channel you choose.
 
-**Please do not report security vulnerabilities through public GitHub issues.**
+1. Name the affected path, for example `engine/` or `editors/vscode/`. Every path in this repository is in scope, `.github/` and `scripts/` included. Give the closest path you know, and say so if you are unsure.
+2. Describe the vulnerability. Include the version you tested, your platform, and the steps to reproduce it.
+
+Send a partial report rather than none. We will ask for anything else we need.
 
 ## Response Timeline
 
-- **Acknowledgment:** Within 48 hours
-- **Initial assessment:** Within 1 week
-- **Fix timeline:** Depends on severity, typically within 90 days
+| Stage | When |
+|---|---|
+| We acknowledge your report | Within 48 hours |
+| We send an initial assessment | Within 1 week |
+| We ship a fix | Depends on severity, typically within 90 days |
 
 ## Supported Versions
 
-Each Rocky artifact (engine, dagster integration, VS Code extension) is versioned and released independently. Only the latest release of each is supported.
+Each Rocky artifact is versioned and released independently. Only the latest release of each one receives security fixes.
 
 | Artifact | Tag Prefix | Supported |
 |----------|------------|-----------|
 | Rocky CLI engine | `engine-v*` | Latest only |
+| rocky-sdk package | `sdk-v*` | Latest only |
 | dagster-rocky package | `dagster-v*` | Latest only |
 | Rocky VS Code extension | `vscode-v*` | Latest only |
 
+`@rocky-data/compiler`, the WebAssembly build of the compiler pipeline, has never been published. There is no released version of it to support.
+
 ## Scope
 
-This policy covers all code in the `rocky-data/rocky` monorepo. Out of scope: third-party dependencies (report directly to the upstream project), credentials accidentally committed by users to their own forks, and configuration mistakes in user projects that consume Rocky.
+This policy covers all code in the `rocky-data/rocky` monorepo. Three things fall outside it:
+
+- Third-party dependencies. Report those to the upstream project.
+- Credentials a user commits to their own fork.
+- Configuration mistakes in a project that consumes Rocky.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -7,35 +7,60 @@
 
 # Rocky VS Code Extension
 
-Editor support for [Rocky](https://github.com/rocky-data/rocky), the typed graph between your code and your warehouse: a real LSP backed by the Rocky compiler, interactive column-level lineage, inline compile-time diagnostics, and AI model generation gated through the compiler.
+Editor support for [Rocky](https://github.com/rocky-data/rocky), the typed graph between your code and your warehouse.
+
+The extension is a language client. It starts `rocky lsp` and asks it the language questions. So the diagnostics, the hover types, and the lineage all come from the same compiler that builds your tables.
+
+```
+  .rocky files          ┌───────────────┐                    ┌──────────────┐
+  models/**/*.sql ─────►│  VS Code      │◄──stdio JSON-RPC──►│  rocky lsp   │
+                        │  extension    │  diagnostics,      │  (compiler)  │
+                        └───────┬───────┘  hover, rename     └──────────────┘
+                                │
+                                │ spawns `rocky <verb>` for commands
+                                ▼
+                        ┌───────────────┐
+                        │  rocky CLI    │──► your warehouse
+                        └───────────────┘
+```
+
+Rocky reads plain SQL as well as the `.rocky` DSL. The language server attaches to both.
 
 ## In action
 
-**See the SQL behind the DSL.** Open any model and reveal its compiled SQL side by side, including the transformations Rocky applies for you (here `!=` becomes a null-safe `IS DISTINCT FROM`, and the post-aggregate filter becomes `HAVING`).
+**See the SQL behind the DSL.** Open a model and run `Rocky: Open Compiled SQL`. The compiled SQL appears beside it and refreshes every time you save. Here `!=` becomes a null-safe `IS DISTINCT FROM`, and the post-aggregate filter becomes `HAVING`.
 
-<p align="center"><img src="https://raw.githubusercontent.com/rocky-data/rocky/main/editors/vscode/media/demo-compiledSql.gif" alt="A Rocky DSL model on the left and its compiled SQL on the right, updating live" width="820" /></p>
+<p align="center"><img src="https://raw.githubusercontent.com/rocky-data/rocky/main/editors/vscode/media/demo-compiledSql.gif" alt="A Rocky DSL model on the left and its compiled SQL on the right" width="820" /></p>
 
-**Inspect any model.** The Inspector is a model trust dashboard in the bottom panel: an Overview (cost, blast radius, drift, governance, freshness), Columns, an interactive Lineage canvas, Tests, Preview, and per-column Profile. Here a PII-classified model flags a column left unmasked, the Columns tab traces each column's upstream lineage, and the Lineage canvas shows the model's neighborhood with a cost overlay.
+**Inspect a model.** The Inspector opens in the bottom panel with six tabs: Overview, Columns, Lineage, Tests, Preview, and Profile. Overview is a trust dashboard. It carries cards for cost, blast radius, contract, freshness, drift, and classified columns.
+
+In the recording below, a PII-classified model flags a column left unmasked. Columns then traces each column to its upstream source. The Lineage canvas draws the model's neighbourhood with a cost overlay.
 
 <p align="center"><img src="https://raw.githubusercontent.com/rocky-data/rocky/main/editors/vscode/media/demo-inspector.gif" alt="The Rocky Inspector touring a PII-classified model: an Overview trust dashboard with a red Governance card, Columns, the lineage canvas with a cost overlay, Tests, and per-column Profile" width="820" /></p>
 
-**Drive it from the keyboard.** Every Rocky command is one palette away.
+**Drive it from the keyboard.** Every command carries the `Rocky:` prefix in the VS Code command palette.
 
 <p align="center"><img src="https://raw.githubusercontent.com/rocky-data/rocky/main/editors/vscode/media/demo-quickstart.gif" alt="Opening the command palette filtered to the Rocky commands" width="820" /></p>
 
 ## Features
 
-**Editor intelligence**: diagnostics, hover, go-to-definition, find references, rename, code actions, signature help, document symbols, and inlay hints for inferred column types.
+**Editor intelligence**: diagnostics, hover, completion, go-to-definition, find references, rename, quick-fix code actions, signature help, document symbols, and inlay hints for inferred column types. Formatting applies to `.rocky` files only. Folding also works on the `.sql` files under `models/`.
 
-**Syntax**: `.rocky` TextMate grammar + semantic tokens, plus code snippets for every DSL construct (`from`, `where`, `group`, `derive`, `select`, `join`, `sort`, `match`, `window`).
+**Syntax**: a TextMate grammar and semantic tokens for `.rocky` files. Snippets cover the DSL operators (`from`, `where`, `derive`, `group`, `join`, `select`, `sort`, `take`, `match`) and the sidecar blocks (`model`, `source`, `target`, `strategy-incremental`).
 
-**Activity bar sidebar**: Get Started, Extension Info, Models, Runs, Sources, and Help panels. Workspaces without a `rocky.toml` show orientation and one-click actions for Initialize Project, Try Playground, and Open Documentation instead of CLI errors.
+**Activity bar sidebar**: Get Started, Extension Info, Models, Runs, Sources, Schema, Previews, Branches, and Help. A workspace with no `rocky.toml` shows orientation instead of CLI errors, with buttons for Initialize Rocky Project, Try the Playground, and Open Documentation.
 
-**Lineage view**: `Rocky: Show Model Lineage` renders the column-level DAG as an interactive graph.
+**Lineage**: `Rocky: Show Model Lineage` opens the Inspector on its Lineage tab, framed on the model you are editing.
 
-**AI generate**: `Rocky: Generate Model from Intent` creates a model from a natural language description using the Rocky AI intent layer.
+**AI generate**: `Rocky: Generate Model from Intent` turns a description in plain English into a model. Rocky compiles each attempt and retries up to three times. It writes the model and its sidecar into `models/` only when the model type-checks. The command opens the result in a new tab, including the path of each file it wrote.
 
-**Status bar**: LSP server status and live error count.
+**Agent mode**: the extension registers `rocky mcp` as a Model Context Protocol server for each workspace folder that has a `rocky.toml` at its root. Agent mode then drives Rocky through the engine's 30 tools. Most of them only read: compile, lineage, schema, row samples, and run history. Six of them write.
+
+`draft_model`, `draft_contract`, and `draft_check` write files under `models/`. `propose` records a plan for a human to review, and applies nothing itself. `pause_schedule` pauses a pipeline's schedule, and `review_queue` can sign off a pending plan. Those last two refuse to act unless the agent passes `confirm: true`.
+
+A `@rocky` chat participant handles four single-shot requests: `/generate`, `/explain`, `/sync`, and `/test`.
+
+**Status bar**: language server state and a live error count.
 
 ## Requirements
 
@@ -50,7 +75,7 @@ From the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemNa
 2. Search for **Rocky**.
 3. Install and reload.
 
-The extension spawns `rocky lsp` on startup and attaches it as the language server for `.rocky` files.
+The extension starts `rocky lsp` on activation. It attaches the server to every `.rocky` file, and to every `.sql` file under a `models/` directory.
 
 ## Settings
 
@@ -59,19 +84,30 @@ The extension spawns `rocky lsp` on startup and attaches it as the language serv
 | `rocky.server.path` | `"rocky"` | Path to the Rocky binary |
 | `rocky.server.extraArgs` | `[]` | Extra arguments passed to `rocky lsp` |
 | `rocky.inlayHints.enabled` | `true` | Show inferred types inline |
+| `rocky.diagnostics.enabled` | `true` | Show inline errors and warnings from `rocky compile` |
+| `rocky.costAnnotations.enabled` | `true` | Show inline cost annotations above model files |
+| `rocky.statusBar.segments` | `[]` | Extra status bar segments: `warehouse`, `lastRunAge`, `driftCount`, `branchState` |
+| `rocky.preview.rowLimit` | `100` | Maximum rows returned by a row preview |
+| `rocky.preview.allowWarehouse` | `false` | Allow row previews to run against a non-DuckDB warehouse |
 
 ## Commands
 
-A subset of the most common commands; see `Rocky: Open Command Palette` for the full list (58 commands across compile, run, AI, lineage, branch, preview, and ops).
+Press `Cmd+Shift+R` (`Ctrl+Shift+R` on Windows and Linux) for a grouped shortlist of the everyday commands, under Pipeline, Model, Infra, and AI.
+
+For anything else, open the VS Code command palette and type `Rocky:`. The table below is the common handful.
 
 | Command | Description |
 |---------|-------------|
-| `Rocky: Initialize Rocky Project` | Scaffold a new Rocky project in the current workspace |
-| `Rocky: Try the Playground` | Create the self-contained DuckDB playground |
-| `Rocky: Restart Language Server` | Restart the LSP server |
-| `Rocky: Show Model Lineage` | Open lineage graph for the current model |
-| `Rocky: Generate Model from Intent` | Create a model from a natural language description |
-| `Rocky: Doctor` | Run health checks; results render in a webview |
+| `Rocky: Compile Models` | Type-check the models and validate the contracts |
+| `Rocky: Run Pipeline` | Execute the full pipeline against your warehouse |
+| `Rocky: Plan Pipeline (Dry Run)` | Preview the SQL without writing to the warehouse |
+| `Rocky: Open Compiled SQL` | Show the compiled SQL for the model you are editing |
+| `Rocky: Show Model Lineage` | Open the Inspector's lineage canvas on the current model |
+| `Rocky: Generate Model from Intent` | Write a model from a description in plain English |
+| `Rocky: Run Health Check` | Check the CLI install and the project config; results open in a webview |
+| `Rocky: Initialize Project` | Scaffold a Rocky project in the current workspace |
+| `Rocky: Open Playground` | Create the self-contained DuckDB playground |
+| `Rocky: Restart Language Server` | Restart `rocky lsp` |
 
 ## Contributing
 
@@ -79,4 +115,4 @@ Local development setup, architecture notes, and testing commands live in [`DEVE
 
 ## License
 
-[Apache 2.0](../../LICENSE)
+[Apache 2.0](./LICENSE)

--- a/engine/README.md
+++ b/engine/README.md
@@ -1,124 +1,34 @@
 # Rocky
 
-**Rocky is the typed graph between your code and whichever warehouse, table format, or query engine you've chosen.** It is a typed compiler that sits above Databricks, Snowflake, BigQuery, or DuckDB and owns the graph between your code and your data: named branches, content-addressed run records, column-level lineage, compile-time contracts, and per-model cost attribution. It ships as a single static Rust binary, and storage and compute stay where they are.
+Rocky is a SQL transformation engine. You write each model as a plain SQL file,
+or in the optional `.rocky` DSL. Rocky type-checks the model, resolves the
+dependency graph, generates SQL in your warehouse's dialect, and runs it.
 
-**Rocky is a real compiler** with type inference, diagnostic codes, and an IDE, not a warehouse, table format, query engine, or templating layer. The failures that quietly cost data teams the most (silent schema drift, column-rename blast radius, dialect divergence, cost spikes nobody can attribute) become compile errors and blocked PRs.
+Rocky does not store your data. Storage and compute stay in Databricks,
+Snowflake, BigQuery, Trino, or DuckDB. There is no Jinja templating, no
+manifest file, and no separate parse step.
 
-There is no Jinja, no manifest, and no separate parse step.
-
-## Why Rocky exists
-
-The expensive failures in modern data platforms aren't slow queries. They're trust failures:
-
-- A source column type changes upstream and a revenue dashboard quietly diverges for three days.
-- An engineer renames a column on `stg_orders` and 47 downstream models break in production.
-- A `SELECT *` pulls a new column nobody designed for; a downstream join silently double-counts.
-- A Snowflake-only function lands in a Databricks-targeted project and only fails in prod.
-- Warehouse spend doubles in a month and nobody can attribute which model caused it.
-- An auditor asks who changed `fct_revenue.amount`, when, and why, and the answer involves `git blame` and screenshots.
-
-Rocky turns each of these into a compile error or a blocked PR before it ships: a column-type change is `E011` at compile, a rename's blast radius is a `rocky lineage-diff` comment, an unbudgeted cost spike is a `[budget]` block that fails the run, and unmasked classified data fails `rocky compliance`. These failures are invisible to the warehouse and out of scope for the templating layer above it. Rocky is the typed graph in between: real type inference and diagnostic codes, not text macros or runtime checks. For how Rocky compares to other SQL transformation tools, see the [comparison page](https://rocky-data.dev/getting-started/comparison/).
-
-## Scope on the ELT spectrum
-
-| Stage | Rocky | Notes |
-|---|---|---|
-| Extract (SaaS sources) | — | Use Fivetran, Airbyte, Stitch, or warehouse-native CDC |
-| Extract (files) | ✅ | `rocky load`: CSV / Parquet / JSONL from a directory |
-| Load (bronze replication) | ✅ | Config-driven replication pipelines |
-| Transform | ✅ | Compiled SQL models |
-| Quality | ✅ | Inline assertions during `rocky run` |
-| Orchestration | Partial | First-class Dagster integration; `rocky serve` standalone |
-
-## The trust dimensions
-
-1. **SQL as a typed, compiled language.** Real type inference, diagnostic codes (`E###` errors, `W###` warnings, `P###` portability lints), and a real LSP, not text macros or runtime checks.
-2. **Compile-time column-level lineage.** Rocky knows every column's lineage before a row is written, so `rocky lineage-diff main` can block a PR when a downstream contract breaks.
-3. **Branches and a replayable run ledger.** `rocky branch create`, `rocky run --branch`, and `rocky replay`: branches are isolated schemas, and every run is recorded in an auditable ledger (who ran it, the commit, the per-model SQL hash, and row counts). On the content-addressed materialization path, output files are named by the hash of their bytes, and `rocky replay --execute --verify` re-runs a recorded recipe and checks the output reproduces bit-for-bit, locally or on the live warehouse in an isolated replay schema. A standalone `rocky-verify` binary checks a run's manifest offline, with no engine installed.
-4. **Per-model cost attribution.** Cost is a column on every run record. `[budget]` blocks fail the run, `budget_breach` fires a hook, and `rocky preview cost` projects spend at PR time.
-5. **AI gated through the compiler.** Every AI suggestion is type-checked before it lands. The `Attempts: 2` retry on `rocky ai` is the loop: generate, type-check, auto-fix, then land.
-6. **Dialect-divergence lint.** Cross-warehouse teams write SQL once, and `P001` catches Snowflake-only constructs in a Databricks project at compile time.
-7. **Declarative governance.** RBAC as code with GRANT/REVOKE diffing, Unity Catalog tags, workspace isolation, and masking strategies bound to classification tags, so compliance becomes a CI check.
-8. **An agent policy plane.** A `[policy]` block in `rocky.toml` grades what a principal (a person, CI, or an AI agent) may do, by capability and scope: allow, require review, or deny. Enforcement runs at `apply`, `promote`, and the MCP write tools; blast-radius ceilings and `verify_after` gates fail closed; decisions are recorded to a ledger you query with `rocky audit` and read each morning with `rocky brief`. AI-authored plans stop for human review by default; only an explicit `[policy]` rule you wrote can let one through.
-
-## Quick start
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.sh | bash
-rocky playground my-first-project
-cd my-first-project
-rocky compile       # Type-check all models
-rocky test          # Run assertions locally with DuckDB
-rocky run           # Execute the pipeline
+```
+   models/*.sql + *.toml        models/*.rocky
+              │                        │
+              └───────────┬────────────┘
+                          ▼
+                   rocky compile ───────► diagnostics
+                          │               E001-E036  errors
+                          ▼               W001-W031  warnings
+                      typed IR            P001-P002  lints
+              (every column's type)       I001-I002  information
+                          │
+                          ▼
+                    dialect SQL ──► rocky plan prints it
+                          │
+                          │ rocky run executes it
+                          ▼
+                  your warehouse ──► run record ──► state store
 ```
 
-The playground is self-contained: sample models, contracts, and a DuckDB backend. No credentials needed.
-
-## Features
-
-| Category | Capabilities |
-|----------|-------------|
-| **Compiler** | Type checking, column-level lineage, data contracts, DAG resolution, diagnostics with suggestions |
-| **Branches** | `rocky branch create`/`delete`/`list`/`show`, `rocky run --branch`, `rocky replay <run_id>` |
-| **Agent governance** | `[policy]` rules (allow / require review / deny), blast-radius ceilings, `verify_after` gates, autonomy budgets + `rocky policy freeze`, `rocky policy test` scenario runner, decision ledger (`rocky audit`, `rocky brief`, `rocky review --queue`) |
-| **Reproducibility** | Content-addressed run records with recipe identity, `rocky replay --execute --verify` bit-exact re-execution, `rocky gc --derivable` + hash-verified `rocky restore`, offline `rocky-verify` manifests |
-| **Resilience** | Classified retry of proven-transient failures, opt-in failure containment with honest partial results, review-gated `rocky backfill` plans |
-| **Cost** | Per-model cost attribution on every run, `[budget]` blocks, `budget_breach` hook event |
-| **Observability** | `rocky trace` Gantt output, OpenTelemetry OTLP export, structured JSON events |
-| **Portability** | Dialect-divergence lint across Databricks / Snowflake / BigQuery / DuckDB |
-| **DSL** | Pipeline-oriented `.rocky` syntax; optional, models stay plain SQL by default |
-| **AI** | Intent metadata, schema-sync, intent extraction, test generation |
-| **IDE** | VS Code extension, full LSP (completion, hover, go-to-def, rename, code actions, inlay hints) |
-| **Quality** | Pipeline-level checks + 13 declarative assertions with severity, filters, and row quarantine |
-| **Execution** | DuckDB (local), Databricks (prod), Snowflake + BigQuery (beta) |
-| **Optimization** | Cost-based materialization, storage profiling, compaction, partition archival |
-| **Governance** | Unity Catalog tags, workspace isolation, declarative RBAC with GRANT/REVOKE diffing |
-| **Integration** | Dagster ([dagster-rocky](../integrations/dagster/)), dbt import, CI pipeline |
-
-## CLI at a glance
-
-```bash
-rocky init           # Scaffold a new project
-rocky validate       # Check config without API calls
-rocky compile        # Type-check all models
-rocky test           # Run assertions locally (DuckDB)
-rocky plan           # Preview generated SQL (dry-run)
-rocky run            # Execute the pipeline
-rocky state          # Inspect stored watermarks
-rocky ai "<intent>"  # Generate a model from natural language
-rocky lineage        # Trace column-level lineage
-rocky lineage-diff   # Per-changed-column downstream blast-radius for PR review
-rocky replay         # Verify a recorded run; --execute re-runs deterministic content-addressed models bit-exact
-rocky policy check   # Explain what a policy allows, requires review for, or denies
-rocky policy test    # Run pinned policy scenarios through the real evaluator (CI)
-rocky review         # Approve plans; --queue ranks pending escalations
-rocky audit          # Query the decision ledger; --for walks a custody chain
-rocky brief          # Estate digest with every line cited to the ledger
-rocky gc             # Inventory derivable (recipe-bound) artifacts; eviction behind review
-rocky restore        # Rebuild an evicted artifact, hash-verified, or refuse
-rocky mcp            # Model Context Protocol server for AI agents (28 tools)
-rocky doctor         # Aggregate health checks
-rocky serve          # HTTP API + live watch
-rocky lsp            # Language Server Protocol for IDEs
-```
-
-Full reference: [CLI commands](https://rocky-data.dev/reference/cli/).
-
-## Adapters
-
-| Role | Adapter | Status | Notes |
-|------|---------|--------|-------|
-| Source | Fivetran | Production | REST API discovery of connectors and tables |
-| Source | Airbyte | Beta | Airbyte API discovery of connections and streams |
-| Source | Iceberg | Beta | REST catalog discovery of namespaces and tables |
-| Source | Manual | Production | Schema/table lists inline in `rocky.toml` |
-| Warehouse | Databricks | Production | SQL Statement API + Unity Catalog governance |
-| Warehouse | Snowflake | Beta | SQL execution via Snowflake connector |
-| Warehouse | BigQuery | Beta | SQL execution via BigQuery connector |
-| Warehouse | DuckDB | Local / Testing | Embedded execution for development and CI |
-| Warehouse | Trino | Beta | REST `/v1/statement` polling client; Basic + JWT auth; Docker conformance harness behind the `trino-conformance` feature |
-
-Build a custom adapter in Rust or any language with the [Adapter SDK guide](https://rocky-data.dev/guides/adapter-sdk/), which walks through a ClickHouse-shaped skeleton, the trait surface, auth, testing, and distribution. Concepts overview: [Adapter SDK](https://rocky-data.dev/concepts/adapters/).
+The typed IR is the compiler's internal model of the project. It holds every
+model, every column, and every column's type.
 
 ## Installation
 
@@ -134,7 +44,11 @@ curl -fsSL https://raw.githubusercontent.com/rocky-data/rocky/main/engine/instal
 irm https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.ps1 | iex
 ```
 
-**Build from source** (requires Rust 1.88+):
+Both scripts install the `rocky` binary. Each also installs `rocky-lsp`
+alongside it when the release ships that archive. There is no runtime to
+install.
+
+**Build from source** (requires Rust 1.88 or newer):
 
 ```bash
 git clone https://github.com/rocky-data/rocky.git
@@ -142,9 +56,262 @@ cd rocky/engine
 cargo build --release
 ```
 
+## Quick start
+
+```bash
+rocky playground my-first-project
+cd my-first-project
+rocky compile       # Type-check every model
+rocky test          # Run the models on an in-memory DuckDB
+rocky run           # Execute the pipeline
+```
+
+The playground is self-contained. It ships three sample models, a contract, and
+a DuckDB backend. You need no credentials.
+
+## Main commands
+
+Commands that work on a project read `rocky.toml` from the current directory.
+Some need no project at all, such as `rocky init` and `rocky playground`. To
+read a config somewhere else, put `--config <path>` before the command name:
+`rocky --config path/to/rocky.toml compile`. `--config` is not a global flag,
+so it does not work after the command name.
+
+`--output` is global, so it goes anywhere on the line. Pass `--output json` or
+`--output table` to force a format. Rocky picks `table` for an interactive
+terminal and `json` otherwise.
+
+**Build and check**
+
+```bash
+rocky init           # Scaffold a new project
+rocky validate       # Check the config without connecting to any API
+rocky compile        # Type-check models and validate contracts
+rocky test           # Run local model tests on DuckDB, no warehouse needed
+rocky ci             # Compile + test, no warehouse credentials needed
+rocky plan           # Print the SQL a run would execute
+rocky run            # Execute the pipeline
+rocky state          # Show stored watermarks
+```
+
+`rocky test` runs on an in-memory DuckDB. `rocky test --declarative` does not:
+it runs the `[[tests]]` from your model sidecars against the warehouse adapter
+you configured.
+
+**Understand a project**
+
+```bash
+rocky lineage <model>   # Trace column-level lineage
+rocky lineage-diff      # Report the downstream blast radius of changed columns
+rocky dag               # Show the unified DAG across every pipeline stage
+rocky history           # Show run and model execution history
+rocky metrics <model>   # Show quality metrics; add --alerts or --trend
+rocky trace <run-id>    # Render one run as a Gantt-style timeline
+rocky doctor            # Check config, state, adapters, pipelines, state_sync
+```
+
+**Branch, review, and replay**
+
+```bash
+rocky branch create <name>   # Create a branch (an isolated schema)
+rocky run --branch <name>    # Run the pipeline into that branch
+rocky branch promote <name>  # Promote branch tables to production targets
+rocky replay <run-id>        # Inspect a recorded run
+rocky review <plan-id>       # Review a plan; --queue ranks pending escalations
+rocky audit                  # Query the decision ledger; --for walks a subject
+rocky brief                  # Estate digest, every line cited to the ledger
+```
+
+`rocky brief` defaults to `--since last`. It reports what changed since the
+previous brief, then advances that cursor. The next `--since last` window
+starts where this one ended, so `rocky brief` writes state. The other windows,
+`--since 24h` and `--since 7d`, never touch the cursor.
+
+**Serve and integrate**
+
+```bash
+rocky serve          # HTTP API over the compiler's semantic graph
+rocky lsp            # Language Server Protocol for IDEs
+rocky mcp            # Model Context Protocol server (30 agent tools, 6 write)
+rocky load           # Load CSV, Parquet, or JSONL files from a directory
+rocky ai "<intent>"  # Generate a model from a natural-language description
+```
+
+The engine ships more commands than this page lists. Run `rocky --help` for the
+full set, or read the [CLI reference](https://rocky-data.dev/reference/cli/).
+
+## The gate on agent-authored changes
+
+An AI agent can author a plan. A bare `rocky apply` refuses to execute one. A
+human clears it with `rocky review <plan-id> --approve`, which writes the
+sign-off marker that unblocks the apply.
+
+A `[policy]` block supersedes that default. Rocky evaluates every model the
+plan touches and takes the most restrictive answer. `allow` proceeds with no
+marker, `require_review` still demands one, and `deny` refuses outright. So
+only a `[policy]` rule you wrote lets an agent-authored plan through
+unreviewed.
+
+Rocky enforces the same `[policy]` block at three seams: `rocky apply`,
+`rocky branch promote`, and the MCP authoring tools. Two of its mechanisms
+fail closed. A `max_downstreams` ceiling degrades `allow` to `require_review`
+when the blast radius is over the limit, or cannot be counted at all. A
+`verify_after` gate runs its named checks after the apply, and fails when a
+check did not run at all, not only when a check fails. The write has already
+landed by then, so that failure halts and alerts you. It does not roll the
+write back.
+
+Most of the 30 MCP tools only read. Six can write. Four go through that same
+policy evaluator: `draft_model`, `draft_contract`, `draft_check`, and
+`propose`. In a governed scope the evaluator returns a denial or a review
+requirement, and a denied draft leaves nothing on disk.
+
+The other two carry their own guard. `pause_schedule` needs `confirm: true`.
+Only a human can resume a schedule, with
+`rocky state schedule resume <pipeline>`. `review_queue` can record the human
+sign-off that unblocks `rocky apply`. It needs `confirm: true`, and it refuses
+any plan that is not already in the pending review queue.
+
+To see what a rule resolves to before you rely on it, run
+`rocky policy check --principal agent --capability apply --model <name>`. It
+prints the effect, the winning rule, and the reason. It is read-only.
+
+## What the compiler reports
+
+`rocky compile` prints one diagnostic per problem. Each diagnostic carries a
+stable code, so you can grep for it and gate on it.
+
+| Prefix | Codes | What it means |
+|---|---|---|
+| `E` | E001-E036 | Error. `rocky compile` exits non-zero. |
+| `W` | W001-W031 | Warning. Compilation still succeeds. |
+| `P` | P001-P002 | Lint. P001 flags SQL that does not port to your target dialect. P002 warns on a `SELECT *` whose downstream consumers name specific columns. |
+| `I` | I001-I002 | Information. |
+
+Two examples. A column whose type no longer matches its contract is `E011`. A
+Snowflake-only construct in a Databricks project is `P001`.
+
+The portability lint is opt-in. Run `rocky compile --target-dialect dbx`, or set
+`[portability] target_dialect` in `rocky.toml`. The four targets are `dbx`,
+`sf`, `bq`, and `duckdb`. When it fires, P001 is error severity, so the compile
+exits non-zero. Exempt a construct project-wide with `[portability] allow`, or
+per model with a `-- rocky-allow: <construct>` comment.
+
+## What the engine does
+
+| Category | Capabilities |
+|----------|-------------|
+| **Compiler** | Type checking, column-level lineage, data contracts, DAG resolution, diagnostics with suggestions |
+| **Branches** | `rocky branch create`/`delete`/`list`/`show`/`compare`/`approve`/`promote`, `rocky run --branch`, `rocky replay <run-id>` |
+| **Agent governance** | `[policy]` rules (allow / require review / deny), `max_downstreams` blast-radius ceilings, `verify_after` gates, `autonomy_budget`, `rocky policy check` decision explainer, `rocky policy freeze`, `rocky policy test` scenario runner, decision ledger (`rocky audit`, `rocky brief`, `rocky review --queue`) |
+| **Reproducibility** | Content-addressed run records with recipe identity, `rocky replay --execute --verify` bit-exact re-execution, `rocky gc --derivable --dry-run` inventory of reclaimable artifacts (drop `--dry-run` and it writes a review-gated eviction plan instead), hash-verified `rocky restore` |
+| **Resilience** | Classified retry of transient failures, opt-in failure containment (`contain_failures`), review-gated `rocky backfill` plans |
+| **Cost** | Per-model cost attribution on every run, `[budget]` limits, `budget_breach` hook event, `rocky preview cost --name <branch>` reports a pull request's per-model cost delta against the base branch, plus the budget breaches it projects. It reads a branch that `rocky preview create` registered |
+| **Observability** | `rocky trace` Gantt output, structured JSON events, OpenTelemetry OTLP export when `OTEL_EXPORTER_OTLP_ENDPOINT` is set |
+| **Portability** | Opt-in dialect-divergence lint targeting Databricks, Snowflake, BigQuery, or DuckDB |
+| **DSL** | Pipeline-oriented `.rocky` syntax. It is optional, and models stay plain SQL by default |
+| **AI** | Intent metadata, schema-sync, intent extraction, test generation |
+| **IDE** | VS Code extension, full LSP (completion, hover, go-to-def, rename, code actions, inlay hints) |
+| **Quality** | Pipeline-level checks plus 13 declarative assertions with severity, filters, and row quarantine |
+| **Execution** | DuckDB (local), Databricks (production), Snowflake + BigQuery + Trino (beta) |
+| **Optimization** | Cost-based materialization, storage profiling, compaction, partition archival |
+| **Governance** | Unity Catalog tags, workspace isolation, declarative RBAC with GRANT/REVOKE diffing |
+| **Integration** | Dagster ([dagster-rocky](../integrations/dagster/)), `rocky import-dbt`, `rocky validate-migration`, CI pipeline |
+
+## Gates you can put in CI
+
+Rocky turns several classes of failure into a command that exits non-zero.
+Wire the ones you need into your pipeline.
+
+| You want to catch | Command | How it fails |
+|---|---|---|
+| A model that no longer type-checks | `rocky compile` | Exits non-zero on any `E` code |
+| A broken contract or missing column | `rocky compile` | `E010`-`E013` |
+| A breaking change reaching production | `rocky branch promote <name>` | Refuses unless you pass `--allow-breaking`. The gate skips itself, and records that it did, when the models directory is missing or when either the base ref or the working tree fails to compile |
+| SQL that will not run on your target warehouse | `rocky compile --target-dialect <dbx\|sf\|bq\|duckdb>` | `P001` at error severity |
+| Classified data left unmasked | `rocky compliance --fail-on exception` | Exits 1 on any exception |
+| A run that costs more than budgeted | `rocky run` with `[budget] on_breach = "error"` | Fails the run. The default, `warn`, only fires the `budget_breach` event |
+| A policy edit that opens a hole | `rocky policy test` | Exits non-zero when a `[[policy.tests]]` scenario resolves to the wrong effect |
+
+`rocky lineage-diff` reports the per-column downstream blast radius for a pull
+request. It is a report, not a gate. No finding fails it. It still exits
+non-zero when it cannot produce the report at all, such as an empty base ref or
+a `git diff` that fails.
+
+## Where Rocky sits in an ELT pipeline
+
+| Stage | Rocky | Notes |
+|---|---|---|
+| Extract (SaaS sources) | — | Use Fivetran, Airbyte, Stitch, or warehouse-native CDC |
+| Extract (files) | ✅ | `rocky load`: CSV, Parquet, or JSONL from a directory |
+| Load (bronze replication) | ✅ | Config-driven replication pipelines |
+| Transform | ✅ | Compiled SQL models |
+| Quality | ✅ | Inline assertions during `rocky run` |
+| Orchestration | Partial | Dagster integration; `rocky serve --scheduler` runs an in-process scheduler (experimental) |
+
+For how Rocky compares to other SQL transformation tools, see the
+[comparison page](https://rocky-data.dev/getting-started/comparison/).
+
+## Adapters
+
+| Role | Adapter | Status | Notes |
+|------|---------|--------|-------|
+| Source | Fivetran | Production | REST API discovery of connectors and tables |
+| Source | Airbyte | Beta | Airbyte API discovery of connections and streams |
+| Source | Iceberg | Beta | REST catalog discovery of namespaces and tables |
+| Source | Manual | Production | Schema and table lists inline in `rocky.toml` |
+| Warehouse | Databricks | Production | SQL Statement API + Unity Catalog governance |
+| Warehouse | Snowflake | Beta | SQL execution via the Snowflake connector |
+| Warehouse | BigQuery | Beta | SQL execution via the BigQuery connector |
+| Warehouse | DuckDB | Local / Testing | Embedded execution for development and CI |
+| Warehouse | Trino | Beta | REST `/v1/statement` polling client, Basic + JWT auth |
+
+Build a custom adapter in Rust, or in any language, with the
+[Adapter SDK guide](https://rocky-data.dev/guides/adapter-sdk/). It walks
+through a ClickHouse-shaped skeleton, the trait surface, auth, testing, and
+distribution. For the concepts, see
+[Adapter SDK](https://rocky-data.dev/concepts/adapters/).
+
+## Replaying a recorded run
+
+`rocky replay --execute --verify` re-runs a recorded recipe and checks that the
+output reproduces byte for byte. It runs on a local DuckDB engine by default.
+Pass `--warehouse` to re-run on the live warehouse. Those writes go into an
+isolated replay schema, never a production target. Rocky drops that schema
+afterwards unless you pass `--keep`.
+
+The workspace also contains `rocky-verify`, which validates a run manifest
+offline. Releases do not ship it, so build it with
+`cargo build --release --bin rocky-verify`.
+
+## Migrating from dbt
+
+`rocky import-dbt` converts a dbt project into a runnable Rocky repo. It reads
+`manifest.json` from `target/` when it finds one. Pass `--no-manifest` to force
+the regex-based import instead.
+
+```bash
+rocky import-dbt --dbt-project ./my-dbt --output-dir ./rocky-out
+```
+
+Rocky picks the adapter from the dbt project's `profiles.yml`. It falls back to
+`duckdb` when that profile is unreadable or names an unsupported warehouse.
+Override it with `--target-adapter <duckdb|databricks|snowflake|bigquery>`. The
+importer refuses to write into a non-empty directory unless you pass
+`--overwrite`.
+
+`rocky validate-migration` compares the two projects side by side.
+
+```bash
+rocky validate-migration --dbt-project ./my-dbt --rocky-project ./rocky-out
+```
+
+Add `--sample-size <n>` to compare rows from the warehouse as well as structure.
+
 ## Documentation
 
-**[rocky-data.dev](https://rocky-data.dev)**: concepts, guides, CLI reference, Dagster integration, and the adapter SDK.
+**[rocky-data.dev](https://rocky-data.dev)**: concepts, guides, CLI reference,
+Dagster integration, and the adapter SDK.
 
 ## License
 

--- a/examples/playground/README.md
+++ b/examples/playground/README.md
@@ -1,10 +1,10 @@
 # Rocky Playground
 
-A curated catalog of small POCs that showcase the distinctive capabilities of [Rocky](https://github.com/rocky-data/rocky), plus the benchmark suite comparing Rocky against dbt-core, dbt-fusion, and PySpark.
+A catalog of small POCs, each isolating one [Rocky](https://github.com/rocky-data/rocky) feature. Each one is a complete project you can run.
 
-This catalog is a **learning / reference** companion to the official [rocky/engine/examples/](https://github.com/rocky-data/rocky/tree/main/engine/examples) starter projects. The starters show you the shape of a Rocky project; the POCs here show you *what Rocky can do that other tools can't*.
+This catalog is a **learning / reference** companion to the [rocky/engine/examples/](https://github.com/rocky-data/rocky/tree/main/engine/examples) starter projects. A starter shows you the shape of a Rocky project. A POC here isolates one feature and demonstrates it end to end.
 
-To start your own project, run `rocky playground my-project`: it scaffolds a throwaway DuckDB project you can iterate on freely (the recommended starting point). The [`quickstart`](https://github.com/rocky-data/rocky/tree/main/engine/examples/quickstart) example below is the same shape, checked into the repo as a fixed reference to read rather than scaffold.
+To start your own project, run `rocky playground my-project`. It scaffolds a throwaway DuckDB project you can change freely. The [`quickstart`](https://github.com/rocky-data/rocky/tree/main/engine/examples/quickstart) example is the same shape, checked into the repo to read rather than scaffold.
 
 ## When to look here vs `engine/examples/`
 
@@ -19,7 +19,19 @@ To start your own project, run `rocky playground my-project`: it scaffolds a thr
 
 ## Running a POC
 
-Each POC is a self-contained folder with its own `rocky.toml`, `models/`, and `run.sh`. Most POCs run on local DuckDB with zero credentials.
+Every POC is one self-contained folder. Two files are always there: a `README.md` and a `run.sh`. `run.sh` drives the whole demo, so you never assemble the pieces by hand.
+
+```
+pocs/<category>/<id>-<name>/
+├── README.md     always — the feature, and the output to expect
+├── run.sh        always ──► the one entry point: runs the demo end to end
+├── rocky.toml    the pipeline config, when the POC runs a pipeline
+├── models/       when the POC ships models: .sql / .rocky + .toml sidecars
+├── data/         when the POC needs seed rows, usually seed.sql
+└── contracts/    only when contracts are part of the feature
+```
+
+Clone the repo, then run any POC from the playground root:
 
 ```bash
 git clone https://github.com/rocky-data/rocky.git
@@ -29,14 +41,14 @@ cd rocky/examples/playground
 ./pocs/02-performance/01-incremental-watermark/run.sh
 ```
 
-Or, from inside a POC folder:
+Or run it from inside the POC folder:
 
 ```bash
 cd pocs/02-performance/01-incremental-watermark
 ./run.sh
 ```
 
-**Prerequisites:** Rocky CLI on PATH. Most POCs only need the [DuckDB CLI](https://duckdb.org) for seeding (`brew install duckdb`).
+**Prerequisites:** the Rocky CLI on your `PATH`. Many POCs also use the [DuckDB CLI](https://duckdb.org) to load seed data (`brew install duckdb`).
 
 **88 of 100 POCs run with no external credentials.** See each POC's README for prerequisites.
 
@@ -44,7 +56,7 @@ cd pocs/02-performance/01-incremental-watermark
 
 ### 00 — Foundations (17 POCs · DuckDB)
 
-DSL syntax, materialization basics, playground baseline, the trust-arc 1 storage primitives, file-format ingest and per-tenant routing, plus the plan/apply deployment workflow and project scaffolding.
+Start here. These POCs cover the language, the config layers, and the deploy loop you use in every project.
 
 | POC | Feature |
 |---|---|
@@ -68,7 +80,7 @@ DSL syntax, materialization basics, playground baseline, the trust-arc 1 storage
 
 ### 01 — Quality (11 POCs · DuckDB)
 
-Contracts, inline checks, anomaly detection, local testing, SCD-2 snapshots, standalone quality pipeline, freshness SLAs, cross-source overlap.
+How Rocky catches bad data. These POCs cover contracts, inline checks, named and unit tests, freshness SLAs, anomaly alerts, and SCD-2 history.
 
 | POC | Feature |
 |---|---|
@@ -86,7 +98,7 @@ Contracts, inline checks, anomaly detection, local testing, SCD-2 snapshots, sta
 
 ### 02 — Performance (14 POCs · DuckDB)
 
-Incremental, merge, drift, optimization, ephemeral CTE, delete+insert, adaptive concurrency, cost + budgets, side-by-side strategy showcase, per-table override rules, EXPLAIN-based cost estimation.
+How Rocky avoids rebuilding what has not changed. These POCs cover the incremental, merge, ephemeral, and delete_insert strategies, plus schema drift, cost controls, and concurrency.
 
 | POC | Feature |
 |---|---|
@@ -107,7 +119,7 @@ Incremental, merge, drift, optimization, ephemeral CTE, delete+insert, adaptive 
 
 ### 03 — AI (7 POCs · `ANTHROPIC_API_KEY` for 01–05, DuckDB for 06–07)
 
-AI-powered model generation, intent extraction, schema sync, test generation, schema-grounded validation, MCP data-grounding, and agent-policy testing.
+How Rocky keeps a language model honest. A generated model goes through the compiler first, and Rocky writes it only when it type-checks.
 
 | POC | Feature |
 |---|---|
@@ -121,7 +133,7 @@ AI-powered model generation, intent extraction, schema sync, test generation, sc
 
 ### 04 — Governance (11 POCs · Databricks / DuckDB)
 
-Unity Catalog grants, schema patterns, workspace isolation, tagging, classification + masking, retention, auto-create schemas.
+Who may read what, and who proved it. The Databricks POCs need credentials; the rest run on local DuckDB.
 
 | POC | Feature | Credentials |
 |---|---|---|
@@ -139,7 +151,7 @@ Unity Catalog grants, schema patterns, workspace isolation, tagging, classificat
 
 ### 05 — Orchestration (12 POCs · DuckDB / docker)
 
-Hooks, webhooks, remote state, checkpoint/resume, Valkey cache, Dagster DAG mode, circuit breaker, idempotency.
+How a run starts, where its state lives, and what happens when it fails. Some POCs need Docker for a local backing service.
 
 | POC | Feature |
 |---|---|
@@ -154,10 +166,11 @@ Hooks, webhooks, remote state, checkpoint/resume, Valkey cache, Dagster DAG mode
 | [09-idempotency-key](pocs/05-orchestration/09-idempotency-key) | `rocky run --idempotency-key` dedup — second run with the same key yields `status = "skipped_idempotent"` |
 | [10-state-retention-sweep](pocs/05-orchestration/10-state-retention-sweep) | `[state.retention]` + `rocky state retention sweep` — manual + end-of-run auto-sweep of run history / lineage / audit domains |
 | [11-state-namespacing](pocs/05-orchestration/11-state-namespacing) | `rocky --state-namespace <key>` routes each pipeline/client to its own `<models>/.rocky-state/<key>.redb` (own single-writer lock) — opt-in, byte-identical when off |
+| [12-webhook-ingress](pocs/05-orchestration/12-webhook-ingress) | `rocky serve --scheduler` exposes `POST /api/v1/hooks/trigger/{pipeline}`; an `X-Rocky-Signature` HMAC-SHA256 body signature queues a durable at-most-once run demand, and an `X-Rocky-Delivery` id deduplicates a redelivery |
 
 ### 06 — Developer Experience (21 POCs · DuckDB)
 
-Lineage, HTTP API, dbt import, shadow mode, CI, hybrid workflows, trace Gantt, portability lint, SQL types, PR-preview, lineage-diff, run-watch, dbt-import failure modes, view strategy, dbt unit-test import.
+The daily loop: edit, check, review, ship. Lineage, previews, CI gates, dbt import, and the plain-SQL exit path.
 
 | POC | Feature |
 |---|---|
@@ -185,7 +198,7 @@ Lineage, HTTP API, dbt import, shadow mode, CI, hybrid workflows, trace Gantt, p
 
 ### 07 — Adapters (7 POCs · mixed)
 
-Snowflake, Databricks, Fivetran, custom process adapter, BigQuery, Rust-native adapter skeleton, Trino-via-Docker.
+One POC each for Snowflake, Databricks, BigQuery, Trino, and Fivetran, plus two starters for writing your own adapter. Rocky ships more adapters than this section covers. Check the Credentials column before you run one.
 
 | POC | Feature | Credentials |
 |---|---|---|
@@ -199,20 +212,29 @@ Snowflake, Databricks, Fivetran, custom process adapter, BigQuery, Rust-native a
 
 ## Benchmarks
 
-The [`benchmarks/`](benchmarks/) folder contains a reproducible suite comparing Rocky against dbt-core, dbt-fusion, and PySpark on identical transformation workloads. See [`benchmarks/REPORT_CURRENT.md`](benchmarks/REPORT_CURRENT.md) for the latest numbers.
+The [`benchmarks/`](benchmarks/) folder holds a suite that compares Rocky against dbt-core and dbt-fusion on a generated transformation DAG. `make bench` measures compile time and DAG resolution, and records peak memory for each. Startup, lineage, warm compile, and config validation are separate targets. Run `make help` to list them.
 
-Headline (50k models): Rocky compiles in **10.5s**, **15× faster** than dbt-core, **21× faster** than dbt-fusion, with **5.3× less memory**.
+The suite uses the engine's release binary from this repository, and builds it when it is missing. So it needs the repository and a Rust toolchain, not just the Rocky CLI on your `PATH`. It also needs dbt-core installed. dbt-fusion is optional: the run warns and skips it when it is absent.
 
 ```bash
 cd benchmarks
-make bench          # Run the full suite
+pip install -r requirements.txt   # dbt-core, dbt-duckdb, matplotlib, psutil
+make bench                        # Compile + DAG, at SCALE=10000 models
 ```
+
+[`benchmarks/REPORT_CURRENT.md`](benchmarks/REPORT_CURRENT.md) records one past run. It is dated, and it names the Rocky version it measured. Treat it as a snapshot, not as the current performance of the engine.
 
 ## Adding a POC
 
+Scaffold the folder, write the POC, then update the counts on this page.
+
 ```bash
-./scripts/new-poc.sh 02-performance 10-my-new-feature
+./scripts/new-poc.sh 02-performance 15-my-new-feature
+# ... write models/, run.sh, README.md ...
+bash ../../scripts/update-poc-counts.sh
 ```
+
+The second command rewrites every count in this file from the folders on disk. Never edit those numbers by hand. CI recomputes them and fails the pull request if they drift.
 
 See the monorepo [CONTRIBUTING.md](../../CONTRIBUTING.md) for conventions.
 

--- a/integrations/dagster/README.md
+++ b/integrations/dagster/README.md
@@ -2,15 +2,61 @@
 
 Dagster integration for [Rocky](https://github.com/rocky-data/rocky), the typed graph between your code and your warehouse.
 
-`dagster-rocky` wraps the `rocky` CLI as a Dagster `ConfigurableResource` and exposes Rocky-managed
-tables as materializable Dagster assets. Compile-time contracts, column-level lineage, schema-drift
-detection, quality check results, and per-model cost surface as native Dagster events, so the
-guarantees Rocky enforces at compile time appear directly in the Dagster asset graph.
+`dagster-rocky` runs the `rocky` command-line binary from a Dagster
+`ConfigurableResource` and exposes Rocky-managed tables as materializable
+assets. It is a thin adapter over the
+[`rocky-sdk`](https://pypi.org/project/rocky-sdk/) client, so the guarantees
+Rocky enforces at compile time land in the Dagster asset graph.
 
-Two behaviors worth knowing. Rocky's per-check severity maps to Dagster's, so a failing
-advisory check emits `WARN` instead of paging anyone. And when the engine's failure containment
-is enabled, the models Rocky withholds behind a failed upstream appear as `AssetObservation`
-events naming the blocking model, so a partial run reads honestly in the asset graph.
+```
+  ┌──────────────────┐  selected assets  ┌───────────────────────────┐
+  │  Dagster run     │──────────────────►│ RockyComponent, or your   │
+  │  (materialize)   │   become a filter │ own asset + RockyResource │
+  └──────────────────┘                   └─────────────┬─────────────┘
+                                                       │ argv
+                                                       ▼
+                                   ┌────────────────────────────┐
+                                   │ rocky run --filter k=v     │──► warehouse
+                                   │ --output json              │◄── rows
+                                   └───────┬───────────┬────────┘
+                              stderr lines │           │  stdout JSON
+                                           ▼           ▼
+                                   context.log.info  RunResult
+                                 (via run_streaming) (the component turns
+                                                      it into Dagster events)
+```
+
+## What Rocky output becomes in Dagster
+
+These mappings describe `RockyComponent` on the default
+`execution_mode = "streaming"` path. The `pipes` mode reports over the Pipes
+wire, and `dag_mode` emits through its own path.
+
+| Rocky output | Dagster shape | Fires when |
+|---|---|---|
+| a copied table | `MaterializeResult` | on by default |
+| quality check results | `AssetCheckResult` | on by default |
+| schema drift | `AssetObservation` | on by default |
+| contract violations | `AssetCheckResult` | you set `contracts_dir` |
+| column-level lineage | `TableColumnLineage` metadata | you set `surface_column_lineage: true` |
+| per-model cost recommendations | `AssetSpec` metadata | `surface_optimize_metadata` (on by default), `models_dir` exists, and `rocky optimize` has run history to analyze |
+
+If you build your own assets instead of using the component, the
+`emit_materializations()` helper does the first row for you. It returns a list
+of `AssetMaterialization` events, which you log with `context.log_event`.
+
+Two behaviors are worth knowing.
+
+**A check's severity carries across.** Rocky's per-check severity maps to
+Dagster's. A check that Rocky marks `warning` emits `WARN` when it fails. `WARN`
+does not degrade asset health, so an advisory check does not page anyone.
+
+**Failure containment shows up on the timeline.** Set `contain_failures = true`
+under `[resilience]` in `rocky.toml`. Rocky then withholds the models behind a
+failed upstream instead of failing the whole run. Each withheld model gets an
+`AssetObservation` naming what blocked it, so a partial run reads honestly. Only
+the default `execution_mode = "streaming"` emits these. The `pipes` mode and
+`dag_mode` do not.
 
 ## Install
 
@@ -33,13 +79,34 @@ attributes:
   models_dir: models
 ```
 
-Dagster's component loader will:
+The component reads a cached state file, so write that file before you load the
+definitions. The `dg defs state refresh` workflow calls `write_state_to_path()`
+for you. A scheduled job that resolves the state path from the `defs_state`
+config does the same.
 
-1. Run `rocky discover` (and `rocky compile`, when models are present) and cache the result.
-2. Build one subset-aware `multi_asset` per Rocky group, with declared
-   `row_count` / `column_match` / `freshness` checks per table.
-3. On materialization, shell out to `rocky run --filter <key>=<value>` for the selected subset and
-   yield `MaterializeResult` + `AssetCheckResult` events with rich metadata.
+That refresh is what calls Rocky. It runs `rocky discover`. It also runs
+`rocky compile` and `rocky optimize` when `models_dir` exists on disk, and it
+caches each result it gets.
+
+Compile and optimize are best-effort for transport failures, such as a missing
+binary or a timeout. The refresh logs those and still writes the discovery
+state. One failure is not best-effort. A schema mismatch between
+`dagster-rocky` and the `rocky` binary raises `dg.Failure`, and no state is
+written at all.
+
+Loading the definitions then reads that cached state:
+
+1. Build one subset-aware `multi_asset` per Rocky group. Each table gets at
+   least four declared checks: `row_count`, `column_match`, `freshness`, and
+   `row_count_anomaly`. Contract rules from `contracts_dir` add more, and so do
+   `surface_compliance` and `surface_configured_checks` when you turn them on.
+2. Run `rocky run --filter <key>=<value>` on materialization, for the selected
+   subset only.
+
+Without a state file the component loads no Rocky assets. Set
+`discover_on_missing_state: true` and the loader runs that refresh itself the
+first time, when state lives on the local filesystem. It skips that under
+`dg dev`, where the refresh workflow above is the intended path.
 
 ## Quick start (resource)
 
@@ -61,11 +128,19 @@ Then in an asset:
 ```python
 @dg.asset
 def acme_orders(rocky: RockyResource) -> dg.MaterializeResult:
-    result = rocky.run(filter="tenant=acme")
+    result = rocky.run("tenant=acme")
     return dg.MaterializeResult(
         metadata={"tables_copied": result.tables_copied, "duration_ms": result.duration_ms},
     )
 ```
+
+`run()` takes the filter first and returns a `RunResult`. A partial failure
+returns a result rather than raising, so read `result.errors` to see what did
+not build.
+
+`run()` buffers the output. For a run longer than a few seconds, call
+`run_streaming(context, filter)` instead. It forwards each engine stderr line to
+`context.log.info` as the run progresses. `RockyComponent` uses it by default.
 
 ## Public API
 
@@ -75,7 +150,7 @@ def acme_orders(rocky: RockyResource) -> dg.MaterializeResult:
 | `RockyComponent` | State-backed Dagster component that loads Rocky tables as assets |
 | `RockyDagsterTranslator` | Subclass to customize asset key / group / tag mapping |
 | `RockyMetadataSet` | Namespaced metadata (`source_id`, `strategy`, `watermark`, …) |
-| `load_rocky_assets()` | Functional helper that returns `AssetSpec` for each Rocky table |
+| `load_rocky_assets()` | Functional helper that returns an `AssetSpec` for each enabled Rocky table |
 | `emit_materializations()` / `emit_check_results()` | Convert a `RunResult` into Dagster events |
 | `check_metadata()` | Build a metadata mapping for a single Rocky `CheckResult` |
 | `cost_metadata_from_optimize()` | Extract per-model cost recommendations from `OptimizeResult` |
@@ -84,12 +159,13 @@ def acme_orders(rocky: RockyResource) -> dg.MaterializeResult:
 ## Documentation
 
 * **[Dagster Integration docs](https://rocky-data.dev/dagster/introduction/)**: resource, component, translator, schedules, sensors, pipes, and more
-* **[DEVELOPMENT.md](./DEVELOPMENT.md)**: local setup, architecture, testing
-* **[CHANGELOG.md](./CHANGELOG.md)**: release notes
+* **[DEVELOPMENT.md](https://github.com/rocky-data/rocky/blob/main/integrations/dagster/DEVELOPMENT.md)**: local setup, architecture, testing
+* **[CHANGELOG.md](https://github.com/rocky-data/rocky/blob/main/integrations/dagster/CHANGELOG.md)**: release notes
 
 ## Related projects
 
 * **[Rocky](https://github.com/rocky-data/rocky)**: the Rust SQL transformation engine
+* **[rocky-sdk](https://pypi.org/project/rocky-sdk/)**: the typed Python client this package is built on
 * **[Rocky VS Code extension](https://github.com/rocky-data/rocky/tree/main/editors/vscode)**: VS Code extension with LSP and AI features
 
 ## License

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,17 +1,32 @@
 # rocky-sdk
 
-A typed Python client for the [Rocky](https://rocky-data.dev/) SQL transformation engine.
+A typed Python client for the [Rocky](https://rocky-data.dev/) SQL
+transformation engine.
 
-`rocky-sdk` wraps the `rocky` CLI binary (subprocess + `--output json`) behind a
-typed `RockyClient`. Each method builds the right argv, runs the binary, parses
-the JSON output, and returns a Pydantic model. Failures surface as `RockyError`
-subclasses carrying structured fields (exit code, stderr tail, version strings)
-rather than opaque messages.
+`rocky-sdk` drives the `rocky` command-line binary for you. A `RockyClient`
+method builds the argv, runs the binary with `--output json`, and parses the
+output. Almost every method returns a Pydantic model. A failure raises a
+`RockyError` subclass carrying structured fields, such as the exit code, the
+stderr tail, and the version strings.
 
-It is for **human Python callers**: notebooks, scripts, and orchestrators. The
-[`dagster-rocky`](https://pypi.org/project/dagster-rocky/) integration is a thin
-Dagster adapter built on this client. For AI agents, use `rocky mcp`; for a
-language-agnostic HTTP surface, use `rocky serve`.
+```
+  your code             rocky-sdk            rocky binary        your warehouse
+ ┌──────────┐          ┌────────────┐       ┌───────────┐        ┌───────────┐
+ │ notebook │   call   │            │ argv  │ rocky run │  SQL   │           │
+ │  script  ├─────────►│ RockyClient├──────►│  --output ├───────►│  tables   │
+ │   task   │◄─────────┤            │◄──────┤    json   │◄───────┤           │
+ └──────────┘ Pydantic └────────────┘ JSON  └─────┬─────┘  rows  └───────────┘
+               model         ▲                    │
+                             └────────────────────┘
+                          one stderr line per progress event.
+                          RockyClient passes each line to your
+                          `log_callback`, or to its own logger at INFO.
+```
+
+The SDK is for human Python callers: notebooks, scripts, and orchestrators. For
+AI agents, use `rocky mcp`. For an HTTP surface that any language can call, use
+`rocky serve`. The [`dagster-rocky`](https://pypi.org/project/dagster-rocky/)
+integration is a thin Dagster adapter over this same client.
 
 ## Install
 
@@ -19,10 +34,10 @@ language-agnostic HTTP surface, use `rocky serve`.
 pip install rocky-sdk
 ```
 
-The `rocky` binary is not bundled. Install it separately and put it on `$PATH`
-(or pass `binary_path=`). See the
+The `rocky` binary is not bundled. Install it separately and put it on `$PATH`,
+or pass `binary_path=` to the client. See the
 [releases page](https://github.com/rocky-data/rocky/releases). The SDK requires
-engine **v1.34.0 or newer**.
+engine **v1.34.0 or newer** and checks the version on first use.
 
 ## Usage
 
@@ -31,28 +46,45 @@ from rocky_sdk import RockyClient
 
 client = RockyClient(config_path="rocky.toml")
 
-# Read-only inspection — all return typed Pydantic models
-result = client.compile()
-for diag in result.diagnostics:
-    print(diag.severity, diag.message)
+# Each call below returns a typed Pydantic model.
+# `compile` and `lineage` read the project. They write nothing.
+compiled = client.compile()
+print(compiled.models, "models,", "errors" if compiled.has_errors else "clean")
+for diag in compiled.diagnostics:
+    print(diag.severity, diag.code, diag.message)
 
 lineage = client.lineage("customer_orders", column="email")
-catalog = client.catalog()
+print(lineage.model, lineage.column, len(lineage.trace), "hops")
 
-# Execute a pipeline; stream live progress to a callback
-run = client.run(filter="tenant=acme", log_callback=print)
-print(run.summary)
+# `catalog` writes to disk. It puts `catalog.json`, `edges.parquet` and
+# `assets.parquet` in `./.rocky/catalog/`. `out=` moves that directory.
+# The method has no option that stops the write.
+catalog = client.catalog()
+print(catalog.project_name, len(catalog.assets), "assets")
+
+# Run a pipeline. `filter` is required. `log_callback` gets each stderr line.
+result = client.run("tenant=acme", log_callback=print)
+print(result.status, result.tables_copied, "tables copied")
+print(len(result.materializations), "models materialized")
+
+# A partial failure returns a result, it does not raise. Read `errors` to see
+# what did not build. `asset_key` is a list of path segments, not a string.
+for failure in result.errors:
+    print("failed:", ".".join(failure.asset_key), failure.error)
 ```
 
-### Errors
+## Errors
+
+Every failure is a `RockyError` subclass. Import them from
+`rocky_sdk.exceptions`.
 
 ```python
 from rocky_sdk import RockyClient
-from rocky_sdk.exceptions import RockyVersionError, RockyCommandError, RockyTimeoutError
+from rocky_sdk.exceptions import RockyCommandError, RockyTimeoutError
 
 client = RockyClient(config_path="rocky.toml", timeout_seconds=600)
 try:
-    client.run(filter="tenant=acme")
+    client.run("tenant=acme")
 except RockyTimeoutError as exc:
     print("timed out after", exc.timeout_seconds, "s")
     print(exc.stderr_tail)
@@ -61,28 +93,40 @@ except RockyCommandError as exc:
     print(exc.stderr_tail)
 ```
 
-`RockyError` is the base of the hierarchy:
+`timeout_seconds` is a wall-clock budget for one CLI call. It defaults to 3600.
+A watchdog thread kills the command when the budget runs out. On POSIX it kills
+the whole process group, so any child the binary spawned dies too. On Windows it
+kills the one process.
 
 | Exception | Raised when |
 |---|---|
-| `RockyBinaryNotFoundError` | the `rocky` binary is missing |
+| `RockyBinaryNotFoundError` | the `rocky` binary is missing, or the path is there but will not execute |
 | `RockyVersionError` | the binary is older than the SDK's minimum |
-| `RockyTimeoutError` | a command exceeds `timeout_seconds` |
-| `RockyCommandError` | a command exits non-zero |
-| `RockyPartialFailure` | a non-zero run still returned a parseable partial result (only with `allow_partial=False`) |
-| `RockyOutputParseError` | stdout was not the expected JSON shape |
+| `RockyTimeoutError` | the watchdog killed the command |
+| `RockyCommandError` | the command exited non-zero |
+| `RockyPartialFailure` | the command exited non-zero but printed usable JSON. `run`, `compile`, `test` and the other partial-tolerant methods return that result instead of raising. To get the raise, call `run_cli` yourself: its `allow_partial` defaults to `False`. Subclasses `RockyCommandError` |
+| `RockyOutputParseError` | stdout was not the JSON shape the SDK expected |
 | `RockyServerError` | a `rocky serve` HTTP request failed |
-| `RockyGovernanceError` | a `governance_override` would silently full-revoke |
+| `RockyGovernanceError` | a `governance_override` is malformed, or its empty `workspace_ids` would revoke every workspace binding on the target catalog |
 
-## Example
+## Example script
 
-A runnable end-to-end script lives at [`examples/quickstart.py`](examples/quickstart.py). With the `rocky` binary on your `PATH`:
+A runnable end-to-end script lives in the repository at
+[`sdk/python/examples/quickstart.py`](https://github.com/rocky-data/rocky/blob/main/sdk/python/examples/quickstart.py).
+The wheel does not ship it, so download that file first. Then, with the `rocky`
+binary on your `PATH`:
 
 ```bash
-python examples/quickstart.py
+python quickstart.py
 ```
 
-It spins up a throwaway DuckDB playground (no credentials) and walks through compile, DAG, lineage, a real run, and typed error handling.
+It creates a throwaway DuckDB playground that needs no credentials. It then
+walks through compile, DAG, lineage, a real run, and typed error handling.
+
+## Documentation
+
+* **[SDK introduction](https://rocky-data.dev/python-sdk/introduction/)**: setup and the full client surface
+* **[SDK recipes](https://rocky-data.dev/python-sdk/recipes/)**: common tasks, end to end
 
 ## License
 


### PR DESCRIPTION
Applies the `docs/STYLE.md` standard to the documentation the site sweep (#1434) did not reach, and fixes the factual drift found on the way.

**Files:** `engine/README.md`, `sdk/python/README.md`, `integrations/dagster/README.md`, `editors/vscode/README.md`, `examples/playground/README.md`, `CONTRIBUTING.md`, `SECURITY.md`.

Three of these are published surfaces: the two Python READMEs are the PyPI package pages (`readme = "README.md"` in each `pyproject.toml`), and the VS Code README is the Marketplace listing.

## The audit mattered more than the rewrite

Each file was rewritten by one agent and audited by an independent one. The audit found **43 defects**. Ranked by consequence:

**Two false safety claims, both on published pages.** The Marketplace listing described the engine's 30 MCP tools as "read-only". Six of them write — four go through the policy evaluator (`draft_model`, `draft_contract`, `draft_check`, `propose`) and two carry their own guard (`pause_schedule`, `review_queue`). The PyPI page labelled `client.catalog()` "read-only inspection" when it persists `catalog.json` and more to disk. A false read-only claim tells someone it is safe to point a tool at production.

**An invented artifact.** The rewrite added `@rocky-data/compiler` to the release table, and SECURITY.md then promised to support it. It has never been published: 404 on npm, its single `engine-wasm-v*` tag has no GitHub Release, and the publish step exits early because the repository has no `NPM_TOKEN` secret. Both files now state that plainly instead.

**A security policy that had quietly narrowed.** The rewrite demoted the direct email channel to a fallback and turned the list of reportable subprojects into a closed set. Email is co-equal again, and every path in the repository is explicitly in scope, `.github/` and `scripts/` named.

**Deleted safety content on the engine README.** The rewrite removed the line stating that a bare `rocky apply` refuses an AI-authored plan until a human approves it — from a page that advertises `rocky ai` and 30 agent tools. Restored, together with where policy is enforced (`apply`, `branch promote`, the MCP authoring tools).

Notably the old wording was **not** restored verbatim. "Blast-radius ceilings and `verify_after` gates fail closed" is false in both halves: `max_downstreams` degrades `allow` to `require_review` rather than denying, and `verify_after` runs *after* the apply — its own failure message says the mutation "has already landed". The page now says it halts and alerts, and does not claim a rollback.

**A command that could not work as printed.** `--config` is not a global flag (only `output`, `cache_ttl` and `principal` are), so `rocky compile --config x.toml` fails with "unexpected argument". The flag must precede the command.

The rest are the same shape as the last sweep: a qualifier dropped and a conditional flattened into an absolute — an open check list rendered as a closed count, an opt-in `--alerts` shown as default output, a guarded promote gate described as unconditional, and a mapping table stated unconditionally when two of its five rows only fire behind flags that default to off.

## A real bug outside the docs

`.git-hooks/pre-commit` checked `integrations/dagster/src/dagster_rocky/types_generated/` for codegen drift. That path stopped existing when the generated Pydantic models moved to `sdk/python/src/rocky_sdk/types_generated/`. The local hook has been silently passing on every Python binding change while CI would fail it. Fixed, and every path it now checks exists.

## Verification

```
python samples on both PyPI pages ... 4/4 parse
relative links across all 8 files .... 0 broken
```

One verifier agent crashed mid-run, leaving `engine/README.md` unaudited while every sibling was checked. It was re-run rather than assumed clean — it turned out to hold 12 defects, including the two deletions above.