### PR TITLE
docs(engine): correct three justifications that no longer match the code

### DIFF
--- a/docs/src/content/docs/concepts/compiler.md
+++ b/docs/src/content/docs/concepts/compiler.md
@@ -253,7 +253,7 @@ span, and sometimes a suggested fix.
 | `W030` | Imported producer added a column, surfaced only to consumers reading it via `SELECT *` |
 | `W031` | Imported producer widened the type of a column this project reads (cross-team contract) |
 | `I001` | Model dependency inferred from SQL |
-| `I002` | Model compiled with `SELECT *` |
+| `I002` | Some columns have unknown types — provide source schemas for full type checking |
 | `P001` | Construct not portable to the target dialect (opt-in via `--target-dialect`) |
 | `P002` | `SELECT *` model has downstream consumers that read specific columns |
 

--- a/engine/crates/rocky-adapter-sdk/src/conformance.rs
+++ b/engine/crates/rocky-adapter-sdk/src/conformance.rs
@@ -12,8 +12,9 @@
 //! ```
 //!
 //! Pass `None` for the dialect when no live adapter is available (for example,
-//! `rocky test-adapter --builtin`). Dialect-category tests are reported as
-//! skipped in that mode rather than executed against a stub.
+//! the built-in path, `rocky test-adapter --adapter <name>`). Dialect-category
+//! tests are reported as skipped in that mode rather than executed against a
+//! stub.
 
 use std::time::Instant;
 
@@ -321,8 +322,9 @@ fn test_specs() -> Vec<TestSpec> {
 ///
 /// When `dialect` is `Some`, the harness executes one real trait call
 /// (`SqlDialect::format_table_ref`) as the first incremental live check.
-/// When `dialect` is `None` — for example in `rocky test-adapter --builtin`,
-/// which validates the test plan without a live warehouse — that spec is
+/// When `dialect` is `None` — for example on the built-in path
+/// (`rocky test-adapter --adapter <name>`), which validates the test plan
+/// without constructing a live adapter — that spec is
 /// reported as `Skipped` rather than executed against a stub. Remaining
 /// specs return placeholder passes; broader live execution lands in future
 /// SDK releases.

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -6032,10 +6032,15 @@ pub(crate) fn dialect_case_rules(
         // resolution (see `defer.rs`'s
         // `snowflake_resolves_unquoted_identifiers_before_matching`), and
         // enabling it here is a one-line change. It is NOT enabled because doing
-        // so refuses every lowercase-configured Snowflake project — including
-        // this repo's own fixtures — and while the reasoning says such a project
-        // could not read its upstream in production either, that conclusion has
-        // not been verified against a live Snowflake account. Shipping it
+        // so refuses any lowercase-configured Snowflake project, and while the
+        // reasoning says such a project could not read its upstream in
+        // production either, that conclusion has not been verified against a
+        // live Snowflake account.
+        //
+        // The in-repo blast radius is one test fixture, not the examples: the
+        // only Snowflake POC (`05-orchestration/08-circuit-breaker`) is
+        // uppercase throughout (`catalog = "ANALYTICS"`), so it is unaffected.
+        // Do not read this deferral as "it would break our own examples". Shipping it
         // untested would trade a known, pre-existing and unchanged hazard for an
         // unmeasured break. Tracked as #1282; #1281 would settle it exactly.
         //

--- a/engine/crates/rocky-compiler/src/diagnostic.rs
+++ b/engine/crates/rocky-compiler/src/diagnostic.rs
@@ -222,7 +222,10 @@ pub const W031: &str = "W031";
 // Info
 /// Model dependency inferred from SQL.
 pub const I001: &str = "I001";
-/// Model compiled with SELECT *.
+/// Some columns have unknown types — source schemas would complete the check.
+///
+/// Emitted only on *partial* inference (some columns typed, some not), not for
+/// `SELECT *` as such: see the sole emitter in `typecheck.rs`.
 pub const I002: &str = "I002";
 
 // Lints — portability + blast-radius


### PR DESCRIPTION
Three comments a reader would act on, all wrong. Found while verifying issue claims against `main`; each confirmed by reading the code it describes. **No behaviour change** — comments plus one docs table.

## 1. An inflated cost keeping a correctness fix deferred (#1282)

`run.rs` explains why `uniform_uppercasing` is not enabled:

> It is NOT enabled because doing so refuses every lowercase-configured Snowflake project — **including this repo's own fixtures**

The repo's only Snowflake POC (`05-orchestration/08-circuit-breaker`) is uppercase throughout:

```toml
catalog = "ANALYTICS"
catalog_template = "ANALYTICS"
schema_template = "STAGING__{source}"
```

So it is unaffected. The real in-repo blast radius is **one test fixture**, not the examples.

This is the one worth caring about. An overstated cost is how a deferred fix stays deferred — the next person to weigh enabling this reads "it breaks our own examples" and stops. The comment now states the actual scope and says explicitly not to read it that way.

## 2. A flag the CLI does not have (#475)

Two places told the reader to run `rocky test-adapter --builtin`:

- `conformance.rs:15` (module docs)
- `conformance.rs:324` (`run_conformance` docs)

There is no `--builtin`. The flags are `--adapter`, `--command`, `--adapter-config`, `--cache-ttl`, `--principal`. The *concept* is real — the built-in path constructs no live adapter, which is exactly when `dialect` is `None` — so both now name it `rocky test-adapter --adapter <name>`.

## 3. A diagnostic documented as something it never emits (#1240)

Both the published table (`concepts/compiler.md`) and `I002`'s own doc comment said:

> `I002` | Model compiled with `SELECT *`

Its sole emitter says something else entirely:

```rust
format!("{unknown_count} column(s) have unknown types — provide source schemas for full type checking")
```

and it is gated on **partial** inference:

```rust
if unknown_count > 0 && unknown_count < typed_cols.len()
```

So a plain `SELECT *` with nothing typed does not raise `I002` at all — the documented trigger is close to the opposite of the real one. Fixed in both places; the constant's doc comment is the likely origin of the table's wording, which is why leaving it would have let the error return.

## Scope

Each fix is one word or one sentence, but I swept for the shape rather than fixing the reported line — which is how sites 1 of 2 (`conformance.rs:15`) and the `I002` constant turned up after the first pass.

**Closes nothing.** #1282, #475 and #1240 each still have their underlying engineering question open; this only stops their comments misinforming the next reader.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | 0 |
| `cargo clippy --all-targets --workspace -- -D warnings` | 0 |
| `cargo test -p rocky-compiler --lib` | 433 passed |
| `cargo test -p rocky-adapter-sdk` | passed, incl. doctests |

No `output.rs` change, so no codegen cascade and no fixture movement.

## Red team

Not sent to an independent model: this is the "mechanical, behaviour-neutral corrections" case AGENTS.md exempts, and every claim is a direct quote of the code beside it. Flagging the judgement rather than leaving it implicit.
