### PR TITLE
docs: plain-language sweep for the starter examples and DSL spec

### DIFF
--- a/docs/rocky-lang-spec.md
+++ b/docs/rocky-lang-spec.md
@@ -2,21 +2,57 @@
 
 Version: 0.1.0
 
-## Overview
+This is the full reference for the Rocky DSL. It describes the syntax the
+parser accepts, the SQL each construct lowers to, and the limits the parser
+enforces. For a shorter tour with worked examples, read the
+[Rocky DSL concept page](src/content/docs/concepts/rocky-dsl.md).
 
-The Rocky DSL is a pipeline-oriented language for SQL transformations. Data flows top to bottom through a series of pipeline steps, each transforming the result of the previous step. The DSL compiles to standard SQL through Rocky's compiler, targeting any supported warehouse dialect (Databricks, Snowflake, DuckDB).
+## Scope
 
-## Design Principles
+The DSL is one of two ways to write a Rocky transformation model. The other is
+plain SQL in a `.sql` file. Both compile the same way and produce the same
+kind of model. Neither replaces the other, and one project can hold both.
 
-1. **Pipeline-oriented** — data flows top to bottom, not inside-out like SQL
-2. **Typed** — compile-time type checking via inference
-3. **NULL-safe** — `!=` compiles to `IS DISTINCT FROM`, not SQL's `!=`
-4. **Dialect-agnostic** — no warehouse-specific syntax leaks through
-5. **SQL-interoperable** — `.sql` and `.rocky` files coexist in the same project
+The DSL has no warehouse-specific syntax of its own. Rocky picks the SQL
+dialect later, when it generates the statement it sends to the warehouse.
 
-## File Format
+## How a `.rocky` file becomes warehouse SQL
 
-Rocky DSL files use the `.rocky` extension. A file contains a sequence of pipeline steps, optionally preceded by comments.
+A `.rocky` file passes through two stages that a `.sql` file skips. The parser
+turns tokens into a pipeline AST. `lower_to_sql()` walks that AST and returns
+**one SQL string**. From there a DSL model and a SQL model follow the same
+path.
+
+```
+  models/top_customers.rocky       models/fct_orders.sql
+             │                               │
+   parse     │ tokens ──► pipeline AST       │ used as written
+             │                               │
+   lower     │ lower_to_sql()                │
+             ▼                               ▼
+             └───────► one SQL string ◄──────┘
+                             │
+   compile                   │ type check, resolve depends_on
+                             ▼
+                        one ModelIr ────► compile errors E001-E036
+                             │            (nothing runs)
+   generate                  │ per-dialect SQL generation
+                             ▼
+                        dialect SQL ────► warehouse
+```
+
+There is no separate high-level IR. A model reduces to a single `ModelIr`, and
+the DSL reaches it through the SQL string, not through a direct lowering.
+
+A `.rocky` file that fails to parse never reaches the SQL string. Nor does one
+that parses but cannot lower. Rocky reports the file path and the reason in
+both cases. A pipeline with no `from` step fails to lower with `pipeline must
+start with 'from'`.
+
+## File format
+
+A DSL model is a file with the `.rocky` extension. It holds an optional list of
+`let` bindings, then a sequence of pipeline steps.
 
 ```rocky
 -- This is a comment
@@ -25,12 +61,23 @@ where status != "cancelled"
 select { id, amount }
 ```
 
-Configuration is provided via a sidecar `.toml` file (same name, different extension):
+The lexer drops newlines before the parser runs. A step therefore starts at its
+own keyword and ends where the next step's keyword begins. Newlines and `|`
+between steps are both cosmetic, so put one step per line for readability.
+
+A file with no `let` bindings and no pipeline steps is a parse error.
+
+### The sidecar `.toml` file
+
+A `.rocky` file may sit beside a `.toml` file of the same name. The sidecar
+carries the model's name, its materialization strategy, its target table, and
+its declared tests.
+
 ```toml
 name = "filtered_orders"
 
 [strategy]
-type = "FullRefresh"
+type = "full_refresh"
 
 [target]
 catalog = "warehouse"
@@ -38,11 +85,34 @@ schema = "silver"
 table = "filtered_orders"
 ```
 
-## Pipeline Steps
+The sidecar is optional, and so is every key in it. A `_defaults.toml` file in
+the same directory supplies directory-wide values for `[target]` and
+`[strategy]`. Declare a dependency on another model with `depends_on`.
+
+What Rocky fills in depends on whether the sidecar exists at all:
+
+| Setting | No sidecar | Sidecar present |
+|---|---|---|
+| `name` | the file name without its extension | the same |
+| `[strategy] type` | `full_refresh` | `_defaults.toml`, else `full_refresh` |
+| `[target] catalog` | `_defaults.toml`, else `warehouse` | `_defaults.toml`, else the load fails |
+| `[target] schema` | `_defaults.toml`, else `default` | `_defaults.toml`, else the load fails |
+| `[target] table` | the model name | the model name |
+
+A sidecar that resolves no `catalog` or no `schema` fails to load. Rocky names
+the model and the missing field.
+
+Precedence runs sidecar key first, then the model's config group, then
+`_defaults.toml`.
+
+## Pipeline steps
+
+The parser accepts exactly ten pipeline steps. Data flows from the first step
+to the last.
 
 ### `from`
 
-Start a pipeline from a model or source table.
+Name the table or model the pipeline reads. Every pipeline needs one.
 
 ```rocky
 from orders
@@ -51,13 +121,12 @@ from source.fivetran.orders
 from catalog.schema.table
 ```
 
-- Bare names resolve to other models in the project
-- Dotted names resolve to external sources
-- Optional alias with `as`
+Lowering copies the name into the SQL unchanged. An alias follows the name with
+no `AS` keyword, so `from orders as o` lowers to `FROM orders o`.
 
 ### `where`
 
-Filter rows. Multiple `where` steps are ANDed together. After a `group`, `where` compiles to `HAVING`.
+Filter rows. Rocky joins several `where` steps with `AND`.
 
 ```rocky
 where status == "completed"
@@ -65,9 +134,16 @@ where amount >= 100 and order_date >= @2025-01-01
 where email is not null
 ```
 
+A `where` before a `group` lowers to `WHERE`. A `where` after a `group` lowers
+to `HAVING`.
+
+A `WHERE` clause cannot reference a projection alias. So when a `where` names a
+column an earlier `derive` computed, Rocky substitutes the expression behind
+that name.
+
 ### `group`
 
-Aggregate rows by grouping keys. Aggregation functions are defined inside braces.
+Aggregate rows. Grouping keys come before the braces, aggregations inside them.
 
 ```rocky
 group customer_id {
@@ -77,16 +153,23 @@ group customer_id {
 }
 ```
 
-Multiple grouping keys:
+Use a comma-separated list for several keys:
+
 ```rocky
 group customer_id, region {
     total: sum(amount)
 }
 ```
 
+The keys are optional. `group { total: sum(amount) }` aggregates the whole
+input and emits no `GROUP BY` clause.
+
+A `group` replaces the projection with its keys and its aggregations, in that
+order.
+
 ### `derive`
 
-Add computed columns. Existing columns are preserved.
+Add computed columns and keep the existing ones.
 
 ```rocky
 derive {
@@ -96,9 +179,24 @@ derive {
 }
 ```
 
+A `derive` lowers in one of three ways, depending on where it sits:
+
+| Position | What Rocky does |
+|---|---|
+| Last step, no `group` | Emits `SELECT *, <expr> AS <name>` |
+| Before a `group` | Substitutes the expression into any later step that names it |
+| After a `group` | Adds `<expr> AS <name>` to the projection |
+
+Substitution reaches a later `group`, `where`, `select`, or `derive`. So
+`derive { total: amount * quantity }` followed by `group c { revenue:
+sum(total) }` lowers to `SUM(amount * quantity) AS revenue`.
+
+Substitution replaces bare names only. A qualified name such as `c.total` comes
+from a join, so Rocky leaves it alone.
+
 ### `select`
 
-Choose specific columns. Unlike `derive`, this replaces the column set.
+Choose the columns to keep. Unlike `derive`, this replaces the column set.
 
 ```rocky
 select { id, name, amount }
@@ -106,26 +204,52 @@ select { o.id, c.name }
 select { * }
 ```
 
+Naming a `derive`d column resolves it to its expression. `select { doubled }`
+lowers to `<expr> AS doubled`.
+
 ### `join`
 
-Join with another model. Specify join key and optionally which columns to keep.
+Join another model on one or more shared key columns.
 
 ```rocky
+from orders as o
 join customers as c on customer_id {
     keep c.name, c.email
 }
 ```
 
-Multiple join keys:
+Use a comma-separated list for several keys:
+
 ```rocky
 join products as p on product_id, variant_id {
     keep p.category, p.price
 }
 ```
 
+Rocky builds the join condition from the key names. It qualifies the left side
+with the `from` alias, or with the `from` name when there is no alias. The first
+example therefore lowers to `JOIN customers AS c ON o.customer_id =
+c.customer_id`.
+
+The `{ keep ... }` block is optional. Its columns are appended to the
+projection.
+
+Name a join type before the `join` keyword, or write the pair as one
+underscored word. Both spellings mean the same thing:
+
+| DSL | SQL |
+|---|---|
+| `join` | `JOIN` |
+| `left join` or `left_join` | `LEFT JOIN` |
+| `right join` or `right_join` | `RIGHT JOIN` |
+| `full join` or `full_join` | `FULL JOIN` |
+| `cross join` or `cross_join` | `CROSS JOIN` |
+
+A cross join takes no `on` clause. Every other join type requires one.
+
 ### `sort`
 
-Order results. Default is ascending.
+Order the result. Ascending is the default.
 
 ```rocky
 sort amount desc
@@ -134,7 +258,7 @@ sort name asc, created_at desc
 
 ### `take`
 
-Limit the number of rows.
+Limit the row count. The number must fit in an unsigned 64-bit integer.
 
 ```rocky
 take 100
@@ -143,7 +267,7 @@ take 1_000
 
 ### `distinct`
 
-Deduplicate rows.
+Deduplicate rows. This adds `DISTINCT` to the `SELECT`.
 
 ```rocky
 distinct
@@ -151,16 +275,47 @@ distinct
 
 ### `replicate`
 
-Copy a source table 1:1 (no transformation).
+Copy the source unchanged.
 
 ```rocky
 from source.fivetran.orders
 replicate
 ```
 
+`replicate` lowers the whole pipeline to `SELECT * FROM <source>`. It discards
+every other step in the file, so do not combine it with a filter or a
+projection.
+
+## `let` bindings
+
+A `let` binding names a sub-pipeline. Rocky lowers each one to a common table
+expression (CTE). Bindings come before the main pipeline.
+
+```rocky
+let active = from users
+where is_active == true
+
+from active
+select { id, name }
+```
+
+This lowers to:
+
+```sql
+WITH active AS (SELECT *
+FROM users
+WHERE is_active = TRUE)
+SELECT id, name
+FROM active
+```
+
+A binding ends at the next `let`, at the end of the file, or at a `from` step
+when the binding already has one. Several bindings become a comma-separated
+`WITH` list.
+
 ## Expressions
 
-### Column References
+### Column references
 
 ```rocky
 column_name
@@ -172,23 +327,46 @@ alias.column_name
 ```rocky
 42                    -- integer
 3.14                  -- decimal
-1_000_000             -- numeric separators
-"hello"               -- string (double quotes)
-'world'               -- string (single quotes)
+1_000_000             -- underscores are stripped
+"hello"               -- string, double quotes
+'world'               -- string, single quotes
 true                  -- boolean
 false                 -- boolean
 null                  -- null
 @2025-01-01           -- date literal
-@2025-01-01T10:30:00Z -- timestamp literal
+@2025-01-01T10:30:00Z -- date literal with a time part
 ```
 
-### Operators
+A string literal ends at its own quote character. It has no escape sequences,
+so write a double-quoted string to include an apostrophe. Rocky escapes the
+apostrophe for you: `"it's"` lowers to `'it''s'`.
 
-#### Comparison
-| Operator | SQL Equivalent | Notes |
-|----------|---------------|-------|
+### Date literals
+
+The `@` prefix marks a date literal. It accepts `@YYYY-MM-DD`, optionally
+followed by `THH:MM:SS` and an optional `Z`.
+
+```rocky
+where order_date >= @2025-01-01
+where created_at < @2025-06-15T12:00:00Z
+```
+
+Both forms lower to a `DATE` literal that carries the text verbatim:
+
+```sql
+WHERE order_date >= DATE '2025-01-01'
+WHERE created_at < DATE '2025-06-15T12:00:00Z'
+```
+
+Rocky never emits a `TIMESTAMP` literal here, not even for the form with a time
+part. Check that your warehouse reads that value the way you expect.
+
+### Comparison operators
+
+| Operator | SQL | Notes |
+|---|---|---|
 | `==` | `=` | Equality |
-| `!=` | `IS DISTINCT FROM` | **NULL-safe inequality** |
+| `!=` | `IS DISTINCT FROM` | NULL-safe inequality |
 | `>` | `>` | |
 | `>=` | `>=` | |
 | `<` | `<` | |
@@ -196,25 +374,48 @@ null                  -- null
 | `is null` | `IS NULL` | |
 | `is not null` | `IS NOT NULL` | |
 
-**Key semantic difference:** `!=` in Rocky is NULL-safe. `status != "cancelled"` includes rows where `status IS NULL`, unlike SQL's `status != 'cancelled'` which silently excludes NULLs.
+**`!=` is NULL-safe.** `status != "cancelled"` keeps the rows where `status` is
+`NULL`. SQL's `status != 'cancelled'` drops them, because comparing anything
+with `NULL` yields `NULL` rather than true.
 
-#### Arithmetic
+A single comparison takes at most one operator. Rocky does not chain them, so
+write `a < b and b < c` rather than `a < b < c`.
+
+### Arithmetic operators
+
 | Operator | Meaning |
-|----------|---------|
+|---|---|
 | `+` | Addition |
-| `-` | Subtraction / Negation |
+| `-` | Subtraction, and negation as a prefix |
 | `*` | Multiplication |
 | `/` | Division |
 | `%` | Modulo |
 
-#### Boolean
-| Operator | SQL Equivalent |
-|----------|---------------|
+### Boolean operators
+
+| Operator | SQL |
+|---|---|
 | `and` | `AND` |
 | `or` | `OR` |
 | `not` | `NOT` |
 
-### Function Calls
+### Operator precedence
+
+Operators bind in this order, loosest first:
+
+```
+or
+and
+==  !=  <  <=  >  >=
++   -
+*   /   %
+not  -            (prefix, binds tightest)
+```
+
+Rocky parenthesises a sub-expression in the generated SQL whenever precedence
+requires it. Use your own parentheses to group an expression differently.
+
+### Function calls
 
 ```rocky
 sum(amount)
@@ -224,86 +425,227 @@ max(price)
 coalesce(email, "unknown")
 ```
 
-Functions compile to their SQL equivalents with dialect-specific translations where needed.
+Rocky uppercases the function name and lowers each argument in place. It does
+not check the name or the argument count, and it does not rewrite the call for
+a particular warehouse. `coalesce(email, "unknown")` lowers to `COALESCE(email,
+'unknown')`.
 
-### Date Literals
+The argument list passes through unchanged, so `count()` lowers to `COUNT()`.
+Check that your warehouse accepts that form. `count(1)` lowers to `COUNT(1)`.
 
-Date and timestamp literals use the `@` prefix:
+### Window functions
+
+Add an `over` clause to a function call. The clause holds an optional
+`partition` list, an optional `sort` list, and an optional frame.
+
+Write `partition` and `sort` in either order. Put the frame last, because a
+comma after the frame is a parse error.
 
 ```rocky
-where order_date >= @2025-01-01
-where created_at < @2025-06-15T12:00:00Z
+derive {
+    rn: row_number() over (partition customer_id, sort -order_date),
+    running: sum(amount) over (sort order_date, rows unbounded..current),
+    prev: lag(amount, 1) over (sort order_date)
+}
 ```
 
-Compiles to:
+A `-` prefix on a window sort column means descending. This differs from the
+`sort` pipeline step, which uses the `asc` and `desc` keywords.
+
+A frame starts with `rows` or `range`, then two bounds joined by `..`. Each
+bound is `unbounded`, `current`, or a number.
+
+| Bound | As a start | As an end |
+|---|---|---|
+| `unbounded` | `UNBOUNDED PRECEDING` | `UNBOUNDED FOLLOWING` |
+| `current` | `CURRENT ROW` | `CURRENT ROW` |
+| `3` | `3 PRECEDING` | `3 FOLLOWING` |
+
+So `rows unbounded..current` lowers to `ROWS BETWEEN UNBOUNDED PRECEDING AND
+CURRENT ROW`.
+
+### `match` expressions
+
+A `match` expression lowers to `CASE WHEN`.
+
+```rocky
+from orders
+derive {
+    tier: match amount {
+        > 10000 => "enterprise",
+        > 1000  => "mid-market",
+        _       => "smb"
+    }
+}
+```
+
+This lowers to:
+
 ```sql
-WHERE order_date >= DATE '2025-01-01'
-WHERE created_at < TIMESTAMP '2025-06-15T12:00:00Z'
+SELECT *, CASE WHEN amount > 10000 THEN 'enterprise' WHEN amount > 1000 THEN 'mid-market' ELSE 'smb' END AS tier
+FROM orders
 ```
 
-## Compilation
+A pattern is one of these:
 
-The Rocky DSL compiles through SQL to the same IR used by `.sql` models. The compilation pipeline:
+- `_` — the default arm, which lowers to `ELSE`
+- A comparison operator followed by a value, such as `> 1000`
+- A bare value, which is shorthand for `== value`
 
-```
-.rocky file → Lexer → Parser → AST → Lowering → SQL → Compiler → IR → Dialect SQL
-```
+The `_` arm is optional. Without it the `CASE` has no `ELSE`, so an unmatched
+row yields `NULL`.
 
-### Lowering Rules
-
-| DSL Construct | SQL Output |
-|--------------|-----------|
-| `from X` | `FROM X` |
-| `from X as a` | `FROM X a` |
-| `where expr` | `WHERE expr` (or `HAVING` after `group`) |
-| `group keys { name: agg() }` | `SELECT keys, agg() AS name ... GROUP BY keys` |
-| `derive { name: expr }` | `SELECT *, expr AS name` |
-| `select { cols }` | `SELECT cols` |
-| `join X as a on k` | `JOIN X AS a ON left.k = a.k` |
-| `sort col desc` | `ORDER BY col DESC` |
-| `take N` | `LIMIT N` |
-| `distinct` | `SELECT DISTINCT` |
-| `replicate` | `SELECT *` |
-| `!=` | `IS DISTINCT FROM` |
-| `@2025-01-01` | `DATE '2025-01-01'` |
+`!=` in a match arm lowers to `IS DISTINCT FROM`, the same as it does
+everywhere else.
 
 ## Comments
 
-Line comments start with `--`:
+A line comment starts with `--` and runs to the end of the line.
 
 ```rocky
 -- This is a comment
 from orders  -- inline comment
 ```
 
-## Grammar (Informal)
+## Reserved words
+
+The lexer reserves these 36 words. None of them can be a column name, an alias,
+or a model name.
 
 ```
-file        = pipeline_step+
-pipeline_step = from | where | group | derive | select | join | sort | take | distinct | replicate
+and       as        asc       by        check     current
+derive    desc      distinct  false     from      group
+in        is        join      keep      let       match
+not       null      on        or        order     over
+partition range     replicate rows      select    sort
+take      true      unbounded union     where     window
+```
 
-from        = "from" dotted_name ("as" IDENT)?
-where       = "where" expr
-group       = "group" ident_list "{" (IDENT ":" expr ",")* "}"
-derive      = "derive" "{" (IDENT ":" expr ",")* "}"
-select      = "select" "{" select_item ("," select_item)* "}"
-join        = "join" IDENT ("as" IDENT)? "on" ident_list ("{" "keep" qualified_list "}")?
-sort        = "sort" (IDENT ("asc" | "desc")? ",")*
-take        = "take" NUMBER
-distinct    = "distinct"
-replicate   = "replicate"
+Six of them are reserved but unused. The parser has no construct today that
+accepts `by`, `check`, `in`, `order`, `union`, or `window`. They are reserved
+so a future release can use them without breaking a file that already parses.
 
-expr        = or_expr
-or_expr     = and_expr ("or" and_expr)*
-and_expr    = comparison ("and" comparison)*
-comparison  = additive (("==" | "!=" | "<" | "<=" | ">" | ">=") additive)?
-            | additive "is" "not"? "null"
-additive    = multiplicative (("+" | "-") multiplicative)*
+The join-type words are not on this list. `left`, `right`, `full` and `cross`
+lex as ordinary identifiers, and the parser reads them as a join type only
+where a `join` keyword follows.
+
+## Parser limits
+
+| Limit | Value | What happens past it |
+|---|---|---|
+| Expression nesting depth | 256 | `expression nested too deeply: depth <n> exceeds limit 256` |
+
+The depth cap covers nested parentheses, chained `not`, and function arguments.
+It bounds the parser's stack use, which matters most in the WebAssembly build.
+
+## Lowering reference
+
+| DSL | SQL |
+|---|---|
+| `from X` | `FROM X` |
+| `from X as a` | `FROM X a` |
+| `where e` before a `group` | `WHERE e` |
+| `where e` after a `group` | `HAVING e` |
+| `group k { n: f(c) }` | `SELECT k, F(c) AS n … GROUP BY k` |
+| `derive { n: e }` as the last step | `SELECT *, e AS n` |
+| `derive { n: e }` before a `group` | `e` is substituted into the later step |
+| `derive { n: e }` after a `group` | `e AS n` joins the projection |
+| `select { a, b }` | `SELECT a, b` |
+| `select { * }` | `SELECT *` |
+| `join X as a on k` | `JOIN X AS a ON <left>.k = a.k` |
+| `left join X as a on k` | `LEFT JOIN X AS a ON <left>.k = a.k` |
+| `cross join X as a` | `CROSS JOIN X AS a` |
+| `{ keep a.c }` | `a.c` joins the projection |
+| `sort c desc` | `ORDER BY c DESC` |
+| `take N` | `LIMIT N` |
+| `distinct` | `SELECT DISTINCT` |
+| `replicate` | `SELECT * FROM <source>` for the whole file |
+| `let n = …` | `WITH n AS (…)` |
+| `a == b` | `a = b` |
+| `a != b` | `a IS DISTINCT FROM b` |
+| `e is null` | `e IS NULL` |
+| `f(x)` | `F(x)` |
+| `f(x) over (…)` | `F(x) OVER (…)` |
+| `match e { > v => r, _ => d }` | `CASE WHEN e > v THEN r ELSE d END` |
+| `@2025-01-01` | `DATE '2025-01-01'` |
+| `1_000` | `1000` |
+| `true` | `TRUE` |
+| `null` | `NULL` |
+
+## Grammar
+
+The parser is recursive descent. This grammar describes what it accepts.
+
+```
+file          = let_binding* pipeline_step*   -- at least one of the two
+let_binding   = "let" IDENT "=" pipeline_step+
+pipeline_step = from | where | group | derive | select
+              | join | cross_join | sort | take | distinct | replicate
+
+from       = "from" dotted_name ("as" IDENT)?
+where      = "where" expr
+group      = "group" ident_list? "{" binding_list? "}"
+derive     = "derive" "{" binding_list? "}"
+select     = "select" "{" select_item ("," select_item)* "}"
+join       = join_keyword IDENT ("as" IDENT)? "on" ident_list keep_block?
+cross_join = ("cross" "join" | "cross_join") IDENT ("as" IDENT)? keep_block?
+sort       = "sort" (sort_key ("," sort_key)*)?
+take       = "take" NUMBER
+distinct   = "distinct"
+replicate  = "replicate"
+
+join_keyword = "join"
+             | "left"  "join" | "left_join"
+             | "right" "join" | "right_join"
+             | "full"  "join" | "full_join"
+keep_block   = "{" "keep" qualified ("," qualified)* "}"
+binding_list = IDENT ":" expr ("," IDENT ":" expr)* ","?
+sort_key     = IDENT ("asc" | "desc")?
+select_item  = "*" | qualified
+
+expr           = or_expr
+or_expr        = and_expr ("or" and_expr)*
+and_expr       = comparison ("and" comparison)*
+comparison     = additive "is" "not"? "null"
+               | additive (("==" | "!=" | "<" | "<=" | ">" | ">=") additive)?
+additive       = multiplicative (("+" | "-") multiplicative)*
 multiplicative = unary (("*" | "/" | "%") unary)*
-unary       = "not" unary | "-" unary | primary
-primary     = IDENT ("." IDENT)? | IDENT "(" expr_list ")" | literal | "(" expr ")"
+unary          = ("not" | "-") unary | primary
+primary        = literal
+               | "(" expr ")"
+               | match_expr
+               | IDENT "(" (expr ("," expr)*)? ")" ("over" window_spec)?
+               | qualified
+
+match_expr    = "match" additive "{" match_arm ("," match_arm)* ","? "}"
+match_arm     = match_pattern "=>" expr
+match_pattern = "_" | ("==" | "!=" | "<" | "<=" | ">" | ">=")? additive
+
+window_spec  = "(" window_part* window_frame? ")"
+window_part  = "partition" ident_list
+             | "sort" window_sort ("," window_sort)*
+window_frame = ("rows" | "range") frame_bound ".." frame_bound
+window_sort  = "-"? IDENT
+frame_bound  = "unbounded" | "current" | NUMBER
 
 literal     = STRING | NUMBER | DATE | "true" | "false" | "null"
 dotted_name = IDENT ("." IDENT)*
 ident_list  = IDENT ("," IDENT)*
+qualified   = IDENT ("." IDENT)?
 ```
+
+Terminals:
+
+| Terminal | Pattern |
+|---|---|
+| `IDENT` | `[a-zA-Z_][a-zA-Z0-9_]*`, and not a reserved word |
+| `NUMBER` | `[0-9][0-9_]*` with an optional `.[0-9][0-9_]*` fraction |
+| `STRING` | `"…"` or `'…'`, with no escape sequences |
+| `DATE` | `@YYYY-MM-DD`, optionally `THH:MM:SS` and an optional `Z` |
+
+A `|` between two pipeline steps is skipped. A `--` comment and any whitespace
+are skipped before the parser sees the token stream.
+
+The parser accepts a comma between two items in a brace list, and a trailing
+comma after the last one. It does not require either. Write the commas anyway,
+so the file stays readable.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -902,14 +902,29 @@ rocky retention-status [--model NAME] [--drift]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--model <NAME>` | (all) | Scope the report to a single model. |
-| `--drift` | `false` | Stretch goal reserved for v2; today this filters output to models with a declared policy and leaves `warehouse_days` null. The warehouse probe (`SHOW TBLPROPERTIES` / `SHOW PARAMETERS`) is deferred. |
+| `--drift` | `false` | Keep only the models that declare a policy, and probe the warehouse for the value it currently applies. |
 | `--models <PATH>` | `models` (via `rocky.toml`) | Models directory. |
 
 **Behavior:**
 
-- Compiles the project, then emits one `ModelRetentionStatus` per model with `configured_days`, `warehouse_days` (always `None` in v1), and `in_sync`.
+- Compiles the project, then emits one `ModelRetentionStatus` per model with `configured_days`, `warehouse_days`, and `in_sync`.
 - Models without a `retention` sidecar value report `configured_days = null` and `in_sync = true`.
+- `--drift` probes the warehouse through the governance adapter. Databricks reads the Delta table properties; Snowflake reads `DATA_RETENTION_TIME_IN_DAYS`. BigQuery and DuckDB have no probe, so they report `warehouse_days = null`.
+- A probe failure prints a warning on stderr for that model and leaves `warehouse_days` null. It does not fail the command.
 - JSON output is [`RetentionStatusOutput`](/reference/json-output/).
+
+**An unknown `--model` fails.** `rocky retention-status --model <NAME>` exits `1` when no model carries that name. Stderr reads `model '<NAME>' not found (no transformation model with that name)`, and stdout stays empty even under `--output json`.
+
+**An empty `--drift` result says why it is empty.** `--drift` keeps only the models that declare a policy, so it can legitimately return nothing. That case exits `0` and the JSON payload gains a `message` field, absent whenever `models` is non-empty.
+
+| Situation | `message` |
+|---|---|
+| `--drift --model <NAME>`, and that model declares no policy | `model '<NAME>' declares no retention policy` |
+| `--drift` with no model selected, and none declares a policy | `no models declare a retention policy` |
+
+:::caution[This is a behavior change]
+Earlier engine versions exited `0` for an unknown `--model` and returned an empty `models` array. A CI job that treated the empty array as a pass now fails on a bad selector.
+:::
 
 ---
 
@@ -1052,6 +1067,19 @@ rocky estimate --verbose          # Show the full EXPLAIN plan and pricing rates
 | `--verbose` | `false` | Print extra context per model: the full `EXPLAIN` plan, the pricing rates used, and any models skipped before `EXPLAIN`. |
 
 **Where the prices come from.** Rocky carries one built-in rate table per adapter type: Databricks, Snowflake, BigQuery, and DuckDB. It picks the table matching the pipeline's target adapter. An unrecognized adapter type falls back to the Databricks rates, and `--verbose` labels that as a fallback. `rocky estimate` does not read the [`[cost]`](/reference/configuration/#cost) block, so editing those keys does not move these numbers. For a recommendation rather than an estimate, use `rocky optimize`.
+
+**An unknown `--model` fails.** `rocky estimate --model <NAME>` exits `1` when no model carries that name. Stderr reads `model '<NAME>' not found (no transformation model with that name)`, and stdout stays empty even under `--output json`.
+
+**An empty result says why it is empty.** A run that produces no estimate still exits `0`. Its JSON payload gains a `message` field, absent whenever `estimates` is non-empty.
+
+| Situation | `message` |
+|---|---|
+| The project has no models to estimate | `no models found to estimate` |
+| Models were selected, but SQL generation or `EXPLAIN` failed for every one | `no model produced an estimate` |
+
+:::caution[This is a behavior change]
+Earlier engine versions exited `0` for an unknown `--model` and returned an empty `estimates` array. They also emitted that bare array with no `message`, so text output said `No models found.` while JSON output said nothing. A CI job that treated the empty array as a pass now fails on a bad selector.
+:::
 
 ---
 

--- a/docs/src/content/docs/reference/commands/administration.md
+++ b/docs/src/content/docs/reference/commands/administration.md
@@ -1237,17 +1237,42 @@ rocky retention-status [--model NAME] [--drift]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--model <NAME>` | `string` | | Scope the report to a single model by name. |
-| `--drift` | `bool` | `false` | **v2 stretch, deferred.** v1 filters output to models with a declared policy and leaves `warehouse_days` `null`. In v2, Rocky will probe the warehouse via `SHOW TBLPROPERTIES` (Databricks) / `SHOW PARAMETERS ... FOR TABLE` (Snowflake) and populate `warehouse_days`. The JSON schema is already stable so v2 fills the field without a shape break. Text output prints a `note: --drift probe is deferred to v2` on stderr. |
+| `--drift` | `bool` | `false` | Keep only the models that declare a policy, and probe the warehouse for the value it currently applies. |
 | `--models <PATH>` | `string` | `models` | Models directory. |
 
 ### Behavior
 
 - Compiles the project so each model's resolved `retention` sidecar value surfaces as a typed `Option<RetentionPolicy>`.
 - `configured_days` is `None` when the model's sidecar carries no `retention` key.
-- `warehouse_days` is always `None` in v1 (the probe is deferred).
-- `in_sync` is `true` iff `configured_days == warehouse_days`. In v1, unconfigured models collapse to `in_sync = true` (both sides are `None`).
-- Currently applied only by Databricks (Delta `delta.logRetentionDuration` + `delta.deletedFileRetentionDuration`) and Snowflake (`DATA_RETENTION_TIME_IN_DAYS`). BigQuery and DuckDB are default-unsupported.
+- `warehouse_days` is `None` unless `--drift` probed a warehouse that reports a value.
+- `in_sync` is `true` iff `configured_days == warehouse_days`. Without `--drift`, unconfigured models collapse to `in_sync = true` (both sides are `None`).
+- The `--drift` probe reads Delta `delta.logRetentionDuration` + `delta.deletedFileRetentionDuration` on Databricks, and `DATA_RETENTION_TIME_IN_DAYS` on Snowflake. BigQuery and DuckDB have no probe and report `warehouse_days = null`.
+- A probe failure prints a warning on stderr naming the model and its adapter. The command continues with `warehouse_days = null` rather than aborting.
 - JSON output is `RetentionStatusOutput` (a flat `models` array of `ModelRetentionStatus`).
+
+### A selector that matches nothing fails
+
+`rocky retention-status --model <NAME>` exits `1` when no model carries that name. Stderr reads `model '<NAME>' not found (no transformation model with that name)`. Rocky refuses before it writes any output, so stdout stays empty even under `--output json`.
+
+`--drift` keeps only the models that declare a policy, so it can legitimately return nothing. That case exits `0` and the payload gains a `message` field explaining the empty result. The field is absent whenever `models` is non-empty.
+
+| Situation | `message` |
+|---|---|
+| `--drift --model <NAME>`, and that model declares no policy | `model '<NAME>' declares no retention policy` |
+| `--drift` with no model selected, and none declares a policy | `no models declare a retention policy` |
+
+```json
+{
+  "version": "1.70.1",
+  "command": "retention-status",
+  "models": [],
+  "message": "no models declare a retention policy"
+}
+```
+
+:::caution[This is a behavior change]
+Earlier engine versions exited `0` for an unknown `--model` and returned an empty `models` array. A misspelled or renamed model therefore looked like a project with nothing to report. A CI job that treated the empty array as a pass now fails on a bad selector. `rocky test` and `rocky estimate` gained the same refusal.
+:::
 
 ### Example
 

--- a/docs/src/content/docs/reference/commands/modeling.md
+++ b/docs/src/content/docs/reference/commands/modeling.md
@@ -661,6 +661,23 @@ Each `results` entry carries the model name, the `[[test]]` block's `test` name,
 
 `--declarative` is a separate surface: it adds a `declarative` block summarising `[[tests]]` (plural) declared in model sidecars, run against the configured warehouse adapter rather than DuckDB. See [Testing and Contracts](/concepts/testing/) for both surfaces.
 
+### A selector that matches nothing fails
+
+`rocky test` exits `1` when a selector names something the project does not have. This holds with and without `--declarative`.
+
+| What you passed | Message on stderr |
+|---|---|
+| `--model <NAME>` naming no model in the project | `model '<NAME>' not found (no transformation model with that name)` |
+| `--models <PATH>` naming a missing or empty directory | `no models found in <PATH>` |
+
+Rocky refuses before it writes any output. Under `--output json` stdout stays empty, so read the exit code and stderr rather than the payload.
+
+A model that exists but declares no tests is not an error. It still exits `0` and reports `total: 0`.
+
+:::caution[This is a behavior change]
+Earlier engine versions exited `0` in both rows above. A misspelled or renamed `--model` reported `total: 0` and passed, which looks the same as a real model with no tests. `rocky test --declarative` accepted a models directory that does not exist. A CI job that relied on either no-op now fails. Correct the selector, or remove it to test every model.
+:::
+
 ### Related Commands
 
 - [`rocky compile`](#rocky-compile) -- compile models before testing

--- a/engine/examples/ai-intent/README.md
+++ b/engine/examples/ai-intent/README.md
@@ -1,85 +1,193 @@
 # AI Intent
 
-Demonstrates Rocky's AI features: intent-driven development, automatic test generation, and model explanation.
+Two models that carry an `intent` field in their `.toml` sidecar, plus four
+example test files in `tests/`.
 
-## What is Intent?
+## What `intent` is
 
-The `intent` field in a model's `.toml` sidecar describes what the model should accomplish in plain English. Rocky's AI layer uses this to:
+`intent` is a plain-English sentence in a model's sidecar. It states what the
+model should produce. The `rocky ai-*` commands send it to the Anthropic API
+alongside the compiled schema, so the request carries real column names and
+types.
 
-1. **Generate tests** -- `rocky ai-test` reads the intent and produces SQL assertions that verify the model satisfies its business requirements
-2. **Explain models** -- `rocky ai-explain` generates a human-readable description of what a model does
-3. **Sync models** -- `rocky ai-sync` detects schema changes and proposes intent-guided updates
-4. **Generate models** -- `rocky ai "description"` creates a new model from natural language
+`stg_orders.toml` declares:
 
-## Project Structure
+```toml
+name = "stg_orders"
+intent = "Clean raw order data for downstream consumption. Exclude cancelled orders and orders with non-positive amounts. One row per order. order_id is the unique grain."
+```
+
+## Files
 
 ```
 ai-intent/
-  rocky.toml                 # DuckDB adapter + pipeline config
+  rocky.toml
   models/
-    stg_orders.rocky           # Staging model with intent
-    stg_orders.toml            # intent = "Clean raw orders..."
-    fct_daily_revenue.rocky    # Fact model with intent
-    fct_daily_revenue.toml     # intent = "Daily revenue metrics..."
-  tests/
-    test_stg_orders_not_null.sql           # AI-generated test
-    test_stg_orders_no_cancelled.sql       # AI-generated test
-    test_fct_daily_revenue_positive.sql    # AI-generated test
-    test_fct_daily_revenue_unique.sql      # AI-generated test
+    stg_orders.rocky           + stg_orders.toml         # has intent
+    fct_daily_revenue.rocky    + fct_daily_revenue.toml  # has intent
+  tests/                                                 # example fixtures
+    test_stg_orders_not_null.sql
+    test_stg_orders_no_cancelled.sql
+    test_fct_daily_revenue_positive.sql
+    test_fct_daily_revenue_unique.sql
 ```
 
-## Workflow
+## Prerequisite
 
-### 1. Write models with intent
+`rocky ai`, `rocky ai-test`, `rocky ai-explain`, and `rocky ai-sync` all call
+the Anthropic API. Set `ANTHROPIC_API_KEY` first. Without it each one exits
+with this error:
 
-Add an `intent` field to your `.toml` sidecar:
+```
+Error: ANTHROPIC_API_KEY not set. Set it to use `rocky ai`.
 
-```toml
-name = "fct_daily_revenue"
-intent = "Daily revenue metrics grouped by date. One row per day. Only completed orders."
+Caused by:
+    environment variable not found
 ```
 
-### 2. Generate tests from intent
+Run these from the repository root:
 
 ```bash
-# Requires ANTHROPIC_API_KEY environment variable
-rocky ai-test --models models/
+export ANTHROPIC_API_KEY=...
+cd engine/examples/ai-intent
 ```
 
-Rocky sends the model source code, column schema, and intent to the LLM. The LLM returns SQL assertions -- queries that return 0 rows when the assertion holds.
-
-### 3. Explain existing models
+`rocky compile` needs no key and no warehouse:
 
 ```bash
-rocky ai-explain --models models/ --model stg_orders
+rocky compile
 ```
 
-### 4. Generate a new model from natural language
+## Generate tests from intent
+
+`rocky ai-test` takes a model name as a positional argument, or `--all` for
+every model. It prints the assertions. Add `--save` to write them to disk.
+
+```bash
+rocky ai-test stg_orders
+rocky ai-test --all --save
+```
+
+Running `rocky ai-test` with neither a model name nor `--all` prints
+`Specify a model name or use --all.` and generates nothing.
+
+`--save` writes one `.sql` file per assertion into a `tests/` directory beside
+the models directory. It names each file `<model>_<assertion>.sql` and
+lower-cases the assertion name. A saved file therefore always starts with the
+model name, `stg_orders_` or `fct_daily_revenue_`. The four files already in
+`tests/` start with `test_`, so `--save` adds files beside them. It replaces
+none of them.
+
+## Explain a model
+
+`rocky ai-explain` also takes the model name as a positional argument. There
+is no `--model` flag.
+
+```bash
+rocky ai-explain stg_orders
+rocky ai-explain --all --save
+```
+
+`--save` writes the generated sentence back into the model's `.toml` sidecar
+as its `intent`.
+
+### `--all` means two different things
+
+`--all` does not select the same models on both commands. Read the help text
+before you use it:
+
+| Command | What `--all` selects |
+|---|---|
+| `rocky ai-test --all` | every model |
+| `rocky ai-explain --all` | only the models that declare no `intent` |
+
+Both models in this example declare `intent`, so `rocky ai-explain --all`
+selects nothing. It prints this, writes no file, and exits `0`:
+
+```
+No models to explain. Specify a model name or use --all.
+```
+
+Adding `--save` changes nothing, because there is no explanation to save.
+Name a model instead to explain one that already has an `intent`.
+
+## Propose updates after a schema change
+
+```bash
+rocky ai-sync --with-intent
+```
+
+`--with-intent` limits the report to models that declare an `intent`. The
+command is a dry run by default. Add `--apply` to write the proposed changes.
+
+## Generate a new model
 
 ```bash
 rocky ai "Monthly active customers who placed at least one order"
 ```
 
-### 5. Sync after schema changes
+The intent is a positional argument. `--models` supplies the schema context
+and the destination directory. `--materialization`, `--watermark`,
+`--unique-key`, and `--target` fill in the generated sidecar. An existing file
+at the destination stops the command unless you pass `--overwrite`.
 
-```bash
-# Detect upstream schema changes and propose model updates
-rocky ai-sync --models models/ --with-intent
+## What the generated tests look like
+
+`rocky ai-test --save` writes two comment lines, then the assertion SQL:
+
+```
+-- Test: <assertion name>
+-- <assertion description>
+<assertion SQL>
 ```
 
-## Test Format
+Rocky checks each assertion name before it builds the path. The name may hold
+only letters, digits, `_`, and `-`. Anything else, such as a space, a dot, or
+a slash, stops the save with an error. That guard keeps a generated name from
+writing outside `tests/`.
 
-Each generated test is a SQL query that returns 0 rows when the assertion passes. If any rows are returned, the test fails.
+## The four files in `tests/`
+
+The four files are example fixtures. They ship with this example so you can
+read the shape of an assertion without an API key. Each one is a query that
+returns zero rows when the assertion holds. `tests/test_stg_orders_not_null.sql`
+holds:
 
 ```sql
--- test_stg_orders_not_null.sql
--- Assertion: order_id should never be null
+-- AI-generated test assertion
+-- Intent: order_id is the unique grain and must never be null
+-- Returns 0 rows when assertion holds
+
 SELECT *
 FROM warehouse.staging.stg_orders
 WHERE order_id IS NULL
 ```
 
-## Prerequisites
+Their header is not the header `rocky ai-test --save` writes, so treat them as
+fixtures rather than as a record of a past run.
 
-- Rocky CLI with AI features enabled
-- `ANTHROPIC_API_KEY` environment variable set
+No Rocky command reads a file in `tests/` back. `rocky ai-test --save` only
+writes. Run the queries yourself, or paste them into your own test job. For
+assertions Rocky executes, put `[[tests]]` blocks in the model sidecar and run
+`rocky test --declarative`. See `engine/examples/test-declarative`.
+
+## Where `--config` goes
+
+`--config` is a top-level flag, not a per-command flag. It comes before the
+subcommand, never after:
+
+```bash
+rocky --config rocky.toml compile   # works
+rocky compile --config rocky.toml   # error: unexpected argument '--config' found
+```
+
+The commands above omit it, because `--config` already defaults to
+`rocky.toml` in the working directory.
+
+To run from somewhere else, pass `--models` as well. It defaults to `models`
+relative to the working directory, not relative to the config:
+
+```bash
+rocky --config engine/examples/ai-intent/rocky.toml compile \
+  --models engine/examples/ai-intent/models/
+```

--- a/engine/examples/compare-demo/README.md
+++ b/engine/examples/compare-demo/README.md
@@ -1,76 +1,125 @@
-# Compare Demo
+# Compare demo
 
-Demonstrates `rocky compare` -- validates shadow table copies against production tables. Shadow mode lets you test pipeline changes safely by writing to suffixed tables, then comparing them row-by-row against the existing production output.
+This example shows shadow mode and `rocky compare`. Shadow mode writes a run's
+output to renamed copies of the target tables. `rocky compare` then checks each
+shadow table against the production table it shadows.
 
-## Models
+## The two models
+
+`models/` holds two Rocky DSL models, each with a TOML sidecar.
+
+- `stg_orders` drops cancelled orders and derives `order_amount_usd` and
+  `is_completed`.
+- `fct_daily_orders` aggregates completed orders by `order_date`.
+
+The sidecar `fct_daily_orders.toml` declares `depends_on = ["stg_orders"]`.
+
+## How shadow mode and compare fit together
 
 ```
-raw_orders ──> stg_orders ──> fct_daily_orders
+                ┌─────────────────────┐  writes   ┌──────────────────────┐
+ rocky run ────►│ --shadow            │──────────►│ <table><suffix>      │
+                │ --shadow-suffix     │           └──────────┬───────────┘
+                └─────────────────────┘                      │
+                                                             │ compares
+                                                             │ row count
+                                                             │ + schema
+                ┌─────────────────────┐  reads    ┌──────────▼───────────┐
+ rocky compare ►│ --shadow-suffix     │──────────►│ <table>  (production)│
+                └─────────────────────┘           └──────────────────────┘
 ```
 
-1. **stg_orders** -- Filters cancelled orders, normalizes columns
-2. **fct_daily_orders** -- Daily order aggregation from completed orders
+`--shadow-schema` replaces the suffix instead of adding one. The table keeps its
+name and moves to the schema you name.
 
-## Project Structure
+## Type-check the models
 
-```
-compare-demo/
-  rocky.toml                     # DuckDB backend with checks enabled
-  models/
-    stg_orders.rocky             # Staging model
-    stg_orders.toml              # Sidecar config
-    fct_daily_orders.rocky       # Fact model
-    fct_daily_orders.toml        # Sidecar config
-```
-
-## The Shadow Workflow
-
-Shadow mode is a safe way to validate pipeline changes before they touch production tables. The workflow has two steps:
-
-### Step 1: Run in Shadow Mode
-
-Execute the pipeline with `--shadow`, which writes to suffixed copies of each target table instead of the production tables:
+Run this from the example directory. It needs no warehouse data.
 
 ```bash
-rocky --config engine/examples/compare-demo/rocky.toml run \
-  --shadow --shadow-suffix _shadow
+cd engine/examples/compare-demo
+rocky compile --models models/
 ```
 
-This creates tables like `stg_orders_shadow` and `fct_daily_orders_shadow` alongside the originals.
+Rocky prints:
 
-### Step 2: Compare Shadow vs Production
+```
+  ✓ stg_orders (6 columns)
+  ✓ fct_daily_orders (4 columns)
+  Compiled: 2 models, 0 errors, 0 warnings
+```
 
-Run `rocky compare` to validate the shadow tables against production:
+## Run the two shadow steps
 
 ```bash
-rocky --config engine/examples/compare-demo/rocky.toml compare \
-  --shadow-suffix _shadow
+rocky run --shadow --shadow-suffix _shadow
+rocky compare --shadow-suffix _shadow
 ```
 
-Rocky compares each table pair and reports:
-- **Row count** -- do both tables have the same number of rows?
-- **Schema match** -- do both tables have the same columns and types?
-- **Data diff** -- are there any row-level differences?
+`--shadow-suffix` defaults to `_rocky_shadow` on both commands. Leave it off if
+that name suits you. Pass the same value to both commands when you do set it.
 
-### JSON Output
+## What compare reports
 
-Use `--output json` for machine-readable results:
+`rocky compare` opens both tables in a pair, the shadow one and the production
+one. It reads two things from them.
 
-```bash
-rocky --config engine/examples/compare-demo/rocky.toml compare \
-  --shadow-suffix _shadow --output json
+- **Row count.** It reports both counts, the difference, and the percentage
+  difference.
+- **Schema.** It reports each column that differs between the two tables.
+
+It does not diff rows. `--thresholds` takes JSON and overrides three settings:
+`row_count_diff_pct_warn` (default `0.01`), `row_count_diff_pct_fail` (default
+`0.05`), and `allow_column_order_diff` (default `true`).
+
+## What this example cannot execute
+
+`rocky.toml` declares a DuckDB adapter with no `path`, so Rocky opens an
+in-memory database. That database has no `raw_orders` table and no catalog named
+`warehouse`. Two consequences follow.
+
+The pipeline is a replication pipeline, so `rocky run --shadow` discovers its
+tables from the source. It finds none and copies nothing:
+
+```
+Copied 0 tables in 0.1s (run_id: run-20260816-144334-637)
 ```
 
-## Use Cases
+`rocky compare` enumerates the same discovered tables, so it compares nothing:
 
-- **Testing model changes** -- modify a `.rocky` file, run in shadow mode, compare to verify the change produces expected results
-- **Migration validation** -- when migrating from dbt to Rocky, run both and compare output tables
-- **Branch deployments** -- in Dagster branch deploys, use the branch name as the shadow suffix to isolate changes
+```
+  Rocky Compare
 
-## Flags Reference
+  Tables: 0 compared, 0 passed, 0 warned, 0 failed
+  Overall: PASS
+```
 
-| Flag | Description |
-|------|-------------|
-| `--shadow` | Write to shadow tables instead of production |
-| `--shadow-suffix <suffix>` | Suffix appended to target table names (e.g., `_shadow`, `_branch_123`) |
-| `--output json` | Machine-readable comparison results |
+To see real table pairs, give the adapter a catalog that exists, then create
+schemas named `raw__<source>` inside it. `raw__` is the pipeline's
+`schema_pattern` prefix. Discovery lists schemas by that prefix and returns the
+tables inside each one, so a table called `raw_orders` never enters the
+comparison.
+
+The two models are a separate matter. `rocky run --shadow --models models/`
+compiles them and writes `stg_orders_shadow` and `fct_daily_orders_shadow`.
+`rocky compare` still ignores them: this pipeline is a replication pipeline, so
+compare takes its targets from source discovery. Only a transformation pipeline
+reads compare targets off its models.
+
+## Flags
+
+| Flag | Command | Description |
+|------|---------|-------------|
+| `--shadow` | `run` | Write to shadow targets instead of production |
+| `--shadow-suffix <s>` | `run`, `compare` | Suffix appended to the table name (default `_rocky_shadow`) |
+| `--shadow-schema <s>` | `run`, `compare` | Write shadow tables to this schema instead of adding a suffix |
+| `--models <dir>` | `run` | Models directory for transformation execution |
+| `--all` | `run` | Execute both replication and compiled models |
+| `--thresholds <json>` | `compare` | Comparison thresholds, for example `'{"row_count_diff_pct_fail": 0.05}'` |
+| `--pipeline <name>` | `run`, `compare` | Select a pipeline when the config declares more than one |
+| `--filter <key>=<value>` | `run`, `compare` | Restrict the run to sources whose parsed component matches |
+| `--output json` | `run`, `compare` | Emit `RunOutput` / `CompareOutput` instead of the text report |
+
+`rocky run --branch <name>` is the branch equivalent. It behaves like
+`--shadow --shadow-schema <prefix>`, and it conflicts with `--shadow` and
+`--shadow-schema`.

--- a/engine/examples/dagster-integration/README.md
+++ b/engine/examples/dagster-integration/README.md
@@ -1,66 +1,134 @@
 # Dagster Integration
 
-Orchestrate a Rocky pipeline with Dagster using the `dagster-rocky` package.
+Configuration for orchestrating this Rocky project from Dagster with the
+`dagster-rocky` package. It holds a `rocky.toml`, two models, a `defs.yaml`,
+and a `definitions.py`.
 
-## Architecture
+## How dagster-rocky reaches the engine
 
 ```
-Dagster (orchestrator)
-  |
-  +-- dagster-rocky.RockyComponent
-  |     |
-  |     +-- rocky discover  -->  AssetSpecs (cached, no API calls on reload)
-  |     +-- rocky dag       -->  Full unified DAG (dag_mode)
-  |     +-- rocky run       -->  Execute pipeline
-  |
-  +-- rocky.toml (Rocky config)
-  +-- models/ (Rocky models)
+  Dagster process
+      │
+      ├── RockyComponent  ── builds assets from a cached state file
+      │        │                  at code-location load time
+      │        │
+      │        └── write_state_to_path()  ── runs the CLI, caches JSON
+      │                   │
+      │                   ├──► rocky discover   sources → AssetSpecs
+      │                   ├──► rocky compile    diagnostics → asset checks
+      │                   ├──► rocky optimize   strategy hints → metadata
+      │                   │                     (surface_optimize_metadata, on by default)
+      │                   └──► rocky dag        full graph (dag_mode=True only)
+      │
+      └── RockyResource   ── runs the CLI inside an asset body
+                   └──► rocky run / plan / apply / discover
 ```
 
-## Project Structure
+`RockyComponent` splits the work in two. `write_state_to_path(state_path)`
+shells out to the CLI and writes the JSON. `build_defs_from_state()` reads
+that JSON on every code-location reload and builds the assets from it.
+
+One opt-in changes that. With `discover_on_missing_state: true`, a load that
+finds no state file calls `write_state_to_path` first, so that load does shell
+out. The attribute defaults to `false` and `defs.yaml` here leaves it unset.
+
+`RockyResource` is the imperative alternative. You call `rocky.run(...)` or
+`rocky.plan(...)` from inside an `@dg.asset` function.
+
+## Files
 
 ```
 dagster-integration/
-  rocky.toml              # Rocky pipeline config
-  defs.yaml                  # Dagster component config
-  definitions.py             # Dagster code location
+  rocky.toml               # Rocky pipeline config
+  defs.yaml                # RockyComponent attributes
+  definitions.py           # RockyResource assets
   models/
-    stg_orders.rocky         # Staging model
-    stg_orders.toml
-    fct_order_summary.rocky  # Fact model
-    fct_order_summary.toml
+    stg_orders.rocky       + stg_orders.toml
+    fct_order_summary.rocky + fct_order_summary.toml
 ```
 
-## How It Works
+`defs.yaml` sets three attributes:
 
-### RockyComponent (recommended)
+```yaml
+type: dagster_rocky.RockyComponent
+attributes:
+  binary_path: rocky
+  config_path: rocky.toml
+  state_path: .rocky-state.redb
+```
 
-`RockyComponent` is a state-backed Dagster component that caches `rocky discover` output. Assets appear in the Dagster UI instantly on code location reload without calling any external APIs.
+## Check the Rocky side first
 
-1. **`write_state_to_path()`** calls `rocky discover`, serializes to JSON, and saves to a state file
-2. **`build_defs_from_state()`** reads the cached JSON and creates `AssetSpec` objects without API calls
-
-With `dag_mode=True`, the component also calls `rocky dag` to build a fully connected asset graph where every pipeline stage (source, load, transformation) becomes a Dagster asset with resolved dependencies.
-
-### RockyResource
-
-`RockyResource` wraps the Rocky CLI binary. Use it inside asset functions to run discover, plan, and run commands.
-
-## Setup
+Run these from the repository root. Rocky reads `rocky.toml` from the working
+directory by default, so the `cd` is what lets the rest omit `--config`.
 
 ```bash
-# Install dagster-rocky
-uv add dagster-rocky
-
-# Ensure rocky binary is on PATH
-rocky --version
-
-# Start Dagster dev server
-uv run dg dev
+cd engine/examples/dagster-integration
+rocky compile
+rocky dag
 ```
 
-## Running
+`rocky compile` reports two models. `rocky dag` prints the unified graph.
+
+## This directory is not a runnable Dagster project
+
+There is no `pyproject.toml` here, and none in any parent directory. So
+`uv add dagster-rocky` fails from this directory:
+
+```
+error: No `pyproject.toml` found in current directory or any parent directory
+```
+
+`uv run dg dev` fails too, for a different reason. `uv run` does not need a
+`pyproject.toml`. It fails because `dg` is not installed here:
+
+```
+error: Failed to spawn: `dg`
+  Caused by: No such file or directory (os error 2)
+```
+
+Treat these files as fragments to copy into a Dagster project you have already
+scaffolded.
+
+To use them, create a `dg` project and add `dagster-rocky` to it. Copy
+`rocky.toml`, `models/`, and `defs.yaml` across. Then point `config_path` at
+your copy of `rocky.toml`.
+
+## `rocky discover` returns nothing here
+
+`RockyComponent` builds its assets from `rocky discover`. This example's
+pipeline is a replication pipeline whose source schema pattern needs a
+`raw__*` schema in DuckDB. A fresh database has none, so discover reports
+zero sources and the component builds zero assets:
 
 ```bash
-uv run dg dev
+rocky --output json discover
 ```
+
+```json
+{
+  "version": "...",
+  "command": "discover",
+  "sources": []
+}
+```
+
+Point the pipeline at a warehouse that holds `raw__*` schemas to see assets
+appear.
+
+## Where `--config` goes
+
+`--config` is a top-level flag, not a per-command flag. It comes before the
+subcommand, never after:
+
+```bash
+rocky --config rocky.toml compile   # works
+rocky compile --config rocky.toml   # error: unexpected argument '--config' found
+```
+
+The commands above omit it, because `--config` already defaults to
+`rocky.toml` in the working directory.
+
+`RockyComponent` and `RockyResource` build the argument list through
+`rocky-sdk`, which places `--config` first. Set `config_path` and let the SDK
+order the flags.

--- a/engine/examples/dbt-migration/README.md
+++ b/engine/examples/dbt-migration/README.md
@@ -1,61 +1,213 @@
 # dbt Migration
 
-A side-by-side comparison of a dbt project and its Rocky equivalent, demonstrating how to migrate from dbt to Rocky.
+A small dbt project and the same two models written for Rocky. Use it to try
+`rocky import-dbt` and `rocky validate-migration` on input you can read in
+full.
 
-## Before (dbt)
-
-```
-dbt-project/
-  dbt_project.yml
-  models/
-    staging/
-      stg_customers.sql       # Jinja {{ ref() }}, {{ config() }}
-    marts/
-      fct_orders.sql           # Jinja {{ ref() }}, {{ config() }}
-```
-
-## After (Rocky)
+## Files
 
 ```
-rocky-project/
-  rocky.toml
-  models/
-    stg_customers.sql          # Plain SQL, no Jinja
-    stg_customers.toml         # Config lives in sidecar TOML
-    fct_orders.rocky           # Rocky DSL — pipeline syntax
-    fct_orders.toml            # Config lives in sidecar TOML
+dbt-migration/
+  dbt-project/                       # the input
+    dbt_project.yml
+    models/staging/stg_customers.sql # {{ config() }}, {{ source() }}
+    models/marts/fct_orders.sql      # {{ config() }}, {{ ref() }}
+
+  rocky-project/                     # a hand-written Rocky equivalent
+    rocky.toml
+    models/stg_customers.sql   + stg_customers.toml   # plain SQL
+    models/fct_orders.rocky    + fct_orders.toml      # Rocky DSL
 ```
 
-## Key Differences
+`rocky-project/` shows both model forms. `stg_customers` stays plain SQL with
+the Jinja removed. `fct_orders` is rewritten in the Rocky DSL. Rocky runs SQL
+models and DSL models in the same project, so rewriting is optional.
 
-| Concept | dbt | Rocky |
-|---------|-----|-------|
-| Config | `{{ config(materialized='table') }}` in SQL | Separate `.toml` sidecar file |
-| References | `{{ ref('model_name') }}` | Bare name `from stg_customers` |
-| Templating | Jinja2 | None — compiled DSL or plain SQL |
-| Incremental | Compile or manually rewrite `{% if is_incremental() %}` blocks; raw imports fail closed | `type = "incremental"` in `.toml` + timestamp column |
-| Schema tests | YAML `schema.yml` files | Contracts (`.contract.toml`) or AI-generated tests |
-| CLI | `dbt run`, `dbt test` | `rocky run`, `rocky plan` |
+## Import the dbt project
 
-## Migration Steps
+Run these from the repository root:
 
-1. **Remove Jinja from SQL** -- Replace `{{ ref('model') }}` with the bare model name. Remove `{{ config(...) }}` blocks entirely.
+```bash
+cd engine/examples/dbt-migration
+rocky import-dbt --dbt-project dbt-project/ --output-dir imported/
+```
 
-2. **Create sidecar `.toml` files** -- Move materialization config, tags, and descriptions into `.toml` files alongside each model.
+The importer prints a report and writes a runnable Rocky project:
 
-3. **Convert to Rocky DSL (optional)** -- Models can stay as `.sql` files. Optionally rewrite complex models in `.rocky` for better readability and NULL-safety.
+```
+dbt Migration Report
+====================
 
-4. **Create `rocky.toml`** -- Define your adapter, target, and execution settings. Rocky uses a single config file instead of `profiles.yml` + `dbt_project.yml`.
+Project: ecommerce
+Method:  regex
 
-5. **Validate** -- Run `rocky plan` to preview generated SQL without executing.
+Models:  2 total
+  1 imported successfully  (view: 1, full_refresh: 1)
+  1 with warnings
+
+Next Steps:
+  1. rocky compile
+  2. rocky ai explain --all --save
+Output:  2 models translated, 0 seeds copied → imported/
+         rocky.toml         → imported/rocky.toml
+         MIGRATION-NOTES.md → imported/MIGRATION-NOTES.md
+
+Warnings:
+  stg_customers: source('raw', 'customers') not found in sources.yml
+    -> add a sources.yml definition for this source
+```
+
+Rocky prints the second next step as `rocky ai explain`. The command is
+`rocky ai-explain`, with a hyphen.
+
+`imported/` then holds `rocky.toml`, `MIGRATION-NOTES.md`, and a `models/`
+directory with one `.sql` and one `.toml` per model, plus `_defaults.toml`.
+
+Read `MIGRATION-NOTES.md` before you trust the output. It records what the
+importer could not translate.
+
+### Import flags worth knowing
+
+| Flag | Effect |
+|---|---|
+| `--output-dir <dir>` | Destination. Defaults to `rocky-out`. |
+| `--overwrite` | Write into a non-empty destination. Refused otherwise. |
+| `--manifest <path>` | Use a specific `manifest.json`. Auto-detected from `target/` when omitted. |
+| `--no-manifest` | Force the regex importer even when a manifest exists. |
+| `--target-adapter <name>` | Override the adapter. Read from `profiles.yml` otherwise. |
+| `--skip-unit-tests` | Skip dbt unit-test translation. |
+| `--microbatch-as <mode>` | `merge` (default) or `time_interval` for dbt microbatch models. |
+
+This example ships no `target/manifest.json`, so the importer falls back to
+the regex path and reports `Method: regex`. Run `dbt compile` in your own
+project first to get the manifest path, which resolves `ref()` and `source()`
+exactly.
+
+### Two kinds of Jinja the importer refuses
+
+The importer fails a model rather than translate it when it cannot render the
+Jinja faithfully. It writes no `.sql` and no `.toml` for that model, and the
+report lists it under `Failed:`.
+
+Case one is `is_incremental()`. When a model still holds a
+`{% if is_incremental() %}` block that dbt has not compiled away, every raw
+import path refuses it. For a model named `stg_events` the line reads:
+
+```
+  stg_events: contains an unresolved reference to dbt's `is_incremental()` macro; the raw SQL importer cannot preserve dbt's false-on-bootstrap, true-on-existing-target semantics without either referencing a missing target during bootstrap or deleting bounded incremental logic. Compile dbt in an incremental context, verify the compiled SQL retains its intended predicate and is valid for Rocky's initial target state, and import that manifest; otherwise, rewrite the model with a Rocky-supported strategy
+```
+
+The message names both ways out. Compile dbt in an incremental context and
+import that manifest. Or rewrite the model with a Rocky strategy: set
+`type = "incremental"` and a `timestamp_column` in the sidecar.
+
+```toml
+[strategy]
+type = "incremental"
+timestamp_column = "updated_at"
+```
+
+Case two is `{% for %}` and `{% set %}`. The regex importer strips the
+delimiters and leaves the body behind once, which is wrong, so it refuses
+these instead. The manifest path resolves them, so this refusal is specific to
+a no-manifest import:
+
+```
+  stg_wide: contains unsupported Jinja control flow ({% for %} or {% set %}) that the no-manifest importer cannot faithfully render — re-run after `dbt compile` (the manifest path resolves Jinja) or rewrite the model without loops/assignments
+```
+
+A `{% if %}` block that is not `is_incremental()` is a warning, not a failure.
+The importer keeps the model, heads it with
+`-- TODO: dbt-jinja-not-translated — see MIGRATION-NOTES.md`, and wraps the
+block in `/* TODO: unsupported Jinja block */`. The conditional body then runs
+unconditionally, so review those models.
+
+`rocky import-dbt` still exits `0` when a model fails either way, so read the
+report rather than the exit code. Neither model in `dbt-project/` hits either
+case, so you will not see these here.
+
+## Compare the two projects
+
+```bash
+rocky validate-migration --dbt-project dbt-project/ --rocky-project rocky-project/
+```
+
+The report lists models it could not match and metadata it found missing.
+`--rocky-project` is optional; drop it to inspect the dbt side alone. Add
+`--sample-size <n>` to sample rows when a warehouse is reachable.
+
+## Compile the Rocky project
 
 ```bash
 cd rocky-project
-rocky plan --config rocky.toml
-rocky run --config rocky.toml
+rocky compile
 ```
 
-## NULL-Safety Bonus
+```
+  ✓ stg_customers (7 columns)
+  ✓ fct_orders (7 columns)
+  Compiled: 2 models, 0 errors, 0 warnings
+```
 
-In dbt SQL: `WHERE status != 'cancelled'` silently drops NULL rows.
-In Rocky DSL: `where status != "cancelled"` compiles to `WHERE status IS DISTINCT FROM 'cancelled'`, preserving NULLs.
+`rocky plan` also works here and writes a plan file without executing SQL.
+
+`rocky run` does not work here, for three reasons.
+
+The sidecars target `warehouse.staging` and `warehouse.analytics`. A DuckDB
+session has no catalog called `warehouse`, so `rocky run --models models/`
+reports `Catalog with name warehouse does not exist`.
+
+The models read `source.raw.customers`. This example ships no such table.
+
+`fct_orders.rocky` opens `from stg_orders`, and `rocky-project/` ships no
+`stg_orders` model. That is a missing model, not a missing table. Rocky reads
+an unknown name as a relation it will find in the warehouse, so the compile
+above still passes. The gap shows only at run time. Add a `stg_orders` model,
+or point that line at a table you have.
+
+## What changes when you move a model
+
+| Concern | dbt | Rocky |
+|---|---|---|
+| Materialization, schema, tags | `{{ config(...) }}` in the SQL body | `.toml` sidecar beside the body |
+| Model reference | `{{ ref('stg_orders') }}` | bare name: `FROM stg_orders` or `from stg_orders` |
+| Source reference | `{{ source('raw', 'customers') }}` | qualified name: `source.raw.customers` |
+| Project + connection | `dbt_project.yml` plus `profiles.yml` | one `rocky.toml` |
+| Templating | Jinja | none; the body is SQL or Rocky DSL |
+| Incremental logic | `{% if is_incremental() %}` in the SQL body | `type = "incremental"` plus `timestamp_column` in the sidecar |
+
+The last row is the one that can block an import. `rocky import-dbt` refuses a
+model whose SQL still holds an unresolved `is_incremental()`, as described
+above.
+
+## NULL handling in the Rocky DSL
+
+`fct_orders.rocky` writes `where status != "cancelled"`. The DSL compiles `!=`
+to `IS DISTINCT FROM`:
+
+```sql
+WHERE status IS DISTINCT FROM 'cancelled'
+```
+
+`NULL IS DISTINCT FROM 'cancelled'` is true, so rows with a NULL `status`
+survive the filter. SQL's `!=` evaluates to NULL there and drops them.
+
+This rewrite applies to the DSL only. A `.sql` model keeps SQL's own
+three-valued logic, so `WHERE status != 'cancelled'` still drops NULL rows.
+Check `rocky emit-sql` when you want to see exactly what a model will run.
+
+## Where `--config` goes
+
+`--config` is a top-level flag, not a per-command flag. It comes before the
+subcommand, never after:
+
+```bash
+rocky --config rocky.toml compile   # works
+rocky compile --config rocky.toml   # error: unexpected argument '--config' found
+```
+
+The `rocky compile` above omits it, because `--config` already defaults to
+`rocky.toml` in the working directory.
+
+`rocky import-dbt` and `rocky validate-migration` never read a `rocky.toml`.
+Each takes its paths from its own flags, so neither needs `--config`.

--- a/engine/examples/docs-demo/README.md
+++ b/engine/examples/docs-demo/README.md
@@ -1,67 +1,85 @@
-# Docs Demo
+# Docs demo
 
-Demonstrates `rocky docs` -- generates a self-contained HTML documentation catalog from your models and their `.toml` sidecar metadata.
+This example shows `rocky docs`. The command reads your models and their TOML
+sidecars, then writes one self-contained HTML page. The page has no external
+CSS, no external JavaScript, and no server.
 
-## Models
+## The four models
 
-```
-raw_customers (SQL) ──> stg_customers (Rocky DSL) ──┐
-                                                     ├──> fct_customer_orders (Rocky DSL)
-raw_orders (SQL) ───────────────────────────────────┘
-```
-
-1. **raw_customers** -- Source customer data with profile information
-2. **raw_orders** -- Source order data with status and amounts
-3. **stg_customers** -- Active customers with derived full name and tenure
-4. **fct_customer_orders** -- Per-customer order aggregation joining orders with customer profiles
-
-## Project Structure
+`models/` mixes both model formats. Rocky reads plain SQL files and Rocky DSL
+files from the same directory.
 
 ```
-docs-demo/
-  rocky.toml                        # DuckDB backend, local state
-  models/
-    raw_customers.sql               # Source model (plain SQL)
-    raw_customers.toml              # Sidecar: intent, tests
-    raw_orders.sql                  # Source model (plain SQL)
-    raw_orders.toml                 # Sidecar: intent, tests
-    stg_customers.rocky             # Staging model (Rocky DSL)
-    stg_customers.toml              # Sidecar: depends_on, intent, tests
-    fct_customer_orders.rocky       # Fact model (Rocky DSL)
-    fct_customer_orders.toml        # Sidecar: depends_on, intent, tests
+raw_customers ──► stg_customers ──┐
+                                  ├──► fct_customer_orders
+raw_orders ───────────────────────┘
 ```
 
-## Running
+- `raw_customers` and `raw_orders` are `.sql` files, each with a `.toml`
+  sidecar.
+- `stg_customers` is a `.rocky` file. It keeps active customers and derives a
+  full name and a tenure.
+- `fct_customer_orders` is a `.rocky` file. It aggregates orders per customer.
+
+## Generate the page
 
 ```bash
-# Generate the HTML documentation catalog
-rocky --config engine/examples/docs-demo/rocky.toml docs \
-  --models engine/examples/docs-demo/models/
-
-# Open the generated file in your browser
-open docs/index.html
+cd engine/examples/docs-demo
+rocky docs --models models/
 ```
 
-## What Gets Generated
+Rocky prints:
 
-The generated HTML site includes:
+```
+Documentation generated: docs/catalog.html (4 models, 2 ms)
+```
 
-- **Model catalog** -- all models listed with name, intent (description), and strategy
-- **Dependency graph** -- visual DAG showing how models connect
-- **Model detail pages** -- generated SQL, sidecar config, column list, and test definitions
-- **Search** -- full-text search across model names and descriptions
-- **Self-contained** -- single HTML file with embedded CSS and JS, no server needed
+Open `docs/catalog.html` in a browser.
 
-## Key Sidecar Fields
+Pass `--output-path <file>` to write somewhere else. The default is
+`docs/catalog.html`. Rocky creates the parent directory if it is missing.
 
-The `.toml` sidecars drive the documentation content:
+## What the page contains
 
-| Field | Purpose |
-|-------|---------|
-| `name` | Model display name |
-| `intent` | Description shown in the catalog (maps to the model's documentation) |
-| `depends_on` | Upstream model references, used to build the DAG |
-| `[strategy]` | Materialization strategy (full_refresh, incremental, etc.) |
-| `[target]` | Where the model materializes (catalog, schema, table) |
-| `[[tests]]` | Data quality assertions listed on the model detail page |
+A banner at the top counts models, pipelines, and adapters. Below it sits one
+filterable table. Each row is one model, with these columns: Model, Target,
+Strategy, Deps, and Tests. Deps and Tests are counts.
 
+Click a model name to expand a panel below it. The panel shows the model's
+`intent` text, then three sections: Columns, Dependencies, and Tests.
+
+The search box filters rows by model name. It does not search descriptions,
+targets, or column names.
+
+## Why the Columns section is empty here
+
+`rocky docs` builds the page from `rocky.toml` and the model files. It opens no
+warehouse adapter, so it has no column types to show. Every model in this
+example therefore reports `No column metadata available`.
+
+`rocky.toml` is not optional. The command reads it before it reads a model, and
+it counts the configured pipelines and adapters for the banner. Run `rocky docs`
+in a directory that holds `models/` but no config and it stops with exit 1:
+
+```
+  × No rocky.toml found at 'rocky.toml'
+  help: Run `rocky init` to create a new project, or use `--config <path>` to
+        specify a config file.
+        Run `rocky playground` to try Rocky with a sample DuckDB project.
+```
+
+## Sidecar fields the page reads
+
+| Field | What the page does with it |
+|-------|----------------------------|
+| `name` | Names the row and the expandable panel |
+| `intent` | Renders as the model's description |
+| `depends_on` | Fills the Deps count and the Dependencies list |
+| `[strategy]` | Renders as the Strategy badge, for example `full_refresh` |
+| `[target]` | Renders as the Target column, as `catalog.schema.table` |
+| `[[tests]]` | Fills the Tests count and the Tests list, with each test's severity |
+
+A sidecar may also carry a `[columns]` table of per-column descriptions. Rocky
+parses that table, but `rocky docs` does not render it today. Each description
+hangs off a column entry, and the page has no column entries to hang one on. No
+flag and no earlier command changes that.

--- a/engine/examples/fmt-demo/README.md
+++ b/engine/examples/fmt-demo/README.md
@@ -1,21 +1,39 @@
-# Fmt Demo
+# Fmt demo
 
-Demonstrates `rocky fmt` -- an opinionated formatter for `.rocky` files, similar to `rustfmt` or `prettier`. No `rocky.toml` is needed because formatting operates on files directly.
+This example shows `rocky fmt`, the formatter for `.rocky` files. The command
+takes file and directory paths, so it needs no `rocky.toml`.
 
-## Project Structure
+## The two files
 
 ```
 fmt-demo/
   models/
-    messy_model.rocky    # Deliberately poorly formatted
-    clean_model.rocky    # Already well-formatted (no-op)
+    messy_model.rocky    # indentation is wrong; rocky fmt rewrites it
+    clean_model.rocky    # already formatted; rocky fmt leaves it alone
 ```
 
-## Before / After
+Both files hold the same pipeline. `clean_model.rocky` is hand-spaced, so it
+shows the house style, not the formatter's output.
 
-**Before** (`messy_model.rocky`):
+## What the formatter changes
+
+`rocky fmt` applies four rules.
+
+1. It trims trailing whitespace from every line.
+2. It re-indents each line by brace depth, four spaces per level. Pipeline
+   keywords such as `from`, `where`, and `select` sit at column 0.
+3. It collapses three or more blank lines into two.
+4. It ends the file with exactly one newline.
+
+It does not change spacing inside a line. `amount>100` stays `amount>100`, and
+`where   status` keeps its three spaces.
+
+## Before and after
+
+`models/messy_model.rocky` before:
 
 ```rocky
+-- This file is deliberately poorly formatted to demonstrate rocky fmt
 from    raw_orders
   where   status   !=    "cancelled"
 derive    {
@@ -33,46 +51,73 @@ order_id,
     sort    order_amount_usd    desc
 ```
 
-**After** (formatted):
+The same file after `rocky fmt models/`:
 
 ```rocky
-from raw_orders
-where status != "cancelled"
-derive {
-    order_amount_usd: amount,
-    is_high_value: amount > 100,
-    days_since_order: current_date - order_date
+-- This file is deliberately poorly formatted to demonstrate rocky fmt
+from    raw_orders
+where   status   !=    "cancelled"
+derive    {
+    order_amount_usd:     amount,
+    is_high_value:amount>100,
+    days_since_order: current_date  -   order_date
 }
-select {
+select   {
     order_id,
     customer_id,
     order_amount_usd,
     is_high_value,
     days_since_order
 }
-sort order_amount_usd desc
+sort    order_amount_usd    desc
 ```
 
-## Running
+Every line now starts at the right depth. The spacing inside each line is
+untouched.
+
+## Run it
+
+Check without writing. Rocky names each file it would change and exits 1:
 
 ```bash
-# Check formatting without modifying files (exits non-zero if changes needed)
-rocky fmt --check engine/examples/fmt-demo/models/
-
-# Format files in place
-rocky fmt engine/examples/fmt-demo/models/
-
-# Format a single file
-rocky fmt engine/examples/fmt-demo/models/messy_model.rocky
+cd engine/examples/fmt-demo
+rocky fmt --check models/
 ```
 
-## CI Usage
+```
+would reformat: models/messy_model.rocky
+Error: 1 file(s) would be reformatted
+```
 
-Use `rocky fmt --check` in CI pipelines to enforce consistent formatting:
+Rewrite the files in place:
+
+```bash
+rocky fmt models/
+```
+
+```
+reformatted: models/messy_model.rocky
+```
+
+Format one file:
+
+```bash
+rocky fmt models/messy_model.rocky
+```
+
+A directory path is searched recursively. Rocky picks up every `.rocky` file
+below it and ignores every other extension. With no path at all, `rocky fmt`
+searches the current directory.
+
+## Use it as a CI gate
+
+`--check` never writes. It exits 1 when any file needs formatting, so it works
+as a build step or a pre-commit hook:
 
 ```yaml
 - name: Check Rocky formatting
   run: rocky fmt --check models/
 ```
 
-The `--check` flag prints a diff of what would change and exits with code 1 if any file needs formatting -- useful as a pre-commit hook or CI gate.
+`--check` reports which files differ. It does not print the diff. Run
+`rocky fmt` locally and read the result with `git diff`.

--- a/engine/examples/multi-layer/README.md
+++ b/engine/examples/multi-layer/README.md
@@ -1,65 +1,153 @@
 # Multi-Layer Pipeline
 
-A medallion architecture (Bronze, Silver, Gold) pipeline with data contracts.
+A bronze, silver, gold pipeline with a data contract on the gold model. It
+shows how Rocky resolves a layered graph and how a contract gates the compile.
 
-## Architecture
+## The layer graph
 
 ```
-Bronze (raw)          Silver (cleaned)           Gold (business)
-  |                     |                          |
-  raw_events.sql  -->  stg_events.rocky   -+-->  fct_user_activity.rocky
-                       stg_users.rocky    -+       |
-                                                   contract enforced
+  BRONZE                 SILVER                     GOLD
+  models/bronze/         models/silver/             models/gold/
+
+  raw_events.sql  ──►    stg_events.rocky   ──┐
+  reads                  drops NULL keys      ├──►  fct_user_activity.rocky
+  source.raw.events      adds event flags     │     joins, groups by user_id
+                                              │           │
+                         stg_users.rocky   ───┘           ▼
+                         reads source.raw.users     contracts/
+                         drops NULL keys            fct_user_activity.contract.toml
 ```
 
-### Bronze Layer
-Raw data ingestion. Plain SQL, full refresh. No transformations -- just a faithful copy of the source.
+Bronze copies the source columns with no transformation. Silver removes rows
+with NULL keys and adds computed columns. Gold joins the two silver models and
+aggregates per user.
 
-### Silver Layer
-Cleaned and standardized data. Rocky DSL for NULL-safe filtering and column normalization. Removes invalid records, renames columns, adds computed fields.
-
-### Gold Layer
-Business-ready aggregations. Joins silver models, applies business logic. Protected by a data contract that enforces required columns and types.
-
-## Project Structure
+## Files
 
 ```
 multi-layer/
   rocky.toml
   models/
-    bronze/
-      raw_events.sql             # Source ingestion
-      raw_events.toml
-    silver/
-      stg_events.rocky           # Clean events
-      stg_events.toml
-      stg_users.rocky            # Clean users
-      stg_users.toml
-    gold/
-      fct_user_activity.rocky    # Business aggregation
-      fct_user_activity.toml
+    bronze/raw_events.sql          + raw_events.toml
+    silver/stg_events.rocky        + stg_events.toml
+    silver/stg_users.rocky         + stg_users.toml
+    gold/fct_user_activity.rocky   + fct_user_activity.toml
   contracts/
-    fct_user_activity.contract.toml   # Data contract
+    fct_user_activity.contract.toml
 ```
 
-## Data Contract
+Rocky walks `models/` recursively, so the layer directories are for humans.
+The graph comes from the model bodies, not from the folder names.
 
-The `fct_user_activity.contract.toml` enforces:
-- **Required columns** -- `user_id`, `total_events`, `first_event_date`, `last_event_date` must exist
-- **Protected columns** -- `user_id` cannot be removed or renamed
-- **Type constraints** -- `user_id` is `Int64` (not nullable), `total_events` is `Int64` (not nullable)
+## Compile the graph
 
-If a model change would violate the contract, `rocky plan` fails with an error before any SQL is executed.
-
-## Running
+Run these from the repository root. Rocky reads `rocky.toml` from the working
+directory by default, so the `cd` is what lets the rest omit `--config`.
 
 ```bash
-# Validate contract compliance
-rocky plan --config rocky.toml
+cd engine/examples/multi-layer
+rocky compile
+```
 
-# Execute all layers in dependency order
-rocky run --config rocky.toml
+```
+  ✓ raw_events (9 columns)
+  ✓ stg_events (10 columns)
+  ✓ stg_users (6 columns)
+  ✓ fct_user_activity (12 columns)
+  Compiled: 4 models, 0 errors, 0 warnings
+```
 
-# Check stored watermarks
-rocky state --config rocky.toml
+## The contract gate
+
+`contracts/fct_user_activity.contract.toml` declares nine columns with a type
+and a nullability flag, plus two rules:
+
+- `required` lists `user_id`, `total_events`, `first_event_date`, and
+  `last_event_date`. Each must appear in the model's output columns.
+- `protected` lists `user_id`. It must also appear in the output, so dropping
+  it from the model is a violation.
+
+The compiler runs four checks and raises a different code for each:
+
+| Check | Code | Raised when |
+|---|---|---|
+| `required` column present | `E010` | a `required` column is missing from the model output |
+| `protected` column present | `E013` | a `protected` column is missing from the model output |
+| declared `type` matches | `E011` | the inferred type differs from the declared one |
+| declared `nullable` matches | `E012` | the column is nullable and the contract declares `nullable = false` |
+
+The type check has one gap. When Rocky cannot infer a column's type, it skips
+that column rather than report a mismatch. So `E011` means the two types
+disagree, never that Rocky could not tell.
+
+A declared column that the model does not output is a warning, not an error,
+unless `required` lists it. The code is `W010` and the message is
+`contract column '<name>' not found in model output`. This contract declares
+nine columns and the model outputs all nine, so no `W010` appears here.
+
+A contract is loaded only when a command receives `--contracts <dir>`. The
+commands that accept the flag are `compile`, `test`, `ci`, `dag`, `publish-ir`,
+`serve`, and `watch`. `rocky plan` and `rocky run` have no `--contracts` flag,
+so neither one checks a contract.
+
+```bash
+rocky compile --contracts contracts/
+```
+
+## This example fails its own contract
+
+The contract marks four columns `nullable = false`. The compiler infers all
+four as nullable in `fct_user_activity`. The compile therefore reports `E012`
+four times and exits `1`:
+
+```
+  ✓ raw_events (9 columns)
+  ✓ stg_events (10 columns)
+  ✓ stg_users (6 columns)
+  ✗ fct_user_activity
+  x error[E012]: column 'user_id' must be non-nullable per contract, but is nullable
+  help: filter out NULLs (e.g. `WHERE user_id IS NOT NULL`) or COALESCE `user_id` to a default, or relax `nullable = true` in the contract
+
+  (the same error repeats for total_events, first_event_date, last_event_date)
+
+  Compiled: 4 models, 4 errors, 0 warnings
+```
+
+That is the gate doing its job. Follow either branch of the `help` line to
+clear it: add a NULL filter or a `COALESCE` in `fct_user_activity.rocky`, or
+set `nullable = true` for those columns in the contract.
+
+## What `rocky run` does here
+
+`rocky run` on its own executes the replication stage, not the models. Its
+source pattern matches no schema in a fresh DuckDB database, so it reports
+`Copied 0 tables` and exits `0`.
+
+`rocky run --models models/` executes the models and fails. The sidecars
+target `warehouse.bronze`, `warehouse.silver`, and `warehouse.gold`, and a
+DuckDB session has no catalog called `warehouse`. The models also read
+`source.raw.events` and `source.raw.users`, which this example does not ship.
+
+`rocky compile` and `rocky plan` need neither a catalog nor a source table.
+
+## Where `--config` goes
+
+`--config` is a top-level flag, not a per-command flag. It comes before the
+subcommand, never after:
+
+```bash
+rocky --config rocky.toml compile   # works
+rocky compile --config rocky.toml   # error: unexpected argument '--config' found
+```
+
+The commands above omit it, because `--config` already defaults to
+`rocky.toml` in the working directory.
+
+To run from somewhere else, pass `--models` and `--contracts` as well. Both
+resolve against the working directory, not against the config:
+
+```bash
+rocky --config engine/examples/multi-layer/rocky.toml compile \
+  --models engine/examples/multi-layer/models/ \
+  --contracts engine/examples/multi-layer/contracts/
 ```

--- a/engine/examples/process-adapter-echo/README.md
+++ b/engine/examples/process-adapter-echo/README.md
@@ -1,46 +1,139 @@
-# `rocky-echo` — process-adapter example
+# `rocky-echo` — a process adapter in one script
 
-A minimal Rocky process adapter implemented as a single Python script.
-Demonstrates the JSON-RPC-over-stdio wire protocol and acts as a smoke-test
-target for `rocky test-adapter` and `rocky adapter list/info`.
+A process adapter is an executable that speaks Rocky's warehouse interface over
+JSON-RPC 2.0 on stdin and stdout. `rocky-echo` is a single Python script that
+implements every method. It answers each call without touching a warehouse, so
+it is a way to read the protocol and a target to test it against.
 
-## Run it locally
+[`PROTOCOL.md`](./PROTOCOL.md) is the full wire-protocol reference.
+
+## How Rocky talks to the adapter
+
+Rocky spawns the executable and keeps it running. It writes one JSON object per
+line and waits for one JSON object back before it sends the next.
+
+```
+  ┌───────────┐  request  {"id":1,"method":"initialize"}  ┌────────────┐
+  │           │────────────────── stdin ─────────────────►│            │
+  │   rocky   │                                           │ rocky-echo │
+  │           │◄───────────────── stdout ─────────────────│            │
+  └───────────┘  response {"id":1,"result":{…}}           └─────┬──────┘
+                                                                │ logs
+  one call at a time, in this order:                            ▼
+    initialize → execute_statement / execute_query            stderr
+               → describe_table / table_exists
+               → shutdown
+```
+
+Every response must carry the `id` of the request it answers. Rocky sends one
+call at a time, so an adapter never tracks concurrent requests. The manifest
+that `initialize` returns tells Rocky which capabilities the adapter has.
+
+## How Rocky finds the adapter
+
+Rocky uses the same convention as `cargo` subcommands. Any executable on `$PATH`
+named `rocky-<name>` registers as the adapter `<name>`. The first hit on `$PATH`
+wins. `rocky-lsp` is excluded, because that is the bundled language server.
+
+## Run it
+
+Link the script into a directory on your `$PATH`. It is already executable.
 
 ```bash
-# 1. Drop the script on $PATH (or invoke it directly with --command).
+cd engine/examples/process-adapter-echo
 ln -s "$PWD/rocky-echo" /usr/local/bin/rocky-echo
+```
 
-# 2. List discovered process adapters.
+List every process adapter Rocky can see:
+
+```bash
 rocky adapter list
+```
 
-# 3. Read the adapter manifest.
+```
+NAME                 VERSION      DIALECT        PATH
+echo                 0.1.0        echo           /usr/local/bin/rocky-echo
+```
+
+Print one adapter's manifest:
+
+```bash
 rocky adapter info echo
+```
 
-# 4. Run the conformance suite. `--adapter echo` works because the
-#    builtin lookup falls back to a `rocky-<name>` binary on $PATH.
+```
+name:          echo
+path:          /usr/local/bin/rocky-echo
+version:       0.1.0
+sdk_version:   0.1.0
+dialect:       echo
+auth_methods:
+capabilities:
+  warehouse       = true
+  discovery       = false
+  governance      = false
+  batch_checks    = false
+  create_catalog  = false
+  create_schema   = true
+  merge           = false
+  tablesample     = false
+  file_load       = false
+```
+
+Run the conformance suite:
+
+```bash
 rocky test-adapter --adapter echo
+```
 
-# Equivalent without the PATH-based shortcut:
+```
+Adapter Conformance: echo (SDK 0.1.0)
+==================================================
+
+Connection:
+  + connect                       0ms
+
+DDL:
+  + create_table                  0ms
+  + drop_table                    0ms
+  - create_catalog                SKIPPED (not supported)
+  + create_schema                 0ms
+...
+Result: 19 passed, 0 failed, 7 skipped
+```
+
+Seven tests are skipped: `create_catalog`, `merge_into`, `set_tags`,
+`get_grants`, `batch_row_counts`, `batch_freshness`, and `discover`. Each one is
+guarded by a capability the manifest reports as `false`. Flip a capability to
+`true` in the script and its tests run.
+
+The built-in list is `databricks`, `snowflake`, and `duckdb`. `--adapter echo`
+works because a name outside that list falls back to a `rocky-<name>` binary on
+`$PATH`. Point at the file instead if you would rather not link it:
+
+```bash
 rocky test-adapter --command "$PWD/rocky-echo"
 ```
 
 ## What the adapter does
 
-* Returns a fixed manifest from `initialize`.
-* Accepts every `execute_statement` and replies `{ok: true}`; it does
-  **not** talk to a real warehouse, it just confirms the protocol.
-* Pretends `main.demo.events` exists with three columns, so
-  `describe_table` and `table_exists` return something useful.
-* Logs every executed statement to stderr.
+- `initialize` returns a fixed manifest.
+- `execute_statement` writes the statement to stderr and replies `{"ok": true}`.
+- `execute_query` replies with an empty result set.
+- `describe_table` and `table_exists` know one table, `main.demo.events`, with
+  three columns. Any other table gets `TABLE_NOT_FOUND` and `{"exists": false}`.
+- `shutdown` replies and then stops the loop.
 
-The adapter is **deliberately not a real warehouse**: it exists to (a)
-exercise the wire protocol end-to-end and (b) give engine developers a
-target for the integration test.
+The adapter connects to nothing and stores nothing. It reads stdin, writes
+stdout, and logs statements to stderr. Its answers are hard-coded, so it proves
+the protocol works and proves nothing about a warehouse.
 
-## See also
+## Read the other side
 
-* [`PROTOCOL.md`](./PROTOCOL.md) — full wire-protocol reference.
-* [`engine/crates/rocky-adapter-sdk/src/process.rs`](../../crates/rocky-adapter-sdk/src/process.rs) — the engine side
-  (spawn, request/response loop, `WarehouseAdapter` impl).
-* [`engine/crates/rocky-cli/src/commands/adapter.rs`](../../crates/rocky-cli/src/commands/adapter.rs) — the
-  `rocky adapter list/info` and PATH-based resolution.
+- [`PROTOCOL.md`](./PROTOCOL.md) — the wire protocol, method by method.
+- [`crates/rocky-adapter-sdk/src/process.rs`](../../crates/rocky-adapter-sdk/src/process.rs)
+  — the engine side: spawn, request and response loop, `WarehouseAdapter` impl.
+- [`crates/rocky-cli/src/commands/adapter.rs`](../../crates/rocky-cli/src/commands/adapter.rs)
+  — `rocky adapter list` and `info`, plus the `$PATH` lookup.
+- [`crates/rocky-cli/tests/process_adapter_round_trip.rs`](../../crates/rocky-cli/tests/process_adapter_round_trip.rs)
+  — the integration test that spawns this script.

--- a/engine/examples/quickstart/README.md
+++ b/engine/examples/quickstart/README.md
@@ -1,47 +1,160 @@
 # Quickstart
 
-A minimal 3-model pipeline that demonstrates the core Rocky workflow: source, staging, and fact table.
+A three-model pipeline that shows the core Rocky workflow. One model is plain
+SQL. Two models use the Rocky DSL. All three compile into one typed graph.
 
-## Models
+## The model graph
 
 ```
-raw_orders (SQL)  -->  stg_orders (Rocky DSL)  -->  fct_revenue (Rocky DSL)
+  raw_orders            stg_orders             fct_revenue
+  (.sql)         ──►    (.rocky)        ──►    (.rocky)
+  reads                 drops cancelled        groups by order_date
+  source.raw.orders     adds computed cols     sums revenue
 ```
 
-1. **raw_orders** -- Reads raw order data from an external source table
-2. **stg_orders** -- Filters cancelled orders, renames columns, adds computed fields
-3. **fct_revenue** -- Aggregates daily revenue by date
+- **raw_orders** reads `source.raw.orders` and selects nine columns.
+- **stg_orders** drops cancelled orders and adds `order_amount_usd` and
+  `is_completed`.
+- **fct_revenue** groups completed orders by `order_date` and sums revenue.
 
-## Project Structure
+## Files
 
 ```
 quickstart/
-  rocky.toml              # DuckDB backend, local state
+  rocky.toml               # DuckDB adapter, local state store
   models/
-    raw_orders.sql           # Source model (plain SQL)
-    raw_orders.toml          # Sidecar config
-    stg_orders.rocky         # Staging model (Rocky DSL)
-    stg_orders.toml          # Sidecar config
-    fct_revenue.rocky        # Fact model (Rocky DSL)
-    fct_revenue.toml         # Sidecar config
+    raw_orders.sql         # Plain SQL
+    raw_orders.toml        # Sidecar: name, strategy, target
+    stg_orders.rocky       # Rocky DSL
+    stg_orders.toml
+    fct_revenue.rocky      # Rocky DSL
+    fct_revenue.toml
 ```
 
-## Running
+A model is a body file plus a `.toml` sidecar. The body is either `.sql` or
+`.rocky`. The sidecar sets the model name, the materialization strategy, and
+the target table.
+
+## Run the example
+
+Run these from the repository root. Rocky reads `rocky.toml` from the working
+directory by default, so the `cd` is what lets the rest omit `--config`.
 
 ```bash
-# Preview the generated SQL without executing
-rocky plan --config rocky.toml
-
-# Execute the pipeline
-rocky run --config rocky.toml
-
-# Check state after execution
-rocky state --config rocky.toml
+cd engine/examples/quickstart
+rocky compile
 ```
 
-## Key Concepts
+`rocky compile` type-checks every model and reports the column count:
 
-- **`.sql` files** contain plain SQL and coexist with `.rocky` files in the same project
-- **`.rocky` files** use Rocky's pipeline DSL where data flows top to bottom
-- **`.toml` sidecar files** configure model name, materialization strategy, and target location
-- **`!=` in Rocky is NULL-safe** -- `status != "cancelled"` includes rows where status is NULL
+```
+  ✓ raw_orders (9 columns)
+  ✓ stg_orders (6 columns)
+  ✓ fct_revenue (4 columns)
+  Compiled: 3 models, 0 errors, 0 warnings
+```
+
+Print the SQL each model would run:
+
+```bash
+rocky emit-sql
+```
+
+Print the SQL for one model:
+
+```bash
+rocky emit-sql --model stg_orders
+```
+
+```sql
+-- model: stg_orders
+CREATE OR REPLACE TABLE warehouse.staging.stg_orders AS
+SELECT order_id, customer_id, order_date, status, amount AS order_amount_usd, status = 'completed' AS is_completed
+FROM raw_orders
+WHERE status IS DISTINCT FROM 'cancelled';
+```
+
+`rocky compile` and `rocky emit-sql` need no warehouse connection.
+
+## Build a plan
+
+```bash
+rocky plan
+```
+
+`rocky plan` executes no SQL. It writes a plan file to `.rocky/plans/` and
+prints the plan id:
+
+```
+Run plan persisted — 3 model(s) across 3 layer(s)
+Plan ID:   170efd38be46b340994a6cce423a194b5aa812b9812fdd3d4b3ab4e62bdc4ef4
+Apply with: rocky apply 170efd38be46b340994a6cce423a194b5aa812b9812fdd3d4b3ab4e62bdc4ef4
+```
+
+`rocky apply <id>` executes a stored plan. A plan built by bare `rocky plan`
+carries the replication stage, so applying it reports `Copied 0 tables` and
+exits `0`. A plan built by `rocky plan --models models/` carries the models,
+and applying that one hits the catalog error described in the next section.
+
+## What `rocky run` does here
+
+`rocky run` on its own executes the replication stage, not the models. This
+pipeline is `type = "replication"`. Its source pattern matches no schema in a
+fresh DuckDB database, so the command reports `Copied 0 tables` and exits `0`.
+
+```bash
+rocky run              # Copied 0 tables — the models are untouched
+rocky run --models models/   # executes the models, and fails here
+```
+
+`rocky run --models models/` fails on `raw_orders` and exits `1`. The last
+line it prints is:
+
+```
+Error: 1 table(s) failed during parallel execution (run_id: run-20260816-155426-513, use --resume run-20260816-155426-513 to retry)
+```
+
+The run id changes on every run, so yours will differ. Rocky logs the cause
+first, as a `WARN table error` line. Its `error` field holds:
+
+```
+model 'raw_orders' failed: DuckDB error: Catalog Error: Catalog with name warehouse does not exist!: Catalog Error: Catalog with name warehouse does not exist!: Error code 1: Unknown error code
+```
+
+The sidecars target `warehouse.staging.raw_orders`, and a DuckDB session has
+no catalog called `warehouse`. Setting `auto_create_catalogs = true` in
+`rocky.toml` produces the same error.
+
+To execute this graph, retarget the sidecars at a catalog your warehouse has,
+and point `raw_orders.sql` at a table that exists. `engine/examples/seed-demo`
+shows the loading half with `rocky seed`.
+
+## Where `--config` goes
+
+`--config` is a top-level flag, not a per-command flag. It comes before the
+subcommand, never after:
+
+```bash
+rocky --config rocky.toml compile   # works
+rocky compile --config rocky.toml   # error: unexpected argument '--config' found
+```
+
+The commands above omit it, because `--config` already defaults to
+`rocky.toml` in the working directory.
+
+To run from somewhere else, pass `--models` as well. It defaults to `models`
+relative to the working directory, not relative to the config:
+
+```bash
+rocky --config engine/examples/quickstart/rocky.toml compile \
+  --models engine/examples/quickstart/models/
+```
+
+## What to notice
+
+- `.sql` and `.rocky` models live in the same project and depend on each
+  other. Rocky compiles both into one graph.
+- A `.rocky` file reads top to bottom. Each step feeds the next.
+- `!=` in the Rocky DSL compiles to `IS DISTINCT FROM`, shown in the emitted
+  SQL above. `NULL IS DISTINCT FROM 'cancelled'` is true, so rows with a NULL
+  `status` survive the filter. SQL's `!=` drops them.

--- a/engine/examples/seed-demo/README.md
+++ b/engine/examples/seed-demo/README.md
@@ -1,72 +1,190 @@
-# Seed Demo
+# Seed demo
 
-Demonstrates `rocky seed` loading CSV files into DuckDB. Seeds are static reference data (lookup tables, dimension data, test fixtures) that Rocky discovers, infers column types for, and loads into the target warehouse.
+This example shows `rocky seed`. The command reads CSV files from a directory
+and loads each one into a table. Use it for small reference data that lives in
+git: country codes, category lookups, date spines, test fixtures.
 
-## How It Works
+`rocky seed` writes to your warehouse. For every file it loads, it runs
+`DROP TABLE IF EXISTS` and then recreates the table. Anything already in that
+table is gone.
 
-1. Place `.csv` files in a `seeds/` directory
-2. Rocky discovers all CSV files and infers column types from the data
-3. For each file, Rocky generates `DROP TABLE IF EXISTS` + `CREATE TABLE` + `INSERT INTO` SQL
-4. Tables are created in the `main.seeds` schema by default (configurable via sidecar `.toml`)
-
-## Project Structure
+## The files
 
 ```
 seed-demo/
-  rocky.toml                # DuckDB adapter + replication pipeline
+  rocky.toml              # DuckDB adapter, one replication pipeline
   seeds/
-    customers.csv           # 8 rows: id, name, email, country, created_at
-    products.csv            # 7 rows: id, name, price, category
+    customers.csv         # 8 rows: id, name, email, country, created_at
+    products.csv          # 7 rows: id, name, price, category
 ```
 
-## Running
+## What one seed file goes through
+
+```
+  seeds/customers.csv
+         │
+         ▼
+  ┌──────────────┐  reads the header row and samples up to 1000 data rows
+  │ infer types  │
+  └──────┬───────┘
+         │  id BIGINT, name STRING, …
+         ▼
+  ┌──────────────┐  create the schema if the dialect supports it
+  │ create       │  drop the table if it exists
+  │ the table    │  create <catalog>.<schema>.customers (id BIGINT, …)
+  └──────┬───────┘
+         │
+         ▼
+  ┌──────────────┐  INSERT INTO … VALUES (…), (…), … in batches
+  │ load rows    │
+  └──────┬───────┘
+         │
+         ▼
+  8 rows in <catalog>.<schema>.customers
+```
+
+Rocky picks up every `.csv` file directly inside the seeds directory. It does
+not descend into subdirectories.
+
+Rocky also finds `.tsv` files, but only a single-column one loads. Type
+inference splits every seed file on commas. A tab-separated header of two or
+more columns therefore becomes one column name, and the `CREATE TABLE` fails.
+
+## Run it
+
+Every command in this section exits 1 on the example as shipped. The pipeline
+targets a catalog named `warehouse`, and the in-memory database does not have
+it. The fix is below, under
+[This example needs a catalog that exists](#this-example-needs-a-catalog-that-exists).
 
 ```bash
-# Load all seed files into DuckDB
-rocky --config engine/examples/seed-demo/rocky.toml seed \
-  --seeds-dir engine/examples/seed-demo/seeds/
-
-# Load a specific seed by name
-rocky --config engine/examples/seed-demo/rocky.toml seed \
-  --seeds-dir engine/examples/seed-demo/seeds/ \
-  --filter customers
-
-# JSON output for programmatic consumption
-rocky --config engine/examples/seed-demo/rocky.toml seed \
-  --seeds-dir engine/examples/seed-demo/seeds/ \
-  --output json
+cd engine/examples/seed-demo
+rocky seed --seeds seeds/
 ```
 
-## Expected Output
+Load one file by name:
 
-```
-Seed complete: 2 loaded, 0 failed (XXX ms)
-  [OK] customers -> main.seeds.customers (8 rows, 5 cols, XX ms)
-  [OK] products -> main.seeds.products (7 rows, 4 cols, XX ms)
+```bash
+rocky seed --seeds seeds/ --filter customers
 ```
 
-## Type Inference
+Get machine-readable results:
 
-Rocky infers column types from CSV data:
+```bash
+rocky seed --seeds seeds/ --output json
+```
 
-| CSV Value | Inferred Type |
-|-----------|---------------|
-| `1`, `42` | `BIGINT` |
-| `29.99` | `DOUBLE` |
-| `2024-01-15 09:30:00` | `TIMESTAMP` |
-| `alice@example.com` | `VARCHAR` |
+The flag is `--seeds`, and it defaults to `seeds`. Add `--pipeline <name>` when
+the config declares more than one pipeline.
 
-You can override inferred types with a `.toml` sidecar next to the CSV:
+## Where the table lands
+
+Rocky resolves each table's three parts in this order.
+
+| Part | First choice | Fallback |
+|------|--------------|----------|
+| Catalog | sidecar `[target] catalog` | the replication pipeline's `catalog_template`, otherwise `main` |
+| Schema | sidecar `[target] schema` | `seeds` |
+| Table | sidecar `[target] table` | the seed's name |
+
+The seed's name is the sidecar `name` when the sidecar sets one, and the file
+name without its extension otherwise.
+
+Rocky uses `main` when the pipeline is not a replication pipeline, and when the
+`catalog_template` holds a `{placeholder}` it cannot resolve here.
+
+`catalog` and `table` are optional inside a `[target]` block. `schema` is not.
+A `[target]` block without `schema` stops the whole command at discovery,
+before Rocky loads any seed:
+
+```
+Error: failed to discover seeds in seeds/
+
+Caused by:
+    0: failed to parse sidecar TOML seeds/customers.toml: TOML parse error at line 1, column 1
+         |
+       1 | [target]
+         | ^^^^^^^^
+       missing field `schema`
+    ...
+```
+
+## This example needs a catalog that exists
+
+`rocky.toml` declares a DuckDB adapter with no `path`, so Rocky opens an
+in-memory database. Its catalog is called `memory`. The pipeline's
+`catalog_template` is `warehouse`, so `rocky seed` targets
+`warehouse.seeds.customers` and DuckDB rejects it:
+
+```
+Seed complete: 0 loaded, 2 failed (5 ms)
+  [FAIL] customers -> warehouse.seeds.customers (0 rows, 0 cols, 0 ms)
+       DDL execution failed for customers: DuckDB error: Binder Error: Catalog "warehouse" does not exist!
+  [FAIL] products -> warehouse.seeds.products (0 rows, 0 cols, 0 ms)
+       DDL execution failed for products: DuckDB error: Binder Error: Catalog "warehouse" does not exist!
+Error: 2 seed(s) failed
+```
+
+Name a catalog that exists and the load succeeds. One sidecar covers one seed,
+so write one next to each CSV. A sidecar for `customers.csv` alone leaves
+`products.csv` failing, and the command still exits 1.
 
 ```toml
-# seeds/customers.toml (optional)
+# seeds/customers.toml
+[target]
+catalog = "memory"
+schema = "seeds"
+```
+
+```toml
+# seeds/products.toml
+[target]
+catalog = "memory"
+schema = "seeds"
+```
+
+Run the command again:
+
+```
+Seed complete: 2 loaded, 0 failed (5 ms)
+  [OK] customers -> memory.seeds.customers (8 rows, 5 cols, 1 ms)
+  [OK] products -> memory.seeds.products (7 rows, 4 cols, 0 ms)
+```
+
+A file-backed DuckDB names its catalog after the database file, and a real
+warehouse uses its own catalog names. Match the config to whichever you use.
+
+## Type inference
+
+Rocky reads the header row, then samples up to 1000 data rows. It widens a
+column's type as it goes and picks the first rule that fits each value.
+
+| Example value | Type |
+|---------------|------|
+| `true`, `FALSE` | `BOOLEAN` |
+| `1`, `-42` | `BIGINT` |
+| `29.99` | `DOUBLE` |
+| `2024-01-15`, `2024-01-15 09:30:00` | `TIMESTAMP` |
+| `alice@example.com` | `STRING` |
+
+Empty cells never narrow a type. A column whose sampled cells are all empty
+becomes `STRING`.
+
+Pin a type in the sidecar when the heuristic guesses wrong:
+
+```toml
+# seeds/customers.toml
 [column_types]
 id = "INTEGER"
 ```
 
-## Key Concepts
+A pinned column skips inference entirely.
 
-- **Automatic discovery** -- any `.csv` in the seeds directory is picked up
-- **Type inference** -- column types are inferred from data, with sensible defaults
-- **Sidecar overrides** -- optional `.toml` files can override target table name, schema, and column types
-- **Idempotent** -- re-running seed drops and recreates the table
+## Other sidecar keys
+
+- `name` renames the seed. `--filter` matches this name, and so does the table
+  name when `[target] table` is absent.
+- `pre_hook` is a list of SQL statements run before any write, including before
+  the `DROP TABLE`. A failing statement aborts that seed with nothing written.
+  Use it to refuse a reload when the target already holds rows.
+- `post_hook` is a list of SQL statements run after a successful load.

--- a/engine/examples/seed-demo/rocky.toml
+++ b/engine/examples/seed-demo/rocky.toml
@@ -4,7 +4,7 @@
 # inferring column types, and loading them into the target warehouse.
 #
 # Usage:
-#   rocky --config engine/examples/seed-demo/rocky.toml seed --seeds-dir engine/examples/seed-demo/seeds/
+#   rocky --config engine/examples/seed-demo/rocky.toml seed --seeds engine/examples/seed-demo/seeds/
 
 [adapter.local]
 type = "duckdb"

--- a/engine/examples/shell-demo/README.md
+++ b/engine/examples/shell-demo/README.md
@@ -1,103 +1,130 @@
-# Shell Demo
+# Shell demo
 
-Demonstrates `rocky shell` -- an interactive SQL REPL that connects to the configured warehouse adapter. No models are needed; the shell connects directly to the database.
+This example shows `rocky shell`, an interactive SQL prompt. The shell sends
+each statement straight to a warehouse adapter and prints the result. It does
+not compile models, so this example needs no `models/` directory.
 
-## Running
+The shell runs whatever you type, including `INSERT`, `CREATE`, and `DROP`.
+
+## Which adapter the shell connects to
+
+Rocky picks the adapter in this order.
+
+1. The pipeline named by `--pipeline`, using that pipeline's target adapter.
+2. The only pipeline in the config, using its target adapter.
+3. The only warehouse adapter in the config.
+
+If several adapters are configured and none of the rules above resolve, Rocky
+stops and asks for `--pipeline`.
+
+## Start it
 
 ```bash
-rocky --config engine/examples/shell-demo/rocky.toml shell
+cd engine/examples/shell-demo
+rocky shell
 ```
 
-You'll see a prompt like:
+```
+Connecting... ok
+
+Rocky Shell (adapter: duckdb, name: local)
+Type SQL to execute. Special commands:
+  .tables              List tables in a schema (.tables catalog.schema)
+  .schema <table>      Describe a table's columns
+  .quit / .exit        Exit the shell
+  Lines ending with \ continue on the next line.
+
+rocky>
+```
+
+`rocky.toml` declares a DuckDB adapter with no `path`, so this session runs
+against an in-memory database. Nothing you create survives the process.
+
+## A session
+
+Every transcript below is DuckDB output. Result shapes differ by warehouse.
 
 ```
-rocky> 
-```
-
-## Example Session
-
-```sql
 rocky> SELECT 1 + 1 AS result;
-+--------+
-| result |
-+--------+
-| 2      |
-+--------+
+ result
+--------
+ 2
+(1 rows)
 
 rocky> CREATE TABLE demo (id INTEGER, name VARCHAR, value DOUBLE);
+(0 rows)
 
 rocky> INSERT INTO demo VALUES (1, 'alpha', 10.5), (2, 'beta', 20.3), (3, 'gamma', 30.1);
+ Count
+-------
+ 3
+(1 rows)
 
 rocky> SELECT name, value FROM demo WHERE value > 15 ORDER BY value DESC;
-+-------+-------+
-| name  | value |
-+-------+-------+
-| gamma | 30.1  |
-| beta  | 20.3  |
-+-------+-------+
-
-rocky> SELECT COUNT(*) AS total, AVG(value) AS avg_value FROM demo;
-+-------+-----------+
-| total | avg_value |
-+-------+-----------+
-| 3     | 20.3      |
-+-------+-----------+
+ name  | value
+-------+-------
+ gamma | 30.1
+ beta  | 20.3
+(2 rows)
 ```
 
-## Meta-Commands
+Rocky strips a trailing semicolon before it sends the statement, so the
+semicolon is optional.
 
-The shell supports special dot-prefixed commands:
+## Dot-commands
 
-| Command | Description |
-|---------|-------------|
-| `.tables` | List all tables in the current database |
-| `.schema <table>` | Show the column definitions for a table |
-| `.quit` | Exit the shell (also: `Ctrl+D`) |
+| Command | What it runs |
+|---------|--------------|
+| `.tables` | `SHOW TABLES` |
+| `.tables <catalog>.<schema>` | `SHOW TABLES IN <catalog>.<schema>` |
+| `.schema <table>` | `DESCRIBE TABLE <table>` |
+| `.quit` or `.exit` | Leaves the shell |
 
-### Example
+Each one is a shortcut for the SQL beside it, so the result columns come from
+your warehouse:
 
 ```
 rocky> .tables
-+--------+
-| name   |
-+--------+
-| demo   |
-+--------+
+ name
+------
+ demo
+(1 rows)
 
 rocky> .schema demo
-+---------+---------+
-| column  | type    |
-+---------+---------+
-| id      | INTEGER |
-| name    | VARCHAR |
-| value   | DOUBLE  |
-+---------+---------+
-
-rocky> .quit
+ column_name | column_type | null | key  | default | extra
+-------------+-------------+------+------+---------+-------
+ id          | INTEGER     | YES  | NULL | NULL    | NULL
+ name        | VARCHAR     | YES  | NULL | NULL    | NULL
+ value       | DOUBLE      | YES  | NULL | NULL    | NULL
+(3 rows)
 ```
 
-## Multi-Line Queries
+Ctrl-D also exits. Both routes print `Bye.` and leave with status 0.
 
-The shell supports multi-line SQL. A statement is executed when it ends with a semicolon:
+## Continue a statement across lines
 
-```sql
-rocky> SELECT
-   ...>   name,
-   ...>   value,
-   ...>   value / (SELECT SUM(value) FROM demo) AS pct_of_total
-   ...> FROM demo
-   ...> ORDER BY value DESC;
+End a line with a backslash. Only a backslash continues a statement. Leaving
+off the semicolon does not.
+
+```
+rocky> SELECT name, \
+   ... value \
+   ... FROM demo ORDER BY value DESC;
+ name  | value
+-------+-------
+ gamma | 30.1
+ beta  | 20.3
+ alpha | 10.5
+(3 rows)
 ```
 
-The continuation prompt (`...>`) indicates the shell is waiting for more input.
+The `   ... ` prompt means Rocky is waiting for the rest of the statement.
 
-## Use Cases
+## What the shell is useful for
 
-- **Ad-hoc exploration** -- query source or target tables during development
-- **Debugging** -- inspect table contents after a `rocky run` to verify results
-- **Quick prototyping** -- test SQL snippets before adding them to a model
-- **Schema inspection** -- use `.tables` and `.schema` to understand the database layout
+- Look at a table while you are writing the model that reads it.
+- Try a SQL snippet before you paste it into a `.sql` model.
+- Use `.tables` and `.schema` to learn an unfamiliar database.
 
-## Adapter Compatibility
-
-The shell works with any configured adapter. When connected to DuckDB (as in this demo), queries execute locally with no external credentials. When connected to Databricks or Snowflake, queries execute against the remote warehouse.
+Point the config at a file-backed DuckDB or a remote warehouse when you want
+the results of a `rocky run` to still be there.

--- a/engine/examples/snapshot/README.md
+++ b/engine/examples/snapshot/README.md
@@ -1,32 +1,99 @@
-# Snapshot POC — SCD Type 2
+# Snapshot
 
-Demonstrates `rocky snapshot` for tracking historical changes using the
-SCD Type 2 pattern (slowly-changing dimensions).
+A snapshot pipeline that tracks row history with the SCD Type 2 pattern
+(slowly changing dimensions: keep the old row, mark it closed, insert the new
+version). The whole example is one `rocky.toml`. There are no model files.
 
-## How it works
+## What the config declares
 
-1. A `customers` source table has rows with `customer_id` and `updated_at`
-2. Rocky generates MERGE SQL that:
-   - Creates a `customers_history` table with `valid_from`, `valid_to`, `is_current`, `snapshot_id` columns
-   - Detects changed rows by comparing `updated_at` between source and current target rows
-   - Closes changed rows (sets `valid_to`, `is_current = FALSE`)
-   - Inserts new versions (with `valid_from = CURRENT_TIMESTAMP`, `is_current = TRUE`)
-   - Optionally invalidates hard-deleted rows
+```toml
+[pipeline.customers_history]
+type = "snapshot"
+unique_key = ["customer_id"]
+updated_at = "updated_at"
+invalidate_hard_deletes = true
+```
+
+- `unique_key` identifies a row across versions.
+- `updated_at` is the column Rocky compares to detect a change.
+- `invalidate_hard_deletes` closes rows that vanished from the source.
+
+The source is `main.raw.customers`. The target is
+`main.history.customers_history`.
+
+## The four statements Rocky generates
+
+```
+  main.raw.customers                    main.history.customers_history
+         │                                          │
+         │  initial_load ─── CREATE TABLE IF NOT EXISTS, source columns
+         │                   plus valid_from, valid_to, is_current, snapshot_id
+         │                                          │
+         ├─ merge_1 ──► updated_at differs?  ──► close the current row
+         │              (IS DISTINCT FROM)        valid_to = now, is_current = FALSE
+         │              new key?             ──► INSERT first version
+         │                                          │
+         ├─ merge_2 ──► key closed but has no current row
+         │                                    ──► INSERT the new version
+         │                                          │
+         └─ merge_3 ──► key gone from source  ──► close the current row
+                        (invalidate_hard_deletes)
+```
 
 ## Try it
 
-```bash
-# Preview the generated MERGE SQL (no warehouse needed)
-rocky --config engine/examples/snapshot/rocky.toml snapshot --dry-run
+Run these from the repository root:
 
-# JSON output
-rocky --config engine/examples/snapshot/rocky.toml snapshot --dry-run --output json
+```bash
+cd engine/examples/snapshot
+rocky snapshot --dry-run
 ```
 
-## Configuration
+`--dry-run` prints the four statements and executes none of them. It still
+builds the target adapter, because the adapter chooses the SQL dialect. It
+reads no rows from `main.raw.customers`.
 
-See `rocky.toml` for the pipeline config. Key settings:
+It does write one directory. Rocky creates `.rocky/` here and logs the run to
+`.rocky/traces/{timestamp}-{pid}.jsonl`, one file per process. It also writes
+`.rocky/.gitignore`, which holds a comment and a single `*`, so git ignores
+the whole directory. Delete `.rocky/` when you are done.
 
-- `unique_key` — column(s) that identify a row
-- `updated_at` — timestamp column for change detection
-- `invalidate_hard_deletes` — close rows deleted from source
+```bash
+rocky --output json snapshot --dry-run
+```
+
+Without `--dry-run`, `rocky snapshot` executes those statements against the
+configured adapter. It reads `main.raw.customers` and writes
+`main.history.customers_history`. This example ships neither table, so create
+`main.raw.customers` first.
+
+## The four history columns
+
+`initial_load` adds them to the target:
+
+| Column | Meaning |
+|---|---|
+| `valid_from` | when this version became current |
+| `valid_to` | when it stopped being current; NULL while current |
+| `is_current` | TRUE for the live version of a key |
+| `snapshot_id` | identifier of the snapshot run that wrote the row |
+
+## Where `--config` goes
+
+`--config` is a top-level flag, not a per-command flag. It comes before the
+subcommand, never after:
+
+```bash
+rocky --config rocky.toml snapshot --dry-run   # works
+rocky snapshot --dry-run --config rocky.toml   # error: unexpected argument '--config' found
+```
+
+`rocky snapshot` reads only the config, so a path from anywhere works. From
+the repository root:
+
+```bash
+rocky --config engine/examples/snapshot/rocky.toml snapshot --dry-run
+```
+
+Pass `--pipeline <name>` when a config declares more than one pipeline. This
+one declares a single pipeline, so the flag is optional here.

--- a/engine/examples/test-declarative/README.md
+++ b/engine/examples/test-declarative/README.md
@@ -1,111 +1,166 @@
 # Declarative Tests
 
-Demonstrates `rocky test --declarative` using `[[tests]]` entries in model TOML sidecars. Instead of writing separate SQL test files, you declare data quality assertions inline next to the model definition.
+One model whose `.toml` sidecar declares four `[[tests]]` blocks. Run them
+with `rocky test --declarative`. No separate test files are involved.
 
-## Test Types
-
-Rocky supports six declarative test types:
-
-| Type | Purpose | Requires `column` |
-|------|---------|-------------------|
-| `not_null` | Assert no NULL values in a column | Yes |
-| `unique` | Assert no duplicate values in a column | Yes |
-| `accepted_values` | Assert column values are from a fixed set | Yes |
-| `relationships` | Assert foreign key integrity | Yes |
-| `expression` | Assert a custom SQL expression holds for every row | No |
-| `row_count_range` | Assert total row count falls within bounds | No |
-
-## Project Structure
+## Files
 
 ```
 test-declarative/
-  rocky.toml                  # DuckDB adapter
+  rocky.toml
   models/
-    fct_orders.sql            # Order fact table (plain SQL)
-    fct_orders.toml           # Sidecar with 4 [[tests]] entries
+    fct_orders.sql     # plain SQL, reads source.raw.orders
+    fct_orders.toml    # sidecar: target + four [[tests]] blocks
 ```
 
-## Running
-
-```bash
-# Run all declarative tests
-rocky --config engine/examples/test-declarative/rocky.toml test \
-  --declarative --models engine/examples/test-declarative/models/
-
-# JSON output
-rocky --config engine/examples/test-declarative/rocky.toml test \
-  --declarative --models engine/examples/test-declarative/models/ \
-  --output json
-
-# Filter to a single model
-rocky --config engine/examples/test-declarative/rocky.toml test \
-  --declarative --models engine/examples/test-declarative/models/ \
-  --model fct_orders
-```
-
-## Expected Output
-
-```
-Declarative tests for fct_orders (warehouse.analytics.fct_orders):
-  [PASS] not_null(order_id)
-  [PASS] unique(order_id)
-  [PASS] accepted_values(status)
-  [PASS] expression(amount > 0)
-
-  Result: 4 passed, 0 failed, 0 warned, 0 errored
-```
-
-## Test Configuration
-
-Tests are declared as `[[tests]]` TOML array entries in the model sidecar:
+## The four tests in the sidecar
 
 ```toml
-# Assert order_id is never NULL
 [[tests]]
 type = "not_null"
 column = "order_id"
 
-# Assert order_id is unique
 [[tests]]
 type = "unique"
 column = "order_id"
 
-# Assert status is one of the known values (soft failure)
 [[tests]]
 type = "accepted_values"
 column = "status"
 values = ["pending", "shipped", "completed", "returned"]
 severity = "warning"
 
-# Assert a custom SQL expression holds for every row
 [[tests]]
 type = "expression"
 expression = "amount > 0"
 ```
 
-## Severity Levels
+Each block names a `type` and supplies that type's own parameters, such as
+`values` or `expression`. Three more keys work with every type:
 
-Each test has an optional `severity` field:
+| Key | Meaning |
+|---|---|
+| `column` | the column under test; ignored by `expression` and `row_count_range` |
+| `severity` | `error` (default) fails the command; `warning` reports and continues |
+| `filter` | SQL predicate that scopes the assertion to a subset of rows |
 
-- **`error`** (default) -- test failure causes the command to exit with a non-zero code
-- **`warning`** -- test failure is reported but does not fail the command
+## How a test becomes SQL
 
-## How It Works
+```
+  models/fct_orders.toml            the warehouse
+        │                                 │
+   [[tests]] block                        │
+        │                                 │
+        ▼                                 │
+   type + column ──► assertion SQL ───────┤ run against the model's
+                     built by Rocky       │ TARGET table, not the SQL body
+                                          │
+                     0 rows / count 0 ◄───┘  pass
+                     anything else          fail
+```
 
-For each `[[tests]]` entry, Rocky generates assertion SQL against the model's target table:
-
-| Test Type | Generated SQL |
-|-----------|--------------|
+| Type | SQL Rocky builds |
+|---|---|
 | `not_null` | `SELECT COUNT(*) FROM <table> WHERE <col> IS NULL` |
 | `unique` | `SELECT <col>, COUNT(*) FROM <table> GROUP BY <col> HAVING COUNT(*) > 1` |
 | `accepted_values` | `SELECT DISTINCT <col> FROM <table> WHERE <col> NOT IN (...)` |
 | `expression` | `SELECT COUNT(*) FROM <table> WHERE NOT (<expr>)` |
 
-A test passes when the query returns 0 rows (or a count of 0).
+## Every test type
 
-## Key Concepts
+Thirteen types are available:
 
-- **Co-located with models** -- tests live in the same `.toml` sidecar as model config
-- **No separate test files** -- unlike `rocky test` (which runs `.sql` files from a tests/ directory), declarative tests need no extra files
-- **Severity control** -- mark non-critical tests as `warning` to avoid blocking pipelines
-- **Generated SQL** -- Rocky generates the assertion SQL from the test type, so you only declare the intent
+`not_null`, `unique`, `unique_expr`, `accepted_values`, `relationships`,
+`expression`, `row_count_range`, `in_range`, `regex_match`, `aggregate`,
+`composite`, `not_in_future`, `older_than_n_days`.
+
+## Run the tests
+
+Run these from the repository root. Rocky reads `rocky.toml` from the working
+directory by default, so the `cd` is what lets the rest omit `--config`.
+
+```bash
+cd engine/examples/test-declarative
+rocky test --declarative
+```
+
+Useful flags:
+
+```bash
+rocky --output json test --declarative     # machine-readable results
+rocky test --declarative --model fct_orders  # one model
+rocky test --declarative --pipeline test_demo  # required if the config has several pipelines
+```
+
+## The target table must exist first
+
+Declarative tests query the model's target table. Here that is
+`warehouse.analytics.fct_orders`. This example ships no data and never creates
+that table, so every test reports an execution error and the command exits
+`1`:
+
+```
+Declarative tests: 4 total
+
+  ✗ fct_orders.order_id [not_null] — execution error: DuckDB error: Binder Error: Catalog "warehouse" does not exist!
+  ✗ fct_orders.order_id [unique] — execution error: DuckDB error: Binder Error: Catalog "warehouse" does not exist!
+  ✗ fct_orders.status [accepted_values] — execution error: DuckDB error: Binder Error: Catalog "warehouse" does not exist!
+  ✗ fct_orders [expression] — execution error: DuckDB error: Binder Error: Catalog "warehouse" does not exist!
+
+  Result: 0 passed, 0 failed, 0 warned, 4 errored
+Error: declarative test failures: 0 hard failure(s), 4 execution error(s)
+```
+
+That is the expected output here. Build `warehouse.analytics.fct_orders`
+first, then rerun, and the four assertions report real results.
+
+`rocky compile` needs no table and no warehouse:
+
+```bash
+rocky compile
+```
+
+## `--declarative` versus plain `rocky test`
+
+`rocky test --declarative` runs the `[[tests]]` blocks against warehouse
+tables. Plain `rocky test` is a different runner. It does two things: it
+executes every model against DuckDB to check that the SQL runs, and it runs
+the fixture-driven `[[test]]` blocks declared in model sidecars. Note the
+singular `[[test]]`. Neither command reads `.sql` files from a `tests/`
+directory.
+
+Plain `rocky test` is not a no-op here, even though this example declares no
+`[[test]]` blocks. It still executes `fct_orders`, which reads
+`source.raw.orders`. A fresh DuckDB session has no catalog called `source`, so
+the model fails and the command exits `1`:
+
+```
+Testing 1 models...
+
+  ✗ fct_orders — DuckDB error: Binder Error: Catalog "source" does not exist!
+
+  Result: 0 passed, 1 failed
+```
+
+Rocky then prints `Error: test failures detected`.
+
+## Where `--config` goes
+
+`--config` is a top-level flag, not a per-command flag. It comes before the
+subcommand, never after:
+
+```bash
+rocky --config rocky.toml test --declarative   # works
+rocky test --declarative --config rocky.toml   # error: unexpected argument '--config' found
+```
+
+The commands above omit it, because `--config` already defaults to
+`rocky.toml` in the working directory.
+
+To run from somewhere else, pass `--models` as well. It defaults to `models`
+relative to the working directory, not relative to the config:
+
+```bash
+rocky --config engine/examples/test-declarative/rocky.toml test --declarative \
+  --models engine/examples/test-declarative/models/
+```

--- a/engine/examples/watch-demo/README.md
+++ b/engine/examples/watch-demo/README.md
@@ -1,33 +1,69 @@
-# Watch Demo
+# Watch demo
 
-Demonstrates `rocky watch` -- a file watcher that auto-recompiles `.rocky` models whenever you save a change. Useful during development to get instant feedback on syntax errors and generated SQL.
+This example shows two watchers. `rocky watch` recompiles on every save, and one
+Ctrl-C stops it. `rocky run --watch` re-runs the whole pipeline on every save.
 
-## Project Structure
+## The files
 
 ```
 watch-demo/
-  rocky.toml                   # DuckDB backend, local state
+  rocky.toml                   # DuckDB adapter, one replication pipeline
   models/
-    orders_summary.rocky       # Model to edit while watching
-    orders_summary.toml        # Sidecar config
+    orders_summary.rocky       # the model to edit while a watcher runs
+    orders_summary.toml        # sidecar: name, strategy, target
 ```
 
-## Running
-
-Start the watcher in a terminal:
+## `rocky watch` — recompile on save
 
 ```bash
-rocky --config engine/examples/watch-demo/rocky.toml watch \
-  --models engine/examples/watch-demo/models/
+cd engine/examples/watch-demo
+rocky watch --models models/
 ```
 
-The watcher prints compiled SQL for each model on startup, then monitors for changes.
+`rocky watch` never opens `rocky.toml` and never connects to a warehouse. It
+works on a project that has no adapter configured at all.
 
-## Try It
+```
+     start
+       │
+       ▼
+  ┌──────────┐  prints ✓ or errors  ┌───────────────────┐
+  │ compile  │─────────────────────►│ wait for a change │
+  │ every    │                      └─────────┬─────────┘
+  │ model    │                                │ a .rocky, .sql
+  └──────────┘                                │ or .toml file is
+       ▲                                      │ saved under --models
+       │                                      ▼
+       │                            ┌───────────────────┐
+       └────────────────────────────│ wait 200 ms, then │
+        recompile the whole dir     │ coalesce the      │
+                                    │ burst of saves    │
+                                    └───────────────────┘
+```
 
-1. Start the watcher (command above)
-2. Open `models/orders_summary.rocky` in your editor
-3. Change the aggregation -- for example, add a new derived column:
+Every pass compiles the whole directory. There is no per-model incremental
+recompile.
+
+What you see on start, then after one save:
+
+```
+[watch] compiling...
+  ✓ orders_summary (3 columns)
+  Compiled: 1 models, 0 errors, 0 warnings
+[watch] compilation succeeded
+[watch] waiting for changes...
+[watch] file changed: /path/to/watch-demo/models/orders_summary.rocky
+[watch] compiling...
+  ✓ orders_summary (3 columns)
+  Compiled: 1 models, 0 errors, 0 warnings
+[watch] compilation succeeded
+[watch] waiting for changes...
+```
+
+## Try it
+
+1. Start `rocky watch --models models/`.
+2. Open `models/orders_summary.rocky` and add a derived column:
 
 ```rocky
 from raw_orders
@@ -39,13 +75,83 @@ group status {
 sort total_revenue desc
 ```
 
-4. Save the file -- the watcher detects the change and recompiles immediately
-5. Introduce a syntax error (e.g., remove a closing brace) to see diagnostic output
-6. Press `Ctrl+C` to stop
+3. Save. The watcher recompiles and reports four columns instead of three.
+4. Delete the group's closing brace `}` and the `sort` line under it, then save
+   again. Delete the brace alone and the parser reaches `sort` instead, which
+   gives a different message with a byte offset in it. The watcher reports the
+   error and keeps waiting:
 
-## What to Observe
+```
+[watch] compilation failed: failed to parse .rocky file 'models/orders_summary.rocky': unexpected end of file: expected identifier
+```
 
-- On startup, Rocky compiles all models in the directory and prints generated SQL
-- On each save, only the changed model is recompiled (incremental)
-- Syntax and type errors appear inline with file path and line number
-- The watcher uses OS-native file notifications (inotify/kqueue) for near-instant response
+5. Press Ctrl-C. The watcher prints `[watch] stopped` and exits with status 0.
+
+## See the generated SQL
+
+`rocky watch` prints compile results, not SQL. Use `rocky emit-sql` for that:
+
+```bash
+rocky emit-sql --models models/
+```
+
+For the model as shipped, that prints:
+
+```sql
+-- model: orders_summary
+CREATE OR REPLACE TABLE warehouse.analytics.orders_summary AS
+SELECT status, COUNT() AS order_count, SUM(amount) AS total_revenue
+FROM raw_orders
+GROUP BY status
+ORDER BY total_revenue DESC;
+```
+
+Add `--out-dir <dir>` to write one `.sql` file per model instead of printing.
+
+## `rocky run --watch` — re-run on save
+
+```bash
+rocky run --watch --models models/
+```
+
+This one does connect to the warehouse. It watches `rocky.toml` and the models
+directory, coalesces saves over the same 200 ms window, and re-runs the entire
+pipeline each time. It reloads `rocky.toml` on every pass, so an edit to the
+config takes effect on the next run.
+
+Each pass fails on this example. `rocky.toml` declares a DuckDB adapter with no
+`path`, so Rocky opens an in-memory database. The model targets a `warehouse`
+catalog, which that database does not have. One save produces this:
+
+```
+[watch] watching /path/to/watch-demo/rocky.toml, /path/to/watch-demo/models (Ctrl-C to stop)
+[watch] run failed in 115ms: 1 table(s) failed during parallel execution (run_id: run-20260816-143748-426, use --resume run-20260816-143748-426 to retry)
+[watch] detected change: /path/to/watch-demo/models/orders_summary.rocky
+[watch] run failed in 102ms: 1 table(s) failed during parallel execution (run_id: run-20260816-143751-638, use --resume run-20260816-143751-638 to retry)
+
+[watch] stopped
+```
+
+The loop itself is doing its job: it re-ran on the save and stopped on Ctrl-C
+with status 0. The model is what fails, and two things have to change.
+
+Point the config at a catalog the database really has. Until you do, every pass
+stops on `Catalog with name warehouse does not exist!`. Then put a `raw_orders`
+table in that catalog. Without it the next pass stops on
+`Table with name raw_orders does not exist!`.
+
+Change both and each pass prints `[watch] run completed in <n>ms` instead.
+`rocky watch` needs neither change and works as shipped.
+
+Banner lines go to stderr. With `--output json`, each pass writes one compact
+`RunOutput` object on its own line to stdout, so you can pipe the stream into
+`jq`.
+
+A Ctrl-C that lands between runs stops the watcher at once. A Ctrl-C that lands
+during a run reaches the run first. The watcher stops once that run reports the
+interrupt back to it. On this example every pass fails on its own before it can
+report anything. A mid-run Ctrl-C therefore leaves the watcher waiting, and you
+need a second one.
+
+`--watch` is rejected at parse time alongside `--dag`, `--resume`,
+`--resume-latest`, `--idempotency-key`, `--model`, and `--assume-fresh-state`.

--- a/engine/examples/window-functions/README.md
+++ b/engine/examples/window-functions/README.md
@@ -1,103 +1,177 @@
 # Window Functions
 
-Demonstrates Rocky DSL window function syntax (Plan 11 feature) side by side with equivalent SQL. Each transformation is implemented in both `.rocky` (DSL) and `.sql` (standard SQL) so you can compare the approaches.
+Four models. Two write window functions in the Rocky DSL. Two write the same
+logic in SQL. Compile them together and compare the SQL Rocky emits with the
+SQL you would have written by hand.
 
-## Models
-
-| Rocky DSL | SQL Equivalent | What it shows |
-|-----------|---------------|---------------|
-| `customer_order_ranking.rocky` | `customer_order_ranking_sql.sql` | `row_number`, `rank`, `dense_rank` with partition and sort |
-| `running_totals.rocky` | `running_totals_sql.sql` | `sum` with frame specification, running count, grand total |
-
-## Project Structure
+## Files
 
 ```
 window-functions/
-  rocky.toml                              # DuckDB adapter
+  rocky.toml
   models/
-    customer_order_ranking.rocky          # DSL: ranking functions
-    customer_order_ranking.toml           # Sidecar config
-    customer_order_ranking_sql.sql        # SQL equivalent
-    customer_order_ranking_sql.toml       # Sidecar config
-    running_totals.rocky                  # DSL: running aggregations
-    running_totals.toml                   # Sidecar config
-    running_totals_sql.sql               # SQL equivalent
-    running_totals_sql.toml              # Sidecar config
+    customer_order_ranking.rocky      + .toml   # DSL: row_number, rank, dense_rank
+    customer_order_ranking_sql.sql    + .toml   # the same logic in SQL
+    running_totals.rocky              + .toml   # DSL: running sum, running count, grand total
+    running_totals_sql.sql            + .toml   # the same logic in SQL
 ```
 
-## Running
+Both model forms live in one project and compile to the same column set.
+
+## Compile and read the SQL
+
+Run these from the repository root. Rocky reads `rocky.toml` from the working
+directory by default, so the `cd` is what lets the rest omit `--config`.
 
 ```bash
-# Compile models and see generated SQL
-rocky --config engine/examples/window-functions/rocky.toml compile \
-  --models engine/examples/window-functions/models/
-
-# Preview execution plan
-rocky --config engine/examples/window-functions/rocky.toml plan \
-  --models engine/examples/window-functions/models/
+cd engine/examples/window-functions
+rocky compile
 ```
 
-## Syntax Comparison
+```
+  ✓ customer_order_ranking (7 columns)
+  ✓ customer_order_ranking_sql (7 columns)
+  ✓ running_totals (7 columns)
+  ✓ running_totals_sql (7 columns)
+  Compiled: 4 models, 0 errors, 0 warnings
+```
 
-### Ranking (row_number, rank, dense_rank)
+Print the SQL for one model:
 
-**Rocky DSL:**
+```bash
+rocky emit-sql --model customer_order_ranking
+```
+
+`rocky compile` and `rocky emit-sql` need no warehouse connection.
+
+`rocky run` does not work here. The sidecars target `warehouse.analytics`. A
+DuckDB session has no catalog called `warehouse`, so `rocky run --models
+models/` reports `Catalog with name warehouse does not exist`. The models also
+read `source.raw.orders` and `source.raw.transactions`, which this example
+does not ship. Read the SQL with `rocky emit-sql` instead.
+
+## Ranking, DSL and SQL
+
+`customer_order_ranking.rocky`:
+
 ```rocky
+-- Rank customers by order value within each region.
+-- Demonstrates: row_number, rank, dense_rank with partition and sort.
 from source.raw.orders
 derive {
+    -- Sequential number per customer within their region (no gaps)
     rn: row_number() over (partition region, sort -amount),
+    -- Rank with gaps (tied amounts get same rank, next rank skips)
     order_rank: rank() over (partition region, sort -amount),
+    -- Dense rank without gaps (tied amounts get same rank, next rank is +1)
     order_dense_rank: dense_rank() over (partition region, sort -amount)
 }
-```
-
-**SQL:**
-```sql
-SELECT
-    ROW_NUMBER() OVER (PARTITION BY region ORDER BY amount DESC) AS rn,
-    RANK() OVER (PARTITION BY region ORDER BY amount DESC) AS order_rank,
-    DENSE_RANK() OVER (PARTITION BY region ORDER BY amount DESC) AS order_dense_rank
-FROM source.raw.orders
-```
-
-### Running Total with Frame Specification
-
-**Rocky DSL:**
-```rocky
-from source.raw.transactions
-derive {
-    running_total: sum(amount) over (partition account_id, sort txn_date, rows unbounded..current),
-    grand_total: sum(amount) over ()
+select {
+    order_id,
+    customer_id,
+    region,
+    amount,
+    rn,
+    order_rank,
+    order_dense_rank
 }
 ```
 
-**SQL:**
+`rocky emit-sql --model customer_order_ranking` returns this, wrapped here for
+reading:
+
 ```sql
-SELECT
-    SUM(amount) OVER (
-        PARTITION BY account_id ORDER BY txn_date
-        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
-    ) AS running_total,
-    SUM(amount) OVER () AS grand_total
-FROM source.raw.transactions
+-- model: customer_order_ranking
+CREATE OR REPLACE TABLE warehouse.analytics.customer_order_ranking AS
+SELECT order_id, customer_id, region, amount,
+       ROW_NUMBER() OVER (PARTITION BY region ORDER BY amount DESC) AS rn,
+       RANK() OVER (PARTITION BY region ORDER BY amount DESC) AS order_rank,
+       DENSE_RANK() OVER (PARTITION BY region ORDER BY amount DESC) AS order_dense_rank
+FROM source.raw.orders;
 ```
 
-## DSL Window Syntax Reference
+`customer_order_ranking_sql.sql` holds that `SELECT` written by hand.
+
+## Running totals, DSL and SQL
+
+`running_totals.rocky`:
+
+```rocky
+-- Running totals and cumulative aggregations per account.
+-- Demonstrates: sum with frame specification (rows unbounded..current),
+-- count as a running count, and a grand total via empty over().
+from source.raw.transactions
+derive {
+    -- Cumulative sum of amount per account, ordered by transaction date
+    running_total: sum(amount) over (partition account_id, sort txn_date, rows unbounded..current),
+    -- Running count of transactions per account
+    running_count: count() over (partition account_id, sort txn_date, rows unbounded..current),
+    -- Grand total across all rows (empty partition = entire result set)
+    grand_total: sum(amount) over ()
+}
+select {
+    txn_id,
+    account_id,
+    txn_date,
+    amount,
+    running_total,
+    running_count,
+    grand_total
+}
+```
+
+`rocky emit-sql --model running_totals` returns this, wrapped here for
+reading:
+
+```sql
+-- model: running_totals
+CREATE OR REPLACE TABLE warehouse.analytics.running_totals AS
+SELECT txn_id, account_id, txn_date, amount,
+       SUM(amount) OVER (PARTITION BY account_id ORDER BY txn_date
+                         ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS running_total,
+       COUNT() OVER (PARTITION BY account_id ORDER BY txn_date
+                     ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS running_count,
+       SUM(amount) OVER () AS grand_total
+FROM source.raw.transactions;
+```
+
+## The `over` clause
 
 ```
 func(args) over (partition col1, col2, sort -col3, col4, rows start..end)
+                 └── PARTITION BY ──┘  └── ORDER BY ──┘  └─ frame bounds ─┘
 ```
 
-- **`partition`** -- columns to partition by (optional, comma-separated)
-- **`sort`** -- columns to order by (prefix `-` for descending)
-- **`rows`/`range`** -- frame bounds separated by `..`:
-  - `unbounded` -- start/end of partition
-  - `current` -- current row
-  - `N` -- offset of N rows
+| Part | Meaning | SQL it produces |
+|---|---|---|
+| `partition a, b` | group rows before the window runs | `PARTITION BY a, b` |
+| `sort c` | order rows inside the group | `ORDER BY c` |
+| `sort -c` | order descending; the `-` replaces `DESC` | `ORDER BY c DESC` |
+| `rows a..b` | frame in rows | `ROWS BETWEEN … AND …` |
+| `range a..b` | frame in values | `RANGE BETWEEN … AND …` |
+| `over ()` | one window over every row | `OVER ()` |
 
-## Key Concepts
+Frame bounds accept `unbounded`, `current`, and a row offset `N`. So
+`rows unbounded..current` becomes
+`ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`.
 
-- Rocky's window syntax is more compact than SQL's `OVER (PARTITION BY ... ORDER BY ... ROWS BETWEEN ... AND ...)`
-- `-column` in sort means descending (no `DESC` keyword needed)
-- `rows unbounded..current` maps to `ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`
-- Empty `over ()` means the window spans the entire result set
+## Where `--config` goes
+
+`--config` is a top-level flag, not a per-command flag. It comes before the
+subcommand, never after:
+
+```bash
+rocky --config rocky.toml compile   # works
+rocky compile --config rocky.toml   # error: unexpected argument '--config' found
+```
+
+The commands above omit it, because `--config` already defaults to
+`rocky.toml` in the working directory.
+
+To run from somewhere else, pass `--models` as well. It defaults to `models`
+relative to the working directory, not relative to the config:
+
+```bash
+rocky --config engine/examples/window-functions/rocky.toml compile \
+  --models engine/examples/window-functions/models/
+```


### PR DESCRIPTION
Applies `docs/STYLE.md` to the 15 official starter examples under `engine/examples/`, the Rocky language spec, and three reference pages.

## Verification found 26 defects, because it ran the commands

Every rewrite was audited by an independent agent that copied each example to a scratch directory and **executed** it against the 1.70.1 binary. Three earlier reading-only passes across this documentation effort found nothing of this kind.

**Examples that do not work as shipped.** `seed-demo`'s three documented commands all exit 1 — the target catalog does not exist, and the README did not say so until two sections later. `compare-demo` opens by describing two models that neither of its commands builds. `watch-demo` quoted a parse error the binary does not produce for the step described; the real message differs, and the quoted one appears only if you delete an extra line the instruction never mentions. All three now state what the reader will actually see, next to the command.

**Fabricated provenance.** `ai-intent` claimed its four shipped test files were generated by `rocky ai-test --save`. They cannot have been: `testgen.rs` writes `<model>_<assertion>.sql` with a different header template, and rejects assertion names containing spaces. They are example fixtures. The page also warned that `--save` overwrites files in your clone — backwards, since the names differ it would add four more.

**Features documented as reachable that are not.** `rocky docs` never renders `[columns]` descriptions: `column_map` is hardcoded `None` at the only production call site, and the command exits 0 with no warning. The rewrite had also introduced a `.tsv` support claim; type inference always splits on commas, so a multi-column `.tsv` fails at `CREATE TABLE` while a single-column one loads.

**Traps worth naming.** `--all` means *every model* on `ai-test` but *only models without `intent`* on `ai-explain` — so `rocky ai-explain --all --save` is a silent no-op in an example where both models declare intent. A seed sidecar `[target]` block must include `schema`, or the whole command aborts before any seed loads. And `rocky snapshot --dry-run` writes `.rocky/traces/`, contradicting a sentence whose entire purpose was to promise it wrote nothing.

## Also here

Documents the behaviour change from #1429: `rocky test`, `rocky estimate` and `rocky retention` now **fail** on a selector matching nothing, where they used to exit 0. The reference pages now record the old behaviour too, including that text output said `No models found.` while JSON said nothing — so anyone whose CI treated the empty result as a pass understands why it started failing.

Fixes a phantom flag in `engine/examples/seed-demo/rocky.toml`: its usage header told readers to run `seed --seeds-dir`. That flag has never existed. It is `--seeds`, confirmed against `rocky seed --help`.

## Notes on the process

The fixing agents corrected their own verifiers twice — the `test-declarative` exit code is 1 rather than 0, and E011 is the type mismatch while E012 is nullability. One caught its own overclaim ("the one thing that blocks a migration") before shipping, after finding that `{% for %}` and `{% set %}` are refused as well as `is_incremental()`.

A verifier crashed mid-run for the second time in this effort (machine sleep), leaving the eight most important examples unaudited while their siblings were checked. It was re-run rather than assumed clean; those eight held 13 of the 26 defects.

```
astro build .............. PASS
links / anchors .......... 0 broken
flags not in engine ...... 0
run artifacts in tree .... 0
```