### PR TITLE
docs: resolve two contradictions the docs sweep left behind

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ You write one spec file. `products/<name>.toml` states what the product must be:
    Each verb also runs on its own, in any order you need.
 ```
 
-`rocky fulfill` runs the drafting agent as a subprocess. You choose the command in `[fulfill.driver]`. The worker sees only the environment variables you allowlist, and the whole task runs in one process group the loop kills when the task ends.
+`rocky fulfill` runs the drafting agent through the driver you set in `[fulfill.driver]`. There are two. The subprocess driver runs a command you choose: the worker sees only the environment variables you allowlist, and the whole task runs in one process group the loop kills when the task ends. The replay driver runs a recorded session against the worker-profile MCP server instead, which is what CI uses.
 
 Rocky ships a narrowed MCP surface for that worker. `rocky mcp --profile worker` serves the read and inspect tools, the compile and test loop, and two draft tools. It serves no other tools, and a tool added later stays out until someone adds it deliberately. The MCP prompts stay available in both profiles. Point your driver command at it. The engine does not force the command you configure to use it.
 

--- a/engine/crates/rocky-cli/src/plan_store.rs
+++ b/engine/crates/rocky-cli/src/plan_store.rs
@@ -83,10 +83,12 @@ use serde::{Deserialize, Serialize};
 /// > structurally cannot observe an invalid shape.
 ///
 /// Persisting a value is not the same as replaying the check that validated it.
-/// `ReplicationPlan.config_snapshot` is the counterexample: it is written at
-/// plan time and no production apply-side code reads it, so a plan whose
-/// adapter or destination changed between plan and apply is not detected by it.
-/// Guards over *derived* state — discovery output, compiled models, live
+/// `ReplicationPlan.config_snapshot` WAS the counterexample: it was written at
+/// plan time and no production apply-side code read it, so a plan whose adapter
+/// or destination changed between plan and apply went undetected. #1460 closed
+/// that specific hole — apply now compares the snapshot whole — but the SHAPE
+/// is the lesson here, not the instance, and it recurred often enough to be
+/// worth stating. Guards over *derived* state — discovery output, compiled models, live
 /// warehouse shape — are likewise only re-established where that derivation
 /// repeats at apply.
 ///


### PR DESCRIPTION
Tail of #1518. Its review found two more contradictions after that PR was already merged, so they land here.

**1. A doc comment contradicted itself.** #1518 corrected a table row in `plan_store.rs` to say #1460 closed the replication config-snapshot hole — but the prose two paragraphs above still presented that same field as a live counterexample of a guard nobody reads. The prose now says it *was* the counterexample, that #1460 closed it, and that the shape is the lesson rather than the instance.

That contradiction was introduced by the fix, which is worth stating plainly: correcting one half of a claim and leaving the other half is how a document ends up arguing with itself.

**2. The README described one driver when there are two.** It said `rocky fulfill` "runs the drafting agent as a subprocess". `FulfillDriverConfig` has two variants — the subprocess driver runs a command you choose, and the replay driver runs a recorded session against the worker-profile MCP server, which is what CI uses. Both are now named.

Doc comments and prose only; no behaviour change, no codegen surface. `cargo test -p rocky-cli`, `fmt --check`, and the docs build all pass.