### PR TITLE
fix(engine/rocky-cli): reject malformed compile config

### DIFF
--- a/engine/crates/rocky-cli/src/commands/compile.rs
+++ b/engine/crates/rocky-cli/src/commands/compile.rs
@@ -87,6 +87,15 @@ fn compile_inner(
     cache_ttl_override: Option<u64>,
     run_vars: &rocky_core::run_vars::RunVars,
 ) -> Result<(CompileOutput, CompileTextData)> {
+    let project_config = match config_path {
+        Some(path) => match rocky_config::load_rocky_config(path) {
+            Ok(config) => Some(config),
+            Err(rocky_config::ConfigError::FileNotFound { .. }) => None,
+            Err(error) => return Err(error.into()),
+        },
+        None => None,
+    };
+
     // `source_schemas` precedence:
     //   1. `--with-seed` wins -> seed loader (explicit user intent,
     //      used for tests/playgrounds where the cache is irrelevant).
@@ -99,17 +108,16 @@ fn compile_inner(
         // from `RockyType::Unknown` into concrete types for any project
         // that ships a runnable seed (the entire playground).
         load_source_schemas_from_seed(models_dir)?
-    } else if let Some(path) = config_path {
+    } else if let Some(config) = &project_config {
         // TTL-filtered load from `state.redb`'s `SCHEMA_CACHE` table.
         // Honours `[cache.schemas] enabled` + `ttl_seconds` (after
         // applying the optional CLI `--cache-ttl` override).
-        match rocky_config::load_rocky_config(path) {
-            Ok(cfg) => {
-                let schema_cfg = cfg.cache.schemas.with_ttl_override(cache_ttl_override);
-                crate::source_schemas::load_cached_source_schemas(&schema_cfg, state_path)
-            }
-            Err(_) => HashMap::new(),
-        }
+        let schema_cfg = config
+            .cache
+            .schemas
+            .clone()
+            .with_ttl_override(cache_ttl_override);
+        crate::source_schemas::load_cached_source_schemas(&schema_cfg, state_path)
     } else {
         HashMap::new()
     };
@@ -122,15 +130,12 @@ fn compile_inner(
     // suppression bit — when the top-level `[freshness]` block declares
     // an `expected_lag_seconds`, every model inherits the default and
     // W005 stays silent.
-    let (mask, allow_unmasked, project_freshness_default) = match config_path {
-        Some(path) => match rocky_config::load_rocky_config(path) {
-            Ok(cfg) => (
-                cfg.mask.clone(),
-                cfg.classifications.allow_unmasked.clone(),
-                cfg.freshness.has_default(),
-            ),
-            Err(_) => (std::collections::BTreeMap::new(), Vec::new(), false),
-        },
+    let (mask, allow_unmasked, project_freshness_default) = match &project_config {
+        Some(config) => (
+            config.mask.clone(),
+            config.classifications.allow_unmasked.clone(),
+            config.freshness.has_default(),
+        ),
         None => (std::collections::BTreeMap::new(), Vec::new(), false),
     };
 
@@ -157,14 +162,9 @@ fn compile_inner(
     // Portability lint. Effective target_dialect = CLI flag > [portability]
     // config > unset. Project-wide allow list and per-model `-- rocky-allow:`
     // pragmas suppress matching constructs before they become diagnostics.
-    let portability_cfg = match config_path {
-        Some(path) => rocky_config::load_rocky_config(path)
-            .ok()
-            .map(|c| c.portability),
-        None => None,
-    };
+    let portability_cfg = project_config.as_ref().map(|config| &config.portability);
     let effective_dialect =
-        target_dialect.or_else(|| portability_cfg.as_ref().and_then(|p| p.target_dialect));
+        target_dialect.or_else(|| portability_cfg.and_then(|p| p.target_dialect));
     let project_allow: std::collections::HashSet<String> = portability_cfg
         .as_ref()
         .map(|p| {
@@ -255,12 +255,12 @@ fn compile_inner(
     // recipe-hash pin mismatch surfaces as E033. Projects with no `[imports]`
     // block incur no work — `imports_diagnostics` returns empty immediately.
     if let Some(path) = config_path
-        && let Ok(cfg) = rocky_config::load_rocky_config(path)
-        && !cfg.imports.is_empty()
+        && let Some(config) = &project_config
+        && !config.imports.is_empty()
     {
         let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
         let import_diags = crate::commands::imports_check::imports_diagnostics(
-            &cfg,
+            config,
             config_dir,
             &result.project.models,
         );
@@ -934,6 +934,33 @@ schema_template = "s"
             &rocky_core::run_vars::RunVars::new(),
         )
         .expect("missing config should fall through, not error");
+    }
+
+    #[test]
+    fn malformed_config_file_fails_compile() {
+        let dir = TempDir::new().unwrap();
+        let models_dir = dir.path().join("models");
+        fs::create_dir_all(&models_dir).unwrap();
+        write_model(&models_dir, "m1", "SELECT 1 AS id");
+        let config = dir.path().join("rocky.toml");
+        fs::write(&config, "[portability\n").unwrap();
+
+        let err = run_compile(
+            Some(&config),
+            Path::new(".rocky-state.redb"),
+            &models_dir,
+            None,
+            None,
+            true,
+            false,
+            None,
+            false,
+            None,
+            &rocky_core::run_vars::RunVars::new(),
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("failed to parse TOML"));
     }
 
     // ---- --with-seed source-schema loading ----


### PR DESCRIPTION
## Summary

Make `rocky compile` fail when a supplied `rocky.toml` exists but cannot be loaded, while preserving config-free standalone compilation when the file is genuinely absent.

Closes #1521.

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Changes

- Load the optional project config once at the start of `compile_inner`.
- Preserve the existing `ConfigError::FileNotFound` fallback.
- Propagate parse, validation, read, and other config-load failures.
- Reuse the same parsed config for schema-cache typing, masks/classifications, freshness, portability, and imports.
- Add a regression test proving malformed present config fails compilation.

## Behavior boundary

- Malformed present config: exits nonzero with the TOML parse error.
- Valid config: compiles successfully with config-driven behavior intact.
- Missing config: continues to support flag-only standalone compilation.
- CLI JSON schemas and generated consumers are unchanged.

## Test Plan

- `cargo test -p rocky-cli commands::compile::tests::malformed_config_file_fails_compile` — passed.
- `cargo nextest run --all-features` — 6,512 passed, 112 skipped, 0 failed.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt -- --check` — passed.
- `cargo build --release --bin rocky` — passed.
- Release `rocky doctor` valkey-feature smoke — reached adapters with expected fake-credential failures and did not report a missing tiered-cache backend.
- `just codegen` and `just regen-fixtures` — completed; generated schemas, SDKs, OpenAPI, and 40 fixtures produced no diff.
- End-to-end CLI control cases — malformed config exits 1; valid and missing configs exit 0.
- `git diff --check` — passed.

## Independent review

An independent GPT-5.4 red-team review traced `ConfigError`, compile consumers, imports, and the missing/valid/malformed boundary tests. Decision: **Approve**, with no actionable findings. The review noted only a pre-existing API/MCP error-taxonomy question outside this CLI issue; no scope expansion was recommended.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/), scoped by subproject when relevant (e.g. `feat(engine/rocky-databricks): ...`, `fix(dagster): ...`)
- [x] No `Co-Authored-By` trailers
- [x] This does not change a CLI JSON schema or DSL syntax; generated consumers have zero drift

### Engine (`engine/`)

- [ ] `cargo test --all-targets` passes (not run verbatim; the current CI command `cargo nextest run --all-features` passed all 6,512 runnable tests, while Clippy type-checked all targets)
- [x] `cargo clippy --all-targets -- -D warnings` is clean (run with the stricter `--all-features` flag)
- [x] `cargo fmt --check` passes

### Dagster (`integrations/dagster/`)

- [ ] `uv run pytest` passes (not applicable; no Dagster source or generated fixture changes)
- [ ] `uv run ruff check` is clean (not applicable)
- [ ] `uv run ruff format --check` passes (not applicable)

### VS Code (`editors/vscode/`)

- [ ] `npm run compile` succeeds (not applicable; generated VS Code schema has zero drift)
- [ ] `npm run test:unit` passes (not applicable)
- [ ] `npm run lint` is clean (not applicable)

## Reviewer questions

**What are you least confident about?** Whether maintainers eventually want malformed project config represented as a structured compile diagnostic over API/MCP surfaces rather than the pre-existing hard-error path. This patch only fixes the CLI swallowing behavior and does not alter those contracts.

**What’s the most important thing I’m missing?** Explicit product intent for that broader API/MCP error taxonomy. Static tracing found no enforced contract that this patch violates, and it is separable from the CLI correctness bug.
