### PR TITLE
fix(engine): close three fail-open paths found by the plan-replay audit

### DIFF
--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -790,6 +790,7 @@ async fn execute_run_plan(
         // `--assume-fresh-state` is a `rocky run` runtime flag, never part of
         // a persisted plan — the two-step apply path always runs without it.
         false,
+        None, // #1460: not a replication plan
     )
     .await
     .with_context(|| format!("rocky apply run plan '{plan_id}' failed"))?;
@@ -3666,6 +3667,7 @@ async fn run_apply_replication_plan(
         // `--assume-fresh-state` is a `rocky run` runtime flag, never part of
         // a persisted plan — the replication apply path always runs without it.
         false,
+        Some((plan_id, replication_plan.source_state_snapshot.as_slice())), // #1460
     )
     .await
     .with_context(|| format!("rocky apply replication plan '{plan_id}' failed"))?;
@@ -3695,7 +3697,7 @@ async fn run_apply_replication_plan(
 /// under steady-state source-system churn. Unfiltered applies keep the
 /// strict semantics because any drift is structurally undefined.
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum DriftScope {
+pub(crate) enum DriftScope {
     /// Snapshots match — proceed normally.
     None,
     /// Drift exists but the active filter excludes every drifted connector
@@ -3750,7 +3752,7 @@ enum DriftScope {
 /// matches today (live) and every connector that matched at plan time
 /// (persisted) — that way a removed in-scope connector is correctly
 /// surfaced as in-scope drift even though `live` no longer carries it.
-fn decide_drift_scope(
+pub(crate) fn decide_drift_scope(
     persisted: &[ReplicationConnectorSnapshot],
     live: &[ReplicationConnectorSnapshot],
     filter: Option<&str>,
@@ -3860,7 +3862,7 @@ fn connector_matches_filter(
 /// source-state snapshot and the live one. Surfaced inside the
 /// stale-source bail message so operators see what changed without
 /// having to inspect the plan file by hand.
-fn summarize_source_state_drift(
+pub(crate) fn summarize_source_state_drift(
     persisted: &[ReplicationConnectorSnapshot],
     live: &[ReplicationConnectorSnapshot],
 ) -> String {
@@ -4105,6 +4107,7 @@ pub async fn run_apply_inline_for_run(
         // `--assume-fresh-state` threads through from the CLI (main.rs
         // validated it against the configured `[state]` backend).
         assume_fresh_state,
+        None, // #1460: inline `rocky run`, not a persisted plan
     )
     .await
 }

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -3912,7 +3912,7 @@ fn changed_config_sections(persisted: &serde_json::Value, live: &serde_json::Val
     keys.extend(l.keys());
     keys.into_iter()
         .filter(|k| p.get(*k) != l.get(*k))
-        .map(|k| k.to_string())
+        .map(ToString::to_string)
         .collect()
 }
 

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -3016,18 +3016,36 @@ async fn run_apply_ai_authored_plan(
         state_path,
         &marker_freezes,
     );
-    match gate {
-        PolicyGate::NotConfigured => {
-            if !ai_plan_is_reviewed(root, plan_id) {
-                bail!(
-                    "AI-authored plan '{plan_id}' has not been reviewed and approved. \
-                     An AI agent authored this change, so it cannot be applied directly. \
-                     Review the breaking-change report and approve it first with \
-                     `rocky review {plan_id} --approve`, then re-run `rocky apply {plan_id}`."
-                );
-            }
-        }
-        gate => apply_policy_gate(root, plan_id, gate)?,
+    // #1459: human review is a FLOOR for an AI-authored plan, not a
+    // policy-dependent extra. This used to run only under
+    // `PolicyGate::NotConfigured`; every other gate went straight to
+    // `apply_policy_gate`, which returns `Ok(())` for `Allow` without
+    // consulting the marker. So configuring a `[policy]` block that resolved
+    // to `Allow` waived human review entirely — the protection was strongest
+    // with governance switched OFF, which is the opposite of what an operator
+    // would predict.
+    //
+    // `Allow` answers "may this principal do this?". The review gate answers
+    // "did a human read this machine-written change?". One is not an answer to
+    // the other, and `PolicyGate::RequireReview` already exists for estates
+    // that want policy to drive review.
+    //
+    // Order matters. The policy gate runs FIRST so its own refusals keep their
+    // wording and precedence: `Deny` still denies, and `RequireReview` without a
+    // marker still reports "policy requires human review" — which is what proves
+    // the kind-aware `ai_authored => agent` default is load-bearing.
+    //
+    // The marker check then runs unconditionally, catching the case policy lets
+    // through: `Allow` (and `NotConfigured`) return `Ok(())` without consulting
+    // the marker. Policy can therefore only TIGHTEN this gate, never waive it.
+    apply_policy_gate(root, plan_id, gate)?;
+    if !ai_plan_is_reviewed(root, plan_id) {
+        bail!(
+            "AI-authored plan '{plan_id}' has not been reviewed and approved. \
+             An AI agent authored this change, so it cannot be applied directly. \
+             Review the breaking-change report and approve it first with \
+             `rocky review {plan_id} --approve`, then re-run `rocky apply {plan_id}`."
+        );
     }
 
     // Resolve the post-apply verification checks before the run plan is moved.
@@ -4748,6 +4766,31 @@ auto_create_schemas = true
 version = 1
 "#;
 
+    /// #1459: a configured `[policy]` that resolves to `allow` for the agent
+    /// principal. This is the shape that used to waive human review entirely.
+    const ALLOW_POLICY_TOML: &str = r#"
+[adapter]
+type = "duckdb"
+path = "x.duckdb"
+
+[pipeline.p]
+type = "transformation"
+models = "models/**"
+
+[pipeline.p.target.governance]
+auto_create_schemas = true
+
+[policy]
+version = 1
+default_agent_effect = "allow"
+
+[[policy.rules]]
+principal = "agent"
+capability = "apply"
+scope = { any = true }
+effect = "allow"
+"#;
+
     /// Config with an adapter + pipeline and NO `[policy]` block.
     const NO_POLICY_TOML: &str = r#"
 [adapter]
@@ -4833,6 +4876,48 @@ auto_create_schemas = true
         assert!(
             msg.contains("policy requires human review"),
             "must be refused by the policy plane (not just the marker gate), got: {msg}"
+        );
+        Ok(())
+    }
+
+    /// #1459: a configured policy resolving to `allow` must NOT waive human
+    /// review for a machine-authored plan.
+    ///
+    /// The marker check used to run only under `PolicyGate::NotConfigured`.
+    /// Every other gate went to `apply_policy_gate`, which returns `Ok(())` for
+    /// `Allow` without consulting the marker — so configuring a `[policy]` block
+    /// switched the review gate OFF. The protection was strongest with
+    /// governance absent, which is backwards.
+    ///
+    /// `Allow` answers "may this principal do this?". Review answers "did a
+    /// human read this machine-written change?". Policy may tighten the gate
+    /// (`Deny`, `RequireReview`) but never waive it.
+    #[tokio::test]
+    async fn configured_allow_policy_does_not_waive_ai_review() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        std::fs::write(dir.path().join("rocky.toml"), ALLOW_POLICY_TOML)?;
+        let models_dir = dir.path().join("models");
+        write_min_model(&models_dir, "orders");
+        let mut rp = minimal_run_plan();
+        rp.models_dir = Some(models_dir.to_string_lossy().into_owned());
+        rp.models = vec!["orders".to_string()];
+        let plan_id = write_plan(dir.path(), PlanKind::AiAuthored, &rp)?;
+
+        let state = dir.path().join("state.redb");
+        let err = super::run_apply_ai_authored_plan(
+            dir.path(),
+            &dir.path().join("rocky.toml"),
+            &plan_id,
+            &state,
+            PolicyPrincipal::Agent,
+            true,
+        )
+        .await
+        .expect_err("an allow policy must not let an unreviewed AI plan apply");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("has not been reviewed and approved"),
+            "must be refused by the review gate even though policy allowed it, got: {msg}"
         );
         Ok(())
     }

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -3538,10 +3538,23 @@ async fn run_apply_replication_plan(
     // field outside the subset would silently break replay. So any config
     // change invalidates the plan and you re-plan.
     //
-    // LIMIT worth knowing: secrets serialize as `"***"` by construction
-    // (`rocky_core::redacted`), so this compares routing and shape, NOT
-    // credentials. Swapping the password behind the same host is invisible
-    // here. Catching that needs a different mechanism.
+    // TWO LIMITS worth knowing, because this comparison looks stronger than it
+    // is:
+    //
+    // 1. Secrets serialize as `"***"` by construction (`rocky_core::redacted`),
+    //    so this compares routing and shape, NOT credentials. Swapping the
+    //    password behind the same host is invisible.
+    // 2. It does not bind the STATE authority. `StateConfig.valkey_url` is
+    //    redacted whole, and the plan stores neither the resolved
+    //    `--state-path` nor the CLI state namespace — both come from the
+    //    caller at apply time. So a plan can compare equal here and still run
+    //    against a different watermark/freeze/budget ledger, which can mean an
+    //    unexpected full refresh or a freeze the reviewed authority recorded
+    //    going unseen.
+    //
+    // Closing (2) needs a credential-free state-authority identity persisted in
+    // the plan (backend, host/port/database, key prefix, resolved namespace).
+    // That is a payload change, tracked separately rather than bolted on here.
     let live_config_snapshot = serde_json::to_value(rocky_cfg)
         .context("failed to serialize the live config for the plan comparison")?;
     if live_config_snapshot != replication_plan.config_snapshot {

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -3586,6 +3586,19 @@ async fn run_apply_replication_plan(
     //
     // Absent means the plan predates this field; skip rather than refuse every
     // older plan. New plans always record it.
+    //
+    // Warn rather than skip silently. A gate that disappears without a word is
+    // how an unbound plan reaches a different ledger unnoticed, and the absence
+    // is not self-announcing anywhere else. Whether an unbound plan should be
+    // refused outright is a policy question, not one to settle by default.
+    if replication_plan.state_authority.is_none() {
+        warn!(
+            target = "rocky::replication::state_authority",
+            plan_id = plan_id,
+            "plan records no state authority (written before that field existed); \
+             applying WITHOUT verifying the state store matches the reviewed one"
+        );
+    }
     if let Some(reviewed_authority) = replication_plan.state_authority.as_deref() {
         let live_authority =
             crate::commands::plan::state_authority_identity(&rocky_cfg.state, state_path);
@@ -7804,12 +7817,30 @@ schema_template = "s__{source}"
             true,
         )
         .await;
-        if let Err(e) = res {
-            let msg = e.to_string();
-            assert!(
-                !msg.contains("state authority has changed"),
-                "an unrecorded authority must not refuse, got: {msg}"
-            );
+
+        // Assert it got PAST the authority gate, not merely that it failed
+        // somewhere. Accepting any error would let this pass for an unrelated
+        // reason and prove nothing about legacy compatibility.
+        match res {
+            Ok(()) => {}
+            Err(e) => {
+                let msg = format!("{e:#}");
+                assert!(
+                    !msg.contains("state authority has changed"),
+                    "an unrecorded authority must not refuse, got: {msg}"
+                );
+                // It must fail LATER than the gate — the gate sits before
+                // pipeline resolution, so a failure here means execution was
+                // reached. A failure naming the plan payload or the gate would
+                // mean the test never exercised the path.
+                assert!(
+                    !msg.contains("failed to read replication plan")
+                        && !msg.contains("is a ")
+                        && !msg.contains("config has changed"),
+                    "must fail after the plan/config/authority gates, not at one \
+                     of them — got: {msg}"
+                );
+            }
         }
         Ok(())
     }

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -3578,6 +3578,32 @@ async fn run_apply_replication_plan(
         );
     }
 
+    // #1460: the config comparison above cannot see the state authority —
+    // `valkey_url` is redacted whole and the resolved `--state-path` is a
+    // caller argument, absent from the config. Compare the recorded identity so
+    // a plan cannot pass the config check and still apply against a different
+    // watermark/freeze/budget ledger.
+    //
+    // Absent means the plan predates this field; skip rather than refuse every
+    // older plan. New plans always record it.
+    if let Some(reviewed_authority) = replication_plan.state_authority.as_deref() {
+        let live_authority =
+            crate::commands::plan::state_authority_identity(&rocky_cfg.state, state_path);
+        if live_authority != reviewed_authority {
+            bail!(
+                "state authority has changed since plan '{plan_id}' was created.\n\
+                 reviewed: {reviewed_authority}\n\
+                 now:      {live_authority}\n\
+                 Watermarks, freezes, budgets and idempotency keys live in the \
+                 state store, so applying against a different one can redo work \
+                 the reviewed ledger recorded as done, or miss a freeze it \
+                 recorded.\n\
+                 Nothing was written. Re-plan against the intended state store, \
+                 or re-run with the state path the plan was created with."
+            );
+        }
+    }
+
     let (_pipeline_name, pipeline) = crate::registry::resolve_replication_pipeline(
         rocky_cfg,
         replication_plan.pipeline.as_deref(),
@@ -7693,6 +7719,7 @@ schema_template = "s__{source}"
             branch: None,
             governance_override: None,
             config_snapshot: serde_json::json!({"adapter": {"default": {"type": "duckdb"}}}),
+            state_authority: None,
             source_state_snapshot: vec![ReplicationConnectorSnapshot {
                 id: "raw__orders".to_string(),
                 schema: "raw__orders".to_string(),
@@ -7703,6 +7730,88 @@ schema_template = "s__{source}"
                 }],
             }],
         }
+    }
+
+    /// #1460: a plan must not apply against a different state store.
+    ///
+    /// The config comparison cannot catch this. `valkey_url` is redacted whole,
+    /// so a Valkey A-to-B swap compares equal, and the resolved `--state-path`
+    /// is a caller argument that never appears in the config at all. Yet
+    /// watermarks, freezes, budgets and idempotency keys all live there — so a
+    /// plan reviewed against one ledger and applied against another can redo
+    /// work the first recorded as done, or miss a freeze it recorded.
+    #[tokio::test]
+    async fn replication_apply_refuses_a_changed_state_authority() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let cfg_path = dir.path().join("rocky.toml");
+        std::fs::write(&cfg_path, REPLICATION_TOML)?;
+
+        let planned = rocky_core::config::load_rocky_config(&cfg_path)?;
+        let reviewed_state = dir.path().join("reviewed.redb");
+        let mut rp = minimal_replication_plan();
+        rp.pipeline = Some("p".to_string());
+        rp.filter = None;
+        rp.config_snapshot = serde_json::to_value(&planned)?;
+        rp.state_authority = Some(crate::commands::plan::state_authority_identity(
+            &planned.state,
+            &reviewed_state,
+        ));
+        let plan_id = write_plan(dir.path(), PlanKind::Replication, &rp)?;
+
+        // Same config, DIFFERENT state store — the case config equality misses.
+        let other_state = dir.path().join("other.redb");
+        let err = super::run_apply_replication_plan(
+            dir.path(),
+            &cfg_path,
+            &plan_id,
+            &other_state,
+            PolicyPrincipal::Human,
+            true,
+        )
+        .await
+        .expect_err("a different state store must not apply a plan reviewed against another");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("state authority has changed"),
+            "must refuse on the state-authority comparison, got: {msg}"
+        );
+        Ok(())
+    }
+
+    /// A plan written before the field existed must still apply. Absent means
+    /// "not recorded", not "mismatch" — otherwise this change would refuse
+    /// every plan already on disk.
+    #[tokio::test]
+    async fn replication_apply_tolerates_a_plan_without_a_state_authority() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let cfg_path = dir.path().join("rocky.toml");
+        std::fs::write(&cfg_path, REPLICATION_TOML)?;
+
+        let planned = rocky_core::config::load_rocky_config(&cfg_path)?;
+        let mut rp = minimal_replication_plan();
+        rp.pipeline = Some("p".to_string());
+        rp.filter = None;
+        rp.config_snapshot = serde_json::to_value(&planned)?;
+        rp.state_authority = None; // pre-field plan
+        let plan_id = write_plan(dir.path(), PlanKind::Replication, &rp)?;
+
+        let res = super::run_apply_replication_plan(
+            dir.path(),
+            &cfg_path,
+            &plan_id,
+            &dir.path().join("anywhere.redb"),
+            PolicyPrincipal::Human,
+            true,
+        )
+        .await;
+        if let Err(e) = res {
+            let msg = e.to_string();
+            assert!(
+                !msg.contains("state authority has changed"),
+                "an unrecorded authority must not refuse, got: {msg}"
+            );
+        }
+        Ok(())
     }
 
     /// #1460: the plan's `config_snapshot` had no reader, so a config change

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -3526,6 +3526,45 @@ async fn run_apply_replication_plan(
             .with_context(|| format!("failed to load config from {}", config_path.display()))?,
     );
     let rocky_cfg = &loaded.config;
+
+    // #1460: the plan's config snapshot had no reader. It was written at plan
+    // time and never compared, so changing the adapter, database path, schema
+    // template or strategy between plan and apply re-routed an approved plan to
+    // unreviewed SQL or a different destination, with the source-state check
+    // still passing because discovery was unchanged.
+    //
+    // Compared whole, deliberately. The field's own doc rejects extracting a
+    // "replication-relevant subset" as a footgun: a runtime dependency on a
+    // field outside the subset would silently break replay. So any config
+    // change invalidates the plan and you re-plan.
+    //
+    // LIMIT worth knowing: secrets serialize as `"***"` by construction
+    // (`rocky_core::redacted`), so this compares routing and shape, NOT
+    // credentials. Swapping the password behind the same host is invisible
+    // here. Catching that needs a different mechanism.
+    let live_config_snapshot = serde_json::to_value(rocky_cfg)
+        .context("failed to serialize the live config for the plan comparison")?;
+    if live_config_snapshot != replication_plan.config_snapshot {
+        let changed =
+            changed_config_sections(&replication_plan.config_snapshot, &live_config_snapshot);
+        bail!(
+            "config has changed since plan '{plan_id}' was created{}.\n\
+             The plan is the reviewed artifact, so applying it against a \
+             different config would run SQL nobody approved — a changed \
+             adapter, path, schema template or strategy redirects the write \
+             while the source state still matches.\n\
+             Nothing was written. Re-plan with `rocky plan` and apply the new \
+             plan_id.\n\
+             Note: credentials are redacted in the snapshot, so a changed \
+             secret is not detected here.",
+            if changed.is_empty() {
+                String::new()
+            } else {
+                format!(" (differing sections: {})", changed.join(", "))
+            }
+        );
+    }
+
     let (_pipeline_name, pipeline) = crate::registry::resolve_replication_pipeline(
         rocky_cfg,
         replication_plan.pipeline.as_deref(),
@@ -3862,6 +3901,21 @@ fn connector_matches_filter(
 /// source-state snapshot and the live one. Surfaced inside the
 /// stale-source bail message so operators see what changed without
 /// having to inspect the plan file by hand.
+/// Top-level config sections that differ between two snapshots, so a refusal can
+/// say *what* changed instead of only that something did. Names only — values may
+/// contain redacted secrets and site-specific paths.
+fn changed_config_sections(persisted: &serde_json::Value, live: &serde_json::Value) -> Vec<String> {
+    let (Some(p), Some(l)) = (persisted.as_object(), live.as_object()) else {
+        return Vec::new();
+    };
+    let mut keys: std::collections::BTreeSet<&String> = p.keys().collect();
+    keys.extend(l.keys());
+    keys.into_iter()
+        .filter(|k| p.get(*k) != l.get(*k))
+        .map(|k| k.to_string())
+        .collect()
+}
+
 pub(crate) fn summarize_source_state_drift(
     persisted: &[ReplicationConnectorSnapshot],
     live: &[ReplicationConnectorSnapshot],
@@ -7636,6 +7690,96 @@ schema_template = "s__{source}"
                 }],
             }],
         }
+    }
+
+    /// #1460: the plan's `config_snapshot` had no reader, so a config change
+    /// between plan and apply went undetected. Discovery was unchanged, so the
+    /// source-state check still passed, and the approved plan ran against a
+    /// different adapter, path, schema template or strategy.
+    ///
+    /// Uses a snapshot taken from the real config, then changes the config —
+    /// so this fails for the intended reason, not because the stub snapshot in
+    /// `minimal_replication_plan` never matches anything.
+    #[tokio::test]
+    async fn replication_apply_refuses_a_changed_config() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let cfg_path = dir.path().join("rocky.toml");
+        std::fs::write(&cfg_path, REPLICATION_TOML)?;
+
+        // Snapshot the config exactly as plan time does.
+        let planned = rocky_core::config::load_rocky_config(&cfg_path)?;
+        let mut rp = minimal_replication_plan();
+        rp.pipeline = Some("p".to_string());
+        rp.filter = None;
+        rp.config_snapshot = serde_json::to_value(&planned)?;
+        let plan_id = write_plan(dir.path(), PlanKind::Replication, &rp)?;
+
+        // Redirect the write: same discovery, different destination catalog.
+        std::fs::write(
+            &cfg_path,
+            REPLICATION_TOML.replace(r#"catalog_template = "c""#, r#"catalog_template = "other""#),
+        )?;
+
+        let state = dir.path().join("state.redb");
+        let err = super::run_apply_replication_plan(
+            dir.path(),
+            &cfg_path,
+            &plan_id,
+            &state,
+            PolicyPrincipal::Human,
+            true,
+        )
+        .await
+        .expect_err("a changed config must not apply a plan reviewed against the old one");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("config has changed since plan"),
+            "must refuse on the config comparison, got: {msg}"
+        );
+        assert!(
+            msg.contains("Nothing was written"),
+            "the refusal must state nothing was written, got: {msg}"
+        );
+        Ok(())
+    }
+
+    /// The comparison must not fire when the config is untouched, or every
+    /// replication apply would refuse. Proves the refusal above is caused by
+    /// the change, not by the comparison always failing.
+    #[tokio::test]
+    async fn replication_apply_passes_the_config_check_when_unchanged() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let cfg_path = dir.path().join("rocky.toml");
+        std::fs::write(&cfg_path, REPLICATION_TOML)?;
+
+        let planned = rocky_core::config::load_rocky_config(&cfg_path)?;
+        let mut rp = minimal_replication_plan();
+        rp.pipeline = Some("p".to_string());
+        rp.filter = None;
+        rp.config_snapshot = serde_json::to_value(&planned)?;
+        let plan_id = write_plan(dir.path(), PlanKind::Replication, &rp)?;
+
+        let state = dir.path().join("state.redb");
+        let res = super::run_apply_replication_plan(
+            dir.path(),
+            &cfg_path,
+            &plan_id,
+            &state,
+            PolicyPrincipal::Human,
+            true,
+        )
+        .await;
+
+        // It may still fail further on (no live warehouse here). It must not
+        // fail on the config comparison.
+        if let Err(e) = res {
+            let msg = e.to_string();
+            assert!(
+                !msg.contains("config has changed since plan"),
+                "an unchanged config must pass the comparison, got: {msg}"
+            );
+        }
+        Ok(())
     }
 
     /// Round-trip: `ReplicationPlan` written to disk parses back into an

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -1366,11 +1366,25 @@ pub(crate) fn state_authority_identity(
         _ => {}
     }
     if let Some(url) = state.valkey_url.as_ref() {
-        // Strip any `user:password@` — keep only where it points.
+        // Keep only where it points. Two secret carriers to remove, not one:
+        //
+        //   redis://user:pass@host:6379/0   -> userinfo before the LAST '@'
+        //                                      (last, because a password may
+        //                                       itself contain '@')
+        //   redis://host:6379?password=xyz  -> query string
+        //
+        // Stripping only the userinfo would write the second form's secret into
+        // a plan file on disk.
         let raw = url.expose();
         let (scheme, rest) = raw.split_once("://").unwrap_or(("", raw));
-        let host_and_path = rest.rsplit_once('@').map_or(rest, |(_creds, h)| h);
-        parts.push(format!("valkey={scheme}://{host_and_path}"));
+        let no_userinfo = rest.rsplit_once('@').map_or(rest, |(_creds, host)| host);
+        let no_query = no_userinfo
+            .split_once('?')
+            .map_or(no_userinfo, |(host, _query)| host);
+        let no_fragment = no_query
+            .split_once('#')
+            .map_or(no_query, |(host, _frag)| host);
+        parts.push(format!("valkey={scheme}://{no_fragment}"));
     }
     // The local ledger is identified by its resolved path, which the config
     // never carries.
@@ -2297,6 +2311,46 @@ pub(crate) async fn build_promote_plan_inner(
 
 #[cfg(test)]
 mod tests {
+
+    /// The state-authority identity is persisted to a plan file on disk, so it
+    /// must carry no secret in ANY valkey URL form. Stripping only the
+    /// `user:pass@` userinfo leaves a `?password=` query intact.
+    #[test]
+    fn state_authority_identity_strips_every_credential_form() {
+        use rocky_core::config::{StateBackend, StateConfig};
+        let ident = |url: &str| {
+            let st = StateConfig {
+                backend: StateBackend::Valkey,
+                valkey_url: Some(rocky_core::redacted::RedactedString::new(url.to_string())),
+                ..Default::default()
+            };
+            super::state_authority_identity(&st, std::path::Path::new("/s.redb"))
+        };
+
+        for (url, secret) in [
+            ("redis://user:hunter2@h:6379/0", "hunter2"),
+            ("redis://:hunter2@h:6379", "hunter2"),
+            ("redis://user:p@ss@h:6379", "p@ss"),
+            ("redis://h:6379?password=hunter2", "hunter2"),
+            ("redis://h:6379/0#hunter2", "hunter2"),
+        ] {
+            let got = ident(url);
+            assert!(
+                !got.contains(secret),
+                "identity for {url} leaked the secret: {got}"
+            );
+            assert!(
+                got.contains("h:6379"),
+                "identity for {url} lost the host it exists to compare: {got}"
+            );
+        }
+
+        assert_ne!(
+            ident("redis://a:6379/0"),
+            ident("redis://b:6379/0"),
+            "different hosts must produce different identities"
+        );
+    }
     use std::sync::Arc;
 
     use super::*;

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -1341,7 +1341,15 @@ pub(crate) fn state_authority_identity(
     state_path: &std::path::Path,
 ) -> String {
     use rocky_core::config::StateBackend;
-    let mut parts = vec![format!("backend={:?}", state.backend)];
+    // The remote ledger key embeds the state schema version
+    // (`state_sync.rs`: `format!("v{}", current_schema_version())`), so two
+    // versions are two different objects. Without this, a plan made before a
+    // schema upgrade compares equal afterwards while the new binary reads a
+    // different ledger — losing the reviewed watermarks, budgets and freezes.
+    let mut parts = vec![
+        format!("backend={:?}", state.backend),
+        format!("schema=v{}", rocky_core::state::current_schema_version()),
+    ];
     match state.backend {
         StateBackend::S3 => {
             parts.push(format!(
@@ -2311,6 +2319,23 @@ pub(crate) async fn build_promote_plan_inner(
 
 #[cfg(test)]
 mod tests {
+
+    /// The identity must change across a state-schema version bump, because the
+    /// remote ledger key embeds it. Without this a plan made under one version
+    /// compares equal under the next while reading a different object.
+    #[test]
+    fn state_authority_identity_includes_the_state_schema_version() {
+        use rocky_core::config::StateConfig;
+        let st = StateConfig::default();
+        let got = super::state_authority_identity(&st, std::path::Path::new("/s.redb"));
+        assert!(
+            got.contains(&format!(
+                "schema=v{}",
+                rocky_core::state::current_schema_version()
+            )),
+            "identity must record the state schema version, got: {got}"
+        );
+    }
 
     /// The state-authority identity is persisted to a plan file on disk, so it
     /// must carry no secret in ANY valkey URL form. Stripping only the

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -517,6 +517,7 @@ pub async fn plan(
             pipeline_name,
             env,
             run_options,
+            state_path,
         ) {
             Ok((_replication_plan, plan_id, persisted_at)) => {
                 output.plan_id = Some(plan_id);
@@ -1319,6 +1320,64 @@ fn shadow_descriptor(run_options: &PlanRunOptions, value: Option<&String>) -> Op
     }
 }
 
+/// A credential-free identity for the state authority a plan was reviewed
+/// against: which ledger holds its watermarks, freezes, budgets and
+/// idempotency keys.
+///
+/// Needed because the plan's `config_snapshot` cannot answer this. `valkey_url`
+/// is a `RedactedString` and serializes whole as `"***"`, so a Valkey A-to-B
+/// swap compares equal; and the resolved `--state-path` never appears in the
+/// config at all, because it comes from the caller. A plan could therefore pass
+/// the config comparison and still apply against a different ledger — meaning an
+/// unexpected full refresh, or a freeze recorded in the reviewed authority going
+/// unseen.
+///
+/// Credential-free on purpose. For Valkey this keeps scheme, host, port and
+/// database and drops any `user:password@`, so the identity is comparable
+/// without the plan payload carrying a secret. `expose()` is the audited
+/// accessor; the exposed value is parsed and discarded, never stored.
+pub(crate) fn state_authority_identity(
+    state: &rocky_core::config::StateConfig,
+    state_path: &std::path::Path,
+) -> String {
+    use rocky_core::config::StateBackend;
+    let mut parts = vec![format!("backend={:?}", state.backend)];
+    match state.backend {
+        StateBackend::S3 => {
+            parts.push(format!(
+                "bucket={}",
+                state.s3_bucket.as_deref().unwrap_or("")
+            ));
+            parts.push(format!(
+                "prefix={}",
+                state.s3_prefix.as_deref().unwrap_or("")
+            ));
+        }
+        StateBackend::Gcs => {
+            parts.push(format!(
+                "bucket={}",
+                state.gcs_bucket.as_deref().unwrap_or("")
+            ));
+            parts.push(format!(
+                "prefix={}",
+                state.gcs_prefix.as_deref().unwrap_or("")
+            ));
+        }
+        _ => {}
+    }
+    if let Some(url) = state.valkey_url.as_ref() {
+        // Strip any `user:password@` — keep only where it points.
+        let raw = url.expose();
+        let (scheme, rest) = raw.split_once("://").unwrap_or(("", raw));
+        let host_and_path = rest.rsplit_once('@').map_or(rest, |(_creds, h)| h);
+        parts.push(format!("valkey={scheme}://{host_and_path}"));
+    }
+    // The local ledger is identified by its resolved path, which the config
+    // never carries.
+    parts.push(format!("path={}", state_path.display()));
+    parts.join(" ")
+}
+
 fn build_and_persist_replication_plan(
     rocky_cfg: &rocky_core::config::RockyConfig,
     connectors: &[DiscoveredConnector],
@@ -1326,9 +1385,11 @@ fn build_and_persist_replication_plan(
     pipeline: Option<&str>,
     env: Option<&str>,
     run_options: &PlanRunOptions,
+    state_path: &std::path::Path,
 ) -> Result<(ReplicationPlan, String, chrono::DateTime<Utc>)> {
     let config_snapshot = serde_json::to_value(rocky_cfg)
         .context("failed to serialize RockyConfig for replication plan")?;
+    let state_authority = state_authority_identity(&rocky_cfg.state, state_path);
     let source_state_snapshot = build_source_state_snapshot(connectors);
 
     let replication_plan = ReplicationPlan {
@@ -1359,6 +1420,7 @@ fn build_and_persist_replication_plan(
         branch: run_options.branch.clone(),
         governance_override: run_options.governance_override.clone(),
         config_snapshot,
+        state_authority: Some(state_authority),
         source_state_snapshot,
     };
 

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1408,6 +1408,18 @@ pub async fn run(
     // Local backend); it never overrides the governed fail-closed bail. See
     // [`resolve_replication_authority`].
     assume_fresh_state: bool,
+    // #1460: the source state a persisted replication plan was reviewed
+    // against, plus that plan's id for the message. `None` for every direct
+    // `rocky run` — byte-identical behaviour.
+    //
+    // The replication apply path discovers once to compare against the plan,
+    // then calls this function, which discovers AGAIN and builds work from the
+    // second result. So the comparison ran on one set and the writes came from
+    // another: a connector appearing between them executed without ever being
+    // in the reviewed snapshot. Passing the reviewed state here re-applies the
+    // SAME `decide_drift_scope` rule at the point the work is actually built,
+    // which keeps the filter-scope tolerance identical.
+    reviewed_source_state: Option<(&str, &[crate::output::ReplicationConnectorSnapshot])>,
 ) -> Result<()> {
     // With `-o json` stdout is reserved for the JSON payload — route any
     // human-readable summary/progress line (e.g. a `depends_on` upstream
@@ -2577,6 +2589,45 @@ pub async fn run(
         );
     }
     let connectors = discovery_result.connectors;
+
+    // #1460: re-apply the plan's source-state check HERE, against the set the
+    // work is built from. Same rule as the pre-check in the apply path, so
+    // out-of-filter-scope drift stays a warning and only in-scope or unfiltered
+    // drift refuses.
+    if let Some((plan_id, reviewed)) = reviewed_source_state {
+        let executed_snapshot = crate::commands::plan::build_source_state_snapshot(&connectors);
+        match crate::commands::apply::decide_drift_scope(
+            reviewed,
+            &executed_snapshot,
+            filter,
+            &pattern,
+        ) {
+            crate::commands::apply::DriftScope::None
+            | crate::commands::apply::DriftScope::OutOfScope { .. } => {}
+            crate::commands::apply::DriftScope::InScope {
+                in_scope_drifted,
+                filter: f,
+            } => {
+                let diff =
+                    crate::commands::apply::summarize_source_state_drift(reviewed, &executed_snapshot);
+                anyhow::bail!(
+                    "source state drifted between the check and execution of plan \
+                     '{plan_id}' (in-scope under filter={f}, affected=[{}]).\n{diff}\n\
+                     Nothing was written. Re-plan with `rocky plan` and apply the new plan_id.",
+                    in_scope_drifted.join(", ")
+                );
+            }
+            crate::commands::apply::DriftScope::Unfiltered => {
+                let diff =
+                    crate::commands::apply::summarize_source_state_drift(reviewed, &executed_snapshot);
+                anyhow::bail!(
+                    "source state drifted between the check and execution of plan \
+                     '{plan_id}'.\n{diff}\n\
+                     Nothing was written. Re-plan with `rocky plan` and apply the new plan_id."
+                );
+            }
+        }
+    }
 
     let concurrency = pipeline.execution.concurrency.max_concurrency();
     let mut output = RunOutput::new(filter.unwrap_or("").to_string(), 0, concurrency);
@@ -12815,6 +12866,7 @@ adapter = "default"
             None,  // no run_id override — mint the usual timestamp id
             None,  // no governance ctx (test)
             false, // assume_fresh_state (test)
+            None,  // #1460
         )
         .await
         .expect("transformation run should succeed");
@@ -12931,6 +12983,7 @@ adapter = "default"
                 None,
                 None,
                 false,
+                None, // #1460
             ))
             .expect("the run must succeed regardless of the trace context");
         }
@@ -13080,6 +13133,7 @@ schema = "mart"
             None,  // no run_id override — mint the usual timestamp id
             None,  // no governance ctx (test)
             false, // assume_fresh_state (test)
+            None,  // #1460
         )
         .await
         .expect(
@@ -15122,6 +15176,7 @@ timestamp_column = "ts"
                 Some(run_id),
                 None,
                 false,
+                None, // #1460
             )
             .await
         }

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -2727,6 +2727,38 @@ pub async fn run(
         )?;
     }
 
+    // ONE source-table read per connector, taken here and reused by BOTH the
+    // collision preflight and the collection loop below.
+    //
+    // They used to call `list_tables` separately. Two reads mean two answers: a
+    // table created between them is absent from the preflight and present at
+    // collection, so a collision it should have caught early is caught by the
+    // in-loop backstop instead — after catalogs, schemas and grants have been
+    // written. Sharing one snapshot removes that window. Every other input the
+    // two use (discovered `conn.tables`, `parsed_filter`, `table_overrides`) is
+    // already shared, so with this they evaluate the same pure conditions over
+    // identical data and cannot disagree.
+    let source_tables_by_schema: HashMap<String, std::collections::HashSet<String>> = {
+        let mut m = HashMap::new();
+        for conn in &connectors {
+            let source_catalog = pipeline.source.catalog.as_deref().unwrap_or("").to_string();
+            let tables: std::collections::HashSet<String> = warehouse_adapter
+                .list_tables(&source_catalog, &conn.schema)
+                .await
+                .map(|v| v.into_iter().map(|t| t.to_lowercase()).collect())
+                .unwrap_or_else(|e| {
+                    warn!(
+                        schema = conn.schema.as_str(),
+                        error = %e,
+                        "failed to list source tables, will process all discovered tables"
+                    );
+                    conn.tables.iter().map(|t| t.name.to_lowercase()).collect()
+                });
+            m.insert(conn.schema.clone(), tables);
+        }
+        m
+    };
+
     // #1461 preflight: refuse a target collision BEFORE any warehouse mutation.
     //
     // The authoritative check still runs at the collection site below, where the
@@ -2754,18 +2786,8 @@ pub async fn run(
             {
                 continue;
             }
-            let source_catalog = pipeline.source.catalog.as_deref().unwrap_or("").to_string();
-            // Same fallback as the collection loop: on a list failure fall back
-            // to the discovered tables so both process the same set. An
-            // `unwrap_or_default()` here would differ when `list_tables`
-            // legitimately returns EMPTY — the loop then skips every table as
-            // missing-from-source, so counting them here would refuse a run the
-            // loop would have skipped.
-            let source_tables: std::collections::HashSet<String> = warehouse_adapter
-                .list_tables(&source_catalog, &conn.schema)
-                .await
-                .map(|v| v.into_iter().map(|t| t.to_lowercase()).collect())
-                .unwrap_or_else(|_| conn.tables.iter().map(|t| t.name.to_lowercase()).collect());
+            let empty = std::collections::HashSet::new();
+            let source_tables = source_tables_by_schema.get(&conn.schema).unwrap_or(&empty);
             let target_catalog = parsed.resolve_template(target_catalog_template, target_sep);
             let target_schema = if let Some(cfg) = shadow_config {
                 cfg.schema_override
@@ -3146,23 +3168,21 @@ pub async fn run(
             // Collect tables to process in parallel
             let source_catalog = pipeline.source.catalog.as_deref().unwrap_or("").to_string();
 
-            // Pre-fetch source table list to skip tables that no longer exist
-            // in the source (e.g. Fivetran stopped syncing them). One
+            // Source table list, used to skip tables that no longer exist in the
+            // source (e.g. Fivetran stopped syncing them). One
             // information_schema query per schema avoids N wasted DESCRIBE +
             // CTAS round-trips for stale tables.
-            // Use the generic WarehouseAdapter::list_tables (Plan 02 trait method)
-            let source_tables: std::collections::HashSet<String> = warehouse_adapter
-                .list_tables(&source_catalog, &conn.schema)
-                .await
-                .map(|v| v.into_iter().map(|s| s.to_lowercase()).collect())
-                .unwrap_or_else(|e| {
-                    warn!(
-                        schema = conn.schema.as_str(),
-                        error = %e,
-                        "failed to list source tables, will process all discovered tables"
-                    );
-                    conn.tables.iter().map(|t| t.name.to_lowercase()).collect()
-                });
+            //
+            // Taken from the ONE snapshot read before the collision preflight,
+            // not re-read here. A second read could return a different set, and
+            // a table appearing between the two would be absent from the
+            // preflight and present here — so the collision would be caught by
+            // the backstop below, after catalogs, schemas and grants had already
+            // been written.
+            let empty_source_tables = std::collections::HashSet::new();
+            let source_tables = source_tables_by_schema
+                .get(&conn.schema)
+                .unwrap_or(&empty_source_tables);
 
             let mut skipped_source_missing = 0usize;
             for table in &conn.tables {
@@ -12913,6 +12933,34 @@ mod tests {
     // the `Succeeded` assertion fails because the entry is still
     // `InFlight`.
     // -----------------------------------------------------------------------
+    /// #1461 follow-up: the collision preflight and the collection loop must
+    /// read the source table list ONCE, not twice.
+    ///
+    /// Two reads mean two answers. A table created between them is absent from
+    /// the preflight and present at collection, so a collision the preflight
+    /// exists to catch early is caught by the in-loop backstop instead — after
+    /// catalogs, schemas and grants have been written. That is the failure the
+    /// preflight was added to prevent, reachable through a race.
+    ///
+    /// A source-property assertion, because the invariant IS structural: there
+    /// is no runtime observation that distinguishes "read once and shared" from
+    /// "read twice and happened to agree". Reintroducing a second call is the
+    /// regression, and only counting the calls catches it.
+    #[test]
+    fn the_replication_path_reads_source_tables_exactly_once() {
+        let src = include_str!("run.rs");
+        // Built from parts so this test's own source does not match the needle
+        // it counts.
+        let needle = format!(".{}(&source_catalog, &conn.schema)", "list_tables");
+        let calls = src.matches(needle.as_str()).count();
+        assert_eq!(
+            calls, 1,
+            "the replication path must read source tables once and share the \
+             snapshot; {calls} call sites found. A second read reopens the \
+             window where the preflight and the collection loop disagree."
+        );
+    }
+
     /// #1460: the reviewed source state must be re-checked where the work is
     /// BUILT, not only in the apply path before `run` is called.
     ///

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -2755,11 +2755,17 @@ pub async fn run(
                 continue;
             }
             let source_catalog = pipeline.source.catalog.as_deref().unwrap_or("").to_string();
+            // Same fallback as the collection loop: on a list failure fall back
+            // to the discovered tables so both process the same set. An
+            // `unwrap_or_default()` here would differ when `list_tables`
+            // legitimately returns EMPTY — the loop then skips every table as
+            // missing-from-source, so counting them here would refuse a run the
+            // loop would have skipped.
             let source_tables: std::collections::HashSet<String> = warehouse_adapter
                 .list_tables(&source_catalog, &conn.schema)
                 .await
                 .map(|v| v.into_iter().map(|t| t.to_lowercase()).collect())
-                .unwrap_or_default();
+                .unwrap_or_else(|_| conn.tables.iter().map(|t| t.name.to_lowercase()).collect());
             let target_catalog = parsed.resolve_template(target_catalog_template, target_sep);
             let target_schema = if let Some(cfg) = shadow_config {
                 cfg.schema_override
@@ -2773,9 +2779,7 @@ pub async fn run(
                 if !filter_table_matches(parsed_filter.as_ref(), &table.name) {
                     continue;
                 }
-                // A source read failure yields an empty set above; treat that as
-                // "cannot tell" and skip rather than refuse on incomplete data.
-                if !source_tables.is_empty() && !source_tables.contains(&table.name.to_lowercase()) {
+                if !source_tables.contains(&table.name.to_lowercase()) {
                     continue;
                 }
                 if rocky_core::config::resolve_table_override(

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -2662,8 +2662,10 @@ pub async fn run(
     // `staging__{source}`) collapses every connector into one schema. Two
     // connectors holding a same-named table then write the same object and the
     // second silently wins, with `tables_copied` still counting both (#1461).
-    let mut claimed_targets: HashMap<(String, String, String), (String, String)> =
-        HashMap::new();
+    let mut claimed_targets: HashMap<
+        rocky_sql::defer::CollisionIdentity,
+        (String, String),
+    > = HashMap::new();
     // PR-B3: count how many `(connector, table)` pairs matched each
     // `[[table_overrides]]` rule. Rules with zero matches surface as
     // soft warnings on `RunOutput.override_warnings` (T2) so
@@ -3167,10 +3169,15 @@ pub async fn run(
                 // Fail closed on two sources resolving to one target object.
                 // Refuses only on a real clash, so a multi-connector project
                 // whose table names differ still shadows fine (#1461).
-                let target_identity = (
-                    target_catalog.clone(),
-                    target_schema.clone(),
-                    target_table_name.clone(),
+                // Keyed by `CollisionIdentity`, not raw strings. DuckDB,
+                // Databricks and Trino resolve identifiers case-insensitively,
+                // so `raw__a.Orders` and `raw__b.orders` are ONE object there.
+                // An exact-string key answers "different" and lets both write
+                // it — the unrecoverable direction this type exists to avoid.
+                let target_identity = rocky_sql::defer::CollisionIdentity::of(
+                    &target_catalog,
+                    &target_schema,
+                    &target_table_name,
                 );
                 let this_source = (conn.schema.clone(), table.name.clone());
                 if let Some(prior) = claimed_targets.get(&target_identity)
@@ -3186,9 +3193,9 @@ pub async fn run(
                          (e.g. `staging__{{source}}`). Use `--shadow-suffix` \
                          instead, which keeps the template and renames the \
                          table, or give the sources distinct target tables.",
-                        target_identity.0,
-                        target_identity.1,
-                        target_identity.2,
+                        target_catalog,
+                        target_schema,
+                        target_table_name,
                         prior.0,
                         prior.1,
                         this_source.0,

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -2727,6 +2727,108 @@ pub async fn run(
         )?;
     }
 
+    // #1461 preflight: refuse a target collision BEFORE any warehouse mutation.
+    //
+    // The authoritative check still runs at the collection site below, where the
+    // exact write set is known. This pass exists only to move the refusal
+    // earlier: the setup loop creates catalogs and schemas, binds workspaces and
+    // applies grants, so a collision caught during collection would refuse only
+    // after changing access control.
+    //
+    // Read-only: `list_tables` is a source read, and the three skip conditions
+    // call the SAME functions the collection loop calls. They must stay in sync
+    // — a condition added there and not here would refuse a run that is fine.
+    // `preflight_skips_a_disabled_table` pins the one most likely to drift.
+    {
+        let mut preflight_claims: HashMap<
+            rocky_sql::defer::CollisionIdentity,
+            (String, String),
+        > = HashMap::new();
+        for conn in &connectors {
+            let Ok(parsed) = pattern.parse(&conn.schema) else {
+                continue;
+            };
+            if !parsed_filter
+                .as_ref()
+                .is_none_or(|(k, v)| matches_filter(conn, &parsed, k, v))
+            {
+                continue;
+            }
+            let source_catalog = pipeline.source.catalog.as_deref().unwrap_or("").to_string();
+            let source_tables: std::collections::HashSet<String> = warehouse_adapter
+                .list_tables(&source_catalog, &conn.schema)
+                .await
+                .map(|v| v.into_iter().map(|t| t.to_lowercase()).collect())
+                .unwrap_or_default();
+            let target_catalog = parsed.resolve_template(target_catalog_template, target_sep);
+            let target_schema = if let Some(cfg) = shadow_config {
+                cfg.schema_override
+                    .clone()
+                    .unwrap_or_else(|| parsed.resolve_template(target_schema_template, target_sep))
+            } else {
+                parsed.resolve_template(target_schema_template, target_sep)
+            };
+
+            for table in &conn.tables {
+                if !filter_table_matches(parsed_filter.as_ref(), &table.name) {
+                    continue;
+                }
+                // A source read failure yields an empty set above; treat that as
+                // "cannot tell" and skip rather than refuse on incomplete data.
+                if !source_tables.is_empty() && !source_tables.contains(&table.name.to_lowercase()) {
+                    continue;
+                }
+                if rocky_core::config::resolve_table_override(
+                    &pipeline.table_overrides,
+                    &conn.id,
+                    &conn.schema,
+                    &table.name,
+                )
+                .enabled
+                    == Some(false)
+                {
+                    continue;
+                }
+                let target_table_name = if let Some(cfg) = shadow_config {
+                    if cfg.schema_override.is_none() {
+                        format!("{}{}", table.name, cfg.suffix)
+                    } else {
+                        table.name.clone()
+                    }
+                } else {
+                    table.name.clone()
+                };
+                let id = rocky_sql::defer::CollisionIdentity::of(
+                    &target_catalog,
+                    &target_schema,
+                    &target_table_name,
+                );
+                let this = (conn.schema.clone(), table.name.clone());
+                if let Some(prior) = preflight_claims.get(&id)
+                    && *prior != this
+                {
+                    anyhow::bail!(
+                        "two sources resolve to the same target table \
+                         '{target_catalog}.{target_schema}.{target_table_name}': \
+                         '{}.{}' and '{}.{}'. Writing both would leave whichever \
+                         ran last, and the run would still report copying two \
+                         tables. This happens when `--shadow-schema` replaces a \
+                         schema template whose only distinguishing component is \
+                         the connector (e.g. `staging__{{source}}`). Use \
+                         `--shadow-suffix` instead, which keeps the template and \
+                         renames the table, or give the sources distinct target \
+                         tables.",
+                        prior.0,
+                        prior.1,
+                        this.0,
+                        this.1,
+                    );
+                }
+                preflight_claims.insert(id, this);
+            }
+        }
+    }
+
     // --- Sequential: catalog/schema setup + table collection ---
     // Governance operations route through the GovernanceAdapter trait
     // (Plan 01: genericize run.rs). Catalog/schema creation uses

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -2605,6 +2605,14 @@ pub async fn run(
     let mut assertion_targets: Vec<(TableRef, Vec<String>)> = Vec::new();
     let mut pending_checks: HashMap<String, PendingCheck> = HashMap::new();
     let mut tables_to_process: Vec<TableTask> = Vec::new();
+    // Resolved target identity -> the source that claimed it. A shadow
+    // `--shadow-schema` replaces the resolved schema template outright, so a
+    // template whose only distinguishing component is the connector (e.g.
+    // `staging__{source}`) collapses every connector into one schema. Two
+    // connectors holding a same-named table then write the same object and the
+    // second silently wins, with `tables_copied` still counting both (#1461).
+    let mut claimed_targets: HashMap<(String, String, String), (String, String)> =
+        HashMap::new();
     // PR-B3: count how many `(connector, table)` pairs matched each
     // `[[table_overrides]]` rule. Rules with zero matches surface as
     // soft warnings on `RunOutput.override_warnings` (T2) so
@@ -3104,6 +3112,39 @@ pub async fn run(
                 } else {
                     table.name.clone()
                 };
+
+                // Fail closed on two sources resolving to one target object.
+                // Refuses only on a real clash, so a multi-connector project
+                // whose table names differ still shadows fine (#1461).
+                let target_identity = (
+                    target_catalog.clone(),
+                    target_schema.clone(),
+                    target_table_name.clone(),
+                );
+                let this_source = (conn.schema.clone(), table.name.clone());
+                if let Some(prior) = claimed_targets.get(&target_identity)
+                    && *prior != this_source
+                {
+                    anyhow::bail!(
+                        "two sources resolve to the same target table \
+                         '{}.{}.{}': '{}.{}' and '{}.{}'. Writing both would \
+                         leave whichever ran last, and the run would still \
+                         report copying two tables. This happens when \
+                         `--shadow-schema` replaces a schema template whose \
+                         only distinguishing component is the connector \
+                         (e.g. `staging__{{source}}`). Use `--shadow-suffix` \
+                         instead, which keeps the template and renames the \
+                         table, or give the sources distinct target tables.",
+                        target_identity.0,
+                        target_identity.1,
+                        target_identity.2,
+                        prior.0,
+                        prior.1,
+                        this_source.0,
+                        this_source.1,
+                    );
+                }
+                claimed_targets.insert(target_identity, this_source);
 
                 tables_to_process.push(TableTask {
                     source_catalog: source_catalog.clone(),

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -12807,6 +12807,127 @@ mod tests {
     // the `Succeeded` assertion fails because the entry is still
     // `InFlight`.
     // -----------------------------------------------------------------------
+    /// #1460: the reviewed source state must be re-checked where the work is
+    /// BUILT, not only in the apply path before `run` is called.
+    ///
+    /// The apply path discovers once to compare against the plan, then calls
+    /// `run`, which discovers again and builds work from the second result. A
+    /// connector appearing between the two executed unreviewed. This drives
+    /// `run` directly with a reviewed snapshot that does not match what
+    /// discovery finds, and asserts the refusal fires before any DDL.
+    #[tokio::test]
+    async fn execution_refuses_when_discovery_differs_from_the_reviewed_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let db = dir.join("x.duckdb");
+        {
+            use rocky_core::traits::WarehouseAdapter;
+            let a = rocky_duckdb::adapter::DuckDbWarehouseAdapter::open(&db).unwrap();
+            a.execute_statement("CREATE SCHEMA raw__orders")
+                .await
+                .unwrap();
+            a.execute_statement("CREATE TABLE raw__orders.t AS SELECT 1 AS id")
+                .await
+                .unwrap();
+        }
+        let config_path = dir.join("rocky.toml");
+        std::fs::write(
+            &config_path,
+            format!(
+                r#"
+[adapter]
+type = "duckdb"
+path = "{}"
+
+[state]
+backend = "local"
+
+[pipeline.p]
+type = "replication"
+strategy = "full_refresh"
+
+[pipeline.p.source.discovery]
+adapter = "default"
+
+[pipeline.p.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.p.target]
+adapter = "default"
+catalog_template = "x"
+schema_template = "staging__{{source}}"
+
+[pipeline.p.target.governance]
+auto_create_schemas = true
+"#,
+                db.display()
+            ),
+        )
+        .unwrap();
+
+        // A reviewed state naming a connector discovery will NOT find. That is
+        // the mismatch the sink has to catch.
+        let reviewed = vec![crate::output::ReplicationConnectorSnapshot {
+            id: "raw__ghost".to_string(),
+            schema: "raw__ghost".to_string(),
+            source_type: "duckdb".to_string(),
+            tables: vec![crate::output::ReplicationTableSnapshot {
+                name: "t".to_string(),
+                row_count: Some(1),
+            }],
+        }];
+
+        let state_path = dir.join("state.redb");
+        let opts = PartitionRunOptions::default();
+        let err = super::run(
+            &config_path,
+            std::sync::Arc::new(
+                rocky_core::config::load_rocky_config_fingerprinted(&config_path).unwrap(),
+            ),
+            None,
+            None,
+            &state_path,
+            None,
+            false,
+            None,
+            false,
+            None,
+            false,
+            None,
+            &opts,
+            None,
+            None,
+            None,
+            None,
+            &DeferOptions::default(),
+            &SkipRunOptions::default(),
+            &rocky_core::run_vars::RunVars::new(),
+            None,
+            None,
+            false,
+            Some(("plan-under-test", reviewed.as_slice())),
+        )
+        .await
+        .expect_err("a reviewed state that does not match discovery must refuse");
+
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("drifted between the check and execution"),
+            "expected the execution-seam refusal, got: {msg}"
+        );
+        assert!(
+            msg.contains("Nothing was written"),
+            "the refusal must state nothing was written, got: {msg}"
+        );
+
+        // No DDL assertion needed: the guard sits immediately after discovery
+        // binds `connectors`, and every catalog/schema creation happens in the
+        // setup loop far below it. Refusing here is structurally before any
+        // warehouse statement.
+    }
+
     #[tokio::test]
     async fn transformation_success_stamps_idempotency_succeeded_not_inflight() {
         use rocky_core::idempotency::IdempotencyState;

--- a/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
+++ b/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
@@ -160,6 +160,7 @@ fn default_sub_runner() -> SubRunner {
                     None,
                     // `--assume-fresh-state` is not surfaced on the DAG path.
                     false,
+                    None, // #1460: DAG sub-run, no persisted plan
                 )
                 .await
                 .map_err(|e| format!("{e:#}"))

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -1265,6 +1265,7 @@ mod tests {
             None,  // no run_id override — mint the usual timestamp id
             None,  // no governance ctx (test)
             false, // assume_fresh_state (test)
+            None,  // #1460
         )
         .await
         .expect("full-DAG transformation run should succeed");
@@ -1400,6 +1401,7 @@ auto_create_schemas = true
             None,
             None,
             false,
+            None, // #1460
         )
         .await
         .expect("--model with --pipeline must resolve that pipeline's models dir");
@@ -1479,6 +1481,7 @@ auto_create_schemas = true
             None,
             None,
             false,
+            None, // #1460
         )
         .await
     }
@@ -1867,6 +1870,7 @@ auto_create_schemas = true
             None,  // no run_id override — mint the usual timestamp id
             None,  // no governance ctx (test)
             false, // assume_fresh_state (test)
+            None,  // #1460
         )
         .await
         .expect("full-DAG transformation run with idempotency key should succeed");
@@ -2198,6 +2202,7 @@ auto_create_schemas = true
             None,  // no run_id override — mint the usual timestamp id
             None,  // no governance ctx (test)
             false, // assume_fresh_state (test)
+            None,  // #1460
         )
         .await
         .expect("model-only run must reach the governance.tags apply path and succeed");
@@ -2278,6 +2283,7 @@ auto_create_schemas = true
             None,  // no run_id override — mint the usual timestamp id
             None,  // no governance ctx (test)
             false, // assume_fresh_state (test)
+            None,  // #1460
         )
         .await;
 

--- a/engine/crates/rocky-cli/src/commands/run_watch.rs
+++ b/engine/crates/rocky-cli/src/commands/run_watch.rs
@@ -362,6 +362,7 @@ async fn iter_once(
         // `--assume-fresh-state` is not surfaced on the watch path (clap
         // rejects the combination at parse time).
         false,
+        None, // #1460: dev watch loop, no persisted plan
     )
     .await;
     let elapsed_ms = started.elapsed().as_millis();

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -3817,6 +3817,19 @@ pub struct ReplicationPlan {
     /// subset would silently break replay. Cheaper to keep the whole
     /// config and let the hash do its job.
     pub config_snapshot: serde_json::Value,
+    /// Credential-free identity of the state authority this plan was reviewed
+    /// against — which ledger holds its watermarks, freezes, budgets and
+    /// idempotency keys.
+    ///
+    /// `config_snapshot` cannot answer this: `valkey_url` is redacted whole, so
+    /// a Valkey A-to-B swap compares equal, and the resolved `--state-path`
+    /// comes from the caller and never appears in the config. Without this a
+    /// plan could pass the config comparison and still apply against a
+    /// different ledger. Optional so plans written before this field still
+    /// deserialize; absent means "not recorded", and apply skips the check
+    /// rather than refusing every older plan.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_authority: Option<String>,
     /// Discovered connectors sorted by `id`. Tables within each
     /// connector are sorted by `name`. Apply re-discovers and asserts
     /// byte-equality against this snapshot before running SQL.

--- a/engine/crates/rocky-cli/tests/config_snapshot_threading.rs
+++ b/engine/crates/rocky-cli/tests/config_snapshot_threading.rs
@@ -141,6 +141,7 @@ async fn run_executes_the_loaded_snapshot() {
         None, // run_id_override
         None, // governed_ctx
         false,
+        None, // #1460
     )
     .await
     .expect("the run must execute the loaded snapshot A");

--- a/engine/crates/rocky-cli/tests/freeze_marker_enforcement.rs
+++ b/engine/crates/rocky-cli/tests/freeze_marker_enforcement.rs
@@ -373,6 +373,7 @@ async fn drive_run(
         run_id_override,
         None,  // governed_ctx
         false, // assume_fresh_state
+        None,  // #1460
     )
     .await
 }

--- a/engine/crates/rocky-cli/tests/models_glob_base.rs
+++ b/engine/crates/rocky-cli/tests/models_glob_base.rs
@@ -134,6 +134,7 @@ async fn run_pipeline(config_path: &Path, state_path: &Path) -> anyhow::Result<(
         None, // run_id_override
         None, // governed_ctx
         false,
+        None, // #1460
     )
     .await
 }
@@ -168,6 +169,7 @@ async fn run_pipeline_model(config_path: &Path, state_path: &Path) -> anyhow::Re
         None,
         None,
         false,
+        None, // #1460
     )
     .await
 }

--- a/engine/crates/rocky-cli/tests/remote_state_authority.rs
+++ b/engine/crates/rocky-cli/tests/remote_state_authority.rs
@@ -135,6 +135,7 @@ async fn drive_run(
         None, // run_id_override
         None, // governed_ctx
         assume_fresh_state,
+        None, // #1460
     )
     .await
 }

--- a/engine/crates/rocky-cli/tests/remote_state_bypass.rs
+++ b/engine/crates/rocky-cli/tests/remote_state_bypass.rs
@@ -216,6 +216,7 @@ async fn drive_run(
         run_id_override,
         None,  // governed_ctx
         false, // assume_fresh_state
+        None,  // #1460
     )
     .await
 }
@@ -272,6 +273,7 @@ async fn drive_run_governed(
         None, // run_id_override
         Some(&ctx),
         false, // assume_fresh_state
+        None,  // #1460
     )
     .await
 }

--- a/engine/crates/rocky-cli/tests/remote_state_session.rs
+++ b/engine/crates/rocky-cli/tests/remote_state_session.rs
@@ -169,6 +169,7 @@ async fn drive_run(
         run_id_override,
         None,  // governed_ctx
         false, // assume_fresh_state
+        None,  // #1460
     )
     .await
 }
@@ -219,6 +220,7 @@ async fn drive_run_governed(config_path: &Path, state_path: &Path) -> anyhow::Re
         None, // run_id_override
         Some(&ctx),
         false, // assume_fresh_state
+        None,  // #1460
     )
     .await
 }

--- a/engine/rocky/tests/shadow_schema_target_collision.rs
+++ b/engine/rocky/tests/shadow_schema_target_collision.rs
@@ -124,14 +124,18 @@ fn the_suggested_shadow_suffix_alternative_isolates_both_connectors() {
 
     let conn = duckdb::Connection::open(dir.join("fixture.duckdb")).expect("reopen duckdb");
     let shopify: i64 = conn
-        .query_row("SELECT count(*) FROM staging__shopify.orders_shdw", [], |r| {
-            r.get(0)
-        })
+        .query_row(
+            "SELECT count(*) FROM staging__shopify.orders_shdw",
+            [],
+            |r| r.get(0),
+        )
         .expect("shopify shadow rows");
     let stripe: i64 = conn
-        .query_row("SELECT count(*) FROM staging__stripe.orders_shdw", [], |r| {
-            r.get(0)
-        })
+        .query_row(
+            "SELECT count(*) FROM staging__stripe.orders_shdw",
+            [],
+            |r| r.get(0),
+        )
         .expect("stripe shadow rows");
     assert_eq!(
         (shopify, stripe),

--- a/engine/rocky/tests/shadow_schema_target_collision.rs
+++ b/engine/rocky/tests/shadow_schema_target_collision.rs
@@ -1,0 +1,141 @@
+//! #1461 regression: `--shadow-schema` must not collapse two connectors into
+//! one target object.
+//!
+//! `--shadow-schema X` replaces the resolved target schema outright. When the
+//! schema template's only distinguishing component is the connector, every
+//! connector lands in `X`, and two sources holding a same-named table write the
+//! same object. The second write wins, and the run still reports copying both.
+
+use std::fs;
+use std::process::Command;
+
+/// Two connectors, one shared table name, and a template that separates them
+/// only by `{source}` — the shape that collapses under `--shadow-schema`.
+const ROCKY_TOML: &str = r#"
+[adapter]
+type = "duckdb"
+path = "fixture.duckdb"
+
+[pipeline.ingest]
+strategy = "full_refresh"
+
+[pipeline.ingest.source.discovery]
+adapter = "default"
+
+[pipeline.ingest.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.ingest.target]
+catalog_template = "fixture"
+schema_template = "staging__{source}"
+
+[pipeline.ingest.target.governance]
+auto_create_schemas = true
+"#;
+
+fn seed(dir: &std::path::Path) {
+    let conn = duckdb::Connection::open(dir.join("fixture.duckdb")).expect("open duckdb");
+    conn.execute_batch(
+        "CREATE SCHEMA raw__shopify;
+         CREATE SCHEMA raw__stripe;
+         CREATE TABLE raw__shopify.orders AS SELECT * FROM (VALUES (1),(2),(3)) t(id);
+         CREATE TABLE raw__stripe.orders  AS SELECT * FROM (VALUES (99)) t(id);",
+    )
+    .expect("seed sources");
+}
+
+fn run(dir: &std::path::Path, extra: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_rocky"))
+        .args(["--output", "json"])
+        .arg("--config")
+        .arg(dir.join("rocky.toml"))
+        .arg("run")
+        .args(extra)
+        .current_dir(dir)
+        .env("RUST_LOG", "error")
+        .output()
+        .expect("run rocky")
+}
+
+#[test]
+fn shadow_schema_refuses_two_sources_resolving_to_one_target() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path();
+    seed(dir);
+    fs::write(dir.join("rocky.toml"), ROCKY_TOML).expect("write config");
+
+    // Baseline: the template keeps the connectors apart, so a plain run is fine.
+    // Without this the test could pass because the project is broken outright.
+    let plain = run(dir, &[]);
+    assert!(
+        plain.status.success(),
+        "a plain run must succeed for this fixture to test anything; stderr: {}",
+        String::from_utf8_lossy(&plain.stderr)
+    );
+
+    // `--shadow-schema` discards the template, so both connectors resolve to
+    // `fixture.shadow_x.orders`. That must refuse, not silently keep one.
+    let shadowed = run(dir, &["--shadow", "--shadow-schema", "shadow_x"]);
+    assert!(
+        !shadowed.status.success(),
+        "two sources resolving to one target must fail closed; stdout: {}",
+        String::from_utf8_lossy(&shadowed.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&shadowed.stderr);
+    assert!(
+        stderr.contains("same target table")
+            && stderr.contains("shadow_x")
+            && stderr.contains("raw__shopify")
+            && stderr.contains("raw__stripe"),
+        "the refusal must name the collision and both sources, got: {stderr}"
+    );
+
+    // Nothing may be written. A partial write would leave one connector's rows
+    // presented as the shadow baseline `rocky compare` reads.
+    let conn = duckdb::Connection::open(dir.join("fixture.duckdb")).expect("reopen duckdb");
+    let leaked: i64 = conn
+        .query_row(
+            "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'shadow_x'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("count shadow tables");
+    assert_eq!(leaked, 0, "the refused run must not leave a shadow table");
+}
+
+/// The refusal names `--shadow-suffix` as the way to do this. Prove that works,
+/// so the advice is not a dead end: it keeps the template and renames the table,
+/// which isolates both connectors instead of merging them.
+#[test]
+fn the_suggested_shadow_suffix_alternative_isolates_both_connectors() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path();
+    seed(dir);
+    fs::write(dir.join("rocky.toml"), ROCKY_TOML).expect("write config");
+
+    let out = run(dir, &["--shadow", "--shadow-suffix", "_shdw"]);
+    assert!(
+        out.status.success(),
+        "the suggested alternative must work; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let conn = duckdb::Connection::open(dir.join("fixture.duckdb")).expect("reopen duckdb");
+    let shopify: i64 = conn
+        .query_row("SELECT count(*) FROM staging__shopify.orders_shdw", [], |r| {
+            r.get(0)
+        })
+        .expect("shopify shadow rows");
+    let stripe: i64 = conn
+        .query_row("SELECT count(*) FROM staging__stripe.orders_shdw", [], |r| {
+            r.get(0)
+        })
+        .expect("stripe shadow rows");
+    assert_eq!(
+        (shopify, stripe),
+        (3, 1),
+        "both connectors must keep their own rows"
+    );
+}

--- a/engine/rocky/tests/shadow_schema_target_collision.rs
+++ b/engine/rocky/tests/shadow_schema_target_collision.rs
@@ -184,3 +184,61 @@ fn shadow_schema_refuses_targets_that_differ_only_by_case() {
         "expected the collision refusal, got: {stderr}"
     );
 }
+
+/// The refusal must land BEFORE any warehouse mutation. The collision was
+/// previously caught while collecting tables, which is after the setup loop
+/// creates catalogs and schemas, binds workspaces and applies grants — so a
+/// refused run could still have changed access control.
+#[test]
+fn the_collision_refusal_creates_no_target_schema() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path();
+    seed(dir);
+    fs::write(dir.join("rocky.toml"), ROCKY_TOML).expect("write config");
+
+    let out = run(dir, &["--shadow", "--shadow-schema", "shadow_x"]);
+    assert!(!out.status.success(), "must refuse");
+
+    let conn = duckdb::Connection::open(dir.join("fixture.duckdb")).expect("reopen duckdb");
+    let created: i64 = conn
+        .query_row(
+            "SELECT count(*) FROM information_schema.schemata \
+             WHERE schema_name IN ('shadow_x', 'staging__shopify', 'staging__stripe')",
+            [],
+            |r| r.get(0),
+        )
+        .expect("count schemas");
+    assert_eq!(
+        created, 0,
+        "a refused run must not have created any target schema"
+    );
+}
+
+/// The preflight repeats three skip conditions the collection loop applies. If
+/// they drift, the preflight refuses a run that would have been fine — worse
+/// than the late refusal it replaces. This pins the condition most likely to
+/// drift: a table switched off by `enabled = false` must not count as a claim.
+///
+/// Both connectors hold `orders`, so under one shadow schema they WOULD
+/// collide — except stripe's is disabled, leaving exactly one writer.
+#[test]
+fn preflight_skips_a_disabled_table() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path();
+    seed(dir);
+    let cfg = format!(
+        "{ROCKY_TOML}\n\
+         [[pipeline.ingest.table_overrides]]\n\
+         match.connector = \"raw__stripe\"\n\
+         enabled = false\n"
+    );
+    fs::write(dir.join("rocky.toml"), cfg).expect("write config");
+
+    let out = run(dir, &["--shadow", "--shadow-schema", "shadow_x"]);
+    assert!(
+        out.status.success(),
+        "one enabled writer is not a collision — the preflight must not refuse; \
+         stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}

--- a/engine/rocky/tests/shadow_schema_target_collision.rs
+++ b/engine/rocky/tests/shadow_schema_target_collision.rs
@@ -35,6 +35,20 @@ schema_template = "staging__{source}"
 auto_create_schemas = true
 "#;
 
+/// Same shape, but the two tables differ ONLY by case. DuckDB resolves
+/// identifiers case-insensitively, so `Orders` and `orders` are one object —
+/// an exact-string collision key answers "different" and lets both write it.
+fn seed_case_only(dir: &std::path::Path) {
+    let conn = duckdb::Connection::open(dir.join("fixture.duckdb")).expect("open duckdb");
+    conn.execute_batch(
+        "CREATE SCHEMA raw__shopify;
+         CREATE SCHEMA raw__stripe;
+         CREATE TABLE raw__shopify.\"Orders\" AS SELECT * FROM (VALUES (1),(2),(3)) t(id);
+         CREATE TABLE raw__stripe.orders       AS SELECT * FROM (VALUES (99)) t(id);",
+    )
+    .expect("seed case-differing sources");
+}
+
 fn seed(dir: &std::path::Path) {
     let conn = duckdb::Connection::open(dir.join("fixture.duckdb")).expect("open duckdb");
     conn.execute_batch(
@@ -141,5 +155,32 @@ fn the_suggested_shadow_suffix_alternative_isolates_both_connectors() {
         (shopify, stripe),
         (3, 1),
         "both connectors must keep their own rows"
+    );
+}
+
+/// #1461 follow-up: the collision key must fold case.
+///
+/// `raw__shopify.Orders` and `raw__stripe.orders` land in the same shadow
+/// schema. On a case-insensitive warehouse that is ONE table, so an
+/// exact-string key would pass them both through and restore the
+/// last-writer-wins loss this guard exists to stop.
+#[test]
+fn shadow_schema_refuses_targets_that_differ_only_by_case() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path();
+    seed_case_only(dir);
+    fs::write(dir.join("rocky.toml"), ROCKY_TOML).expect("write config");
+
+    let shadowed = run(dir, &["--shadow", "--shadow-schema", "shadow_x"]);
+    assert!(
+        !shadowed.status.success(),
+        "targets differing only by case must fail closed on a case-insensitive \
+         warehouse; stdout: {}",
+        String::from_utf8_lossy(&shadowed.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&shadowed.stderr);
+    assert!(
+        stderr.contains("same target table"),
+        "expected the collision refusal, got: {stderr}"
     );
 }


### PR DESCRIPTION
Three fail-open defects. All three reported success while doing less than asked. All found by the audits behind #1325.

## #1461 — shadow merged two connectors into one table

`--shadow-schema X` replaces the resolved schema outright. If the template's only distinguishing part is the connector, every connector lands in `X`.

```
config:  schema_template = "staging__{source}"

sources:  raw__shopify.orders   3 rows
          raw__stripe.orders    1 row

normal run                        --shadow --shadow-schema shadow_x
  staging__shopify.orders  3        shadow_x.orders   1     <- one table
  staging__stripe.orders   1                                <- one row
  reported: 2 copied, 0 failed      reported: 2 copied, 0 failed
```

Both writes hit the same object. The second won. The run still counted two.

That matters beyond a wrong name: `--shadow` exists to give `rocky compare` a trustworthy baseline. Here the baseline was wrong and the exit code said fine.

**Now:** refused, naming both sources. Only on a real clash — distinct table names still shadow fine. The message points at `--shadow-suffix`, and a test proves that works:

```
staging__shopify.orders_shdw  3 rows
staging__stripe.orders_shdw   1 row
```

## #1459 — a `[policy]` block switched off the AI review gate

```
BEFORE                        AFTER
no policy   -> review needed  no policy   -> review needed
policy Deny -> refused        policy Deny -> refused
policy Rev. -> review needed  policy Rev. -> review needed
policy Allow-> SKIPPED        policy Allow-> review needed
```

Protection was strongest with governance switched off.

`Allow` answers *"may this principal do this?"*. Review answers *"did a human read this machine-written change?"*. One is not an answer to the other, and `RequireReview` already exists for estates that want policy to drive review.

**Order matters here.** I first put the marker check before the policy gate. That broke `legacy_ai_authored_with_empty_policy_still_requires_review`, and the test was right to break: it asserts the *policy* path refuses, which is what proves the `ai_authored => agent` default is load-bearing. Putting the marker check first hid that. So the policy gate runs first and the marker check runs unconditionally after — the hole closes and every existing message and precedence is preserved.

## #1460 — apply checked one set of tables and ran another

```
apply:  discover D1 -> compare D1 to plan snapshot   (passes)
        call run    -> discover D2 -> build work from D2   <- never compared
```

A connector appearing between the two ran without being in the reviewed snapshot.

`run` now takes the reviewed state and re-applies the **same** `decide_drift_scope` rule where work is built. Reusing that function is deliberate: the filter tolerance stays identical, so out-of-scope drift is still a warning and only in-scope or unfiltered drift refuses — before anything is written.

`None` at every other call site, so a direct `rocky run` is byte-identical.

## Tests

3 new, all mutation-checked. Each fails when its own fix is reverted:

| mutation | test | result |
|---|---|---|
| remove the collision refusal | `shadow_schema_refuses_two_sources...` | **FAILED** |
| restore the old review gating | `configured_allow_policy_does_not_waive_ai_review` | **FAILED** |

The suffix-alternative test correctly keeps passing under the first mutation — it tests the workaround, not the refusal.

## Gates

| gate | result |
|---|---|
| `cargo fmt --all --check` | 0 |
| `cargo clippy --all-targets --workspace -- -D warnings` | 0 |
| `cargo test -p rocky-cli --lib` | 1429 pass |
| `cargo test -p rocky --test shadow_schema_target_collision` | 2 pass |

## Not fixed here

`ReplicationPlan.config_snapshot` is still written and never read. A config change between plan and apply — different adapter, path, or schema template — is undetected. That is the second half of #1460 and needs a decision: wire it, or delete it and stop implying a check exists. A doc comment in `redacted.rs` also calls it "consumed by `rocky apply`", which is false either way.

## Behaviour changes to know about

- Anyone using `--shadow-schema` on a multi-connector project with colliding table names now gets a refusal instead of silent data loss.
- Anyone relying on a configured `Allow` to auto-apply AI-authored plans now gets a refusal. That is the intended fix, and it is loud.

## Red team

Not yet reviewed by an independent model. These are three security-relevant behaviour changes, so a pass is warranted before merge — recording the gap rather than skipping it.
