### PR TITLE
fix(engine/rocky-cli): race every watch iteration against the signal arms

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run_watch.rs
+++ b/engine/crates/rocky-cli/src/commands/run_watch.rs
@@ -211,28 +211,72 @@ pub async fn run_watch(
         tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).ok();
 
     // First run is immediate so the user gets feedback without having to
-    // touch a file. A Ctrl-C during it stops the watcher: the signal was the
-    // user's, and the inner run consumed it (#1405).
-    if iter_once(
-        config_path,
-        filter,
-        pipeline_name_arg,
-        state_path,
-        governance_override,
-        output_json,
-        models_dir,
-        run_all,
-        shadow_config,
-        partition_opts,
-        cache_ttl_override,
-        env,
-        skip_opts,
-    )
-    .await
-    .interrupted
+    // touch a file.
+    //
+    // The run is RACED against the signal arms rather than plainly awaited.
+    // With the streams registered above, a signal arriving mid-run is only
+    // latched — nothing polls the streams while `iter_once` is in flight —
+    // and the replication path's own graceful arms (`run.rs`) exist only
+    // after its setup, while the transformation path has none at all. An
+    // un-raced await would therefore defer shutdown to the end of the
+    // iteration and make a stalled run unkillable by SIGTERM, where the
+    // pre-registration code died instantly on the default disposition.
+    // Racing restores prompt shutdown: the outer arm fires, the iteration
+    // future is dropped, and the process exits. Dropping mid-run is
+    // crash-parity — the state store's commit protocol and `InProgress`
+    // breadcrumbs are designed for exactly that — and is strictly cleaner
+    // than the old mid-run default-disposition kill.
     {
-        eprintln!("\n[watch] stopped");
-        return Ok(());
+        let first_run = iter_once(
+            config_path,
+            filter,
+            pipeline_name_arg,
+            state_path,
+            governance_override,
+            output_json,
+            models_dir,
+            run_all,
+            shadow_config,
+            partition_opts,
+            cache_ttl_override,
+            env,
+            skip_opts,
+        );
+        tokio::pin!(first_run);
+        let interrupted = tokio::select! {
+            outcome = &mut first_run => outcome.interrupted,
+            _ = &mut ctrl_c_signal => true,
+            Some(()) = async {
+                #[cfg(unix)]
+                {
+                    match sigint_stream.as_mut() {
+                        Some(stream) => stream.recv().await,
+                        None => std::future::pending().await,
+                    }
+                }
+                #[cfg(not(unix))]
+                {
+                    std::future::pending().await
+                }
+            } => true,
+            Some(()) = async {
+                #[cfg(unix)]
+                {
+                    match sigterm_stream.as_mut() {
+                        Some(stream) => stream.recv().await,
+                        None => std::future::pending().await,
+                    }
+                }
+                #[cfg(not(unix))]
+                {
+                    std::future::pending().await
+                }
+            } => true,
+        };
+        if interrupted {
+            eprintln!("\n[watch] stopped");
+            return Ok(());
+        }
     }
 
     // Steady-state loop: wait for an event, debounce, drain, re-run.
@@ -297,7 +341,13 @@ pub async fn run_watch(
                     .unwrap_or_default();
                 eprintln!("[watch] detected change: {display}");
 
-                if iter_once(
+                // Same race as the first run, for the same reason: a signal
+                // during the debounce sleep or the re-run is only latched by
+                // the streams above, and an un-raced await would defer
+                // shutdown to the end of the iteration (or forever, for a
+                // stalled one). A signal latched during the debounce fires
+                // here immediately, before the re-run starts.
+                let rerun = iter_once(
                     config_path,
                     filter,
                     pipeline_name_arg,
@@ -311,10 +361,39 @@ pub async fn run_watch(
                     cache_ttl_override,
                     env,
                     skip_opts,
-                )
-                .await
-                .interrupted
-                {
+                );
+                tokio::pin!(rerun);
+                let interrupted = tokio::select! {
+                    outcome = &mut rerun => outcome.interrupted,
+                    _ = &mut ctrl_c_signal => true,
+                    Some(()) = async {
+                        #[cfg(unix)]
+                        {
+                            match sigint_stream.as_mut() {
+                                Some(stream) => stream.recv().await,
+                                None => std::future::pending().await,
+                            }
+                        }
+                        #[cfg(not(unix))]
+                        {
+                            std::future::pending().await
+                        }
+                    } => true,
+                    Some(()) = async {
+                        #[cfg(unix)]
+                        {
+                            match sigterm_stream.as_mut() {
+                                Some(stream) => stream.recv().await,
+                                None => std::future::pending().await,
+                            }
+                        }
+                        #[cfg(not(unix))]
+                        {
+                            std::future::pending().await
+                        }
+                    } => true,
+                };
+                if interrupted {
                     eprintln!("\n[watch] stopped");
                     return Ok(());
                 }


### PR DESCRIPTION
## Summary

Follow-up to #1497. That PR shipped the swallow-window fix (register the watch
signal streams before the first run). The red team on it — Codex, confirmed by an
independent gpt-5.6-terra pass — found a real gap the merge did not include:
registration alone is not enough, because nothing **polls** the streams while an
iteration is in flight.

## The gap on main today

With #1497, a signal arriving **during** a watch run is latched but only acted on
when the run ends. The transformation path has no inner signal listener at all
(`dag_executor.rs` / `unified_dag.rs` have none; the graceful arms at `run.rs`
belong to the replication fan-out). So a stalled iteration is unkillable by
SIGTERM — where the pre-#1497 code died instantly on the default disposition.
The same deferral has applied to every in-loop re-run since #1490.

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)

## The fix

Race every iteration — the first run and each in-loop re-run — in a `select!`
against the ctrl-c future and the sigint/sigterm streams. A signal at any moment
stops the watcher promptly; one latched during the debounce fires before the
re-run starts.

Dropping the in-flight iteration is crash-parity: the state store's commit
protocol and `InProgress` breadcrumbs are designed for exactly that, and it is
strictly cleaner than the old mid-run default-disposition kill. Trade, stated
plainly: in watch mode the replication path's graceful mid-run drain is
superseded by prompt stop; plain `rocky run` keeps its graceful drain unchanged.

## Evidence

- Exhibit of the exact blocker scenario: with `iter_once` stalled 600s at entry,
  SIGTERM after the banner exits **0** in **0.024s** printing `[watch] stopped`.
  Without the race, the same signal waits out the stall.
- All three `run_watch` integration tests green 4 consecutive rounds locally.
- `cargo +1.98.0 clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt --check`: clean.

## Behavioral boundary

Watch-mode signal handling only. No planning, SQL, IR, or JSON output change.

## Standing questions

**What am I least confident about?** Whether dropping a replication iteration
mid-copy on a real warehouse leaves anything the next run does not heal. The
design says crash-parity covers it (resume, watermarks not advanced, InProgress
breadcrumbs); I have exercised that reasoning, not a live mid-drop on every
adapter.

**What's the most important thing I may be missing?** A caller that depended on
watch-mode's graceful drain semantics (finish in-flight work on Ctrl-C). No
in-repo caller does — watch is a dev loop — but the trade is called out here so
it is a decision, not an accident.

Red team: Codex + gpt-5.6-terra (BLOCK on #1497's v1; this PR is the agreed fix
for both findings — the first-run deferral it introduced and the pre-existing
re-run deferral).
