### PR TITLE
docs: publish the capability matrix — what Rocky enforces, attempts, and records

### DIFF
--- a/.agents/skills/rocky-config/SKILL.md
+++ b/.agents/skills/rocky-config/SKILL.md
@@ -213,10 +213,12 @@ connector-level `--filter id=<conn_id>` keys remain unchanged.
 
 ```toml
 [pipeline.silver]
-type        = "transformation"
-models_dir  = "models/silver"
-contracts_dir = "contracts/silver"
-depends_on  = ["raw"]
+type       = "transformation"
+models     = "models/silver/**"   # glob, relative to rocky.toml; default "models/**"
+depends_on = ["raw"]
+
+# There is no contracts key: a model's contract is auto-discovered as the
+# sibling `<model>.contract.toml`, or passed at the CLI via `--contracts <dir>`.
 
 [pipeline.silver.target]
 catalog = "analytics"

--- a/.agents/skills/rocky-config/SKILL.md
+++ b/.agents/skills/rocky-config/SKILL.md
@@ -220,9 +220,18 @@ depends_on = ["raw"]
 # There is no contracts key: a model's contract is auto-discovered as the
 # sibling `<model>.contract.toml`, or passed at the CLI via `--contracts <dir>`.
 
+# A transformation target takes an adapter ref (plus optional governance)
+# and nothing else — `catalog`/`schema` here are parse errors
+# (`deny_unknown_fields`). Each model names its own destination in its
+# sidecar `[target]`:
+#
+#   # models/silver/dim_customers.toml
+#   [target]
+#   catalog = "analytics"
+#   schema  = "marts"
+#   table   = "dim_customers"
 [pipeline.silver.target]
-catalog = "analytics"
-schema  = "marts"
+adapter = "warehouse"
 ```
 
 ### Quality pipeline
@@ -232,14 +241,19 @@ schema  = "marts"
 type       = "quality"
 depends_on = ["silver"]
 
+# A quality target is an adapter ref only. The tables to check are listed
+# in `[[pipeline.qa.tables]]` (omit `table` to check the whole schema).
 [pipeline.qa.target]
+adapter = "warehouse"
+
+[[pipeline.qa.tables]]
 catalog = "analytics"
 schema  = "marts"
 
+# Quality runs execute `row_count`, `custom`, and `assertions` only. Other
+# check kinds are inert here — `rocky validate` warns (V034).
 [pipeline.qa.checks]
-row_count    = true
-column_match = true
-freshness    = { threshold_seconds = 86400 }
+row_count = true
 ```
 
 ### Snapshot pipeline
@@ -247,6 +261,8 @@ freshness    = { threshold_seconds = 86400 }
 ```toml
 [pipeline.dim_history]
 type       = "snapshot"
+unique_key = ["customer_id"]     # required: row identity in the source table
+updated_at = "updated_at"        # required: change-detection column
 depends_on = ["silver"]
 
 [pipeline.dim_history.source]
@@ -257,6 +273,7 @@ table   = "dim_customers"
 [pipeline.dim_history.target]
 catalog = "analytics_history"
 schema  = "snapshots"
+table   = "dim_customers_history"   # required: explicit history table
 ```
 
 ## Minimal-config defaults (omit these)
@@ -274,7 +291,14 @@ The parser applies sane defaults — keep configs lean by omitting anything that
 | Model `target.table` | `name` | Renaming on write |
 | Directory-level `target` | `models/_defaults.toml` inherited | Overriding per-model |
 
-## Checks (all four pipeline types)
+## Checks
+
+Every pipeline type accepts a `[checks]` block, but execution differs:
+replication runs the full set; quality runs `row_count`, `custom`, and
+`assertions` only; transformation, snapshot, and load run no pipeline-level
+checks today (`executed_check_kinds` in `config.rs` is the source of
+truth). `rocky validate` warns (V034) on a check the pipeline type never
+executes.
 
 ```toml
 [pipeline.<name>.checks]

--- a/.claude/skills/rocky-config/SKILL.md
+++ b/.claude/skills/rocky-config/SKILL.md
@@ -213,10 +213,12 @@ connector-level `--filter id=<conn_id>` keys remain unchanged.
 
 ```toml
 [pipeline.silver]
-type        = "transformation"
-models_dir  = "models/silver"
-contracts_dir = "contracts/silver"
-depends_on  = ["raw"]
+type       = "transformation"
+models     = "models/silver/**"   # glob, relative to rocky.toml; default "models/**"
+depends_on = ["raw"]
+
+# There is no contracts key: a model's contract is auto-discovered as the
+# sibling `<model>.contract.toml`, or passed at the CLI via `--contracts <dir>`.
 
 [pipeline.silver.target]
 catalog = "analytics"

--- a/.claude/skills/rocky-config/SKILL.md
+++ b/.claude/skills/rocky-config/SKILL.md
@@ -220,9 +220,18 @@ depends_on = ["raw"]
 # There is no contracts key: a model's contract is auto-discovered as the
 # sibling `<model>.contract.toml`, or passed at the CLI via `--contracts <dir>`.
 
+# A transformation target takes an adapter ref (plus optional governance)
+# and nothing else — `catalog`/`schema` here are parse errors
+# (`deny_unknown_fields`). Each model names its own destination in its
+# sidecar `[target]`:
+#
+#   # models/silver/dim_customers.toml
+#   [target]
+#   catalog = "analytics"
+#   schema  = "marts"
+#   table   = "dim_customers"
 [pipeline.silver.target]
-catalog = "analytics"
-schema  = "marts"
+adapter = "warehouse"
 ```
 
 ### Quality pipeline
@@ -232,14 +241,19 @@ schema  = "marts"
 type       = "quality"
 depends_on = ["silver"]
 
+# A quality target is an adapter ref only. The tables to check are listed
+# in `[[pipeline.qa.tables]]` (omit `table` to check the whole schema).
 [pipeline.qa.target]
+adapter = "warehouse"
+
+[[pipeline.qa.tables]]
 catalog = "analytics"
 schema  = "marts"
 
+# Quality runs execute `row_count`, `custom`, and `assertions` only. Other
+# check kinds are inert here — `rocky validate` warns (V034).
 [pipeline.qa.checks]
-row_count    = true
-column_match = true
-freshness    = { threshold_seconds = 86400 }
+row_count = true
 ```
 
 ### Snapshot pipeline
@@ -247,6 +261,8 @@ freshness    = { threshold_seconds = 86400 }
 ```toml
 [pipeline.dim_history]
 type       = "snapshot"
+unique_key = ["customer_id"]     # required: row identity in the source table
+updated_at = "updated_at"        # required: change-detection column
 depends_on = ["silver"]
 
 [pipeline.dim_history.source]
@@ -257,6 +273,7 @@ table   = "dim_customers"
 [pipeline.dim_history.target]
 catalog = "analytics_history"
 schema  = "snapshots"
+table   = "dim_customers_history"   # required: explicit history table
 ```
 
 ## Minimal-config defaults (omit these)
@@ -274,7 +291,14 @@ The parser applies sane defaults — keep configs lean by omitting anything that
 | Model `target.table` | `name` | Renaming on write |
 | Directory-level `target` | `models/_defaults.toml` inherited | Overriding per-model |
 
-## Checks (all four pipeline types)
+## Checks
+
+Every pipeline type accepts a `[checks]` block, but execution differs:
+replication runs the full set; quality runs `row_count`, `custom`, and
+`assertions` only; transformation, snapshot, and load run no pipeline-level
+checks today (`executed_check_kinds` in `config.rs` is the source of
+truth). `rocky validate` warns (V034) on a check the pipeline type never
+executes.
 
 ```toml
 [pipeline.<name>.checks]

--- a/docs/src/content/docs/concepts/architecture-of-trust.md
+++ b/docs/src/content/docs/concepts/architecture-of-trust.md
@@ -187,9 +187,11 @@ silent divergence.
 Replay means two distinct things. Being precise about which one ships matters.
 
 **The first is deterministic recording with ledger verification.** Rocky records
-each run's per-model SQL hashes, row counts, bytes, and timings. It
-content-addresses the written artifacts: it names each one by the hash of its own
-bytes. The same inputs and code therefore produce the same physical files.
+each run's per-model SQL hashes, row counts, bytes, and timings when the
+execution path supplies them. Deterministic content-addressed materializations
+produce hash-named artifacts; ordinary warehouse runs do not provide byte-level
+replay proof. On the content-addressed path, each file is named by the hash of
+its own bytes, so the same inputs and code produce the same physical files.
 `rocky replay <run_id>` inspects that record and verifies it against the ledger.
 That ships today.
 

--- a/docs/src/content/docs/concepts/capability-matrix.md
+++ b/docs/src/content/docs/concepts/capability-matrix.md
@@ -160,10 +160,10 @@ the plan. Three properties of that gate, as it ships today:
   machine, not who wrote the bytes. Signed approvals are a planned
   hardening, not a shipped one.
 
-The first two properties are newer than engine v1.70.1. Releases up to and
+The first two properties arrived in engine v1.71.0. Releases up to and
 including v1.70.1 check only that a marker file exists, and skip even that
-when a `[policy]` rule resolves to `allow`. Upgrade before you rely on the
-floor.
+when a `[policy]` rule resolves to `allow`. Upgrade to v1.71.0 or later before
+you rely on the floor.
 
 Gate: `run_apply_ai_authored_plan`,
 `engine/crates/rocky-cli/src/commands/apply.rs`. Marker shape and the

--- a/docs/src/content/docs/concepts/capability-matrix.md
+++ b/docs/src/content/docs/concepts/capability-matrix.md
@@ -131,10 +131,15 @@ an observation job that you own.
 
 One separate, opt-in run-time check exists, for replication pipelines only:
 `[checks] freshness = { threshold_seconds = ... }` measures the real lag with
-SQL after the pipeline runs, and the check fails when the lag exceeds the
-threshold. Other pipeline types do not execute that check today; `rocky
-validate` flags it there as inert (V034). It is a pipeline check with its
-own key, not the model's `[freshness]` declaration.
+SQL after the pipeline runs, and records the check as failed when the lag
+exceeds the threshold. Other pipeline types do not execute that check today;
+`rocky validate` flags it there as inert (V034). It is a pipeline check with
+its own key, not the model's `[freshness]` declaration.
+
+That recorded failure is advisory. The replication runner does not stop on it.
+The run's status comes from copied and failed tables, never from check results,
+so the exit code does not change. Rocky reports the outcome and leaves the
+decision to your orchestrator.
 
 Declaration: `ModelFreshnessConfig`, `engine/crates/rocky-core/src/models.rs`
 (its own doc comment states the compiler does not enforce it). Scheduler

--- a/docs/src/content/docs/concepts/capability-matrix.md
+++ b/docs/src/content/docs/concepts/capability-matrix.md
@@ -43,8 +43,8 @@ Four more words appear across the rows, always with the same meaning:
 | [Classification tag completeness](#classification-tag-completeness) | Not enforced: Rocky warns (W004). Nothing blocks. |
 | [Masking application](#masking-application) | Adapter-dependent: Databricks only, attempted |
 | [Freshness](#freshness) | Declared metadata, not enforced. One opt-in run-time check, replication pipelines only. |
-| [Human review of AI-authored plans](#human-review-of-ai-authored-plans) | Rocky-guaranteed: enforced floor at apply |
-| [Audit ledger](#audit-ledger) | Rocky records it: attempted for ordinary rules, durable for budget and `verify_after` decisions |
+| [Human review of AI-authored plans](#human-review-of-ai-authored-plans) | Rocky-guaranteed: enforced floor at apply. The marker is checked, the approver is not authenticated. |
+| [Audit ledger](#audit-ledger) | Rocky records it: attempted for ordinary rules, durable for budget and `verify_after` decisions. Some refusals produce no row. |
 | [Byte-identical replay](#byte-identical-replay) | One write path only: content-addressed S3/UniForm. Elsewhere, recorded when available. |
 | [Rollback after a bad apply](#rollback-after-a-bad-apply) | No automatic restoration. Rocky halts; recovery is yours. |
 | [Grain and uniqueness](#grain-and-uniqueness) | Test-time assertion, not enforced at build |
@@ -149,9 +149,11 @@ demand: `engine/crates/rocky-core/src/schedule/demand.rs`. Run-time check:
 ## Human review of AI-authored plans
 
 **Rocky-guaranteed: enforced at apply, as a floor.** A plan proposed by an agent is marked
-AI-authored. `rocky apply` refuses to execute it until a human runs
-`rocky review <plan-id> --approve`, which writes an approval marker next to
-the plan. Three properties of that gate, as it ships today:
+AI-authored. `rocky apply` refuses to execute it unless an approval marker is
+present that parses and names that exact plan. `rocky review <plan-id> --approve`
+is the command that writes that marker. What apply enforces is the marker check,
+not the identity of the approver. Three properties of that gate, as it ships
+today:
 
 - **It is a floor.** The marker check runs on every AI-authored apply,
   whatever your `[policy]` rules say. A policy `allow` cannot waive it; a
@@ -180,12 +182,15 @@ three gates".
 ## Audit ledger
 
 **Rocky recording: attempted for ordinary rules, durable for the two gating kinds.**
-Policy-decision recording is best-effort for ordinary rules: at a mutating
-seam (`rocky apply`, promote), Rocky writes each decision to a
-`policy_decisions` table in the embedded redb state store, and when that
-write fails it warns and continues. Decisions relevant to an autonomy
-budget or to `verify_after` are durable instead: when they cannot be
-persisted, the apply fails closed. `rocky audit` lists the decisions.
+Policy-decision recording is best-effort for ordinary rules. At a mutating seam
+— `rocky apply` and promote, plus the `draft_*` and `propose` tools, which run
+the same evaluator into the same sink — Rocky writes each evaluated decision to
+a `policy_decisions` table in the embedded redb state store, and when that write
+fails it warns and continues. Some refusals never reach the table at all,
+because the gate can return a verdict before any rule is evaluated. Decisions
+relevant to an autonomy budget or to `verify_after` are durable instead: when
+they cannot be persisted, the apply fails closed. Treat the ledger as a
+best-effort record rather than proof that a decision happened. `rocky audit` lists the decisions.
 `rocky audit --for <table|run|plan>` assembles the custody chain for one
 subject: who proposed, what policy decided, what the plan changed, which runs
 materialized it, and what verification found. A link with no recorded signal

--- a/docs/src/content/docs/concepts/capability-matrix.md
+++ b/docs/src/content/docs/concepts/capability-matrix.md
@@ -1,0 +1,234 @@
+---
+title: Who Enforces What
+description: Each Rocky capability classified by who enforces it, so you know what the engine guarantees, what one adapter does, and what stays yours.
+sidebar:
+  order: 2.5
+---
+
+Rocky makes promises with three different owners. Some promises the engine
+enforces itself, the same way on every warehouse. Some depend on which
+warehouse adapter you run. Some belong to your warehouse or your operations,
+and Rocky only observes or records.
+
+This page classifies each capability by its owner. Read it before you build a
+compliance story, an approval workflow, or an incident plan on top of Rocky.
+Each section names the file or the page where you can check the claim. The
+[Architecture of Trust](/concepts/architecture-of-trust/) page grades the same
+primitives by maturity. This page answers a different question: when this
+check matters, who actually runs it?
+
+The three classes:
+
+- **Rocky-guaranteed.** The engine enforces it at compile time or apply time.
+  It behaves the same on DuckDB, Databricks, Snowflake, and BigQuery.
+- **Adapter-dependent.** The engine asks the warehouse adapter to do it. What
+  happens depends on the adapter, so the section names the warehouses.
+- **External control.** Your warehouse or your operations own it. Rocky
+  records what it saw, and nothing more.
+
+## The matrix
+
+| Capability | Who enforces it |
+|---|---|
+| [Contract columns, types, required, protected](#contracts-columns-types-required-protected) | Rocky-guaranteed (E010–E013), with two stated limits |
+| [Classification tag completeness](#classification-tag-completeness) | Rocky warns (W004). Nothing blocks. |
+| [Masking application](#masking-application) | Adapter-dependent: Databricks only, best-effort |
+| [Freshness](#freshness) | Declared metadata, not a gate. One opt-in run-time check exists. |
+| [Human review of AI-authored plans](#human-review-of-ai-authored-plans) | Rocky-guaranteed floor at apply |
+| [Audit ledger](#audit-ledger) | Rocky-guaranteed recording |
+| [Byte-identical replay](#byte-identical-replay) | One write path only: content-addressed S3/UniForm |
+| [Rollback after a bad apply](#rollback-after-a-bad-apply) | Does not exist. Rocky halts; recovery is yours. |
+| [Grain and uniqueness](#grain-and-uniqueness) | Test-time assertion, not a declared constraint |
+
+## Contracts: columns, types, required, protected
+
+**Rocky-guaranteed.** A `.contract.toml` declares what a model must produce.
+`rocky compile` checks the model's inferred schema against it, before anything
+runs, and fails on any of these four errors:
+
+- `E010`: a required column is missing.
+- `E011`: a column's type does not match.
+- `E012`: the contract says non-nullable, the model output is nullable.
+- `E013`: a protected column was removed.
+
+Two limits, stated plainly:
+
+- The type check (`E011`) applies only when Rocky infers a concrete type for
+  the column. When inference returns `Unknown`, the check is skipped by
+  design, so an unresolvable expression does not fail its contract.
+- `Decimal` matches on the name alone. A contract that says `Decimal(18,2)`
+  accepts any precision and scale today
+  ([#1466](https://github.com/rocky-data/rocky/issues/1466)).
+
+Checked in `validate_contract` and `type_name_matches`,
+`engine/crates/rocky-compiler/src/contracts.rs`. Workflow:
+[Testing](/concepts/testing/) and
+[Cross-team contracts](/concepts/cross-team-contracts/).
+
+## Classification tag completeness
+
+**Rocky warns. Nothing blocks.** When a column carries a classification tag
+(for example `pii`) that no `[mask]` or `[mask.<env>]` block resolves, the
+compiler emits warning `W004`. A tag listed in
+`[classifications] allow_unmasked` silences it. The warning does not fail the
+compile, and the compiler has no switch that turns it into an error. If your
+policy is "every tagged column must have a masking strategy", enforce that in
+CI: fail on `W004` in the compile output, or gate on
+`rocky compliance --fail-on exception`.
+
+Checked in `check_classification_tags`,
+`engine/crates/rocky-compiler/src/typecheck.rs`. Tag and mask semantics:
+[Governance](/guides/governance/), sections "Allowed unmasked tags" and
+"Compliance Rollup".
+
+## Masking application
+
+**Adapter-dependent: Databricks only, and best-effort there.** After a
+successful run, `rocky apply` walks each model's `[classification]` block and
+calls the governance adapter's masking hooks. On Databricks, Rocky writes
+Unity Catalog column tags and issues masking DDL, one statement per column. On
+DuckDB, Snowflake, and BigQuery the masking hooks do nothing today.
+
+Best-effort means: when a masking statement fails, Rocky logs a warning and
+the run continues. A masking failure is not a build error and does not roll
+anything back. Do not state a compliance guarantee on top of this on any
+warehouse. On warehouses other than Databricks, masking is an external
+control: apply it with the warehouse's own tools.
+
+Described, with the same caveats, in [Governance](/guides/governance/),
+section "How apply works", and graded in the
+[Architecture of Trust](/concepts/architecture-of-trust/).
+
+## Freshness
+
+**Declared metadata, not a gate.** A model's `[freshness]` block
+(`expected_lag_seconds`, `time_column`) declares how stale the model may get.
+Three things consume the declaration:
+
+- The scheduler (`rocky tick`, `rocky serve --scheduler`) turns the declared
+  budget into demand: a pipeline with a freshness schedule runs again once
+  too much time passes since its last successful run.
+- `rocky validate` checks the declaration itself is well-formed.
+- The compiler warns (`W005`) when a model has a temporal column but no
+  freshness declaration in scope.
+
+What the declaration does **not** do: `rocky test` does not evaluate it, and
+no materialization is blocked by it. Declaring `[freshness]` on a model does
+not create a run-time staleness alarm. Detecting stale data in production is
+an observation job that you own.
+
+One separate, opt-in run-time check exists: a pipeline's
+`[checks] freshness = { threshold_seconds = ... }` measures the real lag with
+SQL after the pipeline runs, and the check fails when the lag exceeds the
+threshold. That is a pipeline check with its own key, not the model's
+`[freshness]` declaration.
+
+Declaration: `ModelFreshnessConfig`, `engine/crates/rocky-core/src/models.rs`
+(its own doc comment states the compiler does not enforce it). Scheduler
+demand: `engine/crates/rocky-core/src/schedule/demand.rs`. Run-time check:
+`check_freshness`, `engine/crates/rocky-core/src/checks.rs`.
+
+## Human review of AI-authored plans
+
+**Rocky-guaranteed, as a floor.** A plan proposed by an agent is marked
+AI-authored. `rocky apply` refuses to execute it until a human runs
+`rocky review <plan-id> --approve`, which writes an approval marker next to
+the plan. Three properties of that gate, as it ships today:
+
+- **It is a floor.** The marker check runs on every AI-authored apply,
+  whatever your `[policy]` rules say. A policy `allow` cannot waive it; a
+  policy rule can only add restrictions on top.
+- **It is parse-and-match, not file-exists.** The marker must parse and must
+  name the exact plan being applied. A truncated, malformed, or mispasted
+  marker is refused with its own error. It never counts as an approval.
+- **It is not cryptographic.** The marker records who approved (best-effort
+  git identity) and when, and `rocky review <plan-id> --status` reports it.
+  The marker carries no signature. It proves an approval was recorded on this
+  machine, not who wrote the bytes. Signed approvals are a planned
+  hardening, not a shipped one.
+
+The first two properties are newer than engine v1.70.1. Releases up to and
+including v1.70.1 check only that a marker file exists, and skip even that
+when a `[policy]` rule resolves to `allow`. Upgrade before you rely on the
+floor.
+
+Gate: `run_apply_ai_authored_plan`,
+`engine/crates/rocky-cli/src/commands/apply.rs`. Marker shape and the
+absent/approved/invalid states: `ReviewMarkerState`,
+`engine/crates/rocky-cli/src/commands/review.rs`. Workflow:
+[Operating Rocky with agents](/concepts/operating-rocky-with-agents/), "The
+three gates".
+
+## Audit ledger
+
+**Rocky-guaranteed recording.** Every policy decision at a mutating seam
+(`rocky apply`, promote) is written to a `policy_decisions` table in the
+embedded redb state store. `rocky audit` lists the decisions.
+`rocky audit --for <table|run|plan>` assembles the custody chain for one
+subject: who proposed, what policy decided, what the plan changed, which runs
+materialized it, and what verification found. A link with no recorded signal
+renders as `unavailable`. Rocky does not fabricate a value to complete the
+chain.
+
+The ledger records what Rocky did. It is evidence, not enforcement: it stops
+nothing by itself, and it is exactly as durable as the state store you
+configure it to live in.
+
+Ledger tables: `engine/crates/rocky-core/src/state.rs`. Command:
+`engine/crates/rocky-cli/src/commands/audit.rs`. Reading the ledger without
+Rocky: [Verify a Run Without Rocky](/guides/verify-a-run/).
+
+## Byte-identical replay
+
+**One write path only.** On the content-addressed write path (S3-backed
+Delta/UniForm materialization), Rocky names each output Parquet file after
+the BLAKE3 hash of its own bytes and records the hash in the ledger. An
+engine test pins that the writer is byte-stable across runs. On that path,
+`rocky replay --execute --verify` re-derives a past run and compares hashes.
+
+A general run against DuckDB, Databricks, Snowflake, or BigQuery still
+records the per-model `sql_hash`, row counts, and recipe-identity hashes in
+the ledger. It emits no hash-named artifacts, so there is no byte-level
+replay proof on those targets. Treat any byte-identical claim as unverified on a given adapter
+until you have run the verification against that adapter yourself.
+
+Scope and walkthrough: [Verify a Run Without Rocky](/guides/verify-a-run/).
+Byte-stability test: `build_parquet_is_byte_stable_across_runs`,
+`engine/crates/rocky-iceberg/src/uniform_writer/parquet_builder.rs`. Replay
+grading: [Architecture of Trust](/concepts/architecture-of-trust/).
+
+## Rollback after a bad apply
+
+**Does not exist.** When a post-apply verification check
+(`verify_after` in a policy rule) fails, Rocky halts and reports. The
+mutation has already landed in the warehouse and it stays there. Rocky does
+not attempt an automatic rollback anywhere, because no rollback substrate
+exists to run one: a plain warehouse table has no engine-owned prior version
+to restore.
+
+Recovery after a bad apply is an external control. Plan for it with the
+warehouse's own tools: time travel, snapshots, or a re-run from upstream
+data. Rocky's role ends at halting loudly and recording what happened.
+
+Halt-only behavior and its rationale: the `verify_after` gate in
+`engine/crates/rocky-cli/src/commands/apply.rs` (the failure message states
+the mutation has already landed).
+
+## Grain and uniqueness
+
+**Test-time assertion, not a declared constraint.** Rocky has no compile-time
+grain declaration. To assert a model's grain, you declare tests: `type =
+"unique"` for one column, or a composite unique test for a multi-column key.
+`rocky test` runs them as SQL against the materialized data, so a duplicate
+is caught after the data exists, not before. Rocky does not prevent a
+duplicate from landing between test runs.
+
+Test kinds: `engine/crates/rocky-core/src/tests.rs`. Workflow:
+[Testing](/concepts/testing/).
+
+## How to read a gap
+
+A row that says "adapter-dependent" or "external control" is not a defect
+list. It is the boundary of what the engine can honestly promise. Build your
+controls on the rows marked Rocky-guaranteed, name the adapter when you rely
+on an adapter-dependent row, and own the external rows in your runbook.

--- a/docs/src/content/docs/concepts/capability-matrix.md
+++ b/docs/src/content/docs/concepts/capability-matrix.md
@@ -26,23 +26,32 @@ The three classes:
 - **External control.** Your warehouse or your operations own it. Rocky
   records what it saw, and nothing more.
 
+Four more words appear across the rows, always with the same meaning:
+
+- **Enforced.** The build or the apply fails when the condition does not
+  hold.
+- **Attempted.** Best-effort: Rocky tries, warns on failure, and continues.
+- **Recorded when available.** Rocky writes the value when the execution
+  path supplies it. A missing value is normal, not an error.
+- **Durable.** The write must persist, or the operation fails closed.
+
 ## The matrix
 
 | Capability | Who enforces it |
 |---|---|
-| [Contract columns, types, required, protected](#contracts-columns-types-required-protected) | Rocky-guaranteed (E010–E013), with two stated limits |
-| [Classification tag completeness](#classification-tag-completeness) | Rocky warns (W004). Nothing blocks. |
-| [Masking application](#masking-application) | Adapter-dependent: Databricks only, best-effort |
-| [Freshness](#freshness) | Declared metadata, not a gate. One opt-in run-time check exists. |
-| [Human review of AI-authored plans](#human-review-of-ai-authored-plans) | Rocky-guaranteed floor at apply |
-| [Audit ledger](#audit-ledger) | Rocky-guaranteed recording |
-| [Byte-identical replay](#byte-identical-replay) | One write path only: content-addressed S3/UniForm |
-| [Rollback after a bad apply](#rollback-after-a-bad-apply) | Does not exist. Rocky halts; recovery is yours. |
-| [Grain and uniqueness](#grain-and-uniqueness) | Test-time assertion, not a declared constraint |
+| [Contract columns, types, required, protected](#contracts-columns-types-required-protected) | Rocky-guaranteed: enforced at compile (E010–E013), with two stated limits |
+| [Classification tag completeness](#classification-tag-completeness) | Not enforced: Rocky warns (W004). Nothing blocks. |
+| [Masking application](#masking-application) | Adapter-dependent: Databricks only, attempted |
+| [Freshness](#freshness) | Declared metadata, not enforced. One opt-in run-time check, replication pipelines only. |
+| [Human review of AI-authored plans](#human-review-of-ai-authored-plans) | Rocky-guaranteed: enforced floor at apply |
+| [Audit ledger](#audit-ledger) | Rocky records it: attempted for ordinary rules, durable for budget and `verify_after` decisions |
+| [Byte-identical replay](#byte-identical-replay) | One write path only: content-addressed S3/UniForm. Elsewhere, recorded when available. |
+| [Rollback after a bad apply](#rollback-after-a-bad-apply) | No automatic restoration. Rocky halts; recovery is yours. |
+| [Grain and uniqueness](#grain-and-uniqueness) | Test-time assertion, not enforced at build |
 
 ## Contracts: columns, types, required, protected
 
-**Rocky-guaranteed.** A `.contract.toml` declares what a model must produce.
+**Rocky-guaranteed: enforced at compile.** A `.contract.toml` declares what a model must produce.
 `rocky compile` checks the model's inferred schema against it, before anything
 runs, and fails on any of these four errors:
 
@@ -67,7 +76,7 @@ Checked in `validate_contract` and `type_name_matches`,
 
 ## Classification tag completeness
 
-**Rocky warns. Nothing blocks.** When a column carries a classification tag
+**Not enforced. Rocky warns; nothing blocks.** When a column carries a classification tag
 (for example `pii`) that no `[mask]` or `[mask.<env>]` block resolves, the
 compiler emits warning `W004`. A tag listed in
 `[classifications] allow_unmasked` silences it. The warning does not fail the
@@ -83,13 +92,16 @@ Checked in `check_classification_tags`,
 
 ## Masking application
 
-**Adapter-dependent: Databricks only, and best-effort there.** After a
-successful run, `rocky apply` walks each model's `[classification]` block and
-calls the governance adapter's masking hooks. On Databricks, Rocky writes
-Unity Catalog column tags and issues masking DDL, one statement per column. On
-DuckDB, Snowflake, and BigQuery the masking hooks do nothing today.
+**Adapter-dependent: Databricks only, attempted there.** After a clean
+full-replication `--all`/`--models` model phase, Rocky reconciles masking
+best-effort: it walks each model's `[classification]` block and calls the
+governance adapter's masking hooks. Other execution paths (a single
+`--model` run, a backfill, a transformation pipeline) do not reconcile
+masks today. On Databricks, Rocky writes Unity Catalog column tags and
+issues masking DDL, one statement per column. On DuckDB, Snowflake, and
+BigQuery the masking hooks do nothing today.
 
-Best-effort means: when a masking statement fails, Rocky logs a warning and
+Attempted means: when a masking statement fails, Rocky logs a warning and
 the run continues. A masking failure is not a build error and does not roll
 anything back. Do not state a compliance guarantee on top of this on any
 warehouse. On warehouses other than Databricks, masking is an external
@@ -117,11 +129,12 @@ no materialization is blocked by it. Declaring `[freshness]` on a model does
 not create a run-time staleness alarm. Detecting stale data in production is
 an observation job that you own.
 
-One separate, opt-in run-time check exists: a pipeline's
+One separate, opt-in run-time check exists, for replication pipelines only:
 `[checks] freshness = { threshold_seconds = ... }` measures the real lag with
 SQL after the pipeline runs, and the check fails when the lag exceeds the
-threshold. That is a pipeline check with its own key, not the model's
-`[freshness]` declaration.
+threshold. Other pipeline types do not execute that check today; `rocky
+validate` flags it there as inert (V034). It is a pipeline check with its
+own key, not the model's `[freshness]` declaration.
 
 Declaration: `ModelFreshnessConfig`, `engine/crates/rocky-core/src/models.rs`
 (its own doc comment states the compiler does not enforce it). Scheduler
@@ -130,7 +143,7 @@ demand: `engine/crates/rocky-core/src/schedule/demand.rs`. Run-time check:
 
 ## Human review of AI-authored plans
 
-**Rocky-guaranteed, as a floor.** A plan proposed by an agent is marked
+**Rocky-guaranteed: enforced at apply, as a floor.** A plan proposed by an agent is marked
 AI-authored. `rocky apply` refuses to execute it until a human runs
 `rocky review <plan-id> --approve`, which writes an approval marker next to
 the plan. Three properties of that gate, as it ships today:
@@ -161,9 +174,13 @@ three gates".
 
 ## Audit ledger
 
-**Rocky-guaranteed recording.** Every policy decision at a mutating seam
-(`rocky apply`, promote) is written to a `policy_decisions` table in the
-embedded redb state store. `rocky audit` lists the decisions.
+**Rocky recording: attempted for ordinary rules, durable for the two gating kinds.**
+Policy-decision recording is best-effort for ordinary rules: at a mutating
+seam (`rocky apply`, promote), Rocky writes each decision to a
+`policy_decisions` table in the embedded redb state store, and when that
+write fails it warns and continues. Decisions relevant to an autonomy
+budget or to `verify_after` are durable instead: when they cannot be
+persisted, the apply fails closed. `rocky audit` lists the decisions.
 `rocky audit --for <table|run|plan>` assembles the custody chain for one
 subject: who proposed, what policy decided, what the plan changed, which runs
 materialized it, and what verification found. A link with no recorded signal
@@ -171,8 +188,8 @@ renders as `unavailable`. Rocky does not fabricate a value to complete the
 chain.
 
 The ledger records what Rocky did. It is evidence, not enforcement: it stops
-nothing by itself, and it is exactly as durable as the state store you
-configure it to live in.
+nothing by itself, and it lives in whatever state store you configure. The
+ledger is only as safe as that store.
 
 Ledger tables: `engine/crates/rocky-core/src/state.rs`. Command:
 `engine/crates/rocky-cli/src/commands/audit.rs`. Reading the ledger without
@@ -186,11 +203,14 @@ the BLAKE3 hash of its own bytes and records the hash in the ledger. An
 engine test pins that the writer is byte-stable across runs. On that path,
 `rocky replay --execute --verify` re-derives a past run and compares hashes.
 
-A general run against DuckDB, Databricks, Snowflake, or BigQuery still
-records the per-model `sql_hash`, row counts, and recipe-identity hashes in
-the ledger. It emits no hash-named artifacts, so there is no byte-level
-replay proof on those targets. Treat any byte-identical claim as unverified on a given adapter
-until you have run the verification against that adapter yourself.
+A general run against DuckDB, Databricks, Snowflake, or BigQuery records
+less. When persistence succeeds, successful materializations record recipe
+identity; SQL hashes and row counts are recorded only when the execution
+path supplies them (a replication copy, for example, supplies neither). A
+general run emits no hash-named artifacts, so there is no byte-level replay
+proof on those targets. Treat any byte-identical claim as unverified on a
+given adapter until you have run the verification against that adapter
+yourself.
 
 Scope and walkthrough: [Verify a Run Without Rocky](/guides/verify-a-run/).
 Byte-stability test: `build_parquet_is_byte_stable_across_runs`,
@@ -201,10 +221,12 @@ grading: [Architecture of Trust](/concepts/architecture-of-trust/).
 
 **Does not exist.** When a post-apply verification check
 (`verify_after` in a policy rule) fails, Rocky halts and reports. The
-mutation has already landed in the warehouse and it stays there. Rocky does
-not attempt an automatic rollback anywhere, because no rollback substrate
-exists to run one: a plain warehouse table has no engine-owned prior version
-to restore.
+mutation has already landed in the warehouse and it stays there. Rocky has
+no automatic restoration after a failed `verify_after` check; transactional
+statement failures may still roll back an uncommitted partition. That
+narrower mechanism is mid-run hygiene on transactional warehouses, not a
+restore. No restore substrate exists, because a plain warehouse table has
+no engine-owned prior version.
 
 Recovery after a bad apply is an external control. Plan for it with the
 warehouse's own tools: time travel, snapshots, or a re-run from upstream

--- a/docs/src/content/docs/concepts/testing.md
+++ b/docs/src/content/docs/concepts/testing.md
@@ -60,7 +60,6 @@ nullable = false
 [rules]
 required = ["customer_id", "total_revenue"]
 protected = ["customer_id"]
-no_new_nullable = true
 ```
 
 ### Column constraints
@@ -84,7 +83,7 @@ The `[rules]` section enforces schema-level constraints:
 |------|-------------|
 | `required` | Columns that must exist in the model's output. Missing required columns produce error `E010`. |
 | `protected` | Columns that must never be removed. If a protected column disappears from the output, it produces error `E013`. |
-| `no_new_nullable` | If `true`, no new nullable columns may be added to the model's output. |
+| `no_new_nullable` | Parsed but not enforced today. The compiler accepts the key and checks nothing ([#1467](https://github.com/rocky-data/rocky/issues/1467)). Leave it out. |
 
 ### Diagnostic codes
 

--- a/docs/src/content/docs/dagster/contracts.md
+++ b/docs/src/content/docs/dagster/contracts.md
@@ -36,7 +36,6 @@ project/
 [rules]
 required = ["id", "amount"]
 protected = ["customer_id"]
-no_new_nullable = true
 
 # Per-column type and nullability constraints
 [[columns]]


### PR DESCRIPTION
A public page saying, per capability, what Rocky actually does: **enforced**, **attempted**, **recorded when available**, or **durable**. The point is that a reader can tell a guarantee from a best effort without reading the source.

## Two rows were genuinely stale, and both are fixed

The page was written before the last engine release, so I re-verified the two most volatile rows against the tree rather than trusting them:

- **Review floor.** It said "upgrade" without naming a target. Checked against the tags: `engine-v1.71.0` carries both halves of the floor (the marker state with its `Invalid` arm, and the unconditional marker check); `v1.70.1` carries neither. The row now names the version.
- **Freshness.** It said the check "fails when the lag exceeds the threshold". It does not — the run status is derived from copies, materializations, interruption and failures, and never reads the check results; the replication runner explicitly does not bail. A failing freshness check is **recorded and advisory**, and the row now says so.

That second one is the kind of claim worth being strict about: a reader planning around "this fails the run" would build on something that doesn't happen.

## Notes for review

- The content had already been through adversarial review; this rebase was clean, so only the two claims above changed.
- Required engine checks don't run on a docs-only change, so this needs an admin merge.
- File-disjoint from the E4 cleanup PR (#1510) — either order is fine.