### PR TITLE
fix(engine): report the fulfill verify bundle's unevaluated data checks as deferred (#1495)

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3887,6 +3887,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "toml",
  "tracing",
 ]
 

--- a/engine/crates/rocky-cli/src/commands/fulfill_api.rs
+++ b/engine/crates/rocky-cli/src/commands/fulfill_api.rs
@@ -34,6 +34,12 @@ pub use crate::commands::review::{compute_review_status, run_review_status};
 pub use crate::commands::run::RunTermination;
 #[cfg(feature = "duckdb")]
 pub use crate::commands::test::test_output;
+// How many declarative tests the runner WOULD execute for a model. The
+// loop reports these as deferred at `verifying`, where the target is not
+// materialised yet and none of them can run. Shares the declarative
+// runner's own loader so the counted set is the executed set.
+#[cfg(feature = "duckdb")]
+pub use crate::commands::test::declarative_test_count;
 // The loop's stop report (registered in export-schemas as `fulfill`),
 // and the one JSON printer, so the loop's whole rocky-cli surface stays
 // this module.

--- a/engine/crates/rocky-cli/src/commands/test.rs
+++ b/engine/crates/rocky-cli/src/commands/test.rs
@@ -207,6 +207,34 @@ fn load_all_models(models_dir: &Path) -> Result<Vec<rocky_core::models::Model>> 
     Ok(all)
 }
 
+/// How many declarative tests [`run_declarative_tests`] would execute for
+/// `model` — the number a caller may report as deferred when the target is
+/// not materialised yet.
+///
+/// Counts the model loader's EXPANDED `ModelConfig.tests` vector, which is
+/// the exact vector the runner iterates. That matters: the loader appends
+/// every `[[use_test]]` reference to `tests` after resolving it against
+/// `test_definitions.toml`, and the runner cannot tell an expanded
+/// reference from an inline test. Counting the sidecar's raw `[[tests]]`
+/// array instead would undercount by exactly the `[[use_test]]`
+/// references — and the sidecar merge preserves those, because the product
+/// lowering owns only `tests`.
+///
+/// Goes through [`load_all_models`], the same loader the runner uses, so
+/// the counted set is the executed set by construction rather than by a
+/// re-derivation that has to be kept in step by hand.
+///
+/// An unknown model is an error, never a zero: a caller must be able to
+/// tell "no checks" from "no answer".
+pub fn declarative_test_count(models_dir: &Path, model: &str) -> Result<usize> {
+    let all_models = load_all_models(models_dir)?;
+    let found = all_models
+        .iter()
+        .find(|loaded| loaded.config.name == model)
+        .ok_or_else(|| anyhow::Error::new(ModelNotFound(model.to_string())))?;
+    Ok(found.config.tests.len())
+}
+
 /// Model names, for [`reject_unknown_model`] — which takes `&[String]` so it
 /// can serve both the declarative path (loaded `Model`s) and the compiled
 /// path (`TestResult::all_models`).
@@ -556,7 +584,63 @@ fn test_type_label(tt: &TestType) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::load_all_models;
+    use super::{declarative_test_count, load_all_models};
+
+    /// Write a one-model project whose sidecar carries `sidecar_extra`,
+    /// plus a named-test registry. Returns the models dir.
+    fn project(sidecar_extra: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let models = tmp.path().join("models");
+        std::fs::create_dir(&models).expect("create models dir");
+        std::fs::write(
+            models.join("test_definitions.toml"),
+            "[positive]\ntype = \"expression\"\nexpression = \"amount > 0\"\n",
+        )
+        .expect("write test definitions");
+        std::fs::write(models.join("orders.sql"), "SELECT 1 AS id").expect("write model sql");
+        std::fs::write(
+            models.join("orders.toml"),
+            format!(
+                "name = \"orders\"\n\n[strategy]\ntype = \"full_refresh\"\n\n\
+                 [target]\ncatalog = \"c\"\nschema = \"s\"\ntable = \"orders\"\n\n\
+                 [[tests]]\ntype = \"not_null\"\ncolumn = \"id\"\n{sidecar_extra}"
+            ),
+        )
+        .expect("write model sidecar");
+        (tmp, models)
+    }
+
+    #[test]
+    fn declarative_test_count_includes_expanded_use_test_references() {
+        // #1495: the model loader resolves every `[[use_test]]` against
+        // `test_definitions.toml` and APPENDS it to `ModelConfig.tests`,
+        // which is the vector `run_declarative_tests` iterates. Counting
+        // the sidecar's raw `[[tests]]` array would report 1 here and
+        // silently drop the reference — an undercount, and the third
+        // one found in this area. Counting through the runner's own
+        // loader makes the counted set the executed set.
+        let (_tmp, models) = project("\n[[use_test]]\nname = \"positive\"\n");
+        assert_eq!(
+            declarative_test_count(&models, "orders").expect("count"),
+            2,
+            "the expanded [[use_test]] reference must be counted alongside the inline test"
+        );
+        // The loader agrees with the counter, by construction.
+        let loaded = load_all_models(&models).expect("load models");
+        assert_eq!(loaded[0].config.tests.len(), 2);
+    }
+
+    #[test]
+    fn declarative_test_count_refuses_an_unknown_model_rather_than_returning_zero() {
+        // A caller must be able to tell "no checks" from "no answer".
+        let (_tmp, models) = project("");
+        assert_eq!(declarative_test_count(&models, "orders").expect("count"), 1);
+        let err = declarative_test_count(&models, "nope").expect_err("unknown model");
+        assert!(
+            err.to_string().contains("nope"),
+            "the refusal must name the model: {err}"
+        );
+    }
 
     #[test]
     fn declarative_loader_includes_tests_from_rocky_models() {

--- a/engine/crates/rocky-fulfill/src/inventory.rs
+++ b/engine/crates/rocky-fulfill/src/inventory.rs
@@ -42,6 +42,11 @@ const CONSUMED_ENGINE_PATHS: &[&str] = &[
     "rocky_cli::commands::fulfill_api::apply_plan",
     "rocky_cli::commands::fulfill_api::compile_output",
     "rocky_cli::commands::fulfill_api::compute_review_status",
+    // Asks the DECLARATIVE runner's own loader how many checks it would
+    // execute, so the deferred count the verify bundle reports is the
+    // executed set by construction (it includes `[[use_test]]`
+    // expansion, which reading the sidecar's raw array misses).
+    "rocky_cli::commands::fulfill_api::declarative_test_count",
     "rocky_cli::commands::fulfill_api::lookup_apply_receipt",
     "rocky_cli::commands::fulfill_api::observe_max_time_column",
     "rocky_cli::commands::fulfill_api::print_json",
@@ -67,14 +72,6 @@ const CONSUMED_ENGINE_PATHS: &[&str] = &[
     // Spec identity + the confined write target (the runner's candidate
     // write and the snapshot re-verification).
     "rocky_core::product::commit::contained_write_target",
-    // Counting the declared data checks the verify bundle defers.
-    // `sidecar_rel` is the SAME path derivation `run_phase_b` writes
-    // through, and `parse_ordered` is the same reader the merge uses,
-    // so the count cannot drift from the merged artifact that `rocky
-    // test --declarative` would actually run. Read-only: the loop
-    // never writes a sidecar.
-    "rocky_core::product::lowering::sidecar_rel",
-    "rocky_core::product::toml_compat::parse_ordered",
     "rocky_core::product::spec::ParsedSpec",
     "rocky_core::product::spec::parse_spec_bytes",
     "rocky_core::product::spec::spec_digest",

--- a/engine/crates/rocky-fulfill/src/inventory.rs
+++ b/engine/crates/rocky-fulfill/src/inventory.rs
@@ -67,11 +67,14 @@ const CONSUMED_ENGINE_PATHS: &[&str] = &[
     // Spec identity + the confined write target (the runner's candidate
     // write and the snapshot re-verification).
     "rocky_core::product::commit::contained_write_target",
-    // The spec-owned `[[tests]]` lowering. Read-only, and the SAME
-    // function the sidecar merge emits from — so the verify bundle's
-    // deferred-checks count cannot drift from what was actually
-    // lowered. Counting only; the loop never writes a sidecar.
-    "rocky_core::product::lowering::generated_tests",
+    // Counting the declared data checks the verify bundle defers.
+    // `sidecar_rel` is the SAME path derivation `run_phase_b` writes
+    // through, and `parse_ordered` is the same reader the merge uses,
+    // so the count cannot drift from the merged artifact that `rocky
+    // test --declarative` would actually run. Read-only: the loop
+    // never writes a sidecar.
+    "rocky_core::product::lowering::sidecar_rel",
+    "rocky_core::product::toml_compat::parse_ordered",
     "rocky_core::product::spec::ParsedSpec",
     "rocky_core::product::spec::parse_spec_bytes",
     "rocky_core::product::spec::spec_digest",

--- a/engine/crates/rocky-fulfill/src/inventory.rs
+++ b/engine/crates/rocky-fulfill/src/inventory.rs
@@ -67,6 +67,11 @@ const CONSUMED_ENGINE_PATHS: &[&str] = &[
     // Spec identity + the confined write target (the runner's candidate
     // write and the snapshot re-verification).
     "rocky_core::product::commit::contained_write_target",
+    // The spec-owned `[[tests]]` lowering. Read-only, and the SAME
+    // function the sidecar merge emits from — so the verify bundle's
+    // deferred-checks count cannot drift from what was actually
+    // lowered. Counting only; the loop never writes a sidecar.
+    "rocky_core::product::lowering::generated_tests",
     "rocky_core::product::spec::ParsedSpec",
     "rocky_core::product::spec::parse_spec_bytes",
     "rocky_core::product::spec::spec_digest",

--- a/engine/crates/rocky-fulfill/src/machine.rs
+++ b/engine/crates/rocky-fulfill/src/machine.rs
@@ -382,13 +382,22 @@ pub enum Event {
     VerifyBundle {
         /// `compile_output` had no errors.
         compile_green: bool,
-        /// `test_output` had no failures.
+        /// The model executed and its unit tests passed. This does NOT
+        /// cover the product's declared data checks — see
+        /// `tests_deferred`.
         test_green: bool,
         /// `product verify` still passes (policy-check agreement).
         posture_green: bool,
         /// The committed manifest is total and byte-clean.
         manifest_total: bool,
-        /// Rendered detail for the red path.
+        /// How many of the product's declared data checks were NOT
+        /// evaluated. They run against a materialised table, and verify
+        /// runs before apply, so at this point none of them can run.
+        /// Reported, never gated: deferred is not a failure, so this
+        /// field is deliberately absent from the green pattern below.
+        tests_deferred: usize,
+        /// Rendered detail. Carries the deferred-checks note on every
+        /// path, plus the red legs' reasons when there are any.
         detail: String,
     },
     /// The governed propose ran.
@@ -1015,13 +1024,24 @@ pub fn decide(observed: &FulfillStateRecord, event: Event, now: DateTime<Utc>) -
         // ------------------------------------------------------------------
         FulfillState::Verifying => match event {
             Event::Reentry => Decision::Act(TaskKind::VerifyBundle),
+            // `tests_deferred` is deliberately NOT in this pattern:
+            // deferred checks are reported, never gated, so any count
+            // still proposes. The green verdict is journaled first —
+            // without this row the bundle would leave no trace at all,
+            // and "verify green" would be a claim with no record of
+            // what green did and did not cover.
             Event::VerifyBundle {
                 compile_green: true,
                 test_green: true,
                 posture_green: true,
                 manifest_total: true,
+                detail,
                 ..
-            } => Decision::Act(TaskKind::Propose),
+            } => Decision::AdvanceAndAct {
+                record: to_state(observed, FulfillState::Verifying, now),
+                event: verify_green_event(&detail),
+                task: TaskKind::Propose,
+            },
             Event::VerifyBundle { detail, .. } => {
                 if observed.repair_rounds >= MAX_REPAIR_ROUNDS {
                     let record = blocked(
@@ -1622,6 +1642,45 @@ fn dispatch_drafting(
         record: next,
         event: format!("drafting attempt {}", observed.drafting_attempts + 1),
         task,
+    }
+}
+
+/// The ONE wording for unevaluated declared data checks.
+///
+/// The verify bundle runs before apply, so the target table does not
+/// exist yet and the product's declared checks (the grain-uniqueness
+/// test, one not-null test per non-nullable column, and one expression
+/// test per declared check) cannot run. Saying "deferred" keeps the
+/// claim true: they did not pass and they did not fail.
+///
+/// `None` when nothing is deferred, so a caller never renders an empty
+/// or zero-valued clause.
+pub fn deferred_note(tests_deferred: usize) -> Option<String> {
+    if tests_deferred == 0 {
+        return None;
+    }
+    let checks = if tests_deferred == 1 {
+        "check"
+    } else {
+        "checks"
+    };
+    Some(format!(
+        "{tests_deferred} declared data {checks} deferred \
+         (not evaluable before the model is materialized)"
+    ))
+}
+
+/// The journal event for an all-green verify bundle.
+///
+/// `detail` is the bundle's own rendering; on the green path it is the
+/// deferred-checks note (every red leg is what pushes anything else).
+/// Carrying it verbatim is what stops "verify green" from being a bare
+/// claim in the journal.
+fn verify_green_event(detail: &str) -> String {
+    if detail.is_empty() {
+        "verify green".to_string()
+    } else {
+        format!("verify green: {detail}")
     }
 }
 
@@ -2483,14 +2542,21 @@ mod tests {
     // red ≤ repair rounds → drafting; else blocked
     // =====================================================================
 
-    fn green_bundle() -> Event {
+    /// An all-green bundle reporting `tests_deferred` unevaluated
+    /// declared data checks, rendered exactly as `verify_bundle` does.
+    fn green_bundle_with(tests_deferred: usize) -> Event {
         Event::VerifyBundle {
             compile_green: true,
             test_green: true,
             posture_green: true,
             manifest_total: true,
-            detail: String::new(),
+            tests_deferred,
+            detail: deferred_note(tests_deferred).unwrap_or_default(),
         }
+    }
+
+    fn green_bundle() -> Event {
+        green_bundle_with(0)
     }
 
     #[test]
@@ -2498,7 +2564,93 @@ mod tests {
         let d = decide(&rec(FulfillState::Verifying), Event::Reentry, now());
         assert_eq!(d, Decision::Act(TaskKind::VerifyBundle));
         let d = decide(&rec(FulfillState::Verifying), green_bundle(), now());
-        assert_eq!(d, Decision::Act(TaskKind::Propose));
+        let Decision::AdvanceAndAct {
+            record,
+            task,
+            event,
+        } = d
+        else {
+            panic!("expected AdvanceAndAct (the green verdict is journaled), got {d:?}");
+        };
+        assert_eq!(record.state, FulfillState::Verifying);
+        assert_eq!(task, TaskKind::Propose);
+        assert_eq!(event, "verify green");
+    }
+
+    #[test]
+    fn deferred_declared_checks_are_journaled_and_never_block_the_propose() {
+        // The anti-vacuity pin for #1495. A product whose declared check
+        // WOULD fail (say `revenue_eur >= 0` against negative rows) still
+        // verifies green, because that check runs against a materialised
+        // table and this gate runs before apply. Gating is deliberately
+        // unchanged — the loop still proposes — but the journal now
+        // records what green did NOT cover, with the exact count.
+        let d = decide(&rec(FulfillState::Verifying), green_bundle_with(6), now());
+        let Decision::AdvanceAndAct {
+            record,
+            task,
+            event,
+        } = d
+        else {
+            panic!("deferred checks must not change the decision, got {d:?}");
+        };
+        assert_eq!(task, TaskKind::Propose, "deferred is not a failure");
+        assert_eq!(record.state, FulfillState::Verifying);
+        assert_eq!(
+            event,
+            "verify green: 6 declared data checks deferred \
+             (not evaluable before the model is materialized)"
+        );
+        assert!(
+            !event.contains("passed"),
+            "a deferred check must never read as passed: {event}"
+        );
+    }
+
+    #[test]
+    fn the_deferred_note_states_the_exact_count_and_vanishes_at_zero() {
+        // No false alarm: nothing deferred renders no clause at all, and
+        // the bare green event stays bare. (A real product spec always
+        // lowers at least its grain test, so zero is unreachable through
+        // `verify_bundle`; the helper still has to be honest at zero.)
+        assert_eq!(deferred_note(0), None);
+        assert_eq!(verify_green_event(""), "verify green");
+        // The count is stated exactly, and reads as English at one.
+        assert_eq!(
+            deferred_note(1).expect("one is deferred"),
+            "1 declared data check deferred \
+             (not evaluable before the model is materialized)"
+        );
+        assert_eq!(
+            deferred_note(6).expect("six are deferred"),
+            "6 declared data checks deferred \
+             (not evaluable before the model is materialized)"
+        );
+    }
+
+    #[test]
+    fn a_model_that_fails_to_execute_is_still_red_even_with_checks_deferred() {
+        // The gate this fix must NOT relax: a model that fails to run is
+        // red, deferred count or not.
+        let mut prior = rec(FulfillState::Verifying);
+        prior.repair_rounds = 1;
+        let d = decide(
+            &prior,
+            Event::VerifyBundle {
+                compile_green: true,
+                test_green: false,
+                posture_green: true,
+                manifest_total: true,
+                tests_deferred: 6,
+                detail: "test failures: revenue_daily: binder error".into(),
+            },
+            now(),
+        );
+        let Decision::AdvanceAndAct { record, task, .. } = d else {
+            panic!("a failing model must still dispatch a repair, got {d:?}");
+        };
+        assert_eq!(task, TaskKind::Repair, "an execution failure is still red");
+        assert_eq!(record.state, FulfillState::Drafting);
     }
 
     #[test]
@@ -2513,6 +2665,7 @@ mod tests {
                 test_green: true,
                 posture_green: true,
                 manifest_total: true,
+                tests_deferred: 6,
                 detail: "E012 on revenue_eur".into(),
             },
             now(),
@@ -2543,6 +2696,7 @@ mod tests {
                 test_green: false,
                 posture_green: true,
                 manifest_total: true,
+                tests_deferred: 6,
                 detail: "unique(client_id,date) failed".into(),
             },
             now(),

--- a/engine/crates/rocky-fulfill/src/machine.rs
+++ b/engine/crates/rocky-fulfill/src/machine.rs
@@ -2649,7 +2649,10 @@ mod tests {
         let note = uncounted_deferred_note("models/revenue_daily.toml does not parse: bad line 3");
         assert!(note.starts_with("declared data checks deferred"));
         assert!(note.contains("count unavailable: models/revenue_daily.toml does not parse"));
-        assert!(!note.contains(" 0 "), "an unknown count must not render as zero: {note}");
+        assert!(
+            !note.contains(" 0 "),
+            "an unknown count must not render as zero: {note}"
+        );
         let d = decide(
             &rec(FulfillState::Verifying),
             Event::VerifyBundle {
@@ -2665,7 +2668,11 @@ mod tests {
         let Decision::AdvanceAndAct { task, event, .. } = d else {
             panic!("an uncountable sidecar must not change the decision, got {d:?}");
         };
-        assert_eq!(task, TaskKind::Propose, "not knowing is still not a failure");
+        assert_eq!(
+            task,
+            TaskKind::Propose,
+            "not knowing is still not a failure"
+        );
         assert_eq!(event, format!("verify green: {note}"));
     }
 

--- a/engine/crates/rocky-fulfill/src/machine.rs
+++ b/engine/crates/rocky-fulfill/src/machine.rs
@@ -393,14 +393,19 @@ pub enum Event {
         /// How many of the product's declared data checks were NOT
         /// evaluated. They run against a materialised table, and verify
         /// runs before apply, so at this point none of them can run.
-        /// `None` when the count could not be read at all — distinct
-        /// from `Some(0)`, which claims there are none.
+        ///
+        /// `None` when this bundle carries no count of its own —
+        /// either the sidecar could not be read, or the bundle is the
+        /// synthesized propose-failure one, whose pass already
+        /// journaled the authoritative count. Distinct from `Some(0)`,
+        /// which positively claims there are none.
         ///
         /// Reported, never gated: deferred is not a failure, so this
         /// field is deliberately absent from the green pattern below.
         tests_deferred: Option<usize>,
-        /// Rendered detail. Carries the deferred-checks note on every
-        /// path, plus the red legs' reasons when there are any.
+        /// Rendered detail. Carries the deferred-checks note on the
+        /// paths that counted, plus the red legs' reasons when there
+        /// are any.
         detail: String,
     },
     /// The governed propose ran.

--- a/engine/crates/rocky-fulfill/src/machine.rs
+++ b/engine/crates/rocky-fulfill/src/machine.rs
@@ -393,9 +393,12 @@ pub enum Event {
         /// How many of the product's declared data checks were NOT
         /// evaluated. They run against a materialised table, and verify
         /// runs before apply, so at this point none of them can run.
+        /// `None` when the count could not be read at all — distinct
+        /// from `Some(0)`, which claims there are none.
+        ///
         /// Reported, never gated: deferred is not a failure, so this
         /// field is deliberately absent from the green pattern below.
-        tests_deferred: usize,
+        tests_deferred: Option<usize>,
         /// Rendered detail. Carries the deferred-checks note on every
         /// path, plus the red legs' reasons when there are any.
         detail: String,
@@ -1648,10 +1651,9 @@ fn dispatch_drafting(
 /// The ONE wording for unevaluated declared data checks.
 ///
 /// The verify bundle runs before apply, so the target table does not
-/// exist yet and the product's declared checks (the grain-uniqueness
-/// test, one not-null test per non-nullable column, and one expression
-/// test per declared check) cannot run. Saying "deferred" keeps the
-/// claim true: they did not pass and they did not fail.
+/// exist yet and the model sidecar's declared checks cannot run.
+/// Saying "deferred" keeps the claim true: they did not pass and they
+/// did not fail.
 ///
 /// `None` when nothing is deferred, so a caller never renders an empty
 /// or zero-valued clause.
@@ -1668,6 +1670,17 @@ pub fn deferred_note(tests_deferred: usize) -> Option<String> {
         "{tests_deferred} declared data {checks} deferred \
          (not evaluable before the model is materialized)"
     ))
+}
+
+/// The wording when the declared checks could not even be counted.
+///
+/// Still deferred — nothing ran — but the count is withheld rather
+/// than guessed, because a number nobody read is not evidence.
+pub fn uncounted_deferred_note(why: &str) -> String {
+    format!(
+        "declared data checks deferred (not evaluable before the model \
+         is materialized); count unavailable: {why}"
+    )
 }
 
 /// The journal event for an all-green verify bundle.
@@ -2550,7 +2563,7 @@ mod tests {
             test_green: true,
             posture_green: true,
             manifest_total: true,
-            tests_deferred,
+            tests_deferred: Some(tests_deferred),
             detail: deferred_note(tests_deferred).unwrap_or_default(),
         }
     }
@@ -2629,6 +2642,34 @@ mod tests {
     }
 
     #[test]
+    fn a_count_that_could_not_be_read_is_never_reported_as_zero() {
+        // `Some(0)` claims "there are none"; `None` admits "nobody
+        // read it". Collapsing the second into the first would be the
+        // same lie in a new place.
+        let note = uncounted_deferred_note("models/revenue_daily.toml does not parse: bad line 3");
+        assert!(note.starts_with("declared data checks deferred"));
+        assert!(note.contains("count unavailable: models/revenue_daily.toml does not parse"));
+        assert!(!note.contains(" 0 "), "an unknown count must not render as zero: {note}");
+        let d = decide(
+            &rec(FulfillState::Verifying),
+            Event::VerifyBundle {
+                compile_green: true,
+                test_green: true,
+                posture_green: true,
+                manifest_total: true,
+                tests_deferred: None,
+                detail: note.clone(),
+            },
+            now(),
+        );
+        let Decision::AdvanceAndAct { task, event, .. } = d else {
+            panic!("an uncountable sidecar must not change the decision, got {d:?}");
+        };
+        assert_eq!(task, TaskKind::Propose, "not knowing is still not a failure");
+        assert_eq!(event, format!("verify green: {note}"));
+    }
+
+    #[test]
     fn a_model_that_fails_to_execute_is_still_red_even_with_checks_deferred() {
         // The gate this fix must NOT relax: a model that fails to run is
         // red, deferred count or not.
@@ -2641,7 +2682,7 @@ mod tests {
                 test_green: false,
                 posture_green: true,
                 manifest_total: true,
-                tests_deferred: 6,
+                tests_deferred: Some(6),
                 detail: "test failures: revenue_daily: binder error".into(),
             },
             now(),
@@ -2665,7 +2706,7 @@ mod tests {
                 test_green: true,
                 posture_green: true,
                 manifest_total: true,
-                tests_deferred: 6,
+                tests_deferred: Some(6),
                 detail: "E012 on revenue_eur".into(),
             },
             now(),
@@ -2696,7 +2737,7 @@ mod tests {
                 test_green: false,
                 posture_green: true,
                 manifest_total: true,
-                tests_deferred: 6,
+                tests_deferred: Some(6),
                 detail: "unique(client_id,date) failed".into(),
             },
             now(),

--- a/engine/crates/rocky-fulfill/src/step.rs
+++ b/engine/crates/rocky-fulfill/src/step.rs
@@ -541,12 +541,7 @@ impl Runner {
     /// The deferred-checks report: the typed count, and the
     /// plain-language note for `detail`.
     fn deferred_declared_checks(&self, spec: &ApprovedSpec) -> (Option<usize>, Option<String>) {
-        match self.count_declared_checks(spec) {
-            Ok(count) => (Some(count), machine::deferred_note(count)),
-            // Never silently zero: "0 deferred" and "could not tell"
-            // are different claims, and only one of them is true here.
-            Err(why) => (None, Some(machine::uncounted_deferred_note(&why))),
-        }
+        deferred_report(self.count_declared_checks(spec))
     }
 
     /// Count every declared data check that `rocky test --declarative`
@@ -1125,6 +1120,18 @@ struct ApprovedSpec {
     parsed: rocky_core::product::spec::ParsedSpec,
 }
 
+/// Turn a count attempt into the typed field plus its `detail` note.
+///
+/// Pure, so the rule that a FAILED count never becomes `Some(0)` is
+/// pinned by a test rather than by reading the code. "0 deferred" and
+/// "could not tell" are different claims and only one can be true.
+fn deferred_report(counted: Result<usize, String>) -> (Option<usize>, Option<String>) {
+    match counted {
+        Ok(count) => (Some(count), machine::deferred_note(count)),
+        Err(why) => (None, Some(machine::uncounted_deferred_note(&why))),
+    }
+}
+
 /// Count every `[[tests]]` entry a model sidecar declares — the set
 /// `rocky test --declarative` would run against the materialised table.
 ///
@@ -1173,7 +1180,26 @@ fn fault_point(_name: &str) {}
 
 #[cfg(test)]
 mod deferred_check_counting {
-    use super::count_sidecar_tests;
+    use super::{count_sidecar_tests, deferred_report};
+
+    #[test]
+    fn a_failed_count_reports_unknown_rather_than_zero() {
+        // The step-side half of the same rule the machine pins: a count
+        // that could not be read must NOT collapse into `Some(0)`,
+        // which would read as "nothing is deferred".
+        let (count, note) = deferred_report(Err("models/x.toml unreadable: nope".to_string()));
+        assert_eq!(count, None, "an unread count is not a zero count");
+        let note = note.expect("an unknown count still says checks are deferred");
+        assert!(note.contains("deferred"));
+        assert!(note.contains("count unavailable: models/x.toml unreadable: nope"));
+
+        let (count, note) = deferred_report(Ok(4));
+        assert_eq!(count, Some(4));
+        assert!(note.expect("four deferred").starts_with("4 declared data checks deferred"));
+
+        // A genuine zero is a real answer, and renders no clause.
+        assert_eq!(deferred_report(Ok(0)), (Some(0), None));
+    }
 
     /// A merged sidecar exactly as Phase B leaves it for the walking
     /// skeleton's product: three spec-owned tests (the composite grain,

--- a/engine/crates/rocky-fulfill/src/step.rs
+++ b/engine/crates/rocky-fulfill/src/step.rs
@@ -627,21 +627,22 @@ impl Runner {
                 // A pre-gate failure (compile, ledger, plan write) is a
                 // red verify bundle in spirit: surface it as a verify
                 // failure so the repair budget applies.
-                let (tests_deferred, deferred_note) = self.deferred_declared_checks(&spec);
-                let mut detail = vec![format!("propose failed before the policy gate: {err}")];
-                // Still true on this path, and for the same reason: the
-                // target was never materialised, so nothing declarative
-                // ran here either.
-                if let Some(note) = deferred_note {
-                    detail.push(note);
-                }
+                //
+                // No deferred count of its own. `TaskKind::Propose` is
+                // dispatched from exactly one place — the all-green
+                // bundle arm — so a `verify green: N declared data
+                // checks deferred` row is ALREADY in the journal for
+                // this same pass. Re-reading the sidecar here would be
+                // a second, independent reading that could state a
+                // different number and make the journal tell two
+                // stories about one pass.
                 return Ok(Event::VerifyBundle {
                     compile_green: false,
                     test_green: true,
                     posture_green: true,
                     manifest_total: true,
-                    tests_deferred,
-                    detail: detail.join(" | "),
+                    tests_deferred: None,
+                    detail: format!("propose failed before the policy gate: {err}"),
                 });
             }
         };

--- a/engine/crates/rocky-fulfill/src/step.rs
+++ b/engine/crates/rocky-fulfill/src/step.rs
@@ -479,6 +479,24 @@ impl Runner {
 
         let test_green = self.scoped_tests_green(&model, &mut detail);
 
+        // The product's declared data checks are lowered into the model
+        // sidecar as `[[tests]]` (grain uniqueness, not-null per
+        // non-nullable column, one expression per declared check). They
+        // execute only via `rocky test --declarative`, against the
+        // MATERIALISED table — and this gate runs before apply, so the
+        // table does not exist yet. `test_green` above therefore covers
+        // model execution and unit tests ONLY. Counting them here, from
+        // the approved spec, is what keeps the bundle's claim honest:
+        // they are reported deferred, never counted as passed.
+        //
+        // Computed in the bundle rather than inside `scoped_tests_green`
+        // so the count survives the `#[cfg(not(feature = "duckdb"))]`
+        // build, which has no local test surface at all.
+        let tests_deferred = rocky_core::product::lowering::generated_tests(&spec.parsed).len();
+        if let Some(note) = machine::deferred_note(tests_deferred) {
+            detail.push(note);
+        }
+
         let posture_green = match self.verify_posture()? {
             PostureStatus::Pass => true,
             PostureStatus::NeedsInput { reason, .. } | PostureStatus::Fail { reason } => {
@@ -517,6 +535,7 @@ impl Runner {
             test_green,
             posture_green,
             manifest_total,
+            tests_deferred,
             detail: detail.join(" | "),
         })
     }
@@ -582,12 +601,22 @@ impl Runner {
                 // A pre-gate failure (compile, ledger, plan write) is a
                 // red verify bundle in spirit: surface it as a verify
                 // failure so the repair budget applies.
+                let tests_deferred =
+                    rocky_core::product::lowering::generated_tests(&spec.parsed).len();
+                let mut detail = vec![format!("propose failed before the policy gate: {err}")];
+                // Still true on this path, and for the same reason: the
+                // target was never materialised, so nothing declarative
+                // ran here either.
+                if let Some(note) = machine::deferred_note(tests_deferred) {
+                    detail.push(note);
+                }
                 return Ok(Event::VerifyBundle {
                     compile_green: false,
                     test_green: true,
                     posture_green: true,
                     manifest_total: true,
-                    detail: format!("propose failed before the policy gate: {err}"),
+                    tests_deferred,
+                    detail: detail.join(" | "),
                 });
             }
         };

--- a/engine/crates/rocky-fulfill/src/step.rs
+++ b/engine/crates/rocky-fulfill/src/step.rs
@@ -1195,7 +1195,10 @@ mod deferred_check_counting {
 
         let (count, note) = deferred_report(Ok(4));
         assert_eq!(count, Some(4));
-        assert!(note.expect("four deferred").starts_with("4 declared data checks deferred"));
+        assert!(
+            note.expect("four deferred")
+                .starts_with("4 declared data checks deferred")
+        );
 
         // A genuine zero is a real answer, and renders no clause.
         assert_eq!(deferred_report(Ok(0)), (Some(0), None));

--- a/engine/crates/rocky-fulfill/src/step.rs
+++ b/engine/crates/rocky-fulfill/src/step.rs
@@ -547,23 +547,32 @@ impl Runner {
     /// Count every declared data check that `rocky test --declarative`
     /// would run for this product's model.
     ///
-    /// The MERGED SIDECAR is the authority, not `generated_tests(spec)`.
-    /// Phase B merges the spec-owned tests (grain uniqueness, not-null
-    /// per non-nullable column, one expression per declared check) with
-    /// the worker's own appended `[[tests]]` — the engine's
-    /// `draft_check` tool appends those, and `lower_phase_b` preserves
-    /// every one it did not generate. `run_declarative_tests` then runs
-    /// every entry it finds in the sidecar. Counting only the
-    /// spec-owned subset would undercount by exactly the worker's
-    /// checks, which is the same class of lie this whole gate is being
-    /// fixed for.
+    /// ASKS THE RUNNER'S OWN LOADER rather than re-deriving the set.
+    /// Two earlier re-derivations both undercounted: the spec's
+    /// `generated_tests` misses the worker's appended `[[tests]]` (the
+    /// merge preserves them), and the sidecar's raw `[[tests]]` array
+    /// misses every `[[use_test]]` reference (the model loader resolves
+    /// those against `test_definitions.toml` and appends them to
+    /// `ModelConfig.tests`, which is the vector the runner iterates).
     ///
-    /// The path is derived through `sidecar_rel` against `self.root` —
-    /// the SAME derivation `run_phase_b` writes through, so the count
-    /// cannot read a different file from the one that was merged.
+    /// Counting through `declarative_test_count` makes the counted set
+    /// the executed set by construction, so a future layer of expansion
+    /// cannot silently reopen the same hole.
+    #[cfg(feature = "duckdb")]
     fn count_declared_checks(&self, spec: &ApprovedSpec) -> Result<usize, String> {
-        let rel = rocky_core::product::lowering::sidecar_rel(&spec.parsed);
-        count_sidecar_tests(&self.root.join(&rel)).map_err(|why| format!("{rel} {why}"))
+        fulfill_api::declarative_test_count(&self.models_dir, spec.parsed.output_model())
+            .map_err(|err| format!("{err:#}"))
+    }
+
+    /// Without the duckdb feature there is no declarative test surface
+    /// to ask, so the count is unavailable rather than invented. This
+    /// build already fails the verify gate closed (see
+    /// `scoped_tests_green`), so nothing is lost by declining here.
+    #[cfg(not(feature = "duckdb"))]
+    fn count_declared_checks(&self, _spec: &ApprovedSpec) -> Result<usize, String> {
+        Err("this build has no duckdb feature, so the declarative test loader \
+             cannot be asked what it would run"
+            .to_string())
     }
 
     #[cfg(feature = "duckdb")]
@@ -1133,25 +1142,6 @@ fn deferred_report(counted: Result<usize, String>) -> (Option<usize>, Option<Str
     }
 }
 
-/// Count every `[[tests]]` entry a model sidecar declares — the set
-/// `rocky test --declarative` would run against the materialised table.
-///
-/// A free function so the counting rule is testable without a live
-/// runner. Counts the WHOLE array: the spec-owned tests Phase B
-/// generated AND the worker's own appended checks, which the merge
-/// preserves and the declarative runner does not distinguish.
-fn count_sidecar_tests(path: &Path) -> Result<usize, String> {
-    let text = std::fs::read_to_string(path).map_err(|err| format!("unreadable: {err}"))?;
-    let document = rocky_core::product::toml_compat::parse_ordered(&text)
-        .map_err(|reject| format!("does not parse: {reject}"))?;
-    // A sidecar with no `[[tests]]` array declares no checks. That is a
-    // real zero, not a failure to count.
-    Ok(document
-        .get("tests")
-        .and_then(|value| value.as_array())
-        .map_or(0, <[_]>::len))
-}
-
 fn render_refusal(refusal: &fulfill_api::PolicyRefusal) -> String {
     format!(
         "model '{}', rule {}, {}",
@@ -1181,18 +1171,18 @@ fn fault_point(_name: &str) {}
 
 #[cfg(test)]
 mod deferred_check_counting {
-    use super::{count_sidecar_tests, deferred_report};
+    use super::deferred_report;
 
     #[test]
     fn a_failed_count_reports_unknown_rather_than_zero() {
         // The step-side half of the same rule the machine pins: a count
         // that could not be read must NOT collapse into `Some(0)`,
         // which would read as "nothing is deferred".
-        let (count, note) = deferred_report(Err("models/x.toml unreadable: nope".to_string()));
+        let (count, note) = deferred_report(Err("model 'x' not found".to_string()));
         assert_eq!(count, None, "an unread count is not a zero count");
         let note = note.expect("an unknown count still says checks are deferred");
         assert!(note.contains("deferred"));
-        assert!(note.contains("count unavailable: models/x.toml unreadable: nope"));
+        assert!(note.contains("count unavailable: model 'x' not found"));
 
         let (count, note) = deferred_report(Ok(4));
         assert_eq!(count, Some(4));
@@ -1203,83 +1193,5 @@ mod deferred_check_counting {
 
         // A genuine zero is a real answer, and renders no clause.
         assert_eq!(deferred_report(Ok(0)), (Some(0), None));
-    }
-
-    /// A merged sidecar exactly as Phase B leaves it for the walking
-    /// skeleton's product: three spec-owned tests (the composite grain,
-    /// one not-null, one declared check) PLUS the worker's own appended
-    /// check, which `lower_phase_b` preserves verbatim.
-    const MERGED_SIDECAR: &str = concat!(
-        "name = \"revenue_daily\"\n",
-        "intent = \"Daily gross revenue per client in EUR, refunds excluded\"\n",
-        "\n",
-        "[[tests]]\n",
-        "type = \"composite\"\n",
-        "kind = \"unique\"\n",
-        "columns = [\"client_id\", \"date\"]\n",
-        "\n",
-        "[[tests]]\n",
-        "type = \"not_null\"\n",
-        "column = \"client_id\"\n",
-        "\n",
-        "[[tests]]\n",
-        "type = \"expression\"\n",
-        "expression = \"revenue_eur >= 0\"\n",
-        "severity = \"error\"\n",
-        "\n",
-        // The worker's own check, appended by the engine's `draft_check`
-        // tool. `rocky test --declarative` runs it like any other.
-        "[[tests]]\n",
-        "type = \"expression\"\n",
-        "expression = \"client_id > 0\"\n",
-    );
-
-    fn write(text: &str) -> (tempfile::TempDir, std::path::PathBuf) {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("revenue_daily.toml");
-        std::fs::write(&path, text).expect("write sidecar");
-        (dir, path)
-    }
-
-    #[test]
-    fn a_worker_appended_check_is_counted_too() {
-        // The undercount guard. Counting the SPEC-OWNED subset
-        // (`generated_tests`) would report 3 here and quietly drop the
-        // worker's check — an undercount is the same class of lie as
-        // the green badge this whole change exists to fix. The sidecar
-        // is the authority because it is what the declarative runner
-        // reads.
-        let (_dir, path) = write(MERGED_SIDECAR);
-        assert_eq!(
-            count_sidecar_tests(&path).expect("count"),
-            4,
-            "the worker's appended check must be counted, not just the spec-owned three"
-        );
-    }
-
-    #[test]
-    fn a_sidecar_with_no_tests_array_counts_zero() {
-        // No false alarm: a sidecar that declares no checks defers none.
-        let (_dir, path) = write("name = \"revenue_daily\"\nintent = \"none\"\n");
-        assert_eq!(count_sidecar_tests(&path).expect("count"), 0);
-    }
-
-    #[test]
-    fn an_unreadable_or_unparseable_sidecar_refuses_to_guess() {
-        // Never silently zero — the caller turns these into "count
-        // unavailable", not "0 deferred".
-        let dir = tempfile::tempdir().expect("tempdir");
-        let missing = dir.path().join("revenue_daily.toml");
-        assert!(
-            count_sidecar_tests(&missing)
-                .expect_err("a missing sidecar is not a zero count")
-                .starts_with("unreadable:")
-        );
-        let (_dir, bad) = write("name = \"revenue_daily\"\n[[tests]\n");
-        assert!(
-            count_sidecar_tests(&bad)
-                .expect_err("a broken sidecar is not a zero count")
-                .starts_with("does not parse:")
-        );
     }
 }

--- a/engine/crates/rocky-fulfill/src/step.rs
+++ b/engine/crates/rocky-fulfill/src/step.rs
@@ -479,21 +479,19 @@ impl Runner {
 
         let test_green = self.scoped_tests_green(&model, &mut detail);
 
-        // The product's declared data checks are lowered into the model
-        // sidecar as `[[tests]]` (grain uniqueness, not-null per
-        // non-nullable column, one expression per declared check). They
-        // execute only via `rocky test --declarative`, against the
-        // MATERIALISED table — and this gate runs before apply, so the
-        // table does not exist yet. `test_green` above therefore covers
-        // model execution and unit tests ONLY. Counting them here, from
-        // the approved spec, is what keeps the bundle's claim honest:
-        // they are reported deferred, never counted as passed.
+        // The product's declared data checks live in the model sidecar
+        // as `[[tests]]`. They execute only via `rocky test
+        // --declarative`, against the MATERIALISED table — and this gate
+        // runs before apply, so the table does not exist yet.
+        // `test_green` above therefore covers model execution and unit
+        // tests ONLY. Counting the rest here is what keeps the bundle's
+        // claim honest: they are reported deferred, never as passed.
         //
         // Computed in the bundle rather than inside `scoped_tests_green`
         // so the count survives the `#[cfg(not(feature = "duckdb"))]`
         // build, which has no local test surface at all.
-        let tests_deferred = rocky_core::product::lowering::generated_tests(&spec.parsed).len();
-        if let Some(note) = machine::deferred_note(tests_deferred) {
+        let (tests_deferred, deferred_note) = self.deferred_declared_checks(&spec);
+        if let Some(note) = deferred_note {
             detail.push(note);
         }
 
@@ -538,6 +536,39 @@ impl Runner {
             tests_deferred,
             detail: detail.join(" | "),
         })
+    }
+
+    /// The deferred-checks report: the typed count, and the
+    /// plain-language note for `detail`.
+    fn deferred_declared_checks(&self, spec: &ApprovedSpec) -> (Option<usize>, Option<String>) {
+        match self.count_declared_checks(spec) {
+            Ok(count) => (Some(count), machine::deferred_note(count)),
+            // Never silently zero: "0 deferred" and "could not tell"
+            // are different claims, and only one of them is true here.
+            Err(why) => (None, Some(machine::uncounted_deferred_note(&why))),
+        }
+    }
+
+    /// Count every declared data check that `rocky test --declarative`
+    /// would run for this product's model.
+    ///
+    /// The MERGED SIDECAR is the authority, not `generated_tests(spec)`.
+    /// Phase B merges the spec-owned tests (grain uniqueness, not-null
+    /// per non-nullable column, one expression per declared check) with
+    /// the worker's own appended `[[tests]]` — the engine's
+    /// `draft_check` tool appends those, and `lower_phase_b` preserves
+    /// every one it did not generate. `run_declarative_tests` then runs
+    /// every entry it finds in the sidecar. Counting only the
+    /// spec-owned subset would undercount by exactly the worker's
+    /// checks, which is the same class of lie this whole gate is being
+    /// fixed for.
+    ///
+    /// The path is derived through `sidecar_rel` against `self.root` —
+    /// the SAME derivation `run_phase_b` writes through, so the count
+    /// cannot read a different file from the one that was merged.
+    fn count_declared_checks(&self, spec: &ApprovedSpec) -> Result<usize, String> {
+        let rel = rocky_core::product::lowering::sidecar_rel(&spec.parsed);
+        count_sidecar_tests(&self.root.join(&rel)).map_err(|why| format!("{rel} {why}"))
     }
 
     #[cfg(feature = "duckdb")]
@@ -601,13 +632,12 @@ impl Runner {
                 // A pre-gate failure (compile, ledger, plan write) is a
                 // red verify bundle in spirit: surface it as a verify
                 // failure so the repair budget applies.
-                let tests_deferred =
-                    rocky_core::product::lowering::generated_tests(&spec.parsed).len();
+                let (tests_deferred, deferred_note) = self.deferred_declared_checks(&spec);
                 let mut detail = vec![format!("propose failed before the policy gate: {err}")];
                 // Still true on this path, and for the same reason: the
                 // target was never materialised, so nothing declarative
                 // ran here either.
-                if let Some(note) = machine::deferred_note(tests_deferred) {
+                if let Some(note) = deferred_note {
                     detail.push(note);
                 }
                 return Ok(Event::VerifyBundle {
@@ -1095,6 +1125,25 @@ struct ApprovedSpec {
     parsed: rocky_core::product::spec::ParsedSpec,
 }
 
+/// Count every `[[tests]]` entry a model sidecar declares — the set
+/// `rocky test --declarative` would run against the materialised table.
+///
+/// A free function so the counting rule is testable without a live
+/// runner. Counts the WHOLE array: the spec-owned tests Phase B
+/// generated AND the worker's own appended checks, which the merge
+/// preserves and the declarative runner does not distinguish.
+fn count_sidecar_tests(path: &Path) -> Result<usize, String> {
+    let text = std::fs::read_to_string(path).map_err(|err| format!("unreadable: {err}"))?;
+    let document = rocky_core::product::toml_compat::parse_ordered(&text)
+        .map_err(|reject| format!("does not parse: {reject}"))?;
+    // A sidecar with no `[[tests]]` array declares no checks. That is a
+    // real zero, not a failure to count.
+    Ok(document
+        .get("tests")
+        .and_then(|value| value.as_array())
+        .map_or(0, <[_]>::len))
+}
+
 fn render_refusal(refusal: &fulfill_api::PolicyRefusal) -> String {
     format!(
         "model '{}', rule {}, {}",
@@ -1121,3 +1170,86 @@ fn fault_point(name: &str) {
 
 #[cfg(not(debug_assertions))]
 fn fault_point(_name: &str) {}
+
+#[cfg(test)]
+mod deferred_check_counting {
+    use super::count_sidecar_tests;
+
+    /// A merged sidecar exactly as Phase B leaves it for the walking
+    /// skeleton's product: three spec-owned tests (the composite grain,
+    /// one not-null, one declared check) PLUS the worker's own appended
+    /// check, which `lower_phase_b` preserves verbatim.
+    const MERGED_SIDECAR: &str = concat!(
+        "name = \"revenue_daily\"\n",
+        "intent = \"Daily gross revenue per client in EUR, refunds excluded\"\n",
+        "\n",
+        "[[tests]]\n",
+        "type = \"composite\"\n",
+        "kind = \"unique\"\n",
+        "columns = [\"client_id\", \"date\"]\n",
+        "\n",
+        "[[tests]]\n",
+        "type = \"not_null\"\n",
+        "column = \"client_id\"\n",
+        "\n",
+        "[[tests]]\n",
+        "type = \"expression\"\n",
+        "expression = \"revenue_eur >= 0\"\n",
+        "severity = \"error\"\n",
+        "\n",
+        // The worker's own check, appended by the engine's `draft_check`
+        // tool. `rocky test --declarative` runs it like any other.
+        "[[tests]]\n",
+        "type = \"expression\"\n",
+        "expression = \"client_id > 0\"\n",
+    );
+
+    fn write(text: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("revenue_daily.toml");
+        std::fs::write(&path, text).expect("write sidecar");
+        (dir, path)
+    }
+
+    #[test]
+    fn a_worker_appended_check_is_counted_too() {
+        // The undercount guard. Counting the SPEC-OWNED subset
+        // (`generated_tests`) would report 3 here and quietly drop the
+        // worker's check — an undercount is the same class of lie as
+        // the green badge this whole change exists to fix. The sidecar
+        // is the authority because it is what the declarative runner
+        // reads.
+        let (_dir, path) = write(MERGED_SIDECAR);
+        assert_eq!(
+            count_sidecar_tests(&path).expect("count"),
+            4,
+            "the worker's appended check must be counted, not just the spec-owned three"
+        );
+    }
+
+    #[test]
+    fn a_sidecar_with_no_tests_array_counts_zero() {
+        // No false alarm: a sidecar that declares no checks defers none.
+        let (_dir, path) = write("name = \"revenue_daily\"\nintent = \"none\"\n");
+        assert_eq!(count_sidecar_tests(&path).expect("count"), 0);
+    }
+
+    #[test]
+    fn an_unreadable_or_unparseable_sidecar_refuses_to_guess() {
+        // Never silently zero — the caller turns these into "count
+        // unavailable", not "0 deferred".
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("revenue_daily.toml");
+        assert!(
+            count_sidecar_tests(&missing)
+                .expect_err("a missing sidecar is not a zero count")
+                .starts_with("unreadable:")
+        );
+        let (_dir, bad) = write("name = \"revenue_daily\"\n[[tests]\n");
+        assert!(
+            count_sidecar_tests(&bad)
+                .expect_err("a broken sidecar is not a zero count")
+                .starts_with("does not parse:")
+        );
+    }
+}

--- a/engine/crates/rocky-fulfill/src/step.rs
+++ b/engine/crates/rocky-fulfill/src/step.rs
@@ -570,9 +570,11 @@ impl Runner {
     /// `scoped_tests_green`), so nothing is lost by declining here.
     #[cfg(not(feature = "duckdb"))]
     fn count_declared_checks(&self, _spec: &ApprovedSpec) -> Result<usize, String> {
-        Err("this build has no duckdb feature, so the declarative test loader \
+        Err(
+            "this build has no duckdb feature, so the declarative test loader \
              cannot be asked what it would run"
-            .to_string())
+                .to_string(),
+        )
     }
 
     #[cfg(feature = "duckdb")]

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -52,6 +52,10 @@ chrono = { workspace = true }
 # to the real binary for review/apply — same client feature set as
 # rocky-mcp's own round-trip tests.
 rmcp = { version = "3.0", features = ["server", "macros", "transport-io", "client"] }
+# `fulfill_e2e` counts the merged sidecar's declared checks through a
+# DIFFERENT TOML parser than the engine's own `product::toml_compat`, so the
+# deferred-count assertion cannot agree with a buggy counter by construction.
+toml = { workspace = true }
 
 [lints]
 workspace = true

--- a/engine/rocky/tests/fulfill_e2e.rs
+++ b/engine/rocky/tests/fulfill_e2e.rs
@@ -197,10 +197,17 @@ fn declared_check_count(dir: &Path) -> usize {
         .unwrap_or_else(|err| panic!("merged sidecar {}: {err}", sidecar.display()));
     let document: toml::Value = toml::from_str(&text)
         .unwrap_or_else(|err| panic!("merged sidecar {}: {err}", sidecar.display()));
-    document
-        .get("tests")
-        .and_then(toml::Value::as_array)
-        .map_or(0, Vec::len)
+    // Both arrays: the model loader appends every resolved `[[use_test]]`
+    // to `ModelConfig.tests`, so the executed set is inline + referenced.
+    // Counting only `tests` here would rebuild the very blind spot the
+    // production counter was fixed to avoid.
+    let count = |key: &str| {
+        document
+            .get(key)
+            .and_then(toml::Value::as_array)
+            .map_or(0, Vec::len)
+    };
+    count("tests") + count("use_test")
 }
 
 /// Drive the loop up to the plan-review ask, returning the plan id.

--- a/engine/rocky/tests/fulfill_e2e.rs
+++ b/engine/rocky/tests/fulfill_e2e.rs
@@ -180,6 +180,29 @@ fn state_store(dir: &Path) -> rocky_core::state::StateStore {
     rocky_core::state::StateStore::open(&dir.join("models/.rocky-state.redb")).expect("store")
 }
 
+/// Count the declared data checks in the MERGED sidecar, independently
+/// of the engine's own counter.
+///
+/// Deliberately a different parser from the one under test — the `toml`
+/// crate, not the engine's `product::toml_compat` — so this cannot
+/// agree with a buggy counter by construction.
+///
+/// Counting `[[tests]]` headers in the TEXT would NOT work: the
+/// sidecar renderer inlines an array of tables whenever every entry
+/// fits the line budget, so short checks appear as `tests = [ { … } ]`
+/// with no header at all. Parse, never scan.
+fn declared_check_count(dir: &Path) -> usize {
+    let sidecar = dir.join(format!("models/{PRODUCT}.toml"));
+    let text = std::fs::read_to_string(&sidecar)
+        .unwrap_or_else(|err| panic!("merged sidecar {}: {err}", sidecar.display()));
+    let document: toml::Value = toml::from_str(&text)
+        .unwrap_or_else(|err| panic!("merged sidecar {}: {err}", sidecar.display()));
+    document
+        .get("tests")
+        .and_then(toml::Value::as_array)
+        .map_or(0, Vec::len)
+}
+
 /// Drive the loop up to the plan-review ask, returning the plan id.
 fn drive_to_plan_review(dir: &Path) -> String {
     // 1. Cold init: elicitation writes the candidate, stop at approval.
@@ -293,6 +316,40 @@ fn happy_path_cold_init_to_observing() {
         );
         let applied_rows = rows.iter().filter(|r| r.to_state == "applied").count();
         assert_eq!(applied_rows, 1, "exactly one applied journal row");
+
+        // #1495: the verify bundle's green verdict must say what green
+        // did NOT cover. The product's declared data checks lower into
+        // the model sidecar and run only against a materialised table,
+        // so at verify time (before apply) none of them can run. The
+        // journal names them deferred, with the real count read from
+        // the merged sidecar on disk.
+        //
+        // This is the WIRING pin: the count is read through
+        // `sidecar_rel` against the runner's project root, so a wrong
+        // root would silently degrade every run to "count unavailable"
+        // — which no unit test can catch.
+        let verdict = rows
+            .iter()
+            .find(|r| r.event.starts_with("verify green"))
+            .expect("the green verify verdict is journaled");
+        let declared = declared_check_count(dir);
+        assert!(
+            declared > 0,
+            "fixture must declare at least one data check to make this pin meaningful"
+        );
+        assert_eq!(
+            verdict.event,
+            format!(
+                "verify green: {declared} declared data checks deferred \
+                 (not evaluable before the model is materialized)"
+            ),
+            "the green verdict must state the real deferred count"
+        );
+        assert!(
+            !verdict.event.contains("count unavailable"),
+            "the sidecar must actually be found: {}",
+            verdict.event
+        );
     }
 
     // A rerun re-observes and stays observing — idempotent resume.


### PR DESCRIPTION
The `rocky fulfill` verify bundle counted a product's declared data checks as **passed** when they were never evaluated. They can only run against a materialized table, and verify runs before apply — so they cannot have run. This reports them as deferred instead.

```
 before   verify green  ("tests passed" — the data checks never ran)
 after    verify green  ("6 declared data checks deferred — not evaluable
                          before the model is materialized")
```

**Gating is unchanged on purpose.** Deferred is not a failure: a plan that could be proposed before can still be proposed. This fixes what the engine *claims*, not what it allows.

## Why it needed three passes at the count

The honest count is the whole point, so a count that quietly undercounts would be the same bug wearing a different hat. It undercounted twice before landing:

| Counted from | Missed |
|---|---|
| the spec | tests the worker appended, which the Phase-B merge preserves |
| the raw sidecar array | `[[use_test]]` references, which the model loader expands |
| **the runner's own loader** | **nothing — counted set == executed set by construction** |

The final version calls `declarative_test_count`, which goes through `load_all_models` — the same loader `run_declarative_tests` iterates. Re-deriving "what would execute" is what failed twice; asking the thing that executes it cannot drift.

An unreadable or unloadable model reports `count unavailable: <why>`, never a fabricated zero — "there are none" and "nobody could tell" are different claims.

## One change beyond reporting

The verify-green arm moved from `Act` to `AdvanceAndAct`. `Act` writes nothing, so on the green path the bundle detail was being **discarded entirely** — a reporting fix would have been invisible exactly where it matters. The green verdict is now journaled. Independently reviewed for crash and replay safety: record and journal row commit atomically, only a winning compare-and-set proceeds, a crash re-runs verification, a replay loses the CAS without writing. The extra row advances `journal_seq`, which feeds the apply idempotency key — that key is pinned on the record and read back at lookup, so an in-flight apply cannot be orphaned.

## Known gap, deliberately not closed here

The count is durable in the journal, but **no human-facing surface shows verify evidence at all** — before or after this change. `rocky product status` prints a journal row *count*; `rocky review --approve` shows only breaking-change findings. Closing that needs a state-schema change to thread the evidence into the sign-off surface, which is a separate decision, not a quiet add-on. Flagged in #1495.

## Evidence

`cargo test --workspace` 146 suites, `-p rocky-fulfill -p rocky-core`, `--test fulfill_e2e` (10), clippy `-D warnings`, `fmt --check` — all exit 0. The walking-skeleton POC's `run.sh` and `mutation-pass.sh` (12/12) pass. Every new guard is mutation-checked, including the undercount fix (count the raw array instead → the `use_test` test fails). No codegen cascade: no output/config/schema surface touched.