### PR TITLE
docs: make the safety claims match the code, and say what shipped (#1509, #1512)

### DIFF
--- a/.agents/skills/rocky-ai-workflow/SKILL.md
+++ b/.agents/skills/rocky-ai-workflow/SKILL.md
@@ -7,7 +7,7 @@ description: How an AI agent should author or modify a Rocky data model. Use whe
 
 This is the workflow for an AI agent that has been asked to build or change a Rocky model. It assumes you can run the `rocky` CLI (or call the equivalent tools) and read its `--output json`. For the config format see the `rocky-config` skill; for the full command surface see the `rocky` skill. This skill is specifically about *how to converge on a correct model* and *how to ship it safely*.
 
-The shape of the job: **you propose, Rocky's compiler verifies, an approval marker gates the apply.** Your edits are not trusted because they compiled — they're trusted because the typed substrate checked them and someone reviewed the reported delta.
+The shape of the job: **you propose, Rocky's compiler verifies, an approval marker gates the apply.** Your edits are not trusted because they compiled — they're trusted because the typed substrate checked them and the apply is gated on a marker naming that plan.
 
 ## Author SQL, not the DSL
 
@@ -38,7 +38,7 @@ The path:
 
 1. **Propose.** Generate the plan that materializes your change (it is recorded as an *AI-authored* plan with a `plan_id`). A propose can also bind the plan to a product identity — `product_id` plus `spec_digest`, both together or neither. A product-bound plan refuses a bare `rocky apply`; the applier must pass `rocky apply <plan-id> --expect-spec-digest <digest>` with the digest of the approved spec. When you do not work for a product runner, omit both fields.
 2. **Review.** Run `rocky review <plan-id>`. This compiles your working tree against the base ref and runs the semantic breaking-change classifier, then reports the delta — added/removed/retyped columns, anything downstream consumers depend on. Read it.
-3. **Approve.** `rocky review <plan-id> --approve` writes the approval marker. Approving over breaking changes is allowed, and the report lists them, so raise them explicitly rather than assuming the approver read the output.
+3. **Approve.** `rocky review <plan-id> --approve` writes the approval marker. Approving over breaking changes is allowed. The marker is written even when the classifier could not run: if either tree fails to compile, findings are absent and `breaking_change_count` falls back to 0. So a marker is not evidence a delta was computed — raise the findings explicitly.
 4. **Apply.** Only after the approval marker exists does `rocky apply <plan-id>` execute.
 
 Your job ends at *propose* and at *surfacing the review report clearly*. The approval is a human decision; do not approve on the user's behalf unless they explicitly tell you to.

--- a/.agents/skills/rocky-ai-workflow/SKILL.md
+++ b/.agents/skills/rocky-ai-workflow/SKILL.md
@@ -7,7 +7,7 @@ description: How an AI agent should author or modify a Rocky data model. Use whe
 
 This is the workflow for an AI agent that has been asked to build or change a Rocky model. It assumes you can run the `rocky` CLI (or call the equivalent tools) and read its `--output json`. For the config format see the `rocky-config` skill; for the full command surface see the `rocky` skill. This skill is specifically about *how to converge on a correct model* and *how to ship it safely*.
 
-The shape of the job: **you propose, Rocky's compiler verifies, a human approves the invariants.** Your edits are not trusted because they compiled — they're trusted because the typed substrate checked them and a person signed off.
+The shape of the job: **you propose, Rocky's compiler verifies, an approval marker gates the apply.** Your edits are not trusted because they compiled — they're trusted because the typed substrate checked them and someone reviewed the reported delta.
 
 ## Author SQL, not the DSL
 
@@ -32,13 +32,13 @@ Write models as **raw SQL** (`models/<name>.sql` + a `<name>.toml` sidecar for m
 
 ## Shipping safely: propose → review → apply
 
-**Never apply an AI-authored change directly.** A bare `rocky apply` of an AI-authored plan is refused by design — an agent can confidently write a model that drops a column or rewrites a result, so a human checkpoint is mandatory.
+**Never apply an AI-authored change directly.** A bare `rocky apply` of an AI-authored plan is refused by design — an agent can confidently write a model that drops a column or rewrites a result, so the apply waits on a review step. The engine checks that an approval marker parses and names that exact plan. It does not check who wrote the marker, so treat the review as yours to surface, not yours to satisfy.
 
 The path:
 
 1. **Propose.** Generate the plan that materializes your change (it is recorded as an *AI-authored* plan with a `plan_id`). A propose can also bind the plan to a product identity — `product_id` plus `spec_digest`, both together or neither. A product-bound plan refuses a bare `rocky apply`; the applier must pass `rocky apply <plan-id> --expect-spec-digest <digest>` with the digest of the approved spec. When you do not work for a product runner, omit both fields.
 2. **Review.** Run `rocky review <plan-id>`. This compiles your working tree against the base ref and runs the semantic breaking-change classifier, then reports the delta — added/removed/retyped columns, anything downstream consumers depend on. Read it.
-3. **Approve.** A human runs `rocky review <plan-id> --approve` to sign off. Approving over breaking changes is allowed, but the report makes those changes loud — the sign-off is informed, never silent.
+3. **Approve.** `rocky review <plan-id> --approve` writes the approval marker. Approving over breaking changes is allowed, and the report lists them, so raise them explicitly rather than assuming the approver read the output.
 4. **Apply.** Only after the approval marker exists does `rocky apply <plan-id>` execute.
 
 Your job ends at *propose* and at *surfacing the review report clearly*. The approval is a human decision; do not approve on the user's behalf unless they explicitly tell you to.

--- a/.claude/skills/rocky-ai-workflow/SKILL.md
+++ b/.claude/skills/rocky-ai-workflow/SKILL.md
@@ -7,7 +7,7 @@ description: How an AI agent should author or modify a Rocky data model. Use whe
 
 This is the workflow for an AI agent that has been asked to build or change a Rocky model. It assumes you can run the `rocky` CLI (or call the equivalent tools) and read its `--output json`. For the config format see the `rocky-config` skill; for the full command surface see the `rocky` skill. This skill is specifically about *how to converge on a correct model* and *how to ship it safely*.
 
-The shape of the job: **you propose, Rocky's compiler verifies, an approval marker gates the apply.** Your edits are not trusted because they compiled — they're trusted because the typed substrate checked them and someone reviewed the reported delta.
+The shape of the job: **you propose, Rocky's compiler verifies, an approval marker gates the apply.** Your edits are not trusted because they compiled — they're trusted because the typed substrate checked them and the apply is gated on a marker naming that plan.
 
 ## Author SQL, not the DSL
 
@@ -38,7 +38,7 @@ The path:
 
 1. **Propose.** Generate the plan that materializes your change (it is recorded as an *AI-authored* plan with a `plan_id`). A propose can also bind the plan to a product identity — `product_id` plus `spec_digest`, both together or neither. A product-bound plan refuses a bare `rocky apply`; the applier must pass `rocky apply <plan-id> --expect-spec-digest <digest>` with the digest of the approved spec. When you do not work for a product runner, omit both fields.
 2. **Review.** Run `rocky review <plan-id>`. This compiles your working tree against the base ref and runs the semantic breaking-change classifier, then reports the delta — added/removed/retyped columns, anything downstream consumers depend on. Read it.
-3. **Approve.** `rocky review <plan-id> --approve` writes the approval marker. Approving over breaking changes is allowed, and the report lists them, so raise them explicitly rather than assuming the approver read the output.
+3. **Approve.** `rocky review <plan-id> --approve` writes the approval marker. Approving over breaking changes is allowed. The marker is written even when the classifier could not run: if either tree fails to compile, findings are absent and `breaking_change_count` falls back to 0. So a marker is not evidence a delta was computed — raise the findings explicitly.
 4. **Apply.** Only after the approval marker exists does `rocky apply <plan-id>` execute.
 
 Your job ends at *propose* and at *surfacing the review report clearly*. The approval is a human decision; do not approve on the user's behalf unless they explicitly tell you to.

--- a/.claude/skills/rocky-ai-workflow/SKILL.md
+++ b/.claude/skills/rocky-ai-workflow/SKILL.md
@@ -7,7 +7,7 @@ description: How an AI agent should author or modify a Rocky data model. Use whe
 
 This is the workflow for an AI agent that has been asked to build or change a Rocky model. It assumes you can run the `rocky` CLI (or call the equivalent tools) and read its `--output json`. For the config format see the `rocky-config` skill; for the full command surface see the `rocky` skill. This skill is specifically about *how to converge on a correct model* and *how to ship it safely*.
 
-The shape of the job: **you propose, Rocky's compiler verifies, a human approves the invariants.** Your edits are not trusted because they compiled — they're trusted because the typed substrate checked them and a person signed off.
+The shape of the job: **you propose, Rocky's compiler verifies, an approval marker gates the apply.** Your edits are not trusted because they compiled — they're trusted because the typed substrate checked them and someone reviewed the reported delta.
 
 ## Author SQL, not the DSL
 
@@ -32,13 +32,13 @@ Write models as **raw SQL** (`models/<name>.sql` + a `<name>.toml` sidecar for m
 
 ## Shipping safely: propose → review → apply
 
-**Never apply an AI-authored change directly.** A bare `rocky apply` of an AI-authored plan is refused by design — an agent can confidently write a model that drops a column or rewrites a result, so a human checkpoint is mandatory.
+**Never apply an AI-authored change directly.** A bare `rocky apply` of an AI-authored plan is refused by design — an agent can confidently write a model that drops a column or rewrites a result, so the apply waits on a review step. The engine checks that an approval marker parses and names that exact plan. It does not check who wrote the marker, so treat the review as yours to surface, not yours to satisfy.
 
 The path:
 
 1. **Propose.** Generate the plan that materializes your change (it is recorded as an *AI-authored* plan with a `plan_id`). A propose can also bind the plan to a product identity — `product_id` plus `spec_digest`, both together or neither. A product-bound plan refuses a bare `rocky apply`; the applier must pass `rocky apply <plan-id> --expect-spec-digest <digest>` with the digest of the approved spec. When you do not work for a product runner, omit both fields.
 2. **Review.** Run `rocky review <plan-id>`. This compiles your working tree against the base ref and runs the semantic breaking-change classifier, then reports the delta — added/removed/retyped columns, anything downstream consumers depend on. Read it.
-3. **Approve.** A human runs `rocky review <plan-id> --approve` to sign off. Approving over breaking changes is allowed, but the report makes those changes loud — the sign-off is informed, never silent.
+3. **Approve.** `rocky review <plan-id> --approve` writes the approval marker. Approving over breaking changes is allowed, and the report lists them, so raise them explicitly rather than assuming the approver read the output.
 4. **Apply.** Only after the approval marker exists does `rocky apply <plan-id>` execute.
 
 Your job ends at *propose* and at *surfacing the review report clearly*. The approval is a human decision; do not approve on the user's behalf unless they explicitly tell you to.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Write for a person who is busy. These rules apply to chat replies, PR descriptio
 
 | Path | Language | What it is |
 |---|---|---|
-| `engine/` | Rust | Core CLI + engine — SQL transformation, schema drift, incremental loads, adapters. Multi-crate Cargo workspace. |
+| `engine/` | Rust | Core CLI + engine — SQL transformation, schema drift, incremental loads, adapters. Also carries spec-driven data products: `rocky product` (parse, verify, lower, approve) and the `rocky fulfill` loop (experimental), in the `rocky-fulfill` crate. Multi-crate Cargo workspace. |
 | `sdk/python/` | Python | `rocky-sdk` — standalone typed Python client (`RockyClient`) over the `rocky` CLI. Owns the generated Pydantic models. For notebooks, scripts, and orchestrators. |
 | `integrations/dagster/` | Python | Dagster integration — a thin `ConfigurableResource` adapter over `rocky-sdk`'s `RockyClient`; maps results to assets/checks. Depends on `rocky-sdk`. |
 | `editors/vscode/` | TypeScript | VS Code extension — LSP client (stdio to `rocky lsp`), syntax highlighting, commands for AI features. |

--- a/README.md
+++ b/README.md
@@ -181,14 +181,13 @@ Rocky type-checks every change an agent writes. The agent produces a plan. A pla
               │
      ┌────────┴────────┬──────────────────┐
      │ require review  │ allow            │ deny
-     ▼                 │                  ▼
-  ┌──────────────┐     │        ┌───────────────────┐
-  │ an approval  │     │        │ refused. No SQL   │
-  │ marker, then │     │        │ runs, so there is │
-  │ it applies   │     │        │ nothing to undo.  │
-  └──────┬───────┘     │        └─────────┬─────────┘
-         │             │                  │
-         └──────┬──────┘                  │
+     ▼                 ▼                  ▼
+  ┌───────────────────────────┐ ┌───────────────────┐
+  │ an AI-authored plan needs │ │ refused. No SQL   │
+  │ an approval marker naming │ │ runs, so there is │
+  │ it. BOTH branches cross   │ │ nothing to undo.  │
+  │ this check.               │ └─────────┬─────────┘
+  └─────────────┬─────────────┘           │
                 ▼                         │
      ┌────────────────────┐               │
      │ the warehouse runs │               │
@@ -241,7 +240,7 @@ Full detail: [Operating Rocky with agents](https://rocky-data.dev/concepts/opera
 
 ## Declare a data product
 
-You write one spec file. `products/<name>.toml` states what the product must be: its grain, its columns, its checks, and how fresh it has to be. The spec adds no new runtime machinery. Every field lowers onto something the engine already checks, such as a contract or the model's sidecar metadata. A field that cannot lower is refused when the spec is parsed.
+You write one spec file. `products/<name>.toml` states what the product must be: its grain, its columns, its checks, and how fresh it has to be. The spec adds no new runtime machinery. A field either lowers onto something the engine already has, such as a contract or the model's sidecar, or it is refused when the spec is parsed. Not every field ends up as an engine check: freshness is observed by the loop after the apply, not enforced at compile time.
 
 ```
    products/<name>.toml
@@ -250,15 +249,19 @@ You write one spec file. `products/<name>.toml` states what the product must be:
           │                          tags, and identity collisions
           ├── rocky product approve  freezes the revision as a snapshot
           │                          addressed by its digest
-          ├── rocky product compile  renders the model's contract, then
-          │                          merges spec-owned sidecar metadata
+          ├── rocky product compile  one phase per call: renders the
+          │                          contract, or merges the sidecar
           │
           └── rocky fulfill <name>   drives these verbs, and the drafting
                                      agent between them. Stops at each gate
                                      with the exact next command to run
 ```
 
-`rocky fulfill` starts a drafting agent on the worker MCP profile. That profile serves the read and inspect tools, the compile and test loop, and two draft tools. It serves nothing else, and a tool added later stays out until someone adds it deliberately. The runner then re-reads what the agent wrote from disk, re-verifies it, and hands it to the same governed `propose` as any other agent change.
+`rocky fulfill` runs the drafting agent as a subprocess. You choose the command in `[fulfill.driver]`. The worker sees only the environment variables you allowlist, and the whole task runs in one process group the loop kills when the task ends.
+
+Rocky ships a narrowed MCP surface for that worker. `rocky mcp --profile worker` serves the read and inspect tools, the compile and test loop, and two draft tools. It serves nothing else, and a tool added later stays out until someone adds it deliberately. Point your driver command at it. The engine does not force the command you configure to use it.
+
+The runner then re-reads what the agent wrote from disk, re-verifies it, and hands it to the same governed `propose` as any other agent change.
 
 The plan records the digest of the approved spec. A bare `rocky apply` refuses a product-bound plan. You run `rocky apply <plan-id> --expect-spec-digest <digest>`, and it refuses when the digest you pass does not match the one on the plan. `rocky fulfill` is experimental.
 

--- a/README.md
+++ b/README.md
@@ -245,10 +245,10 @@ You write one spec file. `products/<name>.toml` states what the product must be:
 ```
    products/<name>.toml
           │
-          ├── rocky product verify   checks the trust posture, the masking
-          │                          tags, and identity collisions
           ├── rocky product approve  freezes the revision as a snapshot
           │                          addressed by its digest
+          ├── rocky product verify   checks the trust posture, the masking
+          │                          tags, and identity collisions
           ├── rocky product compile  one phase per call: renders the
           │                          contract, or merges the sidecar
           │                          (grain, non-null columns and checks
@@ -257,11 +257,14 @@ You write one spec file. `products/<name>.toml` states what the product must be:
           └── rocky fulfill <name>   drives these verbs, and the drafting
                                      agent between them. Stops at each gate
                                      with the exact next command to run
+
+   The loop stops for spec approval FIRST, then verifies, then lowers.
+   Each verb also runs on its own, in any order you need.
 ```
 
 `rocky fulfill` runs the drafting agent as a subprocess. You choose the command in `[fulfill.driver]`. The worker sees only the environment variables you allowlist, and the whole task runs in one process group the loop kills when the task ends.
 
-Rocky ships a narrowed MCP surface for that worker. `rocky mcp --profile worker` serves the read and inspect tools, the compile and test loop, and two draft tools. It serves nothing else, and a tool added later stays out until someone adds it deliberately. Point your driver command at it. The engine does not force the command you configure to use it.
+Rocky ships a narrowed MCP surface for that worker. `rocky mcp --profile worker` serves the read and inspect tools, the compile and test loop, and two draft tools. It serves no other tools, and a tool added later stays out until someone adds it deliberately. The MCP prompts stay available in both profiles. Point your driver command at it. The engine does not force the command you configure to use it.
 
 The runner then re-reads what the agent wrote from disk, re-verifies it, and hands it to the same governed `propose` as any other agent change.
 

--- a/README.md
+++ b/README.md
@@ -253,9 +253,9 @@ You write one spec file. `products/<name>.toml` states what the product must be:
           ├── rocky product compile  renders the model's contract, then
           │                          merges spec-owned sidecar metadata
           │
-          └── rocky fulfill <name>   drives the steps above in order, and
-                                     stops at each gate with the exact
-                                     next command to run
+          └── rocky fulfill <name>   drives these verbs, and the drafting
+                                     agent between them. Stops at each gate
+                                     with the exact next command to run
 ```
 
 `rocky fulfill` starts a drafting agent on the worker MCP profile. That profile serves the read and inspect tools, the compile and test loop, and two draft tools. It serves nothing else, and a tool added later stays out until someone adds it deliberately. The runner then re-reads what the agent wrote from disk, re-verifies it, and hands it to the same governed `propose` as any other agent change.

--- a/README.md
+++ b/README.md
@@ -183,9 +183,9 @@ Rocky type-checks every change an agent writes. The agent produces a plan. A pla
      │ require review  │ allow            │ deny
      ▼                 │                  ▼
   ┌──────────────┐     │        ┌───────────────────┐
-  │ a human      │     │        │ refused. No SQL   │
-  │ approves,    │     │        │ runs, so there is │
-  │ then applies │     │        │ nothing to undo.  │
+  │ an approval  │     │        │ refused. No SQL   │
+  │ marker, then │     │        │ runs, so there is │
+  │ it applies   │     │        │ nothing to undo.  │
   └──────┬───────┘     │        └─────────┬─────────┘
          │             │                  │
          └──────┬──────┘                  │
@@ -213,10 +213,10 @@ The diagram shows the gate at `rocky apply`. The MCP `draft` and `propose` tools
 A rule can also name checks that must pass in that run. If one fails, or never ran, Rocky stops and records the failure. It cannot undo the write: the change stays until a human reverts it.
 
 - **You write the rules.** A `[policy]` rule in `rocky.toml` says what each principal may do, and where. The answer is allow, require review, or deny. Set `max_downstreams` to cap how far one change may reach.
-- **A plan written by AI waits for a human.** The engine enforces this. It is not a convention you can forget.
+- **An AI-written plan needs an approval marker.** `rocky apply` refuses an AI-authored plan unless a marker file is present that parses and names that exact plan. That check runs whatever your rules say, so an `allow` rule cannot waive it. The marker is not signed, so it records that an approval was made on this machine, not who made it.
 - **You can test the rules.** `[[policy.tests]]` scenarios run through the real evaluator, so `rocky policy test` catches an edit that opens a hole.
 - **You can ask what happened.** `rocky audit --for <table>` says who changed what, and under whose authority. `rocky review --queue` ranks what waits on you.
-- **Agents connect over MCP.** `rocky mcp` exposes 31 tools. Seven of them write, and those seven pass the same rules.
+- **Agents connect over MCP.** `rocky mcp` exposes 31 tools. Seven can write. Five of those pass the same rules; `pause_schedule` and `review_queue` carry their own guards.
 
 <p align="center">
   <img src="docs/public/demo-policy-enforce.gif" alt="an agent's change to a contracted model is planned, rocky apply run as the agent principal is denied by the policy plane with the rule named, and rocky audit shows the recorded decision" width="900" />

--- a/README.md
+++ b/README.md
@@ -239,6 +239,31 @@ An agent earns freedom one step at a time. You grant each step. `rocky policy fr
 
 Full detail: [Operating Rocky with agents](https://rocky-data.dev/concepts/operating-rocky-with-agents/).
 
+## Declare a data product
+
+You write one spec file. `products/<name>.toml` states what the product must be: its grain, its columns, its checks, and how fresh it has to be. The spec adds no new runtime machinery. Every field lowers onto something the engine already checks, such as a contract, declarative tests, or sidecar metadata. A field that cannot lower is refused when the spec is parsed.
+
+```
+   products/<name>.toml
+          │
+          ├── rocky product verify   checks the trust posture, the masking
+          │                          tags, and identity collisions
+          ├── rocky product approve  freezes the revision as a snapshot
+          │                          addressed by its digest
+          ├── rocky product compile  lowers the spec onto a contract and
+          │                          declarative tests
+          │
+          └── rocky fulfill <name>   drives the steps above in order, and
+                                     stops at each gate with the exact
+                                     next command to run
+```
+
+`rocky fulfill` starts a drafting agent on the worker MCP profile. That profile serves the read and inspect tools, the compile and test loop, and two draft tools. It serves nothing else, and a tool added later stays out until someone adds it deliberately. The runner then re-reads what the agent wrote from disk, re-verifies it, and hands it to the same governed `propose` as any other agent change.
+
+The plan records the digest of the approved spec. A bare `rocky apply` refuses a product-bound plan. You run `rocky apply <plan-id> --expect-spec-digest <digest>`, and it refuses when the digest you pass does not match the one on the plan. `rocky fulfill` is experimental.
+
+Full detail: [Product commands](https://rocky-data.dev/reference/commands/products/) and [Fulfill commands](https://rocky-data.dev/reference/commands/fulfill/).
+
 ## Where Rocky is today
 
 The checker, named branches, replay, column lineage, rule enforcement and per-model cost are the most complete parts. Here is what is still thin.

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Full detail: [Operating Rocky with agents](https://rocky-data.dev/concepts/opera
 
 ## Declare a data product
 
-You write one spec file. `products/<name>.toml` states what the product must be: its grain, its columns, its checks, and how fresh it has to be. The spec adds no new runtime machinery. Every field lowers onto something the engine already checks, such as a contract, declarative tests, or sidecar metadata. A field that cannot lower is refused when the spec is parsed.
+You write one spec file. `products/<name>.toml` states what the product must be: its grain, its columns, its checks, and how fresh it has to be. The spec adds no new runtime machinery. Every field lowers onto something the engine already checks, such as a contract or the model's sidecar metadata. A field that cannot lower is refused when the spec is parsed.
 
 ```
    products/<name>.toml
@@ -250,8 +250,8 @@ You write one spec file. `products/<name>.toml` states what the product must be:
           │                          tags, and identity collisions
           ├── rocky product approve  freezes the revision as a snapshot
           │                          addressed by its digest
-          ├── rocky product compile  lowers the spec onto a contract and
-          │                          declarative tests
+          ├── rocky product compile  renders the model's contract, then
+          │                          merges spec-owned sidecar metadata
           │
           └── rocky fulfill <name>   drives the steps above in order, and
                                      stops at each gate with the exact

--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ You write one spec file. `products/<name>.toml` states what the product must be:
           │                          addressed by its digest
           ├── rocky product compile  one phase per call: renders the
           │                          contract, or merges the sidecar
+          │                          (grain, non-null columns and checks
+          │                          become declarative [[tests]])
           │
           └── rocky fulfill <name>   drives these verbs, and the drafting
                                      agent between them. Stops at each gate

--- a/ROCKY_EXPLAINED.md
+++ b/ROCKY_EXPLAINED.md
@@ -588,7 +588,7 @@ The gate is a best-effort optimization. It is not a promise that a rebuild would
 
 ## 15. The Plan / Review / Apply Safety Gate
 
-Rocky has a safety gate for AI-generated changes. An AI can propose a plan, but it can't apply it without a human signing off.
+Rocky has a gate for AI-generated changes. An AI can propose a plan. `rocky apply` refuses to run it until an approval marker names that exact plan. The gate checks the marker, not who wrote it.
 
 ```
 1. AI proposes change
@@ -606,19 +606,19 @@ Rocky has a safety gate for AI-generated changes. An AI can propose a plan, but 
        ✓ ADDITIVE: new column 'region' added
        ~ RETYPED: column 'amount' widened Int32 → Int64 (safe)
 
-3. Human approves
-   ───────────────
+3. Approve
+   ────────
    rocky review plan_abc123 --approve
-   → writes approval marker (who, when)
+   → writes approval marker (best-effort git identity, when)
 
-4. Apply (only possible after approval)
-   ─────────────────────────────────────
+4. Apply (refused without a matching marker)
+   ──────────────────────────────────────────
    rocky apply plan_abc123
-   → checks approval marker exists
+   → checks the marker parses and names this plan
    → executes the plan
 ```
 
-**Rocky refuses `rocky apply` on AI-authored plans without an approval marker.** This is enforced in the engine — not a convention.
+**Rocky refuses `rocky apply` on AI-authored plans without an approval marker.** The engine performs that check, and it runs whatever your `[policy]` rules say. The marker is unsigned, so it records that an approval was made on this machine, not who made it.
 
 The breaking-change classifier lives in `rocky-core` (consumed by `rocky review` and `rocky plan`, not the compiler) and knows 16 kinds of change:
 - Model added or removed; column dropped, added, retyped (narrowing flagged), nullability flipped, or reordered
@@ -1188,7 +1188,7 @@ Everything Rocky does, in one ASCII map:
 
  SAFETY GATES:
  ─────────────
- AI plans:   propose → review (breaking-change classifier) → human approve → apply
+ AI plans:   propose → review (breaking-change classifier) → approval marker → apply
  Contracts:  staging → validate types/columns → promote to prod
  SQL safety: every identifier is regex-validated before interpolation
              (no SQL injection)

--- a/docs/src/content/docs/concepts/architecture-of-trust.md
+++ b/docs/src/content/docs/concepts/architecture-of-trust.md
@@ -93,24 +93,30 @@ project, not across project boundaries.
 `rocky branch create` and `rocky run --branch <name>` give you isolated branches
 for development and review. A branch today is a schema prefix: models for branch
 `feature_x` materialize under a `branch__feature_x` namespace, so a branch never
-touches a production table. Approval writes an artifact under
-`.rocky/approvals/<branch>/`. Before promotion merges the branch forward, it
-checks four things on that artifact: the blake3 digest over its own contents
-still matches, the branch state hash has not moved, the approval is not older
-than `max_age_seconds`, and the approver's email is in `allowed_signers`.
+touches a production table. `rocky branch approve` writes an artifact under
+`.rocky/approvals/<branch>/`.
 
-The digest is not a cryptographic signature. It is unkeyed, so it detects an
-artifact edited after it was written, and it does not authenticate the
-approver. The approver's email is a self-asserted git identity that is hashed
-with the rest of the artifact. Anything that can write the approvals directory
-can set that email and recompute the digest.
+The gate that reads those artifacts is off by default. Set
+`[branch.approval] required = true` to turn it on. With it off, `branch
+promote` does not read the directory at all. With it on, promotion loads every
+artifact for the branch and counts the valid ones against `min_approvers`. An
+artifact is valid when its blake3 digest still matches its own contents, its
+recorded branch state hash matches the branch now, and it is not older than
+`max_age_seconds`. When `allowed_signers` is not empty, the approver's email
+must also be on that list.
+
+That digest is not a cryptographic signature. It is unkeyed, so it detects an
+artifact edited after it was written, and it authenticates nobody. The
+approver's email is a self-asserted git identity hashed with the rest of the
+artifact. Anything that can write the approvals directory can set that email
+and recompute the digest.
 
 What you get today is schema-prefix isolation, not a warehouse-native zero-copy
 clone. Delta `SHALLOW CLONE` and Snowflake zero-copy `CLONE` would make branch
 creation near-instant and free of storage cost. That integration is a follow-up,
 not what runs now.
 
-**Partial.** Schema-prefix branches with digest-checked approval and promotion ship today. Warehouse-native clones do not. Nor do signed approvals.
+**Partial.** Schema-prefix branches and promotion ship today. The approval gate ships too, but it is off until you set `[branch.approval] required = true`, and its check is a digest, not a signature. Warehouse-native clones and signed approvals do not ship.
 
 ### Per-model cost
 
@@ -272,7 +278,7 @@ surprised.
 | Schema drift handling (ignore / safe widen / drop-and-recreate) | Shipped | Explicit graded response with a grace period. |
 | Dialect-divergence lint (`P001`) | Shipped | Opt-in via `--target-dialect`; error severity. |
 | VS Code trust overlays | Shipped | Exactly four: Drift, Breaking, Replay, Governance. |
-| Branches | Partial | Schema-prefix isolation with digest-checked approval/promotion (unkeyed, so it detects tamper but authenticates nobody); no warehouse-native zero-copy clones yet. |
+| Branches | Partial | Schema-prefix isolation with promotion. The approval gate is opt-in (`[branch.approval] required = true`) and checks an unkeyed digest, so it detects tamper but authenticates nobody. No warehouse-native zero-copy clones yet. |
 | Replay | Partial | Deterministic recording + ledger verification, plus re-execution (`rocky replay --execute --verify`, local or `--warehouse`) for deterministic content-addressed models; mutable-source models are `non_replayable`, non-deterministic recipes flagged. |
 | Content-addressed writes | Partial | Single-writer Delta/UniForm; no multi-writer, broad schema evolution, or deletion vectors yet. |
 | Per-model cost | Partial | Billing-exact on BigQuery; a duration × DBU-rate estimate on Databricks and Snowflake; zero on DuckDB. Databricks surfaces scanned bytes for observability; Snowflake's warehouse-reported-bytes plumbing is the follow-up. |

--- a/docs/src/content/docs/concepts/architecture-of-trust.md
+++ b/docs/src/content/docs/concepts/architecture-of-trust.md
@@ -105,6 +105,11 @@ recorded branch state hash matches the branch now, and it is not older than
 `max_age_seconds`. When `allowed_signers` is not empty, the approver's email
 must also be on that list.
 
+Two things bypass the gate even when it is on. `rocky branch promote
+--skip-approval` skips it, and so does the `ROCKY_BRANCH_APPROVAL_SKIP`
+environment variable. Both record the reason as an audit event rather than
+failing.
+
 That digest is not a cryptographic signature. It is unkeyed, so it detects an
 artifact edited after it was written, and it authenticates nobody. The
 approver's email is a self-asserted git identity hashed with the rest of the

--- a/docs/src/content/docs/concepts/architecture-of-trust.md
+++ b/docs/src/content/docs/concepts/architecture-of-trust.md
@@ -94,7 +94,9 @@ project, not across project boundaries.
 for development and review. A branch today is a schema prefix: models for branch
 `feature_x` materialize under a `branch__feature_x` namespace, so a branch never
 touches a production table. `rocky branch approve` writes an artifact under
-`.rocky/approvals/<branch>/`.
+`.rocky/approvals/<branch>/` by default. `--out` sends it somewhere else, and
+the gate only reads the default directory, so an artifact written elsewhere
+does not count.
 
 The gate that reads those artifacts is off by default. Set
 `[branch.approval] required = true` to turn it on. With it off, the promote
@@ -104,22 +106,29 @@ With it on, the gate runs when the promote plan is built. That is `rocky plan
 promote`, and bare `rocky branch promote <name>`, which builds a plan first.
 Applying a promote plan that already exists does not repeat the check, so the
 approvals are the ones that were valid at plan time. The gate loads every
-artifact for the branch and counts the valid ones against `min_approvers`. An
-artifact is valid when its blake3 digest still matches its own contents, its
-recorded branch state hash matches the branch now, and it is not older than
-`max_age_seconds`. When `allowed_signers` is not empty, the approver's email
-must also be on that list.
+artifact in that directory and counts the valid ones against `min_approvers`.
+
+An artifact is valid when its blake3 digest still matches its own contents, its
+recorded branch state hash matches the branch now, it is not dated in the
+future, and it is not older than `max_age_seconds`. When `allowed_signers` is
+not empty, the approver's email must also be on that list.
+
+`min_approvers` counts artifact FILES, not distinct people. Nothing
+de-duplicates by identity, so one approver can satisfy a threshold of two by
+writing two artifacts. It defaults to 1, and setting it to 0 makes the count
+pass with no approvals at all.
 
 Two things bypass the gate even when it is on. `rocky branch promote
 --skip-approval` skips it, and so does the `ROCKY_BRANCH_APPROVAL_SKIP`
 environment variable. Both record the reason as an audit event rather than
 failing.
 
-That digest is not a cryptographic signature. It is unkeyed, so it detects an
-artifact edited after it was written, and it authenticates nobody. The
-approver's email is a self-asserted git identity hashed with the rest of the
-artifact. Anything that can write the approvals directory can set that email
-and recompute the digest.
+That digest is not a cryptographic signature, and it is not a tamper boundary.
+It is unkeyed, so anything that can write the file can change the artifact and
+recompute the digest together. What it catches is a modification that was not
+re-hashed. It authenticates nobody: the approver's email is a self-asserted git
+identity hashed with the rest of the artifact, and a writer can set it to
+anything.
 
 What you get today is schema-prefix isolation, not a warehouse-native zero-copy
 clone. Delta `SHALLOW CLONE` and Snowflake zero-copy `CLONE` would make branch
@@ -288,7 +297,7 @@ surprised.
 | Schema drift handling (ignore / safe widen / drop-and-recreate) | Shipped | Explicit graded response with a grace period. |
 | Dialect-divergence lint (`P001`) | Shipped | Opt-in via `--target-dialect`; error severity. |
 | VS Code trust overlays | Shipped | Exactly four: Drift, Breaking, Replay, Governance. |
-| Branches | Partial | Schema-prefix isolation with promotion. The approval gate is opt-in (`[branch.approval] required = true`) and checks an unkeyed digest, so it detects tamper but authenticates nobody. No warehouse-native zero-copy clones yet. |
+| Branches | Partial | Schema-prefix isolation with promotion. The approval gate is opt-in (`[branch.approval] required = true`) and checks an unkeyed digest: an integrity checksum, not a tamper boundary, and it authenticates nobody. No warehouse-native zero-copy clones yet. |
 | Replay | Partial | Deterministic recording + ledger verification, plus re-execution (`rocky replay --execute --verify`, local or `--warehouse`) for deterministic content-addressed models; mutable-source models are `non_replayable`, non-deterministic recipes flagged. |
 | Content-addressed writes | Partial | Single-writer Delta/UniForm; no multi-writer, broad schema evolution, or deletion vectors yet. |
 | Per-model cost | Partial | Billing-exact on BigQuery; a duration × DBU-rate estimate on Databricks and Snowflake; zero on DuckDB. Databricks surfaces scanned bytes for observability; Snowflake's warehouse-reported-bytes plumbing is the follow-up. |

--- a/docs/src/content/docs/concepts/architecture-of-trust.md
+++ b/docs/src/content/docs/concepts/architecture-of-trust.md
@@ -93,16 +93,24 @@ project, not across project boundaries.
 `rocky branch create` and `rocky run --branch <name>` give you isolated branches
 for development and review. A branch today is a schema prefix: models for branch
 `feature_x` materialize under a `branch__feature_x` namespace, so a branch never
-touches a production table. Approval writes a signed artifact under
-`.rocky/approvals/<branch>/`, and promotion verifies that signature before it
-merges the branch forward.
+touches a production table. Approval writes an artifact under
+`.rocky/approvals/<branch>/`. Before promotion merges the branch forward, it
+checks four things on that artifact: the blake3 digest over its own contents
+still matches, the branch state hash has not moved, the approval is not older
+than `max_age_seconds`, and the approver's email is in `allowed_signers`.
+
+The digest is not a cryptographic signature. It is unkeyed, so it detects an
+artifact edited after it was written, and it does not authenticate the
+approver. The approver's email is a self-asserted git identity that is hashed
+with the rest of the artifact. Anything that can write the approvals directory
+can set that email and recompute the digest.
 
 What you get today is schema-prefix isolation, not a warehouse-native zero-copy
 clone. Delta `SHALLOW CLONE` and Snowflake zero-copy `CLONE` would make branch
 creation near-instant and free of storage cost. That integration is a follow-up,
 not what runs now.
 
-**Partial.** Schema-prefix branches with signed approval and promotion ship today. Warehouse-native clones do not.
+**Partial.** Schema-prefix branches with digest-checked approval and promotion ship today. Warehouse-native clones do not. Nor do signed approvals.
 
 ### Per-model cost
 
@@ -264,7 +272,7 @@ surprised.
 | Schema drift handling (ignore / safe widen / drop-and-recreate) | Shipped | Explicit graded response with a grace period. |
 | Dialect-divergence lint (`P001`) | Shipped | Opt-in via `--target-dialect`; error severity. |
 | VS Code trust overlays | Shipped | Exactly four: Drift, Breaking, Replay, Governance. |
-| Branches | Partial | Schema-prefix isolation with signed approval/promotion; no warehouse-native zero-copy clones yet. |
+| Branches | Partial | Schema-prefix isolation with digest-checked approval/promotion (unkeyed, so it detects tamper but authenticates nobody); no warehouse-native zero-copy clones yet. |
 | Replay | Partial | Deterministic recording + ledger verification, plus re-execution (`rocky replay --execute --verify`, local or `--warehouse`) for deterministic content-addressed models; mutable-source models are `non_replayable`, non-deterministic recipes flagged. |
 | Content-addressed writes | Partial | Single-writer Delta/UniForm; no multi-writer, broad schema evolution, or deletion vectors yet. |
 | Per-model cost | Partial | Billing-exact on BigQuery; a duration × DBU-rate estimate on Databricks and Snowflake; zero on DuckDB. Databricks surfaces scanned bytes for observability; Snowflake's warehouse-reported-bytes plumbing is the follow-up. |

--- a/docs/src/content/docs/concepts/architecture-of-trust.md
+++ b/docs/src/content/docs/concepts/architecture-of-trust.md
@@ -97,8 +97,13 @@ touches a production table. `rocky branch approve` writes an artifact under
 `.rocky/approvals/<branch>/`.
 
 The gate that reads those artifacts is off by default. Set
-`[branch.approval] required = true` to turn it on. With it off, `branch
-promote` does not read the directory at all. With it on, promotion loads every
+`[branch.approval] required = true` to turn it on. With it off, the promote
+path does not read the directory at all.
+
+With it on, the gate runs when the promote plan is built. That is `rocky plan
+promote`, and bare `rocky branch promote <name>`, which builds a plan first.
+Applying a promote plan that already exists does not repeat the check, so the
+approvals are the ones that were valid at plan time. The gate loads every
 artifact for the branch and counts the valid ones against `min_approvers`. An
 artifact is valid when its blake3 digest still matches its own contents, its
 recorded branch state hash matches the branch now, and it is not older than

--- a/docs/src/content/docs/concepts/mcp-authoring.md
+++ b/docs/src/content/docs/concepts/mcp-authoring.md
@@ -126,7 +126,7 @@ returns an empty result rather than failing.
 
 ### Write path (draft tools)
 
-These are the safe way for an agent to change the project. Each one writes into
+These are the governed way for an agent to change the project. Each one writes into
 the project's `models/` directory and **compiles in the same call**, so you get
 the type-check with the write. Each one is also checked against your policy
 rules. A `draft_*` tool never applies a change to the warehouse.
@@ -151,7 +151,7 @@ one ends at a proposed plan or an enumerated gap, never at an applied change.
 
 | Prompt | What it walks |
 |---|---|
-| `build_model` | inspect_schema → sample_rows → profile_column → compile → plan preview → propose. Stops at the human approval gate. |
+| `build_model` | inspect_schema → sample_rows → profile_column → compile → plan preview → propose. Stops at the approval gate. |
 | `find_untested_models` | compile → identify untested models → `ai_test` / `ai_contract` → `draft_check` / `draft_contract` → propose. Stops at the gate. |
 | `add_tests_to_pks` | inspect_schema → identify key columns → `draft_check` (uniqueness + not-null) → propose. |
 | `summarize_project` | A read-only project tour; proposes nothing — points at `find_untested_models` / `build_model` for next steps. |
@@ -182,13 +182,13 @@ tools on the allowlist and end at a hand-off to the trusted runner — never at
 
 The write path has three gates. No single call passes all three. A `draft_*`
 call passes two: the compiler type-checks what it wrote, then Rocky evaluates
-your `[policy]` rules before the call returns. The third gate is a human, and it
-sits at apply time. `propose` records an AI-authored plan and returns a
+your `[policy]` rules before the call returns. The third gate is the approval
+marker, and it sits at apply time. `propose` records an AI-authored plan and returns a
 `plan_id`; it executes nothing:
 
 ```bash
-rocky review <plan_id> --approve    # human sign-off, required
-rocky apply  <plan_id>              # only runs after approval
+rocky review <plan_id> --approve    # writes the approval marker
+rocky apply  <plan_id>              # refused until that marker names it
 ```
 
 A bare `rocky apply <plan_id>` on an unapproved AI-authored plan is rejected by

--- a/docs/src/content/docs/concepts/operating-rocky-with-agents.md
+++ b/docs/src/content/docs/concepts/operating-rocky-with-agents.md
@@ -52,9 +52,9 @@ does. The tools are named so the loop reads in sequence.
         └───────┬────────┘
                 ▼
         ┌────────────────┐   rocky review <plan_id> --approve
-        │ 6. a human     │   rocky apply  <plan_id>
-        │    approves    │   No MCP tool writes that approval.
-        └────────────────┘
+        │ 6. an approval │   rocky apply  <plan_id>
+        │    marker      │   The worker profile serves no tool
+        └────────────────┘   that writes that marker.
 ```
 
 Steps 1 and 2 are the reason the rest works. A column name does not tell you its
@@ -92,8 +92,8 @@ See [MCP Authoring](/concepts/mcp-authoring/) for every tool in both families.
 
 ## The three gates
 
-Nothing an agent produces reaches your warehouse without clearing three
-independent checks. The engine performs all three in code.
+Nothing an agent produces reaches your warehouse without clearing three checks.
+The engine performs all three in code.
 [What the three gates do not defend against](#what-the-three-gates-do-not-defend-against)
 states what each check actually verifies, and where that stops.
 
@@ -147,8 +147,14 @@ recorded, the ledger does not give you that today.
 
 **Gate 3, the approval marker.** `propose` writes a plan marked as AI-authored.
 `rocky apply` refuses to run one unless an approval marker is present that parses
-and names that exact plan. `rocky review <plan-id> --approve` is the command that
-writes that marker, and no MCP tool writes it.
+and names that exact plan. `rocky review <plan-id> --approve` writes that marker.
+
+One MCP tool can write it too. `review_queue` writes the marker when it is
+called with `approve_plan_id` and `confirm: true`. It refuses any plan that is
+not already in the pending review queue. The `confirm` flag is set by the
+caller, and Rocky does not check that a person set it. `rocky mcp --profile
+worker` does not serve `review_queue`, so a drafting worker on that profile has
+no tool that writes a marker.
 
 Be exact about what this check verifies. It reads a file, parses it, and compares
 the plan id. It does not authenticate who approved, or that a person approved at

--- a/docs/src/content/docs/getting-started/roadmap.md
+++ b/docs/src/content/docs/getting-started/roadmap.md
@@ -132,8 +132,11 @@ authored by agents rather than people. The question that matters shifts from
 
 Rocky's long arc is the governed estate. Humans declare the invariants:
 contracts, policies, budgets. Agents do the operating: author, run, diagnose,
-remediate. The engine checks and records every step, so any consumer, human or
-machine, can read a table's recorded custody before relying on it.
+remediate. The engine checks each mutating step and records what it decided, so
+any consumer, human or machine, can read a table's recorded custody before
+relying on it. Read that record as best-effort: a failed ledger write warns and
+lets the operation continue, and a refusal issued before the rules are
+evaluated writes no row at all.
 
 The pieces above are that arc's foundation, shipped in their first form: the
 policy plane, the custody ledger, bit-exact replay, and the engine-free manifest

--- a/docs/src/content/docs/getting-started/roadmap.md
+++ b/docs/src/content/docs/getting-started/roadmap.md
@@ -132,8 +132,8 @@ authored by agents rather than people. The question that matters shifts from
 
 Rocky's long arc is the governed estate. Humans declare the invariants:
 contracts, policies, budgets. Agents do the operating: author, run, diagnose,
-remediate. The engine enforces and records every step, so any consumer, human or
-machine, can check a table's custody before relying on it.
+remediate. The engine checks and records every step, so any consumer, human or
+machine, can read a table's recorded custody before relying on it.
 
 The pieces above are that arc's foundation, shipped in their first form: the
 policy plane, the custody ledger, bit-exact replay, and the engine-free manifest

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -52,6 +52,9 @@ you catch before a row is written. See
   <Card title="Declarative tests, not templated SQL" icon="list-format">
     Tests are declarative TOML. Rocky generates the assertion SQL for your target dialect, and `rocky test` runs fixture-driven tests locally on DuckDB.
   </Card>
+  <Card title="Data products declared in a spec file" icon="document">
+    `products/<name>.toml` states a product's grain, columns, checks, and freshness. `rocky product compile` lowers it onto a contract and declarative tests. `rocky fulfill` then drives an agent through drafting and verification, and stops at each gate for you (experimental).
+  </Card>
   <Card title="A tested exit door, not a one-way door" icon="cloud-download">
     `rocky emit-sql` renders the compiled SQL for your transformation models with no warehouse connection. The output is plain runnable SQL, so adopting Rocky never locks you in.
   </Card>
@@ -115,4 +118,5 @@ by default. Those adapters are Beta today. See the
 <CardGrid>
   <LinkCard title="Import an existing project" href="/guides/migrate-from-dbt/" description="Run rocky import-dbt against a dbt Core project. You get a Rocky repo on disk, and you can move over one piece at a time." />
   <LinkCard title="Using Dagster?" href="/dagster/introduction/" description="dagster-rocky wraps the CLI as a ConfigurableResource: auto-discovery, asset checks, and Pipes through one subprocess hop." />
+  <LinkCard title="Declare a data product" href="/reference/commands/products/" description="Write the spec, lower it onto a contract and tests, and approve a revision. rocky fulfill drives the agent loop between those steps." />
 </CardGrid>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -53,7 +53,7 @@ you catch before a row is written. See
     Tests are declarative TOML. Rocky generates the assertion SQL for your target dialect, and `rocky test` runs fixture-driven tests locally on DuckDB.
   </Card>
   <Card title="Data products declared in a spec file" icon="document">
-    `products/<name>.toml` states a product's grain, columns, checks, and freshness. `rocky product compile` lowers it onto a contract and declarative tests. `rocky fulfill` then drives an agent through drafting and verification, and stops at each gate for you (experimental).
+    `products/<name>.toml` states a product's grain, columns, checks, and freshness. `rocky product compile` renders the model's contract, then merges spec-owned sidecar metadata. `rocky fulfill` then drives an agent through drafting and verification, and stops at each gate for you (experimental).
   </Card>
   <Card title="A tested exit door, not a one-way door" icon="cloud-download">
     `rocky emit-sql` renders the compiled SQL for your transformation models with no warehouse connection. The output is plain runnable SQL, so adopting Rocky never locks you in.
@@ -118,5 +118,5 @@ by default. Those adapters are Beta today. See the
 <CardGrid>
   <LinkCard title="Import an existing project" href="/guides/migrate-from-dbt/" description="Run rocky import-dbt against a dbt Core project. You get a Rocky repo on disk, and you can move over one piece at a time." />
   <LinkCard title="Using Dagster?" href="/dagster/introduction/" description="dagster-rocky wraps the CLI as a ConfigurableResource: auto-discovery, asset checks, and Pipes through one subprocess hop." />
-  <LinkCard title="Declare a data product" href="/reference/commands/products/" description="Write the spec, lower it onto a contract and tests, and approve a revision. rocky fulfill drives the agent loop between those steps." />
+  <LinkCard title="Declare a data product" href="/reference/commands/products/" description="Write the spec, lower it onto the model's contract and sidecar, and approve a revision. rocky fulfill drives the agent loop between those steps." />
 </CardGrid>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -53,7 +53,7 @@ you catch before a row is written. See
     Tests are declarative TOML. Rocky generates the assertion SQL for your target dialect, and `rocky test` runs fixture-driven tests locally on DuckDB.
   </Card>
   <Card title="Data products declared in a spec file" icon="document">
-    `products/<name>.toml` states a product's grain, columns, checks, and freshness. `rocky product compile` renders the model's contract, then merges spec-owned sidecar metadata. `rocky fulfill` then drives an agent through drafting and verification, and stops at each gate for you (experimental).
+    `products/<name>.toml` states a product's grain, columns, checks, and freshness. `rocky product compile` renders the model's contract and merges spec-owned sidecar metadata, turning the grain and checks into declarative `[[tests]]`. `rocky fulfill` then drives an agent through drafting and verification, and stops at each gate for you (experimental).
   </Card>
   <Card title="A tested exit door, not a one-way door" icon="cloud-download">
     `rocky emit-sql` renders the compiled SQL for your transformation models with no warehouse connection. The output is plain runnable SQL, so adopting Rocky never locks you in.

--- a/docs/src/content/docs/reference/commands/ai.md
+++ b/docs/src/content/docs/reference/commands/ai.md
@@ -381,19 +381,20 @@ What leaves your machine is bounded: warehouse queries go to your warehouse; the
 The server **never materializes anything**. No tool runs SQL that changes your warehouse. An agent can write project files and record a plan. One tool, `review_queue`, can also write the approval marker for a plan that is already in the pending review queue.
 
 ```
-   agent, through rocky mcp                human
-   ────────────────────────                ──────────────────────────
+   through rocky mcp                       through the CLI
+   ─────────────────                       ───────────────
    draft_model     ──writes──► models/<name>.sql + sidecar
    draft_contract  ──writes──► models/<model>.contract.toml
    draft_check     ──writes──► [[tests]] in the sidecar
         │
         ▼
    propose         ──writes──► .rocky/plans/<plan-id>.json
-        │
-        │ review_queue, with confirm: true, writes the
-        │ marker for a plan already in the pending queue
-        ▼
+                                        │
+                                        ▼
                               rocky review <plan-id> --approve
+                              writes the approval marker. The
+                              review_queue MCP tool writes it
+                              too, with confirm: true.
                                         │
                                         ▼
                               rocky apply <plan-id> ──► warehouse

--- a/docs/src/content/docs/reference/commands/ai.md
+++ b/docs/src/content/docs/reference/commands/ai.md
@@ -405,7 +405,7 @@ Three rules keep that boundary in place:
 
 - The generators (`ai_contract`, `ai_test`, `explain_model`) return **drafts** and mutate nothing. Hand a draft to the `draft_contract` or `draft_check` write tool, or save it to disk and run `compile` and `test` yourself.
 - `governance_preview` and `drift_preview` are **read-only** previews.
-- The server does not apply. `rocky apply` is the only step that reaches the warehouse, and no MCP tool runs it. `review_queue` can write a plan's approval marker, so treat approval as a step the server can take: it needs `confirm: true` from the caller, and it refuses a plan that is not already in the pending review queue. `rocky mcp --profile worker` does not serve `review_queue`.
+- The server does not apply. `rocky apply` is the only step that reaches the warehouse, and no MCP tool runs it. `review_queue` can write a plan's approval marker, so treat approval as a step the server can take. It needs `confirm: true` from the caller. It refuses a plan that is not already in the pending review queue. `rocky mcp --profile worker` does not serve it.
 
 ### Tools
 

--- a/docs/src/content/docs/reference/commands/ai.md
+++ b/docs/src/content/docs/reference/commands/ai.md
@@ -376,9 +376,9 @@ The server is **stateless**: every tool call resolves the project from the confi
 
 What leaves your machine is bounded: warehouse queries go to your warehouse; the generators send your model's SQL and schema to **your own** Anthropic key, and for `ai_contract` only aggregate column counts (row / null / distinct), **never raw cell values**.
 
-### Safety model: read-only and propose-only
+### Safety model: the server does not materialize
 
-The server **never materializes anything**. An agent can write files and record a plan. It stops there.
+The server **never materializes anything**. No tool runs SQL that changes your warehouse. An agent can write project files and record a plan. One tool, `review_queue`, can also write the approval marker for a plan that is already in the pending review queue.
 
 ```
    agent, through rocky mcp                human
@@ -387,22 +387,24 @@ The server **never materializes anything**. An agent can write files and record 
    draft_contract  ──writes──► models/<model>.contract.toml
    draft_check     ──writes──► [[tests]] in the sidecar
         │
-        │ this is as far as the agent goes
         ▼
    propose         ──writes──► .rocky/plans/<plan-id>.json
-                                        │
-                                        ▼
+        │
+        │ review_queue, with confirm: true, writes the
+        │ marker for a plan already in the pending queue
+        ▼
                               rocky review <plan-id> --approve
                                         │
                                         ▼
                               rocky apply <plan-id> ──► warehouse
+                              no MCP tool runs this step
 ```
 
 Three rules keep that boundary in place:
 
 - The generators (`ai_contract`, `ai_test`, `explain_model`) return **drafts** and mutate nothing. Hand a draft to the `draft_contract` or `draft_check` write tool, or save it to disk and run `compile` and `test` yourself.
 - `governance_preview` and `drift_preview` are **read-only** previews.
-- The server never approves on your behalf. Approval is the one step it cannot take.
+- The server does not apply. `rocky apply` is the only step that reaches the warehouse, and no MCP tool runs it. `review_queue` can write a plan's approval marker, so treat approval as a step the server can take: it needs `confirm: true` from the caller, and it refuses a plan that is not already in the pending review queue. `rocky mcp --profile worker` does not serve `review_queue`.
 
 ### Tools
 
@@ -451,11 +453,11 @@ A `draft_*` call made without its content `spec` returns an actionable error poi
 
 | Tool | What it does |
 |---|---|
-| `propose` | Record an **AI-authored plan** for materializing a model. Writes a plan only — it compiles the project and records the plan offline (no LLM call, no warehouse write). A human must run `rocky review <plan_id> --approve` then `rocky apply <plan_id>`. |
+| `propose` | Record an **AI-authored plan** for materializing a model. Writes a plan only — it compiles the project and records the plan offline (no LLM call, no warehouse write). `rocky apply <plan_id>` then runs it only once `rocky review <plan_id> --approve` has written the approval marker. |
 
 ### Prompts (guided trajectories)
 
-The server also exposes MCP prompts that orchestrate the tools above into a guided workflow. Every trajectory **stops at the propose / human-gate step**; it never applies.
+The server also exposes MCP prompts that orchestrate the tools above into a guided workflow. Every trajectory **stops at the propose step**; it never applies.
 
 | Prompt | What it guides |
 |---|---|
@@ -488,4 +490,4 @@ claude mcp add rocky -- rocky mcp --config rocky.toml
 ### Related Commands
 
 - [`rocky ai`](#rocky-ai) -- one-shot model generation from the CLI (no MCP client needed)
-- [`rocky apply`](/reference/commands/core-pipeline/#rocky-apply) -- execute an approved AI-authored plan (a human runs `rocky review <plan_id> --approve` first)
+- [`rocky apply`](/reference/commands/core-pipeline/#rocky-apply) -- execute an AI-authored plan (`rocky review <plan_id> --approve` writes the marker it requires first)

--- a/docs/src/content/docs/reference/commands/ai.md
+++ b/docs/src/content/docs/reference/commands/ai.md
@@ -405,7 +405,7 @@ Three rules keep that boundary in place:
 
 - The generators (`ai_contract`, `ai_test`, `explain_model`) return **drafts** and mutate nothing. Hand a draft to the `draft_contract` or `draft_check` write tool, or save it to disk and run `compile` and `test` yourself.
 - `governance_preview` and `drift_preview` are **read-only** previews.
-- The server does not apply. `rocky apply` is the only step that reaches the warehouse, and no MCP tool runs it. `review_queue` can write a plan's approval marker, so treat approval as a step the server can take. It needs `confirm: true` from the caller. It refuses a plan that is not already in the pending review queue. `rocky mcp --profile worker` does not serve it.
+- The server does not apply. `rocky apply` is the only step that WRITES to the warehouse, and no MCP tool runs it. Some tools do read the warehouse: `sample_rows`, `profile_column`, `inspect_schema`, and `drift_preview` issue queries against it. `review_queue` can write a plan's approval marker, so treat approval as a step the server can take. It needs `confirm: true` from the caller. It refuses a plan that is not already in the pending review queue. `rocky mcp --profile worker` does not serve it.
 
 ### Tools
 

--- a/docs/src/content/docs/reference/commands/core-pipeline.md
+++ b/docs/src/content/docs/reference/commands/core-pipeline.md
@@ -498,7 +498,7 @@ rocky plan --filter client=acme
 rocky apply <plan-id>
 ```
 
-Apply an AI-authored plan. The bare apply is refused until a human signs off:
+Apply an AI-authored plan. The bare apply is refused until an approval marker names that plan:
 
 ```bash
 rocky review <plan-id> --approve

--- a/docs/src/content/docs/reference/commands/governance-reclamation.md
+++ b/docs/src/content/docs/reference/commands/governance-reclamation.md
@@ -7,7 +7,7 @@ sidebar:
 
 These commands govern what an agent, or a person, may change. They also record what was decided and reclaim storage.
 
-One rule runs through all of them: the review gate. Every mutating plan on this page needs an explicit human sign-off before `rocky apply` will execute it. The read-only commands write nothing at all.
+One rule runs through all of them: the review gate. Every mutating plan on this page needs an approval marker before `rocky apply` will execute it. `rocky review <plan-id> --approve` writes that marker. The read-only commands write nothing at all.
 
 For the concepts behind the policy plane and the agent authoring loop, see [Operating Rocky with agents](/concepts/operating-rocky-with-agents/).
 

--- a/docs/src/content/docs/reference/glossary.md
+++ b/docs/src/content/docs/reference/glossary.md
@@ -129,7 +129,7 @@ How a model's output lands in the warehouse: `view`, `table`, `incremental`, `me
 
 ### MCP (Model Context Protocol)
 
-An open protocol that lets an AI agent call tools. `rocky mcp` serves Rocky's tools over it. The read-only ones let an agent check its work against the real project: compile, plan preview, lineage, test, schema inspection, row sampling. Others write into `models/`: `draft_model`, `draft_contract`, and `draft_check` go through the compiler and your `[policy]` rules. Applying an AI-authored plan still needs human approval. See [MCP authoring](/concepts/mcp-authoring/).
+An open protocol that lets an AI agent call tools. `rocky mcp` serves Rocky's tools over it. The read-only ones let an agent check its work against the real project: compile, plan preview, lineage, test, schema inspection, row sampling. Others write into `models/`: `draft_model`, `draft_contract`, and `draft_check` go through the compiler and your `[policy]` rules. Applying an AI-authored plan still needs an approval marker that names that plan. See [MCP authoring](/concepts/mcp-authoring/).
 
 ### MERGE
 

--- a/engine/README.md
+++ b/engine/README.md
@@ -173,9 +173,11 @@ denial or a review requirement, and a denied draft leaves nothing new on disk
 
 The other two carry their own guard. `pause_schedule` needs `confirm: true`.
 Only a human can resume a schedule, with
-`rocky state schedule resume <pipeline>`. `review_queue` can record the human
-sign-off that unblocks `rocky apply`. It needs `confirm: true`, and it refuses
-any plan that is not already in the pending review queue.
+`rocky state schedule resume <pipeline>`. `review_queue` can write the approval
+marker that unblocks `rocky apply`. It needs `confirm: true` from the caller,
+and it refuses any plan that is not already in the pending review queue. Rocky
+does not check that a person set `confirm`, so this is not a human sign-off in
+any sense the engine verifies. `rocky mcp --profile worker` does not serve it.
 
 To see what a rule resolves to before you rely on it, run
 `rocky policy check --principal agent --capability apply --model <name>`. It

--- a/engine/README.md
+++ b/engine/README.md
@@ -142,15 +142,19 @@ full set, or read the [CLI reference](https://rocky-data.dev/reference/cli/).
 
 ## The gate on agent-authored changes
 
-An AI agent can author a plan. A bare `rocky apply` refuses to execute one. A
-human clears it with `rocky review <plan-id> --approve`, which writes the
-sign-off marker that unblocks the apply.
+An AI agent can author a plan. A bare `rocky apply` refuses to execute one. It
+runs the plan only when a marker file is present that parses and names that
+exact plan. `rocky review <plan-id> --approve` writes that marker.
 
-A `[policy]` block supersedes that default. Rocky evaluates every model the
-plan touches and takes the most restrictive answer. `allow` proceeds with no
-marker, `require_review` still demands one, and `deny` refuses outright. So
-only a `[policy]` rule you wrote lets an agent-authored plan through
-unreviewed.
+That check is a floor. It runs on every AI-authored apply whatever your
+`[policy]` block says, so an `allow` rule cannot waive it. A `[policy]` rule can
+only add restrictions on top. Rocky evaluates every model the plan touches and
+takes the most restrictive answer. The policy gate runs first, so a `deny`
+refuses before the marker is read at all.
+
+Be exact about what the marker check verifies. It reads a file, parses it, and
+compares the plan id. It does not authenticate who approved, or that a person
+approved at all. The marker is not signed.
 
 Rocky enforces the same `[policy]` block at three seams: `rocky apply`,
 `rocky branch promote`, and the MCP authoring tools. Two of its mechanisms

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -3389,8 +3389,13 @@ fn run_verify_after(
 /// `rocky review <plan-id> --approve`:
 ///
 /// - marker ABSENT → `bail!` instructing the operator to review first.
-/// - marker PRESENT → the human has signed off; dispatch the identical
+/// - marker INVALID (unreadable, unparseable, or naming a DIFFERENT plan) →
+///   `bail!` with its own distinct error; it never counts as an approval.
+/// - marker APPROVED (parses AND names this plan) → dispatch the identical
 ///   execution path as [`run_apply_run_plan`] via [`execute_run_plan`].
+///
+/// The check runs unconditionally, after the policy gate (#1459), so policy
+/// can only tighten it. It verifies the marker, not the approver.
 async fn run_apply_ai_authored_plan(
     root: &Path,
     config_path: &Path,

--- a/engine/crates/rocky-cli/src/commands/review.rs
+++ b/engine/crates/rocky-cli/src/commands/review.rs
@@ -17,10 +17,15 @@
 //!    and name that exact plan. The marker is unsigned, so it records that an
 //!    approval was made on this machine, not who made it.
 //!
-//! The marker is written even when breaking changes exist — the human
-//! approving has seen the report and is explicitly signing off on them. The
-//! emitted output therefore always lists the full classified delta so the
-//! approval is informed.
+//! The marker is written even when breaking changes exist: approving over a
+//! reported break is allowed.
+//!
+//! The marker is ALSO written when the classifier could not run. Compiling
+//! either tree can fail, and `compute_review_findings` then returns `None`;
+//! `breaking_change_count` falls back to 0 and `--approve` still writes the
+//! marker. So the count on a marker is not evidence that a delta was computed,
+//! and the emitted output does not always carry one. The approver identity
+//! falls back to `unknown` when the git identity cannot be read.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};

--- a/engine/crates/rocky-cli/src/commands/review.rs
+++ b/engine/crates/rocky-cli/src/commands/review.rs
@@ -12,8 +12,10 @@
 //! 3. Without `--approve`: report the findings (dry run); the plan stays
 //!    blocked.
 //! 4. With `--approve`: write a review marker at
-//!    `<root>/.rocky/plans/<plan_id>.reviewed.json`. The marker is the human
-//!    sign-off; `rocky apply` checks for its presence before executing.
+//!    `<root>/.rocky/plans/<plan_id>.reviewed.json`. `rocky apply` checks the
+//!    marker's CONTENTS before executing, not just its presence: it must parse
+//!    and name that exact plan. The marker is unsigned, so it records that an
+//!    approval was made on this machine, not who made it.
 //!
 //! The marker is written even when breaking changes exist — the human
 //! approving has seen the report and is explicitly signing off on them. The

--- a/engine/crates/rocky-cli/src/plan_store.rs
+++ b/engine/crates/rocky-cli/src/plan_store.rs
@@ -97,8 +97,16 @@ use serde::{Deserialize, Serialize};
 /// paths never call (#1310). Such checks belong at the seam every entrypoint
 /// crosses.
 ///
-/// Audited across all nine kinds. Two entries below record a gap rather than a
-/// guarantee; do not read this table as a certification.
+/// Audited across all nine kinds. Some entries below record a gap rather than
+/// a guarantee — `Replication` (#1460), and the point-in-time limit on
+/// `Restore`. Do not read this table as a certification.
+///
+/// The `AiAuthored` row states what the marker check ENFORCES, which is that a
+/// well-formed marker names this plan. It does not establish that a person
+/// approved: the marker is unsigned, its `approver` field is a best-effort git
+/// identity the gate never reads, and anything that can write the plans
+/// directory can produce one. Treat it as a floor against an unreviewed
+/// machine-authored apply, not as proof of human intent.
 ///
 /// | Kind | Load-bearing plan-time invariant | Re-established at apply? |
 /// |---|---|---|
@@ -108,7 +116,7 @@ use serde::{Deserialize, Serialize};
 /// | `Restore` | rebuilt bytes are hash-exact | Point-in-time only — the hash is verified *before* the ledger row is reinstated, and nothing fences the object between the two |
 /// | `Compact` / `Archive` | policy gate | Yes — the gate runs at apply; a denied apply never reaches `execute_statement` |
 /// | `Replication` | source state matches what was reviewed | **Partly — see #1460.** Apply discovers once for comparison, then `run` discovers again and builds work from the second result; `config_snapshot` has no production apply-side reader |
-/// | `AiAuthored` | human review before a machine-authored change executes | **No — see #1459.** The marker is only checked when policy is `NotConfigured`; a configured policy resolving to `Allow` reaches `apply_policy_gate`, which returns `Ok(())` without consulting it |
+/// | `AiAuthored` | a review marker naming the plan before a machine-authored change executes | Yes — unconditionally, since #1459. `apply_policy_gate` runs FIRST (so `Deny` / `RequireReview` keep their wording and precedence), then [`crate::commands::review::review_marker_state`] must return `Approved` for THIS plan id. `Allow` and `NotConfigured` return `Ok(())` without consulting the marker, so the check runs after them and policy can only TIGHTEN the gate, never waive it. It is parse-and-match, not file-exists, and it authenticates nobody — see the caveat below |
 /// | `Backfill` | reviewed closure + run-plan diagnostics | Yes for the closure — see the structural note on `run_apply_backfill_plan` |
 ///
 /// `Backfill` is the one entry whose safety is **structural rather than
@@ -145,9 +153,11 @@ pub enum PlanKind {
     /// An AI-authored run plan. The payload is a `RunPlan` struct — the same
     /// shape as [`PlanKind::Run`] — but the kind discriminator marks it as
     /// machine-authored, so a bare `rocky apply` refuses to execute it until a
-    /// human signs off via `rocky review <plan-id> --approve`. The review step
-    /// writes a marker file alongside the plan; `apply` requires that marker
-    /// before dispatching the same execution path as a `Run` plan.
+    /// review marker names it. `rocky review <plan-id> --approve` writes that
+    /// marker alongside the plan; `apply` requires a marker that PARSES and
+    /// names this exact plan id before dispatching the same execution path as
+    /// a `Run` plan. The check authenticates no one — see the caveat on
+    /// [`PlanKind`].
     #[serde(rename = "ai_authored")]
     AiAuthored,
     /// A supervised-backfill plan composed by `rocky backfill`. The payload is

--- a/engine/crates/rocky-cli/src/plan_store.rs
+++ b/engine/crates/rocky-cli/src/plan_store.rs
@@ -97,9 +97,10 @@ use serde::{Deserialize, Serialize};
 /// paths never call (#1310). Such checks belong at the seam every entrypoint
 /// crosses.
 ///
-/// Audited across all nine kinds. Some entries below record a gap rather than
-/// a guarantee — `Replication` (#1460), and the point-in-time limit on
-/// `Restore`. Do not read this table as a certification.
+/// Audited across all nine kinds. One entry below records a gap rather than a
+/// guarantee: the point-in-time limit on `Restore`. Do not read this table as
+/// a certification, and re-check a row against its code before relying on it —
+/// two rows here described gaps that had already been closed (#1459, #1460).
 ///
 /// The `AiAuthored` row states what the marker check ENFORCES, which is that a
 /// well-formed marker names this plan. It does not establish that a person
@@ -115,7 +116,7 @@ use serde::{Deserialize, Serialize};
 /// | `Gc` | candidate is provably derivable | Yes — re-derives against the live store and takes derivability from the fresh candidate, never the payload; fail-closed on hash mismatch |
 /// | `Restore` | rebuilt bytes are hash-exact | Point-in-time only — the hash is verified *before* the ledger row is reinstated, and nothing fences the object between the two |
 /// | `Compact` / `Archive` | policy gate | Yes — the gate runs at apply; a denied apply never reaches `execute_statement` |
-/// | `Replication` | source state matches what was reviewed | **Partly — see #1460.** Apply discovers once for comparison, then `run` discovers again and builds work from the second result; `config_snapshot` has no production apply-side reader |
+/// | `Replication` | source state + config match what was reviewed | Yes, since #1460. Apply compares the persisted `config_snapshot` WHOLE against a freshly fingerprinted load, and `run` re-applies the source-state check against the discovery the work is actually built from. Two stated limits remain: credentials are redacted in the snapshot, so a changed secret is not detected, and the state identity is credential-free by construction |
 /// | `AiAuthored` | a review marker naming the plan before a machine-authored change executes | Yes — unconditionally, since #1459. `apply_policy_gate` runs FIRST (so `Deny` / `RequireReview` keep their wording and precedence), then [`crate::commands::review::review_marker_state`] must return `Approved` for THIS plan id. `Allow` and `NotConfigured` return `Ok(())` without consulting the marker, so the check runs after them and policy can only TIGHTEN the gate, never waive it. It is parse-and-match, not file-exists, and it authenticates nobody — see the caveat below |
 /// | `Backfill` | reviewed closure + run-plan diagnostics | Yes for the closure — see the structural note on `run_apply_backfill_plan` |
 ///

--- a/examples/playground/pocs/03-ai/06-mcp-grounding/README.md
+++ b/examples/playground/pocs/03-ai/06-mcp-grounding/README.md
@@ -19,7 +19,7 @@ It ships two transformation models over the same source:
 - **"It compiled" is not "it's correct."** Both models pass `rocky compile`. Schema-only verification cannot tell them apart. Only the data can.
 - **The trap is realistic.** A `WHERE status = 'completed'` that silently matches zero rows, and an `amount_cents` summed as dollars (100x too large), are two of the most common reconcile bugs in real pipelines. They are exactly what an agent that reads column names but never samples rows gets wrong.
 - **The fix is a tool, not a prompt trick.** The Rocky MCP server hands an agent `sample_rows` and `profile_column`, so it sees `'COMPLETE'` and the cents scale before it writes a filter. The correctness it learns becomes a `[[tests]]` assertion, not a comment.
-- **Materialization stays human-gated.** The agent can `propose` a plan, but a human runs `rocky review <plan-id> --approve` before `rocky apply`. The agent never ships unreviewed SQL.
+- **Materialization stays gated on a review marker.** The agent can `propose` a plan. `rocky apply` then refuses it until `rocky review <plan-id> --approve` has written a marker naming that exact plan. The check is on the marker, not on who wrote it.
 
 ## The engineered scenario
 


### PR DESCRIPTION
The fulfillment work is merged, so this updates the documentation to match — and along the way corrects a set of safety claims that were stronger than the code. Every statement here was re-derived from source, not from another document.

## The headline claim was false

`README.md` said:

> **A plan written by AI waits for a human.** The engine enforces this.

It doesn't. `rocky apply` refuses an AI-authored plan unless an approval **marker** is present that parses and names that exact plan. It never checks who wrote the marker, or that a person did. The floor is real and worth stating — that check runs whatever your `[policy]` says, so an `allow` rule cannot waive it — so the text now describes the mechanism instead of the intent, matching the wording already agreed in the concepts pages.

## Four safety claims that were not true

Found while checking the rest. Each is corrected in place:

- **"No MCP tool writes that approval."** `review_queue` writes the marker with `approve_plan_id` + `confirm: true`. It is excluded only under `--profile worker`. Filed for a product decision as #1517.
- **Branch approvals described as "signed."** `sign_artifact` is an **unkeyed** blake3 digest — the engine's own output doc says "not asymmetric crypto". The gate is also **off by default**, runs only at plan-build time, is bypassed by `--skip-approval` or an environment variable, and counts files rather than identities.
- **"`rocky fulfill` runs the agent on the worker profile."** The loop passes `--profile worker` for the **replay** driver. A live subprocess driver runs the command you configured, so that boundary is the operator's, not the engine's.
- **"the only step that reaches the warehouse."** Four read tools reach it too; the claim now scopes to writes.

Plus smaller ones: the audit ledger does not record *every* step (writes are best-effort), five tools pass the policy rules rather than seven, and `product compile` runs one phase per call.

## Two issues closed by this

- **#1509** — a doc comment in `plan_store.rs` said the marker is checked only when policy is unconfigured. It is unconditional. Corrected, along with two neighbouring inaccuracies in `review.rs` and `apply.rs`.
- **#1512** — the "engine enforces human review" shape swept from the remaining pages. `architecture-of-trust.md` turned out to be clean of it; the real sites were `mcp-authoring.md`, `ai.md`, the glossary, and several others.

## What shipped is now findable

The engine row in `AGENTS.md` names `rocky product` / `rocky fulfill` and the `rocky-fulfill` crate; the README and docs landing page point at the existing command and concept pages. The sidebar is autogenerated by directory, so no nav edit was needed — confirmed, not assumed.

## Evidence

`cargo test -p rocky-cli` 1518 passed · clippy `-D warnings` · `fmt --check` · docs build · skills mirror `diff -r` clean. The Rust diff is 100% doc comments; no codegen surface touched. Two independent review rounds ran, each with its own second-model pass; both returned BLOCK, and all eleven findings were verified against source and fixed.

One gap worth knowing: the unconditional marker floor arrived in engine v1.71.0. The capability matrix carries that caveat; the README and engine README state the floor without a version note, so a reader on an older binary would read something untrue for them.