### PR TITLE
tools: guards for mutation checks and branch hygiene

### DIFF
--- a/.git-hooks/post-checkout
+++ b/.git-hooks/post-checkout
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Rocky monorepo post-checkout hook.
+#
+# Shouts when a branch switch CARRIED uncommitted work across with it.
+#
+# `git checkout <branch>` does not stop for a dirty worktree: when the change
+# does not conflict, git brings it along silently. The work then belongs to
+# whichever branch you happen to land on, and the next `git add -A` commits it
+# there. That has repeatedly put changes on the wrong branch in this repo —
+# unrelated tooling inside a bugfix PR, a docs edit inside an engine PR, and a
+# branch accidentally stacked on another PR's commits.
+#
+# git has no pre-checkout hook, so this cannot refuse. It can make the carry
+# impossible to miss, which is the whole failure: it happens quietly.
+#
+# Skip with ROCKY_SKIP_HOOKS=1.
+set -uo pipefail
+
+# Args: $1 = previous HEAD, $2 = new HEAD, $3 = 1 for a branch checkout,
+# 0 for a file checkout. Only a branch switch can carry work.
+prev_head="${1:-}"
+new_head="${2:-}"
+branch_switch="${3:-0}"
+
+[ "$branch_switch" = "1" ] || exit 0
+[ "${ROCKY_SKIP_HOOKS:-}" = "1" ] && exit 0
+
+# A no-op checkout of the branch you are already on carries nothing.
+[ "$prev_head" = "$new_head" ] && exit 0
+
+carried="$(git status --porcelain 2>/dev/null)"
+status_rc=$?
+if [ "$status_rc" -ne 0 ]; then
+    echo "post-checkout: WARNING — could not read git status; cannot tell whether" >&2
+    echo "               uncommitted work came across with this switch." >&2
+    exit 0
+fi
+[ -z "$carried" ] && exit 0
+
+branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
+
+cat >&2 <<WARNING
+
+╔════════════════════════════════════════════════════════════════════╗
+║  UNCOMMITTED WORK CAME WITH YOU                                    ║
+╚════════════════════════════════════════════════════════════════════╝
+
+You are now on '$branch', and these changes followed the switch:
+
+$carried
+
+They are NOT part of any branch yet. Committing here puts them on
+'$branch' — which is how unrelated changes end up inside a PR.
+
+If they belong on the branch you just LEFT:
+
+    git stash push -u -m "wip"     # here
+    git checkout -                 # back
+    git stash pop
+
+If they belong here, commit them here deliberately.
+
+WARNING
+
+# Never block: a post-checkout hook that exits nonzero leaves the user on the
+# new branch anyway, so failing would only add confusion to a switch that has
+# already happened.
+exit 0

--- a/AGENT_REVIEW.md
+++ b/AGENT_REVIEW.md
@@ -65,7 +65,10 @@ Key files:
    soundness, content-addressed commit atomicity, no half-committed state on the failure path.
 5. **Rust correctness hazards** — panics on user-reachable paths, `unsafe` without `// SAFETY:`.
 6. **Test evidence** — is the change proven by a coded-diagnostic rejection test and an assertion on the
-   emitted type / SQL?
+   emitted type / SQL? A test only counts when it FAILS with the fix reverted; run
+   `scripts/mutation-check.sh` to show that. It refuses on a dirty worktree, so commit the fix and its
+   test first — the committed state is what the evidence is about. Two failure shapes it catches: a test
+   that reimplements the logic instead of calling it, and a mutation that silently did not apply.
 
 Do **not** spend budget on formatting, import ordering, naming, or doc typos. Collapse those into at most
 a single trailing `nits:` line.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,10 @@ You can also build one subproject directly. The sections below give the commands
 
 Optional: run `just install-hooks` to point `core.hooksPath` at `.git-hooks/`. Every hook check is conditional. A check runs only when the change touches the subproject it covers.
 
+`post-checkout` is a warning, not a check: `git checkout <branch>` does not stop for a dirty worktree — it carries non-conflicting changes across, and they end up committed on whichever branch you landed on. git has no pre-checkout hook, so the switch cannot be refused; the hook makes the carry loud instead of silent.
+
+To start a branch, `scripts/new-branch.sh <name> [base]` refuses on a dirty tree and defaults the base to a freshly-fetched `origin/main`. Branching from whatever happened to be checked out is the other half of the same problem: the new branch inherits the current one's commits, so it conflicts when that branch merges — and a squash-merge of the child can land the parent's work, including its `Closes #NNN` trailers, under the child's number.
+
 - **pre-commit:** `cargo fmt --check` for `engine/`, `ruff format --check` for `integrations/dagster/`, eslint for `editors/vscode/`.
 - **pre-commit, codegen drift:** runs only when you stage `output.rs`, `commands/doctor.rs`, or `commands/export_schemas.rs` under `engine/crates/rocky-cli/src/`.
 - **pre-push:** `cargo clippy` for `engine/`, `ruff check` for `integrations/dagster/`.

--- a/scripts/mutation-check.sh
+++ b/scripts/mutation-check.sh
@@ -35,7 +35,9 @@
 # Exit status:
 #   0  the test FAILED under mutation — the test is fix-sensitive (good)
 #   1  the test PASSED under mutation — the test proves nothing (bad)
-#   2  refused to run (dirty worktree, bad arguments, mutation not applied)
+#   2  refused to run (dirty worktree, bad arguments, mutation not applied,
+#      or the test command does not pass on the clean tree)
+#   3  inconclusive — the mutation broke the build, so the test never ran
 set -uo pipefail
 
 die() {
@@ -58,7 +60,11 @@ cd "$repo_root" || die "cannot enter $repo_root"
 # THE GUARD. A dirty worktree means the restore below could discard work that
 # was never committed. Commit (or stash with a tag) first — then the restore
 # can only take back the mutation.
-dirty="$(git status --porcelain)"
+dirty="$(git status --porcelain)" || die "git status failed — refusing to touch the worktree"
+# `git status` printing nothing is only reassuring if it SUCCEEDED. With a
+# corrupt index it exits nonzero and prints nothing, which would read as a
+# clean tree and let the mutation through — the guard failing open in exactly
+# the situation it exists for.
 if [ -n "$dirty" ]; then
     echo "mutation-check: REFUSING — the worktree is not clean." >&2
     echo "" >&2
@@ -71,9 +77,31 @@ if [ -n "$dirty" ]; then
     exit 2
 fi
 
-before="$(git rev-parse HEAD)"
+baseline_log="$(mktemp)"
+mutated_log="$(mktemp)"
+before="$(git rev-parse HEAD)" || die "cannot read HEAD"
 
+# BASELINE. Run the test command against the clean tree first and require it
+# to pass. Without this, "the command exited nonzero" is not evidence about
+# the mutation at all: a typo'd crate name, a missing binary or a filter that
+# matches nothing all exit nonzero (or zero) for reasons that have nothing to
+# do with the code under test.
+echo "mutation-check: baseline — running the test command against the CLEAN tree"
+if ! "$@" > "$baseline_log" 2>&1; then
+    echo "mutation-check: REFUSING — the test command does not pass before any mutation." >&2
+    echo "" >&2
+    tail -20 "$baseline_log" >&2
+    echo "" >&2
+    echo "Fix the command (or the test) first. A run that already fails proves" >&2
+    echo "nothing about the mutation." >&2
+    exit 2
+fi
+echo "mutation-check: baseline passes"
+
+# ONE exit trap: setting a second `trap ... EXIT` later would silently replace
+# the first, and the one that must never be lost is the restore.
 restore() {
+    rm -f "$baseline_log" "$mutated_log"
     git checkout HEAD -- "$target" 2>/dev/null
     local left
     left="$(git status --porcelain)"
@@ -93,14 +121,28 @@ fi
 echo "mutation-check: applied mutation to $target"
 echo "mutation-check: running: $*"
 echo "---"
-if "$@"; then
+if "$@" > "$mutated_log" 2>&1; then
+    cat "$mutated_log"
     echo "---"
     echo "mutation-check: FAIL — the test PASSED with the fix reverted."
     echo "mutation-check: that test does not guard this change. Fix the test."
     exit 1
 fi
-
+cat "$mutated_log"
 echo "---"
+
+# A nonzero exit is not automatically evidence. If the mutation broke the
+# BUILD, the command failed without running the test — the commonest outcome
+# when a mutation deletes a condition and leaves an unused binding. Reporting
+# that as "fix-sensitive" would be the same false green this script exists to
+# prevent, inside the script.
+if grep -qE '^error(\[E[0-9]+\])?:|error: could not compile' "$mutated_log"; then
+    echo "mutation-check: INCONCLUSIVE — the mutation broke the build, so the test" >&2
+    echo "never ran. Choose a mutation that still compiles (flip a condition to" >&2
+    echo "\`false &&\`, change a constant) rather than one that deletes code." >&2
+    exit 3
+fi
+
 echo "mutation-check: OK — the test failed under mutation, so it is fix-sensitive."
 [ "$(git rev-parse HEAD)" = "$before" ] || die "HEAD moved during the check"
 exit 0

--- a/scripts/mutation-check.sh
+++ b/scripts/mutation-check.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Mutation-check a test: prove it FAILS when the fix it guards is reverted.
+#
+# AGENT_REVIEW.md requires evidence that a test is fix-sensitive. The manual
+# form of that — edit the source, run the test, undo the edit — has one sharp
+# edge: the "undo" step (`git restore` / `git checkout --`) destroys ANY
+# uncommitted work in that file, not just the mutation. That has cost real
+# work in this repo more than once.
+#
+# This script removes the edge by construction: it refuses to run unless the
+# worktree is clean, so the undo can only ever discard the mutation it made.
+#
+# Usage:
+#   scripts/mutation-check.sh <file> <python-expr-file> <test-command...>
+#
+# The mutation is a Python script that reads the file on stdin-style (see
+# below) — it must print nothing and write the mutated content back. The
+# simplest form is a search/replace:
+#
+#   cat > /tmp/mut.py <<'EOF'
+#   import sys
+#   p = sys.argv[1]
+#   s = open(p).read()
+#   old = "if entry.has_prev && prev.exists() {"
+#   new = "if prev.exists() {"
+#   assert s.count(old) == 1, "mutation target not found exactly once"
+#   open(p, "w").write(s.replace(old, new))
+#   EOF
+#
+#   scripts/mutation-check.sh \
+#       engine/crates/rocky-core/src/product/commit.rs \
+#       /tmp/mut.py \
+#       cargo test -p rocky-core --lib product::commit
+#
+# Exit status:
+#   0  the test FAILED under mutation — the test is fix-sensitive (good)
+#   1  the test PASSED under mutation — the test proves nothing (bad)
+#   2  refused to run (dirty worktree, bad arguments, mutation not applied)
+set -uo pipefail
+
+die() {
+    echo "mutation-check: $*" >&2
+    exit 2
+}
+
+[ $# -ge 3 ] || die "usage: $0 <file> <mutation.py> <test-command...>"
+
+target="$1"
+mutation="$2"
+shift 2
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || die "not a git repository"
+cd "$repo_root" || die "cannot enter $repo_root"
+
+[ -f "$target" ] || die "no such file: $target"
+[ -f "$mutation" ] || die "no such mutation script: $mutation"
+
+# THE GUARD. A dirty worktree means the restore below could discard work that
+# was never committed. Commit (or stash with a tag) first — then the restore
+# can only take back the mutation.
+dirty="$(git status --porcelain)"
+if [ -n "$dirty" ]; then
+    echo "mutation-check: REFUSING — the worktree is not clean." >&2
+    echo "" >&2
+    echo "$dirty" >&2
+    echo "" >&2
+    echo "The restore step would discard these changes along with the mutation." >&2
+    echo "Commit them first (the fix AND its test), then re-run. That is also" >&2
+    echo "the order the evidence needs: the committed state is what you are" >&2
+    echo "proving sensitive." >&2
+    exit 2
+fi
+
+before="$(git rev-parse HEAD)"
+
+restore() {
+    git checkout HEAD -- "$target" 2>/dev/null
+    local left
+    left="$(git status --porcelain)"
+    if [ -n "$left" ]; then
+        echo "mutation-check: WARNING — worktree not clean after restore:" >&2
+        echo "$left" >&2
+    fi
+}
+trap restore EXIT
+
+python3 "$mutation" "$target" || die "mutation script failed"
+
+if git diff --quiet -- "$target"; then
+    die "mutation did not change $target — the target text was not found"
+fi
+
+echo "mutation-check: applied mutation to $target"
+echo "mutation-check: running: $*"
+echo "---"
+if "$@"; then
+    echo "---"
+    echo "mutation-check: FAIL — the test PASSED with the fix reverted."
+    echo "mutation-check: that test does not guard this change. Fix the test."
+    exit 1
+fi
+
+echo "---"
+echo "mutation-check: OK — the test failed under mutation, so it is fix-sensitive."
+[ "$(git rev-parse HEAD)" = "$before" ] || die "HEAD moved during the check"
+exit 0

--- a/scripts/new-branch.sh
+++ b/scripts/new-branch.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Start a branch from a known base, with a clean tree.
+#
+# Two failure modes this removes, both of which have cost real rework here:
+#
+#   1. Branching from wherever HEAD happens to be. `git checkout -b fix/x`
+#      inherits the CURRENT branch's commits. A branch cut while sitting on
+#      another PR's branch carries that PR's payload: it conflicts the moment
+#      the parent merges, and a squash-merge of the child can silently land
+#      the parent's work (and fire its `Closes #NNN` trailers) under the
+#      child's number.
+#
+#   2. Carrying uncommitted work across the switch. `git checkout` does not
+#      stop for a dirty tree — it brings non-conflicting changes along, and
+#      they end up committed on the new branch.
+#
+# Usage:
+#   scripts/new-branch.sh <branch-name> [base]
+#
+# `base` defaults to origin/main and is fetched first, so the branch starts
+# from the real remote head rather than a stale local ref.
+#
+# Deliberate stacking is still possible — pass the base explicitly:
+#   scripts/new-branch.sh fix/child feat/parent-pr-branch
+# It prints a warning in that case, because a stacked branch must be declared
+# on its PR or the merge order will surprise someone.
+#
+# Exit status:
+#   0  branch created and checked out
+#   2  refused (dirty tree, bad arguments, unknown base, branch exists)
+set -uo pipefail
+
+die() {
+    echo "new-branch: $*" >&2
+    exit 2
+}
+
+[ $# -ge 1 ] || die "usage: $0 <branch-name> [base]"
+
+branch="$1"
+base="${2:-origin/main}"
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || die "not a git repository"
+cd "$repo_root" || die "cannot enter $repo_root"
+
+dirty="$(git status --porcelain)" || die "git status failed — refusing to switch"
+if [ -n "$dirty" ]; then
+    echo "new-branch: REFUSING — the worktree is not clean." >&2
+    echo "" >&2
+    echo "$dirty" >&2
+    echo "" >&2
+    echo "git would carry these onto '$branch', where a later commit would put" >&2
+    echo "them on the wrong branch. Commit them, or stash them with a tag:" >&2
+    echo "" >&2
+    echo "    git stash push -u -m \"<what this is>\"" >&2
+    exit 2
+fi
+
+git show-ref --verify --quiet "refs/heads/$branch" && die "branch '$branch' already exists"
+
+# Fetch so `origin/main` is the real remote head, not a stale local ref. A
+# branch cut from a stale base looks fine and then conflicts on push.
+if [ "$base" = "origin/main" ]; then
+    git fetch origin main --quiet || die "could not fetch origin/main"
+fi
+
+git rev-parse --verify --quiet "$base" >/dev/null || die "unknown base: $base"
+
+if [ "$base" != "origin/main" ]; then
+    echo "new-branch: NOTE — basing '$branch' on '$base', not origin/main." >&2
+    echo "            That is a STACKED branch. Say so on its pull request, and" >&2
+    echo "            merge the parent first — a squash-merge of this branch will" >&2
+    echo "            otherwise carry the parent's commits under this branch's" >&2
+    echo "            number, including any 'Closes #NNN' trailers they contain." >&2
+fi
+
+git checkout -b "$branch" "$base" --quiet || die "could not create '$branch'"
+
+echo "new-branch: created '$branch' from $base ($(git rev-parse --short HEAD))"


### PR DESCRIPTION
A tool, because the discipline kept failing.

## The problem

`AGENT_REVIEW.md` requires evidence that a test fails when the fix it guards is reverted. Done by hand that is: edit the source, run the test, undo the edit. The undo — `git restore` / `git checkout --` — discards **everything uncommitted in that file**, not just the mutation.

That has destroyed real work in this repo repeatedly, four times in a single session. There is no reflog for content that was never committed.

## The fix

`scripts/mutation-check.sh` refuses to run unless `git status --porcelain` is empty, so its restore can only ever take back the mutation it made.

```
scripts/mutation-check.sh <file> <mutation.py> <test-command...>

exit 0   test FAILED under mutation   -> fix-sensitive (good)
exit 1   test PASSED under mutation   -> the test proves nothing
exit 2   refused (dirty tree / target text not found / bad args)
```

Refusing on a dirty tree also enforces the right order: commit the fix **and** its test first, because the committed state is what the evidence is about.

## Verified on all three paths

```
dirty tree       REFUSED, and the uncommitted scratch line survived
real mutation    exit 0 — caught a tests_passed underflow (PR #1506)
comment-only     exit 1 — "that test does not guard this change"
```

The mutation script must assert its target appears exactly once (`assert s.count(old) == 1`), so a mutation that silently did not apply cannot read as "the test is insensitive". The script also fails if the file is unchanged after the mutation runs.

## Two failure shapes it catches, both seen this week

1. **A test that reimplements the logic instead of calling it.** In #1506 my first regression test copied the override into the test body; mutating the production code changed nothing and the test passed. Extracting the function and calling it made the check meaningful.
2. **A guard that was never wired.** In #1498 the symlink tests called the helper directly, so reverting the production call site left all 38 tests green.

`AGENT_REVIEW.md`'s test-evidence bar now names the tool and both shapes.

## Least confident

Whether `python3` for the mutation script is the right interface — it is what is already used ad hoc in this repo, and it makes the exactly-once assertion natural, but a `sed` form would have fewer moving parts for simple replacements.

---

## Update: two more guards, and a BLOCK on the first one

### The review found this script had the bug it exists to catch

```
$ ./mc.sh src/x.rs mut.py this-binary-does-not-exist
mutation-check: OK - the test failed under mutation, so it is fix-sensitive.
exit=0
```

`if "$@"` treated every nonzero exit as evidence about the mutation. A missing binary, a typo'd crate name, or — the common case for Rust — a mutation that breaks compilation, all printed OK. And `AGENT_REVIEW.md` had just told reviewers to trust that signal, which is what made it blocking rather than merely wrong.

Three fixes, each verified against the reviewer's executed cases:

```
missing binary          was OK/0   now REFUSING at baseline, exit 2
mutation breaks build   was OK/0   now INCONCLUSIVE, exit 3
genuine sensitivity                still OK, exit 0
corrupt git index       guard failed OPEN (git status exits 128 printing
                        nothing, which read as clean)  now refuses
```

The baseline run — the test command must pass on the clean tree before anything is mutated — is what closes the first two. The `git status` exit check closes the third, which mattered most: the guard failing open in the one situation it exists for.

Also folded the log cleanup into `restore()`. A second `trap ... EXIT` would have silently replaced the restore trap.

### Two guards for work landing on the wrong branch

Same session, three incidents: unrelated tooling committed inside a bugfix PR, a docs edit inside an engine PR, and a branch cut from another PR's branch that then carried that PR's payload through a squash-merge — firing its `Closes #NNN` trailers under the wrong number.

`.git-hooks/post-checkout` — `git checkout <branch>` does not stop for a dirty worktree; it carries non-conflicting changes across silently. git has no pre-checkout hook, so this cannot refuse; it makes the carry impossible to miss, which is the actual failure since it happens quietly. It never blocks — the switch has already happened by the time a post-checkout hook runs.

`scripts/new-branch.sh` — refuses on a dirty tree, and defaults the base to a freshly-fetched `origin/main`. Deliberate stacking still works by passing the base explicitly, and warns about the squash-merge hazard.

Verified: the hook fires on a carried change and stays quiet on a clean switch; the script refuses dirty (exit 2), warns on an explicit stacked base, and creates cleanly from `origin/main`.

### Least confident, still

Whether a repo-level `post-checkout` hook is welcome — it is advisory and skippable with `ROCKY_SKIP_HOOKS=1`, but it prints a banner, and anyone who routinely moves work across branches on purpose will find it noisy.
