### PR TITLE
fix(engine): stop import-dbt recommending a command the CLI rejects

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -495,7 +495,7 @@
         "type": "object"
       },
       "AiExplainOutput": {
-        "description": "JSON output for `rocky ai explain`.",
+        "description": "JSON output for `rocky ai-explain`.",
         "properties": {
           "command": {
             "type": "string"
@@ -603,7 +603,7 @@
         "type": "object"
       },
       "AiSyncOutput": {
-        "description": "JSON output for `rocky ai sync`.",
+        "description": "JSON output for `rocky ai-sync`.",
         "properties": {
           "command": {
             "type": "string"
@@ -692,7 +692,7 @@
         "type": "object"
       },
       "AiTestOutput": {
-        "description": "JSON output for `rocky ai test`.",
+        "description": "JSON output for `rocky ai-test`.",
         "properties": {
           "command": {
             "type": "string"

--- a/docs/src/content/docs/guides/migrate-from-dbt.md
+++ b/docs/src/content/docs/guides/migrate-from-dbt.md
@@ -111,8 +111,7 @@ Tests:   8 total
 
 Next Steps:
   1. rocky compile
-  2. rocky ai explain --all --save
-  3. rocky test
+  2. rocky test
 Output:  2 models translated, 0 seeds copied → imported
          rocky.toml         → imported/rocky.toml
          MIGRATION-NOTES.md → imported/MIGRATION-NOTES.md

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The `intent` hover in the config schema names a real command.** It cited `rocky ai sync`, which the CLI rejects; the subcommand is `rocky ai-sync`. (#1443)
+
 ### Removed
 
 - **Dropped the lineage drift overlay and the Overview drift card, which never showed real data.** Both shelled out to `rocky drift`, a command the CLI does not have. The error was caught into an empty result, and because that result was still a value rather than a failure, the Overview card rendered **"None" with an all-clear tone** — a fabricated clean result, in every project, for its entire lifetime. The overlay likewise decorated nothing. Drift continues to be reported by the drift diagnostics provider, which is unaffected and unrelated. (#1431)

--- a/editors/vscode/schemas/rocky-config.schema.json
+++ b/editors/vscode/schemas/rocky-config.schema.json
@@ -61,7 +61,7 @@
     },
     "intent": {
       "type": "string",
-      "description": "Natural language description of what this model does. Used by 'rocky ai sync' to propose updates when upstream schemas change"
+      "description": "Natural language description of what this model does. Used by 'rocky ai-sync' to propose updates when upstream schemas change"
     },
     "freshness": {
       "type": "object",

--- a/editors/vscode/src/types/generated/ai_explain.ts
+++ b/editors/vscode/src/types/generated/ai_explain.ts
@@ -6,7 +6,7 @@
  */
 
 /**
- * JSON output for `rocky ai explain`.
+ * JSON output for `rocky ai-explain`.
  */
 export interface AiExplainOutput {
   command: string;

--- a/editors/vscode/src/types/generated/ai_sync.ts
+++ b/editors/vscode/src/types/generated/ai_sync.ts
@@ -6,7 +6,7 @@
  */
 
 /**
- * JSON output for `rocky ai sync`.
+ * JSON output for `rocky ai-sync`.
  */
 export interface AiSyncOutput {
   command: string;

--- a/editors/vscode/src/types/generated/ai_test.ts
+++ b/editors/vscode/src/types/generated/ai_test.ts
@@ -6,7 +6,7 @@
  */
 
 /**
- * JSON output for `rocky ai test`.
+ * JSON output for `rocky ai-test`.
  */
 export interface AiTestOutput {
   command: string;

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`rocky import-dbt` no longer ends with a command the CLI rejects.** Its Next Steps block printed `rocky ai explain --all --save`, which does not parse — `rocky ai` takes a positional `INTENT`, so `explain` is consumed as the intent and the flags are refused with `error: unexpected argument '--all' found`. The real subcommand is `rocky ai-explain`. The same invalid spelling appeared in a second user-facing hint and in four doc comments, three of which publish as JSON-schema descriptions for the `ai_*` outputs.
+
+  The step is now also **gated**. `ai-explain --all` selects only models whose `intent` is unset, but the recommendation was emitted unconditionally — and the dbt importer seeds `intent` from dbt YAML `description` fields. Importing a documented project therefore produced a next step that, even spelled correctly, prints `No models to explain.` It is now offered only when an imported model actually lacks an intent, matching the predicate the command itself filters on. (#1443)
+
 ### Removed
 
 - **The `drift` JSON schema no longer ships for a command that does not exist.** `schemas/drift.schema.json` and its generated Pydantic/TypeScript bindings described the output of `rocky drift` — a subcommand the binary rejects with `unrecognized subcommand 'drift'`. Drift detection has always run inside `rocky run` / `rocky plan` and is surfaced on `RunOutput.drift`; there was never a command that could emit the standalone envelope. Downstream consumers importing the generated `DriftOutput` type will need to drop it. `DriftSummary` and `DriftActionOutput` are unaffected and now generate from the run schema, which is where drift is actually emitted. (#1431)

--- a/engine/crates/rocky-cli/src/commands/ai.rs
+++ b/engine/crates/rocky-cli/src/commands/ai.rs
@@ -268,7 +268,7 @@ pub async fn run_ai(
     Ok(())
 }
 
-/// Execute `rocky ai sync` — detect schema changes and propose intent-guided updates.
+/// Execute `rocky ai-sync` — detect schema changes and propose intent-guided updates.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_ai_sync(
     config_path: &Path,
@@ -311,7 +311,7 @@ pub async fn run_ai_sync(
             print_json(&output)?;
         } else {
             println!(
-                "No models with intent found. Use `rocky ai explain --save` to add intent to models."
+                "No models with intent found. Use `rocky ai-explain --save` to add intent to models."
             );
         }
         return Ok(());
@@ -410,7 +410,7 @@ pub async fn run_ai_sync(
     Ok(())
 }
 
-/// Execute `rocky ai explain` — generate intent descriptions from code.
+/// Execute `rocky ai-explain` — generate intent descriptions from code.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_ai_explain(
     config_path: &Path,
@@ -480,7 +480,7 @@ pub async fn run_ai_explain(
     Ok(())
 }
 
-/// Execute `rocky ai test` — generate test assertions from intent.
+/// Execute `rocky ai-test` — generate test assertions from intent.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_ai_test(
     config_path: &Path,

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -2595,7 +2595,7 @@ pub struct AiGenerateOutput {
     pub sidecar_path: Option<String>,
 }
 
-/// JSON output for `rocky ai sync`.
+/// JSON output for `rocky ai-sync`.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct AiSyncOutput {
     pub version: String,
@@ -2611,7 +2611,7 @@ pub struct AiSyncProposal {
     pub proposed_source: String,
 }
 
-/// JSON output for `rocky ai explain`.
+/// JSON output for `rocky ai-explain`.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct AiExplainOutput {
     pub version: String,
@@ -2626,7 +2626,7 @@ pub struct AiExplanation {
     pub saved: bool,
 }
 
-/// JSON output for `rocky ai test`.
+/// JSON output for `rocky ai-test`.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct AiTestOutput {
     pub version: String,

--- a/engine/crates/rocky-compiler/src/import/report.rs
+++ b/engine/crates/rocky-compiler/src/import/report.rs
@@ -81,7 +81,7 @@ pub struct MacrosSummary {
 pub enum Recommendation {
     /// Run `rocky compile` to type-check imported models.
     RunCompile,
-    /// Run `rocky ai explain --all --save` to add intent metadata.
+    /// Run `rocky ai-explain --all --save` to add intent metadata.
     GenerateIntent,
     /// Run `rocky test` to validate with DuckDB.
     RunTests,
@@ -257,8 +257,18 @@ fn generate_recommendations(
     // Always recommend compile
     recs.push(Recommendation::RunCompile);
 
-    // Recommend generating intent
-    recs.push(Recommendation::GenerateIntent);
+    // Recommend generating intent only when a model actually lacks one.
+    // `ai-explain --all` selects models whose `intent` is None (ai.rs), so
+    // recommending it after an import that seeded every intent from dbt YAML
+    // descriptions sends the reader to a command that prints
+    // "No models to explain."
+    if import_result
+        .imported
+        .iter()
+        .any(|m| m.config.intent.is_none())
+    {
+        recs.push(Recommendation::GenerateIntent);
+    }
 
     // Recommend running tests if we converted any
     if tests.converted > 0 || tests.converted_custom > 0 {
@@ -433,7 +443,7 @@ pub fn format_report(report: &MigrationReport) -> String {
                     out.push_str(&format!("  {step}. rocky compile\n"));
                 }
                 Recommendation::GenerateIntent => {
-                    out.push_str(&format!("  {step}. rocky ai explain --all --save\n"));
+                    out.push_str(&format!("  {step}. rocky ai-explain --all --save\n"));
                 }
                 Recommendation::RunTests => {
                     out.push_str(&format!("  {step}. rocky test\n"));
@@ -682,6 +692,75 @@ mod tests {
             matches!(r, Recommendation::ManualReview { models, .. } if models.contains(&"bad_model".to_string()))
         });
         assert!(has_manual);
+    }
+
+    /// `ai-explain --all` selects only models whose `intent` is None. Offering
+    /// the step when every imported model already carries an intent sends the
+    /// reader to a command that prints "No models to explain."
+    #[test]
+    fn generate_intent_is_offered_only_when_a_model_lacks_intent() {
+        let with_intent = || {
+            let mut m = make_imported("has_intent", StrategyConfig::View);
+            m.config.intent = Some("already described by dbt YAML".to_string());
+            m
+        };
+        let without_intent = || make_imported("no_intent", StrategyConfig::View);
+
+        let offers_intent = |imported: Vec<ImportedModel>| {
+            let result = make_result(
+                imported,
+                vec![],
+                vec![],
+                ImportMethod::Regex,
+                Some("proj".to_string()),
+                None,
+                0,
+                0,
+            );
+            generate_report(&result, None, None)
+                .recommendations
+                .iter()
+                .any(|r| matches!(r, Recommendation::GenerateIntent))
+        };
+
+        assert!(
+            !offers_intent(vec![with_intent()]),
+            "every model already has an intent — the step would print \"No models to explain.\""
+        );
+        assert!(
+            offers_intent(vec![without_intent()]),
+            "a model without intent must still get the recommendation"
+        );
+        assert!(
+            offers_intent(vec![with_intent(), without_intent()]),
+            "a mixed import must still offer the step for the model that lacks intent"
+        );
+    }
+
+    /// The emitted step must be a command the CLI actually accepts. `rocky ai`
+    /// takes a positional INTENT, so `rocky ai explain --all` is parsed as the
+    /// intent "explain" and rejects `--all`.
+    #[test]
+    fn generate_intent_step_names_the_real_subcommand() {
+        let result = make_result(
+            vec![make_imported("m", StrategyConfig::View)],
+            vec![],
+            vec![],
+            ImportMethod::Regex,
+            Some("proj".to_string()),
+            None,
+            0,
+            0,
+        );
+        let out = format_report(&generate_report(&result, None, None));
+        assert!(
+            out.contains("rocky ai-explain --all --save"),
+            "next steps must name the real subcommand: {out}"
+        );
+        assert!(
+            !out.contains("rocky ai explain"),
+            "the space-separated form is not a valid command: {out}"
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-core/src/models.rs
+++ b/engine/crates/rocky-core/src/models.rs
@@ -133,7 +133,7 @@ pub struct ModelConfig {
     #[serde(default)]
     pub adapter: Option<String>,
     /// Natural language description of what this model does.
-    /// Used by `rocky ai sync` to propose updates when upstream schemas change.
+    /// Used by `rocky ai-sync` to propose updates when upstream schemas change.
     #[serde(default)]
     pub intent: Option<String>,
     /// Per-model freshness expectation. Declarative-only — the compiler does

--- a/engine/examples/dbt-migration/README.md
+++ b/engine/examples/dbt-migration/README.md
@@ -47,7 +47,7 @@ Models:  2 total
 
 Next Steps:
   1. rocky compile
-  2. rocky ai explain --all --save
+  2. rocky ai-explain --all --save
 Output:  2 models translated, 0 seeds copied → imported/
          rocky.toml         → imported/rocky.toml
          MIGRATION-NOTES.md → imported/MIGRATION-NOTES.md
@@ -57,8 +57,9 @@ Warnings:
     -> add a sources.yml definition for this source
 ```
 
-Rocky prints the second next step as `rocky ai explain`. The command is
-`rocky ai-explain`, with a hyphen.
+Rocky offers the intent step only when an imported model has no `intent`.
+This project's dbt models carry no YAML descriptions, so both arrive without
+one and the step appears.
 
 `imported/` then holds `rocky.toml`, `MIGRATION-NOTES.md`, and a `models/`
 directory with one `.sql` and one `.toml` per model, plus `_defaults.toml`.

--- a/schemas/ai_explain.schema.json
+++ b/schemas/ai_explain.schema.json
@@ -21,7 +21,7 @@
       "type": "object"
     }
   },
-  "description": "JSON output for `rocky ai explain`.",
+  "description": "JSON output for `rocky ai-explain`.",
   "properties": {
     "command": {
       "type": "string"

--- a/schemas/ai_sync.schema.json
+++ b/schemas/ai_sync.schema.json
@@ -25,7 +25,7 @@
       "type": "object"
     }
   },
-  "description": "JSON output for `rocky ai sync`.",
+  "description": "JSON output for `rocky ai-sync`.",
   "properties": {
     "command": {
       "type": "string"

--- a/schemas/ai_test.schema.json
+++ b/schemas/ai_test.schema.json
@@ -45,7 +45,7 @@
       "type": "object"
     }
   },
-  "description": "JSON output for `rocky ai test`.",
+  "description": "JSON output for `rocky ai-test`.",
   "properties": {
     "command": {
       "type": "string"

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **AI parse errors now name a command the CLI accepts.** `RockyParseError` from `ai_sync()`, `ai_explain()`, and `ai_test()` reported the command as `ai sync` / `ai explain` / `ai test`. Those forms are rejected by the CLI — `rocky ai` takes a positional intent — so anyone diagnosing malformed output was handed a command that fails. They now read `ai-sync`, `ai-explain`, and `ai-test`. (#1443)
+
 ### Removed
 
 - **BREAKING: `DriftOutput` is no longer exported.** It modelled the output of a `rocky drift` command that does not exist, so nothing could ever produce a payload for it to parse. `DriftSummary` and `DriftActionOutput` remain available and are unchanged — drift is reported on `RunResult.drift`. (#1431)

--- a/sdk/python/src/rocky_sdk/client.py
+++ b/sdk/python/src/rocky_sdk/client.py
@@ -1345,7 +1345,7 @@ class RockyClient:
             args.extend(["--model", model])
         if with_intent:
             args.append("--with-intent")
-        return _parse_rocky_json(self.run_cli(args), AiSyncResult, command="ai sync")
+        return _parse_rocky_json(self.run_cli(args), AiSyncResult, command="ai-sync")
 
     def ai_explain(
         self, model: str | None = None, *, all: bool = False, save: bool = False
@@ -1358,7 +1358,7 @@ class RockyClient:
             args.append("--all")
         if save:
             args.append("--save")
-        return _parse_rocky_json(self.run_cli(args), AiExplainResult, command="ai explain")
+        return _parse_rocky_json(self.run_cli(args), AiExplainResult, command="ai-explain")
 
     def ai_test(
         self, model: str | None = None, *, all: bool = False, save: bool = False
@@ -1371,7 +1371,7 @@ class RockyClient:
             args.append("--all")
         if save:
             args.append("--save")
-        return _parse_rocky_json(self.run_cli(args), AiTestResult, command="ai test")
+        return _parse_rocky_json(self.run_cli(args), AiTestResult, command="ai-test")
 
     def ai_contract(self, model: str, *, save: bool = False) -> AiContractOutput:
         """AI-draft a data contract from a model's observed data (DuckDB only)."""

--- a/sdk/python/src/rocky_sdk/types_generated/ai_explain_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/ai_explain_schema.py
@@ -14,7 +14,7 @@ class AiExplanation(BaseModel):
 
 class AiExplainOutput(BaseModel):
     """
-    JSON output for `rocky ai explain`.
+    JSON output for `rocky ai-explain`.
     """
 
     command: str

--- a/sdk/python/src/rocky_sdk/types_generated/ai_sync_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/ai_sync_schema.py
@@ -15,7 +15,7 @@ class AiSyncProposal(BaseModel):
 
 class AiSyncOutput(BaseModel):
     """
-    JSON output for `rocky ai sync`.
+    JSON output for `rocky ai-sync`.
     """
 
     command: str

--- a/sdk/python/src/rocky_sdk/types_generated/ai_test_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/ai_test_schema.py
@@ -20,7 +20,7 @@ class AiTestModelResult(BaseModel):
 
 class AiTestOutput(BaseModel):
     """
-    JSON output for `rocky ai test`.
+    JSON output for `rocky ai-test`.
     """
 
     command: str


### PR DESCRIPTION
Closes #1443.

`rocky import-dbt` ended its own Next Steps block with a command the CLI rejects:

```
$ rocky ai explain --all --save
error: unexpected argument '--all' found
```

`rocky ai` takes a positional `<INTENT>` ("generate a model from natural language intent"), so `explain` is swallowed as the intent and the flags are refused. The real subcommand is `rocky ai-explain`.

## The spelling was wrong in more places than the issue names

Sweeping for the shape rather than fixing the reported line found **eight** sites:

| Site | Kind |
|---|---|
| `import/report.rs:436` | the emitted Next Steps line (the reported bug) |
| `import/report.rs:84` | doc comment on the `GenerateIntent` variant |
| `ai.rs:314` | second user-facing hint — `rocky ai explain --save`, also rejected |
| `ai.rs` ×3, `models.rs` ×1 | doc comments |
| `output.rs` ×3 | **published as JSON-schema `description` fields** for the `ai_*` outputs |

The `output.rs` three were shipping to `schemas/`, the SDK Pydantic models, and the VS Code types — documenting a command form that does not work.

## The step was also unconditional

`ai-explain --all` selects only models whose `intent` is `None`:

```rust
if all { return m.config.intent.is_none(); }   // ai.rs
```

but `GenerateIntent` was pushed with no guard. The dbt importer **seeds `intent` from dbt YAML `description` fields** (`import/dbt.rs:515`), so importing a documented project produced a next step that — even spelled correctly — prints `No models to explain.`

It is now offered only when an imported model actually lacks an intent, using the same predicate the command filters on. A mixed import still offers it.

## Verification

Both new tests are **mutation-checked** — a test that passes with and without the fix pins nothing:

| Mutation | Test | Result |
|---|---|---|
| restore `rocky ai explain` | `generate_intent_step_names_the_real_subcommand` | **FAILED** |
| push `GenerateIntent` unconditionally | `generate_intent_is_offered_only_when_a_model_lacks_intent` | **FAILED** |

Both pass on the real tree; the worktree was verified clean before and after each mutation.

Gates, with real exit codes:

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | 0 |
| `cargo clippy --all-targets --workspace -- -D warnings` | 0 |
| `cargo test -p rocky-compiler --lib import::report` | 7 passed |
| `just codegen-all` | 0 — descriptions confirmed changed in all three schemas and both binding sets |

Dagster fixtures are untouched: no runtime output shape changed, only description prose.

## Note

The `--all` asymmetry itself is left alone: it means "all models without intent" on `ai-explain` and "all models" on `ai-test`. That is a real inconsistency in the CLI surface, but changing either meaning is a behaviour change for existing users and belongs in its own issue.

## Red team

Reviewed by **Codex**, `needs-attention`, confirmed by an independent **`gpt-5.6-terra`** pass. It cleared the runtime fix, the gate, the tests, and the generated schemas, and found that my sweep was **incomplete** — it covered `engine/crates/` only. Four more user-facing surfaces still printed a rejected spelling:

| Surface | Why it matters |
|---|---|
| `sdk/.../client.py` ×3 | `RockyParseError` labelled the command `ai sync` / `ai explain` / `ai test` — handed to someone already diagnosing broken output |
| `editors/vscode/schemas/rocky-config.schema.json` | the `intent` hover cited `rocky ai sync` |
| `engine/examples/dbt-migration/README.md` | quoted output, plus a note explaining the very discrepancy this PR removes |
| `docs/.../migrate-from-dbt.md` | the published migration guide |

All four fixed in the follow-up commit.

**The guide needed more than hyphenation, and I had this wrong.** Its POC (`03-import-dbt-validate`) gives both models a `description:`, which the importer seeds into `intent` — so under the new gate `GenerateIntent` is not offered at all, and `rocky test` becomes step 2. I had checked `engine/examples/dbt-migration/` for descriptions, found none, and concluded the documented output was structurally unchanged. That is a different fixture from the one the guide runs: right question, wrong artifact.

The renumbering is what the guide already claimed elsewhere — line 176 says "The model `description` becomes `intent`", and 180/217 show both models carrying one. The old block was wrong twice: an invalid spelling, and a step that would have printed `No models to explain.` on the guide's own example.

Codex explicitly endorsed keeping the gate: it "exactly matches `ai-explain --all`", and named `ai-explain <model> --save` still re-explains a model whose description makes a poor intent. It also notes `schemas_hash` changes, so hash-pinning consumers should do their normal review; no payload shape changed and no Dagster fixture moved.

## Gates after the follow-up

| Gate | Result |
|---|---|
| `ruff check` / `ruff format --check` | 0 / 0 |
| `uv run pytest` (sdk) | 214 passed |
| `npm run compile` / `typecheck:webview` | 0 / 0 |
| config schema re-parses | valid JSON |

