### PR TITLE
chore: release engine 1.71.0, sdk 0.12.0, dagster 1.63.0, vscode 1.38.0

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.38.0] — 2026-08-18
+
 ### Fixed
 
 - **The `intent` hover in the config schema names a real command.** It cited `rocky ai sync`, which the CLI rejects; the subcommand is `rocky ai-sync`. (#1443)

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.37.1",
+  "version": "1.38.0",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.71.0] — 2026-08-18
+
+### Added
+
+- **Plans can carry a product identity, and `rocky apply` can require it.** `RunPlan` gains optional `product_id` / `spec_digest` — both or neither. Absent fields serialize exactly as before, so existing plan ids are unchanged. `rocky apply --expect-spec-digest <hex>` fails closed in both directions: a product-bound plan refuses a bare apply, and a mismatched or missing binding refuses before any policy arm runs. The `compact`, `archive` and `branch promote` plan aliases refuse product-bound payloads outright and point at canonical `rocky apply`. MCP `propose` accepts the pair plus an optional idempotency key, deriving `<product>@<digest>` when omitted. (#1472)
+
+- **`rocky review --status`** — a typed marker oracle, with a `review_status` schema, an SDK `review_status()` method and a Dagster resource method. Review markers are now written atomically and parse-and-match validated everywhere they gate, so a truncated or mispasted marker refuses instead of approving. `review_queue` gains a product filter, and a corrupt plan there surfaces as a warning rather than being dropped. (#1472)
+
+- **`draft_metadata` MCP tool** — governed, structured sidecar patches for freshness and classifications. Parse-merge only, rolled back on deny or compile failure, with policy evaluated over the post-image. `draft_model` on an existing model now preserve-merges the sidecar, replacing only `name` and `intent`, and its policy is evaluated over both the pre- and post-image classifications with the most restrictive verdict winning — so adding or erasing a classification can no longer de-scope a deny in either direction. A sidecar that exists but cannot be read is refused rather than clobbered. (#1472)
+
+- **`rocky mcp --profile worker`** — a minimal drafting allowlist that excludes `propose`, `review_queue`, `draft_contract`, `draft_metadata` and `pause_schedule`. Its prompts and next-steps end at a hand-off instead of naming tools the profile does not expose. (#1472)
+
+- **`JobRequest.expect_spec_digest`** threads the apply expectation through the serve API. (#1472)
+
 ### Changed
 
 These three refuse where they previously proceeded. Each closes a path that

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.71.0] — 2026-08-18
 ### Changed
 
 These three refuse where they previously proceeded. Each closes a path that

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.70.1"
+version = "1.71.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3891,7 +3891,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.70.1"
+version = "1.71.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3904,7 +3904,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.70.1"
+version = "1.71.0"
 dependencies = [
  "indexmap",
  "reqwest 0.12.28",
@@ -3925,7 +3925,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.70.1"
+version = "1.71.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3942,7 +3942,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.70.1"
+version = "1.71.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.70.1"
+version = "1.71.0"
 dependencies = [
  "redis",
  "serde",
@@ -3982,7 +3982,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.70.1"
+version = "1.71.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -3993,7 +3993,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.70.1"
+version = "1.71.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4052,7 +4052,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.70.1"
+version = "1.71.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -4080,7 +4080,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.70.1"
+version = "1.71.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4133,7 +4133,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.70.1"
+version = "1.71.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4160,7 +4160,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.70.1"
+version = "1.71.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4179,7 +4179,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.70.1"
+version = "1.71.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.70.1"
+version = "1.71.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.70.1"
+version = "1.71.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4253,7 +4253,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.70.1"
+version = "1.71.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -4266,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.70.1"
+version = "1.71.0"
 dependencies = [
  "logos",
  "miette",
@@ -4278,7 +4278,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.70.1"
+version = "1.71.0"
 dependencies = [
  "rocky-server",
  "rustls",
@@ -4287,7 +4287,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.70.1"
+version = "1.71.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4313,7 +4313,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.70.1"
+version = "1.71.0"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4331,7 +4331,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.70.1"
+version = "1.71.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.70.1"
+version = "1.71.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -4387,7 +4387,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.70.1"
+version = "1.71.0"
 dependencies = [
  "miette",
  "regex",
@@ -4400,7 +4400,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.70.1"
+version = "1.71.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4437,7 +4437,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.70.1"
+version = "1.71.0"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.70.1"
+version = "1.71.0"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.70.1"
+version = "1.71.0"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.70.1"
+version = "1.71.0"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.70.1"
+version = "1.71.0"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.70.1"
+version = "1.71.0"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.70.1"
+version = "1.71.0"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.70.1"
+version = "1.71.0"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.70.1"
+version = "1.71.0"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.70.1"
+version = "1.71.0"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.70.1"
+version = "1.71.0"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.70.1"
+version = "1.71.0"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.70.1"
+version = "1.71.0"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.70.1"
+version = "1.71.0"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.70.1"
+version = "1.71.0"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.70.1"
+version = "1.71.0"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.70.1"
+version = "1.71.0"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.70.1"
+version = "1.71.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.70.1"
+version = "1.71.0"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.70.1"
+version = "1.71.0"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.70.1"
+version = "1.71.0"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.70.1"
+version = "1.71.0"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.70.1"
+version = "1.71.0"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.70.1"
+version = "1.71.0"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.70.1"
+version = "1.71.0"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.70.1"
+version = "1.71.0"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.63.0] — 2026-08-18
 
+### Added
+
+- **`RockyResource.review_status()`** — mirrors the SDK method, so a Dagster op can check whether a plan is approved before applying it. (#1472)
+
 ### Fixed
 
 - **A project with two or more transformation pipelines can now produce an asset graph.** `RockyComponent` caches `rocky.dag(...)`, and that call forced a whole-project `--models`, which the engine refuses on a multi-transformation project — so definitions failed to build at all. The DAG call now lets each pipeline resolve its own models root. (#1348)

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.63.0] — 2026-08-18
+
 ### Fixed
 
 - **A project with two or more transformation pipelines can now produce an asset graph.** `RockyComponent` caches `rocky.dag(...)`, and that call forced a whole-project `--models`, which the engine refuses on a multi-transformation project — so definitions failed to build at all. The DAG call now lets each pipeline resolve its own models root. (#1348)

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.62.0"
+version = "1.63.0"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] — 2026-08-18
+
 ### Fixed
 
 - **`dag()` no longer forces a whole-project models override, which made multi-transformation projects undiscoverable.** It always sent `--models <models_dir>`. The engine reads that as an explicit *whole-project* override and assigns that one directory's models to **every** transformation pipeline, so a project with two of them was refused outright — `model 'x' is claimed by transformation pipelines a and b` — before any caller could see a DAG. `models_dir` now defaults to `None` and the flag is omitted, so each pipeline resolves its own configured root (the branch `rocky run --dag` already used). Pass `models_dir=` to ask for the override deliberately. (#1348)

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.12.0] — 2026-08-18
 
+### Added
+
+- **`review_status()`** — a typed read of a plan's review marker, backed by the new `review_status` schema. Markers are parse-and-match validated, so a truncated or mispasted one reports unapproved rather than approving. (#1472)
+
 ### Fixed
 
 - **`dag()` no longer forces a whole-project models override, which made multi-transformation projects undiscoverable.** It always sent `--models <models_dir>`. The engine reads that as an explicit *whole-project* override and assigns that one directory's models to **every** transformation pipeline, so a project with two of them was refused outright — `model 'x' is claimed by transformation pipelines a and b` — before any caller could see a DAG. `models_dir` now defaults to `None` and the flag is omitted, so each pipeline resolves its own configured root (the branch `rocky run --dag` already used). Pass `models_dir=` to ask for the override deliberately. (#1348)

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rocky-sdk"
-version = "0.11.0"
+version = "0.12.0"
 description = "Typed Python client for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "rocky-sdk"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Version bumps and changelog cuts for all four artifacts. **None is a patch bump** — each removes something or changes behaviour.

| artifact | bump | why not a patch |
|---|---|---|
| engine | 1.70.1 -> **1.71.0** | three new refusals, `drift` schema removed |
| sdk | 0.11.0 -> **0.12.0** | `DriftOutput` removed; `dag()`/`run_model()` argv changed |
| vscode | 1.37.1 -> **1.38.0** | lineage drift overlay removed |
| dagster | 1.62.0 -> **1.63.0** | floors `rocky-sdk>=0.12.0` |

## Release order is load-bearing

`dagster-rocky` now floors `rocky-sdk>=0.12.0`, and the published wheel resolves that from **PyPI**, not the path source in this repo.

```
1. sdk-v0.12.0      -> PyPI          must be first
2. vscode-v1.38.0   -> Marketplace
3. dagster-v1.63.0  -> PyPI          needs step 1 live
4. engine-v1.71.0   -> GitHub        last, so it takes "Latest"
```

Tagging dagster before the SDK publishes produces an unresolvable wheel. **Nothing in CI catches it** — in-repo resolution uses the path source, which now reads 0.12.0 and satisfies the floor either way. The ordering is the only protection.

## What users hit on upgrade

Three engine changes refuse where it previously proceeded. The one most likely to bite: anyone using a permissive `[policy]` to auto-apply AI-authored plans now gets a refusal until `rocky review <plan-id> --approve` runs. All three are in the engine changelog under `Changed` with the remedy stated.

## Checks I ran

- Engine bump touches all **25** workspace `Cargo.toml` files; verified **zero** remain on 1.70.1.
- Each `[Unreleased]` became its release heading with entries intact — engine 9, sdk 4, dagster 2, vscode 2.
- Built at the bumped versions: `cargo check` clean, `import rocky_sdk` works, vscode `package.json` parses.

No code changes. Versions and changelogs only.