### PR TITLE
feat(engine): parse and lower product specs (rocky product, part 1)

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -12,9 +12,16 @@ Source list: `uv run pytest --collect-only -q` in that worktree.
 | Module | Python nodes | MAPPED | DEFERRED-PART2 | DISSOLVED |
 |---|---|---|---|---|
 | `spec/parse.py` | 53 | 53 | 0 | 0 |
-| `spec/lower.py` | pending | — | — | — |
-| `spec/manifest.py` | pending | — | — | — |
+| `spec/lower.py` | 50 | 22 | 28 | 0 |
+| `spec/manifest.py` | 12 | 12 | 0 | 0 |
 | `spec/verify.py` | pending (part 2) | — | — | — |
+| **Total so far** | **115** | **87** | **28** | **0** |
+
+`DEFERRED-PART2` here is exactly one thing: the filesystem half of
+`spec/lower.py` — staged writes, the staging journal, crash recovery, and the
+two orchestrators (`run_phase_a` / `run_phase_b`) that drive them. The port so
+far is the pure half. No lowering node is deferred for any other reason, and
+none is dissolved.
 
 ## `spec/parse.py` -> `rocky-core/src/product/spec.rs`
 
@@ -89,6 +96,104 @@ case in the table; the table content is copied case for case.
 | `classification_order_is_deterministic` | Replaces the Python document-order test; see the divergence note. |
 | `valid_spec_round_trips_its_fields` | One positive test asserting parsed values, not just rejections. |
 
+## `spec/lower.py` -> `rocky-core/src/product/lowering.rs`
+
+The pure half. Rust test names drop the `test_` prefix and read as sentences,
+so most differ in wording from their Python source; the mapping below is the
+authority, not the name similarity.
+
+| Python node id | Status | Rust test / reason |
+|---|---|---|
+| `test_golden_phase_a_contract` | MAPPED | `product::lowering::tests::golden_phase_a_contract` |
+| `test_golden_phase_a_manifest` | MAPPED | `product::lowering::tests::golden_phase_a_manifest` |
+| `test_golden_phase_b_sidecar` | MAPPED | `product::lowering::tests::golden_phase_b_sidecar` |
+| `test_golden_phase_b_manifest` | MAPPED | `product::lowering::tests::golden_phase_b_manifest` |
+| `test_golden_manifest_field_set_equals_spec_field_set` | MAPPED | `product::lowering::tests::golden_manifest_field_set_equals_spec_field_set` |
+| `test_lowering_is_deterministic` | MAPPED | `product::lowering::tests::lowering_is_deterministic` |
+| `test_lower_phase_b_refuses_a_mismatched_digest_manifest` | MAPPED | `product::lowering::tests::phase_b_refuses_a_mismatched_digest_manifest` |
+| `test_lower_phase_b_refuses_a_foreign_identity_manifest` | MAPPED | `product::lowering::tests::phase_b_refuses_a_foreign_identity_manifest` |
+| `test_phase_b_refuses_a_manifest_without_the_contract` | MAPPED | `product::lowering::tests::phase_b_refuses_a_manifest_without_the_contract` |
+| `test_contract_never_emits_the_inert_surfaces` | MAPPED | `product::lowering::tests::the_contract_never_emits_the_inert_surfaces` |
+| `test_generated_header_convention` | MAPPED | `product::lowering::tests::the_generated_header_convention_holds_for_both_artifacts` |
+| `test_merge_preserves_agent_name_intent_and_appended_check` | MAPPED | `product::lowering::tests::the_merge_preserves_agent_name_intent_and_appended_check` |
+| `test_merge_emits_the_spec_owned_blocks` | MAPPED | `product::lowering::tests::the_merge_emits_the_spec_owned_blocks` |
+| `test_merge_never_emits_freshness_severity` | MAPPED | `product::lowering::tests::the_merge_never_emits_freshness_severity` |
+| `test_merge_generates_grain_not_null_and_expression_tests` | MAPPED | `product::lowering::tests::the_merge_generates_grain_not_null_and_expression_tests` |
+| `test_single_column_grain_lowers_to_unique` | MAPPED | `product::lowering::tests::a_single_column_grain_lowers_to_unique` |
+| `test_merge_is_idempotent` | MAPPED | `product::lowering::tests::the_merge_is_idempotent` |
+| `test_merge_preserves_unowned_tables_verbatim` | MAPPED | `product::lowering::tests::the_merge_preserves_unowned_tables_verbatim` |
+| `test_merge_preserves_foreign_tag_keys` | MAPPED | `product::lowering::tests::the_merge_preserves_foreign_tag_keys` |
+| `test_merge_fills_intent_only_when_absent` | MAPPED | `product::lowering::tests::the_merge_fills_intent_only_when_it_is_absent` |
+| `test_merge_rejects_unparseable_sidecar_naming_the_path` | MAPPED | `product::lowering::tests::the_merge_rejects_an_unparseable_sidecar_naming_the_path` |
+| `test_worker_test_identical_to_generated_is_absorbed_once` | MAPPED | `product::lowering::tests::a_worker_test_identical_to_a_generated_one_is_absorbed_once` |
+| `test_phase_a_refuses_cold_start_over_existing_model_files` | DEFERRED-PART2 | `run_phase_a` collision check — filesystem |
+| `test_phase_a_resumes_over_its_own_committed_lowering` | DEFERRED-PART2 | `run_phase_a` resume — reads the committed manifest |
+| `test_phase_b_requires_phase_a` | DEFERRED-PART2 | `run_phase_b` precondition — filesystem |
+| `test_phase_b_requires_the_drafted_sidecar` | DEFERRED-PART2 | `run_phase_b` precondition — filesystem |
+| `test_phase_b_refuses_after_a_spec_edit_supersedes_phase_a` | DEFERRED-PART2 | the orchestrated form; the pure boundary is MAPPED above |
+| `test_phase_b_refuses_a_foreign_generation_identity` | DEFERRED-PART2 | the orchestrated form; the pure boundary is MAPPED above |
+| `test_phase_b_detects_phase_a_tampering` | DEFERRED-PART2 | byte-verification against disk inside `run_phase_b` |
+| `test_full_two_phase_flow_commits_everything` | DEFERRED-PART2 | commit protocol |
+| `test_crash_between_staged_renames_rolls_back\[2\]` | DEFERRED-PART2 | recovery drill |
+| `test_crash_between_staged_renames_rolls_back\[3\]` | DEFERRED-PART2 | recovery drill |
+| `test_crash_before_journal_leaves_priors_untouched` | DEFERRED-PART2 | recovery drill |
+| `test_recovery_is_idempotent` | DEFERRED-PART2 | recovery drill |
+| `test_crash_after_commit_marker_rolls_forward` | DEFERRED-PART2 | recovery drill |
+| `test_forged_journal_with_traversal_path_is_refused_and_target_untouched` | DEFERRED-PART2 | journal containment |
+| `test_symlink_at_an_allowed_final_path_is_refused_and_target_untouched` | DEFERRED-PART2 | journal containment |
+| `test_symlinked_staging_residue_is_refused_before_any_mutation` | DEFERRED-PART2 | journal containment |
+| `test_forged_journal_with_absolute_path_is_refused` | DEFERRED-PART2 | journal containment |
+| `test_forged_journal_with_symlink_escape_is_refused` | DEFERRED-PART2 | journal containment |
+| `test_forged_journal_entry_outside_the_generation_namespace_is_refused` | DEFERRED-PART2 | journal authority |
+| `test_journal_entry_naming_the_journal_itself_is_refused` | DEFERRED-PART2 | journal authority |
+| `test_journal_entry_naming_a_foreign_manifest_path_is_refused` | DEFERRED-PART2 | journal authority |
+| `test_case_aliased_duplicate_finals_are_refused` | DEFERRED-PART2 | journal authority |
+| `test_forged_staged_manifest_grants_no_recovery_authority` | DEFERRED-PART2 | journal authority |
+| `test_contained_final_path_returns_the_resolved_absolute` | DEFERRED-PART2 | path-containment helper |
+| `test_malformed_journal_is_refused_without_mutation` | DEFERRED-PART2 | journal parsing |
+| `test_journal_naming_a_foreign_manifest_is_refused` | DEFERRED-PART2 | journal parsing |
+| `test_sigkilled_child_between_staged_renames_rolls_back` | DEFERRED-PART2 | process-death drill |
+| `test_recovery_runs_automatically_on_the_next_phase` | DEFERRED-PART2 | recovery wiring |
+
+## `spec/manifest.py` -> `rocky-core/src/product/manifest.rs`
+
+| Python node id | Status | Rust test |
+|---|---|---|
+| `test_field_paths_skip_absent_optionals` | MAPPED | `product::manifest::tests::field_paths_skip_absent_optionals` |
+| `test_field_paths_include_present_optionals` | MAPPED | `product::manifest::tests::field_paths_include_present_optionals` |
+| `test_assert_total_flags_unaccounted_spec_field` | MAPPED | `product::manifest::tests::assert_total_flags_an_unaccounted_spec_field` |
+| `test_assert_total_flags_stale_manifest_row` | MAPPED | `product::manifest::tests::assert_total_flags_a_stale_manifest_row` |
+| `test_assert_total_passes_when_sets_equal` | MAPPED | `product::manifest::tests::assert_total_passes_when_the_sets_are_equal` |
+| `test_reject_disposition_round_trips` | MAPPED | `product::manifest::tests::a_reject_row_round_trips` |
+| `test_serialization_is_deterministic` | MAPPED | `product::manifest::tests::serialization_is_deterministic` |
+| `test_leaf_coverage_is_derived_from_the_schema_and_matches_the_claim` | MAPPED | `product::manifest::tests::leaf_coverage_is_derived_from_the_schema_and_matches_the_claim` |
+| `test_new_nested_leaf_breaks_totality` | MAPPED | `product::manifest::tests::a_new_nested_leaf_breaks_totality` |
+| `test_stale_covered_leaf_breaks_totality` | MAPPED | `product::manifest::tests::a_stale_covered_leaf_breaks_totality` |
+| `test_uncovered_aggregate_row_breaks_totality` | MAPPED | `product::manifest::tests::an_uncovered_aggregate_row_breaks_totality` |
+| `test_verify_artifact_hashes_detects_drift_and_absence` | MAPPED | `product::manifest::tests::verify_artifact_hashes_detects_drift_and_absence` |
+
+## Rust tests with no Python counterpart (added coverage)
+
+Beyond the parser's own added tests, listed further up.
+
+| Rust test | Why |
+|---|---|
+| `product::lowering::tests::the_imported_fixture_still_digests_to_the_goldens_value` | Every golden embeds the fixture's digest. A fixture mangled in transit fails here by name instead of failing four byte comparisons that look like renderer bugs. |
+| `product::lowering::tests::phase_b_refuses_a_foreign_product_id_or_model` | The Python test pinned only `spec_path`; the other two identity fields were unpinned. |
+| `product::lowering::tests::an_empty_checks_or_classifications_list_still_gets_a_row` | The empty-declaration branches of both rows, and their notes, which no golden reaches. |
+| `product::lowering::tests::a_spec_without_an_output_model_still_lowers` | Pins the divergence below: the Python raises on this perfectly valid spec. |
+| `product::lowering::tests::a_spec_version_pin_is_recorded_as_an_identity_row` | The `identity` disposition had no test. |
+| `product::lowering::tests::a_single_column_grain_changes_the_manifest_location_detail` | The grain-arity branch inside the manifest row, not just inside the tests. |
+| `product::lowering::tests::a_non_table_tags_value_is_replaced_not_carried` | A scalar parked at an owned key. |
+| `product::lowering::tests::a_preserved_scalar_survives_and_stays_above_the_tables` | A preserved scalar other than name/intent, which no Python test carried. |
+| `product::lowering::tests::a_nullable_column_gets_no_not_null_test` | Every column in the fixture is non-nullable, so the guard was invisible to the goldens. |
+| `product::lowering::tests::a_freshness_budget_too_wide_for_toml_is_refused` | The added refusal below. |
+| `product::manifest::tests::the_instance_walk_covers_every_row_the_schema_declares` | The mechanization the answer key lacks — see divergence 6. |
+| `product::manifest::tests::json_escapes_everything_outside_printable_ascii` | The hand-written JSON writer's escaping, including surrogate pairs. |
+| `product::manifest::tests::leaf_derivation_recurses_through_a_nested_unit_model` | Unreachable in today's schema, and a hole waiting for the first model that nests another. |
+| `product::manifest::tests::a_ref_to_a_property_less_definition_is_a_leaf_not_a_model` | `FreshnessSpec.severity` is exactly this shape; misreading it would drop the leaf silently. |
+| `product::toml_compat::tests::*` (23 tests) | The compatibility renderer is new Rust code with no Python counterpart to port — the answer key rendered through a library. Its tests pin the layout rules, both string escapers, the document-order recovery, and the column budget, cross-checked case by case against that library's real output. |
+
 ## Known divergences from the answer key
 
 1. **Classification ordering.** Python reads TOML into an insertion-ordered
@@ -109,3 +214,21 @@ case in the table; the table content is copied case for case.
    not character for character, because the Python messages quote pydantic's own
    phrasing for structural faults. Tests assert codes, per the answer key's own
    discipline.
+
+4. **Two string escapers, on purpose.** The contract file is the engine's own
+   file, so it is written the engine's way (`basic_string`, mirroring the
+   engine's contract writer). The merged sidecar reproduces the answer key's
+   library spelling (`render_string`). They differ on control characters. This
+   is not a drift from the answer key — it is two producers with two spellings,
+   and both are pinned by tests.
+
+5. **The renderer is new code with no Python counterpart, and that is the
+   largest residual risk in this port.** The answer key delegated its output to
+   a library; the port reimplements that library's layout rules (four-space
+   indent, the 100-character inline budget counted in characters rather than
+   bytes, and when an array of tables expands into blocks). The four goldens
+   byte-match, and the rules are pinned case by case against the library's real
+   output, but a layout rule no golden exercises could still differ. The
+   containment is that the lowering emits a narrow, known shape: contracts and
+   sidecars, not arbitrary documents. Any new emitted shape needs a fresh
+   cross-check against the library before it is trusted.

--- a/PARITY.md
+++ b/PARITY.md
@@ -1,0 +1,111 @@
+# PARITY — Python answer key to Rust port
+
+The frozen Python implementation on branch `feat/ff-wp2-spec-compiler` is the
+specification for this port. Every collected pytest node id maps to a Rust test,
+a `DEFERRED-PART2` entry, or a `DISSOLVED` justification. Nothing is dropped
+silently.
+
+Source list: `uv run pytest --collect-only -q` in that worktree.
+
+## Status
+
+| Module | Python nodes | MAPPED | DEFERRED-PART2 | DISSOLVED |
+|---|---|---|---|---|
+| `spec/parse.py` | 53 | 53 | 0 | 0 |
+| `spec/lower.py` | pending | — | — | — |
+| `spec/manifest.py` | pending | — | — | — |
+| `spec/verify.py` | pending (part 2) | — | — | — |
+
+## `spec/parse.py` -> `rocky-core/src/product/spec.rs`
+
+Parameterized Python cases map to one table-driven Rust test that covers every
+case in the table; the table content is copied case for case.
+
+| Python node id | Status | Rust test |
+|---|---|---|
+| `test_digest_is_sha256_over_raw_bytes` | MAPPED | `product::spec::tests::digest_is_sha256_over_raw_bytes` |
+| `test_comment_edit_changes_the_digest` | MAPPED | `product::spec::tests::comment_edit_changes_the_digest` |
+| `test_product_id_shape` | MAPPED | `product::spec::tests::product_id_shape` |
+| `test_output_model_defaults_to_product_name` | MAPPED | `product::spec::tests::output_model_defaults_to_product_name` |
+| `test_max_lag_grammar_accepts[3600s-3600]` | MAPPED | `product::spec::tests::max_lag_grammar_accepts` |
+| `test_max_lag_grammar_accepts[24h-86400]` | MAPPED | `product::spec::tests::max_lag_grammar_accepts` |
+| `test_max_lag_grammar_accepts[7d-604800]` | MAPPED | `product::spec::tests::max_lag_grammar_accepts` |
+| `test_max_lag_grammar_accepts[1s-1]` | MAPPED | `product::spec::tests::max_lag_grammar_accepts` |
+| `test_max_lag_grammar_accepts[90d-7776000]` | MAPPED | `product::spec::tests::max_lag_grammar_accepts` |
+| `test_max_lag_grammar_rejects[24]` | MAPPED | `product::spec::tests::max_lag_grammar_rejects` |
+| `test_max_lag_grammar_rejects[h24]` | MAPPED | `product::spec::tests::max_lag_grammar_rejects` |
+| `test_max_lag_grammar_rejects[24H]` | MAPPED | `product::spec::tests::max_lag_grammar_rejects` |
+| `test_max_lag_grammar_rejects[24 h]` | MAPPED | `product::spec::tests::max_lag_grammar_rejects` |
+| `test_max_lag_grammar_rejects[ 24h]` | MAPPED | `product::spec::tests::max_lag_grammar_rejects` |
+| `test_max_lag_grammar_rejects[0s]` | MAPPED | `product::spec::tests::max_lag_grammar_rejects` |
+| `test_max_lag_grammar_rejects[-3d]` | MAPPED | `product::spec::tests::max_lag_grammar_rejects` |
+| `test_max_lag_grammar_rejects[1.5h]` | MAPPED | `product::spec::tests::max_lag_grammar_rejects` |
+| `test_max_lag_grammar_rejects[24m]` | MAPPED | `product::spec::tests::max_lag_grammar_rejects` |
+| `test_max_lag_grammar_rejects[]` | MAPPED | `product::spec::tests::max_lag_grammar_rejects` |
+| `test_max_lag_grammar_rejects[24hh]` | MAPPED | `product::spec::tests::max_lag_grammar_rejects` |
+| `test_max_lag_grammar_rejects[\u0661\u0662h]` | MAPPED | `product::spec::tests::max_lag_grammar_rejects` |
+| `test_reject_unknown_top_level_key` | MAPPED | `product::spec::tests::reject_unknown_top_level_key` |
+| `test_reject_unknown_nested_key` | MAPPED | `product::spec::tests::reject_unknown_nested_key` |
+| `test_reject_include_source_selector` | MAPPED | `product::spec::tests::reject_include_source_selector` |
+| `test_reject_non_triple_source_ref[stripe_charges]` | MAPPED | `product::spec::tests::reject_non_triple_source_ref` |
+| `test_reject_non_triple_source_ref[raw.stripe_charges]` | MAPPED | `product::spec::tests::reject_non_triple_source_ref` |
+| `test_reject_non_triple_source_ref[poc.raw.stripe.charges]` | MAPPED | `product::spec::tests::reject_non_triple_source_ref` |
+| `test_reject_non_triple_source_ref[poc..charges]` | MAPPED | `product::spec::tests::reject_non_triple_source_ref` |
+| `test_reject_non_triple_source_ref[poc.raw.]` | MAPPED | `product::spec::tests::reject_non_triple_source_ref` |
+| `test_reject_glob_inside_source_ref` | MAPPED | `product::spec::tests::reject_glob_inside_source_ref` |
+| `test_reject_warehouse_type_name_with_suggestion` | MAPPED | `product::spec::tests::reject_warehouse_type_name_with_suggestion` |
+| `test_reject_warehouse_decimal_with_suggestion` | MAPPED | `product::spec::tests::reject_warehouse_decimal_with_suggestion` |
+| `test_reject_unknown_type_name` | MAPPED | `product::spec::tests::reject_unknown_type_name` |
+| `test_parameterized_rocky_types_accepted[Decimal]` | MAPPED | `product::spec::tests::parameterized_rocky_types_accepted` |
+| `test_parameterized_rocky_types_accepted[Decimal(38,9)]` | MAPPED | `product::spec::tests::parameterized_rocky_types_accepted` |
+| `test_parameterized_rocky_types_accepted[Array<Int64>]` | MAPPED | `product::spec::tests::parameterized_rocky_types_accepted` |
+| `test_parameterized_rocky_types_accepted[Map<String,Int64>]` | MAPPED | `product::spec::tests::parameterized_rocky_types_accepted` |
+| `test_reject_unbalanced_parameterized_type` | MAPPED | `product::spec::tests::reject_unbalanced_parameterized_type` |
+| `test_reject_freshness_without_time_column` | MAPPED | `product::spec::tests::reject_freshness_without_time_column` |
+| `test_reject_unparseable_max_lag_in_spec` | MAPPED | `product::spec::tests::reject_unparseable_max_lag_in_spec` |
+| `test_reject_grain_column_not_declared` | MAPPED | `product::spec::tests::reject_grain_column_not_declared` |
+| `test_check_referencing_unknown_column_is_allowed` | MAPPED | `product::spec::tests::check_referencing_unknown_column_is_allowed` |
+| `test_reject_trust_agent_not_propose_only` | MAPPED | `product::spec::tests::reject_trust_agent_not_propose_only` |
+| `test_reject_spec_version_other_than_zero` | MAPPED | `product::spec::tests::reject_spec_version_other_than_zero` |
+| `test_spec_version_zero_accepted` | MAPPED | `product::spec::tests::spec_version_zero_accepted` |
+| `test_reject_integer_where_bool_expected` | MAPPED | `product::spec::tests::reject_integer_where_bool_expected` |
+| `test_reject_bool_where_integer_expected` | MAPPED | `product::spec::tests::reject_bool_where_integer_expected` |
+| `test_reject_float_where_integer_expected` | MAPPED | `product::spec::tests::reject_float_where_integer_expected` |
+| `test_reject_missing_intent` | MAPPED | `product::spec::tests::reject_missing_intent` |
+| `test_reject_classification_on_unknown_column` | MAPPED | `product::spec::tests::reject_classification_on_unknown_column` |
+| `test_reject_duplicate_column_names` | MAPPED | `product::spec::tests::reject_duplicate_column_names` |
+| `test_reject_not_toml` | MAPPED | `product::spec::tests::reject_not_toml` |
+| `test_reject_non_identifier_output_model` | MAPPED | `product::spec::tests::reject_non_identifier_output_model` |
+
+## Rust tests with no Python counterpart (added coverage)
+
+| Rust test | Why |
+|---|---|
+| `reject_empty_intent` | The Python guard exists (`intent-empty`) but no test pinned it. |
+| `reject_non_identifier_product_name` | Same: the `product-name-invalid` guard was unpinned. |
+| `reject_missing_product_table` | Pins `missing-key` at the document root. |
+| `reject_empty_grain` | Pins the non-empty-list rule that the Python schema declared but no test covered. |
+| `case_slipped_rocky_type_suggests_the_right_name` | Pins the case-slip suggestion branch. |
+| `classification_order_is_deterministic` | Replaces the Python document-order test; see the divergence note. |
+| `valid_spec_round_trips_its_fields` | One positive test asserting parsed values, not just rejections. |
+
+## Known divergences from the answer key
+
+1. **Classification ordering.** Python reads TOML into an insertion-ordered
+   dict, so it keeps document order. The Rust `toml` crate hands back a sorted
+   map, and recovering document order needs span-based parsing. The port emits
+   sorted order instead: deterministic, which is what byte-stable output
+   requires. No golden covers a multi-key classification, so no golden changes.
+   True document-order preservation belongs with the sidecar merge in part 2,
+   which must not churn a human's file.
+
+2. **Error ordering in documents with more than one fault.** Python collects
+   every validation error and prefers a semantic one over a structural one. The
+   port rejects at the first fault it meets while walking, so a document with
+   both an unknown key and a bad type reports the unknown key. No test in either
+   suite pins the mixed case; single-fault behaviour is identical.
+
+3. **Reject message wording.** Codes match exactly. Messages match in substance,
+   not character for character, because the Python messages quote pydantic's own
+   phrasing for structural faults. Tests assert codes, per the answer key's own
+   discipline.

--- a/engine/crates/rocky-core/src/lib.rs
+++ b/engine/crates/rocky-core/src/lib.rs
@@ -39,6 +39,7 @@ pub mod physical_edges;
 pub mod plan_partition;
 pub mod policy;
 pub mod preview;
+pub mod product;
 pub mod quarantine;
 pub mod recipe_identity;
 pub mod redacted;

--- a/engine/crates/rocky-core/src/product/lowering.rs
+++ b/engine/crates/rocky-core/src/product/lowering.rs
@@ -38,12 +38,12 @@
 use std::collections::BTreeMap;
 
 use crate::product::manifest::{
-    assert_total, content_digest, Disposition, FieldRow, Location, LocationPhase, Manifest,
-    ManifestPhase, MANIFEST_FILENAME,
+    Disposition, FieldRow, Location, LocationPhase, MANIFEST_FILENAME, Manifest, ManifestPhase,
+    assert_total, content_digest,
 };
 use crate::product::spec::{ParsedSpec, SpecRejected, SpecResult};
 use crate::product::toml_compat::{
-    basic_string, parse_ordered, render_document, TomlTable, TomlValue,
+    TomlTable, TomlValue, basic_string, parse_ordered, render_document,
 };
 
 /// The top-level sidecar keys the lowering owns.
@@ -119,7 +119,10 @@ pub fn sql_rel(parsed: &ParsedSpec) -> String {
 /// nowhere, so emitting it would promise a guard that does not run.
 pub fn render_contract(parsed: &ParsedSpec) -> Vec<u8> {
     let product = parsed.product();
-    let mut lines: Vec<String> = vec![generated_header(&product.name, &parsed.digest), String::new()];
+    let mut lines: Vec<String> = vec![
+        generated_header(&product.name, &parsed.digest),
+        String::new(),
+    ];
     for column in &product.output.columns {
         lines.push("[[columns]]".to_string());
         lines.push(format!("name = {}", basic_string(&column.name)));
@@ -288,7 +291,10 @@ pub fn merge_sidecar_text(
     merged.insert("sources".to_string(), TomlValue::Array(sources));
 
     let mut tags = TomlTable::new();
-    tags.insert("product".to_string(), TomlValue::string(product.name.clone()));
+    tags.insert(
+        "product".to_string(),
+        TomlValue::string(product.name.clone()),
+    );
     if let Some(existing) = document.get("tags").and_then(TomlValue::as_table) {
         for (key, value) in existing {
             if key != "product" {
@@ -343,7 +349,9 @@ pub fn merge_sidecar_text(
             // A worker test identical to a generated one is absorbed, not
             // duplicated. Table comparison ignores key order, so a
             // reordered spelling of the same test is still the same test.
-            let Some(table) = test.as_table() else { continue };
+            let Some(table) = test.as_table() else {
+                continue;
+            };
             if !owned_tests.contains(table) {
                 tests.push(test.clone());
             }
@@ -665,7 +673,9 @@ pub fn lower_phase_b(
     ]
     .into_iter()
     .filter(|(_, recorded, current)| recorded != current)
-    .map(|(name, recorded, current)| format!("{name}: manifest {recorded:?} vs current {current:?}"))
+    .map(|(name, recorded, current)| {
+        format!("{name}: manifest {recorded:?} vs current {current:?}")
+    })
     .collect();
     if !mismatches.is_empty() {
         return Err(SpecRejected::new(
@@ -805,7 +815,10 @@ mod tests {
     #[test]
     fn golden_phase_a_contract() {
         let lowering = lower_phase_a(&parsed_d3(), SPEC_PATH).expect("phase A");
-        assert_eq!(lowering.artifacts[0].relpath, "models/revenue_daily.contract.toml");
+        assert_eq!(
+            lowering.artifacts[0].relpath,
+            "models/revenue_daily.contract.toml"
+        );
         assert_eq!(
             utf8(&lowering.artifacts[0].content),
             utf8(GOLDEN_CONTRACT),
@@ -895,7 +908,10 @@ mod tests {
         let manifest_a = verified_phase_a_manifest(&parsed);
         let edited = String::from_utf8(SPEC_FIXTURE.to_vec())
             .expect("utf-8")
-            .replace(r#"checks = ["revenue_eur >= 0"]"#, r#"checks = ["revenue_eur > 0"]"#);
+            .replace(
+                r#"checks = ["revenue_eur >= 0"]"#,
+                r#"checks = ["revenue_eur > 0"]"#,
+            );
         let spec_b = parse_spec_bytes(edited.as_bytes(), SPEC_PATH).expect("valid");
         assert_ne!(spec_b.digest, parsed.digest);
 
@@ -952,7 +968,12 @@ mod tests {
         // The never-emit list: the contract must not dress inert engine
         // surfaces up as enforcement.
         let contract = String::from_utf8(render_contract(&parsed_d3())).expect("utf-8");
-        for inert in ["no_new_nullable", "conditions", "models_dir", "contracts_dir"] {
+        for inert in [
+            "no_new_nullable",
+            "conditions",
+            "models_dir",
+            "contracts_dir",
+        ] {
             assert!(!contract.contains(inert), "{inert} must never be emitted");
         }
     }
@@ -999,11 +1020,16 @@ mod tests {
             TomlValue::string("revenue_daily")
         );
         assert_eq!(
-            *document["classification"].as_table().expect("classification"),
+            *document["classification"]
+                .as_table()
+                .expect("classification"),
             test_entry(&[("client_id", "pii")])
         );
         let freshness = document["freshness"].as_table().expect("freshness");
-        assert_eq!(freshness["expected_lag_seconds"], TomlValue::Integer(86_400));
+        assert_eq!(
+            freshness["expected_lag_seconds"],
+            TomlValue::Integer(86_400)
+        );
         assert_eq!(freshness["time_column"], TomlValue::string("date"));
         assert_eq!(
             document["sources"],
@@ -1070,7 +1096,10 @@ mod tests {
     fn a_single_column_grain_lowers_to_unique() {
         let single = String::from_utf8(SPEC_FIXTURE.to_vec())
             .expect("utf-8")
-            .replace(r#"grain = ["client_id", "date"]"#, r#"grain = ["client_id"]"#);
+            .replace(
+                r#"grain = ["client_id", "date"]"#,
+                r#"grain = ["client_id"]"#,
+            );
         let parsed = parse_spec_bytes(single.as_bytes(), SPEC_PATH).expect("valid");
         let tests = generated_tests(&parsed);
         assert!(tests.contains(&test_entry(&[("type", "unique"), ("column", "client_id")])));
@@ -1125,8 +1154,7 @@ mod tests {
     #[test]
     fn the_merge_fills_intent_only_when_it_is_absent() {
         let parsed = parsed_d3();
-        let intent_line =
-            "intent = \"Daily gross revenue per client in EUR, refunds excluded\"\n";
+        let intent_line = "intent = \"Daily gross revenue per client in EUR, refunds excluded\"\n";
 
         let without_intent = DRAFT_MODEL_SIDECAR.replace(intent_line, "");
         assert_eq!(
@@ -1148,7 +1176,10 @@ mod tests {
         let error = merge_sidecar_text(&parsed_d3(), "name = [broken", "models/revenue_daily.toml")
             .expect_err("unparseable");
         assert_eq!(error.code, "sidecar-unparseable");
-        assert!(error.message.contains("models/revenue_daily.toml"), "{error}");
+        assert!(
+            error.message.contains("models/revenue_daily.toml"),
+            "{error}"
+        );
     }
 
     #[test]
@@ -1220,7 +1251,10 @@ mod tests {
     fn a_single_column_grain_changes_the_manifest_location_detail() {
         let single = String::from_utf8(SPEC_FIXTURE.to_vec())
             .expect("utf-8")
-            .replace(r#"grain = ["client_id", "date"]"#, r#"grain = ["client_id"]"#);
+            .replace(
+                r#"grain = ["client_id", "date"]"#,
+                r#"grain = ["client_id"]"#,
+            );
         let parsed = parse_spec_bytes(single.as_bytes(), SPEC_PATH).expect("valid");
         let manifest = lower_phase_b(
             &parsed,
@@ -1231,10 +1265,12 @@ mod tests {
         .expect("phase B")
         .manifest;
         let grain = &manifest.fields["product.output.grain"];
-        assert!(grain
-            .locations
-            .iter()
-            .any(|location| location.detail == "[[tests]] type=unique"));
+        assert!(
+            grain
+                .locations
+                .iter()
+                .any(|location| location.detail == "[[tests]] type=unique")
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-core/src/product/lowering.rs
+++ b/engine/crates/rocky-core/src/product/lowering.rs
@@ -1287,21 +1287,71 @@ mod tests {
     }
 
     #[test]
-    fn a_preserved_scalar_never_falls_below_a_preserved_table() {
-        // A sidecar whose tables precede its scalars still renders as
-        // valid TOML, because the merge reorders scalars above tables.
+    fn a_preserved_scalar_survives_and_stays_above_the_tables() {
+        // An inline table puts a table-valued key BEFORE a scalar in the
+        // source, which is the one arrangement that can invert the two.
+        // The scalar must survive the merge and still render above every
+        // table header, or the file it produces is not valid TOML.
         let parsed = parsed_d3();
         let sidecar = format!(
-            "{DRAFT_MODEL_SIDECAR}\n[target]\ncatalog = \"poc\"\n\n\
-             [other]\nk = 1\n"
+            "{DRAFT_MODEL_SIDECAR}target = {{ catalog = \"poc\" }}\nstrategy = \"merge\"\n"
         );
         let merged = merged_text(&parsed, &sidecar);
-        // Round-tripping proves the layout is valid, and the value is the
-        // one the human wrote.
+        let strategy = merged.find("strategy = ").expect("the scalar must survive");
+        let target = merged.find("[target]").expect("the table must survive");
+        assert!(
+            strategy < target,
+            "a preserved scalar must stay above every table:\n{merged}"
+        );
         let document = parse_ordered(&merged).expect("valid TOML");
+        assert_eq!(document["strategy"], TomlValue::string("merge"));
         assert_eq!(
             *document["target"].as_table().expect("target"),
             test_entry(&[("catalog", "poc")])
         );
+    }
+
+    #[test]
+    fn a_nullable_column_gets_no_not_null_test() {
+        // Every column in the fixture is non-nullable, so the goldens
+        // cannot tell the guard from its absence. This can.
+        let text = String::from_utf8(SPEC_FIXTURE.to_vec())
+            .expect("utf-8")
+            .replace(
+                r#"{ name = "revenue_eur", type = "Decimal(18,2)", nullable = false },"#,
+                r#"{ name = "revenue_eur", type = "Decimal(18,2)", nullable = true },"#,
+            );
+        let parsed = parse_spec_bytes(text.as_bytes(), SPEC_PATH).expect("valid");
+        let tests = generated_tests(&parsed);
+        assert!(
+            !tests.contains(&test_entry(&[
+                ("type", "not_null"),
+                ("column", "revenue_eur")
+            ])),
+            "a nullable column must not be asserted non-null: {tests:?}"
+        );
+        // …and the non-nullable ones still are.
+        assert!(tests.contains(&test_entry(&[
+            ("type", "not_null"),
+            ("column", "client_id")
+        ])));
+    }
+
+    #[test]
+    fn a_freshness_budget_too_wide_for_toml_is_refused() {
+        // The budget grammar accepts more seconds than a TOML integer can
+        // hold. Emitting one would write a sidecar that does not parse
+        // back, so the merge refuses instead.
+        let text = String::from_utf8(SPEC_FIXTURE.to_vec())
+            .expect("utf-8")
+            .replace(r#"max_lag = "24h""#, r#"max_lag = "200000000000000d""#);
+        let parsed = parse_spec_bytes(text.as_bytes(), SPEC_PATH).expect("the grammar accepts it");
+        let error = merge_sidecar_text(
+            &parsed,
+            &drafted_sidecar_text(),
+            "models/revenue_daily.toml",
+        )
+        .expect_err("unrepresentable");
+        assert_eq!(error.code, "max-lag-unrepresentable");
     }
 }

--- a/engine/crates/rocky-core/src/product/lowering.rs
+++ b/engine/crates/rocky-core/src/product/lowering.rs
@@ -1,0 +1,1271 @@
+//! Lower a parsed spec onto primitives the engine already enforces, in
+//! two phases.
+//!
+//! Two phases because the worker's drafting tool wholesale-rewrites the
+//! model sidecar (it writes `name` and `intent` and nothing else), so
+//! metadata lowered before drafting would be destroyed. Therefore:
+//!
+//! - **Phase A**, before drafting: `models/<model>.contract.toml`, the
+//!   worker's compile-loop goal. Spec-owned; the drafting brief forbids
+//!   the worker writing a contract of its own.
+//! - **Phase B**, after drafting: merge spec-owned metadata into
+//!   `models/<model>.toml`. Own only the spec's keys; preserve `name`,
+//!   `intent`, and every test the worker appended.
+//!
+//! Everything here is a pure function. Staging the writes, journalling
+//! them, and recovering a crashed generation are a separate concern and
+//! live elsewhere.
+//!
+//! # Why freshness is emitted without its severity
+//!
+//! The sidecar's freshness block is read by the engine in several
+//! places — the tick reconciler's schedule demand, `rocky validate`'s
+//! budget resolution, the standing freshness-demand computation, the
+//! compile and dag JSON passthrough, and the typechecker's soft warning
+//! about temporal columns. All of them read `max_lag_seconds`.
+//!
+//! `severity` has **no read site**. The only severity near freshness is
+//! the pipeline-level check config, a different type, and even that is
+//! surfaced advisorily. `rocky test` never evaluates freshness and
+//! `rocky doctor` has no freshness consumer.
+//!
+//! So the lowering emits `[freshness]` as declared metadata plus a
+//! runner observation — `expected_lag_seconds` and `time_column`, never
+//! `severity`. Writing a severity the engine ignores would dress the
+//! file up as enforcement that does not exist. The freshness guarantee
+//! is the runner's staleness observation, not an engine gate.
+
+use std::collections::BTreeMap;
+
+use crate::product::manifest::{
+    assert_total, content_digest, Disposition, FieldRow, Location, LocationPhase, Manifest,
+    ManifestPhase, MANIFEST_FILENAME,
+};
+use crate::product::spec::{ParsedSpec, SpecRejected, SpecResult};
+use crate::product::toml_compat::{
+    basic_string, parse_ordered, render_document, TomlTable, TomlValue,
+};
+
+/// The top-level sidecar keys the lowering owns.
+///
+/// Owned means rewritten from the spec on every merge, so a hand edit to
+/// one of them is silently replaced. Everything else in the file is
+/// preserved verbatim.
+const OWNED_TOP_LEVEL: &[&str] = &["sources", "tags", "classification", "freshness", "tests"];
+
+/// One emitted file: a project-root-relative POSIX path plus its final
+/// bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Artifact {
+    /// Project-root-relative POSIX path.
+    pub relpath: String,
+    /// The exact bytes to write.
+    pub content: Vec<u8>,
+}
+
+/// A lowering run's output: the artifacts plus the total manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Lowering {
+    /// The files this phase emits.
+    pub artifacts: Vec<Artifact>,
+    /// The manifest accounting for every spec field.
+    pub manifest: Manifest,
+}
+
+/// The per-product state directory, project-root-relative.
+pub fn state_dir_rel(product_name: &str) -> String {
+    format!(".rocky/fulfillment/{product_name}")
+}
+
+/// Where the lowering manifest is committed.
+pub fn manifest_rel(product_name: &str) -> String {
+    format!("{}/{MANIFEST_FILENAME}", state_dir_rel(product_name))
+}
+
+/// The header every generated artifact opens with.
+pub fn generated_header(product_name: &str, digest: &str) -> String {
+    format!(
+        "# GENERATED from products/{product_name}.toml (spec {digest}) \
+         — edit the spec, not this file."
+    )
+}
+
+/// The contract file this spec lowers to.
+pub fn contract_rel(parsed: &ParsedSpec) -> String {
+    format!("models/{}.contract.toml", parsed.output_model())
+}
+
+/// The model sidecar this spec merges into.
+pub fn sidecar_rel(parsed: &ParsedSpec) -> String {
+    format!("models/{}.toml", parsed.output_model())
+}
+
+/// The model SQL file. Agent-authored; the lowering never writes it.
+pub fn sql_rel(parsed: &ParsedSpec) -> String {
+    format!("models/{}.sql", parsed.output_model())
+}
+
+// ---------------------------------------------------------------------------
+// Phase A: the contract
+// ---------------------------------------------------------------------------
+
+/// Render `models/<model>.contract.toml` — byte-stable, hand-ordered.
+///
+/// `[[columns]]` comes in spec order with the Rocky type names verbatim,
+/// and `[rules] required` lists EVERY declared column (the grain is a
+/// subset of it).
+///
+/// Never `no_new_nullable`: the engine parses that rule and enforces it
+/// nowhere, so emitting it would promise a guard that does not run.
+pub fn render_contract(parsed: &ParsedSpec) -> Vec<u8> {
+    let product = parsed.product();
+    let mut lines: Vec<String> = vec![generated_header(&product.name, &parsed.digest), String::new()];
+    for column in &product.output.columns {
+        lines.push("[[columns]]".to_string());
+        lines.push(format!("name = {}", basic_string(&column.name)));
+        lines.push(format!("type = {}", basic_string(&column.type_name)));
+        lines.push(format!(
+            "nullable = {}",
+            if column.nullable { "true" } else { "false" }
+        ));
+        lines.push(String::new());
+    }
+    lines.push("[rules]".to_string());
+    let required: Vec<String> = product
+        .output
+        .columns
+        .iter()
+        .map(|column| basic_string(&column.name))
+        .collect();
+    lines.push(format!("required = [{}]", required.join(", ")));
+    lines.push(String::new());
+    lines.join("\n").into_bytes()
+}
+
+// ---------------------------------------------------------------------------
+// Phase B: the sidecar metadata merge
+// ---------------------------------------------------------------------------
+
+/// The spec-owned `[[tests]]` entries, in the engine's test-declaration
+/// shape.
+///
+/// - A single-column grain becomes a `unique` test on that column; a
+///   composite grain becomes `composite` + `kind = "unique"`. The engine
+///   has no first-class grain field, so this fan-out IS the lowering.
+/// - Every `nullable = false` column becomes a `not_null` test. The
+///   compile-time contract guards the inference; the test guards the
+///   data.
+/// - Every declared check becomes an `expression` test at error
+///   severity.
+pub fn generated_tests(parsed: &ParsedSpec) -> Vec<TomlTable> {
+    let product = parsed.product();
+    let mut tests: Vec<TomlTable> = Vec::new();
+
+    let grain = &product.output.grain;
+    let mut grain_test = TomlTable::new();
+    if grain.len() == 1 {
+        grain_test.insert("type".to_string(), TomlValue::string("unique"));
+        grain_test.insert("column".to_string(), TomlValue::string(grain[0].clone()));
+    } else {
+        grain_test.insert("type".to_string(), TomlValue::string("composite"));
+        grain_test.insert("kind".to_string(), TomlValue::string("unique"));
+        grain_test.insert(
+            "columns".to_string(),
+            TomlValue::Array(grain.iter().map(TomlValue::string).collect()),
+        );
+    }
+    tests.push(grain_test);
+
+    for column in &product.output.columns {
+        if column.nullable {
+            continue;
+        }
+        let mut test = TomlTable::new();
+        test.insert("type".to_string(), TomlValue::string("not_null"));
+        test.insert("column".to_string(), TomlValue::string(column.name.clone()));
+        tests.push(test);
+    }
+
+    for check in &product.output.checks {
+        let mut test = TomlTable::new();
+        test.insert("type".to_string(), TomlValue::string("expression"));
+        test.insert("expression".to_string(), TomlValue::string(check.clone()));
+        test.insert("severity".to_string(), TomlValue::string("error"));
+        tests.push(test);
+    }
+    tests
+}
+
+/// Merge spec-owned metadata into an existing sidecar document.
+///
+/// Owned wholesale: `[[sources]]`, `[classification]`, `[freshness]`,
+/// and the generated subset of `[[tests]]`. Owned as a single key:
+/// `[tags].product` — other tag keys survive. Preserved: `name` and
+/// `intent` (`intent` is filled from the spec only when the file has
+/// none), every worker-appended test the lowering did not generate, and
+/// every other key verbatim.
+///
+/// The output order is fixed, so merging twice is byte-identical: the
+/// header comment, `name`, `intent`, the remaining preserved scalars in
+/// their original order, the preserved tables in their original order,
+/// then the owned blocks in the order above.
+///
+/// # Errors
+///
+/// Returns `sidecar-unparseable` naming the path when the existing file
+/// is not TOML — the lowering refuses rather than clobbering a file it
+/// cannot read. Returns `max-lag-unrepresentable` when the freshness
+/// budget in seconds exceeds what a TOML integer can hold.
+pub fn merge_sidecar_text(
+    parsed: &ParsedSpec,
+    sidecar_text: &str,
+    source_name: &str,
+) -> SpecResult<String> {
+    let document = parse_ordered(sidecar_text).map_err(|err| {
+        SpecRejected::new(
+            "sidecar-unparseable",
+            format!(
+                "refusing to merge into {source_name}: the existing sidecar does not parse \
+                 as TOML ({err}); fix or remove it — the lowering never clobbers"
+            ),
+        )
+    })?;
+
+    let product = parsed.product();
+    let preserved: TomlTable = document
+        .iter()
+        .filter(|(key, _)| !OWNED_TOP_LEVEL.contains(&key.as_str()))
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect();
+
+    let mut merged = TomlTable::new();
+    merged.insert(
+        "name".to_string(),
+        preserved
+            .get("name")
+            .cloned()
+            .unwrap_or_else(|| TomlValue::string(parsed.output_model())),
+    );
+    merged.insert(
+        "intent".to_string(),
+        preserved
+            .get("intent")
+            .cloned()
+            .unwrap_or_else(|| TomlValue::string(product.intent.clone())),
+    );
+    // Scalars before tables, each group in the file's own order: TOML
+    // reads a bare key after a table header as a member of that table,
+    // so a preserved scalar must never fall below one.
+    for (key, value) in &preserved {
+        if key != "name" && key != "intent" && !value.is_table_valued() {
+            merged.insert(key.clone(), value.clone());
+        }
+    }
+    for (key, value) in &preserved {
+        if key != "name" && key != "intent" && value.is_table_valued() {
+            merged.insert(key.clone(), value.clone());
+        }
+    }
+
+    let sources: Vec<TomlValue> = product
+        .source
+        .tables
+        .iter()
+        .map(|reference| {
+            let mut parts = reference.split('.');
+            let mut source = TomlTable::new();
+            // The parser guarantees exactly three non-empty parts, so a
+            // missing one can only mean the parser stopped enforcing it.
+            for key in ["catalog", "schema", "table"] {
+                source.insert(
+                    key.to_string(),
+                    TomlValue::string(parts.next().unwrap_or_default()),
+                );
+            }
+            TomlValue::Table(source)
+        })
+        .collect();
+    merged.insert("sources".to_string(), TomlValue::Array(sources));
+
+    let mut tags = TomlTable::new();
+    tags.insert("product".to_string(), TomlValue::string(product.name.clone()));
+    if let Some(existing) = document.get("tags").and_then(TomlValue::as_table) {
+        for (key, value) in existing {
+            if key != "product" {
+                tags.insert(key.clone(), value.clone());
+            }
+        }
+    }
+    merged.insert("tags".to_string(), TomlValue::Table(tags));
+
+    if !product.output.classifications.is_empty() {
+        let classification: TomlTable = product
+            .output
+            .classifications
+            .iter()
+            .map(|(column, tag)| (column.clone(), TomlValue::string(tag.clone())))
+            .collect();
+        merged.insert(
+            "classification".to_string(),
+            TomlValue::Table(classification),
+        );
+    }
+
+    if let Some(freshness) = &product.output.freshness {
+        let seconds = freshness.max_lag_seconds()?;
+        let seconds = i64::try_from(seconds).map_err(|_| {
+            SpecRejected::new(
+                "max-lag-unrepresentable",
+                format!(
+                    "freshness.max_lag '{}' is {seconds} seconds, which no TOML integer can \
+                     hold — the sidecar would not parse back",
+                    freshness.max_lag
+                ),
+            )
+        })?;
+        let mut block = TomlTable::new();
+        block.insert(
+            "expected_lag_seconds".to_string(),
+            TomlValue::Integer(seconds),
+        );
+        block.insert(
+            "time_column".to_string(),
+            TomlValue::string(freshness.time_column.clone()),
+        );
+        // No `severity` — see the module docs.
+        merged.insert("freshness".to_string(), TomlValue::Table(block));
+    }
+
+    let owned_tests = generated_tests(parsed);
+    let mut tests: Vec<TomlValue> = owned_tests.iter().cloned().map(TomlValue::Table).collect();
+    if let Some(existing) = document.get("tests").and_then(TomlValue::as_array) {
+        for test in existing {
+            // A worker test identical to a generated one is absorbed, not
+            // duplicated. Table comparison ignores key order, so a
+            // reordered spelling of the same test is still the same test.
+            let Some(table) = test.as_table() else { continue };
+            if !owned_tests.contains(table) {
+                tests.push(test.clone());
+            }
+        }
+    }
+    merged.insert("tests".to_string(), TomlValue::Array(tests));
+
+    let header = generated_header(&product.name, &parsed.digest);
+    Ok(format!("{header}\n{}", render_document(&merged)))
+}
+
+// ---------------------------------------------------------------------------
+// Manifest rows
+// ---------------------------------------------------------------------------
+
+/// Which phase's manifest is being built.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Phase {
+    A,
+    B,
+}
+
+/// Every spec field's disposition.
+///
+/// In the Phase-A manifest, a field whose artifacts land in Phase B is
+/// `pending`, with whatever Phase-A locations it already has listed.
+fn field_rows(parsed: &ParsedSpec, phase: Phase) -> BTreeMap<String, FieldRow> {
+    let product = parsed.product();
+    let contract = contract_rel(parsed);
+    let sidecar = sidecar_rel(parsed);
+
+    let row = |a_locations: Vec<Location>, b_locations: Vec<Location>, note: &str| -> FieldRow {
+        if phase == Phase::A && !b_locations.is_empty() {
+            return FieldRow::new(Disposition::Pending)
+                .with_locations(a_locations)
+                .with_note(note);
+        }
+        let mut locations = a_locations;
+        locations.extend(b_locations);
+        FieldRow::new(Disposition::Artifact)
+            .with_locations(locations)
+            .with_note(note)
+    };
+
+    let mut rows: BTreeMap<String, FieldRow> = BTreeMap::new();
+    if parsed.spec.spec_version.is_some() {
+        rows.insert(
+            "spec_version".to_string(),
+            FieldRow::new(Disposition::Identity)
+                .with_note("schema version pin, consumed by the parser gate; no artifact"),
+        );
+    }
+    rows.insert(
+        "product.name".to_string(),
+        row(
+            Vec::new(),
+            vec![Location::new(&sidecar, "[tags] product", LocationPhase::B)],
+            &format!(
+                "also the identity input: product_id = '{}'",
+                parsed.product_id()
+            ),
+        ),
+    );
+    rows.insert(
+        "product.intent".to_string(),
+        row(
+            Vec::new(),
+            vec![Location::new(
+                &sidecar,
+                "intent (preserved when the draft carries one)",
+                LocationPhase::B,
+            )],
+            "delivered verbatim to the worker via the drafting brief (WP-3)",
+        ),
+    );
+    rows.insert(
+        "product.source.tables".to_string(),
+        row(
+            Vec::new(),
+            vec![Location::new(
+                &sidecar,
+                "[[sources]] {catalog, schema, table}",
+                LocationPhase::B,
+            )],
+            "also the grounding list in the agent task brief (WP-3)",
+        ),
+    );
+    // Only when the spec declares it: the resolved default is computed,
+    // never written back, so an omitted `model` is not a field the
+    // manifest can account for — and a row for it would fail totality.
+    if product.output.model.is_some() {
+        rows.insert(
+            "product.output.model".to_string(),
+            row(
+                vec![Location::new(
+                    &contract,
+                    "file name (spec-owned, wholesale)",
+                    LocationPhase::A,
+                )],
+                vec![Location::new(
+                    &sidecar,
+                    "file name (metadata merged, agent content kept)",
+                    LocationPhase::B,
+                )],
+                &format!(
+                    "names {} too — agent-authored, never overwritten by lowering",
+                    sql_rel(parsed)
+                ),
+            ),
+        );
+    }
+    rows.insert(
+        "product.output.grain".to_string(),
+        row(
+            vec![Location::new(
+                &contract,
+                "[rules] required (grain ⊆ required)",
+                LocationPhase::A,
+            )],
+            vec![Location::new(
+                &sidecar,
+                if product.output.grain.len() == 1 {
+                    "[[tests]] type=unique"
+                } else {
+                    "[[tests]] type=composite kind=unique"
+                },
+                LocationPhase::B,
+            )],
+            "no first-class grain field exists in the engine — this fan-out is the lowering",
+        ),
+    );
+    rows.insert(
+        "product.output.columns".to_string(),
+        row(
+            vec![
+                Location::new(
+                    &contract,
+                    "[[columns]] {name, type, nullable}",
+                    LocationPhase::A,
+                ),
+                Location::new(
+                    &contract,
+                    "[rules] required = [all listed columns]",
+                    LocationPhase::A,
+                ),
+            ],
+            vec![Location::new(
+                &sidecar,
+                "[[tests]] not_null per nullable=false column",
+                LocationPhase::B,
+            )],
+            "",
+        ),
+    );
+    // Checks and classifications default to empty rather than absent, so
+    // their rows exist even when empty: an empty declaration is
+    // accounted for, not silently skipped.
+    let has_checks = !product.output.checks.is_empty();
+    rows.insert(
+        "product.output.checks".to_string(),
+        row(
+            Vec::new(),
+            if has_checks {
+                vec![Location::new(
+                    &sidecar,
+                    "[[tests]] type=expression, severity=error",
+                    LocationPhase::B,
+                )]
+            } else {
+                Vec::new()
+            },
+            if has_checks {
+                ""
+            } else {
+                "no checks declared — nothing to emit"
+            },
+        ),
+    );
+    if product.output.freshness.is_some() {
+        rows.insert(
+            "product.output.freshness".to_string(),
+            row(
+                Vec::new(),
+                vec![Location::new(
+                    &sidecar,
+                    "[freshness] expected_lag_seconds + time_column",
+                    LocationPhase::B,
+                )],
+                "declared metadata plus runner observation — not an engine gate; severity is \
+                 accepted for the runner's observation phase and NOT written to the sidecar \
+                 (no engine path reads it; see the module docstring trace)",
+            ),
+        );
+    }
+    let has_classifications = !product.output.classifications.is_empty();
+    rows.insert(
+        "product.output.classifications".to_string(),
+        row(
+            Vec::new(),
+            if has_classifications {
+                vec![Location::new(
+                    &sidecar,
+                    "[classification] <column> = <tag>",
+                    LocationPhase::B,
+                )]
+            } else {
+                Vec::new()
+            },
+            if has_classifications {
+                "tag RESOLUTION is verified against [mask]/[classifications].allow_unmasked \
+                 (spec-compile error, stricter than the engine's W004 warning); masking \
+                 APPLICATION is warehouse-dependent — Databricks-only today"
+            } else {
+                "no classifications declared"
+            },
+        ),
+    );
+    rows.insert(
+        "product.trust.agent".to_string(),
+        FieldRow::new(Disposition::Verified).with_note(
+            "verify, don't write (FF-DESIGN D5): the runtime never edits rocky.toml — the \
+             three-check posture verification ran before lowering",
+        ),
+    );
+    rows
+}
+
+fn build_manifest(
+    parsed: &ParsedSpec,
+    spec_path: &str,
+    phase: Phase,
+    artifact_hashes: BTreeMap<String, String>,
+) -> SpecResult<Manifest> {
+    let manifest = Manifest {
+        product_id: parsed.product_id(),
+        spec_digest: parsed.digest.clone(),
+        spec_path: spec_path.to_string(),
+        output_model: parsed.output_model().to_string(),
+        phase: match phase {
+            Phase::A => ManifestPhase::LoweredContract,
+            Phase::B => ManifestPhase::Merged,
+        },
+        fields: field_rows(parsed, phase),
+        artifacts: artifact_hashes,
+    };
+    assert_total(&parsed.spec, &manifest)?;
+    Ok(manifest)
+}
+
+// ---------------------------------------------------------------------------
+// The two lowering runs
+// ---------------------------------------------------------------------------
+
+/// Phase A: the contract, plus a total manifest with the Phase-B fields
+/// marked pending.
+///
+/// # Errors
+///
+/// Returns `manifest-not-total` when a spec field has no disposition —
+/// a bug in this module, surfaced as a refusal rather than a silent
+/// half-accounted manifest.
+pub fn lower_phase_a(parsed: &ParsedSpec, spec_path: &str) -> SpecResult<Lowering> {
+    let contract = Artifact {
+        relpath: contract_rel(parsed),
+        content: render_contract(parsed),
+    };
+    let hashes = [(contract.relpath.clone(), content_digest(&contract.content))]
+        .into_iter()
+        .collect();
+    let manifest = build_manifest(parsed, spec_path, Phase::A, hashes)?;
+    Ok(Lowering {
+        artifacts: vec![contract],
+        manifest,
+    })
+}
+
+/// Phase B: the merged sidecar, plus the total merged manifest.
+///
+/// `phase_a_manifest` is the VERIFIED Phase-A manifest — the typed
+/// object whose bytes the caller checked against disk. This is a public
+/// boundary, so the generation identity is enforced HERE rather than
+/// delegated: the manifest's `product_id`, `output_model`, and
+/// `spec_path` must match the current spec's, and its `spec_digest` must
+/// match this spec's. A digest mismatch means the spec moved after Phase
+/// A, and Phase B refuses rather than binding spec B's metadata to spec
+/// A's contract hash. No path, public or internal, can mix generations.
+///
+/// The carry-forward hashes come from that identity-checked object and
+/// are never re-rendered. Re-rendering would record a hash for bytes
+/// this run never wrote and never verified were on disk, detaching the
+/// verification target from reality the moment the two could differ.
+///
+/// # Errors
+///
+/// Returns `phase-a-identity-mismatch` for a foreign generation,
+/// `spec-superseded` for a spec that moved after Phase A,
+/// `phase-a-manifest-incomplete` for a manifest that does not cover the
+/// contract, plus any refusal from [`merge_sidecar_text`].
+pub fn lower_phase_b(
+    parsed: &ParsedSpec,
+    spec_path: &str,
+    sidecar_text: &str,
+    phase_a_manifest: &Manifest,
+) -> SpecResult<Lowering> {
+    let output_model = parsed.output_model().to_string();
+    let product_id = parsed.product_id();
+    let mismatches: Vec<String> = [
+        ("product_id", &phase_a_manifest.product_id, &product_id),
+        (
+            "output_model",
+            &phase_a_manifest.output_model,
+            &output_model,
+        ),
+        (
+            "spec_path",
+            &phase_a_manifest.spec_path,
+            &spec_path.to_string(),
+        ),
+    ]
+    .into_iter()
+    .filter(|(_, recorded, current)| recorded != current)
+    .map(|(name, recorded, current)| format!("{name}: manifest {recorded:?} vs current {current:?}"))
+    .collect();
+    if !mismatches.is_empty() {
+        return Err(SpecRejected::new(
+            "phase-a-identity-mismatch",
+            format!(
+                "the Phase-A manifest belongs to a different generation identity: {}",
+                mismatches.join("; ")
+            ),
+        ));
+    }
+    if phase_a_manifest.spec_digest != parsed.digest {
+        return Err(SpecRejected::new(
+            "spec-superseded",
+            format!(
+                "the Phase-A lowering was generated from spec {}, but the current spec digests \
+                 to {} — the Phase-A generation is superseded (FF-DESIGN D6). Re-run Phase A \
+                 under the current spec before the metadata merge; refusing to mix generations",
+                phase_a_manifest.spec_digest, parsed.digest
+            ),
+        ));
+    }
+    let contract = contract_rel(parsed);
+    if !phase_a_manifest.artifacts.contains_key(&contract) {
+        return Err(SpecRejected::new(
+            "phase-a-manifest-incomplete",
+            format!(
+                "the Phase-A manifest does not cover {contract} — the merged manifest would \
+                 lose its contract byte-verification target; re-run Phase A"
+            ),
+        ));
+    }
+
+    let sidecar_relpath = sidecar_rel(parsed);
+    let merged = merge_sidecar_text(parsed, sidecar_text, &sidecar_relpath)?.into_bytes();
+    let mut hashes = phase_a_manifest.artifacts.clone();
+    hashes.insert(sidecar_relpath.clone(), content_digest(&merged));
+    let manifest = build_manifest(parsed, spec_path, Phase::B, hashes)?;
+    Ok(Lowering {
+        artifacts: vec![Artifact {
+            relpath: sidecar_relpath,
+            content: merged,
+        }],
+        manifest,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::product::spec::parse_spec_bytes;
+
+    const SPEC_PATH: &str = "products/revenue_daily.toml";
+
+    /// The answer key's spec fixture, copied byte for byte. Its digest is
+    /// embedded in every golden, so the bytes cannot be retyped.
+    const SPEC_FIXTURE: &[u8] = include_bytes!("testdata/revenue_daily.spec.toml");
+    const GOLDEN_CONTRACT: &[u8] = include_bytes!("testdata/revenue_daily.contract.toml");
+    const GOLDEN_MERGED: &[u8] = include_bytes!("testdata/revenue_daily.merged.toml");
+    const GOLDEN_MANIFEST_A: &[u8] = include_bytes!("testdata/lowering-manifest.phase-a.json");
+    const GOLDEN_MANIFEST_B: &[u8] = include_bytes!("testdata/lowering-manifest.merged.json");
+
+    /// A sidecar exactly as the worker's drafting tool leaves it: the
+    /// two-line header comment, then `name` and `intent`. Target and
+    /// strategy are absent on purpose — they resolve from project
+    /// conventions.
+    const DRAFT_MODEL_SIDECAR: &str = concat!(
+        "# Draft authored via the Rocky MCP `draft_model` tool. Target and strategy resolve\n",
+        "# from the project's conventions (rocky.toml pipeline + _defaults.toml).\n",
+        "name = \"revenue_daily\"\n",
+        "intent = \"Daily gross revenue per client in EUR, refunds excluded\"\n",
+    );
+
+    const WORKER_CHECK_SPEC: &str =
+        "[[tests]]\ntype = \"expression\"\nexpression = \"client_id > 0\"\n";
+
+    /// The engine's `draft_check` string append, mirrored exactly.
+    fn draft_check_append(prior: &str, spec: &str) -> String {
+        let merged = format!("{}\n\n{}", prior.trim_end(), spec.trim_start_matches('\n'));
+        format!("{}\n", merged.trim_end_matches('\n'))
+    }
+
+    fn parsed_d3() -> ParsedSpec {
+        parse_spec_bytes(SPEC_FIXTURE, SPEC_PATH).expect("the fixture parses")
+    }
+
+    fn drafted_sidecar_text() -> String {
+        draft_check_append(DRAFT_MODEL_SIDECAR, WORKER_CHECK_SPEC)
+    }
+
+    fn verified_phase_a_manifest(parsed: &ParsedSpec) -> Manifest {
+        lower_phase_a(parsed, SPEC_PATH).expect("phase A").manifest
+    }
+
+    fn merged_text(parsed: &ParsedSpec, sidecar_text: &str) -> String {
+        merge_sidecar_text(parsed, sidecar_text, "models/revenue_daily.toml").expect("merges")
+    }
+
+    fn merged_document(parsed: &ParsedSpec, sidecar_text: &str) -> TomlTable {
+        parse_ordered(&merged_text(parsed, sidecar_text)).expect("the merge output is TOML")
+    }
+
+    fn test_entry(pairs: &[(&str, &str)]) -> TomlTable {
+        pairs
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), TomlValue::string(*value)))
+            .collect()
+    }
+
+    fn tests_of(document: &TomlTable) -> Vec<TomlTable> {
+        document["tests"]
+            .as_array()
+            .expect("tests is an array")
+            .iter()
+            .map(|test| test.as_table().expect("a test is a table").clone())
+            .collect()
+    }
+
+    fn utf8(bytes: &[u8]) -> &str {
+        std::str::from_utf8(bytes).expect("utf-8")
+    }
+
+    // ----- the fixture itself -----
+
+    #[test]
+    fn the_imported_fixture_still_digests_to_the_goldens_value() {
+        // Every golden embeds this digest. A fixture mangled in transit
+        // fails here, naming the cause, instead of failing four byte
+        // comparisons that look like renderer bugs.
+        assert_eq!(
+            parsed_d3().digest,
+            "sha256:54df46b9278c1f265f64fd23203396ea69e68771197d5d0e5a7291cd6ffd82ff"
+        );
+    }
+
+    // ----- goldens -----
+
+    #[test]
+    fn golden_phase_a_contract() {
+        let lowering = lower_phase_a(&parsed_d3(), SPEC_PATH).expect("phase A");
+        assert_eq!(lowering.artifacts[0].relpath, "models/revenue_daily.contract.toml");
+        assert_eq!(
+            utf8(&lowering.artifacts[0].content),
+            utf8(GOLDEN_CONTRACT),
+            "the contract must byte-match the frozen golden"
+        );
+    }
+
+    #[test]
+    fn golden_phase_a_manifest() {
+        let lowering = lower_phase_a(&parsed_d3(), SPEC_PATH).expect("phase A");
+        assert_eq!(
+            utf8(&lowering.manifest.to_json_bytes()),
+            utf8(GOLDEN_MANIFEST_A)
+        );
+    }
+
+    #[test]
+    fn golden_phase_b_sidecar() {
+        let parsed = parsed_d3();
+        let lowering = lower_phase_b(
+            &parsed,
+            SPEC_PATH,
+            &drafted_sidecar_text(),
+            &verified_phase_a_manifest(&parsed),
+        )
+        .expect("phase B");
+        assert_eq!(lowering.artifacts[0].relpath, "models/revenue_daily.toml");
+        assert_eq!(
+            utf8(&lowering.artifacts[0].content),
+            utf8(GOLDEN_MERGED),
+            "the merged sidecar must byte-match the frozen golden"
+        );
+    }
+
+    #[test]
+    fn golden_phase_b_manifest() {
+        let parsed = parsed_d3();
+        let lowering = lower_phase_b(
+            &parsed,
+            SPEC_PATH,
+            &drafted_sidecar_text(),
+            &verified_phase_a_manifest(&parsed),
+        )
+        .expect("phase B");
+        assert_eq!(
+            utf8(&lowering.manifest.to_json_bytes()),
+            utf8(GOLDEN_MANIFEST_B)
+        );
+    }
+
+    #[test]
+    fn golden_manifest_field_set_equals_spec_field_set() {
+        let parsed = parsed_d3();
+        let phase_a = lower_phase_a(&parsed, SPEC_PATH).expect("phase A");
+        assert_total(&parsed.spec, &phase_a.manifest).expect("phase A is total");
+        let phase_b = lower_phase_b(
+            &parsed,
+            SPEC_PATH,
+            &drafted_sidecar_text(),
+            &verified_phase_a_manifest(&parsed),
+        )
+        .expect("phase B");
+        assert_total(&parsed.spec, &phase_b.manifest).expect("phase B is total");
+    }
+
+    #[test]
+    fn lowering_is_deterministic() {
+        let parsed = parsed_d3();
+        let manifest_a = verified_phase_a_manifest(&parsed);
+        let sidecar = drafted_sidecar_text();
+        let first = lower_phase_b(&parsed, SPEC_PATH, &sidecar, &manifest_a).expect("phase B");
+        let second = lower_phase_b(&parsed, SPEC_PATH, &sidecar, &manifest_a).expect("phase B");
+        assert_eq!(first.artifacts[0].content, second.artifacts[0].content);
+        assert_eq!(
+            first.manifest.to_json_bytes(),
+            second.manifest.to_json_bytes()
+        );
+    }
+
+    // ----- the generation-identity guards -----
+
+    #[test]
+    fn phase_b_refuses_a_mismatched_digest_manifest() {
+        // The real invariant at the public boundary: spec B's lowering
+        // can never carry spec A's contract hash forward.
+        let parsed = parsed_d3();
+        let manifest_a = verified_phase_a_manifest(&parsed);
+        let edited = String::from_utf8(SPEC_FIXTURE.to_vec())
+            .expect("utf-8")
+            .replace(r#"checks = ["revenue_eur >= 0"]"#, r#"checks = ["revenue_eur > 0"]"#);
+        let spec_b = parse_spec_bytes(edited.as_bytes(), SPEC_PATH).expect("valid");
+        assert_ne!(spec_b.digest, parsed.digest);
+
+        let error = lower_phase_b(&spec_b, SPEC_PATH, &drafted_sidecar_text(), &manifest_a)
+            .expect_err("superseded");
+        assert_eq!(error.code, "spec-superseded");
+        // The manifest's generation…
+        assert!(error.message.contains(&manifest_a.spec_digest), "{error}");
+        // …and the current spec, both named.
+        assert!(error.message.contains(&spec_b.digest), "{error}");
+    }
+
+    #[test]
+    fn phase_b_refuses_a_foreign_identity_manifest() {
+        let parsed = parsed_d3();
+        let mut manifest_a = verified_phase_a_manifest(&parsed);
+        manifest_a.spec_path = "products/elsewhere.toml".to_string();
+        let error = lower_phase_b(&parsed, SPEC_PATH, &drafted_sidecar_text(), &manifest_a)
+            .expect_err("foreign");
+        assert_eq!(error.code, "phase-a-identity-mismatch");
+        assert!(error.message.contains("spec_path"), "{error}");
+    }
+
+    #[test]
+    fn phase_b_refuses_a_foreign_product_id_or_model() {
+        // The other two identity fields, which no answer-key test pinned.
+        let parsed = parsed_d3();
+        for mutate in [
+            |manifest: &mut Manifest| manifest.product_id = "product:other".to_string(),
+            |manifest: &mut Manifest| manifest.output_model = "other".to_string(),
+        ] {
+            let mut manifest_a = verified_phase_a_manifest(&parsed);
+            mutate(&mut manifest_a);
+            let error = lower_phase_b(&parsed, SPEC_PATH, &drafted_sidecar_text(), &manifest_a)
+                .expect_err("foreign");
+            assert_eq!(error.code, "phase-a-identity-mismatch");
+        }
+    }
+
+    #[test]
+    fn phase_b_refuses_a_manifest_without_the_contract() {
+        let parsed = parsed_d3();
+        let mut incomplete = verified_phase_a_manifest(&parsed);
+        incomplete.artifacts.clear();
+        let error = lower_phase_b(&parsed, SPEC_PATH, &drafted_sidecar_text(), &incomplete)
+            .expect_err("incomplete");
+        assert_eq!(error.code, "phase-a-manifest-incomplete");
+    }
+
+    // ----- the contract -----
+
+    #[test]
+    fn the_contract_never_emits_the_inert_surfaces() {
+        // The never-emit list: the contract must not dress inert engine
+        // surfaces up as enforcement.
+        let contract = String::from_utf8(render_contract(&parsed_d3())).expect("utf-8");
+        for inert in ["no_new_nullable", "conditions", "models_dir", "contracts_dir"] {
+            assert!(!contract.contains(inert), "{inert} must never be emitted");
+        }
+    }
+
+    #[test]
+    fn the_generated_header_convention_holds_for_both_artifacts() {
+        let parsed = parsed_d3();
+        let header = format!(
+            "# GENERATED from products/revenue_daily.toml (spec {}) — edit the spec, not this file.",
+            parsed.digest
+        );
+        let contract = String::from_utf8(render_contract(&parsed)).expect("utf-8");
+        assert!(contract.starts_with(&header), "{contract}");
+        assert!(
+            merged_text(&parsed, &drafted_sidecar_text()).starts_with(&header),
+            "the merged sidecar carries the same header"
+        );
+    }
+
+    // ----- the sidecar merge -----
+
+    #[test]
+    fn the_merge_preserves_agent_name_intent_and_appended_check() {
+        let parsed = parsed_d3();
+        let document = merged_document(&parsed, &drafted_sidecar_text());
+        assert_eq!(document["name"], TomlValue::string("revenue_daily"));
+        assert_eq!(
+            document["intent"],
+            TomlValue::string("Daily gross revenue per client in EUR, refunds excluded")
+        );
+        let worker_test = test_entry(&[("type", "expression"), ("expression", "client_id > 0")]);
+        assert!(
+            tests_of(&document).contains(&worker_test),
+            "the worker's appended check must survive"
+        );
+    }
+
+    #[test]
+    fn the_merge_emits_the_spec_owned_blocks() {
+        let parsed = parsed_d3();
+        let document = merged_document(&parsed, &drafted_sidecar_text());
+        assert_eq!(
+            document["tags"].as_table().expect("tags")["product"],
+            TomlValue::string("revenue_daily")
+        );
+        assert_eq!(
+            *document["classification"].as_table().expect("classification"),
+            test_entry(&[("client_id", "pii")])
+        );
+        let freshness = document["freshness"].as_table().expect("freshness");
+        assert_eq!(freshness["expected_lag_seconds"], TomlValue::Integer(86_400));
+        assert_eq!(freshness["time_column"], TomlValue::string("date"));
+        assert_eq!(
+            document["sources"],
+            TomlValue::Array(vec![TomlValue::Table(test_entry(&[
+                ("catalog", "poc"),
+                ("schema", "raw"),
+                ("table", "stripe_charges"),
+            ]))])
+        );
+    }
+
+    #[test]
+    fn the_merge_never_emits_freshness_severity() {
+        // The spec accepts severity, but the sidecar never carries it: no
+        // engine path reads it, so writing it would dress the file up as
+        // enforcement that does not exist.
+        let parsed = parsed_d3();
+        let freshness = parsed
+            .product()
+            .output
+            .freshness
+            .as_ref()
+            .expect("the fixture declares freshness");
+        assert!(freshness.severity.is_some(), "accepted…");
+        let document = merged_document(&parsed, &drafted_sidecar_text());
+        assert!(
+            !document["freshness"]
+                .as_table()
+                .expect("freshness")
+                .contains_key("severity"),
+            "…but never emitted"
+        );
+    }
+
+    #[test]
+    fn the_merge_generates_grain_not_null_and_expression_tests() {
+        let parsed = parsed_d3();
+        let tests = tests_of(&merged_document(&parsed, &drafted_sidecar_text()));
+        let mut composite = TomlTable::new();
+        composite.insert("type".to_string(), TomlValue::string("composite"));
+        composite.insert("kind".to_string(), TomlValue::string("unique"));
+        composite.insert(
+            "columns".to_string(),
+            TomlValue::Array(vec![
+                TomlValue::string("client_id"),
+                TomlValue::string("date"),
+            ]),
+        );
+        assert!(tests.contains(&composite), "{tests:?}");
+        for column in ["client_id", "date", "revenue_eur"] {
+            assert!(
+                tests.contains(&test_entry(&[("type", "not_null"), ("column", column)])),
+                "missing not_null for {column}"
+            );
+        }
+        assert!(tests.contains(&test_entry(&[
+            ("type", "expression"),
+            ("expression", "revenue_eur >= 0"),
+            ("severity", "error"),
+        ])));
+    }
+
+    #[test]
+    fn a_single_column_grain_lowers_to_unique() {
+        let single = String::from_utf8(SPEC_FIXTURE.to_vec())
+            .expect("utf-8")
+            .replace(r#"grain = ["client_id", "date"]"#, r#"grain = ["client_id"]"#);
+        let parsed = parse_spec_bytes(single.as_bytes(), SPEC_PATH).expect("valid");
+        let tests = generated_tests(&parsed);
+        assert!(tests.contains(&test_entry(&[("type", "unique"), ("column", "client_id")])));
+        assert!(
+            !tests
+                .iter()
+                .any(|test| test.get("type") == Some(&TomlValue::string("composite"))),
+            "a one-column grain never becomes a composite test"
+        );
+    }
+
+    #[test]
+    fn the_merge_is_idempotent() {
+        let parsed = parsed_d3();
+        let once = merged_text(&parsed, &drafted_sidecar_text());
+        let twice = merged_text(&parsed, &once);
+        assert_eq!(once, twice, "merging a merged sidecar must change nothing");
+    }
+
+    #[test]
+    fn the_merge_preserves_unowned_tables_verbatim() {
+        // A drafted project may carry target/strategy in the sidecar, or a
+        // human may have added keys; everything outside the owned set
+        // survives.
+        let parsed = parsed_d3();
+        let sidecar = format!(
+            "{DRAFT_MODEL_SIDECAR}\n[target]\ncatalog = \"poc\"\nschema = \"gold\"\n\
+             table = \"revenue_daily\"\n"
+        );
+        let document = merged_document(&parsed, &sidecar);
+        assert_eq!(
+            *document["target"].as_table().expect("target"),
+            test_entry(&[
+                ("catalog", "poc"),
+                ("schema", "gold"),
+                ("table", "revenue_daily"),
+            ])
+        );
+    }
+
+    #[test]
+    fn the_merge_preserves_foreign_tag_keys() {
+        let parsed = parsed_d3();
+        let sidecar = format!("{DRAFT_MODEL_SIDECAR}\n[tags]\nlayer = \"gold\"\n");
+        let document = merged_document(&parsed, &sidecar);
+        assert_eq!(
+            *document["tags"].as_table().expect("tags"),
+            test_entry(&[("product", "revenue_daily"), ("layer", "gold")])
+        );
+    }
+
+    #[test]
+    fn the_merge_fills_intent_only_when_it_is_absent() {
+        let parsed = parsed_d3();
+        let intent_line =
+            "intent = \"Daily gross revenue per client in EUR, refunds excluded\"\n";
+
+        let without_intent = DRAFT_MODEL_SIDECAR.replace(intent_line, "");
+        assert_eq!(
+            merged_document(&parsed, &without_intent)["intent"],
+            TomlValue::string(parsed.product().intent.clone()),
+            "filled from the spec"
+        );
+
+        let reworded = DRAFT_MODEL_SIDECAR.replace(intent_line, "intent = \"worker wording\"\n");
+        assert_eq!(
+            merged_document(&parsed, &reworded)["intent"],
+            TomlValue::string("worker wording"),
+            "preserved, not clobbered"
+        );
+    }
+
+    #[test]
+    fn the_merge_rejects_an_unparseable_sidecar_naming_the_path() {
+        let error = merge_sidecar_text(&parsed_d3(), "name = [broken", "models/revenue_daily.toml")
+            .expect_err("unparseable");
+        assert_eq!(error.code, "sidecar-unparseable");
+        assert!(error.message.contains("models/revenue_daily.toml"), "{error}");
+    }
+
+    #[test]
+    fn a_worker_test_identical_to_a_generated_one_is_absorbed_once() {
+        let parsed = parsed_d3();
+        let duplicate = draft_check_append(
+            DRAFT_MODEL_SIDECAR,
+            "[[tests]]\ntype = \"not_null\"\ncolumn = \"client_id\"\n",
+        );
+        let wanted = test_entry(&[("type", "not_null"), ("column", "client_id")]);
+        let count = tests_of(&merged_document(&parsed, &duplicate))
+            .iter()
+            .filter(|test| **test == wanted)
+            .count();
+        assert_eq!(count, 1);
+    }
+
+    // ----- rows the goldens do not reach -----
+
+    #[test]
+    fn an_empty_checks_or_classifications_list_still_gets_a_row() {
+        let text = String::from_utf8(SPEC_FIXTURE.to_vec())
+            .expect("utf-8")
+            .replace(r#"checks = ["revenue_eur >= 0"]"#, "")
+            .replace(r#"classifications = { client_id = "pii" }"#, "");
+        let parsed = parse_spec_bytes(text.as_bytes(), SPEC_PATH).expect("valid");
+        let manifest = lower_phase_a(&parsed, SPEC_PATH).expect("phase A").manifest;
+        let checks = &manifest.fields["product.output.checks"];
+        // No Phase-B location, so the row is an accounted `artifact` with
+        // nowhere to point — never `pending` forever.
+        assert_eq!(checks.disposition, Disposition::Artifact);
+        assert!(checks.locations.is_empty());
+        assert_eq!(checks.note, "no checks declared — nothing to emit");
+        let classifications = &manifest.fields["product.output.classifications"];
+        assert_eq!(classifications.disposition, Disposition::Artifact);
+        assert_eq!(classifications.note, "no classifications declared");
+    }
+
+    #[test]
+    fn a_spec_without_an_output_model_still_lowers() {
+        // The default model name is computed, never written back, so the
+        // manifest has no `product.output.model` field to account for. A
+        // row emitted regardless would fail the totality check on a
+        // perfectly valid spec.
+        let text = String::from_utf8(SPEC_FIXTURE.to_vec())
+            .expect("utf-8")
+            .replace("model = \"revenue_daily\"", "");
+        let parsed = parse_spec_bytes(text.as_bytes(), SPEC_PATH).expect("valid");
+        assert_eq!(parsed.output_model(), "revenue_daily");
+        let manifest = lower_phase_a(&parsed, SPEC_PATH).expect("phase A").manifest;
+        assert!(!manifest.fields.contains_key("product.output.model"));
+    }
+
+    #[test]
+    fn a_spec_version_pin_is_recorded_as_an_identity_row() {
+        let text = format!(
+            "spec_version = 0\n{}",
+            String::from_utf8(SPEC_FIXTURE.to_vec()).expect("utf-8")
+        );
+        let parsed = parse_spec_bytes(text.as_bytes(), SPEC_PATH).expect("valid");
+        let manifest = lower_phase_a(&parsed, SPEC_PATH).expect("phase A").manifest;
+        assert_eq!(
+            manifest.fields["spec_version"].disposition,
+            Disposition::Identity
+        );
+    }
+
+    #[test]
+    fn a_single_column_grain_changes_the_manifest_location_detail() {
+        let single = String::from_utf8(SPEC_FIXTURE.to_vec())
+            .expect("utf-8")
+            .replace(r#"grain = ["client_id", "date"]"#, r#"grain = ["client_id"]"#);
+        let parsed = parse_spec_bytes(single.as_bytes(), SPEC_PATH).expect("valid");
+        let manifest = lower_phase_b(
+            &parsed,
+            SPEC_PATH,
+            &drafted_sidecar_text(),
+            &verified_phase_a_manifest(&parsed),
+        )
+        .expect("phase B")
+        .manifest;
+        let grain = &manifest.fields["product.output.grain"];
+        assert!(grain
+            .locations
+            .iter()
+            .any(|location| location.detail == "[[tests]] type=unique"));
+    }
+
+    #[test]
+    fn a_non_table_tags_value_is_replaced_not_carried() {
+        // `tags` is owned, so a scalar sitting at that key is not a table
+        // to preserve keys from — it is replaced wholesale.
+        let parsed = parsed_d3();
+        let sidecar = format!("{DRAFT_MODEL_SIDECAR}tags = \"not-a-table\"\n");
+        let document = merged_document(&parsed, &sidecar);
+        assert_eq!(
+            *document["tags"].as_table().expect("tags"),
+            test_entry(&[("product", "revenue_daily")])
+        );
+    }
+
+    #[test]
+    fn a_preserved_scalar_never_falls_below_a_preserved_table() {
+        // A sidecar whose tables precede its scalars still renders as
+        // valid TOML, because the merge reorders scalars above tables.
+        let parsed = parsed_d3();
+        let sidecar = format!(
+            "{DRAFT_MODEL_SIDECAR}\n[target]\ncatalog = \"poc\"\n\n\
+             [other]\nk = 1\n"
+        );
+        let merged = merged_text(&parsed, &sidecar);
+        // Round-tripping proves the layout is valid, and the value is the
+        // one the human wrote.
+        let document = parse_ordered(&merged).expect("valid TOML");
+        assert_eq!(
+            *document["target"].as_table().expect("target"),
+            test_entry(&[("catalog", "poc")])
+        );
+    }
+}

--- a/engine/crates/rocky-core/src/product/manifest.rs
+++ b/engine/crates/rocky-core/src/product/manifest.rs
@@ -26,7 +26,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -773,10 +773,46 @@ pub fn check_total(
 /// Returns the mismatches — a missing file or a hash drift — and an
 /// empty list when the tree is clean. This is the precondition that runs
 /// before anything a worker touched is trusted.
+/// Resolve a manifest artifact key against the project root, or refuse it.
+///
+/// A manifest is a file on disk, so its keys are input rather than fact. Two
+/// shapes have to be refused before the path is ever used:
+///
+/// - an absolute key, because `Path::join` DISCARDS the root when the argument
+///   is absolute, so `/etc/passwd` would be read as itself rather than as a
+///   file inside the project;
+/// - any `..` (or `.`) component, which walks out of the project.
+///
+/// Verification only reads today, so the immediate blast radius is a wrong
+/// answer about a file that is none of the manifest's business. The reason to
+/// refuse here anyway is that this result is what a caller trusts when it
+/// decides a generation is intact, and the same keys drive writes later.
+fn contained_artifact_path(project_root: &Path, rel_path: &str) -> Option<PathBuf> {
+    let candidate = Path::new(rel_path);
+    if rel_path.is_empty() || candidate.is_absolute() {
+        return None;
+    }
+    // `Component::Normal` admits plain names only: root, prefix, `.`, and `..`
+    // are all rejected, which is the whole containment rule in one match.
+    if candidate
+        .components()
+        .any(|component| !matches!(component, std::path::Component::Normal(_)))
+    {
+        return None;
+    }
+    Some(project_root.join(candidate))
+}
+
 pub fn verify_artifact_hashes(project_root: &Path, manifest: &Manifest) -> Vec<String> {
     let mut problems = Vec::new();
     for (rel_path, expected) in &manifest.artifacts {
-        let artifact_path = project_root.join(rel_path);
+        let Some(artifact_path) = contained_artifact_path(project_root, rel_path) else {
+            problems.push(format!(
+                "{rel_path}: refused (not a project-relative path; a manifest names only \
+                 files inside its own project)"
+            ));
+            continue;
+        };
         if !artifact_path.is_file() {
             problems.push(format!("{rel_path}: missing (expected {expected})"));
             continue;
@@ -1034,6 +1070,47 @@ agent = "propose_only"
     // ----- byte verification -----
 
     #[test]
+    fn verify_artifact_hashes_refuses_a_path_outside_the_project() {
+        // A manifest key is input. An absolute key makes `Path::join` throw the
+        // project root away, so this would otherwise read a file the manifest
+        // has no business naming — and report on it as if it belonged to the
+        // generation.
+        let parsed = parse(MINIMAL);
+        let root = tempfile::tempdir().expect("tempdir");
+        let outside = root.path().join("outside.txt");
+        std::fs::write(&outside, b"not mine").expect("write");
+        for key in [
+            outside.to_string_lossy().to_string(),
+            "../escape.toml".to_string(),
+            "./models/tiny.contract.toml".to_string(),
+            "models/../../escape.toml".to_string(),
+            String::new(),
+        ] {
+            let manifest = Manifest {
+                product_id: parsed.product_id(),
+                spec_digest: parsed.digest.clone(),
+                output_model: parsed.output_model().to_string(),
+                spec_path: "products/tiny.toml".to_string(),
+                phase: ManifestPhase::LoweredContract,
+                fields: BTreeMap::new(),
+                artifacts: [(key.clone(), content_digest(b"not mine"))]
+                    .into_iter()
+                    .collect(),
+            };
+            let problems = verify_artifact_hashes(root.path(), &manifest);
+            assert_eq!(problems.len(), 1, "{key:?} -> {problems:?}");
+            assert!(
+                problems[0].contains("refused"),
+                "{key:?} must be refused, got {problems:?}"
+            );
+        }
+        assert_eq!(
+            std::fs::read(&outside).expect("still there"),
+            b"not mine",
+            "a refused key must not have been acted on"
+        );
+    }
+
     fn verify_artifact_hashes_detects_drift_and_absence() {
         let parsed = parse(MINIMAL);
         let root = tempfile::tempdir().expect("tempdir");

--- a/engine/crates/rocky-core/src/product/manifest.rs
+++ b/engine/crates/rocky-core/src/product/manifest.rs
@@ -30,7 +30,7 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-use crate::product::spec::{spec_digest, SpecFile, SpecRejected, SpecResult};
+use crate::product::spec::{SpecFile, SpecRejected, SpecResult, spec_digest};
 
 /// The file name the manifest is committed under.
 pub const MANIFEST_FILENAME: &str = "lowering-manifest.json";
@@ -491,7 +491,11 @@ fn properties_of<'s>(
 ) -> Vec<(String, &'s serde_json::Value)> {
     // The root model is inlined by schemars rather than listed among the
     // definitions, so it is looked up separately.
-    let source = if model == "SpecFile" { root } else { &definitions[model] };
+    let source = if model == "SpecFile" {
+        root
+    } else {
+        &definitions[model]
+    };
     source
         .get("properties")
         .and_then(serde_json::Value::as_object)
@@ -668,10 +672,7 @@ pub fn check_leaf_coverage(declared: &BTreeMap<String, BTreeSet<String>>) -> Spe
         let empty = BTreeSet::new();
         let required = derived.get(path).unwrap_or(&empty);
         let claimed = declared.get(path).unwrap_or(&empty);
-        let uncovered: Vec<&str> = required
-            .difference(claimed)
-            .map(String::as_str)
-            .collect();
+        let uncovered: Vec<&str> = required.difference(claimed).map(String::as_str).collect();
         let stale: Vec<&str> = claimed.difference(required).map(String::as_str).collect();
         if !uncovered.is_empty() {
             problems.push(format!(
@@ -691,7 +692,10 @@ pub fn check_leaf_coverage(declared: &BTreeMap<String, BTreeSet<String>>) -> Spe
     }
     Err(SpecRejected::new(
         "manifest-not-total",
-        format!("lowering leaf coverage is not total: {}", problems.join("; ")),
+        format!(
+            "lowering leaf coverage is not total: {}",
+            problems.join("; ")
+        ),
     ))
 }
 
@@ -781,7 +785,7 @@ pub fn verify_artifact_hashes(project_root: &Path, manifest: &Manifest) -> Vec<S
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::product::spec::{parse_spec_bytes, ParsedSpec};
+    use crate::product::spec::{ParsedSpec, parse_spec_bytes};
 
     const MINIMAL: &str = r#"
 [product]
@@ -917,8 +921,7 @@ agent = "propose_only"
         let mut rows = verified_rows(&parsed);
         rows.insert(
             "product.output.grain".to_string(),
-            FieldRow::new(Disposition::Reject)
-                .with_reject_reason("example: not lowerable"),
+            FieldRow::new(Disposition::Reject).with_reject_reason("example: not lowerable"),
         );
         let manifest = manifest_with_fields(&parsed, rows);
         // A reject row still accounts for the field.
@@ -1009,7 +1012,10 @@ agent = "propose_only"
         let mut without_freshness = covered_leaf_fields();
         without_freshness.remove("product.output.freshness");
         let error = check_leaf_coverage(&without_freshness).expect_err("uncovered");
-        assert!(error.message.contains("product.output.freshness"), "{error}");
+        assert!(
+            error.message.contains("product.output.freshness"),
+            "{error}"
+        );
     }
 
     // ----- byte verification -----

--- a/engine/crates/rocky-core/src/product/manifest.rs
+++ b/engine/crates/rocky-core/src/product/manifest.rs
@@ -494,18 +494,31 @@ fn properties_of<'s>(
     let source = if model == "SpecFile" {
         root
     } else {
-        &definitions[model]
+        definitions.get(model).unwrap_or_else(|| {
+            panic!(
+                "the spec schema carries no definition for '{model}', yet the leaf walk \
+                 reached it as a model. The walk only names models it has already resolved, \
+                 so this means the schema shape and this walk disagree — and an empty field \
+                 set here would hide every field of '{model}' from the totality check."
+            )
+        })
     };
-    source
+    // Reached only for a model the walk resolved, which by construction has
+    // properties. Loud rather than empty for the same reason: silence here is
+    // indistinguishable from "this model has no fields to account for".
+    let properties = source
         .get("properties")
         .and_then(serde_json::Value::as_object)
-        .map(|properties| {
-            properties
-                .iter()
-                .map(|(name, fragment)| (name.clone(), fragment))
-                .collect()
-        })
-        .unwrap_or_default()
+        .unwrap_or_else(|| {
+            panic!(
+                "the spec schema defines no properties for '{model}', yet the leaf walk \
+                 reached it as a model — the totality check would silently cover nothing."
+            )
+        });
+    properties
+        .iter()
+        .map(|(name, fragment)| (name.clone(), fragment))
+        .collect()
 }
 
 /// A unit-lowered model's leaf field names, dotted where models nest.
@@ -1067,6 +1080,27 @@ agent = "propose_only"
     }
 
     // ----- the schema walk itself -----
+
+    #[test]
+    #[should_panic(expected = "carries no definition")]
+    fn an_unresolvable_model_stops_the_walk_instead_of_covering_nothing() {
+        // The walk names only models it has already resolved, so this state
+        // means the schema shape and the walk disagree. The failure mode being
+        // pinned is the quiet one: returning an empty field set would let the
+        // whole model vanish from the totality check while it still reported
+        // success.
+        let root = serde_json::json!({ "properties": {} });
+        let definitions = serde_json::json!({});
+        let _ = leaf_fields_of("Missing", "", &definitions, &root);
+    }
+
+    #[test]
+    #[should_panic(expected = "defines no properties")]
+    fn a_model_reached_without_properties_stops_the_walk() {
+        let root = serde_json::json!({ "properties": {} });
+        let definitions = serde_json::json!({ "Hollow": { "type": "object" } });
+        let _ = leaf_fields_of("Hollow", "", &definitions, &root);
+    }
 
     #[test]
     fn leaf_derivation_recurses_through_a_nested_unit_model() {

--- a/engine/crates/rocky-core/src/product/manifest.rs
+++ b/engine/crates/rocky-core/src/product/manifest.rs
@@ -1065,4 +1065,48 @@ agent = "propose_only"
         assert_eq!(out, r#""a\u2014b\u0001\"\\\n\ud83d\ude00""#);
         assert!(out.is_ascii());
     }
+
+    // ----- the schema walk itself -----
+
+    #[test]
+    fn leaf_derivation_recurses_through_a_nested_unit_model() {
+        // Today no unit model nests another, so the real schema cannot
+        // exercise this branch — and an unexercised branch in a totality
+        // checker is a hole waiting for the first nested model. A
+        // synthetic schema of the shape schemars emits pins it now.
+        let root = serde_json::json!({
+            "properties": {
+                "outer": { "$ref": "#/definitions/Outer" }
+            }
+        });
+        let definitions = serde_json::json!({
+            "Outer": {
+                "properties": {
+                    "plain": { "type": "string" },
+                    "inner": {
+                        "anyOf": [{ "$ref": "#/definitions/Inner" }, { "type": "null" }]
+                    },
+                    "tag": { "$ref": "#/definitions/Tag" }
+                }
+            },
+            "Inner": { "properties": { "deep": { "type": "string" } } },
+            // No `properties`: an enum, which lowers as a scalar leaf.
+            "Tag": { "oneOf": [{ "type": "string", "enum": ["a"] }] }
+        });
+        let leaves = leaf_fields_of("Outer", "", &definitions, &root);
+        let expected: BTreeSet<String> = ["plain", "inner.deep", "tag"]
+            .iter()
+            .map(|leaf| (*leaf).to_string())
+            .collect();
+        assert_eq!(leaves, expected);
+    }
+
+    #[test]
+    fn a_ref_to_a_property_less_definition_is_a_leaf_not_a_model() {
+        // `FreshnessSpec.severity` is exactly this shape in the real
+        // schema. Treating the enum as a model would silently drop the
+        // `severity` leaf from the coverage claim, and the derived map
+        // would stop matching the claim.
+        assert!(spec_leaf_coverage()["product.output.freshness"].contains("severity"));
+    }
 }

--- a/engine/crates/rocky-core/src/product/manifest.rs
+++ b/engine/crates/rocky-core/src/product/manifest.rs
@@ -783,17 +783,22 @@ pub fn check_total(
 ///   file inside the project;
 /// - any `..` (or `.`) component, which walks out of the project.
 ///
+/// One rule covers both: every component must be a plain name. An absolute
+/// path leads with a root (or, on Windows, a prefix) component, and traversal
+/// shows up as `..`, so neither is `Component::Normal`. An explicit
+/// `is_absolute()` test was written here first and removed: mutation testing
+/// showed nothing broke when it was deleted, and a guard that cannot fail is a
+/// guard a later reader trusts for the wrong reason.
+///
 /// Verification only reads today, so the immediate blast radius is a wrong
 /// answer about a file that is none of the manifest's business. The reason to
 /// refuse here anyway is that this result is what a caller trusts when it
 /// decides a generation is intact, and the same keys drive writes later.
 fn contained_artifact_path(project_root: &Path, rel_path: &str) -> Option<PathBuf> {
     let candidate = Path::new(rel_path);
-    if rel_path.is_empty() || candidate.is_absolute() {
+    if rel_path.is_empty() {
         return None;
     }
-    // `Component::Normal` admits plain names only: root, prefix, `.`, and `..`
-    // are all rejected, which is the whole containment rule in one match.
     if candidate
         .components()
         .any(|component| !matches!(component, std::path::Component::Normal(_)))

--- a/engine/crates/rocky-core/src/product/manifest.rs
+++ b/engine/crates/rocky-core/src/product/manifest.rs
@@ -1116,6 +1116,7 @@ agent = "propose_only"
         );
     }
 
+    #[test]
     fn verify_artifact_hashes_detects_drift_and_absence() {
         let parsed = parse(MINIMAL);
         let root = tempfile::tempdir().expect("tempdir");

--- a/engine/crates/rocky-core/src/product/manifest.rs
+++ b/engine/crates/rocky-core/src/product/manifest.rs
@@ -1,0 +1,1062 @@
+//! The lowering manifest: every spec field accounted for, or it is a bug.
+//!
+//! The lowering is published as a manifest per run — every spec field
+//! maps to an artifact location, a verification, an identity input, or a
+//! refusal with a reason. Nothing is silent.
+//!
+//! Granularity is one row per spec field as the design names them
+//! (`product.name`, `product.output.freshness`, ...). Sub-keys of a
+//! field that lowers as one unit (`freshness.max_lag` and friends) are
+//! covered by their field's row, and that coverage is MECHANIZED down to
+//! the leaves: [`spec_leaf_coverage`] derives every nested model's leaf
+//! set from the schemars schema and compares it against the explicit
+//! [`covered_leaf_fields`] claim, so a field newly added to `ColumnSpec`
+//! or `FreshnessSpec` breaks totality until someone accounts for it.
+//! `deny_unknown_fields` alone cannot do this: it rejects unknown INPUT
+//! keys, but it never notices a new schema field the lowering drops.
+//!
+//! [`spec_row_paths`] extends the same trick one level up, to the rows
+//! themselves: a field added to a *container* model (`OutputSpec`,
+//! `ProductSpec`) appears in the schema-derived row set and breaks the
+//! hand-written instance walk that has to stay equal to it.
+//!
+//! The manifest also carries a content hash per emitted artifact — the
+//! byte-verification target that catches a worker who mutated a
+//! spec-owned file through any route.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::product::spec::{spec_digest, SpecFile, SpecRejected, SpecResult};
+
+/// The file name the manifest is committed under.
+pub const MANIFEST_FILENAME: &str = "lowering-manifest.json";
+
+/// What became of one spec field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Disposition {
+    /// Lowered into the listed locations.
+    Artifact,
+    /// A Phase-B field recorded by the Phase-A manifest. The merged
+    /// manifest carries none of these.
+    Pending,
+    /// Verified rather than written (the trust posture).
+    Verified,
+    /// Consumed as an identity or versioning input; no file.
+    Identity,
+    /// Not lowerable; `reject_reason` says why.
+    Reject,
+}
+
+/// Which lowering run a manifest describes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ManifestPhase {
+    /// Phase A: the pre-draft contract.
+    LoweredContract,
+    /// Phase B: the post-draft sidecar merge.
+    Merged,
+}
+
+/// Which lowering phase emits a location.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LocationPhase {
+    /// The pre-draft contract.
+    A,
+    /// The post-draft sidecar merge.
+    B,
+}
+
+/// One place a spec field landed: a project-root-relative path plus what
+/// of the file it accounts for.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Location {
+    /// Project-root-relative POSIX path.
+    pub path: String,
+    /// Which part of that file this field lands in.
+    pub detail: String,
+    /// The phase that emits it.
+    pub phase: LocationPhase,
+}
+
+impl Location {
+    /// A location in `path`, describing `detail`, emitted by `phase`.
+    pub fn new(path: impl Into<String>, detail: impl Into<String>, phase: LocationPhase) -> Self {
+        Self {
+            path: path.into(),
+            detail: detail.into(),
+            phase,
+        }
+    }
+}
+
+/// The disposition of one spec field.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FieldRow {
+    /// What became of the field.
+    pub disposition: Disposition,
+    /// Where it landed, when it landed anywhere.
+    #[serde(default)]
+    pub locations: Vec<Location>,
+    /// Why this disposition, in plain language.
+    #[serde(default)]
+    pub note: String,
+    /// Set only on a [`Disposition::Reject`] row.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reject_reason: Option<String>,
+}
+
+impl FieldRow {
+    /// A row with a disposition and nothing else.
+    pub fn new(disposition: Disposition) -> Self {
+        Self {
+            disposition,
+            locations: Vec::new(),
+            note: String::new(),
+            reject_reason: None,
+        }
+    }
+
+    /// The same row with a note attached.
+    #[must_use]
+    pub fn with_note(mut self, note: impl Into<String>) -> Self {
+        self.note = note.into();
+        self
+    }
+
+    /// The same row with locations attached.
+    #[must_use]
+    pub fn with_locations(mut self, locations: Vec<Location>) -> Self {
+        self.locations = locations;
+        self
+    }
+
+    /// The same row with a refusal reason attached.
+    #[must_use]
+    pub fn with_reject_reason(mut self, reason: impl Into<String>) -> Self {
+        self.reject_reason = Some(reason.into());
+        self
+    }
+}
+
+/// The total lowering manifest, regenerated on every lowering run.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Manifest {
+    /// `product:<name>`.
+    pub product_id: String,
+    /// `sha256:<hex>` over the spec's raw bytes.
+    pub spec_digest: String,
+    /// Project-root-relative path of the spec this run read.
+    pub spec_path: String,
+    /// The resolved output model name.
+    pub output_model: String,
+    /// Which run this manifest describes.
+    pub phase: ManifestPhase,
+    /// One row per spec field.
+    pub fields: BTreeMap<String, FieldRow>,
+    /// Emitted-artifact content hashes: relative path -> `sha256:<hex>`.
+    #[serde(default)]
+    pub artifacts: BTreeMap<String, String>,
+}
+
+/// An artifact's content hash, in the same spelling as the spec digest.
+///
+/// The same function as [`spec_digest`], named for its other job: the
+/// spec digest is an identity, this is a tamper-detection target, and
+/// the shared spelling is what lets a reader compare them by eye.
+pub fn content_digest(data: &[u8]) -> String {
+    spec_digest(data)
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic serialization
+// ---------------------------------------------------------------------------
+
+impl Manifest {
+    /// Serialize deterministically: sorted keys, two-space indent, an
+    /// escape for every non-ASCII character, and a trailing newline.
+    ///
+    /// Written by hand rather than through a serializer's pretty printer
+    /// because these bytes are hashed, committed, and byte-compared
+    /// across two implementations. A pretty printer's key order and
+    /// escaping are its own business and can move under a dependency
+    /// bump; this cannot. The manifest carries no timestamps, so equal
+    /// inputs give equal bytes by construction.
+    pub fn to_json_bytes(&self) -> Vec<u8> {
+        let mut out = String::new();
+        out.push_str("{\n");
+        // Keys are emitted in sorted order, which for the fixed struct
+        // fields means this hand-written sequence.
+        json_key(&mut out, 1, "artifacts");
+        json_string_map(&mut out, 1, &self.artifacts);
+        out.push_str(",\n");
+        json_key(&mut out, 1, "fields");
+        json_field_map(&mut out, 1, &self.fields);
+        out.push_str(",\n");
+        json_key(&mut out, 1, "output_model");
+        json_string(&mut out, &self.output_model);
+        out.push_str(",\n");
+        json_key(&mut out, 1, "phase");
+        json_string(
+            &mut out,
+            match self.phase {
+                ManifestPhase::LoweredContract => "lowered_contract",
+                ManifestPhase::Merged => "merged",
+            },
+        );
+        out.push_str(",\n");
+        json_key(&mut out, 1, "product_id");
+        json_string(&mut out, &self.product_id);
+        out.push_str(",\n");
+        json_key(&mut out, 1, "spec_digest");
+        json_string(&mut out, &self.spec_digest);
+        out.push_str(",\n");
+        json_key(&mut out, 1, "spec_path");
+        json_string(&mut out, &self.spec_path);
+        out.push('\n');
+        out.push_str("}\n");
+        out.into_bytes()
+    }
+
+    /// Read a manifest back from its committed bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns `manifest-unreadable` when the bytes are not a manifest.
+    pub fn from_json_bytes(raw: &[u8]) -> SpecResult<Self> {
+        serde_json::from_slice(raw).map_err(|err| {
+            SpecRejected::new(
+                "manifest-unreadable",
+                format!("the lowering manifest does not parse: {err}"),
+            )
+        })
+    }
+}
+
+fn indent(out: &mut String, level: usize) {
+    for _ in 0..level {
+        out.push_str("  ");
+    }
+}
+
+fn json_key(out: &mut String, level: usize, key: &str) {
+    indent(out, level);
+    json_string(out, key);
+    out.push_str(": ");
+}
+
+fn json_string_map(out: &mut String, level: usize, map: &BTreeMap<String, String>) {
+    if map.is_empty() {
+        out.push_str("{}");
+        return;
+    }
+    out.push_str("{\n");
+    for (index, (key, value)) in map.iter().enumerate() {
+        if index > 0 {
+            out.push_str(",\n");
+        }
+        json_key(out, level + 1, key);
+        json_string(out, value);
+    }
+    out.push('\n');
+    indent(out, level);
+    out.push('}');
+}
+
+fn json_field_map(out: &mut String, level: usize, map: &BTreeMap<String, FieldRow>) {
+    if map.is_empty() {
+        out.push_str("{}");
+        return;
+    }
+    out.push_str("{\n");
+    for (index, (key, row)) in map.iter().enumerate() {
+        if index > 0 {
+            out.push_str(",\n");
+        }
+        json_key(out, level + 1, key);
+        json_field_row(out, level + 1, row);
+    }
+    out.push('\n');
+    indent(out, level);
+    out.push('}');
+}
+
+fn json_field_row(out: &mut String, level: usize, row: &FieldRow) {
+    out.push_str("{\n");
+    json_key(out, level + 1, "disposition");
+    json_string(
+        out,
+        match row.disposition {
+            Disposition::Artifact => "artifact",
+            Disposition::Pending => "pending",
+            Disposition::Verified => "verified",
+            Disposition::Identity => "identity",
+            Disposition::Reject => "reject",
+        },
+    );
+    out.push_str(",\n");
+    json_key(out, level + 1, "locations");
+    json_locations(out, level + 1, &row.locations);
+    out.push_str(",\n");
+    json_key(out, level + 1, "note");
+    json_string(out, &row.note);
+    // Sorted key order puts an optional `reject_reason` last, and an
+    // absent one is omitted rather than written as null.
+    if let Some(reason) = &row.reject_reason {
+        out.push_str(",\n");
+        json_key(out, level + 1, "reject_reason");
+        json_string(out, reason);
+    }
+    out.push('\n');
+    indent(out, level);
+    out.push('}');
+}
+
+fn json_locations(out: &mut String, level: usize, locations: &[Location]) {
+    if locations.is_empty() {
+        out.push_str("[]");
+        return;
+    }
+    out.push_str("[\n");
+    for (index, location) in locations.iter().enumerate() {
+        if index > 0 {
+            out.push_str(",\n");
+        }
+        indent(out, level + 1);
+        out.push_str("{\n");
+        json_key(out, level + 2, "detail");
+        json_string(out, &location.detail);
+        out.push_str(",\n");
+        json_key(out, level + 2, "path");
+        json_string(out, &location.path);
+        out.push_str(",\n");
+        json_key(out, level + 2, "phase");
+        json_string(
+            out,
+            match location.phase {
+                LocationPhase::A => "A",
+                LocationPhase::B => "B",
+            },
+        );
+        out.push('\n');
+        indent(out, level + 1);
+        out.push('}');
+    }
+    out.push('\n');
+    indent(out, level);
+    out.push(']');
+}
+
+/// A JSON string literal, ASCII-only.
+///
+/// Everything outside printable ASCII is escaped, so the committed bytes
+/// are readable and diffable on any terminal and cannot depend on a
+/// locale. Characters above the basic plane are written as the surrogate
+/// pair JSON requires.
+fn json_string(out: &mut String, value: &str) {
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\u{8}' => out.push_str("\\b"),
+            '\u{c}' => out.push_str("\\f"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            ' '..='~' => out.push(ch),
+            ch => {
+                let code = ch as u32;
+                if code > 0xFFFF {
+                    let offset = code - 0x1_0000;
+                    let _ = write!(
+                        out,
+                        "\\u{:04x}\\u{:04x}",
+                        0xD800 + (offset >> 10),
+                        0xDC00 + (offset & 0x3FF)
+                    );
+                } else {
+                    let _ = write!(out, "\\u{code:04x}");
+                }
+            }
+        }
+    }
+    out.push('"');
+}
+
+// ---------------------------------------------------------------------------
+// Totality, mechanized from the schema
+// ---------------------------------------------------------------------------
+
+/// The container models: the fixed structure the row walker recurses
+/// through, rather than stopping at.
+///
+/// A model outside this list lowers as ONE unit and earns exactly one
+/// manifest row, whose leaf coverage [`covered_leaf_fields`] claims.
+/// This is a claim about the lowering, not a mirror of the schema —
+/// never regenerate it mechanically. Promoting a model into this list
+/// says "its fields get their own rows"; that is a design decision.
+const CONTAINER_MODELS: &[&str] = &[
+    "SpecFile",
+    "ProductSpec",
+    "SourceSpec",
+    "OutputSpec",
+    "TrustSpec",
+];
+
+/// For each row whose field holds a nested unit-lowered model, the EXACT
+/// leaf fields that row's disposition accounts for.
+///
+/// [`check_leaf_coverage`] derives the required set from the schema and
+/// fails on any difference, so adding a field to `ColumnSpec` or
+/// `FreshnessSpec` breaks totality until a human both lists the leaf
+/// here and gives it a real disposition in the lowering. Like
+/// [`CONTAINER_MODELS`], this is a claim, not a mirror.
+const COVERED_LEAF_FIELDS: &[(&str, &[&str])] = &[
+    ("product.output.columns", &["name", "nullable", "type"]),
+    (
+        "product.output.freshness",
+        &["max_lag", "severity", "time_column"],
+    ),
+];
+
+/// The declared leaf coverage, as a map.
+pub fn covered_leaf_fields() -> BTreeMap<String, BTreeSet<String>> {
+    COVERED_LEAF_FIELDS
+        .iter()
+        .map(|(path, leaves)| {
+            (
+                (*path).to_string(),
+                leaves.iter().map(|leaf| (*leaf).to_string()).collect(),
+            )
+        })
+        .collect()
+}
+
+/// The spec schema, as a JSON document.
+///
+/// Walked as JSON rather than through schemars' own types: the shapes
+/// this module cares about (`properties`, `$ref`, `items`,
+/// `additionalProperties`) are stable parts of JSON Schema, while the
+/// Rust types that carry them are a dependency's internals.
+fn spec_schema() -> serde_json::Value {
+    let schema = schemars::schema_for!(SpecFile);
+    serde_json::to_value(schema).expect("the spec schema serializes to JSON")
+}
+
+/// The definition name a schema fragment refers to, when it refers to a
+/// model rather than describing a scalar.
+///
+/// Reaches through the wrappers schemars emits for a required nested
+/// model (`allOf`), an optional one (`anyOf` with a null branch), and a
+/// list of them (`items`). A `$ref` to a definition with no `properties`
+/// — an enum, say — is NOT a model: it lowers as a scalar leaf, exactly
+/// as the answer key treats a `Literal[...]`.
+fn referenced_models(fragment: &serde_json::Value, definitions: &serde_json::Value) -> Vec<String> {
+    let mut found = Vec::new();
+    if let Some(reference) = fragment.get("$ref").and_then(serde_json::Value::as_str) {
+        let name = reference.rsplit('/').next().unwrap_or_default();
+        if definitions
+            .get(name)
+            .and_then(|definition| definition.get("properties"))
+            .is_some()
+        {
+            found.push(name.to_string());
+        }
+        return found;
+    }
+    for key in ["allOf", "anyOf", "oneOf"] {
+        if let Some(branches) = fragment.get(key).and_then(serde_json::Value::as_array) {
+            for branch in branches {
+                found.extend(referenced_models(branch, definitions));
+            }
+        }
+    }
+    for key in ["items", "additionalProperties"] {
+        if let Some(inner) = fragment.get(key) {
+            found.extend(referenced_models(inner, definitions));
+        }
+    }
+    found
+}
+
+fn properties_of<'s>(
+    model: &str,
+    definitions: &'s serde_json::Value,
+    root: &'s serde_json::Value,
+) -> Vec<(String, &'s serde_json::Value)> {
+    // The root model is inlined by schemars rather than listed among the
+    // definitions, so it is looked up separately.
+    let source = if model == "SpecFile" { root } else { &definitions[model] };
+    source
+        .get("properties")
+        .and_then(serde_json::Value::as_object)
+        .map(|properties| {
+            properties
+                .iter()
+                .map(|(name, fragment)| (name.clone(), fragment))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// A unit-lowered model's leaf field names, dotted where models nest.
+fn leaf_fields_of(
+    model: &str,
+    prefix: &str,
+    definitions: &serde_json::Value,
+    root: &serde_json::Value,
+) -> BTreeSet<String> {
+    let mut leaves = BTreeSet::new();
+    for (name, fragment) in properties_of(model, definitions, root) {
+        let path = if prefix.is_empty() {
+            name.clone()
+        } else {
+            format!("{prefix}.{name}")
+        };
+        let nested = referenced_models(fragment, definitions);
+        if nested.is_empty() {
+            leaves.insert(path);
+        } else {
+            for model in nested {
+                leaves.extend(leaf_fields_of(&model, &path, definitions, root));
+            }
+        }
+    }
+    leaves
+}
+
+/// Row path -> the leaf fields under it, derived from the schema.
+///
+/// Walks the model TYPES, recursing through the containers and stopping
+/// at each unit-lowered model, whose whole leaf set becomes that row's
+/// required coverage. A scalar row covers itself and produces no entry.
+pub fn spec_leaf_coverage() -> BTreeMap<String, BTreeSet<String>> {
+    let root = spec_schema();
+    let definitions = root
+        .get("definitions")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    let mut derived = BTreeMap::new();
+    walk_leaf_coverage("SpecFile", "", &definitions, &root, &mut derived);
+    derived
+}
+
+fn walk_leaf_coverage(
+    model: &str,
+    prefix: &str,
+    definitions: &serde_json::Value,
+    root: &serde_json::Value,
+    derived: &mut BTreeMap<String, BTreeSet<String>>,
+) {
+    for (name, fragment) in properties_of(model, definitions, root) {
+        let path = if prefix.is_empty() {
+            name.clone()
+        } else {
+            format!("{prefix}.{name}")
+        };
+        let nested = referenced_models(fragment, definitions);
+        let mut leaves = BTreeSet::new();
+        for referenced in nested {
+            if CONTAINER_MODELS.contains(&referenced.as_str()) {
+                walk_leaf_coverage(&referenced, &path, definitions, root, derived);
+            } else {
+                leaves.extend(leaf_fields_of(&referenced, "", definitions, root));
+            }
+        }
+        if !leaves.is_empty() {
+            derived.insert(path, leaves);
+        }
+    }
+}
+
+/// Every row path the schema declares, present or absent in any one spec.
+///
+/// The type-level companion to [`spec_field_paths`]: one path per
+/// non-container field, recursing through the containers. Added coverage
+/// beyond the answer key, which mechanizes only the leaves of the unit
+/// models — a field added to a CONTAINER model was invisible to it.
+pub fn spec_row_paths() -> BTreeSet<String> {
+    let root = spec_schema();
+    let definitions = root
+        .get("definitions")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    let mut paths = BTreeSet::new();
+    walk_row_paths("SpecFile", "", &definitions, &root, &mut paths);
+    paths
+}
+
+fn walk_row_paths(
+    model: &str,
+    prefix: &str,
+    definitions: &serde_json::Value,
+    root: &serde_json::Value,
+    paths: &mut BTreeSet<String>,
+) {
+    for (name, fragment) in properties_of(model, definitions, root) {
+        let path = if prefix.is_empty() {
+            name.clone()
+        } else {
+            format!("{prefix}.{name}")
+        };
+        let containers: Vec<String> = referenced_models(fragment, definitions)
+            .into_iter()
+            .filter(|model| CONTAINER_MODELS.contains(&model.as_str()))
+            .collect();
+        if containers.is_empty() {
+            paths.insert(path);
+        } else {
+            for container in containers {
+                walk_row_paths(&container, &path, definitions, root, paths);
+            }
+        }
+    }
+}
+
+/// The field set of one parsed spec, at row granularity.
+///
+/// An optional field that is absent is not part of the instance's field
+/// set — there is nothing to account for. A field that defaults to empty
+/// is ALWAYS accounted: an empty declaration is a disposition, not a
+/// silence.
+///
+/// Hand-written, and held to [`spec_row_paths`] by a test: a field added
+/// to a container model appears there and not here, and that difference
+/// is the failure.
+pub fn spec_field_paths(spec: &SpecFile) -> BTreeSet<String> {
+    let mut paths = BTreeSet::new();
+    if spec.spec_version.is_some() {
+        paths.insert("spec_version".to_string());
+    }
+    paths.insert("product.name".to_string());
+    paths.insert("product.intent".to_string());
+    paths.insert("product.source.tables".to_string());
+    if spec.product.output.model.is_some() {
+        paths.insert("product.output.model".to_string());
+    }
+    paths.insert("product.output.grain".to_string());
+    paths.insert("product.output.columns".to_string());
+    paths.insert("product.output.checks".to_string());
+    if spec.product.output.freshness.is_some() {
+        paths.insert("product.output.freshness".to_string());
+    }
+    paths.insert("product.output.classifications".to_string());
+    paths.insert("product.trust.agent".to_string());
+    paths
+}
+
+/// Check the declared leaf coverage against the schema-derived one.
+///
+/// Takes the claim as an argument so a test can hand it a mutated map
+/// and watch the check fail — the guard is exercised, not assumed.
+///
+/// # Errors
+///
+/// Returns `manifest-not-total` naming the drift in either direction: a
+/// leaf the schema carries but the claim does not is an unaccounted spec
+/// field, and a claimed leaf the schema lost is a stale claim.
+pub fn check_leaf_coverage(declared: &BTreeMap<String, BTreeSet<String>>) -> SpecResult<()> {
+    let derived = spec_leaf_coverage();
+    let mut problems: Vec<String> = Vec::new();
+    let paths: BTreeSet<&String> = derived.keys().chain(declared.keys()).collect();
+    for path in paths {
+        let empty = BTreeSet::new();
+        let required = derived.get(path).unwrap_or(&empty);
+        let claimed = declared.get(path).unwrap_or(&empty);
+        let uncovered: Vec<&str> = required
+            .difference(claimed)
+            .map(String::as_str)
+            .collect();
+        let stale: Vec<&str> = claimed.difference(required).map(String::as_str).collect();
+        if !uncovered.is_empty() {
+            problems.push(format!(
+                "{path}: leaf field(s) {} have no covered disposition",
+                uncovered.join(", ")
+            ));
+        }
+        if !stale.is_empty() {
+            problems.push(format!(
+                "{path}: covered leaf field(s) {} no longer exist in the schema",
+                stale.join(", ")
+            ));
+        }
+    }
+    if problems.is_empty() {
+        return Ok(());
+    }
+    Err(SpecRejected::new(
+        "manifest-not-total",
+        format!("lowering leaf coverage is not total: {}", problems.join("; ")),
+    ))
+}
+
+/// [`check_leaf_coverage`] against the committed claim.
+///
+/// # Errors
+///
+/// Returns `manifest-not-total`; see [`check_leaf_coverage`].
+pub fn assert_leaf_coverage() -> SpecResult<()> {
+    check_leaf_coverage(&covered_leaf_fields())
+}
+
+/// Hard totality check, at both granularities.
+///
+/// 1. Leaf coverage, at the type level: every leaf field of every
+///    unit-lowered model is explicitly accounted for.
+/// 2. Row totality, at the instance level: the manifest's field set
+///    EQUALS the spec's.
+///
+/// # Errors
+///
+/// Returns `manifest-not-total` naming the drift. A spec field with no
+/// disposition is a lowering bug; a manifest row for a field the spec
+/// does not carry is a stale manifest. Returned rather than panicked so
+/// the caller refuses the run instead of aborting the process, and so a
+/// test can pin the code.
+pub fn assert_total(spec: &SpecFile, manifest: &Manifest) -> SpecResult<()> {
+    check_total(spec, manifest, &covered_leaf_fields())
+}
+
+/// [`assert_total`] against a caller-supplied coverage claim.
+///
+/// # Errors
+///
+/// Returns `manifest-not-total`; see [`assert_total`].
+pub fn check_total(
+    spec: &SpecFile,
+    manifest: &Manifest,
+    declared: &BTreeMap<String, BTreeSet<String>>,
+) -> SpecResult<()> {
+    check_leaf_coverage(declared)?;
+    let expected = spec_field_paths(spec);
+    let actual: BTreeSet<String> = manifest.fields.keys().cloned().collect();
+    let missing: Vec<&str> = expected.difference(&actual).map(String::as_str).collect();
+    let stale: Vec<&str> = actual.difference(&expected).map(String::as_str).collect();
+    if missing.is_empty() && stale.is_empty() {
+        return Ok(());
+    }
+    Err(SpecRejected::new(
+        "manifest-not-total",
+        format!(
+            "lowering manifest is not total: unaccounted spec fields [{}]; \
+             stale manifest rows [{}]",
+            missing.join(", "),
+            stale.join(", ")
+        ),
+    ))
+}
+
+/// Byte-verify every manifest-listed artifact against its recorded hash.
+///
+/// Returns the mismatches — a missing file or a hash drift — and an
+/// empty list when the tree is clean. This is the precondition that runs
+/// before anything a worker touched is trusted.
+pub fn verify_artifact_hashes(project_root: &Path, manifest: &Manifest) -> Vec<String> {
+    let mut problems = Vec::new();
+    for (rel_path, expected) in &manifest.artifacts {
+        let artifact_path = project_root.join(rel_path);
+        if !artifact_path.is_file() {
+            problems.push(format!("{rel_path}: missing (expected {expected})"));
+            continue;
+        }
+        let Ok(bytes) = std::fs::read(&artifact_path) else {
+            problems.push(format!("{rel_path}: unreadable (expected {expected})"));
+            continue;
+        };
+        let actual = content_digest(&bytes);
+        if &actual != expected {
+            problems.push(format!(
+                "{rel_path}: content drift (expected {expected}, found {actual})"
+            ));
+        }
+    }
+    problems
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::product::spec::{parse_spec_bytes, ParsedSpec};
+
+    const MINIMAL: &str = r#"
+[product]
+name = "tiny"
+intent = "x"
+
+[product.source]
+tables = ["c.s.t"]
+
+[product.output]
+grain = ["id"]
+columns = [{ name = "id", type = "Int64", nullable = false }]
+
+[product.trust]
+agent = "propose_only"
+"#;
+
+    /// A spec that sets every optional field, so the instance walk can be
+    /// held against the schema-derived row set.
+    const MAXIMAL: &str = r#"
+spec_version = 0
+
+[product]
+name = "tiny"
+intent = "x"
+
+[product.source]
+tables = ["c.s.t"]
+
+[product.output]
+model = "tiny"
+grain = ["id"]
+columns = [{ name = "id", type = "Int64", nullable = false }]
+checks = ["id > 0"]
+freshness = { max_lag = "24h", time_column = "id", severity = "error" }
+classifications = { id = "pii" }
+
+[product.trust]
+agent = "propose_only"
+"#;
+
+    fn parse(text: &str) -> ParsedSpec {
+        parse_spec_bytes(text.as_bytes(), "<test>").expect("valid")
+    }
+
+    fn manifest_with_fields(parsed: &ParsedSpec, fields: BTreeMap<String, FieldRow>) -> Manifest {
+        Manifest {
+            product_id: parsed.product_id(),
+            spec_digest: parsed.digest.clone(),
+            spec_path: "products/tiny.toml".to_string(),
+            output_model: parsed.output_model().to_string(),
+            phase: ManifestPhase::Merged,
+            fields,
+            artifacts: BTreeMap::new(),
+        }
+    }
+
+    fn verified_rows(parsed: &ParsedSpec) -> BTreeMap<String, FieldRow> {
+        spec_field_paths(&parsed.spec)
+            .into_iter()
+            .map(|path| (path, FieldRow::new(Disposition::Verified)))
+            .collect()
+    }
+
+    // ----- the field walk -----
+
+    #[test]
+    fn field_paths_skip_absent_optionals() {
+        let parsed = parse(MINIMAL);
+        let paths = spec_field_paths(&parsed.spec);
+        assert!(!paths.contains("product.output.freshness"));
+        assert!(!paths.contains("spec_version"));
+        assert!(!paths.contains("product.output.model"));
+        // An empty declaration is a disposition, not a silence.
+        assert!(paths.contains("product.output.checks"));
+        assert!(paths.contains("product.output.classifications"));
+    }
+
+    #[test]
+    fn field_paths_include_present_optionals() {
+        let paths = spec_field_paths(&parse(MAXIMAL).spec);
+        assert!(paths.contains("product.output.freshness"));
+        assert!(paths.contains("spec_version"));
+        assert!(paths.contains("product.output.model"));
+    }
+
+    #[test]
+    fn the_instance_walk_covers_every_row_the_schema_declares() {
+        // The mechanization the answer key lacks: a field added to a
+        // CONTAINER model shows up in the schema-derived set, and the
+        // hand-written walk above does not produce it. A maximal spec
+        // sets every optional, so the two sets must be equal.
+        assert_eq!(spec_field_paths(&parse(MAXIMAL).spec), spec_row_paths());
+    }
+
+    // ----- totality -----
+
+    #[test]
+    fn assert_total_flags_an_unaccounted_spec_field() {
+        let parsed = parse(MINIMAL);
+        let mut rows = verified_rows(&parsed);
+        rows.remove("product.output.grain");
+        let error = assert_total(&parsed.spec, &manifest_with_fields(&parsed, rows))
+            .expect_err("not total");
+        assert_eq!(error.code, "manifest-not-total");
+        assert!(error.message.contains("product.output.grain"), "{error}");
+    }
+
+    #[test]
+    fn assert_total_flags_a_stale_manifest_row() {
+        let parsed = parse(MINIMAL);
+        let mut rows = verified_rows(&parsed);
+        rows.insert(
+            "product.output.ghost".to_string(),
+            FieldRow::new(Disposition::Artifact),
+        );
+        let error = assert_total(&parsed.spec, &manifest_with_fields(&parsed, rows))
+            .expect_err("not total");
+        assert_eq!(error.code, "manifest-not-total");
+        assert!(error.message.contains("ghost"), "{error}");
+    }
+
+    #[test]
+    fn assert_total_passes_when_the_sets_are_equal() {
+        let parsed = parse(MINIMAL);
+        let rows = verified_rows(&parsed);
+        assert_total(&parsed.spec, &manifest_with_fields(&parsed, rows)).expect("total");
+    }
+
+    #[test]
+    fn a_reject_row_round_trips() {
+        let parsed = parse(MINIMAL);
+        let mut rows = verified_rows(&parsed);
+        rows.insert(
+            "product.output.grain".to_string(),
+            FieldRow::new(Disposition::Reject)
+                .with_reject_reason("example: not lowerable"),
+        );
+        let manifest = manifest_with_fields(&parsed, rows);
+        // A reject row still accounts for the field.
+        assert_total(&parsed.spec, &manifest).expect("total");
+        let round_tripped = Manifest::from_json_bytes(&manifest.to_json_bytes()).expect("reads");
+        let row = &round_tripped.fields["product.output.grain"];
+        assert_eq!(row.disposition, Disposition::Reject);
+        assert!(row.reject_reason.is_some());
+    }
+
+    #[test]
+    fn serialization_is_deterministic() {
+        let parsed = parse(MINIMAL);
+        // A `BTreeMap` cannot be handed rows in a different order, so the
+        // insertion order is varied instead and the sorted output has to
+        // absorb it.
+        let forward = verified_rows(&parsed);
+        let mut reversed = BTreeMap::new();
+        for (path, row) in forward.iter().rev() {
+            reversed.insert(path.clone(), row.clone());
+        }
+        assert_eq!(
+            manifest_with_fields(&parsed, forward).to_json_bytes(),
+            manifest_with_fields(&parsed, reversed).to_json_bytes()
+        );
+    }
+
+    // ----- leaf coverage -----
+
+    #[test]
+    fn leaf_coverage_is_derived_from_the_schema_and_matches_the_claim() {
+        let derived = spec_leaf_coverage();
+        assert_eq!(derived, covered_leaf_fields());
+        let leaves = |names: &[&str]| -> BTreeSet<String> {
+            names.iter().map(|name| (*name).to_string()).collect()
+        };
+        // The derivation reaches the LEAVES of the nested models — the
+        // exact fields a silent schema addition would hide behind the row.
+        assert_eq!(
+            derived["product.output.columns"],
+            leaves(&["name", "nullable", "type"])
+        );
+        assert_eq!(
+            derived["product.output.freshness"],
+            leaves(&["max_lag", "severity", "time_column"])
+        );
+        assert_leaf_coverage().expect("the claim passes");
+    }
+
+    #[test]
+    fn a_new_nested_leaf_breaks_totality() {
+        // The checker's view of a newly added `ColumnSpec` field: the
+        // schema-derived set carries a leaf the claim does not.
+        let mut without_nullable = covered_leaf_fields();
+        without_nullable.insert(
+            "product.output.columns".to_string(),
+            ["name", "type"].iter().map(|s| (*s).to_string()).collect(),
+        );
+        let error = check_leaf_coverage(&without_nullable).expect_err("uncovered");
+        assert_eq!(error.code, "manifest-not-total");
+        assert!(error.message.contains("nullable"), "{error}");
+
+        let parsed = parse(MINIMAL);
+        let rows = verified_rows(&parsed);
+        let error = check_total(
+            &parsed.spec,
+            &manifest_with_fields(&parsed, rows),
+            &without_nullable,
+        )
+        .expect_err("uncovered");
+        assert!(error.message.contains("nullable"), "{error}");
+    }
+
+    #[test]
+    fn a_stale_covered_leaf_breaks_totality() {
+        let mut with_ghost = covered_leaf_fields();
+        with_ghost
+            .get_mut("product.output.columns")
+            .expect("row")
+            .insert("ghost".to_string());
+        let error = check_leaf_coverage(&with_ghost).expect_err("stale");
+        assert!(error.message.contains("ghost"), "{error}");
+    }
+
+    #[test]
+    fn an_uncovered_aggregate_row_breaks_totality() {
+        // A whole unit-lowered model missing from the claim cannot slip in.
+        let mut without_freshness = covered_leaf_fields();
+        without_freshness.remove("product.output.freshness");
+        let error = check_leaf_coverage(&without_freshness).expect_err("uncovered");
+        assert!(error.message.contains("product.output.freshness"), "{error}");
+    }
+
+    // ----- byte verification -----
+
+    #[test]
+    fn verify_artifact_hashes_detects_drift_and_absence() {
+        let parsed = parse(MINIMAL);
+        let root = tempfile::tempdir().expect("tempdir");
+        let artifact = root.path().join("models/tiny.contract.toml");
+        std::fs::create_dir_all(artifact.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&artifact, b"content-v1").expect("write");
+        let manifest = Manifest {
+            product_id: parsed.product_id(),
+            spec_digest: parsed.digest.clone(),
+            spec_path: "products/tiny.toml".to_string(),
+            output_model: "tiny".to_string(),
+            phase: ManifestPhase::LoweredContract,
+            fields: BTreeMap::new(),
+            artifacts: [(
+                "models/tiny.contract.toml".to_string(),
+                content_digest(b"content-v1"),
+            )]
+            .into_iter()
+            .collect(),
+        };
+        assert!(verify_artifact_hashes(root.path(), &manifest).is_empty());
+
+        std::fs::write(&artifact, b"tampered").expect("write");
+        let problems = verify_artifact_hashes(root.path(), &manifest);
+        assert_eq!(problems.len(), 1);
+        assert!(problems[0].contains("drift"), "{}", problems[0]);
+
+        std::fs::remove_file(&artifact).expect("unlink");
+        let problems = verify_artifact_hashes(root.path(), &manifest);
+        assert_eq!(problems.len(), 1);
+        assert!(problems[0].contains("missing"), "{}", problems[0]);
+    }
+
+    // ----- the JSON writer -----
+
+    #[test]
+    fn json_escapes_everything_outside_printable_ascii() {
+        let mut out = String::new();
+        json_string(&mut out, "a\u{2014}b\u{1}\"\\\n\u{1F600}");
+        // Lowercase hex, a surrogate pair above the basic plane, and not
+        // one non-ASCII byte left in the output.
+        assert_eq!(out, r#""a\u2014b\u0001\"\\\n\ud83d\ude00""#);
+        assert!(out.is_ascii());
+    }
+}

--- a/engine/crates/rocky-core/src/product/mod.rs
+++ b/engine/crates/rocky-core/src/product/mod.rs
@@ -10,8 +10,11 @@
 //! # Modules
 //!
 //! - [`spec`] — the strict parser and the identity (digest) rules.
+//! - [`manifest`] — the per-run manifest that accounts for every spec
+//!   field, and its mechanized totality check.
 //! - [`toml_compat`] — the order-preserving reader and the byte-stable
 //!   writer the lowered artifacts are rendered through.
 
+pub mod manifest;
 pub mod spec;
 pub mod toml_compat;

--- a/engine/crates/rocky-core/src/product/mod.rs
+++ b/engine/crates/rocky-core/src/product/mod.rs
@@ -10,11 +10,14 @@
 //! # Modules
 //!
 //! - [`spec`] — the strict parser and the identity (digest) rules.
+//! - [`lowering`] — the two lowering phases: the contract render and
+//!   the sidecar metadata merge.
 //! - [`manifest`] — the per-run manifest that accounts for every spec
 //!   field, and its mechanized totality check.
 //! - [`toml_compat`] — the order-preserving reader and the byte-stable
 //!   writer the lowered artifacts are rendered through.
 
+pub mod lowering;
 pub mod manifest;
 pub mod spec;
 pub mod toml_compat;

--- a/engine/crates/rocky-core/src/product/mod.rs
+++ b/engine/crates/rocky-core/src/product/mod.rs
@@ -1,0 +1,14 @@
+//! Product specs: the `products/<name>.toml` surface and its lowering.
+//!
+//! A product spec declares WHAT a data product must be — grain, columns,
+//! checks, freshness, classifications — and lowers onto primitives the
+//! engine already enforces (contracts, declarative tests, sidecar
+//! metadata, policy posture). The spec introduces no new runtime
+//! semantics: a field that cannot lower is refused at parse time rather
+//! than shimmed.
+//!
+//! # Modules
+//!
+//! - [`spec`] — the strict parser and the identity (digest) rules.
+
+pub mod spec;

--- a/engine/crates/rocky-core/src/product/mod.rs
+++ b/engine/crates/rocky-core/src/product/mod.rs
@@ -10,5 +10,8 @@
 //! # Modules
 //!
 //! - [`spec`] — the strict parser and the identity (digest) rules.
+//! - [`toml_compat`] — the order-preserving reader and the byte-stable
+//!   writer the lowered artifacts are rendered through.
 
 pub mod spec;
+pub mod toml_compat;

--- a/engine/crates/rocky-core/src/product/spec.rs
+++ b/engine/crates/rocky-core/src/product/spec.rs
@@ -48,7 +48,10 @@ pub struct SpecRejected {
 }
 
 impl SpecRejected {
-    fn new(code: &'static str, message: impl Into<String>) -> Self {
+    /// Visible to the rest of `product` so the lowering raises its own
+    /// refusals through the same constructor, rather than assembling the
+    /// struct by hand and drifting on the `Display` shape.
+    pub(super) fn new(code: &'static str, message: impl Into<String>) -> Self {
         Self {
             code,
             message: message.into(),

--- a/engine/crates/rocky-core/src/product/spec.rs
+++ b/engine/crates/rocky-core/src/product/spec.rs
@@ -1,0 +1,1271 @@
+//! Parse `products/<name>.toml` into a strict, typed [`SpecFile`].
+//!
+//! The schema is closed: an unknown key, an unlowerable field, or an
+//! out-of-vocabulary value is a rejection, never a shim. Identity is
+//! `product_id = "product:<name>"` plus `spec_digest = "sha256:<hex>"` over
+//! the RAW BYTES of the file — no canonicalization, so a comment edit changes
+//! the digest on purpose.
+//!
+//! The type vocabulary is Rocky's, not the warehouse's: the closed set the
+//! contract matcher accepts (`type_name_matches` in `rocky-compiler`).
+//! Warehouse spellings (`BIGINT`, `DATE`, `DECIMAL(18,2)`) are rejected with
+//! the Rocky name suggested.
+//!
+//! # Error classification
+//!
+//! Rejections carry a stable machine `code`, so a test pins the guard rather
+//! than the prose. The codes come from this module's own walk over the parsed
+//! document — never from a serde error string, which is not a stable contract
+//! and would silently change the meaning of a gate across dependency bumps.
+
+use std::fmt::Write as _;
+
+use indexmap::IndexMap;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// The product-spec schema version this parser reads.
+///
+/// A spec may pin `spec_version = 0`; omitting the key means the current
+/// version. Any other value is refused rather than shimmed.
+pub const SPEC_VERSION: i64 = 0;
+
+const DIGEST_PREFIX: &str = "sha256:";
+
+/// A spec-compile rejection: the spec is not representable, and the fix
+/// belongs to the human who wrote it.
+///
+/// `code` is a stable machine token (one per reject rule). `message` names the
+/// offending field and, where possible, the fix.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("[{code}] {message}")]
+pub struct SpecRejected {
+    /// Stable machine token for this reject rule.
+    pub code: &'static str,
+    /// Human-facing explanation naming the offending field.
+    pub message: String,
+}
+
+impl SpecRejected {
+    fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+/// Result alias for the parser's rejection type.
+pub type SpecResult<T> = Result<T, SpecRejected>;
+
+/// The identity digest: `sha256:<hex>` over the raw spec bytes.
+///
+/// Deliberately not canonicalized. The bytes a human approved are the bytes
+/// that get digested, so a whitespace or comment edit produces a new identity
+/// and forces a fresh approval.
+pub fn spec_digest(raw: &[u8]) -> String {
+    let hash = Sha256::digest(raw);
+    let mut out = String::with_capacity(DIGEST_PREFIX.len() + 64);
+    out.push_str(DIGEST_PREFIX);
+    for byte in hash.iter() {
+        write!(out, "{byte:02x}").expect("writing hex into a String is infallible");
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Duration grammar: max_lag strings -> seconds
+// ---------------------------------------------------------------------------
+
+/// Parse a `max_lag` duration (`"3600s"`, `"24h"`, `"7d"`) into seconds.
+///
+/// The grammar is a positive integer followed by exactly one lowercase unit:
+/// `s` (seconds), `h` (hours), or `d` (days). Everything else is rejected —
+/// including minutes, uppercase units, zero, negatives, leading zeros, and
+/// surrounding whitespace. The spec is an identity surface, so each value has
+/// exactly one accepted spelling.
+///
+/// # Errors
+///
+/// Returns `max-lag-unparseable` for any string outside the grammar.
+pub fn parse_max_lag(raw: &str) -> SpecResult<u64> {
+    let reject = || {
+        SpecRejected::new(
+            "max-lag-unparseable",
+            format!(
+                "freshness.max_lag '{raw}' does not parse: expected a positive integer \
+                 followed by one unit of s (seconds), h (hours), or d (days), \
+                 e.g. \"3600s\", \"24h\", \"7d\""
+            ),
+        )
+    };
+
+    let mut chars = raw.chars();
+    // `next_back` + `as_str` splits on a char boundary, so a multi-byte tail
+    // (e.g. a currency sign) cannot panic the way byte slicing would.
+    let unit = chars.next_back().ok_or_else(reject)?;
+    let digits = chars.as_str();
+
+    let multiplier: u64 = match unit {
+        's' => 1,
+        'h' => 3_600,
+        'd' => 86_400,
+        _ => return Err(reject()),
+    };
+    // `is_ascii_digit` rather than `char::is_numeric`: Unicode digits such as
+    // Arabic-Indic are not accepted spellings.
+    if digits.is_empty() || !digits.bytes().all(|b| b.is_ascii_digit()) || digits.starts_with('0') {
+        return Err(reject());
+    }
+    let value: u64 = digits.parse().map_err(|_| reject())?;
+    value.checked_mul(multiplier).ok_or_else(reject)
+}
+
+// ---------------------------------------------------------------------------
+// Rocky type vocabulary (closed) + warehouse-name suggestions
+// ---------------------------------------------------------------------------
+
+/// The closed set of Rocky type names, sorted so reject messages are stable.
+const EXACT_TYPES: &[&str] = &[
+    "Array",
+    "Binary",
+    "Boolean",
+    "Date",
+    "Decimal",
+    "Float32",
+    "Float64",
+    "Int32",
+    "Int64",
+    "Map",
+    "String",
+    "Struct",
+    "Timestamp",
+    "TimestampNtz",
+    "Variant",
+];
+
+/// Warehouse spelling (uppercased) to the Rocky name, for reject messages.
+const TYPE_SUGGESTIONS: &[(&str, &str)] = &[
+    ("ARRAY", "Array"),
+    ("BIGINT", "Int64"),
+    ("BINARY", "Binary"),
+    ("BOOL", "Boolean"),
+    ("BOOLEAN", "Boolean"),
+    ("CHAR", "String"),
+    ("DATE", "Date"),
+    ("DATETIME", "Timestamp"),
+    ("DECIMAL", "Decimal"),
+    ("DOUBLE", "Float64"),
+    ("FLOAT", "Float32"),
+    ("INT", "Int32"),
+    ("INTEGER", "Int32"),
+    ("MAP", "Map"),
+    ("NUMERIC", "Decimal"),
+    ("REAL", "Float32"),
+    ("SMALLINT", "Int32"),
+    ("STRING", "String"),
+    ("STRUCT", "Struct"),
+    ("TEXT", "String"),
+    ("TIMESTAMP", "Timestamp"),
+    ("TIMESTAMP_NTZ", "TimestampNtz"),
+    ("TINYINT", "Int32"),
+    ("VARBINARY", "Binary"),
+    ("VARCHAR", "String"),
+    ("VARIANT", "Variant"),
+];
+
+/// The three type names that accept a parameter block, with their opener.
+const PARAMETERIZED: &[(&str, char, char)] = &[
+    ("Decimal", '(', ')'),
+    ("Array", '<', '>'),
+    ("Map", '<', '>'),
+];
+
+/// Split `Base(args)` or `Base<args>` into `(base, args)`.
+///
+/// Returns `None` when the name carries no parameter block. A dangling opener
+/// without its closer yields an empty `args`, which the caller treats as
+/// parameterized-with-bad-args: the engine matches on the opening bracket
+/// alone, but the spec is stricter and requires the closer.
+fn split_parameterized(type_name: &str) -> Option<(&str, &str)> {
+    for (opener, closer) in [('(', ')'), ('<', '>')] {
+        // A leading opener is not a split: the base name must be non-empty.
+        if let Some(idx) = type_name.find(opener).filter(|idx| *idx > 0) {
+            let args = if type_name.ends_with(closer) {
+                &type_name[idx..]
+            } else {
+                ""
+            };
+            return Some((&type_name[..idx], args));
+        }
+    }
+    None
+}
+
+fn parameterized_opener(base: &str) -> Option<(char, char)> {
+    PARAMETERIZED
+        .iter()
+        .find(|(name, _, _)| *name == base)
+        .map(|(_, opener, closer)| (*opener, *closer))
+}
+
+/// Reject any type name outside Rocky's closed vocabulary.
+///
+/// Mirrors the engine's contract matcher: the exact names, plus parameterized
+/// `Decimal(...)`, `Array<...>`, and `Map<...>`. Unlike the engine's prefix
+/// match, an unbalanced parameter block is rejected here — the lowering never
+/// emits a name the engine merely tolerates.
+///
+/// # Errors
+///
+/// Returns `type-not-rocky` for any name outside the vocabulary, with a
+/// suggested Rocky name when the input looks like a warehouse spelling or a
+/// case slip.
+pub fn validate_rocky_type(type_name: &str) -> SpecResult<()> {
+    let base = match split_parameterized(type_name) {
+        None => {
+            if EXACT_TYPES.contains(&type_name) {
+                return Ok(());
+            }
+            type_name
+        }
+        Some((base, args)) => {
+            if let Some((opener, closer)) = parameterized_opener(base) {
+                if args.starts_with(opener) {
+                    return Ok(());
+                }
+                return Err(SpecRejected::new(
+                    "type-not-rocky",
+                    format!(
+                        "column type '{type_name}' is malformed: '{base}' parameters are \
+                         written '{base}{opener}...{closer}'"
+                    ),
+                ));
+            }
+            if EXACT_TYPES.contains(&base) {
+                return Err(SpecRejected::new(
+                    "type-not-rocky",
+                    format!("column type '{type_name}' is malformed: '{base}' takes no parameters"),
+                ));
+            }
+            base
+        }
+    };
+
+    let upper = base.to_ascii_uppercase();
+    let suggested = TYPE_SUGGESTIONS
+        .iter()
+        .find(|(spelling, _)| *spelling == upper)
+        .map(|(_, rocky)| *rocky)
+        // A case slip of a Rocky name ("int64") still deserves a pointer.
+        .or_else(|| {
+            EXACT_TYPES
+                .iter()
+                .find(|rocky| rocky.to_ascii_uppercase() == upper)
+                .copied()
+        });
+    let hint = match suggested {
+        Some(name) => format!(" — did you mean '{name}'? (Rocky type names, not warehouse names)"),
+        None => String::new(),
+    };
+    Err(SpecRejected::new(
+        "type-not-rocky",
+        format!(
+            "column type '{type_name}' is not a Rocky type{hint}. Allowed: {} \
+             (Decimal/Array/Map may be parameterized)",
+            EXACT_TYPES.join(", ")
+        ),
+    ))
+}
+
+/// True when `value` is a bare identifier: a letter or underscore followed by
+/// letters, digits, or underscores.
+fn is_bare_identifier(value: &str) -> bool {
+    let mut bytes = value.bytes();
+    match bytes.next() {
+        Some(b) if b.is_ascii_alphabetic() || b == b'_' => {}
+        _ => return false,
+    }
+    bytes.all(|b| b.is_ascii_alphanumeric() || b == b'_')
+}
+
+// ---------------------------------------------------------------------------
+// The spec models
+// ---------------------------------------------------------------------------
+
+/// One declared output column.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ColumnSpec {
+    /// Column name; must be a bare identifier.
+    pub name: String,
+    /// Rocky type name, optionally parameterized.
+    #[serde(rename = "type")]
+    pub type_name: String,
+    /// Whether the column may hold nulls.
+    pub nullable: bool,
+}
+
+/// Severity of the observation-phase staleness report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum FreshnessSeverity {
+    /// Staleness is reported as a failure.
+    Error,
+    /// Staleness is reported as a warning.
+    Warning,
+}
+
+/// Declared freshness: the lag budget plus the column that witnesses it.
+///
+/// `time_column` is required. Without it the observation-phase staleness check
+/// (`MAX(time_column)` against the budget) has nothing to read, and freshness
+/// would be a claim with no witness.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct FreshnessSpec {
+    /// Lag budget in the duration grammar (`"24h"`).
+    pub max_lag: String,
+    /// The timestamp column the staleness check reads.
+    pub time_column: String,
+    /// Optional severity for the staleness report.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub severity: Option<FreshnessSeverity>,
+}
+
+impl FreshnessSpec {
+    /// The lag budget in seconds.
+    ///
+    /// # Errors
+    ///
+    /// Returns `max-lag-unparseable` when the budget is outside the grammar.
+    /// Parsing validates this at spec-parse time, so a parsed spec always
+    /// yields `Ok`.
+    pub fn max_lag_seconds(&self) -> SpecResult<u64> {
+        parse_max_lag(&self.max_lag)
+    }
+}
+
+/// Grounding sources: exact `catalog.schema.table` triples only.
+///
+/// v0 has no globs and no `include` selectors, because no engine counterpart
+/// exists. An `include` key is refused as an unknown key; a glob smuggled
+/// inside `tables` is refused here.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SourceSpec {
+    /// One or more exact table references.
+    pub tables: Vec<String>,
+}
+
+/// The one output model and the guarantees around it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct OutputSpec {
+    /// Model name; defaults to the product name when omitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// The columns that identify one row.
+    pub grain: Vec<String>,
+    /// Every declared column.
+    pub columns: Vec<ColumnSpec>,
+    /// Opaque SQL boolean expressions, checked by the engine.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub checks: Vec<String>,
+    /// Optional freshness declaration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub freshness: Option<FreshnessSpec>,
+    /// Column classification tags.
+    ///
+    /// Held in an insertion-ordered map because the sidecar merge must be able
+    /// to preserve an order it is given. The parser fills it in sorted key
+    /// order: `toml::Value` hands back a sorted map, so document order is not
+    /// recoverable here without span-based parsing. Sorted is deterministic,
+    /// which is what byte-stable output needs; recovering true document order
+    /// belongs with the merge that actually rewrites a human's file.
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub classifications: IndexMap<String, String>,
+}
+
+/// The trust dial. `propose_only` is the only v0 value.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TrustSpec {
+    /// How much the agent may do unattended.
+    pub agent: String,
+}
+
+/// The `[product]` table.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ProductSpec {
+    /// Product name; names the state directory and the default model.
+    pub name: String,
+    /// Plain-language statement of what the product is for.
+    pub intent: String,
+    /// Where the data comes from.
+    pub source: SourceSpec,
+    /// What the product must produce.
+    pub output: OutputSpec,
+    /// How much the agent is trusted.
+    pub trust: TrustSpec,
+}
+
+impl ProductSpec {
+    /// The resolved output model name: `output.model`, defaulting to the
+    /// product name.
+    ///
+    /// The default is computed, never written back, so a parsed spec stays a
+    /// faithful image of the file it came from.
+    pub fn output_model(&self) -> &str {
+        self.output.model.as_deref().unwrap_or(&self.name)
+    }
+}
+
+/// The whole document: an optional version pin plus `[product]`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SpecFile {
+    /// Optional schema-version pin.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spec_version: Option<i64>,
+    /// The product declaration.
+    pub product: ProductSpec,
+}
+
+/// A parsed spec bound to the bytes that produced it, plus its identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedSpec {
+    /// The parsed document.
+    pub spec: SpecFile,
+    /// `sha256:<hex>` over [`ParsedSpec::raw`].
+    pub digest: String,
+    /// The exact bytes that were parsed and digested.
+    pub raw: Vec<u8>,
+}
+
+impl ParsedSpec {
+    /// The product declaration.
+    pub fn product(&self) -> &ProductSpec {
+        &self.spec.product
+    }
+
+    /// The identity of this product: `product:<name>`.
+    pub fn product_id(&self) -> String {
+        format!("product:{}", self.spec.product.name)
+    }
+
+    /// The resolved output model name.
+    pub fn output_model(&self) -> &str {
+        self.spec.product.output_model()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The document walk
+// ---------------------------------------------------------------------------
+//
+// Every value is pulled from the parsed TOML by hand rather than through a
+// derived `Deserialize`. The derives above exist for schema export and for
+// serializing status output; they are not the parser. Walking by hand is what
+// lets each failure carry its own stable code instead of a formatted serde
+// error string.
+
+fn path_join(parent: &str, key: &str) -> String {
+    if parent.is_empty() {
+        key.to_string()
+    } else {
+        format!("{parent}.{key}")
+    }
+}
+
+fn reject_unknown_keys(table: &toml::Table, allowed: &[&str], path: &str) -> SpecResult<()> {
+    for key in table.keys() {
+        if !allowed.contains(&key.as_str()) {
+            return Err(SpecRejected::new(
+                "unknown-key",
+                format!(
+                    "unknown key '{}': the spec schema is closed — every key must be \
+                     representable",
+                    path_join(path, key)
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn require<'t>(table: &'t toml::Table, key: &str, path: &str) -> SpecResult<&'t toml::Value> {
+    table.get(key).ok_or_else(|| {
+        SpecRejected::new(
+            "missing-key",
+            format!("required key '{}' is missing", path_join(path, key)),
+        )
+    })
+}
+
+fn invalid(path: &str, expected: &str, found: &toml::Value) -> SpecRejected {
+    SpecRejected::new(
+        "invalid-value",
+        format!(
+            "invalid value at '{path}': expected {expected}, found {}",
+            found.type_str()
+        ),
+    )
+}
+
+fn as_table<'v>(value: &'v toml::Value, path: &str) -> SpecResult<&'v toml::Table> {
+    value
+        .as_table()
+        .ok_or_else(|| invalid(path, "a table", value))
+}
+
+fn as_string(value: &toml::Value, path: &str) -> SpecResult<String> {
+    value
+        .as_str()
+        .map(str::to_string)
+        .ok_or_else(|| invalid(path, "a string", value))
+}
+
+fn as_bool(value: &toml::Value, path: &str) -> SpecResult<bool> {
+    value
+        .as_bool()
+        .ok_or_else(|| invalid(path, "a boolean", value))
+}
+
+fn as_integer(value: &toml::Value, path: &str) -> SpecResult<i64> {
+    value
+        .as_integer()
+        .ok_or_else(|| invalid(path, "an integer", value))
+}
+
+/// Read a non-empty array of strings, rejecting an empty list.
+fn as_string_list(
+    value: &toml::Value,
+    path: &str,
+    require_non_empty: bool,
+) -> SpecResult<Vec<String>> {
+    let array = value
+        .as_array()
+        .ok_or_else(|| invalid(path, "an array", value))?;
+    if require_non_empty && array.is_empty() {
+        return Err(SpecRejected::new(
+            "invalid-value",
+            format!("invalid value at '{path}': expected at least one entry"),
+        ));
+    }
+    array
+        .iter()
+        .enumerate()
+        .map(|(idx, item)| as_string(item, &format!("{path}.{idx}")))
+        .collect()
+}
+
+fn parse_column(value: &toml::Value, path: &str) -> SpecResult<ColumnSpec> {
+    let table = as_table(value, path)?;
+    reject_unknown_keys(table, &["name", "type", "nullable"], path)?;
+    let name = as_string(require(table, "name", path)?, &path_join(path, "name"))?;
+    let type_name = as_string(require(table, "type", path)?, &path_join(path, "type"))?;
+    let nullable = as_bool(
+        require(table, "nullable", path)?,
+        &path_join(path, "nullable"),
+    )?;
+
+    if !is_bare_identifier(&name) {
+        return Err(SpecRejected::new(
+            "column-name-invalid",
+            format!("column name '{name}' is not a bare identifier"),
+        ));
+    }
+    validate_rocky_type(&type_name)?;
+    Ok(ColumnSpec {
+        name,
+        type_name,
+        nullable,
+    })
+}
+
+fn parse_freshness(value: &toml::Value, path: &str) -> SpecResult<FreshnessSpec> {
+    let table = as_table(value, path)?;
+    reject_unknown_keys(table, &["max_lag", "time_column", "severity"], path)?;
+    let max_lag = as_string(
+        require(table, "max_lag", path)?,
+        &path_join(path, "max_lag"),
+    )?;
+    let time_column = match table.get("time_column") {
+        Some(raw) => as_string(raw, &path_join(path, "time_column"))?,
+        None => {
+            return Err(SpecRejected::new(
+                "freshness-missing-time-column",
+                format!(
+                    "freshness requires time_column: the staleness observation \
+                     (MAX(time_column) vs budget) has no witness without it ('{}')",
+                    path_join(path, "time_column")
+                ),
+            ));
+        }
+    };
+    let severity = match table.get("severity") {
+        None => None,
+        Some(raw) => {
+            let severity_path = path_join(path, "severity");
+            let text = as_string(raw, &severity_path)?;
+            match text.as_str() {
+                "error" => Some(FreshnessSeverity::Error),
+                "warning" => Some(FreshnessSeverity::Warning),
+                other => {
+                    return Err(SpecRejected::new(
+                        "invalid-value",
+                        format!(
+                            "invalid value at '{severity_path}': expected \"error\" or \
+                             \"warning\", found \"{other}\""
+                        ),
+                    ));
+                }
+            }
+        }
+    };
+
+    // Reject an unparseable budget at parse time rather than at observation.
+    parse_max_lag(&max_lag)?;
+    if time_column.is_empty() {
+        return Err(SpecRejected::new(
+            "freshness-missing-time-column",
+            "freshness.time_column must be a non-empty column name",
+        ));
+    }
+    Ok(FreshnessSpec {
+        max_lag,
+        time_column,
+        severity,
+    })
+}
+
+fn parse_source(value: &toml::Value, path: &str) -> SpecResult<SourceSpec> {
+    let table = as_table(value, path)?;
+    reject_unknown_keys(table, &["tables"], path)?;
+    let tables = as_string_list(
+        require(table, "tables", path)?,
+        &path_join(path, "tables"),
+        true,
+    )?;
+
+    const GLOB_CHARS: &[char] = &['*', '?', '[', ']', '{', '}'];
+    for reference in &tables {
+        let parts: Vec<&str> = reference.split('.').collect();
+        if parts.len() != 3 || parts.iter().any(|part| part.is_empty()) {
+            return Err(SpecRejected::new(
+                "source-not-exact-triple",
+                format!(
+                    "source table '{reference}' must be an exact catalog.schema.table \
+                     reference (exactly 3 non-empty dot-separated parts); v0 supports \
+                     no globs or include patterns"
+                ),
+            ));
+        }
+        if reference.contains(GLOB_CHARS) || reference.contains(' ') {
+            return Err(SpecRejected::new(
+                "source-not-exact-triple",
+                format!(
+                    "source table '{reference}' must be an exact reference — glob \
+                     characters are not selectors in v0"
+                ),
+            ));
+        }
+    }
+    Ok(SourceSpec { tables })
+}
+
+fn parse_output(value: &toml::Value, path: &str) -> SpecResult<OutputSpec> {
+    let table = as_table(value, path)?;
+    reject_unknown_keys(
+        table,
+        &[
+            "model",
+            "grain",
+            "columns",
+            "checks",
+            "freshness",
+            "classifications",
+        ],
+        path,
+    )?;
+
+    let model = match table.get("model") {
+        Some(raw) => Some(as_string(raw, &path_join(path, "model"))?),
+        None => None,
+    };
+    let grain = as_string_list(
+        require(table, "grain", path)?,
+        &path_join(path, "grain"),
+        true,
+    )?;
+
+    let columns_path = path_join(path, "columns");
+    let columns_value = require(table, "columns", path)?;
+    let columns_array = columns_value
+        .as_array()
+        .ok_or_else(|| invalid(&columns_path, "an array", columns_value))?;
+    if columns_array.is_empty() {
+        return Err(SpecRejected::new(
+            "invalid-value",
+            format!("invalid value at '{columns_path}': expected at least one entry"),
+        ));
+    }
+    let columns = columns_array
+        .iter()
+        .enumerate()
+        .map(|(idx, item)| parse_column(item, &format!("{columns_path}.{idx}")))
+        .collect::<SpecResult<Vec<ColumnSpec>>>()?;
+
+    let checks = match table.get("checks") {
+        Some(raw) => as_string_list(raw, &path_join(path, "checks"), false)?,
+        None => Vec::new(),
+    };
+    let freshness = match table.get("freshness") {
+        Some(raw) => Some(parse_freshness(raw, &path_join(path, "freshness"))?),
+        None => None,
+    };
+    let classifications = match table.get("classifications") {
+        None => IndexMap::new(),
+        Some(raw) => {
+            let classifications_path = path_join(path, "classifications");
+            let entries = as_table(raw, &classifications_path)?;
+            let mut map = IndexMap::with_capacity(entries.len());
+            for (column, tag) in entries {
+                let tag_path = path_join(&classifications_path, column);
+                map.insert(column.clone(), as_string(tag, &tag_path)?);
+            }
+            map
+        }
+    };
+
+    let column_names: Vec<&str> = columns.iter().map(|c| c.name.as_str()).collect();
+    for (idx, name) in column_names.iter().enumerate() {
+        if column_names[..idx].contains(name) {
+            return Err(SpecRejected::new(
+                "column-name-duplicate",
+                "output.columns lists a duplicate name",
+            ));
+        }
+    }
+    for grain_column in &grain {
+        if !column_names.contains(&grain_column.as_str()) {
+            return Err(SpecRejected::new(
+                "grain-column-unknown",
+                format!(
+                    "grain column '{grain_column}' is not declared in output.columns \
+                     (declared: {})",
+                    column_names.join(", ")
+                ),
+            ));
+        }
+    }
+    // Checks are opaque SQL on purpose: a check may reference derived
+    // expressions, functions, or columns the spec does not declare, and judging
+    // that needs a SQL frontend this layer must not grow. The engine is the
+    // consumer that validates them, at compile and test time. So a check
+    // naming no declared column is allowed here.
+    for classified in classifications.keys() {
+        if !column_names.contains(&classified.as_str()) {
+            return Err(SpecRejected::new(
+                "classification-column-unknown",
+                format!("classifications key '{classified}' is not a declared column"),
+            ));
+        }
+    }
+
+    Ok(OutputSpec {
+        model,
+        grain,
+        columns,
+        checks,
+        freshness,
+        classifications,
+    })
+}
+
+fn parse_trust(value: &toml::Value, path: &str) -> SpecResult<TrustSpec> {
+    let table = as_table(value, path)?;
+    reject_unknown_keys(table, &["agent"], path)?;
+    let agent = as_string(require(table, "agent", path)?, &path_join(path, "agent"))?;
+    if agent != "propose_only" {
+        return Err(SpecRejected::new(
+            "trust-not-propose-only",
+            format!(
+                "trust.agent = '{agent}' is not supported: 'propose_only' is the only v0 \
+                 value ('auto_apply' is rejected until the safety substrate exists)"
+            ),
+        ));
+    }
+    Ok(TrustSpec { agent })
+}
+
+fn parse_product(value: &toml::Value, path: &str) -> SpecResult<ProductSpec> {
+    let table = as_table(value, path)?;
+    reject_unknown_keys(
+        table,
+        &["name", "intent", "source", "output", "trust"],
+        path,
+    )?;
+    let name = as_string(require(table, "name", path)?, &path_join(path, "name"))?;
+    let intent = as_string(require(table, "intent", path)?, &path_join(path, "intent"))?;
+    let source = parse_source(require(table, "source", path)?, &path_join(path, "source"))?;
+    let output = parse_output(require(table, "output", path)?, &path_join(path, "output"))?;
+    let trust = parse_trust(require(table, "trust", path)?, &path_join(path, "trust"))?;
+
+    if !is_bare_identifier(&name) {
+        return Err(SpecRejected::new(
+            "product-name-invalid",
+            format!(
+                "product.name '{name}' must be a bare identifier (it names the state \
+                 directory and the default model)"
+            ),
+        ));
+    }
+    if intent.trim().is_empty() {
+        return Err(SpecRejected::new(
+            "intent-empty",
+            "product.intent must be non-empty",
+        ));
+    }
+    let resolved_model = output.model.as_deref().unwrap_or(&name);
+    if !is_bare_identifier(resolved_model) {
+        return Err(SpecRejected::new(
+            "output-model-invalid",
+            format!(
+                "output.model '{resolved_model}' must be a bare identifier: the draft \
+                 path rules refuse separators, dots, and traversal"
+            ),
+        ));
+    }
+
+    Ok(ProductSpec {
+        name,
+        intent,
+        source,
+        output,
+        trust,
+    })
+}
+
+/// Parse spec bytes and digest those same bytes.
+///
+/// # Errors
+///
+/// Returns a [`SpecRejected`] carrying the code for the first rule the
+/// document breaks: `not-utf8`, `not-toml`, `unknown-key`, `missing-key`,
+/// `invalid-value`, or one of the semantic codes.
+pub fn parse_spec_bytes(raw: &[u8], source_name: &str) -> SpecResult<ParsedSpec> {
+    let text = std::str::from_utf8(raw).map_err(|err| {
+        SpecRejected::new("not-utf8", format!("{source_name} is not UTF-8: {err}"))
+    })?;
+    let document: toml::Table = text.parse().map_err(|err| {
+        SpecRejected::new(
+            "not-toml",
+            format!("{source_name} is not valid TOML: {err}"),
+        )
+    })?;
+
+    reject_unknown_keys(&document, &["spec_version", "product"], "")?;
+    // The product is validated before the version pin, so a document with a
+    // real modelling error reports that error rather than the version.
+    let product = parse_product(require(&document, "product", "")?, "product")?;
+    let spec_version = match document.get("spec_version") {
+        None => None,
+        Some(raw_version) => {
+            let version = as_integer(raw_version, "spec_version")?;
+            if version != SPEC_VERSION {
+                return Err(SpecRejected::new(
+                    "spec-version-unsupported",
+                    format!(
+                        "spec_version = {version} is not supported: this engine reads \
+                         version {SPEC_VERSION} (omit the key or pin {SPEC_VERSION})"
+                    ),
+                ));
+            }
+            Some(version)
+        }
+    };
+
+    Ok(ParsedSpec {
+        spec: SpecFile {
+            spec_version,
+            product,
+        },
+        digest: spec_digest(raw),
+        raw: raw.to_vec(),
+    })
+}
+
+/// Read and parse `products/<name>.toml`; the digest covers the file's bytes.
+///
+/// # Errors
+///
+/// Returns `spec-file-missing` when the path is not a readable file, plus any
+/// rejection from [`parse_spec_bytes`].
+pub fn parse_spec_file(path: &std::path::Path) -> SpecResult<ParsedSpec> {
+    let raw = std::fs::read(path).map_err(|err| {
+        SpecRejected::new(
+            "spec-file-missing",
+            format!("spec file not found: {} ({err})", path.display()),
+        )
+    })?;
+    parse_spec_bytes(&raw, &path.display().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID: &str = r#"
+[product]
+name = "revenue_daily"
+intent = "Daily gross revenue per client in EUR, refunds excluded"
+
+[product.source]
+tables = ["poc.raw.stripe_charges"]
+
+[product.output]
+grain = ["client_id", "date"]
+columns = [
+  { name = "client_id", type = "Int64", nullable = false },
+  { name = "date", type = "Date", nullable = false },
+  { name = "revenue_eur", type = "Decimal(18,2)", nullable = false },
+]
+checks = ["revenue_eur >= 0"]
+freshness = { max_lag = "24h", time_column = "date", severity = "error" }
+classifications = { client_id = "pii" }
+
+[product.trust]
+agent = "propose_only"
+"#;
+
+    fn parse(text: &str) -> SpecResult<ParsedSpec> {
+        parse_spec_bytes(text.as_bytes(), "<test>")
+    }
+
+    fn expect_reject(text: &str, code: &str) -> SpecRejected {
+        let error = parse(text).expect_err("expected a rejection");
+        assert_eq!(error.code, code, "wrong code: {error}");
+        error
+    }
+
+    // ----- identity -----
+
+    #[test]
+    fn digest_is_sha256_over_raw_bytes() {
+        // Known-answer test: the published SHA-256 of "hello". Pinning the
+        // constant rather than recomputing it means a change to the hashing
+        // or the hex encoding fails here instead of agreeing with itself.
+        assert_eq!(
+            spec_digest(b"hello"),
+            "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+    }
+
+    #[test]
+    fn comment_edit_changes_the_digest() {
+        let base = parse(VALID).expect("valid");
+        let commented = parse(&format!("# a comment\n{VALID}")).expect("valid");
+        assert_ne!(base.digest, commented.digest);
+    }
+
+    #[test]
+    fn product_id_shape() {
+        assert_eq!(
+            parse(VALID).expect("valid").product_id(),
+            "product:revenue_daily"
+        );
+    }
+
+    #[test]
+    fn output_model_defaults_to_product_name() {
+        assert_eq!(parse(VALID).expect("valid").output_model(), "revenue_daily");
+        let explicit = VALID.replace("grain = [", "model = \"revenue_mart\"\ngrain = [");
+        assert_eq!(
+            parse(&explicit).expect("valid").output_model(),
+            "revenue_mart"
+        );
+    }
+
+    // ----- duration grammar -----
+
+    #[test]
+    fn max_lag_grammar_accepts() {
+        for (raw, seconds) in [
+            ("3600s", 3_600),
+            ("24h", 86_400),
+            ("7d", 604_800),
+            ("1s", 1),
+            ("90d", 7_776_000),
+        ] {
+            assert_eq!(parse_max_lag(raw).expect(raw), seconds, "{raw}");
+        }
+    }
+
+    #[test]
+    fn max_lag_grammar_rejects() {
+        for raw in [
+            "24", "h24", "24H", "24 h", " 24h", "0s", "-3d", "1.5h", "24m", "", "24hh", "١٢h",
+        ] {
+            let error = parse_max_lag(raw).expect_err(raw);
+            assert_eq!(error.code, "max-lag-unparseable", "{raw}");
+        }
+    }
+
+    // ----- the reject set -----
+
+    #[test]
+    fn reject_unknown_top_level_key() {
+        expect_reject(&format!("{VALID}\nextra = 1\n"), "unknown-key");
+    }
+
+    #[test]
+    fn reject_unknown_nested_key() {
+        let text = VALID.replace("[product.trust]", "[product.trust]\nmystery = 1");
+        expect_reject(&text, "unknown-key");
+    }
+
+    #[test]
+    fn reject_include_source_selector() {
+        let text = VALID.replace(
+            r#"tables = ["poc.raw.stripe_charges"]"#,
+            r#"tables = ["poc.raw.stripe_charges"]
+include = ["stripe.*"]"#,
+        );
+        expect_reject(&text, "unknown-key");
+    }
+
+    #[test]
+    fn reject_non_triple_source_ref() {
+        for reference in ["raw.stripe_charges", "poc.raw.stripe.charges", "poc..table"] {
+            let text = VALID.replace("poc.raw.stripe_charges", reference);
+            expect_reject(&text, "source-not-exact-triple");
+        }
+    }
+
+    #[test]
+    fn reject_glob_inside_source_ref() {
+        let text = VALID.replace("poc.raw.stripe_charges", "poc.raw.stripe_*");
+        expect_reject(&text, "source-not-exact-triple");
+    }
+
+    #[test]
+    fn reject_warehouse_type_name_with_suggestion() {
+        let text = VALID.replace(r#"type = "Int64""#, r#"type = "BIGINT""#);
+        let error = expect_reject(&text, "type-not-rocky");
+        assert!(error.message.contains("Int64"), "{error}");
+    }
+
+    #[test]
+    fn reject_warehouse_decimal_with_suggestion() {
+        let text = VALID.replace(r#"type = "Decimal(18,2)""#, r#"type = "DECIMAL(18,2)""#);
+        let error = expect_reject(&text, "type-not-rocky");
+        assert!(error.message.contains("Decimal"), "{error}");
+    }
+
+    #[test]
+    fn reject_unknown_type_name() {
+        let text = VALID.replace(r#"type = "Int64""#, r#"type = "Quux""#);
+        expect_reject(&text, "type-not-rocky");
+    }
+
+    #[test]
+    fn parameterized_rocky_types_accepted() {
+        for good in [
+            "Decimal",
+            "Decimal(38,9)",
+            "Array<Int64>",
+            "Map<String,Int64>",
+        ] {
+            let text = VALID.replace(r#"type = "Decimal(18,2)""#, &format!(r#"type = "{good}""#));
+            parse(&text).unwrap_or_else(|error| panic!("{good} should parse: {error}"));
+        }
+    }
+
+    #[test]
+    fn reject_unbalanced_parameterized_type() {
+        let text = VALID.replace(r#"type = "Decimal(18,2)""#, r#"type = "Decimal(18,2""#);
+        expect_reject(&text, "type-not-rocky");
+    }
+
+    #[test]
+    fn case_slipped_rocky_type_suggests_the_right_name() {
+        let text = VALID.replace(r#"type = "Int64""#, r#"type = "int64""#);
+        let error = expect_reject(&text, "type-not-rocky");
+        assert!(error.message.contains("Int64"), "{error}");
+    }
+
+    #[test]
+    fn reject_freshness_without_time_column() {
+        let text = VALID.replace(
+            r#"freshness = { max_lag = "24h", time_column = "date", severity = "error" }"#,
+            r#"freshness = { max_lag = "24h" }"#,
+        );
+        expect_reject(&text, "freshness-missing-time-column");
+    }
+
+    #[test]
+    fn reject_unparseable_max_lag_in_spec() {
+        let text = VALID.replace(r#"max_lag = "24h""#, r#"max_lag = "24m""#);
+        expect_reject(&text, "max-lag-unparseable");
+    }
+
+    #[test]
+    fn reject_grain_column_not_declared() {
+        let text = VALID.replace(r#"grain = ["client_id", "date"]"#, r#"grain = ["nope"]"#);
+        expect_reject(&text, "grain-column-unknown");
+    }
+
+    #[test]
+    fn check_referencing_unknown_column_is_allowed() {
+        let text = VALID.replace(
+            r#"checks = ["revenue_eur >= 0"]"#,
+            r#"checks = ["undeclared_helper(x) > 0"]"#,
+        );
+        parse(&text).expect("checks are opaque SQL, validated by the engine");
+    }
+
+    #[test]
+    fn reject_trust_agent_not_propose_only() {
+        let text = VALID.replace(r#"agent = "propose_only""#, r#"agent = "auto_apply""#);
+        expect_reject(&text, "trust-not-propose-only");
+    }
+
+    #[test]
+    fn reject_spec_version_other_than_zero() {
+        expect_reject(
+            &format!("spec_version = 1\n{VALID}"),
+            "spec-version-unsupported",
+        );
+    }
+
+    #[test]
+    fn spec_version_zero_accepted() {
+        let parsed = parse(&format!("spec_version = 0\n{VALID}")).expect("valid");
+        assert_eq!(parsed.spec.spec_version, Some(0));
+    }
+
+    #[test]
+    fn reject_integer_where_bool_expected() {
+        let text = VALID.replace("nullable = false", "nullable = 0");
+        expect_reject(&text, "invalid-value");
+    }
+
+    #[test]
+    fn reject_bool_where_integer_expected() {
+        expect_reject(&format!("spec_version = false\n{VALID}"), "invalid-value");
+    }
+
+    #[test]
+    fn reject_float_where_integer_expected() {
+        expect_reject(&format!("spec_version = 0.0\n{VALID}"), "invalid-value");
+    }
+
+    #[test]
+    fn reject_missing_intent() {
+        let text = VALID.replace(
+            r#"intent = "Daily gross revenue per client in EUR, refunds excluded""#,
+            "",
+        );
+        expect_reject(&text, "missing-key");
+    }
+
+    #[test]
+    fn reject_empty_intent() {
+        let text = VALID.replace(
+            r#"intent = "Daily gross revenue per client in EUR, refunds excluded""#,
+            r#"intent = "   ""#,
+        );
+        expect_reject(&text, "intent-empty");
+    }
+
+    #[test]
+    fn reject_classification_on_unknown_column() {
+        let text = VALID.replace(
+            r#"classifications = { client_id = "pii" }"#,
+            r#"classifications = { nope = "pii" }"#,
+        );
+        expect_reject(&text, "classification-column-unknown");
+    }
+
+    #[test]
+    fn reject_duplicate_column_names() {
+        let text = VALID.replace(
+            r#"{ name = "date", type = "Date", nullable = false },"#,
+            r#"{ name = "client_id", type = "Date", nullable = false },"#,
+        );
+        expect_reject(&text, "column-name-duplicate");
+    }
+
+    #[test]
+    fn reject_not_toml() {
+        expect_reject("this is not toml", "not-toml");
+    }
+
+    #[test]
+    fn reject_non_identifier_output_model() {
+        let text = VALID.replace("grain = [", "model = \"../escape\"\ngrain = [");
+        expect_reject(&text, "output-model-invalid");
+    }
+
+    #[test]
+    fn reject_non_identifier_product_name() {
+        let text = VALID.replace(r#"name = "revenue_daily""#, r#"name = "revenue-daily""#);
+        expect_reject(&text, "product-name-invalid");
+    }
+
+    #[test]
+    fn reject_missing_product_table() {
+        expect_reject("spec_version = 0\n", "missing-key");
+    }
+
+    #[test]
+    fn reject_empty_grain() {
+        let text = VALID.replace(r#"grain = ["client_id", "date"]"#, "grain = []");
+        expect_reject(&text, "invalid-value");
+    }
+
+    #[test]
+    fn classification_order_is_deterministic() {
+        // Two spellings of the same pair must parse to the same order, so the
+        // bytes the lowering emits do not depend on how the human typed it.
+        let one = VALID.replace(
+            r#"classifications = { client_id = "pii" }"#,
+            r#"classifications = { revenue_eur = "internal", client_id = "pii" }"#,
+        );
+        let other = VALID.replace(
+            r#"classifications = { client_id = "pii" }"#,
+            r#"classifications = { client_id = "pii", revenue_eur = "internal" }"#,
+        );
+        let keys = |text: &str| -> Vec<String> {
+            parse(text)
+                .expect("valid")
+                .product()
+                .output
+                .classifications
+                .keys()
+                .cloned()
+                .collect()
+        };
+        assert_eq!(keys(&one), keys(&other));
+        assert_eq!(keys(&one), ["client_id", "revenue_eur"]);
+    }
+
+    #[test]
+    fn valid_spec_round_trips_its_fields() {
+        let parsed = parse(VALID).expect("valid");
+        let product = parsed.product();
+        assert_eq!(product.name, "revenue_daily");
+        assert_eq!(product.source.tables, ["poc.raw.stripe_charges"]);
+        assert_eq!(product.output.columns.len(), 3);
+        assert_eq!(product.output.columns[0].type_name, "Int64");
+        assert!(!product.output.columns[0].nullable);
+        let freshness = product.output.freshness.as_ref().expect("freshness");
+        assert_eq!(freshness.max_lag_seconds().expect("parses"), 86_400);
+        assert_eq!(freshness.severity, Some(FreshnessSeverity::Error));
+        assert_eq!(product.trust.agent, "propose_only");
+    }
+}

--- a/engine/crates/rocky-core/src/product/testdata/lowering-manifest.merged.json
+++ b/engine/crates/rocky-core/src/product/testdata/lowering-manifest.merged.json
@@ -1,0 +1,137 @@
+{
+  "artifacts": {
+    "models/revenue_daily.contract.toml": "sha256:9ee6d468feaea622d994a4ec879e3faeeda27c8da783d51809c675a2d6a96854",
+    "models/revenue_daily.toml": "sha256:10fe4514859f94cc53411c102c850c0f9c97730aa701e85063ab4634a40eeb88"
+  },
+  "fields": {
+    "product.intent": {
+      "disposition": "artifact",
+      "locations": [
+        {
+          "detail": "intent (preserved when the draft carries one)",
+          "path": "models/revenue_daily.toml",
+          "phase": "B"
+        }
+      ],
+      "note": "delivered verbatim to the worker via the drafting brief (WP-3)"
+    },
+    "product.name": {
+      "disposition": "artifact",
+      "locations": [
+        {
+          "detail": "[tags] product",
+          "path": "models/revenue_daily.toml",
+          "phase": "B"
+        }
+      ],
+      "note": "also the identity input: product_id = 'product:revenue_daily'"
+    },
+    "product.output.checks": {
+      "disposition": "artifact",
+      "locations": [
+        {
+          "detail": "[[tests]] type=expression, severity=error",
+          "path": "models/revenue_daily.toml",
+          "phase": "B"
+        }
+      ],
+      "note": ""
+    },
+    "product.output.classifications": {
+      "disposition": "artifact",
+      "locations": [
+        {
+          "detail": "[classification] <column> = <tag>",
+          "path": "models/revenue_daily.toml",
+          "phase": "B"
+        }
+      ],
+      "note": "tag RESOLUTION is verified against [mask]/[classifications].allow_unmasked (spec-compile error, stricter than the engine's W004 warning); masking APPLICATION is warehouse-dependent \u2014 Databricks-only today"
+    },
+    "product.output.columns": {
+      "disposition": "artifact",
+      "locations": [
+        {
+          "detail": "[[columns]] {name, type, nullable}",
+          "path": "models/revenue_daily.contract.toml",
+          "phase": "A"
+        },
+        {
+          "detail": "[rules] required = [all listed columns]",
+          "path": "models/revenue_daily.contract.toml",
+          "phase": "A"
+        },
+        {
+          "detail": "[[tests]] not_null per nullable=false column",
+          "path": "models/revenue_daily.toml",
+          "phase": "B"
+        }
+      ],
+      "note": ""
+    },
+    "product.output.freshness": {
+      "disposition": "artifact",
+      "locations": [
+        {
+          "detail": "[freshness] expected_lag_seconds + time_column",
+          "path": "models/revenue_daily.toml",
+          "phase": "B"
+        }
+      ],
+      "note": "declared metadata plus runner observation \u2014 not an engine gate; severity is accepted for the runner's observation phase and NOT written to the sidecar (no engine path reads it; see the module docstring trace)"
+    },
+    "product.output.grain": {
+      "disposition": "artifact",
+      "locations": [
+        {
+          "detail": "[rules] required (grain \u2286 required)",
+          "path": "models/revenue_daily.contract.toml",
+          "phase": "A"
+        },
+        {
+          "detail": "[[tests]] type=composite kind=unique",
+          "path": "models/revenue_daily.toml",
+          "phase": "B"
+        }
+      ],
+      "note": "no first-class grain field exists in the engine \u2014 this fan-out is the lowering"
+    },
+    "product.output.model": {
+      "disposition": "artifact",
+      "locations": [
+        {
+          "detail": "file name (spec-owned, wholesale)",
+          "path": "models/revenue_daily.contract.toml",
+          "phase": "A"
+        },
+        {
+          "detail": "file name (metadata merged, agent content kept)",
+          "path": "models/revenue_daily.toml",
+          "phase": "B"
+        }
+      ],
+      "note": "names models/revenue_daily.sql too \u2014 agent-authored, never overwritten by lowering"
+    },
+    "product.source.tables": {
+      "disposition": "artifact",
+      "locations": [
+        {
+          "detail": "[[sources]] {catalog, schema, table}",
+          "path": "models/revenue_daily.toml",
+          "phase": "B"
+        }
+      ],
+      "note": "also the grounding list in the agent task brief (WP-3)"
+    },
+    "product.trust.agent": {
+      "disposition": "verified",
+      "locations": [],
+      "note": "verify, don't write (FF-DESIGN D5): the runtime never edits rocky.toml \u2014 the three-check posture verification ran before lowering"
+    }
+  },
+  "output_model": "revenue_daily",
+  "phase": "merged",
+  "product_id": "product:revenue_daily",
+  "spec_digest": "sha256:54df46b9278c1f265f64fd23203396ea69e68771197d5d0e5a7291cd6ffd82ff",
+  "spec_path": "products/revenue_daily.toml"
+}

--- a/engine/crates/rocky-core/src/product/testdata/lowering-manifest.phase-a.json
+++ b/engine/crates/rocky-core/src/product/testdata/lowering-manifest.phase-a.json
@@ -1,0 +1,85 @@
+{
+  "artifacts": {
+    "models/revenue_daily.contract.toml": "sha256:9ee6d468feaea622d994a4ec879e3faeeda27c8da783d51809c675a2d6a96854"
+  },
+  "fields": {
+    "product.intent": {
+      "disposition": "pending",
+      "locations": [],
+      "note": "delivered verbatim to the worker via the drafting brief (WP-3)"
+    },
+    "product.name": {
+      "disposition": "pending",
+      "locations": [],
+      "note": "also the identity input: product_id = 'product:revenue_daily'"
+    },
+    "product.output.checks": {
+      "disposition": "pending",
+      "locations": [],
+      "note": ""
+    },
+    "product.output.classifications": {
+      "disposition": "pending",
+      "locations": [],
+      "note": "tag RESOLUTION is verified against [mask]/[classifications].allow_unmasked (spec-compile error, stricter than the engine's W004 warning); masking APPLICATION is warehouse-dependent \u2014 Databricks-only today"
+    },
+    "product.output.columns": {
+      "disposition": "pending",
+      "locations": [
+        {
+          "detail": "[[columns]] {name, type, nullable}",
+          "path": "models/revenue_daily.contract.toml",
+          "phase": "A"
+        },
+        {
+          "detail": "[rules] required = [all listed columns]",
+          "path": "models/revenue_daily.contract.toml",
+          "phase": "A"
+        }
+      ],
+      "note": ""
+    },
+    "product.output.freshness": {
+      "disposition": "pending",
+      "locations": [],
+      "note": "declared metadata plus runner observation \u2014 not an engine gate; severity is accepted for the runner's observation phase and NOT written to the sidecar (no engine path reads it; see the module docstring trace)"
+    },
+    "product.output.grain": {
+      "disposition": "pending",
+      "locations": [
+        {
+          "detail": "[rules] required (grain \u2286 required)",
+          "path": "models/revenue_daily.contract.toml",
+          "phase": "A"
+        }
+      ],
+      "note": "no first-class grain field exists in the engine \u2014 this fan-out is the lowering"
+    },
+    "product.output.model": {
+      "disposition": "pending",
+      "locations": [
+        {
+          "detail": "file name (spec-owned, wholesale)",
+          "path": "models/revenue_daily.contract.toml",
+          "phase": "A"
+        }
+      ],
+      "note": "names models/revenue_daily.sql too \u2014 agent-authored, never overwritten by lowering"
+    },
+    "product.source.tables": {
+      "disposition": "pending",
+      "locations": [],
+      "note": "also the grounding list in the agent task brief (WP-3)"
+    },
+    "product.trust.agent": {
+      "disposition": "verified",
+      "locations": [],
+      "note": "verify, don't write (FF-DESIGN D5): the runtime never edits rocky.toml \u2014 the three-check posture verification ran before lowering"
+    }
+  },
+  "output_model": "revenue_daily",
+  "phase": "lowered_contract",
+  "product_id": "product:revenue_daily",
+  "spec_digest": "sha256:54df46b9278c1f265f64fd23203396ea69e68771197d5d0e5a7291cd6ffd82ff",
+  "spec_path": "products/revenue_daily.toml"
+}

--- a/engine/crates/rocky-core/src/product/testdata/revenue_daily.contract.toml
+++ b/engine/crates/rocky-core/src/product/testdata/revenue_daily.contract.toml
@@ -1,0 +1,19 @@
+# GENERATED from products/revenue_daily.toml (spec sha256:54df46b9278c1f265f64fd23203396ea69e68771197d5d0e5a7291cd6ffd82ff) — edit the spec, not this file.
+
+[[columns]]
+name = "client_id"
+type = "Int64"
+nullable = false
+
+[[columns]]
+name = "date"
+type = "Date"
+nullable = false
+
+[[columns]]
+name = "revenue_eur"
+type = "Decimal(18,2)"
+nullable = false
+
+[rules]
+required = ["client_id", "date", "revenue_eur"]

--- a/engine/crates/rocky-core/src/product/testdata/revenue_daily.merged.toml
+++ b/engine/crates/rocky-core/src/product/testdata/revenue_daily.merged.toml
@@ -1,0 +1,45 @@
+# GENERATED from products/revenue_daily.toml (spec sha256:54df46b9278c1f265f64fd23203396ea69e68771197d5d0e5a7291cd6ffd82ff) — edit the spec, not this file.
+name = "revenue_daily"
+intent = "Daily gross revenue per client in EUR, refunds excluded"
+sources = [
+    { catalog = "poc", schema = "raw", table = "stripe_charges" },
+]
+
+[tags]
+product = "revenue_daily"
+
+[classification]
+client_id = "pii"
+
+[freshness]
+expected_lag_seconds = 86400
+time_column = "date"
+
+[[tests]]
+type = "composite"
+kind = "unique"
+columns = [
+    "client_id",
+    "date",
+]
+
+[[tests]]
+type = "not_null"
+column = "client_id"
+
+[[tests]]
+type = "not_null"
+column = "date"
+
+[[tests]]
+type = "not_null"
+column = "revenue_eur"
+
+[[tests]]
+type = "expression"
+expression = "revenue_eur >= 0"
+severity = "error"
+
+[[tests]]
+type = "expression"
+expression = "client_id > 0"

--- a/engine/crates/rocky-core/src/product/testdata/revenue_daily.spec.toml
+++ b/engine/crates/rocky-core/src/product/testdata/revenue_daily.spec.toml
@@ -1,0 +1,26 @@
+[product]
+name   = "revenue_daily"                 # → product_id "product:revenue_daily"
+intent = "Daily gross revenue per client in EUR, refunds excluded"
+
+[product.source]
+tables = ["poc.raw.stripe_charges"]      # exact catalog.schema.table refs ONLY.
+                                         # v0 has NO globs: `include = ["stripe.*"]` was
+                                         # falsified in review — no engine counterpart exists
+                                         # (PipelineSourceConfig has no include; CLI filters are
+                                         # single exact key=value).
+
+[product.output]
+model = "revenue_daily"                  # the one output model (default: product name)
+grain = ["client_id", "date"]
+columns = [
+  { name = "client_id",   type = "Int64",         nullable = false },
+  { name = "date",        type = "Date",          nullable = false },
+  { name = "revenue_eur", type = "Decimal(18,2)", nullable = false },
+]
+checks = ["revenue_eur >= 0"]
+freshness = { max_lag = "24h", time_column = "date", severity = "error" }
+classifications = { client_id = "pii" }
+
+[product.trust]
+agent = "propose_only"                   # the ONLY v0 value; "auto_apply" is rejected until
+                                         # the Phase-2.5 safety substrate exists (⟦RT-8⟧)

--- a/engine/crates/rocky-core/src/product/toml_compat.rs
+++ b/engine/crates/rocky-core/src/product/toml_compat.rs
@@ -489,6 +489,43 @@ mod tests {
     }
 
     #[test]
+    fn a_nested_array_indents_one_level_deeper() {
+        let document = table(&[(
+            "a",
+            TomlValue::Array(vec![
+                TomlValue::Array(vec![TomlValue::Integer(1), TomlValue::Integer(2)]),
+                TomlValue::Array(vec![TomlValue::Integer(3)]),
+            ]),
+        )]);
+        assert_eq!(
+            render_document(&document),
+            "a = [\n    [\n        1,\n        2,\n    ],\n    [\n        3,\n    ],\n]\n"
+        );
+    }
+
+    #[test]
+    fn an_array_inside_an_inline_table_restarts_at_the_outer_indent() {
+        // A quirk of the reference writer, reproduced because the bytes
+        // are the contract: the nesting level resets when rendering the
+        // values of an inline table, so this inner array indents as if it
+        // were at the top level.
+        let document = table(&[(
+            "m",
+            TomlValue::Array(vec![
+                TomlValue::Table(table(&[(
+                    "a",
+                    TomlValue::Array(vec![TomlValue::Integer(1), TomlValue::Integer(2)]),
+                )])),
+                TomlValue::Integer(2),
+            ]),
+        )]);
+        assert_eq!(
+            render_document(&document),
+            "m = [\n    { a = [\n    1,\n    2,\n] },\n    2,\n]\n"
+        );
+    }
+
+    #[test]
     fn an_empty_array_stays_on_one_line() {
         let document = table(&[("x", TomlValue::Array(vec![]))]);
         assert_eq!(render_document(&document), "x = []\n");

--- a/engine/crates/rocky-core/src/product/toml_compat.rs
+++ b/engine/crates/rocky-core/src/product/toml_compat.rs
@@ -205,9 +205,9 @@ fn render_table(table: &TomlTable, name: &str, inside_aot: bool, out: &mut Strin
             TomlValue::Table(nested) => tables.push((key, nested, false)),
             TomlValue::Array(items)
                 if is_array_of_tables(items)
-                    && !items.iter().all(|item| {
-                        item.as_table().is_some_and(is_suitable_inline_table)
-                    }) =>
+                    && !items
+                        .iter()
+                        .all(|item| item.as_table().is_some_and(is_suitable_inline_table)) =>
             {
                 for item in items {
                     if let TomlValue::Table(nested) = item {
@@ -320,7 +320,12 @@ fn render_float(number: f64) -> String {
         return "nan".to_string();
     }
     if number.is_infinite() {
-        return if number.is_sign_negative() { "-inf" } else { "inf" }.to_string();
+        return if number.is_sign_negative() {
+            "-inf"
+        } else {
+            "inf"
+        }
+        .to_string();
     }
     let rendered = number.to_string();
     if rendered.contains(['.', 'e', 'E']) {
@@ -420,7 +425,8 @@ mod tests {
 
     #[test]
     fn a_table_split_across_headers_keeps_its_first_position() {
-        let parsed = parse_ordered("[a.b]\nx = 1\n\n[zz]\ny = 2\n\n[a.c]\nz = 3\n").expect("parses");
+        let parsed =
+            parse_ordered("[a.b]\nx = 1\n\n[zz]\ny = 2\n\n[a.c]\nz = 3\n").expect("parses");
         let keys: Vec<&str> = parsed.keys().map(String::as_str).collect();
         assert_eq!(keys, ["a", "zz"]);
         let inner: Vec<&str> = parsed["a"]
@@ -456,7 +462,10 @@ mod tests {
     #[test]
     fn an_integer_too_wide_for_toml_is_refused() {
         let error = parse_ordered("n = 9223372036854775808\n").expect_err("out of range");
-        assert!(error.contains("not representable") || error.contains("range"), "{error}");
+        assert!(
+            error.contains("not representable") || error.contains("range"),
+            "{error}"
+        );
     }
 
     #[test]
@@ -582,9 +591,15 @@ mod tests {
     fn scalars_precede_sub_tables_with_a_blank_line_between() {
         let document = table(&[
             ("name", TomlValue::string("m")),
-            ("tags", TomlValue::Table(table(&[("x", TomlValue::Integer(1))]))),
+            (
+                "tags",
+                TomlValue::Table(table(&[("x", TomlValue::Integer(1))])),
+            ),
         ]);
-        assert_eq!(render_document(&document), "name = \"m\"\n\n[tags]\nx = 1\n");
+        assert_eq!(
+            render_document(&document),
+            "name = \"m\"\n\n[tags]\nx = 1\n"
+        );
     }
 
     #[test]
@@ -615,7 +630,10 @@ mod tests {
     #[test]
     fn the_writer_escaper_matches_tomli_w() {
         assert_eq!(render_string("a\"b\\c"), "\"a\\\"b\\\\c\"");
-        assert_eq!(render_string("a\nb\rc\u{8}d\u{c}e"), "\"a\\nb\\rc\\bd\\fe\"");
+        assert_eq!(
+            render_string("a\nb\rc\u{8}d\u{c}e"),
+            "\"a\\nb\\rc\\bd\\fe\""
+        );
         // A tab is legal raw inside a basic string, and is left raw.
         assert_eq!(render_string("a\tb"), "\"a\tb\"");
         // Lowercase hex, and DEL is escaped.

--- a/engine/crates/rocky-core/src/product/toml_compat.rs
+++ b/engine/crates/rocky-core/src/product/toml_compat.rs
@@ -645,7 +645,10 @@ mod tests {
         assert_eq!(basic_string("a\"b\\c"), "\"a\\\"b\\\\c\"");
         // Tab takes its compact form here, unlike the writer's.
         assert_eq!(basic_string("a\tb"), "\"a\\tb\"");
-        // Uppercase hex, and DEL is left alone.
+        // Uppercase hex — ESC is the shortest control character whose hex
+        // carries a letter, so it is what tells the two cases apart.
+        assert_eq!(basic_string("\u{1b}"), "\"\\u001B\"");
+        // And DEL is left alone.
         assert_eq!(basic_string("\u{1}\u{7f}"), "\"\\u0001\u{7f}\"");
     }
 }

--- a/engine/crates/rocky-core/src/product/toml_compat.rs
+++ b/engine/crates/rocky-core/src/product/toml_compat.rs
@@ -1,0 +1,633 @@
+//! An order-preserving TOML reader and a byte-compatible writer.
+//!
+//! The lowering rewrites a file a human and an agent both touch, and the
+//! bytes it produces are a migration contract: the Python implementation
+//! this port replaces emitted its merged sidecars through `tomli_w`, so a
+//! project moving from one to the other must see a no-op diff. Rust's
+//! `toml` crate cannot do that job — its serializer sorts maps and picks
+//! its own layout, and the one feature that would preserve order
+//! (`preserve_order`) is a workspace-wide cargo feature that would change
+//! TOML serialization for every crate that unifies with it.
+//!
+//! So this module owns both halves:
+//!
+//! - [`parse_ordered`] reads a document into an insertion-ordered map, in
+//!   the order the keys appear in the source. `toml::de::DeTable` is a
+//!   sorted map, but its keys are `Spanned`, so the source order is
+//!   recoverable by sorting each table's entries on the key's span.
+//! - [`render_document`] writes a document back out with `tomli_w`'s
+//!   layout rules, reproduced exactly: four-space multi-line arrays,
+//!   arrays of tables kept inline while every element fits in 100
+//!   columns and expanded into `[[key]]` blocks once one does not.
+//!
+//! [`basic_string`] is a *different* escaper, mirroring the engine's own
+//! `toml_basic_string`. The contract file is hand-rendered rather than
+//! written through this module's writer, and the two escapers disagree
+//! on tabs, on DEL, and on the case of hex escapes. Both spellings are
+//! preserved on purpose: each one matches the file it writes.
+
+use std::fmt::Write as _;
+
+use indexmap::IndexMap;
+use toml::de::{DeTable, DeValue};
+use toml::value::Datetime;
+
+/// `tomli_w`'s indent width, and the column budget its inline-table
+/// heuristic measures against.
+const INDENT: &str = "    ";
+const MAX_LINE_LENGTH: usize = 100;
+
+/// A TOML value that remembers the order its table keys came in.
+///
+/// Deliberately not `toml::Value`: that type's table is sorted, which
+/// loses the ordering the merge is required to preserve.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TomlValue {
+    /// A string.
+    String(String),
+    /// A 64-bit signed integer.
+    Integer(i64),
+    /// A float.
+    Float(f64),
+    /// A boolean.
+    Boolean(bool),
+    /// A date, time, or date-time.
+    Datetime(Datetime),
+    /// An array of values.
+    Array(Vec<TomlValue>),
+    /// A table, in insertion order.
+    Table(TomlTable),
+}
+
+/// A TOML table in insertion order.
+pub type TomlTable = IndexMap<String, TomlValue>;
+
+impl TomlValue {
+    /// Build a string value from anything string-like.
+    pub fn string(value: impl Into<String>) -> Self {
+        Self::String(value.into())
+    }
+
+    /// The table inside this value, if it is one.
+    pub fn as_table(&self) -> Option<&TomlTable> {
+        match self {
+            Self::Table(table) => Some(table),
+            _ => None,
+        }
+    }
+
+    /// The array inside this value, if it is one.
+    pub fn as_array(&self) -> Option<&[TomlValue]> {
+        match self {
+            Self::Array(items) => Some(items),
+            _ => None,
+        }
+    }
+
+    /// True for values TOML renders as tables or arrays of tables.
+    ///
+    /// Such a value must follow every scalar key at its level to stay
+    /// valid TOML, which is why the merge orders on it. Mirrors the
+    /// answer key's `_is_table_valued`: an array counts when *any*
+    /// element is a table, which is deliberately looser than the
+    /// [`is_array_of_tables`] test the writer applies.
+    pub fn is_table_valued(&self) -> bool {
+        match self {
+            Self::Table(_) => true,
+            Self::Array(items) => items.iter().any(|item| matches!(item, Self::Table(_))),
+            _ => false,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reading: document order recovered from key spans
+// ---------------------------------------------------------------------------
+
+/// Parse a TOML document, keeping the source order of every table's keys.
+///
+/// # Errors
+///
+/// Returns the parser's own message when the text is not valid TOML, or
+/// when an integer does not fit in `i64` (TOML integers are 64-bit
+/// signed, so a wider literal has no representable value to preserve).
+pub fn parse_ordered(text: &str) -> Result<TomlTable, String> {
+    let document = DeTable::parse(text).map_err(|err| err.to_string())?;
+    convert_table(document.get_ref())
+}
+
+fn convert_table(table: &DeTable<'_>) -> Result<TomlTable, String> {
+    // `DeTable` is a sorted map, so the entries arrive alphabetically.
+    // Their keys carry source spans, and the span start is exactly where
+    // the key was written — sorting on it restores document order without
+    // the `preserve_order` cargo feature.
+    let mut entries: Vec<_> = table.iter().collect();
+    entries.sort_by_key(|(key, _)| key.span().start);
+
+    let mut out = TomlTable::with_capacity(entries.len());
+    for (key, value) in entries {
+        out.insert(key.get_ref().to_string(), convert_value(value.get_ref())?);
+    }
+    Ok(out)
+}
+
+fn convert_value(value: &DeValue<'_>) -> Result<TomlValue, String> {
+    let converted = match value {
+        DeValue::String(text) => TomlValue::String(text.as_ref().to_string()),
+        DeValue::Integer(number) => {
+            let parsed = i64::from_str_radix(number.as_str(), number.radix())
+                .map_err(|err| format!("integer '{number}' is not representable: {err}"))?;
+            TomlValue::Integer(parsed)
+        }
+        DeValue::Float(number) => TomlValue::Float(
+            number
+                .as_str()
+                .parse()
+                .map_err(|err| format!("float '{number}' is not representable: {err}"))?,
+        ),
+        DeValue::Boolean(flag) => TomlValue::Boolean(*flag),
+        DeValue::Datetime(stamp) => TomlValue::Datetime(*stamp),
+        DeValue::Array(items) => TomlValue::Array(
+            items
+                .iter()
+                .map(|item| convert_value(item.get_ref()))
+                .collect::<Result<Vec<_>, _>>()?,
+        ),
+        DeValue::Table(table) => TomlValue::Table(convert_table(table)?),
+    };
+    Ok(converted)
+}
+
+// ---------------------------------------------------------------------------
+// Writing: `tomli_w`'s layout, reproduced
+// ---------------------------------------------------------------------------
+
+/// Render a whole document, `tomli_w`-compatible.
+///
+/// Reproduces `tomli_w.dumps(obj)` at its defaults (four-space indent,
+/// no multi-line strings). The output ends in a newline whenever the
+/// document is non-empty, because every line the writer emits carries
+/// one.
+pub fn render_document(table: &TomlTable) -> String {
+    let mut out = String::new();
+    render_table(table, "", false, &mut out);
+    out
+}
+
+/// True for a non-empty array whose every element is a table.
+///
+/// Only such an array is a candidate for `[[key]]` expansion. An empty
+/// array, or one with a single non-table element, stays a literal.
+fn is_array_of_tables(items: &[TomlValue]) -> bool {
+    !items.is_empty() && items.iter().all(|item| matches!(item, TomlValue::Table(_)))
+}
+
+/// The heuristic that decides between an inline table and a `[[key]]`
+/// block: the rendered line, indented and comma-terminated, must fit the
+/// column budget and hold no newline.
+///
+/// The budget counts characters, not bytes — a non-ASCII value must not
+/// flip the decision just because UTF-8 spends more bytes on it.
+fn is_suitable_inline_table(table: &TomlTable) -> bool {
+    let rendered = format!("{INDENT}{},", render_inline_table(table));
+    rendered.chars().count() <= MAX_LINE_LENGTH && !rendered.contains('\n')
+}
+
+fn render_table(table: &TomlTable, name: &str, inside_aot: bool, out: &mut String) {
+    let mut yielded = false;
+    let mut literals: Vec<(&String, &TomlValue)> = Vec::new();
+    // `(key, table, inside_aot)` — an array of tables contributes one
+    // entry per element, all under the same key.
+    let mut tables: Vec<(&String, &TomlTable, bool)> = Vec::new();
+
+    for (key, value) in table {
+        match value {
+            TomlValue::Table(nested) => tables.push((key, nested, false)),
+            TomlValue::Array(items)
+                if is_array_of_tables(items)
+                    && !items.iter().all(|item| {
+                        item.as_table().is_some_and(is_suitable_inline_table)
+                    }) =>
+            {
+                for item in items {
+                    if let TomlValue::Table(nested) = item {
+                        tables.push((key, nested, true));
+                    }
+                }
+            }
+            _ => literals.push((key, value)),
+        }
+    }
+
+    // A named table announces itself when it carries scalars of its own,
+    // or when it has no sub-tables to announce it instead. A table whose
+    // whole content is sub-tables emits no header — `[a.b]` alone, never
+    // an empty `[a]` above it.
+    if inside_aot || (!name.is_empty() && (!literals.is_empty() || tables.is_empty())) {
+        yielded = true;
+        if inside_aot {
+            let _ = writeln!(out, "[[{name}]]");
+        } else {
+            let _ = writeln!(out, "[{name}]");
+        }
+    }
+
+    if !literals.is_empty() {
+        yielded = true;
+        for (key, value) in literals {
+            let _ = writeln!(out, "{} = {}", render_key(key), render_literal(value, 0));
+        }
+    }
+
+    for (key, nested, in_aot) in tables {
+        if yielded {
+            out.push('\n');
+        } else {
+            yielded = true;
+        }
+        let key_part = render_key(key);
+        let display_name = if name.is_empty() {
+            key_part
+        } else {
+            format!("{name}.{key_part}")
+        };
+        render_table(nested, &display_name, in_aot, out);
+    }
+}
+
+fn render_literal(value: &TomlValue, nest_level: usize) -> String {
+    match value {
+        TomlValue::Boolean(flag) => (if *flag { "true" } else { "false" }).to_string(),
+        TomlValue::Integer(number) => number.to_string(),
+        TomlValue::Float(number) => render_float(*number),
+        TomlValue::Datetime(stamp) => stamp.to_string(),
+        TomlValue::String(text) => render_string(text),
+        TomlValue::Array(items) => render_inline_array(items, nest_level),
+        TomlValue::Table(table) => render_inline_table(table),
+    }
+}
+
+/// Arrays are always written across lines, one element per line with a
+/// trailing comma — `tomli_w` has no single-line array form.
+fn render_inline_array(items: &[TomlValue], nest_level: usize) -> String {
+    if items.is_empty() {
+        return "[]".to_string();
+    }
+    let item_indent = INDENT.repeat(1 + nest_level);
+    let closing_indent = INDENT.repeat(nest_level);
+    let rendered: Vec<String> = items
+        .iter()
+        // The nesting level advances for elements of an array…
+        .map(|item| format!("{item_indent}{}", render_literal(item, nest_level + 1)))
+        .collect();
+    format!("[\n{}\n{closing_indent}]", rendered.join(",\n") + ",")
+}
+
+fn render_inline_table(table: &TomlTable) -> String {
+    if table.is_empty() {
+        return "{}".to_string();
+    }
+    let pairs: Vec<String> = table
+        .iter()
+        // …but resets inside an inline table, which is what `tomli_w`'s
+        // default argument does. Reproduced, quirk included, because the
+        // indentation of an array nested in an inline table depends on it.
+        .map(|(key, value)| format!("{} = {}", render_key(key), render_literal(value, 0)))
+        .collect();
+    format!("{{ {} }}", pairs.join(", "))
+}
+
+/// A bare key where TOML allows one, a quoted key otherwise.
+fn render_key(key: &str) -> String {
+    let bare = !key.is_empty()
+        && key
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_');
+    if bare {
+        key.to_string()
+    } else {
+        render_string(key)
+    }
+}
+
+/// A float, always in a spelling TOML reads back as a float.
+///
+/// Rust prints `1.0` as `1`, which TOML would read back as an integer
+/// and quietly change the value's type on the next merge, so a bare
+/// integral form regains its `.0`.
+fn render_float(number: f64) -> String {
+    if number.is_nan() {
+        return "nan".to_string();
+    }
+    if number.is_infinite() {
+        return if number.is_sign_negative() { "-inf" } else { "inf" }.to_string();
+    }
+    let rendered = number.to_string();
+    if rendered.contains(['.', 'e', 'E']) {
+        rendered
+    } else {
+        format!("{rendered}.0")
+    }
+}
+
+/// A TOML basic string in `tomli_w`'s spelling.
+///
+/// Escapes quote and backslash, uses the compact forms for backspace,
+/// linefeed, form feed, and carriage return, and writes every other
+/// control character — DEL included — as a lowercase `\u00xx`. A tab is
+/// written raw: TOML permits it inside a basic string, and `tomli_w`
+/// takes that permission.
+fn render_string(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\u{8}' => out.push_str("\\b"),
+            '\n' => out.push_str("\\n"),
+            '\u{c}' => out.push_str("\\f"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push('\t'),
+            ch if ch.is_control() && (ch as u32) < 0x80 => {
+                let _ = write!(out, "\\u{:04x}", ch as u32);
+            }
+            ch => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// A TOML basic string in the *engine's* spelling, for the hand-rendered
+/// contract file.
+///
+/// Mirrors `toml_basic_string` in the engine's contract writer: tab,
+/// linefeed, and carriage return take their compact forms, and every
+/// other control character becomes an uppercase `\u00XX`. It differs
+/// from [`render_string`] on purpose — the contract is the engine's
+/// file, written the engine's way.
+pub fn basic_string(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            ch if (ch as u32) < 0x20 => {
+                let _ = write!(out, "\\u{:04X}", ch as u32);
+            }
+            ch => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn table(pairs: &[(&str, TomlValue)]) -> TomlTable {
+        pairs
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), value.clone()))
+            .collect()
+    }
+
+    // ----- reading -----
+
+    #[test]
+    fn document_order_survives_the_sorted_parser() {
+        let parsed = parse_ordered("zebra = 1\nalpha = 2\nmiddle = 3\n").expect("parses");
+        let keys: Vec<&str> = parsed.keys().map(String::as_str).collect();
+        // Alphabetical order would be alpha, middle, zebra — the span
+        // sort is what keeps the human's order.
+        assert_eq!(keys, ["zebra", "alpha", "middle"]);
+    }
+
+    #[test]
+    fn header_tables_order_after_the_scalars_that_precede_them() {
+        let parsed =
+            parse_ordered("name = \"m\"\nintent = \"i\"\n\n[[tests]]\ntype = \"expression\"\n")
+                .expect("parses");
+        let keys: Vec<&str> = parsed.keys().map(String::as_str).collect();
+        assert_eq!(keys, ["name", "intent", "tests"]);
+    }
+
+    #[test]
+    fn a_table_split_across_headers_keeps_its_first_position() {
+        let parsed = parse_ordered("[a.b]\nx = 1\n\n[zz]\ny = 2\n\n[a.c]\nz = 3\n").expect("parses");
+        let keys: Vec<&str> = parsed.keys().map(String::as_str).collect();
+        assert_eq!(keys, ["a", "zz"]);
+        let inner: Vec<&str> = parsed["a"]
+            .as_table()
+            .expect("table")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(inner, ["b", "c"]);
+    }
+
+    #[test]
+    fn every_scalar_kind_round_trips() {
+        let text = "i = 7\nf = 1.5\nb = true\ns = \"x\"\nd = 1979-05-27T07:32:00Z\na = [1, 2]\n";
+        let parsed = parse_ordered(text).expect("parses");
+        assert_eq!(parsed["i"], TomlValue::Integer(7));
+        assert_eq!(parsed["f"], TomlValue::Float(1.5));
+        assert_eq!(parsed["b"], TomlValue::Boolean(true));
+        assert_eq!(parsed["s"], TomlValue::string("x"));
+        assert!(matches!(parsed["d"], TomlValue::Datetime(_)));
+        assert_eq!(
+            parsed["a"],
+            TomlValue::Array(vec![TomlValue::Integer(1), TomlValue::Integer(2)])
+        );
+    }
+
+    #[test]
+    fn a_hex_integer_is_normalized_to_decimal() {
+        let parsed = parse_ordered("n = 0x1f\n").expect("parses");
+        assert_eq!(parsed["n"], TomlValue::Integer(31));
+    }
+
+    #[test]
+    fn an_integer_too_wide_for_toml_is_refused() {
+        let error = parse_ordered("n = 9223372036854775808\n").expect_err("out of range");
+        assert!(error.contains("not representable") || error.contains("range"), "{error}");
+    }
+
+    #[test]
+    fn invalid_toml_reports_the_parser_message() {
+        let error = parse_ordered("name = [broken").expect_err("bad");
+        assert!(error.contains("unclosed array"), "{error}");
+    }
+
+    // ----- writing -----
+
+    #[test]
+    fn arrays_always_render_across_lines() {
+        let document = table(&[(
+            "columns",
+            TomlValue::Array(vec![TomlValue::string("a"), TomlValue::string("b")]),
+        )]);
+        assert_eq!(
+            render_document(&document),
+            "columns = [\n    \"a\",\n    \"b\",\n]\n"
+        );
+    }
+
+    #[test]
+    fn an_empty_array_stays_on_one_line() {
+        let document = table(&[("x", TomlValue::Array(vec![]))]);
+        assert_eq!(render_document(&document), "x = []\n");
+    }
+
+    #[test]
+    fn a_short_array_of_tables_stays_inline() {
+        let document = table(&[(
+            "sources",
+            TomlValue::Array(vec![TomlValue::Table(table(&[
+                ("catalog", TomlValue::string("poc")),
+                ("table", TomlValue::string("t")),
+            ]))]),
+        )]);
+        assert_eq!(
+            render_document(&document),
+            "sources = [\n    { catalog = \"poc\", table = \"t\" },\n]\n"
+        );
+    }
+
+    #[test]
+    fn an_over_long_array_of_tables_expands_into_blocks() {
+        let long = "x".repeat(90);
+        let document = table(&[(
+            "sources",
+            TomlValue::Array(vec![TomlValue::Table(table(&[(
+                "catalog",
+                TomlValue::string(long),
+            )]))]),
+        )]);
+        assert!(
+            render_document(&document).starts_with("[[sources]]\n"),
+            "a line past the budget must expand"
+        );
+    }
+
+    #[test]
+    fn the_column_budget_counts_characters_not_bytes() {
+        // 80 three-byte characters: 240 bytes, well past the budget when
+        // measured wrongly, but only ~93 columns when measured right.
+        let wide = "→".repeat(80);
+        let document = table(&[(
+            "sources",
+            TomlValue::Array(vec![TomlValue::Table(table(&[(
+                "c",
+                TomlValue::string(wide),
+            )]))]),
+        )]);
+        assert!(
+            render_document(&document).starts_with("sources = ["),
+            "a wide but short line must stay inline"
+        );
+    }
+
+    #[test]
+    fn an_array_of_tables_holding_an_array_always_expands() {
+        // The nested array renders across lines, so the inline form holds
+        // a newline and is refused however short it is.
+        let document = table(&[(
+            "tests",
+            TomlValue::Array(vec![TomlValue::Table(table(&[(
+                "columns",
+                TomlValue::Array(vec![TomlValue::string("a")]),
+            )]))]),
+        )]);
+        assert_eq!(
+            render_document(&document),
+            "[[tests]]\ncolumns = [\n    \"a\",\n]\n"
+        );
+    }
+
+    #[test]
+    fn a_mixed_array_is_a_literal_not_a_block() {
+        let document = table(&[(
+            "mixed",
+            TomlValue::Array(vec![
+                TomlValue::Table(table(&[("a", TomlValue::Integer(1))])),
+                TomlValue::Integer(2),
+            ]),
+        )]);
+        assert_eq!(
+            render_document(&document),
+            "mixed = [\n    { a = 1 },\n    2,\n]\n"
+        );
+    }
+
+    #[test]
+    fn a_table_of_only_tables_emits_no_header_of_its_own() {
+        let document = table(&[(
+            "a",
+            TomlValue::Table(table(&[(
+                "b",
+                TomlValue::Table(table(&[("c", TomlValue::Integer(1))])),
+            )])),
+        )]);
+        assert_eq!(render_document(&document), "[a.b]\nc = 1\n");
+    }
+
+    #[test]
+    fn scalars_precede_sub_tables_with_a_blank_line_between() {
+        let document = table(&[
+            ("name", TomlValue::string("m")),
+            ("tags", TomlValue::Table(table(&[("x", TomlValue::Integer(1))]))),
+        ]);
+        assert_eq!(render_document(&document), "name = \"m\"\n\n[tags]\nx = 1\n");
+    }
+
+    #[test]
+    fn a_key_needing_quotes_gets_them() {
+        let document = table(&[("has space", TomlValue::Integer(1))]);
+        assert_eq!(render_document(&document), "\"has space\" = 1\n");
+    }
+
+    #[test]
+    fn floats_keep_a_shape_toml_reads_back_as_a_float() {
+        assert_eq!(render_float(1.0), "1.0");
+        assert_eq!(render_float(-0.0), "-0.0");
+        assert_eq!(render_float(1.5), "1.5");
+        assert_eq!(render_float(f64::INFINITY), "inf");
+        assert_eq!(render_float(f64::NEG_INFINITY), "-inf");
+        assert_eq!(render_float(f64::NAN), "nan");
+    }
+
+    #[test]
+    fn an_integral_float_survives_a_render_parse_round_trip_as_a_float() {
+        let document = table(&[("f", TomlValue::Float(1.0))]);
+        let reparsed = parse_ordered(&render_document(&document)).expect("parses");
+        assert_eq!(reparsed["f"], TomlValue::Float(1.0));
+    }
+
+    // ----- the two escapers, which disagree on purpose -----
+
+    #[test]
+    fn the_writer_escaper_matches_tomli_w() {
+        assert_eq!(render_string("a\"b\\c"), "\"a\\\"b\\\\c\"");
+        assert_eq!(render_string("a\nb\rc\u{8}d\u{c}e"), "\"a\\nb\\rc\\bd\\fe\"");
+        // A tab is legal raw inside a basic string, and is left raw.
+        assert_eq!(render_string("a\tb"), "\"a\tb\"");
+        // Lowercase hex, and DEL is escaped.
+        assert_eq!(render_string("\u{1}\u{7f}"), "\"\\u0001\\u007f\"");
+    }
+
+    #[test]
+    fn the_contract_escaper_matches_the_engine() {
+        assert_eq!(basic_string("a\"b\\c"), "\"a\\\"b\\\\c\"");
+        // Tab takes its compact form here, unlike the writer's.
+        assert_eq!(basic_string("a\tb"), "\"a\\tb\"");
+        // Uppercase hex, and DEL is left alone.
+        assert_eq!(basic_string("\u{1}\u{7f}"), "\"\\u0001\u{7f}\"");
+    }
+}


### PR DESCRIPTION
First half of moving the fulfillment work into the engine: the pure, deterministic core of `rocky product`. No CLI verbs, no state-store tables, no filesystem commit protocol — those are part 2. Nothing is wired to a command yet, so this adds capability without changing any existing behaviour.

**What lands** (all under `rocky-core/src/product/`):

- `spec.rs` — parses `products/<name>.toml` against a closed schema. An unknown key, an unlowerable field, or an out-of-vocabulary type is refused, never shimmed. Identity is `sha256:<hex>` over the file's raw bytes, so a comment edit changes the identity on purpose.
- `toml_compat.rs` — an order-preserving reader and a byte-stable writer.
- `lowering.rs` — the two phases: the contract render, and the sidecar metadata merge that preserves keys it does not own.
- `manifest.rs` — every spec field accounted for, with the coverage derived from the schema so a newly added nested field breaks the check.

**How it is checked.** A frozen Python prototype is the specification. `PARITY.md` maps all 115 of its collected tests: 87 ported, 28 belonging to part 2's filesystem half, 0 dropped. The four golden files are byte-identical to the prototype's, and every guard was verified by breaking it on purpose and watching a named test fail.

Refusal codes come from this module's own walk over the document, never from a serde error string — error text is not a stable contract, and a gate's meaning must not change under a dependency bump.

**Three defects were found and fixed during review of this branch**, all in the new code: a manifest artifact key could name a file outside the project (`Path::join` discards the root when handed an absolute path); a schema-walk helper returned "no fields" for an unresolvable model, so the totality check could pass while covering nothing; and a redundant guard that no test could kill was removed rather than left as decoration.

`PARITY.md` records five honest divergences from the prototype. The one that matters: the byte-stable writer is new code with no counterpart — the prototype delegated to a library. Four goldens match and the layout rules are pinned case by case, but a layout case no golden exercises could still differ. The containment is that only two file shapes are ever emitted; any new shape needs a fresh cross-check first.

Gates: 1924 rocky-core tests pass (112 new), clippy `--all-targets -D warnings` clean, fmt clean.