### PR TITLE
docs: date the review floor (unconditional only since v1.71.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ The diagram shows the gate at `rocky apply`. The MCP `draft` and `propose` tools
 A rule can also name checks that must pass in that run. If one fails, or never ran, Rocky stops and records the failure. It cannot undo the write: the change stays until a human reverts it.
 
 - **You write the rules.** A `[policy]` rule in `rocky.toml` says what each principal may do, and where. The answer is allow, require review, or deny. Set `max_downstreams` to cap how far one change may reach.
-- **An AI-written plan needs an approval marker.** `rocky apply` refuses an AI-authored plan unless a marker file is present that parses and names that exact plan. That check runs whatever your rules say, so an `allow` rule cannot waive it. The marker is not signed, so it records that an approval was made on this machine, not who made it.
+- **An AI-written plan needs an approval marker.** `rocky apply` refuses an AI-authored plan unless a marker file is present that parses and names that exact plan. That check runs whatever your rules say, so an `allow` rule cannot waive it — since engine v1.71.0; on earlier versions a rule could waive it. The marker is not signed, so it records that an approval was made on this machine, not who made it.
 - **You can test the rules.** `[[policy.tests]]` scenarios run through the real evaluator, so `rocky policy test` catches an edit that opens a hole.
 - **You can ask what happened.** `rocky audit --for <table>` says who changed what, and under whose authority. `rocky review --queue` ranks what waits on you.
 - **Agents connect over MCP.** `rocky mcp` exposes 31 tools. Seven can write. Five of those pass the same rules; `pause_schedule` and `review_queue` carry their own guards.

--- a/engine/README.md
+++ b/engine/README.md
@@ -146,8 +146,10 @@ An AI agent can author a plan. A bare `rocky apply` refuses to execute one. It
 runs the plan only when a marker file is present that parses and names that
 exact plan. `rocky review <plan-id> --approve` writes that marker.
 
-That check is a floor. It runs on every AI-authored apply whatever your
-`[policy]` block says, so an `allow` rule cannot waive it. A `[policy]` rule can
+That check is a floor, since engine v1.71.0. It runs on every AI-authored
+apply whatever your `[policy]` block says, so an `allow` rule cannot waive it.
+On v1.70.1 and earlier the marker was checked only when no `[policy]` block was
+configured, so a rule could let an agent-authored plan through unreviewed. A `[policy]` rule can
 only add restrictions on top. Rocky evaluates every model the plan touches and
 takes the most restrictive answer. The policy gate runs first, so a `deny`
 refuses before the marker is read at all.


### PR DESCRIPTION
Both READMEs state that the approval-marker check runs whatever your `[policy]` says, so an `allow` rule cannot waive it. True on the current release — but not before it, and neither page said so.

Verified against the tags rather than assumed. In `engine-v1.70.1` the AI-authored apply path read:

```rust
match gate {
    PolicyGate::NotConfigured => { if !ai_plan_is_reviewed(..) { bail!(..) } }
    gate => apply_policy_gate(root, plan_id, gate)?,   // no marker check
}
```

With any `[policy]` block configured, the marker was never checked — the policy gate decided alone. So on v1.70.1 and earlier, a rule really could let an agent-authored plan through unreviewed.

Both pages now carry the version. One clause, not a version matrix: it is a single claim about a single release, and the capability matrix already carries the fuller caveat for anyone who needs it.

Docs only.