### PR TITLE
chore: refresh the hatchling comments now that the ceiling is lifted

### DIFF
--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -72,7 +72,10 @@ dagster_rocky = "dagster_rocky"
 # 1.32.0 (2026-08-11) emits `Metadata-Version: 2.5`, which the twine 6.1.0 in
 # our allow-listed `gh-action-pypi-publish` pin rejects at the publish step.
 # `dagster-release` uses the same action, so it would have failed identically.
-# Lift `<1.32` once that action carries twine >= 7.0.0; see #1395.
+# Ceiling raised to `<1.33` in #1395 (2026-08-17), which bumped that action
+# to a build carrying twine 7.0.0. Still bounded, not open: 1.30.0 and 1.32.0
+# both shipped a metadata bump, so the ceiling is what turns the next one into
+# a caught failure instead of a broken publish.
 requires = ["hatchling>=1.30.1,<1.33"]
 build-backend = "hatchling.build"
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -48,8 +48,11 @@ dev = [
 # built cleanly. 1.30.0 emitted 2.5 too and was reverted in 1.30.1, so this is
 # an in-progress ecosystem transition rather than a one-off.
 #
-# Lift the `<1.32` ceiling once the publish action is bumped to a build
-# carrying twine >= 7.0.0 (verified to accept 2.5); see #1395.
+# Ceiling raised to `<1.33` in #1395 (2026-08-17), which bumped the publish
+# action to a build carrying twine 7.0.0 (verified to accept 2.5). Still
+# bounded, not open: 1.30.0 and 1.32.0 both shipped a metadata bump, so the
+# ceiling is what turns the next one into a caught failure instead of a
+# broken publish.
 requires = ["hatchling>=1.30.1,<1.33"]
 build-backend = "hatchling.build"
 


### PR DESCRIPTION
#1452 and #1457 raised the hatchling bound to `<1.33`. Both left the comment above it untouched, so both files still said:

```
Lift `<1.32` once that action carries twine >= 7.0.0; see #1395.
```

That job is done — #1395 bumped the publish action to a build with twine 7.0.0, which is what let the bound move. So the comment now reads as a pending task for finished work. Dependabot cannot know that, and no gate checks comments.

The comments now say what happened, and why the bound is still a bound: hatchling 1.30.0 and 1.32.0 both shipped a metadata-version change. A ceiling turns the next one into a caught failure instead of a broken publish.

Checked:

| check | result |
|---|---|
| both `pyproject.toml` parse | yes |
| sdk rebuilds under the new bound | 222 tests pass |
| dagster rebuilds under the new bound | 713 tests pass |

Comments only. No version, dependency, or behaviour change.