### PR TITLE
fix(sdk,dagster): resolve the models root per pipeline for discovery and execution

### DIFF
--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A project with two or more transformation pipelines can now produce an asset graph.** `RockyComponent` caches `rocky.dag(...)`, and that call forced a whole-project `--models`, which the engine refuses on a multi-transformation project — so definitions failed to build at all. The DAG call now lets each pipeline resolve its own models root. (#1348)
+
+- **Transformation assets execute under their own pipeline.** `run_model` is called with `pipeline=node.pipeline`, so the engine resolves the pipeline the node was discovered in rather than a project-wide root. A node whose `pipeline` is unset falls back to the previous behaviour. (#1348, #1292)
+
 ## [1.62.0] — 2026-08-11
 
 ### Changed

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -27,7 +27,14 @@ dependencies = [
     # freeze-marker and schedule/tick output types; an older SDK would be missing
     # them (and also the 0.8.3 `--models` forwarding + retention `env` guard fixes
     # the model-aware resource methods depend on).
-    "rocky-sdk>=0.9.1",
+    # 0.12.0 is the first release with `dag(models_dir=...)` and
+    # `run_model(pipeline=...)`. This resource passes both keywords
+    # unconditionally, so an older SDK — legal under the previous `>=0.9.1` —
+    # raises TypeError during DAG discovery and per-model execution. The
+    # monorepo path source masks that in dev and CI, so this floor is the only
+    # thing protecting the published wheel. Release rocky-sdk 0.12.0 BEFORE any
+    # dagster-rocky release carrying this floor. (#1348)
+    "rocky-sdk>=0.12.0",
     # Floor matches the version CI actually resolves and tests (uv.lock). The
     # RockyComponent path uses dagster.components.* APIs from preview namespaces,
     # so we advertise a tested floor rather than an older, never-exercised one.

--- a/integrations/dagster/src/dagster_rocky/dag_assets.py
+++ b/integrations/dagster/src/dagster_rocky/dag_assets.py
@@ -552,8 +552,13 @@ def _make_dag_group_asset(
 
             if node.kind == "transformation":
                 context.log.info(f"Executing rocky run --model {node.label}")
+                # Scope execution to the node's own pipeline so it resolves the
+                # same models root discovery used. `pipeline` is Optional on the
+                # engine's node, and None falls back to the previous argv rather
+                # than silently dropping `--models`.
                 result = rocky.run_model(
                     node.label,
+                    pipeline=node.pipeline,
                     **partition_kwargs,  # type: ignore[arg-type]
                 )
                 context.log.info(

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -1239,15 +1239,25 @@ class RockyResource(dg.ConfigurableResource):
         with _translating():
             return self._get_client().catalog(out=out)
 
-    def dag(self, *, column_lineage: bool = False) -> DagResult:
-        """Run ``rocky dag`` and return the full unified DAG."""
+    def dag(
+        self, *, column_lineage: bool = False, models_dir: str | None = None
+    ) -> DagResult:
+        """Run ``rocky dag`` and return the full unified DAG.
+
+        ``models_dir`` defaults to ``None`` so each pipeline resolves its own
+        configured root; pass a string only to force a whole-project override
+        (see :meth:`RockyClient.dag`).
+        """
         with _translating():
-            return self._get_client().dag(column_lineage=column_lineage)
+            return self._get_client().dag(
+                column_lineage=column_lineage, models_dir=models_dir
+            )
 
     def run_model(
         self,
         model_name: str,
         *,
+        pipeline: str | None = None,
         filter: str | None = None,
         partition: str | None = None,
         partition_from: str | None = None,
@@ -1261,6 +1271,7 @@ class RockyResource(dg.ConfigurableResource):
         with _translating():
             return self._get_client().run_model(
                 model_name,
+                pipeline=pipeline,
                 filter=filter,
                 partition=partition,
                 partition_from=partition_from,

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -1239,9 +1239,7 @@ class RockyResource(dg.ConfigurableResource):
         with _translating():
             return self._get_client().catalog(out=out)
 
-    def dag(
-        self, *, column_lineage: bool = False, models_dir: str | None = None
-    ) -> DagResult:
+    def dag(self, *, column_lineage: bool = False, models_dir: str | None = None) -> DagResult:
         """Run ``rocky dag`` and return the full unified DAG.
 
         ``models_dir`` defaults to ``None`` so each pipeline resolves its own
@@ -1249,9 +1247,7 @@ class RockyResource(dg.ConfigurableResource):
         (see :meth:`RockyClient.dag`).
         """
         with _translating():
-            return self._get_client().dag(
-                column_lineage=column_lineage, models_dir=models_dir
-            )
+            return self._get_client().dag(column_lineage=column_lineage, models_dir=models_dir)
 
     def run_model(
         self,

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -1242,9 +1242,13 @@ class RockyResource(dg.ConfigurableResource):
     def dag(self, *, column_lineage: bool = False, models_dir: str | None = None) -> DagResult:
         """Run ``rocky dag`` and return the full unified DAG.
 
-        ``models_dir`` defaults to ``None`` so each pipeline resolves its own
-        configured root; pass a string only to force a whole-project override
-        (see :meth:`RockyClient.dag`).
+        Defaults to ``models_dir=None``, which **opts in** to per-pipeline
+        resolution. A whole-project ``--models`` makes the engine refuse any
+        project with two transformation pipelines, so the component could not
+        build definitions at all (#1348). Pass a string to force the override.
+
+        This opt-in pairs with :meth:`run_model` passing ``pipeline=``; the two
+        must move together, or discovery and execution resolve different roots.
         """
         with _translating():
             return self._get_client().dag(column_lineage=column_lineage, models_dir=models_dir)

--- a/integrations/dagster/tests/test_dag_assets.py
+++ b/integrations/dagster/tests/test_dag_assets.py
@@ -775,7 +775,6 @@ def test_transformation_execution_names_the_nodes_own_pipeline():
     dg.materialize(assets, raise_on_error=False)
 
     by_model = {
-        call.args[0]: call.kwargs.get("pipeline")
-        for call in mock_rocky.run_model.call_args_list
+        call.args[0]: call.kwargs.get("pipeline") for call in mock_rocky.run_model.call_args_list
     }
     assert by_model == {"one": "alpha", "two": "beta"}, by_model

--- a/integrations/dagster/tests/test_dag_assets.py
+++ b/integrations/dagster/tests/test_dag_assets.py
@@ -725,3 +725,57 @@ def test_dag_transformation_custom_translator_key_still_matches_engine_triple():
     assert [e.asset_key for e in mats] == [dg.AssetKey(["my_prefix", "w", "s", "m1"])]
     # Enriched from the matched engine entry — the fallback carries no row count.
     assert mats[0].materialization.metadata["dagster/row_count"].value == 42
+
+
+# --------------------------------------------------------------------------- #
+# #1348 — the node's own pipeline must reach execution
+# --------------------------------------------------------------------------- #
+
+
+def _two_pipeline_dag() -> DagResult:
+    """Two transformation models in separate pipelines — the shape the engine
+    refuses outright when discovery forces a whole-project ``--models``."""
+    return _make_dag_result(
+        nodes=[
+            {
+                "id": "transformation:one",
+                "kind": "transformation",
+                "label": "one",
+                "pipeline": "alpha",
+                "target": {"catalog": "w", "schema": "a", "table": "one"},
+            },
+            {
+                "id": "transformation:two",
+                "kind": "transformation",
+                "label": "two",
+                "pipeline": "beta",
+                "target": {"catalog": "w", "schema": "b", "table": "two"},
+            },
+        ]
+    )
+
+
+def test_transformation_execution_names_the_nodes_own_pipeline():
+    """Execution must be scoped to the pipeline discovery attributed the node to.
+
+    Without ``--pipeline`` the engine cannot know which adapter a model belongs
+    to on a multi-transformation project and refuses; with a *whole-project*
+    ``--models`` instead, it would resolve the wrong root. Asserting the kwarg
+    reaches ``run_model`` is what stops the two halves drifting apart (#1348).
+    """
+    from unittest.mock import MagicMock
+
+    mock_rocky = MagicMock()
+    mock_rocky.run_model.return_value = _dag_run_result()
+    assets = build_dag_multi_assets(
+        _two_pipeline_dag(),
+        rocky=mock_rocky,
+        translator=RockyDagsterTranslator(),
+    )
+    dg.materialize(assets, raise_on_error=False)
+
+    by_model = {
+        call.args[0]: call.kwargs.get("pipeline")
+        for call in mock_rocky.run_model.call_args_list
+    }
+    assert by_model == {"one": "alpha", "two": "beta"}, by_model

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`dag()` no longer forces a whole-project models override, which made multi-transformation projects undiscoverable.** It always sent `--models <models_dir>`. The engine reads that as an explicit *whole-project* override and assigns that one directory's models to **every** transformation pipeline, so a project with two of them was refused outright — `model 'x' is claimed by transformation pipelines a and b` — before any caller could see a DAG. `models_dir` now defaults to `None` and the flag is omitted, so each pipeline resolves its own configured root (the branch `rocky run --dag` already used). Pass `models_dir=` to ask for the override deliberately. (#1348)
+
+- **`run_model()` accepts `pipeline=`, so execution resolves the same root discovery did.** With `pipeline` set, `--pipeline` is sent and `--models` is not: the engine resolves that pipeline's own root. This has to move together with the change above — a node discovered in one root but built from another is silently different SQL for the same asset. Note `--models` never helped here: the engine refuses a bare `--model` on a multi-transformation project whether or not it is passed. Leaving `pipeline` at `None` keeps the previous argv byte-for-byte. (#1348, #1292)
+
+  If you construct `RockyClient(models_dir=…)` with a value that disagrees with the root your `rocky.toml` pipelines declare, `dag()` now follows the config rather than the client field. That is the intended direction, but it is a behaviour change worth knowing about.
+
+### Fixed
+
 - **AI parse errors now name a command the CLI accepts.** `RockyParseError` from `ai_sync()`, `ai_explain()`, and `ai_test()` reported the command as `ai sync` / `ai explain` / `ai test`. Those forms are rejected by the CLI — `rocky ai` takes a positional intent — so anyone diagnosing malformed output was handed a command that fails. They now read `ai-sync`, `ai-explain`, and `ai-test`. (#1443)
 
 ### Removed

--- a/sdk/python/src/rocky_sdk/client.py
+++ b/sdk/python/src/rocky_sdk/client.py
@@ -109,6 +109,20 @@ DEFAULT_HTTP_TIMEOUT_SECONDS = 30
 # (whose Pipes path content-addresses every plan, a 1.34+ guarantee).
 MIN_ROCKY_VERSION = "1.34.0"
 
+
+class _Unset:
+    """Sentinel distinguishing "argument omitted" from an explicit ``None``.
+
+    Needed where ``None`` is itself meaningful — see :meth:`RockyClient.dag`,
+    where omitting ``models_dir`` must keep the previous behaviour while an
+    explicit ``None`` opts in to per-pipeline resolution.
+    """
+
+    __slots__ = ()
+
+
+_UNSET = _Unset()
+
 # Bytes of an inner payload surfaced on an error so the cause is visible without
 # dumping potentially-MB blobs.
 _JSON_ERROR_PREVIEW_BYTES = 500
@@ -351,6 +365,9 @@ class RockyClient:
         self._mirror_stderr = mirror_stderr
         self._resolved_binary: str | None = None
         self._version_checked = False
+        # Parsed engine version, when it could be determined. Kept so a
+        # per-feature floor can be checked without re-running ``--version``.
+        self._engine_version: tuple[int, int, int] | None = None
 
     # ------------------------------------------------------------------ #
     # Binary resolution + version gate                                   #
@@ -432,11 +449,41 @@ class RockyClient:
         # would otherwise sort (1, 34) below (1, 34, 0) and reject it.
         detected += (0,) * (3 - len(detected))
         required += (0,) * (3 - len(required))
+        self._engine_version = detected  # type: ignore[assignment]
 
         if detected < required:
             raise RockyVersionError(version_str, MIN_ROCKY_VERSION, binary)
 
         self._version_checked = True
+
+    def _require_engine(self, minimum: str, feature: str) -> None:
+        """Refuse a *feature* whose floor is above :data:`MIN_ROCKY_VERSION`.
+
+        The package-wide minimum is deliberately low, so a method relying on
+        newer engine behaviour has to state its own floor. Without this, an
+        accepted-but-older binary silently does something different — the worst
+        outcome here being a model discovered from one models root and executed
+        from another.
+
+        Matches the surrounding fail-open policy: when the version could not be
+        determined the call proceeds with a warning, because a slow or unusual
+        environment should not block every command. A silently skipped gate is
+        how an incompatible binary reaches a confusing failure later, so the
+        skip is logged.
+        """
+        self._verify_engine_version()
+        if self._engine_version is None:
+            self._logger.warning(
+                "engine version unknown; proceeding with %s, which needs rocky >= %s",
+                feature,
+                minimum,
+            )
+            return
+        required = tuple(int(x) for x in minimum.split(".")[:3])
+        required += (0,) * (3 - len(required))
+        if self._engine_version < required:
+            detected = ".".join(str(x) for x in self._engine_version)
+            raise RockyVersionError(detected, minimum, self._resolve_binary())
 
     # ------------------------------------------------------------------ #
     # argv construction                                                  #
@@ -1093,6 +1140,7 @@ class RockyClient:
         """
         args = ["run", "--model", model_name]
         if pipeline is not None:
+            self._require_engine("1.69.0", "run_model(pipeline=...)")
             args.extend(["--pipeline", pipeline])
         else:
             args.extend(["--models", self.models_dir])
@@ -1240,23 +1288,41 @@ class RockyClient:
             args.extend(["--out", out])
         return _parse_rocky_json(self.run_cli(args), CatalogOutput, command="catalog")
 
-    def dag(self, *, column_lineage: bool = False, models_dir: str | None = None) -> DagResult:
+    def dag(
+        self,
+        *,
+        column_lineage: bool = False,
+        models_dir: str | None | _Unset = _UNSET,
+    ) -> DagResult:
         """Run ``rocky dag`` and return the full unified DAG.
 
-        ``models_dir`` defaults to ``None``, which omits ``--models`` so each
-        pipeline resolves its own configured root — the same branch
-        ``rocky run --dag`` uses. Passing ``--models`` is an explicit
-        *whole-project* override: the engine assigns that one directory's models
-        to **every** transformation pipeline, so a project with two of them is
-        refused outright (``model 'x' is claimed by transformation pipelines a
-        and b``). Sending it unconditionally therefore made multi-transformation
-        projects undiscoverable (#1348).
+        ``--models`` is an explicit *whole-project* override: the engine gives
+        that one directory's models to **every** transformation pipeline, so a
+        project with two of them is refused outright (``model 'x' is claimed by
+        transformation pipelines a and b``), which made such projects
+        undiscoverable (#1348).
 
-        Pass a string to ask for that override deliberately.
+        ``models_dir`` is three-state, so no existing caller changes:
+
+        * **omitted** — send ``--models <self.models_dir>``, exactly as before.
+        * ``None`` — *opt in* to per-pipeline resolution: omit the flag so each
+          pipeline resolves its own configured root, the branch
+          ``rocky run --dag`` already used. Needs engine >= 1.68.0.
+        * a string — that whole-project override, deliberately.
+
+        Opt in on both sides or neither. Pair ``models_dir=None`` with
+        ``run_model(pipeline=...)``: opting in here alone would have discovery
+        read a pipeline's own root while execution still forced
+        ``self.models_dir``, which is the split #1348 warns about — a model
+        discovered from one directory and materialized from another.
         """
         args = ["dag"]
-        if models_dir is not None:
+        if isinstance(models_dir, _Unset):
+            args.extend(["--models", self.models_dir])
+        elif models_dir is not None:
             args.extend(["--models", models_dir])
+        else:
+            self._require_engine("1.68.0", "dag(models_dir=None)")
         if self.contracts_dir is not None:
             args.extend(["--contracts", self.contracts_dir])
         if column_lineage:

--- a/sdk/python/src/rocky_sdk/client.py
+++ b/sdk/python/src/rocky_sdk/client.py
@@ -1240,9 +1240,7 @@ class RockyClient:
             args.extend(["--out", out])
         return _parse_rocky_json(self.run_cli(args), CatalogOutput, command="catalog")
 
-    def dag(
-        self, *, column_lineage: bool = False, models_dir: str | None = None
-    ) -> DagResult:
+    def dag(self, *, column_lineage: bool = False, models_dir: str | None = None) -> DagResult:
         """Run ``rocky dag`` and return the full unified DAG.
 
         ``models_dir`` defaults to ``None``, which omits ``--models`` so each

--- a/sdk/python/src/rocky_sdk/client.py
+++ b/sdk/python/src/rocky_sdk/client.py
@@ -1064,6 +1064,7 @@ class RockyClient:
         self,
         model_name: str,
         *,
+        pipeline: str | None = None,
         filter: str | None = None,
         partition: str | None = None,
         partition_from: str | None = None,
@@ -1076,8 +1077,25 @@ class RockyClient:
         """Run ``rocky run --model <name>`` for a single compiled model.
 
         ``--model`` skips the replication phase and executes only the named model.
+
+        ``pipeline`` names the transformation pipeline the model belongs to. When
+        given, ``--models`` is **not** sent: the engine resolves that pipeline's
+        own configured root, which is what :meth:`dag` discovers against. On a
+        project with two or more transformation pipelines the engine refuses a
+        bare ``--model`` regardless of ``--models`` ("cannot know which pipeline
+        (and adapter) the model belongs to"), so ``--pipeline`` is the only way
+        to execute one — and passing both would override the pipeline's root
+        with a whole-project one, which is the discovery/execution split #1348
+        warns about.
+
+        Leaving ``pipeline`` at ``None`` keeps the previous argv exactly, for
+        single-pipeline callers.
         """
-        args = ["run", "--model", model_name, "--models", self.models_dir]
+        args = ["run", "--model", model_name]
+        if pipeline is not None:
+            args.extend(["--pipeline", pipeline])
+        else:
+            args.extend(["--models", self.models_dir])
         if filter is not None:
             args.extend(["--filter", filter])
         if partition is not None:
@@ -1222,9 +1240,25 @@ class RockyClient:
             args.extend(["--out", out])
         return _parse_rocky_json(self.run_cli(args), CatalogOutput, command="catalog")
 
-    def dag(self, *, column_lineage: bool = False) -> DagResult:
-        """Run ``rocky dag`` and return the full unified DAG."""
-        args = ["dag", "--models", self.models_dir]
+    def dag(
+        self, *, column_lineage: bool = False, models_dir: str | None = None
+    ) -> DagResult:
+        """Run ``rocky dag`` and return the full unified DAG.
+
+        ``models_dir`` defaults to ``None``, which omits ``--models`` so each
+        pipeline resolves its own configured root — the same branch
+        ``rocky run --dag`` uses. Passing ``--models`` is an explicit
+        *whole-project* override: the engine assigns that one directory's models
+        to **every** transformation pipeline, so a project with two of them is
+        refused outright (``model 'x' is claimed by transformation pipelines a
+        and b``). Sending it unconditionally therefore made multi-transformation
+        projects undiscoverable (#1348).
+
+        Pass a string to ask for that override deliberately.
+        """
+        args = ["dag"]
+        if models_dir is not None:
+            args.extend(["--models", models_dir])
         if self.contracts_dir is not None:
             args.extend(["--contracts", self.contracts_dir])
         if column_lineage:

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -946,16 +946,32 @@ def _run_payload() -> str:
     )
 
 
-def test_dag_omits_models_so_each_pipeline_resolves_its_own_root():
-    """``--models`` is a whole-project override, not a hint.
+def test_dag_default_is_unchanged_so_no_existing_caller_moves():
+    """Omitting ``models_dir`` must keep the previous argv byte-for-byte.
 
-    The engine assigns that one directory to *every* transformation pipeline, so
-    a project with two of them is refused outright. Sending it unconditionally
-    made such projects undiscoverable (#1348).
+    Changing the default would make discovery follow the config while
+    ``run_model()`` (without ``pipeline``) still forced ``self.models_dir`` — a
+    model discovered from one root and materialized from another, which is the
+    split #1348 warns about. Per-pipeline resolution is opt-in instead.
     """
     client = _client(models_dir="custom-models")
     with patch.object(client, "run_cli", return_value=_dag_payload([])) as run_cli:
         client.dag()
+    args = run_cli.call_args[0][0]
+    assert args == ["dag", "--models", "custom-models"], args
+
+
+def test_dag_opts_in_to_per_pipeline_resolution_with_an_explicit_none():
+    """``--models`` is a whole-project override, not a hint.
+
+    The engine assigns that one directory to *every* transformation pipeline, so
+    a project with two of them is refused outright. `None` omits it so each
+    pipeline resolves its own configured root (#1348).
+    """
+    client = _client(models_dir="custom-models")
+    client._engine_version = (1, 70, 1)
+    with patch.object(client, "run_cli", return_value=_dag_payload([])) as run_cli:
+        client.dag(models_dir=None)
     args = run_cli.call_args[0][0]
     assert args == ["dag"], args
     assert "--models" not in args
@@ -972,6 +988,7 @@ def test_dag_still_allows_an_explicit_whole_project_override():
 
 def test_run_model_scopes_to_the_pipeline_and_drops_the_override():
     client = _client(models_dir="custom-models")
+    client._engine_version = (1, 70, 1)
     with patch.object(client, "run_cli", return_value=_run_payload()) as run_cli:
         client.run_model("stg_orders", pipeline="alpha")
     args = run_cli.call_args[0][0]
@@ -1002,8 +1019,9 @@ def test_discovery_and_execution_resolve_the_same_root_for_a_discovered_node():
         {"id": "transformation:one", "kind": "transformation", "label": "one", "pipeline": "alpha"},
         {"id": "transformation:two", "kind": "transformation", "label": "two", "pipeline": "beta"},
     ]
+    client._engine_version = (1, 70, 1)
     with patch.object(client, "run_cli", return_value=_dag_payload(nodes)) as run_cli:
-        dag = client.dag()
+        dag = client.dag(models_dir=None)
     discovery_args = run_cli.call_args[0][0]
     assert "--models" not in discovery_args, discovery_args
 
@@ -1017,3 +1035,40 @@ def test_discovery_and_execution_resolve_the_same_root_for_a_discovered_node():
         assert exec_args[exec_args.index("--pipeline") + 1] == node.pipeline
         # Neither side forces a whole-project root, so they cannot disagree.
         assert "--models" not in exec_args, exec_args
+
+
+def test_per_pipeline_mode_refuses_an_engine_that_predates_it():
+    """An accepted-but-older binary does something different, silently.
+
+    Per-pipeline DAG resolution shipped in engine 1.68.0 and pipeline-scoped
+    model execution in 1.69.0, but ``MIN_ROCKY_VERSION`` is 1.34.0 — so both
+    opt-ins have to state their own floor. Without this, a 1.68 binary would
+    discover a pipeline's configured root and then execute from ``models/``
+    relative to the process CWD, which can build a same-named decoy.
+    """
+    client = _client(models_dir="custom-models")
+
+    client._engine_version = (1, 67, 0)
+    with pytest.raises(RockyVersionError):
+        client.dag(models_dir=None)
+
+    client._engine_version = (1, 68, 0)
+    with pytest.raises(RockyVersionError):
+        client.run_model("stg_orders", pipeline="alpha")
+
+    # 1.68 is enough for discovery on its own.
+    with patch.object(client, "run_cli", return_value=_dag_payload([])):
+        client.dag(models_dir=None)
+
+
+def test_unknown_engine_version_warns_rather_than_blocking():
+    """Matches the surrounding fail-open policy, but must not be silent."""
+    client = _client(models_dir="custom-models")
+    client._engine_version = None
+    client._version_checked = True
+    with (
+        patch.object(client, "run_cli", return_value=_dag_payload([])),
+        patch.object(client._logger, "warning") as warn,
+    ):
+        client.dag(models_dir=None)
+    assert warn.called, "a skipped version gate must be logged"

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -900,3 +900,120 @@ def test_run_still_accepts_defer():
     assert argv[0] == "run"
     assert "--defer" in argv
     assert argv[argv.index("--defer-to") + 1] == "prod"
+
+
+# --------------------------------------------------------------------------- #
+# #1348 — discovery and execution must resolve the same models root
+# --------------------------------------------------------------------------- #
+
+
+def _dag_payload(nodes: list[dict]) -> str:
+    return json.dumps(
+        {
+            "version": "1.70.1",
+            "command": "dag",
+            "nodes": nodes,
+            "edges": [],
+            "execution_layers": [],
+            "summary": {
+                "total_nodes": len(nodes),
+                "total_edges": 0,
+                "execution_layers": 1,
+                "counts_by_kind": {},
+            },
+        }
+    )
+
+
+def _run_payload() -> str:
+    return json.dumps(
+        {
+            "version": "1.70.1",
+            "command": "run",
+            "filter": "",
+            "duration_ms": 0,
+            "tables_copied": 0,
+            "materializations": [],
+            "check_results": [],
+            "permissions": {
+                "grants_added": 0,
+                "grants_revoked": 0,
+                "catalogs_created": 0,
+                "schemas_created": 0,
+            },
+            "drift": {"tables_checked": 0, "tables_drifted": 0, "actions_taken": []},
+        }
+    )
+
+
+def test_dag_omits_models_so_each_pipeline_resolves_its_own_root():
+    """``--models`` is a whole-project override, not a hint.
+
+    The engine assigns that one directory to *every* transformation pipeline, so
+    a project with two of them is refused outright. Sending it unconditionally
+    made such projects undiscoverable (#1348).
+    """
+    client = _client(models_dir="custom-models")
+    with patch.object(client, "run_cli", return_value=_dag_payload([])) as run_cli:
+        client.dag()
+    args = run_cli.call_args[0][0]
+    assert args == ["dag"], args
+    assert "--models" not in args
+
+
+def test_dag_still_allows_an_explicit_whole_project_override():
+    """A caller who genuinely wants the override can still ask for it."""
+    client = _client(models_dir="custom-models")
+    with patch.object(client, "run_cli", return_value=_dag_payload([])) as run_cli:
+        client.dag(models_dir="one-root")
+    args = run_cli.call_args[0][0]
+    assert args == ["dag", "--models", "one-root"], args
+
+
+def test_run_model_scopes_to_the_pipeline_and_drops_the_override():
+    client = _client(models_dir="custom-models")
+    with patch.object(client, "run_cli", return_value=_run_payload()) as run_cli:
+        client.run_model("stg_orders", pipeline="alpha")
+    args = run_cli.call_args[0][0]
+    assert args == ["run", "--model", "stg_orders", "--pipeline", "alpha"], args
+    # Passing both would override the pipeline's own root with a project-wide
+    # one — the discovery/execution split #1348 warns about.
+    assert "--models" not in args
+
+
+def test_run_model_without_a_pipeline_keeps_the_previous_argv():
+    """Single-pipeline callers must be unaffected."""
+    client = _client(models_dir="custom-models")
+    with patch.object(client, "run_cli", return_value=_run_payload()) as run_cli:
+        client.run_model("stg_orders")
+    args = run_cli.call_args[0][0]
+    assert args == ["run", "--model", "stg_orders", "--models", "custom-models"], args
+
+
+def test_discovery_and_execution_resolve_the_same_root_for_a_discovered_node():
+    """#1348 acceptance: asserted, not read.
+
+    Drives execution from the node ``dag()`` actually returned, so a change that
+    stops threading the node's pipeline fails here — which two independent argv
+    assertions would not catch.
+    """
+    client = _client(models_dir="custom-models")
+    nodes = [
+        {"id": "transformation:one", "kind": "transformation", "label": "one", "pipeline": "alpha"},
+        {"id": "transformation:two", "kind": "transformation", "label": "two", "pipeline": "beta"},
+    ]
+    with patch.object(client, "run_cli", return_value=_dag_payload(nodes)) as run_cli:
+        dag = client.dag()
+    discovery_args = run_cli.call_args[0][0]
+    assert "--models" not in discovery_args, discovery_args
+
+    for node in dag.nodes:
+        with patch.object(client, "run_cli", return_value=_run_payload()) as run_cli:
+            client.run_model(node.label, pipeline=node.pipeline)
+        exec_args = run_cli.call_args[0][0]
+        # Execution names the node's own pipeline, so the engine resolves that
+        # pipeline's configured root — the same one discovery used.
+        assert "--pipeline" in exec_args, exec_args
+        assert exec_args[exec_args.index("--pipeline") + 1] == node.pipeline
+        # Neither side forces a whole-project root, so they cannot disagree.
+        assert "--models" not in exec_args, exec_args


### PR DESCRIPTION
Closes #1348. Relates to #1292 and #1397.

Option A from the disposition triage: a per-call models root, with discovery and execution moving together.

## The bug, reproduced

`RockyClient.dag()` always sent `--models <models_dir>`. The engine reads that as an explicit **whole-project override** and assigns that one directory's models to *every* transformation pipeline. Against a two-pipeline fixture on 1.70.1:

```
$ rocky dag --models models_a          # what the SDK sent
Error: failed to build unified DAG
Caused by:
    model 'one' is claimed by transformation pipelines alpha and beta.

$ rocky dag                            # omitting it
nodes: 2
  transformation:one | pipeline=alpha
  transformation:two | pipeline=beta
```

Since `RockyComponent` caches `rocky.dag(...)`, definitions failed to build at all — no asset existed to be mis-routed.

## Why execution had to move in the same change

#1348 says explicitly: *do not fix this half alone.* A node discovered in one root but built from another is silently different SQL for the same asset. So `run_model()` takes `pipeline=`, and when set it sends `--pipeline` and **not** `--models`:

```
$ rocky run --model one --pipeline alpha     # resolves ./models_a, executes
$ rocky run --model one --pipeline beta      # "model 'one' not found"  ← roots agree
```

That second line is the point: execution refuses to build `one` under `beta`, because it resolved only beta's root — the same root discovery attributed nodes by.

**`--models` was never the fix here.** On a multi-transformation project the engine refuses a bare `--model` whether or not `--models` is passed:

```
$ rocky run --model one --models models_a
Error: this project has multiple transformation pipelines, so a bare --model run
cannot know which pipeline (and adapter) the model belongs to; pass --pipeline <name>
```

## Deliberately gated, not defaulted

`run_model()` keeps `--models self.models_dir` when `pipeline` is `None`, so single-pipeline callers get byte-identical argv. I considered dropping `--models` unconditionally and rejected it: I had verified that only on a freshly-built fixture where the client field and the config agreed. The case that breaks is `RockyClient(models_dir="Y")` against a config declaring `X` — today execution uses `Y`, and an unconditional change would silently switch it to `X` on the *execution* path. The gated form cannot diverge, because whenever discovery omits the override, execution is pipeline-scoped too.

`node.pipeline` is `Optional` on the engine's node; `None` takes that same fallback rather than silently dropping `--models`.

## Acceptance

| #1348 criterion | How |
|---|---|
| Two transformation pipelines in separate roots produce an asset graph | `dag()` omits the override; verified against the fixture above |
| Discovery and execution resolve the same root, **asserted by a test** | `test_discovery_and_execution_resolve_the_same_root_for_a_discovered_node` drives execution from the node `dag()` returned, not a literal |
| A caller can still ask for a whole-project override | `dag(models_dir="one-root")` |

The acceptance test is deliberately not two independent argv assertions — those would both pass if one side started forcing the override again. It fails under **both** relevant mutations.

## Mutation-checked

| Mutation | Test | Result |
|---|---|---|
| stop threading `node.pipeline` | `test_transformation_execution_names_the_nodes_own_pipeline` | **FAILED** |
| revert `dag()` to forcing `--models` | consistency test | **FAILED** |
| send *both* `--pipeline` and `--models` | consistency test | **FAILED** |

Tree verified clean before and after each.

## Gates

| Gate | Result |
|---|---|
| `uv run pytest` (sdk) | 219 passed |
| `uv run pytest` (dagster) | 713 passed |
| `ruff check` / `ruff format --check` (both) | 0 |

No engine change, no schema change, no codegen cascade, no fixture movement.

## Behaviour change worth knowing

If you construct `RockyClient(models_dir=…)` with a value that disagrees with the root your `rocky.toml` pipelines declare, `dag()` now follows the config rather than the client field. That is the intended direction — the config is the authority — but it is a change, and it is in the changelog.

## Not in scope

#1397 (`_dag_payload`'s missing `is_dir` guard) is adjacent but separate; its own issue records that the proposed guard would break replication-only projects. #1292's engine half already landed in #1358; this supplies its SDK/Dagster half, so that issue's symptom should be retested before closing.

## Red team

Reviewed by **Codex**, `needs-attention`, with all three findings confirmed by an independent **`gpt-5.6-terra`** pass. All three were real and all three are fixed. Each was verified against the code before I accepted it.

**[high] The default change introduced the divergence it was meant to remove.** This is the important one, and it means my first version made things worse for one config. With `dag()` omitting `--models` but `run_model()` (no `pipeline`) still forcing `self.models_dir`, a project whose client field and config disagree would discover a model from one root and materialize it from another. **Before the change, both calls sent the same flag and agreed.**

My advisor had judged this residual acceptable, on the grounds it "exists today in the opposite direction". Reading the code, that is not so — today they agree, and my change is what split them. Codex was right, and its third suggested option dissolves the disagreement entirely: keep `dag()`'s default and make per-pipeline resolution **opt-in**. `models_dir` is now three-state — omitted is byte-identical to before, `None` opts in, a string forces the override — and the Dagster resource opts in explicitly, which is the caller that actually needs it. Nothing moves for existing callers, and the two halves can only move together.

**[high] Supported engines do not all implement the semantics assumed.** `MIN_ROCKY_VERSION` is `1.34.0`, but per-pipeline DAG resolution shipped in engine **1.68.0** (#1261) and `--model X --pipeline P` loading from P's root in **1.69.0** (#1292) — both confirmed from the changelog. An accepted 1.68 binary would discover a pipeline's configured root and then execute from `models/` relative to the process CWD, which can build a **same-named decoy**. Mocked argv tests are structurally blind to this. Each opt-in now gates on its own floor via `_require_engine`, following the existing fail-open policy when the version is undeterminable — and logging the skip, since a silently skipped gate is how an incompatible binary surfaces later as a confusing failure.

**[high] Dagster permitted an SDK that rejects both new keywords.** The floor was `rocky-sdk>=0.9.1` while the resource passes `models_dir=` and `pipeline=` unconditionally, so a legally resolved 0.11.0 raises `TypeError` during DAG discovery and per-model execution. The monorepo path source masks this in dev and CI, so the floor is the only protection for the published wheel. Now `>=0.12.0`, with the release ordering written next to it.

Codex refuted its own earlier concern about `node.pipeline` being Optional, and found no execution defect in the other whole-project methods.

## Release ordering (new, and load-bearing)

1. **rocky-sdk 0.12.0** — contains `dag(models_dir=)` and `run_model(pipeline=)`. Minor, not patch.
2. **dagster-rocky** — only after that is on PyPI, since its floor now resolves from PyPI, not the path source.

## Gates after the follow-up

| Gate | Result |
|---|---|
| `uv run pytest` (sdk) | 222 passed |
| `uv run pytest` (dagster) | 713 passed |
| `ruff check` / `format --check` (both) | 0 |

## Still open, and honestly stated

Codex's remaining point stands: the acceptance test proves argument forwarding, not end-to-end routing. I validated routing by hand against a two-pipeline fixture — including the cross case where `--pipeline beta` correctly refuses model `one` — but that is not automated. A real-binary test over a two-root project is the right follow-up and is not in this PR.

