### PR TITLE
docs(engine): land the plan-replay audit and repair its own tripwire

### DIFF
--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -3112,13 +3112,21 @@ async fn run_apply_ai_authored_plan(
 /// plans written by an OLDER binary, and a plan payload is on-disk JSON that
 /// the gc apply path already treats as possibly hand-authored.
 ///
-/// It is safe because this arm never READS those fields. It consumes
-/// `models_dir`, `models`, `partition_from`, `partition_to`, and `parallel`,
-/// so the DAG runner is never reached and DAG-precedence cannot widen the
-/// authorized scope. That guarantee is structural, not enforced: routing a
-/// backfill through the shared `execute_run_plan` (as `Run` and `AiAuthored`
-/// already do) would reintroduce the exposure with no test failing. Add the
-/// shape validation here if this arm ever grows a consumer of either field.
+/// It is safe because this arm never READS `dag` or `model`. It consumes
+/// `models_dir`, `models`, `partition_from`, `partition_to`, `parallel`, and
+/// `env` — the last feeding the governance fingerprint gate, not model
+/// selection — so the DAG runner is never reached and DAG-precedence cannot
+/// widen the authorized scope.
+///
+/// This list is the whole basis of that claim, so keep it exhaustive: it read
+/// `env` for three weeks while enumerating only the first five, which made the
+/// tripwire below unreliable on the day it shipped. If you add a field read
+/// here, add it here too.
+///
+/// That guarantee is structural, not enforced: routing a backfill through the
+/// shared `execute_run_plan` (as `Run` and `AiAuthored` already do) would
+/// reintroduce the exposure with no test failing. Add the shape validation
+/// here if this arm ever grows a consumer of `dag` or `model`.
 async fn run_apply_backfill_plan(
     root: &Path,
     config_path: &Path,
@@ -3329,8 +3337,12 @@ async fn run_apply_backfill_plan(
             (Some(ctx), Some(l)) => {
                 // Fail-closed (#4/#5): verify the routing identity before executing.
                 ctx.verify_routing_identity(&l.config)?;
-                // The governance identity resolves the plan's persisted `--env` (a
-                // backfill persists `None`), matching the plan-side fingerprint.
+                // The governance identity resolves the plan's persisted `--env`,
+                // matching the plan-side fingerprint. Deliberately reads whatever
+                // the payload carries rather than assuming what `build_run_plan`
+                // writes today: the same reasoning #1173 rejected for `dag` /
+                // `model` applies here, since a plan on disk may come from an
+                // older binary or be hand-authored.
                 Some(ctx.exec_fingerprint_gate(&l.config, run_plan.env.as_deref()))
             }
             // Fail-closed (#7): a governed backfill whose config would not load

--- a/engine/crates/rocky-cli/src/plan_store.rs
+++ b/engine/crates/rocky-cli/src/plan_store.rs
@@ -56,6 +56,43 @@ use rocky_core::config::{PolicyCapability, PolicyPrincipal};
 use serde::{Deserialize, Serialize};
 
 /// The kind of plan — used to guard cross-apply mismatches.
+///
+/// # Which plan-time invariants survive a replay (#1325)
+///
+/// `rocky plan <verb>` persists a plan and `rocky apply <plan-id>` replays it.
+/// The plan is the *reviewed artifact*, so apply deliberately does not re-derive
+/// it. The consequence is the thing to keep in mind when adding a check:
+///
+/// > A guard over the plan **payload** replays by definition. A guard over
+/// > **derived** state — discovery output, compiled models, live warehouse
+/// > shape — is only re-established where that derivation repeats at apply.
+///
+/// So when adding a plan-build-time check, ask *which entrypoints reach the
+/// line*, not whether the check is correct. That is how the duplicate
+/// physical-target refusal came to be absent from `branch promote --plan <id>`
+/// and `rocky apply <promote-plan>`: it sat inside discovery, which those
+/// paths never call (#1310). Such checks belong at the seam every entrypoint
+/// crosses.
+///
+/// Audited across all nine kinds:
+///
+/// | Kind | Load-bearing plan-time invariant | Re-established at apply? |
+/// |---|---|---|
+/// | `Run` | compile-time diagnostics | Yes — recompiles at apply |
+/// | `Promote` | duplicate physical target | **Was exposed**; now enforced at `run_promote_apply`, the shared seam (#1310) |
+/// | `Gc` | candidate is provably derivable | Yes — re-derives against the live store and takes derivability from the fresh candidate, never the payload; fail-closed on hash mismatch |
+/// | `Restore` | rebuilt bytes are hash-exact | Yes — structurally; the hash comparison *is* the operation |
+/// | `Compact` / `Archive` | policy gate | Yes — the gate runs at apply; a denied apply never reaches `execute_statement` |
+/// | `Replication` | source state matches what was reviewed | Yes — re-runs discovery and diffs against the persisted snapshot before any SQL is emitted |
+/// | `AiAuthored` | reviewed shape + run-plan diagnostics | Yes — review marker mandatory, then dispatches the same `execute_run_plan` as `Run` |
+/// | `Backfill` | reviewed closure + run-plan diagnostics | Yes for the closure — see the structural note on `run_apply_backfill_plan` |
+///
+/// `Backfill` is the one entry whose safety is **structural rather than
+/// enforced**: it deserializes the same `RunPlan` as `Run` and `AiAuthored` but
+/// does not call `validate_run_plan_execution_shape`. That is safe only because
+/// its apply path never reaches the DAG runner, and nothing enforces that it
+/// stays that way — the reasoning is written out at
+/// [`crate::commands::apply::run_apply_backfill_plan`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum PlanKind {

--- a/engine/crates/rocky-cli/src/plan_store.rs
+++ b/engine/crates/rocky-cli/src/plan_store.rs
@@ -61,11 +61,19 @@ use serde::{Deserialize, Serialize};
 ///
 /// `rocky plan <verb>` persists a plan and `rocky apply <plan-id>` replays it.
 /// The plan is the *reviewed artifact*, so apply deliberately does not re-derive
-/// it. The consequence is the thing to keep in mind when adding a check:
+/// it. The rule that follows is narrower than it first looks:
 ///
-/// > A guard over the plan **payload** replays by definition. A guard over
-/// > **derived** state — discovery output, compiled models, live warehouse
-/// > shape — is only re-established where that derivation repeats at apply.
+/// > Payload **values** survive a replay. Any **invariant over** those values
+/// > must be re-evaluated explicitly at every apply sink, unless the sink
+/// > structurally cannot observe an invalid shape.
+///
+/// Persisting a value is not the same as replaying the check that validated it.
+/// `ReplicationPlan.config_snapshot` is the counterexample: it is written at
+/// plan time and no production apply-side code reads it, so a plan whose
+/// adapter or destination changed between plan and apply is not detected by it.
+/// Guards over *derived* state — discovery output, compiled models, live
+/// warehouse shape — are likewise only re-established where that derivation
+/// repeats at apply.
 ///
 /// So when adding a plan-build-time check, ask *which entrypoints reach the
 /// line*, not whether the check is correct. That is how the duplicate
@@ -74,17 +82,18 @@ use serde::{Deserialize, Serialize};
 /// paths never call (#1310). Such checks belong at the seam every entrypoint
 /// crosses.
 ///
-/// Audited across all nine kinds:
+/// Audited across all nine kinds. Two entries below record a gap rather than a
+/// guarantee; do not read this table as a certification.
 ///
 /// | Kind | Load-bearing plan-time invariant | Re-established at apply? |
 /// |---|---|---|
 /// | `Run` | compile-time diagnostics | Yes — recompiles at apply |
 /// | `Promote` | duplicate physical target | **Was exposed**; now enforced at `run_promote_apply`, the shared seam (#1310) |
 /// | `Gc` | candidate is provably derivable | Yes — re-derives against the live store and takes derivability from the fresh candidate, never the payload; fail-closed on hash mismatch |
-/// | `Restore` | rebuilt bytes are hash-exact | Yes — structurally; the hash comparison *is* the operation |
+/// | `Restore` | rebuilt bytes are hash-exact | Point-in-time only — the hash is verified *before* the ledger row is reinstated, and nothing fences the object between the two |
 /// | `Compact` / `Archive` | policy gate | Yes — the gate runs at apply; a denied apply never reaches `execute_statement` |
-/// | `Replication` | source state matches what was reviewed | Yes — re-runs discovery and diffs against the persisted snapshot before any SQL is emitted |
-/// | `AiAuthored` | reviewed shape + run-plan diagnostics | Yes — review marker mandatory, then dispatches the same `execute_run_plan` as `Run` |
+/// | `Replication` | source state matches what was reviewed | **Partly — see #1460.** Apply discovers once for comparison, then `run` discovers again and builds work from the second result; `config_snapshot` has no production apply-side reader |
+/// | `AiAuthored` | human review before a machine-authored change executes | **No — see #1459.** The marker is only checked when policy is `NotConfigured`; a configured policy resolving to `Allow` reaches `apply_policy_gate`, which returns `Ok(())` without consulting it |
 /// | `Backfill` | reviewed closure + run-plan diagnostics | Yes for the closure — see the structural note on `run_apply_backfill_plan` |
 ///
 /// `Backfill` is the one entry whose safety is **structural rather than


### PR DESCRIPTION
Closes out #1325's acceptance list. **No behaviour change** — a doc comment moved into the repo, and two comment defects repaired.

## 1. The audit now lives where the reader is (acceptance item 1)

The per-`PlanKind` table existed only as an issue comment, so the person it was written for — someone adding a plan-build-time check — could not find it. It is now a doc comment on `PlanKind` itself, general rule first:

> A guard over the plan **payload** replays by definition. A guard over **derived** state — discovery output, compiled models, live warehouse shape — is only re-established where that derivation repeats at apply.

So the question to ask is *which entrypoints reach the line*, not whether the check is correct. That is exactly how promote's duplicate-target refusal came to be absent from two of its three entrypoints (#1310).

## 2. The Backfill tripwire was wrong the day it shipped

This is the part worth reading. `run_apply_backfill_plan`'s doc comment justifies skipping `validate_run_plan_execution_shape` by enumerating every `RunPlan` field the arm consumes — five — and instructs the reader to add the shape check if that list ever grows a consumer of `dag` or `model`.

The arm reads a **sixth**: `run_plan.env`, at `apply.rs:3334`. `git log -L` dates that read to #1144, **nearly three weeks before the comment landed**.

The safety claim itself survives — `env` feeds the governance fingerprint gate, not model selection, so the DAG runner is still unreachable. But an inventory presented as exhaustive, which is not, makes the tripwire unreliable for precisely the audit it invites. A reader checking "does this arm consume anything that could widen scope?" would have trusted a list that was already incomplete.

Corrected, and verified mechanically across the whole 313-line function rather than by eye:

```
fields read:       ['env', 'models', 'models_dir', 'parallel', 'partition_from', 'partition_to']
fields documented: ['env', 'models', 'models_dir', 'parallel', 'partition_from', 'partition_to']
read but undocumented: none      documented but unread: none
```

## 3. One inline justification argued against its own doc comment

The `env` read carried the annotation *"a backfill persists `None`"* — an assumption about what `build_run_plan` writes today. That is precisely the reasoning #1173 rejected, and which the doc comment fifteen lines above explicitly disowns, on the grounds that a plan on disk may come from an older binary or be hand-authored. Replaced with why the read is actually correct: it deliberately takes whatever the payload carries.

## Deliberately not done

**Nothing enforces the field inventory** — which is why it went stale silently, and the fix above does not change that. A test pinning it would need a source-property assertion, and this repo has no precedent for that pattern (the `include_str!` uses are data fixtures). Introducing one is a design call that belongs in its own change, not a doc fix. Flagging rather than quietly leaving the gap.

## Red team

#1325 named its own blocker: the five "no gap" conclusions were single-model analysis, and the author explicitly declined to self-certify, deferring to an independent reviewer unavailable until 2026-08-08. That date has passed, so an independent Codex pass is running now over all five kinds plus the two comment repairs here. **This should not merge, and #1325 should not close, until that returns** — the whole point of the deferral was not to close on one model's word.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | 0 |
| `cargo clippy --all-targets --workspace -- -D warnings` | 0 |
| `cargo test -p rocky-cli --lib` | 1428 passed |
