### PR TITLE
fix(examples): make the fulfillment POC seed independent of the wall clock

### DIFF
--- a/examples/playground/pocs/03-ai/08-fulfillment-walking-skeleton/data/seed.sql
+++ b/examples/playground/pocs/03-ai/08-fulfillment-walking-skeleton/data/seed.sql
@@ -2,6 +2,21 @@
 -- source is the exact triple `wh.raw.stripe_charges`, so we ATTACH a :memory:
 -- database named `wh` and create the source under it. Kept row-identical to
 -- data/warehouse_seed.sql so the in-memory test and the warehouse agree.
+--
+-- Every "recent" row shares ONE offset and the older row is exactly 24h behind
+-- it, so the two calendar days differ at any hour of the night. The previous
+-- seed spread the recent rows over -1h/-2h/-3h and put the old row at -1 day:
+-- run the POC before ~03:00 local and all five collapsed onto the SAME calendar
+-- day, leaving 2 distinct client/day pairs instead of 3. The grain check then
+-- proved nothing and run.sh's own vacuity guard failed the run (#1526).
+--
+-- The 3-hour margin is load-bearing twice over. It keeps MAX(loaded_at) far
+-- enough in the past that the freshness lag stays POSITIVE — DuckDB's now() is
+-- local while the engine computes lag in UTC, so seeding at exactly now()
+-- reports a negative lag, which run.sh's `lag ([0-9]+)s` capture cannot read.
+-- And 3h is well inside the 86400s freshness budget, so the fresh case still
+-- passes before assert 10 deliberately backdates the output.
+
 ATTACH IF NOT EXISTS ':memory:' AS wh;
 CREATE SCHEMA IF NOT EXISTS wh.raw;
 CREATE TABLE IF NOT EXISTS wh.raw.stripe_charges (
@@ -11,8 +26,8 @@ CREATE TABLE IF NOT EXISTS wh.raw.stripe_charges (
   is_refund  BOOLEAN
 );
 INSERT INTO wh.raw.stripe_charges VALUES
-  (1, now()::TIMESTAMP - INTERVAL '2 hours', 100.0, false),
-  (1, now()::TIMESTAMP - INTERVAL '1 hour',   50.0, false),
-  (1, now()::TIMESTAMP - INTERVAL '1 day',    40.0, false),
-  (2, now()::TIMESTAMP - INTERVAL '3 hours',  75.0, false),
-  (2, now()::TIMESTAMP - INTERVAL '1 hour',   10.0, true);
+  (1, now()::TIMESTAMP - INTERVAL '3 hours',  100.0, false),
+  (1, now()::TIMESTAMP - INTERVAL '3 hours',   50.0, false),
+  (1, now()::TIMESTAMP - INTERVAL '27 hours',  40.0, false),
+  (2, now()::TIMESTAMP - INTERVAL '3 hours',   75.0, false),
+  (2, now()::TIMESTAMP - INTERVAL '3 hours',   10.0, true);

--- a/examples/playground/pocs/03-ai/08-fulfillment-walking-skeleton/data/warehouse_seed.sql
+++ b/examples/playground/pocs/03-ai/08-fulfillment-walking-skeleton/data/warehouse_seed.sql
@@ -1,6 +1,21 @@
 -- Seeds the persistent warehouse (wh.duckdb). Inside wh.duckdb the database is
 -- `wh`, so `raw.stripe_charges` here IS `wh.raw.stripe_charges` to the model.
 -- Row-identical to data/seed.sql.
+--
+-- Every "recent" row shares ONE offset and the older row is exactly 24h behind
+-- it, so the two calendar days differ at any hour of the night. The previous
+-- seed spread the recent rows over -1h/-2h/-3h and put the old row at -1 day:
+-- run the POC before ~03:00 local and all five collapsed onto the SAME calendar
+-- day, leaving 2 distinct client/day pairs instead of 3. The grain check then
+-- proved nothing and run.sh's own vacuity guard failed the run (#1526).
+--
+-- The 3-hour margin is load-bearing twice over. It keeps MAX(loaded_at) far
+-- enough in the past that the freshness lag stays POSITIVE — DuckDB's now() is
+-- local while the engine computes lag in UTC, so seeding at exactly now()
+-- reports a negative lag, which run.sh's `lag ([0-9]+)s` capture cannot read.
+-- And 3h is well inside the 86400s freshness budget, so the fresh case still
+-- passes before assert 10 deliberately backdates the output.
+
 CREATE SCHEMA IF NOT EXISTS raw;
 CREATE TABLE IF NOT EXISTS raw.stripe_charges (
   client_id  BIGINT,
@@ -10,8 +25,8 @@ CREATE TABLE IF NOT EXISTS raw.stripe_charges (
 );
 DELETE FROM raw.stripe_charges;
 INSERT INTO raw.stripe_charges VALUES
-  (1, now()::TIMESTAMP - INTERVAL '2 hours', 100.0, false),
-  (1, now()::TIMESTAMP - INTERVAL '1 hour',   50.0, false),
-  (1, now()::TIMESTAMP - INTERVAL '1 day',    40.0, false),
-  (2, now()::TIMESTAMP - INTERVAL '3 hours',  75.0, false),
-  (2, now()::TIMESTAMP - INTERVAL '1 hour',   10.0, true);
+  (1, now()::TIMESTAMP - INTERVAL '3 hours',  100.0, false),
+  (1, now()::TIMESTAMP - INTERVAL '3 hours',   50.0, false),
+  (1, now()::TIMESTAMP - INTERVAL '27 hours',  40.0, false),
+  (2, now()::TIMESTAMP - INTERVAL '3 hours',   75.0, false),
+  (2, now()::TIMESTAMP - INTERVAL '3 hours',   10.0, true);


### PR DESCRIPTION
Fixes #1526.

The fulfillment walking-skeleton POC fails between local midnight and about 03:00. Its seed uses timestamps relative to `now()`, and inside that window every row lands on the same calendar day — so the product collapses from three distinct `(client_id, day)` groups to two, and `run.sh`'s own vacuity guard fires:

```
FAIL: 9 (grain uniqueness is vacuous: <3 distinct (client_id, day) pairs)
```

The guard is right. A uniqueness test over one group per client proves nothing — it would pass on a model that had lost its grain entirely.

## The fix

Every "recent" row now shares one offset, and the older row sits exactly 24h behind it, so the two calendar days differ at any hour.

The 3-hour margin is load-bearing twice, and the second reason cost a round to find. It keeps `MAX(loaded_at)` far enough in the past that the freshness lag stays **positive**: DuckDB's `now()` is local while the engine computes lag in UTC, so an earlier attempt seeding at exactly `now()` reported `lag -3592s`, which `run.sh`'s `lag ([0-9]+)s` capture cannot read — and assert 10 then failed for an entirely different reason. 3h is still well inside the 86400s budget, so the fresh case passes before assert 10 deliberately backdates the output.

One dialect note for anyone editing these files: `CURRENT_DATE::TIMESTAMP - INTERVAL ...` binds to `make_timestamptz` and fails in the engine's bundled DuckDB, though the standalone CLI accepts it. Staying in `TIMESTAMP` arithmetic from `now()` avoids the mismatch.

## Verification

Run inside the failing window (01:00 local), which is the only time this reproduces:

- `run.sh` exits 0 through all 10 asserts
- `mutation-pass.sh` catches 13 / 13

Confirmed pre-existing rather than a regression: `main` was built at `f9c7643d` and its own copy of the POC run with a `main`-built binary in the same window, producing the identical failure and row count.

Both seed files are kept row-identical.

## Why this matters beyond the POC

This blocks the fulfillment observation work: assert 9 fails before assert 11 can run, so that POC's data-red lane has never executed.
