### PR TITLE
fix(engine): stop the strict-scheduling refusal naming a flag that does not exist

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The strict-scheduling refusal no longer tells you to omit a flag that does not exist.** When `[run] strict_scheduling` refused a run whose physical-read ordering could not be resolved, the error offered two remedies: declare `depends_on`, or "omit `--strict-scheduling`". There is no such CLI flag — `rocky run --strict-scheduling` fails with `unexpected argument`. Every real consumer reads the TOML key. The message now names only the key, and the doc comment says plainly that the setting is config-only. Whether to add the flag is tracked on #1357.
+
+### Fixed
+
 - **`rocky import-dbt` no longer ends with a command the CLI rejects.** Its Next Steps block printed `rocky ai explain --all --save`, which does not parse — `rocky ai` takes a positional `INTENT`, so `explain` is consumed as the intent and the flags are refused with `error: unexpected argument '--all' found`. The real subcommand is `rocky ai-explain`. The same invalid spelling appeared in a second user-facing hint and in four doc comments, three of which publish as JSON-schema descriptions for the `ai_*` outputs.
 
   The step is now also **gated**. `ai-explain --all` selects only models whose `intent` is unset, but the recommendation was emitted unconditionally — and the dbt importer seeds `intent` from dbt YAML `description` fields. Importing a documented project therefore produced a next step that, even spelled correctly, prints `No models to explain.` It is now offered only when an imported model actually lacks an intent, matching the predicate the command itself filters on. (#1443)

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -295,8 +295,9 @@ fn arm_hard_exit_on_second_signal() {
 /// #1352 derives ordering edges from physical `schema.table` reads and reports
 /// what it could not safely resolve as advisory warnings — the run still exits
 /// 0, so a consumer that ignores them can read a stale target and report
-/// success. `[run] strict_scheduling` (or `--strict-scheduling`) turns that into
-/// a refusal for estates that want fail-closed ordering (#1355).
+/// success. `[run] strict_scheduling` turns that into a refusal for estates
+/// that want fail-closed ordering (#1355). Config-only — there is no
+/// `--strict-scheduling` CLI flag; adding one is tracked on #1357.
 ///
 /// Shared by the plain and `--dag` paths deliberately. Two copies would let
 /// "strict" come to mean different things depending on how the run was started,
@@ -308,8 +309,8 @@ pub(crate) fn refuse_on_scheduling_warnings(strict: bool, warnings: &[String]) -
     anyhow::bail!(
         "strict scheduling is on and this run's physical-read ordering could not be fully \
          resolved, so execution order is not guaranteed:\n{}\n\nDeclare each upstream in \
-         `depends_on` to resolve it, or unset `[run] strict_scheduling` / omit \
-         `--strict-scheduling` to run with these as advisory warnings.",
+         `depends_on` to resolve it, or unset `[run] strict_scheduling` to run \
+         with these as advisory warnings.",
         warnings
             .iter()
             .map(|w| format!("  - {w}"))


### PR DESCRIPTION
A fail-closed refusal offered a remedy that cannot be typed.

When `[run] strict_scheduling` refuses a run whose physical-read ordering could not be fully resolved, the error said: declare `depends_on`, **or "omit `--strict-scheduling`"**.

```
$ rocky run --strict-scheduling
error: unexpected argument '--strict-scheduling' found
```

There is no such flag. Every real consumer reads the TOML key (`run_dag_exec.rs:316`, `run.rs:1739`, `:4864`, `:6883`); the flag existed only in two user-facing strings, one of them a runtime error message. So an operator who hit a fail-closed refusal was handed a way out they could not use — on the path specifically designed for estates that want strict ordering.

Fixed both: the message names only `[run] strict_scheduling`, and the doc comment states the setting is config-only instead of implying a flag alias.

## Why this does not pre-empt #1357

#1357 has a live yes/no about adding a real `--strict-scheduling` flag. Removing a false promise does not foreclose adding one — the message currently describes a flag that does not exist, and if the flag lands, that same message gets rewritten as part of it. Correct under either answer.

## What I deliberately did NOT change

The `depends_on` remedy stays. A proposed fix wanted it deleted as "verified harmful", on the strength of one construction where declaring an edge converted a warning into a hard refusal. A second construction shows it working exactly as documented — two models with mutual physical reads, add `depends_on` to one, and the declared direction is honoured: exit 0, execution order changes, the warning flips direction. No cycle, no refusal.

That is the behaviour `mutual_physical_reads_serialize_with_a_warning_not_a_refusal` (`run.rs:17798`) pins as canonical, and it is the only working lever in the message. Deleting it would have removed the operator's one remedy on the strength of a single unrepresentative case — a design change dressed as a truth fix.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | 0 |
| `cargo clippy --all-targets --workspace -- -D warnings` | 0 |
| `cargo test -p rocky-cli --lib` | 1428 passed |

No test asserted the removed phrase, so nothing was pinning the false text — which is why it survived.

## Red team

Not sent to an independent model: this deletes an impossible instruction from an error string and adds no behaviour. The one judgement call — keeping the `depends_on` remedy — is backed by a reproduction and an existing canonical test, and is stated above rather than left implicit.

Relates to #1357
