### PR TITLE
fix(mcp): approving is opt-in — the default profile can no longer sign off a plan (#1517)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ A rule can also name checks that must pass in that run. If one fails, or never r
 - **An AI-written plan needs an approval marker.** `rocky apply` refuses an AI-authored plan unless a marker file is present that parses and names that exact plan. That check runs whatever your rules say, so an `allow` rule cannot waive it — since engine v1.71.0; on earlier versions a rule could waive it. The marker is not signed, so it records that an approval was made on this machine, not who made it.
 - **You can test the rules.** `[[policy.tests]]` scenarios run through the real evaluator, so `rocky policy test` catches an edit that opens a hole.
 - **You can ask what happened.** `rocky audit --for <table>` says who changed what, and under whose authority. `rocky review --queue` ranks what waits on you.
-- **Agents connect over MCP.** `rocky mcp` exposes 31 tools. Seven can write. Five of those pass the same rules; `pause_schedule` and `review_queue` carry their own guards.
+- **Agents connect over MCP.** `rocky mcp` exposes 31 tools. Six can write: five pass the same rules, and `pause_schedule` carries its own guard. Writing the approval marker is not on that list — `review_queue` lists the queue but cannot sign anything off unless you start the server as `rocky mcp --profile approver`.
 
 <p align="center">
   <img src="docs/public/demo-policy-enforce.gif" alt="an agent's change to a contracted model is planned, rocky apply run as the agent principal is denied by the policy plane with the rule named, and rocky audit shows the recorded decision" width="900" />
@@ -264,7 +264,7 @@ You write one spec file. `products/<name>.toml` states what the product must be:
 
 `rocky fulfill` runs the drafting agent through the driver you set in `[fulfill.driver]`. There are two. The subprocess driver runs a command you choose: the worker sees only the environment variables you allowlist, and the whole task runs in one process group the loop kills when the task ends. The replay driver runs a recorded session against the worker-profile MCP server instead, which is what CI uses.
 
-Rocky ships a narrowed MCP surface for that worker. `rocky mcp --profile worker` serves the read and inspect tools, the compile and test loop, and two draft tools. It serves no other tools, and a tool added later stays out until someone adds it deliberately. The MCP prompts stay available in both profiles. Point your driver command at it. The engine does not force the command you configure to use it.
+Rocky ships a narrowed MCP surface for that worker. `rocky mcp --profile worker` serves the read and inspect tools, the compile and test loop, and two draft tools. It serves no other tools, and a tool added later stays out until someone adds it deliberately. The MCP prompts stay available in every profile. Point your driver command at it. The engine does not force the command you configure to use it.
 
 The runner then re-reads what the agent wrote from disk, re-verifies it, and hands it to the same governed `propose` as any other agent change.
 

--- a/docs/src/content/docs/concepts/mcp-authoring.md
+++ b/docs/src/content/docs/concepts/mcp-authoring.md
@@ -160,10 +160,19 @@ one ends at a proposed plan or an enumerated gap, never at an applied change.
 A prompt is a recommended sequence, not a privileged path. It calls exactly the
 tools listed above and it stops at the same gate.
 
-## Two profiles
+## Three profiles
 
-`rocky mcp` serves the full 31-tool surface by default. `rocky mcp --profile
-worker` serves a smaller, fixed list meant for an untrusted drafting worker: the
+`rocky mcp` serves all 31 tools by default, with one action held back:
+`review_queue` lists the pending review queue, but its approve action —
+`approve_plan_id` + `confirm: true`, which writes the approval marker that
+unblocks `rocky apply` — is refused with `approve_not_enabled`.
+
+`rocky mcp --profile approver` serves the same 31 tools and allows that one
+action. Use it only for a server you intend to be able to sign off plans.
+Approving is still attributed to the operator's git identity, not to a verified
+person.
+
+`rocky mcp --profile worker` serves a smaller, fixed list meant for an untrusted drafting worker: the
 read and inspect tools (`plan_preview`, `lineage`, `list`, `inspect_schema`,
 `catalog`, `sample_rows`, `profile_column`), the verification loop (`compile`,
 `test`, `breaking_change`, `dependents`), `draft_model` + `draft_check`, and the

--- a/docs/src/content/docs/concepts/operating-rocky-with-agents.md
+++ b/docs/src/content/docs/concepts/operating-rocky-with-agents.md
@@ -149,12 +149,28 @@ recorded, the ledger does not give you that today.
 `rocky apply` refuses to run one unless an approval marker is present that parses
 and names that exact plan. `rocky review <plan-id> --approve` writes that marker.
 
-One MCP tool can write it too. `review_queue` writes the marker when it is
-called with `approve_plan_id` and `confirm: true`. It refuses any plan that is
-not already in the pending review queue. The `confirm` flag is set by the
-caller, and Rocky does not check that a person set it. `rocky mcp --profile
-worker` does not serve `review_queue`, so a drafting worker on that profile has
-no tool that writes a marker.
+One MCP tool can write it too, but only if you ask for that when you start the
+server. `review_queue` writes the marker when it is called with
+`approve_plan_id` and `confirm: true` — and that call is served on one profile
+only:
+
+```
+rocky mcp                      lists the queue, REFUSES to approve
+rocky mcp --profile approver   lists the queue, and may approve
+rocky mcp --profile worker     no review_queue at all
+```
+
+On any other profile the approve call is refused with the error code
+`approve_not_enabled`, nothing is written, and the message names the flag. The
+refusal comes before Rocky looks at the queue, so it does not depend on the
+plan, on `confirm`, or on the state store being readable.
+
+Be exact about what the opt-in buys you. It decides **whether this server can
+approve at all**, and only the operator who starts the server chooses it. It
+does not authenticate the approval: on `--profile approver`, `confirm` is still
+set by the caller, and Rocky still does not check that a person set it. So
+`--profile approver` gives you a server where an agent's `confirm` is
+sufficient. Start one only where that is what you want.
 
 Be exact about what this check verifies. It reads a file, parses it, and compares
 the plan id. It does not authenticate who approved, or that a person approved at

--- a/docs/src/content/docs/reference/commands/ai.md
+++ b/docs/src/content/docs/reference/commands/ai.md
@@ -364,6 +364,7 @@ rocky mcp [flags]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--config <PATH>` | `PathBuf` | `rocky.toml` | Pipeline config file the server resolves the project from. The models directory is resolved as `<config-dir>/models`. |
+| `--profile <PROFILE>` | `default` \| `approver` \| `worker` | `default` | Which tool surface to serve. `default` serves all 31 tools but refuses `review_queue`'s approve action (listing the queue still works). `approver` serves the same 31 tools and allows that action, so the server can write approval markers. `worker` serves the minimal drafting allowlist for an untrusted worker. |
 
 The server is **stateless**: every tool call resolves the project from the config + models dir and compiles fresh, so it always reflects the current on-disk files. Logging goes to stderr (stdout is reserved for the MCP wire protocol).
 
@@ -378,7 +379,7 @@ What leaves your machine is bounded: warehouse queries go to your warehouse; the
 
 ### Safety model: the server does not materialize
 
-The server **never materializes anything**. No tool runs SQL that changes your warehouse. An agent can write project files and record a plan. One tool, `review_queue`, can also write the approval marker for a plan that is already in the pending review queue.
+The server **never materializes anything**. No tool runs SQL that changes your warehouse. An agent can write project files and record a plan. One tool, `review_queue`, can also write the approval marker for a plan that is already in the pending review queue — but only on `rocky mcp --profile approver`. The default server refuses that call.
 
 ```
    through rocky mcp                       through the CLI
@@ -394,7 +395,9 @@ The server **never materializes anything**. No tool runs SQL that changes your w
                               rocky review <plan-id> --approve
                               writes the approval marker. The
                               review_queue MCP tool writes it
-                              too, with confirm: true.
+                              too, with confirm: true — but ONLY
+                              on --profile approver. The default
+                              server refuses (approve_not_enabled).
                                         │
                                         ▼
                               rocky apply <plan-id> ──► warehouse
@@ -405,7 +408,7 @@ Three rules keep that boundary in place:
 
 - The generators (`ai_contract`, `ai_test`, `explain_model`) return **drafts** and mutate nothing. Hand a draft to the `draft_contract` or `draft_check` write tool, or save it to disk and run `compile` and `test` yourself.
 - `governance_preview` and `drift_preview` are **read-only** previews.
-- The server does not apply. `rocky apply` is the only step that WRITES to the warehouse, and no MCP tool runs it. Some tools do read the warehouse: `sample_rows`, `profile_column`, `inspect_schema`, and `drift_preview` issue queries against it. `review_queue` can write a plan's approval marker, so treat approval as a step the server can take. It needs `confirm: true` from the caller. It refuses a plan that is not already in the pending review queue. `rocky mcp --profile worker` does not serve it.
+- The server does not apply. `rocky apply` is the only step that WRITES to the warehouse, and no MCP tool runs it. Some tools do read the warehouse: `sample_rows`, `profile_column`, `inspect_schema`, and `drift_preview` issue queries against it. `review_queue` can write a plan's approval marker, but only on `rocky mcp --profile approver` — the default server refuses the call with `approve_not_enabled` and writes nothing. Where it is served it still needs `confirm: true` from the caller, and it still refuses a plan that is not already in the pending review queue. `rocky mcp --profile worker` does not serve `review_queue` at all. So treat approval as a step the server can take **only on a server you started for that purpose**; the profile is chosen at launch and an agent cannot change it mid-session.
 
 ### Tools
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -54,9 +54,11 @@ In the recording below, a PII-classified model flags a column left unmasked. Col
 
 **AI generate**: `Rocky: Generate Model from Intent` turns a description in plain English into a model. Rocky compiles each attempt and retries up to three times. It writes the model and its sidecar into `models/` only when the model type-checks. The command opens the result in a new tab, including the path of each file it wrote.
 
-**Agent mode**: the extension registers `rocky mcp` as a Model Context Protocol server for each workspace folder that has a `rocky.toml` at its root. Agent mode then drives Rocky through the engine's 31 tools. Most of them only read: compile, lineage, schema, row samples, and run history. Seven of them write.
+**Agent mode**: the extension registers `rocky mcp` as a Model Context Protocol server for each workspace folder that has a `rocky.toml` at its root. Agent mode then drives Rocky through the engine's 31 tools. Most of them only read: compile, lineage, schema, row samples, and run history. Six of them write.
 
-`draft_model`, `draft_contract`, and `draft_check` write files under `models/`, and `draft_metadata` patches a model's sidecar metadata. `propose` records a plan for a human to review, and applies nothing itself. `pause_schedule` pauses a pipeline's schedule, and `review_queue` can sign off a pending plan. Those last two refuse to act unless the agent passes `confirm: true`.
+`draft_model`, `draft_contract`, and `draft_check` write files under `models/`, and `draft_metadata` patches a model's sidecar metadata. `propose` records a plan for a human to review, and applies nothing itself. `pause_schedule` pauses a pipeline's schedule, and refuses to act unless the agent passes `confirm: true`.
+
+`review_queue` lists the plans waiting on you. It **cannot** sign one off from the extension: signing off writes the approval marker that unblocks `rocky apply`, and the engine serves that action only to a server started as `rocky mcp --profile approver`. The extension starts `rocky mcp` without that flag, so the call is refused and nothing is written. Approve a plan yourself with `rocky review <plan-id> --approve`.
 
 A `@rocky` chat participant handles four single-shot requests: `/generate`, `/explain`, `/sync`, and `/test`.
 

--- a/engine/.claude/skills/rust-clippy-triage/SKILL.md
+++ b/engine/.claude/skills/rust-clippy-triage/SKILL.md
@@ -13,7 +13,7 @@ description: Playbook for when `cargo clippy -- -D warnings` fires in the Rocky 
 cargo clippy --all-targets --all-features -- -D warnings
 ```
 
-That means **any** clippy warning in **any** target (lib, bin, tests, examples, benches), across all feature combinations, fails CI. Baseline lint policy lives in a `[workspace.lints.clippy]` table in `engine/Cargo.toml` — `correctness = "deny"` plus a few warn-level lints (`needless_pass_by_value`, `redundant_closure_for_method_calls`, `cloned_instead_of_copied`, `large_enum_variant`). There is no `clippy.toml`. The policy is "correctness is a hard error; zero warnings overall."
+That means **any** clippy warning in **any** target (lib, bin, tests, examples, benches), across all feature combinations, fails CI. Baseline lint policy lives in a `[workspace.lints.clippy]` table in `engine/Cargo.toml` — `correctness = "deny"` plus a few warn-level lints (`needless_pass_by_value`, `redundant_closure_for_method_calls`, `cloned_instead_of_copied`, `large_enum_variant`). `engine/clippy.toml` holds only lints that need configuration DATA rather than a level — today a single `disallowed-methods` entry routing test code away from a bare `Cli::try_parse_from` (it overflows the 2 MB test-thread stack and aborts the test binary; parse through `try_parse_with_big_stack` in `main.rs`). Put lint levels in the Cargo.toml table, not there. The policy is "correctness is a hard error; zero warnings overall."
 
 ## When CI goes red — triage order
 

--- a/engine/README.md
+++ b/engine/README.md
@@ -132,7 +132,8 @@ starts where this one ended, so `rocky brief` writes state. The other windows,
 ```bash
 rocky serve          # HTTP API over the compiler's semantic graph
 rocky lsp            # Language Server Protocol for IDEs
-rocky mcp            # Model Context Protocol server (31 agent tools, 7 write)
+rocky mcp            # Model Context Protocol server (31 agent tools, 6 write;
+                     #   a 7th, approving, needs --profile approver)
 rocky load           # Load CSV, Parquet, or JSONL files from a directory
 rocky ai "<intent>"  # Generate a model from a natural-language description
 ```

--- a/engine/README.md
+++ b/engine/README.md
@@ -167,19 +167,27 @@ check did not run at all, not only when a check fails. The write has already
 landed by then, so that failure halts and alerts you. It does not roll the
 write back.
 
-Most of the 31 MCP tools only read. Seven can write. Five go through that same
-policy evaluator: `draft_model`, `draft_contract`, `draft_check`,
-`draft_metadata`, and `propose`. In a governed scope the evaluator returns a
-denial or a review requirement, and a denied draft leaves nothing new on disk
-(`draft_metadata` restores the sidecar it patched).
+Most of the 31 MCP tools only read. On a default `rocky mcp` six can write.
+Five go through that same policy evaluator: `draft_model`, `draft_contract`,
+`draft_check`, `draft_metadata`, and `propose`. In a governed scope the
+evaluator returns a denial or a review requirement, and a denied draft leaves
+nothing new on disk (`draft_metadata` restores the sidecar it patched).
 
-The other two carry their own guard. `pause_schedule` needs `confirm: true`.
-Only a human can resume a schedule, with
-`rocky state schedule resume <pipeline>`. `review_queue` can write the approval
-marker that unblocks `rocky apply`. It needs `confirm: true` from the caller,
-and it refuses any plan that is not already in the pending review queue. Rocky
-does not check that a person set `confirm`, so this is not a human sign-off in
-any sense the engine verifies. `rocky mcp --profile worker` does not serve it.
+The sixth carries its own guard: `pause_schedule` needs `confirm: true`. Only a
+human can resume a schedule, with `rocky state schedule resume <pipeline>`.
+
+A seventh, `review_queue`, can write the approval marker that unblocks
+`rocky apply` — but only when the operator starts the server as
+`rocky mcp --profile approver`. A default server lists the queue and refuses
+the approve call with `approve_not_enabled`, writing nothing; `rocky mcp
+--profile worker` does not serve `review_queue` at all. The profile is fixed
+when the server starts, so an agent cannot turn approving on mid-session.
+
+Where it is served, the older caveat still holds: it needs `confirm: true` from
+the caller, it refuses any plan not already in the pending review queue, and
+Rocky does not check that a person set `confirm`. So `--profile approver` is not
+a human sign-off in any sense the engine verifies — it is you deciding that this
+server may sign off.
 
 To see what a rule resolves to before you rely on it, run
 `rocky policy check --principal agent --capability apply --model <name>`. It

--- a/engine/clippy.toml
+++ b/engine/clippy.toml
@@ -1,0 +1,15 @@
+# Clippy configuration for the Rocky engine workspace.
+#
+# Lint LEVELS live in `[workspace.lints.clippy]` in Cargo.toml; this file is
+# only for lints that need configuration data, which levels cannot express.
+disallowed-methods = [
+    # `Cli::try_parse_from` on a test thread overflows its 2 MB stack in a
+    # debug build — clap's generated parse code for this `Cli` is deep, and
+    # the failure aborts the whole test binary with "fatal runtime error:
+    # stack overflow", which reads as a crash rather than a test failure.
+    # Test code must parse through `try_parse_with_big_stack` (main.rs), or
+    # an equivalent 8 MB spawned thread. Production `main()` parses on the
+    # OS-default 8 MB main-thread stack and is unaffected, so this is a
+    # test-harness rule, not a product one.
+    { path = "clap::Parser::try_parse_from", reason = "parse via try_parse_with_big_stack: a 2 MB test-thread stack overflows and aborts the test binary" },
+]

--- a/engine/crates/rocky-mcp/src/error.rs
+++ b/engine/crates/rocky-mcp/src/error.rs
@@ -66,6 +66,15 @@ pub enum ToolErrorCode {
     /// (`rocky review <plan_id> --approve`) before `rocky apply`. `policy_rule`
     /// names the deciding rule when one matched.
     PolicyReviewRequired,
+    /// The `review_queue` approve action is not served on this server's
+    /// profile. Distinct from [`Self::PolicyReviewRequired`]: no policy rule
+    /// decided this and no plan was recorded — the operator simply did not
+    /// start the server with `rocky mcp --profile approver`, so this session
+    /// cannot write a human sign-off marker at all. Retrying with
+    /// `confirm: true` can never satisfy it; the recovery is the human's
+    /// terminal (`rocky review <plan_id> --approve`) or an operator restart
+    /// on the approver profile.
+    ApproveNotEnabled,
     /// An unexpected internal failure. `message` carries the detail.
     Internal,
 }
@@ -276,6 +285,30 @@ impl ToolError {
             spec_digest,
         }));
         wrapped
+    }
+
+    /// The `review_queue` approve action is not served on this profile (#1517).
+    ///
+    /// The message and hint are built HERE, in one place, so every refusal
+    /// names the same opt-in and the flag spelling cannot drift per call site.
+    /// The hint gives both recoveries in the order an operator should prefer
+    /// them: the human's own terminal first, the server restart second.
+    pub fn approve_not_enabled(plan_id: &str) -> Json<Self> {
+        Self::wrap(
+            ToolErrorCode::ApproveNotEnabled,
+            format!(
+                "approving '{plan_id}' writes a human sign-off marker that unblocks `rocky \
+                 apply`, and this MCP server does not serve the approve action: it was started \
+                 without `--profile approver`."
+            ),
+            format!(
+                "Ask the human to approve in their own terminal with `rocky review {plan_id} \
+                 --approve`. If approving from this server is genuinely wanted, the OPERATOR \
+                 must restart it as `rocky mcp --profile approver` — an agent cannot turn this \
+                 on mid-session. Listing the queue needs no opt-in: call review_queue with no \
+                 approve_plan_id."
+            ),
+        )
     }
 
     /// An unexpected internal failure.

--- a/engine/crates/rocky-mcp/src/lib.rs
+++ b/engine/crates/rocky-mcp/src/lib.rs
@@ -9,8 +9,14 @@
 //! `draft_metadata`). Materialization stays human-gated: the agent can only
 //! *propose* an AI-authored plan; a human runs `rocky review --approve` +
 //! `rocky apply` (a product-bound plan additionally requires
-//! `--expect-spec-digest`). `rocky mcp --profile worker` serves a minimal
-//! drafting allowlist for untrusted workers ([`McpProfile`]).
+//! `--expect-spec-digest`).
+//!
+//! Three profiles ([`McpProfile`]), chosen once at launch by the operator:
+//! `rocky mcp` serves every tool but REFUSES `review_queue`'s approve action,
+//! so the no-flag command cannot write a sign-off marker (#1517);
+//! `--profile approver` adds that one action back for a server meant to have
+//! it; `--profile worker` serves a minimal drafting allowlist to untrusted
+//! workers.
 //!
 //! ## Statelessness
 //!
@@ -43,7 +49,9 @@ pub use tools::{McpProfile, RockyMcpServer};
 /// `config_path` is the project's `rocky.toml`; the models directory is
 /// resolved as `<config-dir>/models`, matching the CLI's top-level
 /// convention. `profile` selects the tool surface: [`McpProfile::Default`]
-/// serves everything, [`McpProfile::Worker`] the minimal drafting allowlist.
+/// serves every tool with the `review_queue` approve action refused,
+/// [`McpProfile::Approver`] the same tools with that action served, and
+/// [`McpProfile::Worker`] the minimal drafting allowlist.
 /// Logging goes to stderr (stdout is reserved for the MCP wire protocol).
 pub async fn serve_stdio(
     config_path: std::path::PathBuf,

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -108,9 +108,20 @@ pub struct RockyMcpServer {
 /// Which tool surface `rocky mcp` serves.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum McpProfile {
-    /// The full tool surface — unchanged behavior for every existing agent.
+    /// Every tool, with ONE action withheld: `review_queue` lists the pending
+    /// queue but REFUSES to approve (#1517). Approving writes the human
+    /// sign-off marker `rocky apply` requires, so it is not a capability the
+    /// no-flag command should hand an agent; [`Self::Approver`] is the
+    /// explicit opt-in. Every other tool behaves exactly as before.
     #[default]
     Default,
+    /// [`Self::Default`]'s tools, plus the `review_queue` APPROVE action
+    /// (`rocky mcp --profile approver`). Serves the same tool NAMES as the
+    /// default profile — the opt-in enables an action, it does not add a
+    /// tool. Choose it only when the operator intends this server to be able
+    /// to write sign-off markers; approval is still attributed to the
+    /// operator's git identity, never to a verified human.
+    Approver,
     /// The minimal drafting-worker allowlist (`--profile worker`): read /
     /// inspect grounding tools, the compile/test/breaking-change/dependents
     /// verification loop, `draft_model` + `draft_check`, and the prompts.
@@ -490,15 +501,20 @@ pub struct ScorecardArgs {
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct ReviewQueueArgs {
-    /// When set, APPROVE this pending plan_id instead of listing the queue. The
-    /// plan must be one currently awaiting review — call with this unset first
-    /// to see the pending plan_ids.
+    /// When set, APPROVE this pending plan_id instead of listing the queue.
+    /// Served only when the operator started the server as `rocky mcp
+    /// --profile approver`; on any other profile this field is refused with
+    /// `approve_not_enabled` and nothing is written. The plan must also be one
+    /// currently awaiting review — call with this unset first to see the
+    /// pending plan_ids.
     #[serde(default)]
     pub approve_plan_id: Option<String>,
     /// Explicit confirmation for the approve action. Approving writes a human
     /// sign-off marker that unblocks `rocky apply`, so it is refused unless this
     /// is `true`. Set it ONLY when the human has explicitly authorized approving
-    /// this exact plan — it stands in for that human intent.
+    /// this exact plan — it stands in for that human intent. It cannot unlock
+    /// the approve action itself: a server without `--profile approver` refuses
+    /// regardless of this flag.
     #[serde(default)]
     pub confirm: bool,
     /// List mode only: keep only pending plans whose payload carries this
@@ -553,7 +569,8 @@ const PROFILE_TOP_VALUES_MAX: usize = 25;
 impl RockyMcpServer {
     /// Build a server rooted at `config_path`'s directory; the models
     /// directory is `<config-dir>/models` (the CLI's top-level convention).
-    /// Serves the full default tool surface.
+    /// Serves the [`McpProfile::Default`] surface: every tool, with the
+    /// `review_queue` approve action refused (#1517).
     pub fn new(config_path: PathBuf) -> Self {
         Self::new_with_profile(config_path, McpProfile::Default)
     }
@@ -635,12 +652,28 @@ impl RockyMcpServer {
         rocky_core::state::resolve_state_path(None, &self.models_dir).path
     }
 
+    /// Whether this server serves the `review_queue` APPROVE action — writing
+    /// the human sign-off marker that unblocks `rocky apply` (#1517).
+    ///
+    /// ONLY [`McpProfile::Approver`] does. Written as an exhaustive match, not
+    /// `!= Default`, so a future profile has to state its answer here instead
+    /// of inheriting one: a new variant fails to compile until someone
+    /// decides, and the decision defaults to nothing.
+    fn approve_action_served(&self) -> bool {
+        match self.profile {
+            McpProfile::Default | McpProfile::Worker => false,
+            McpProfile::Approver => true,
+        }
+    }
+
     /// The `next_steps` reminder a successful `draft_model` result carries.
     /// The worker profile's variant ends at the trusted-runner hand-off and
-    /// never instructs `propose` (FF-WP1 fix round 2, item 5c).
+    /// never instructs `propose` (FF-WP1 fix round 2, item 5c). The approver
+    /// profile is the default surface plus one action, so it shares the
+    /// default text — which already ends at the human's `rocky review`.
     fn draft_model_next_steps(&self) -> &'static str {
         match self.profile {
-            McpProfile::Default => DRAFT_NEXT_STEPS,
+            McpProfile::Default | McpProfile::Approver => DRAFT_NEXT_STEPS,
             McpProfile::Worker => WORKER_DRAFT_NEXT_STEPS,
         }
     }
@@ -649,7 +682,7 @@ impl RockyMcpServer {
     /// profile-selected like [`Self::draft_model_next_steps`].
     fn draft_check_next_steps(&self) -> &'static str {
         match self.profile {
-            McpProfile::Default => DRAFT_CHECK_NEXT_STEPS,
+            McpProfile::Default | McpProfile::Approver => DRAFT_CHECK_NEXT_STEPS,
             McpProfile::Worker => WORKER_DRAFT_CHECK_NEXT_STEPS,
         }
     }
@@ -3126,8 +3159,9 @@ impl RockyMcpServer {
     // projections of the same decision/run ledger the worker-agent tools write
     // to, so "what did agents do this week, and why was that apply allowed?" is
     // a cited, conversational query. `estate_brief` / `audit_query` /
-    // `scorecard` are read-only; `review_queue` reads the pending queue and,
-    // behind an explicit `confirm`, writes the human sign-off marker. Every
+    // `scorecard` are read-only; `review_queue` reads the pending queue on
+    // every profile and — ONLY on `--profile approver`, and then only behind an
+    // explicit `confirm` — writes the human sign-off marker (#1517). Every
     // projection reuses the shipped `brief` / `audit` / `review` cores, so a
     // section whose underlying query fails renders `unavailable` rather than a
     // smoothed-over narrative — the ledger grounds, no LLM narrates here.
@@ -3390,15 +3424,19 @@ impl RockyMcpServer {
     }
 
     #[tool(
-        description = "The ranked pending-review queue, and a GATED approve action. With no \
+        description = "The ranked pending-review queue, and an OPT-IN approve action. With no \
          `approve_plan_id`, lists every `require_review` escalation not yet signed off, ranked by \
          blast_radius × classification × staleness, each carrying its decision_ref, plan_id, and \
-         `approve_command`. With `approve_plan_id` + `confirm=true`, writes the human sign-off \
-         marker that unblocks `rocky apply` for that plan — refused unless the plan is actually in \
-         the pending queue AND `confirm` is set (the require-review-grade confirmation stands in \
-         for explicit human intent). Policy applies to the governor's agent too: the approval is \
-         attributed to the operator's git identity, not a cryptographically bound principal (a \
-         signed human confirmation is a later step). Never approve on the user's behalf."
+         `approve_command`. Listing works on every profile. APPROVING is different: it writes the \
+         human sign-off marker that unblocks `rocky apply`, and MOST SERVERS DO NOT SERVE IT — it \
+         is refused with `approve_not_enabled` unless the operator started this server as `rocky \
+         mcp --profile approver`. Where it is served, `approve_plan_id` + `confirm=true` is still \
+         refused unless the plan is actually in the pending queue AND `confirm` is set (the \
+         require-review-grade confirmation stands in for explicit human intent). Policy applies to \
+         the governor's agent too: the approval is attributed to the operator's git identity, not \
+         a cryptographically bound principal (a signed human confirmation is a later step). Never \
+         approve on the user's behalf; the normal path is the human running `rocky review \
+         <plan_id> --approve` in their own terminal."
     )]
     async fn review_queue(
         &self,
@@ -3406,6 +3444,20 @@ impl RockyMcpServer {
     ) -> ToolResult<ReviewQueueResult> {
         let args = params.0;
         let state_path = self.state_path();
+
+        // #1517 — the availability gate, deliberately the FIRST thing an
+        // approve meets. Ahead of the queue read so the refusal never depends
+        // on the state store being healthy or on what the queue happens to
+        // hold: on a profile that does not serve approving, the answer is the
+        // same one every time, and it names the opt-in.
+        if args.approve_plan_id.is_some() && !self.approve_action_served() {
+            // Echo the caller's plan id, not a validated one — validating it
+            // first would leak queue contents to a session that may not
+            // approve, and the recovery text is identical either way.
+            return Err(ToolError::approve_not_enabled(
+                args.approve_plan_id.as_deref().unwrap_or_default(),
+            ));
+        }
 
         // Always compute the current queue first — it is both the read result
         // and the guard that an approve targets a genuinely pending escalation.
@@ -4126,8 +4178,13 @@ impl ServerHandler for RockyMcpServer {
         // forks from the canonical file — but under the worker profile it is
         // prefixed with the banner naming the tools this session does not
         // serve and redirecting every ending to the trusted-runner hand-off.
+        // The approver profile serves the same text as the default one: the
+        // skill already ends every workflow at the human's `rocky review`, and
+        // announcing "you may approve here" to the agent would push the wrong
+        // way (#1517). The capability is discoverable where it is used — in
+        // `review_queue`'s own description.
         let instructions = match self.profile {
-            McpProfile::Default => INSTRUCTIONS.to_string(),
+            McpProfile::Default | McpProfile::Approver => INSTRUCTIONS.to_string(),
             McpProfile::Worker => format!("{WORKER_INSTRUCTIONS_BANNER}{INSTRUCTIONS}"),
         };
         ServerInfo::new(

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -5609,4 +5609,67 @@ mod tests {
             );
         }
     }
+
+    /// #1517 — the decision table for "may this server write a sign-off
+    /// marker?", enumerated over EVERY profile rather than sampled. Approving
+    /// is off unless the operator asked for it, and the `#[default]` variant
+    /// is one of the profiles that cannot.
+    ///
+    /// The `McpProfile::default()` assertion is the load-bearing one: the
+    /// whole issue was that the no-flag command pointed the wrong way, and
+    /// `#[derive(Default)]` + `#[default]` means moving that attribute one
+    /// variant down would silently arm approving for every existing agent.
+    #[test]
+    fn only_the_approver_profile_serves_the_approve_action() {
+        assert_eq!(
+            McpProfile::default(),
+            McpProfile::Default,
+            "the profile served with no flag is the one that cannot approve"
+        );
+        assert!(
+            !server_with(McpProfile::Default).approve_action_served(),
+            "default profile: approving is refused"
+        );
+        assert!(
+            !server_with(McpProfile::Worker).approve_action_served(),
+            "worker profile: approving is refused"
+        );
+        assert!(
+            server_with(McpProfile::Approver).approve_action_served(),
+            "approver profile: approving is served — the opt-in does something"
+        );
+    }
+
+    /// #1517 — the opt-in enables an ACTION, it does not add a TOOL.
+    ///
+    /// Two things ride on this. The `briefs.rs` excluded-tool golden derives
+    /// its list as default-minus-worker, so a refactor that tried to express
+    /// the approve opt-in by adding or removing a ROUTE would silently move
+    /// that golden. And the split itself: `review_queue` must still be served
+    /// on the default profile, because listing the queue stays available.
+    #[test]
+    fn approver_profile_adds_an_action_not_a_tool() {
+        let default_tools = server_with(McpProfile::Default).tool_names();
+        let approver_tools = server_with(McpProfile::Approver).tool_names();
+        assert_eq!(
+            default_tools, approver_tools,
+            "the approver profile serves exactly the default profile's tools"
+        );
+        assert!(
+            default_tools.iter().any(|t| t == "review_queue"),
+            "`review_queue` is still served on the default profile — listing is not gated"
+        );
+
+        // The worker profile is untouched by #1517: still the smaller
+        // allowlist, still with no `review_queue` at all.
+        let worker_tools = server_with(McpProfile::Worker).tool_names();
+        assert!(
+            worker_tools.len() < default_tools.len(),
+            "the worker profile is still a strict subset"
+        );
+        assert!(
+            !worker_tools.iter().any(|t| t == "review_queue"),
+            "the worker profile still serves no `review_queue` at all"
+        );
+    }
 }

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -492,7 +492,14 @@ scope = { any = true }
 effect = "require_review"
 "#,
     );
-    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    // The APPROVER profile (#1517): the last assertion here is that combining
+    // `product_id` with an approve is an ARGUMENT error. On the default
+    // profile the availability gate fires first and that call never reaches
+    // the argument check, so testing it needs a server that serves approving.
+    let server = RockyMcpServer::new_with_profile(
+        dir.path().join("rocky.toml"),
+        rocky_mcp::McpProfile::Approver,
+    );
     let client = connect(server).await;
 
     // Two pending escalations: one product-bound, one bare.
@@ -879,6 +886,12 @@ effect = "require_review"
 /// citations, the scorecard matches hand-computed truth, and the `review_queue`
 /// approve action is gated on an explicit confirmation before it writes the
 /// sign-off marker that unblocks `rocky apply`.
+///
+/// Runs on the APPROVER profile (#1517) — the only profile that serves the
+/// approve action at all. The confirm gate tested here is the SECOND gate: it
+/// still holds even once the operator has opted in. The default profile's
+/// refusal is
+/// [`default_profile_lists_the_queue_but_refuses_to_approve`].
 #[tokio::test]
 async fn governor_tools_surface_escalation_and_gate_the_approve() {
     let dir = TempDir::new().unwrap();
@@ -896,7 +909,10 @@ scope = { any = true }
 effect = "require_review"
 "#,
     );
-    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let server = RockyMcpServer::new_with_profile(
+        dir.path().join("rocky.toml"),
+        rocky_mcp::McpProfile::Approver,
+    );
     let client = connect(server).await;
 
     // An agent proposes → recorded as a require_review escalation in the ledger,
@@ -1080,6 +1096,137 @@ effect = "require_review"
     assert!(
         marker.exists(),
         "the confirmed approve wrote the sign-off marker"
+    );
+
+    client.cancel().await.unwrap();
+}
+
+/// #1517 — the split, on the profile `rocky mcp` serves with NO flag: reading
+/// the queue works, approving does not.
+///
+/// This is the whole point of the issue. The stock command used to hand one
+/// agent both halves — propose a plan, then sign it off — with `confirm` as
+/// the only thing standing in the way, and `confirm` is set by the caller.
+/// Here the same call, with `confirm: true` and a genuinely pending plan_id,
+/// leaves no marker on disk and comes back naming the opt-in.
+#[tokio::test]
+async fn default_profile_lists_the_queue_but_refuses_to_approve() {
+    let dir = TempDir::new().unwrap();
+    write_project_with_policy(
+        dir.path(),
+        &dir.path().join("test.duckdb"),
+        r#"[policy]
+version = 1
+default_agent_effect = "require_review"
+
+[[policy.rules]]
+principal = "agent"
+capability = "apply"
+scope = { any = true }
+effect = "require_review"
+"#,
+    );
+    // The DEFAULT profile — exactly what `rocky mcp` serves with no flag.
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+
+    let _ = client
+        .call_tool(CallToolRequestParams::new("propose"))
+        .await
+        .expect("propose returns a result");
+    let plans = plan_files(dir.path());
+    assert_eq!(plans.len(), 1, "the propose persisted one plan for review");
+    let plan_id = plans[0].file_stem().unwrap().to_str().unwrap().to_string();
+
+    // Half one: LISTING is untouched. The queue is useful and harmless to
+    // read, so the gate must not have removed it along with approving.
+    let queue = client
+        .call_tool(CallToolRequestParams::new("review_queue"))
+        .await
+        .expect("review_queue list call");
+    assert_ne!(
+        queue.is_error,
+        Some(true),
+        "listing the queue still works on the default profile: {queue:?}"
+    );
+    let sc = queue.structured_content.expect("queue structured content");
+    assert_eq!(sc["total"], serde_json::json!(1));
+    let pending = sc["pending"].as_array().unwrap();
+    assert_eq!(pending.len(), 1, "the escalation is listed");
+    assert_eq!(pending[0]["plan_id"], serde_json::json!(plan_id));
+
+    // Half two: APPROVING is refused — with confirm=true, on a real pending
+    // plan. Nothing about this call is malformed; the profile is the refusal.
+    let approve = serde_json::json!({ "approve_plan_id": plan_id, "confirm": true })
+        .as_object()
+        .unwrap()
+        .clone();
+    let refused = client
+        .call_tool(CallToolRequestParams::new("review_queue").with_arguments(approve))
+        .await
+        .expect("review_queue approve returns a result");
+    assert_eq!(
+        refused.is_error,
+        Some(true),
+        "the default profile refuses to approve: {refused:?}"
+    );
+    let err = refused
+        .structured_content
+        .expect("structured error envelope");
+
+    // A DISTINCT code. Not `policy_review_required`: no rule decided this and
+    // no plan was recorded by it, and no retry with confirm can satisfy it.
+    assert_eq!(
+        err["code"],
+        serde_json::json!("approve_not_enabled"),
+        "the refusal has its own machine-matchable code: {err:?}"
+    );
+
+    // The refusal NAMES the opt-in. An operator hitting this at 3am must not
+    // have to read source to find out what to do. The flag spelling is pinned
+    // as a literal here on purpose — `mcp_profile_arg_accepts_approver` proves
+    // the same literal is what clap actually parses.
+    let message = err["message"].as_str().expect("a message");
+    let hint = err["remediation_hint"].as_str().expect("a hint");
+    let both = format!("{message}\n{hint}");
+    assert!(
+        both.contains("--profile approver"),
+        "the refusal names the opt-in flag verbatim: {both}"
+    );
+    assert!(
+        both.contains(&plan_id),
+        "the refusal names the plan it refused: {both}"
+    );
+    assert!(
+        hint.contains("rocky review") && hint.contains("--approve"),
+        "the hint offers the human's own terminal as the normal path: {hint}"
+    );
+    assert!(
+        hint.contains("OPERATOR") || hint.contains("operator"),
+        "the hint says WHO can turn it on: {hint}"
+    );
+
+    // The only assertion that really matters: nothing was written.
+    let marker = dir
+        .path()
+        .join(".rocky")
+        .join("plans")
+        .join(format!("{plan_id}.reviewed.json"));
+    assert!(
+        !marker.exists(),
+        "no sign-off marker exists after a refused approve"
+    );
+
+    // And the plan is still pending — the refusal changed no state at all.
+    let after = client
+        .call_tool(CallToolRequestParams::new("review_queue"))
+        .await
+        .expect("review_queue re-list");
+    let after_sc = after.structured_content.expect("queue content");
+    assert_eq!(
+        after_sc["total"],
+        serde_json::json!(1),
+        "the escalation is still awaiting review"
     );
 
     client.cancel().await.unwrap();

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -4973,6 +4973,10 @@ mod tests {
     /// (macOS gets larger defaults; CI is where the overflow shows up).
     /// A scoped thread keeps the workaround local to test code; production
     /// `main()` uses the OS-default 8 MB thread stack and is unaffected.
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "this IS the sanctioned wrapper the disallowed-methods entry points callers at"
+    )]
     fn try_parse_with_big_stack(args: &[&str]) -> Cli {
         std::thread::scope(|s| {
             std::thread::Builder::new()
@@ -5033,6 +5037,11 @@ mod tests {
     /// FF-WP1: `rocky review --status` parses by its literal flag name, and
     /// clap rejects combining it with `--approve` / `--queue`.
     #[test]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "expects a PARSE FAILURE, which the Cli-returning helper cannot express; the \
+                  call already runs on an 8 MB spawned thread"
+    )]
     fn review_status_flag_parses_and_conflicts() {
         let cli = try_parse_with_big_stack(&["rocky", "review", "abc123", "--status"]);
         match cli.command {
@@ -5137,6 +5146,11 @@ mod tests {
     /// Parse on the 8 MiB stack and return whether parsing *succeeded* — used
     /// by the conflict / requires tests (the recursive clap derive overflows
     /// the default test-thread stack).
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "expects a PARSE FAILURE, which the Cli-returning helper cannot express; the \
+                  call already runs on an 8 MB spawned thread"
+    )]
     fn parse_run_ok(args: &[&str]) -> bool {
         let owned: Vec<String> = args.iter().map(|s| (*s).to_string()).collect();
         std::thread::scope(|s| {
@@ -5341,6 +5355,11 @@ mod tests {
     }
 
     #[test]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "expects a PARSE FAILURE, which the Cli-returning helper cannot express; the \
+                  call already runs on an 8 MB spawned thread"
+    )]
     fn plan_rejects_branch_with_shadow() {
         // clap should reject this combination at parse time via the
         // `conflicts_with_all = ["shadow", "shadow_schema"]` modifier.

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -4844,6 +4844,59 @@ mod tests {
     // resolve_output — `--output` default resolution
     // -----------------------------------------------------------------------
 
+    // -----------------------------------------------------------------------
+    // `rocky mcp --profile` — the #1517 approve opt-in
+    // -----------------------------------------------------------------------
+
+    /// The refusal message in `rocky-mcp` tells the operator to run `rocky mcp
+    /// --profile approver`. This proves clap actually PARSES that exact
+    /// spelling: `ValueEnum` derives the value name from the variant, so a
+    /// rename would leave the message pointing at a flag that errors out —
+    /// precisely the 3am failure the opt-in exists to prevent.
+    #[test]
+    fn mcp_profile_arg_accepts_approver() {
+        let cli = Cli::try_parse_from(["rocky", "mcp", "--profile", "approver"])
+            .expect("`--profile approver` is the spelling the refusal message names");
+        let Command::Mcp { profile, .. } = cli.command else {
+            panic!("expected the mcp command");
+        };
+        assert_eq!(profile, McpProfileArg::Approver);
+        assert_eq!(
+            rocky_mcp::McpProfile::from(profile),
+            rocky_mcp::McpProfile::Approver,
+            "the CLI mirror maps to the profile that serves approving"
+        );
+    }
+
+    /// `rocky mcp` with NO flag is the shape the issue was about: it must land
+    /// on the profile that refuses to approve.
+    #[test]
+    fn mcp_with_no_profile_flag_cannot_approve() {
+        let cli = Cli::try_parse_from(["rocky", "mcp"]).expect("bare `rocky mcp` parses");
+        let Command::Mcp { profile, .. } = cli.command else {
+            panic!("expected the mcp command");
+        };
+        assert_eq!(profile, McpProfileArg::Default);
+        assert_eq!(
+            rocky_mcp::McpProfile::from(profile),
+            rocky_mcp::McpProfile::Default,
+        );
+    }
+
+    /// The worker profile is untouched by #1517 — same spelling, same mapping.
+    #[test]
+    fn mcp_profile_arg_worker_is_unchanged() {
+        let cli = Cli::try_parse_from(["rocky", "mcp", "--profile", "worker"])
+            .expect("`--profile worker` still parses");
+        let Command::Mcp { profile, .. } = cli.command else {
+            panic!("expected the mcp command");
+        };
+        assert_eq!(
+            rocky_mcp::McpProfile::from(profile),
+            rocky_mcp::McpProfile::Worker,
+        );
+    }
+
     #[test]
     fn resolve_output_explicit_json_wins_over_tty() {
         assert_eq!(

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -4855,8 +4855,11 @@ mod tests {
     /// precisely the 3am failure the opt-in exists to prevent.
     #[test]
     fn mcp_profile_arg_accepts_approver() {
-        let cli = Cli::try_parse_from(["rocky", "mcp", "--profile", "approver"])
-            .expect("`--profile approver` is the spelling the refusal message names");
+        // `try_parse_with_big_stack`, not a bare `try_parse_from`: clap's
+        // generated parse code for this `Cli` overflows the 2 MB test-thread
+        // stack in a debug build. See that helper's comment — production
+        // `main()` parses on the OS-default 8 MB stack and is unaffected.
+        let cli = try_parse_with_big_stack(&["rocky", "mcp", "--profile", "approver"]);
         let Command::Mcp { profile, .. } = cli.command else {
             panic!("expected the mcp command");
         };
@@ -4872,7 +4875,7 @@ mod tests {
     /// on the profile that refuses to approve.
     #[test]
     fn mcp_with_no_profile_flag_cannot_approve() {
-        let cli = Cli::try_parse_from(["rocky", "mcp"]).expect("bare `rocky mcp` parses");
+        let cli = try_parse_with_big_stack(&["rocky", "mcp"]);
         let Command::Mcp { profile, .. } = cli.command else {
             panic!("expected the mcp command");
         };
@@ -4886,8 +4889,7 @@ mod tests {
     /// The worker profile is untouched by #1517 — same spelling, same mapping.
     #[test]
     fn mcp_profile_arg_worker_is_unchanged() {
-        let cli = Cli::try_parse_from(["rocky", "mcp", "--profile", "worker"])
-            .expect("`--profile worker` still parses");
+        let cli = try_parse_with_big_stack(&["rocky", "mcp", "--profile", "worker"]);
         let Command::Mcp { profile, .. } = cli.command else {
             panic!("expected the mcp command");
         };

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -2304,16 +2304,22 @@ enum Command {
     /// any MCP-capable agent harness can drive Rocky. Long-running: serves
     /// until the client disconnects. Materialization stays human-gated — the
     /// `propose` tool only writes an AI-authored plan; a human runs
-    /// `rocky review --approve` + `rocky apply`. Use `--profile worker` to
-    /// serve only the minimal drafting allowlist to an untrusted worker.
+    /// `rocky review --approve` + `rocky apply`. No profile writes a sign-off
+    /// marker unless you ask for one: `review_queue` lists the pending queue
+    /// everywhere, but its approve action is served ONLY on
+    /// `--profile approver`. Use `--profile worker` to serve only the minimal
+    /// drafting allowlist to an untrusted worker.
     Mcp {
         /// Pipeline config file the server resolves the project from.
         #[arg(long, default_value = "rocky.toml")]
         config: PathBuf,
-        /// Tool surface to serve. `default` exposes every tool; `worker` is
-        /// the minimal drafting allowlist for untrusted workers: the
-        /// read/inspect grounding tools, compile / test / breaking_change /
-        /// dependents, draft_model + draft_check, and the prompts — no
+        /// Tool surface to serve. `default` exposes every tool but REFUSES the
+        /// `review_queue` approve action (listing the queue still works);
+        /// `approver` is `default` plus that one action, for a server the
+        /// operator intends to be able to write human sign-off markers;
+        /// `worker` is the minimal drafting allowlist for untrusted workers:
+        /// the read/inspect grounding tools, compile / test / breaking_change
+        /// / dependents, draft_model + draft_check, and the prompts — no
         /// contract, metadata, propose, review, or schedule surface.
         #[arg(long, value_enum, default_value_t = McpProfileArg::Default)]
         profile: McpProfileArg,
@@ -2324,8 +2330,10 @@ enum Command {
 /// rocky-mcp crate stays clap-free.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 enum McpProfileArg {
-    /// Full tool surface (unchanged behavior).
+    /// Every tool, but `review_queue` cannot approve (it still lists).
     Default,
+    /// Every tool, and `review_queue` MAY approve — write a sign-off marker.
+    Approver,
     /// Minimal drafting-worker allowlist.
     Worker,
 }
@@ -2334,6 +2342,7 @@ impl From<McpProfileArg> for rocky_mcp::McpProfile {
     fn from(value: McpProfileArg) -> Self {
         match value {
             McpProfileArg::Default => rocky_mcp::McpProfile::Default,
+            McpProfileArg::Approver => rocky_mcp::McpProfile::Approver,
             McpProfileArg::Worker => rocky_mcp::McpProfile::Worker,
         }
     }


### PR DESCRIPTION
`rocky mcp` with no flag served `review_queue`, and that tool writes the approval marker `rocky apply` requires before it will run an AI-authored plan. So the obvious command handed an agent both halves — propose and approve — and you had to already know about `--profile worker` to get the safe shape. The default pointed the wrong way.

```
 rocky mcp                      31 tools · review_queue LISTS · approve REFUSED
 rocky mcp --profile approver   31 tools · lists AND approves
 rocky mcp --profile worker     minimal drafting allowlist · no review_queue
```

Listing the queue keeps working everywhere — it is useful and harmless. Only the approve action moved behind an operator's deliberate choice at launch.

## Why a profile, not a flag

`review_queue` is one tool serving both modes, so the worker profile's route removal cannot split list from approve — the gate has to live in-tool keyed on launch state either way. Given that, `--allow-approve` would add a second dimension with an invalid combination (`--profile worker --allow-approve`) to police, while the profile enum is already the single launch-time selector. Adding a variant also made the compiler demand an answer at every `match self.profile` rather than letting the new profile silently inherit the old behaviour.

The refusal names the fix, and says who can apply it:

> approving '<plan_id>' writes a human sign-off marker that unblocks `rocky apply`, and this MCP server does not serve the approve action: it was started without `--profile approver`.
>
> Ask the human to approve in their own terminal with `rocky review <plan_id> --approve`. If approving from this server is genuinely wanted, the OPERATOR must restart it as `rocky mcp --profile approver` — an agent cannot turn this on mid-session.

## What this does and does not buy

It removes a default-on capability from the MCP surface. It does **not** authenticate who approved: on the approver profile, `confirm` is still caller-set, exactly as before. And it does not constrain an agent that has a shell — that agent could start its own approver server, or just run `rocky review --approve`. The docs say all of this plainly.

## Evidence

6 of 6 mutations killed. The strongest: inverting the gate makes the default profile actually write the marker (`marker_written: true`) — the test reproduces the exact vulnerability. Others prove the flag spelling in the refusal cannot drift from clap, and that the default removes the *action* rather than the tool (listing still works).

A seventh mutation checks the guard on the guard: a new `clippy.toml` entry forbids the bare CLI parser in favour of the big-stack helper, and removing one `#[allow]` confirms it fires — a clean clippy run alone could not distinguish "enforced" from "never matches".

Gates: workspace 147 suites, rocky-mcp/rocky-cli/rocky, rocky-fulfill 119, fulfill_e2e 16, clippy `-D warnings`, fmt, docs build, skills mirror. No codegen surface touched.

Independent review returned SHIP with no bypass, verifying that the gate dominates the sole `compute_review` call, that the worker allowlist is byte-identical to before (same SHA-256), and that no in-repo consumer branches on the new error code. Its one finding — a write count in `engine/README.md` contradicting itself — is fixed here.

Also corrected on the way: the VS Code extension's README claimed `review_queue` can sign off a plan, but the extension spawns `rocky mcp` with no profile, so that is now false; and `--profile` was missing from the CLI flags table entirely.