### PR TITLE
fix(engine): fail closed on invalid resume state

### DIFF
--- a/docs/src/content/docs/concepts/execution-flow.md
+++ b/docs/src/content/docs/concepts/execution-flow.md
@@ -247,7 +247,9 @@ Exit code:
 
 ## Checkpoint and resume
 
-A run can be interrupted mid-layer by a killed process or a network failure. Rocky can resume it from the last successful checkpoint, but only when you ask for it. Pass `--resume-latest` or `--resume <run-id>`. Without one of those flags the next run starts fresh and rebuilds every selected table.
+A replication run can be interrupted mid-layer by a killed process or a network failure. Rocky can resume it from the last successful checkpoint, but only when you ask for it. Pass `--resume-latest` or `--resume <run-id>`. Without one of those flags the next run starts fresh and rebuilds every selected table.
+
+Resume flags fail if the checkpoint is missing or unreadable. Other pipeline types and mixed replication/model runs reject them because they do not record compatible per-table resume checkpoints. With a remote state backend, resume also requires an authoritative restore; an absent or unreachable remote state refuses recovery even if a stale local state file exists.
 
 The state store records which tables completed in the `run_progress_entries` table, one entry per `run_id` plus table, with a `run_progress` header row per `run_id`. `rocky run --resume-latest` looks up the most recent `run_id`, reads which tables already completed, and skips them.
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -289,8 +289,8 @@ rocky run [--filter <key=value>] [flags]
 | `--governance-override <JSON>` | | Additional governance config as inline JSON or `@file.json`, merged with defaults. |
 | `--models <PATH>` | | Models directory for transformation execution. |
 | `--all` | | Execute both replication and compiled models. |
-| `--resume <RUN_ID>` | | Resume a specific previous run from its last checkpoint; mints a new `run_id` and records the prior one as `resumed_from`. |
-| `--resume-latest` | | Resume the most recent failed run from its last checkpoint; mints a new `run_id` and records the prior one as `resumed_from`. |
+| `--resume <RUN_ID>` | | Resume a specific previous replication run from its last checkpoint; mints a new `run_id` and records the prior one as `resumed_from`. |
+| `--resume-latest` | | Resume the most recent failed replication run from its last checkpoint; mints a new `run_id` and records the prior one as `resumed_from`. |
 | `--shadow` | | Run in shadow mode: write to shadow targets instead of production. |
 | `--shadow-suffix <SUFFIX>` | | Suffix appended to table names in shadow mode (default `_rocky_shadow`). |
 | `--shadow-schema <NAME>` | | Override schema for shadow tables (mutually exclusive with `--shadow-suffix`). |

--- a/docs/src/content/docs/reference/commands/core-pipeline.md
+++ b/docs/src/content/docs/reference/commands/core-pipeline.md
@@ -321,8 +321,8 @@ Rocky records the execution flags in the plan file, so `rocky apply` replays the
 | `--models <PATH>` | `PathBuf` | | Models directory for transformation execution. |
 | `--all` | `bool` | `false` | Plan both replication and compiled models. |
 | `--governance-override <JSON>` | `string` | | Additional governance config as inline JSON or `@file.json`, merged with the defaults. Resolved at plan time and stored in the plan. |
-| `--resume <RUN_ID>` | `string` | | Resume a specific previous run from its last checkpoint. Mints a new `run_id` and records the prior one as `resumed_from`. |
-| `--resume-latest` | `bool` | `false` | Resume the most recent failed run from its last checkpoint. Which run that is gets resolved at apply time, not plan time. |
+| `--resume <RUN_ID>` | `string` | | Resume a specific previous replication run from its last checkpoint. Mints a new `run_id` and records the prior one as `resumed_from`. |
+| `--resume-latest` | `bool` | `false` | Resume the most recent failed replication run from its last checkpoint. Which run that is gets resolved at apply time, not plan time. |
 | `--shadow` | `bool` | `false` | Write to shadow targets instead of production. |
 | `--shadow-suffix <SUFFIX>` | `string` | `_rocky_shadow` | Suffix appended to table names in shadow mode. |
 | `--shadow-schema <NAME>` | `string` | | Override the schema for shadow tables. Mutually exclusive with `--shadow-suffix`. |
@@ -549,8 +549,8 @@ rocky run [flags]
 | `--governance-override <JSON>` | `string` | | Additional governance config as inline JSON or `@file.json`, merged with defaults. |
 | `--models <PATH>` | `PathBuf` | | Models directory for transformation execution. |
 | `--all` | `bool` | `false` | Execute both replication and compiled models. |
-| `--resume <RUN_ID>` | `string` | | Resume a specific previous run from its last checkpoint; mints a new `run_id` and records the prior one as `resumed_from`. |
-| `--resume-latest` | `bool` | `false` | Resume the most recent failed run from its last checkpoint; mints a new `run_id` and records the prior one as `resumed_from`. |
+| `--resume <RUN_ID>` | `string` | | Resume a specific previous replication run from its last checkpoint; mints a new `run_id` and records the prior one as `resumed_from`. |
+| `--resume-latest` | `bool` | `false` | Resume the most recent failed replication run from its last checkpoint; mints a new `run_id` and records the prior one as `resumed_from`. |
 | `--shadow` | `bool` | `false` | Run in shadow mode: write to shadow targets instead of production. |
 | `--shadow-suffix <SUFFIX>` | `string` | `_rocky_shadow` | Suffix appended to table names in shadow mode. |
 | `--shadow-schema <NAME>` | `string` | | Override schema for shadow tables (mutually exclusive with `--shadow-suffix`). |
@@ -643,7 +643,7 @@ Run both replication and model transformations:
 rocky run --filter client=acme --models models/ --all
 ```
 
-Resume the most recent failed run from its last checkpoint:
+Resume the most recent failed replication run from its last checkpoint:
 
 ```bash
 rocky run --filter client=acme --resume-latest

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -19,7 +19,7 @@ use rocky_core::config::{
 use rocky_core::drift;
 use rocky_core::hooks::{HookContext, HookRegistry};
 use rocky_core::sql_gen;
-use rocky_core::state::StateStore;
+use rocky_core::state::{RunProgress, StateError, StateStore};
 use rocky_core::traits::{
     BatchCheckAdapter, FreshnessResult as BatchFreshnessResult, GovernanceAdapter, MaskingPolicy,
     RowCountResult as BatchRowCountResult, TagTarget, WarehouseAdapter,
@@ -1368,6 +1368,53 @@ pub enum RunTermination {
     },
 }
 
+fn ensure_resume_supported(requested: bool, supported: bool, execution_kind: &str) -> Result<()> {
+    anyhow::ensure!(
+        !requested || supported,
+        "resume is supported only for replication-only execution; {execution_kind} does not support checkpoints"
+    );
+    Ok(())
+}
+
+fn ensure_resume_authority(
+    requested: bool,
+    authority: rocky_core::state_sync::StateAuthority,
+) -> Result<()> {
+    anyhow::ensure!(
+        !requested || authority == rocky_core::state_sync::StateAuthority::Authoritative,
+        "cannot resume from non-authoritative state ({authority:?}); restore the configured remote state backend or start a fresh run without a resume flag"
+    );
+    Ok(())
+}
+
+fn require_resume_progress(
+    progress: std::result::Result<Option<RunProgress>, StateError>,
+    requested: &str,
+) -> Result<RunProgress> {
+    progress
+        .with_context(|| format!("failed to load progress for {requested}"))?
+        .with_context(|| format!("cannot resume {requested}: no progress found"))
+}
+
+fn resolve_resume_progress(
+    state_store: &StateStore,
+    resume_run_id: Option<&str>,
+    resume_latest: bool,
+) -> Result<Option<RunProgress>> {
+    if resume_latest {
+        return require_resume_progress(state_store.get_latest_run_progress(), "the latest run")
+            .map(Some);
+    }
+    if let Some(run_id) = resume_run_id {
+        return require_resume_progress(
+            state_store.get_run_progress(run_id),
+            &format!("run '{run_id}'"),
+        )
+        .map(Some);
+    }
+    Ok(None)
+}
+
 /// Execute `rocky run` — full pipeline.
 #[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip_all, name = "run", fields(run_id))]
@@ -1608,10 +1655,23 @@ pub async fn run(
     let skip_gate =
         SkipGateConfig::resolve(skip_opts, &rocky_cfg.run, shadow_config.is_some());
 
+    let resume_requested = resume_run_id.is_some() || resume_latest;
+
+    // `--all` and `--models` append an uncheckpointed model phase to a
+    // replication run. Resuming only the replication half would silently run
+    // transformations fresh, so reject the mixed execution before opening an
+    // adapter or mutating state.
+    ensure_resume_supported(
+        resume_requested,
+        !run_all && models_dir.is_none(),
+        "mixed replication and transformation execution",
+    )?;
+
     // Model-only execution: skip the entire replication path and execute
     // just the named model. Dagster uses this for per-asset materialization
     // when it controls the DAG scheduling.
     if let Some(target_model) = model_name_filter {
+        ensure_resume_supported(resume_requested, false, "model-only")?;
         let adapter_registry = AdapterRegistry::from_config(rocky_cfg)?;
         // An explicit `--pipeline` alongside `--model` (also how the unified-DAG
         // sub-runner drives each transformation node) resolves the model against
@@ -1963,6 +2023,15 @@ pub async fn run(
 
     let (pipeline_name, pipeline_config) =
         registry::resolve_pipeline(rocky_cfg, pipeline_name_arg)?;
+
+    ensure_resume_supported(
+        resume_requested,
+        matches!(
+            &pipeline_config,
+            rocky_core::config::PipelineConfig::Replication(_)
+        ),
+        pipeline_config.pipeline_type_str(),
+    )?;
 
     info!(
         pipeline = pipeline_name,
@@ -2533,6 +2602,12 @@ pub async fn run(
         }
     };
 
+    // A recovery request must read the durable source of truth. `FreshStart`
+    // proves that no remote checkpoint exists; `Indeterminate` means the
+    // download failed and any local file may be stale. Neither may authorize
+    // table skipping.
+    ensure_resume_authority(resume_requested, authority)?;
+
     // Freeze fence (ADR-CONCURRENCY.md D3 fence granularity): fresh
     // durable-tier marker LISTs at this run's boundaries — before the
     // replication fan-out, at each execution-layer boundary inside
@@ -2581,6 +2656,12 @@ pub async fn run(
             "failed to open state store at {}",
             state_path.display()
         ))?;
+
+    // Resolve an explicit recovery request before discovery or warehouse
+    // setup. A missing or unreadable checkpoint must never degrade into a
+    // fresh run.
+    let resume_progress =
+        resolve_resume_progress(&state_store, resume_run_id, resume_latest)?;
 
     // Suppress both the periodic and the end-of-run upload when either:
     // - the on-disk state was forward-incompatible (newer schema than this
@@ -3521,42 +3602,20 @@ pub async fn run(
     // see the `governed_ctx` gate ahead of `governance_setup` — so no warehouse
     // statement executes for a denied / unreviewed agent replication.)
 
-    let completed_keys: std::collections::HashSet<String> = if resume_latest {
-        if let Ok(Some(prev)) = state_store.get_latest_run_progress() {
-            let keys: std::collections::HashSet<String> = prev
-                .tables
-                .iter()
-                .filter(|t| t.status == rocky_core::state::TableStatus::Success)
-                .map(|t| t.table_key.clone())
-                .collect();
-            if !keys.is_empty() {
-                info!(
-                    resumed_from = prev.run_id,
-                    tables_skipped = keys.len(),
-                    "resuming from previous run"
-                );
-                output.resumed_from = Some(prev.run_id.clone());
-            }
-            keys
-        } else {
-            std::collections::HashSet::new()
-        }
-    } else if let Some(rid) = resume_run_id {
-        if let Ok(Some(prev)) = state_store.get_run_progress(rid) {
-            let keys: std::collections::HashSet<String> = prev
-                .tables
-                .iter()
-                .filter(|t| t.status == rocky_core::state::TableStatus::Success)
-                .map(|t| t.table_key.clone())
-                .collect();
-            if !keys.is_empty() {
-                output.resumed_from = Some(rid.to_string());
-            }
-            keys
-        } else {
-            warn!(run_id = rid, "no progress found for run, starting fresh");
-            std::collections::HashSet::new()
-        }
+    let completed_keys: std::collections::HashSet<String> = if let Some(prev) = resume_progress {
+        let keys: std::collections::HashSet<String> = prev
+            .tables
+            .iter()
+            .filter(|t| t.status == rocky_core::state::TableStatus::Success)
+            .map(|t| t.table_key.clone())
+            .collect();
+        info!(
+            resumed_from = prev.run_id,
+            tables_skipped = keys.len(),
+            "resuming from previous run"
+        );
+        output.resumed_from = Some(prev.run_id);
+        keys
     } else {
         std::collections::HashSet::new()
     };
@@ -11936,6 +11995,270 @@ fn is_rate_limit_error(error_msg: &str) -> bool {
 mod tests {
     use super::*;
     use rocky_core::plan_partition::PartitionSelection;
+
+    #[test]
+    fn resume_rejects_unsupported_execution_paths() {
+        let err = ensure_resume_supported(true, false, "transformation")
+            .expect_err("an unsupported pipeline must not ignore resume");
+        assert!(
+            err.to_string()
+                .contains("only for replication-only execution"),
+            "unexpected error: {err:#}"
+        );
+        ensure_resume_supported(
+            true,
+            false,
+            "mixed replication and transformation execution",
+        )
+        .expect_err("a mixed --all/--models run must not partially resume");
+        ensure_resume_supported(false, false, "transformation")
+            .expect("an ordinary transformation run remains valid");
+    }
+
+    #[test]
+    fn resume_requires_authoritative_state() {
+        use rocky_core::state_sync::StateAuthority;
+
+        ensure_resume_authority(true, StateAuthority::Authoritative)
+            .expect("local or restored state is authoritative");
+        for authority in [StateAuthority::FreshStart, StateAuthority::Indeterminate] {
+            let err = ensure_resume_authority(true, authority)
+                .expect_err("resume must not consult missing or stale local state");
+            assert!(
+                err.to_string().contains("non-authoritative state"),
+                "unexpected error: {err:#}"
+            );
+        }
+        ensure_resume_authority(false, StateAuthority::Indeterminate)
+            .expect("ordinary ungoverned runs retain their degraded-mode behavior");
+    }
+
+    #[test]
+    fn resume_specific_run_requires_an_existing_checkpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = StateStore::open(&dir.path().join("state.redb")).unwrap();
+        let err = resolve_resume_progress(&store, Some("never-recorded"), false)
+            .expect_err("an unknown run must not start fresh");
+        assert!(
+            err.to_string().contains("run 'never-recorded'"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn resume_latest_requires_an_existing_checkpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = StateStore::open(&dir.path().join("state.redb")).unwrap();
+        let err = resolve_resume_progress(&store, None, true)
+            .expect_err("an empty state store must not start fresh");
+        assert!(
+            err.to_string().contains("the latest run"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn resume_accepts_a_valid_zero_progress_checkpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = StateStore::open(&dir.path().join("state.redb")).unwrap();
+        store.init_run_progress("run-empty", 0).unwrap();
+
+        let explicit = resolve_resume_progress(&store, Some("run-empty"), false)
+            .unwrap()
+            .unwrap();
+        assert_eq!(explicit.run_id, "run-empty");
+        assert!(explicit.tables.is_empty());
+
+        let latest = resolve_resume_progress(&store, None, true)
+            .unwrap()
+            .unwrap();
+        assert_eq!(latest.run_id, "run-empty");
+    }
+
+    #[test]
+    fn resume_preserves_state_lookup_errors() {
+        let err = require_resume_progress(
+            Err(StateError::VersionParse("garbled".to_string())),
+            "run 'broken'",
+        )
+        .expect_err("state errors must not start a fresh run");
+        let message = format!("{err:#}");
+        assert!(message.contains("failed to load progress for run 'broken'"));
+        assert!(message.contains("state schema version is corrupt"));
+    }
+
+    async fn drive_resume_test_run(
+        config_path: &std::path::Path,
+        state_path: &std::path::Path,
+        pipeline: &str,
+        resume_run_id: Option<&str>,
+        resume_latest: bool,
+    ) -> anyhow::Result<()> {
+        super::run(
+            config_path,
+            std::sync::Arc::new(
+                rocky_core::config::load_rocky_config_fingerprinted(config_path).unwrap(),
+            ),
+            None,
+            Some(pipeline),
+            state_path,
+            None,
+            true,
+            None,
+            false,
+            resume_run_id,
+            resume_latest,
+            None,
+            &PartitionRunOptions::default(),
+            None,
+            None,
+            None,
+            None,
+            &DeferOptions::default(),
+            &SkipRunOptions::default(),
+            &rocky_core::run_vars::RunVars::new(),
+            None,
+            None,
+            false,
+            None,
+        )
+        .await
+        .map(|_| ())
+    }
+
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn transformation_resume_refuses_before_opening_the_warehouse() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("warehouse.duckdb");
+        let config_path = dir.path().join("rocky.toml");
+        let state_path = dir.path().join("state.redb");
+        std::fs::write(
+            &config_path,
+            format!(
+                r#"
+[adapter]
+type = "duckdb"
+path = "{}"
+
+[state]
+backend = "local"
+
+[pipeline.transform]
+type = "transformation"
+models = "models/**"
+
+[pipeline.transform.target]
+adapter = "default"
+"#,
+                db_path.display()
+            ),
+        )
+        .unwrap();
+
+        let err = drive_resume_test_run(&config_path, &state_path, "transform", None, true)
+            .await
+            .expect_err("a transformation run must not ignore --resume-latest");
+
+        assert!(
+            err.to_string()
+                .contains("only for replication-only execution"),
+            "unexpected error: {err:#}"
+        );
+        assert!(
+            !db_path.exists(),
+            "the unsupported resume must fail before opening the warehouse"
+        );
+        assert!(
+            !state_path.exists(),
+            "the unsupported resume must fail before opening the state store"
+        );
+    }
+
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn missing_replication_checkpoint_refuses_before_warehouse_mutation() {
+        use rocky_core::traits::WarehouseAdapter;
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("warehouse.duckdb");
+        let config_path = dir.path().join("rocky.toml");
+        let state_path = dir.path().join("state.redb");
+        {
+            let warehouse = DuckDbWarehouseAdapter::open(&db_path).unwrap();
+            warehouse
+                .execute_statement("CREATE SCHEMA raw__orders")
+                .await
+                .unwrap();
+            warehouse
+                .execute_statement("CREATE TABLE raw__orders.one AS SELECT 1 AS id")
+                .await
+                .unwrap();
+        }
+        std::fs::write(
+            &config_path,
+            format!(
+                r#"
+[adapter]
+type = "duckdb"
+path = "{}"
+
+[state]
+backend = "local"
+
+[pipeline.replicate]
+type = "replication"
+strategy = "full_refresh"
+
+[pipeline.replicate.source.discovery]
+adapter = "default"
+
+[pipeline.replicate.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.replicate.target]
+adapter = "default"
+catalog_template = "warehouse"
+schema_template = "staging__{{source}}"
+
+[pipeline.replicate.target.governance]
+auto_create_schemas = true
+"#,
+                db_path.display()
+            ),
+        )
+        .unwrap();
+
+        let err = drive_resume_test_run(
+            &config_path,
+            &state_path,
+            "replicate",
+            Some("never-recorded"),
+            false,
+        )
+        .await
+        .expect_err("an unknown checkpoint must not start a fresh run");
+
+        assert!(
+            err.to_string().contains("no progress found"),
+            "unexpected error: {err:#}"
+        );
+        let warehouse = DuckDbWarehouseAdapter::open(&db_path).unwrap();
+        let result = warehouse
+            .execute_query(
+                "SELECT COUNT(*) FROM information_schema.tables \
+                 WHERE table_schema = 'staging__orders' AND table_name = 'one'",
+            )
+            .await
+            .unwrap();
+        let count = result.rows[0][0]
+            .as_u64()
+            .or_else(|| result.rows[0][0].as_str().and_then(|v| v.parse().ok()));
+        assert_eq!(count, Some(0), "the target table must not be created");
+    }
 
     // Serializes the process-global env-var mutations in this module's tests —
     // the trigger-threading ones below and the `TRACEPARENT` adoption ones

--- a/engine/crates/rocky-cli/tests/remote_state_authority.rs
+++ b/engine/crates/rocky-cli/tests/remote_state_authority.rs
@@ -105,6 +105,8 @@ async fn drive_run(
     config_path: &Path,
     state_path: &Path,
     assume_fresh_state: bool,
+    resume_run_id: Option<&str>,
+    resume_latest: bool,
 ) -> anyhow::Result<()> {
     // PR-B: `run` executes from the caller's owned fingerprinted snapshot;
     // this driver loads it the way every production entry point does.
@@ -121,9 +123,9 @@ async fn drive_run(
         false, // output_json
         None,  // models_dir
         false, // run_all
-        None,  // resume_run_id
-        false, // resume_latest
-        None,  // shadow_config
+        resume_run_id,
+        resume_latest,
+        None, // shadow_config
         &rocky_cli::commands::PartitionRunOptions::default(),
         None, // model_name_filter
         None, // cache_ttl_override
@@ -157,9 +159,15 @@ async fn ungoverned_download_failure_suppresses_all_uploads() {
 
     harness.faults.arm(FaultOp::Head, FaultMode::FailAll);
 
-    drive_run(&project.config_path, &project.state_path, false)
-        .await
-        .expect("an ungoverned run continues past a failed download (degraded mode)");
+    drive_run(
+        &project.config_path,
+        &project.state_path,
+        false,
+        None,
+        false,
+    )
+    .await
+    .expect("an ungoverned run continues past a failed download (degraded mode)");
 
     harness.faults.clear();
     assert_eq!(
@@ -179,9 +187,15 @@ async fn fresh_start_bootstrap_still_uploads() {
     let harness = CrossPodHarness::new_s3_like();
     let project = TestProject::new().await;
 
-    drive_run(&project.config_path, &project.state_path, false)
-        .await
-        .expect("a fresh-start replication run must succeed");
+    drive_run(
+        &project.config_path,
+        &project.state_path,
+        false,
+        None,
+        false,
+    )
+    .await
+    .expect("a fresh-start replication run must succeed");
 
     assert!(
         harness.faults.count(FaultOp::Put) >= 1,
@@ -201,7 +215,7 @@ async fn assume_fresh_state_proceeds_and_uploads() {
 
     harness.faults.arm(FaultOp::Head, FaultMode::FailAll);
 
-    drive_run(&project.config_path, &project.state_path, true)
+    drive_run(&project.config_path, &project.state_path, true, None, false)
         .await
         .expect("--assume-fresh-state elects past the failed download");
 
@@ -210,6 +224,67 @@ async fn assume_fresh_state_proceeds_and_uploads() {
         harness.faults.count(FaultOp::Put) >= 1,
         "an asserted fresh start is trusted: the end-of-run upload must fire"
     );
+}
+
+/// A resume must never use a stale local checkpoint when the configured
+/// remote source of truth cannot be read. The ordinary ungoverned path may
+/// continue in degraded mode, but recovery has to fail closed before touching
+/// the warehouse.
+#[tokio::test]
+async fn resume_refuses_indeterminate_remote_state() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+    let project = TestProject::new().await;
+
+    let store = rocky_core::state::StateStore::open(&project.state_path).unwrap();
+    store.init_run_progress("stale-run", 1).unwrap();
+    drop(store);
+
+    harness.faults.arm(FaultOp::Head, FaultMode::FailAll);
+
+    let err = drive_run(
+        &project.config_path,
+        &project.state_path,
+        false,
+        Some("stale-run"),
+        false,
+    )
+    .await
+    .expect_err("resume must refuse indeterminate remote state");
+
+    harness.faults.clear();
+    let message = format!("{err:#}");
+    assert!(
+        message.contains("non-authoritative state (Indeterminate)"),
+        "unexpected error: {message}"
+    );
+    assert_eq!(
+        harness.faults.count(FaultOp::Put),
+        0,
+        "a refused resume must not upload local state"
+    );
+
+    let warehouse = DuckDbWarehouseAdapter::open(
+        &project
+            .config_path
+            .parent()
+            .expect("config has a parent")
+            .join("wh.duckdb"),
+    )
+    .unwrap();
+    let result = warehouse
+        .execute_query(
+            "SELECT COUNT(*) AS count FROM information_schema.tables \
+             WHERE table_schema = 'staging__acme' AND table_name = 'orders'",
+        )
+        .await
+        .unwrap();
+    let count = result.rows[0][0].as_u64().or_else(|| {
+        result.rows[0][0]
+            .as_str()
+            .and_then(|value| value.parse().ok())
+    });
+    assert_eq!(count, Some(0));
 }
 
 /// (d) Seam regression: the pre-gate download seams keep their fail-closed

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -787,11 +787,11 @@ enum Command {
         /// Applies to the default plan subcommand only.
         #[arg(long, global = false)]
         all: bool,
-        /// Resume a failed run; mints a new `run_id` and records the prior one as `resumed_from`.
+        /// Resume a failed replication run; mints a new `run_id` and records the prior one as `resumed_from`.
         /// Applies to the default plan subcommand only.
         #[arg(long, global = false)]
         resume: Option<String>,
-        /// Resume the most recent failed run; mints a new `run_id` and records the prior one as `resumed_from`.
+        /// Resume the most recent failed replication run; mints a new `run_id` and records the prior one as `resumed_from`.
         /// Resolved against the state store at apply time.
         /// Applies to the default plan subcommand only.
         #[arg(long, global = false)]
@@ -945,10 +945,10 @@ enum Command {
         /// Execute both replication and compiled models
         #[arg(long)]
         all: bool,
-        /// Resume a failed run; mints a new `run_id` and records the prior one as `resumed_from`
+        /// Resume a failed replication run; mints a new `run_id` and records the prior one as `resumed_from`
         #[arg(long)]
         resume: Option<String>,
-        /// Resume the most recent failed run; mints a new `run_id` and records the prior one as `resumed_from`
+        /// Resume the most recent failed replication run; mints a new `run_id` and records the prior one as `resumed_from`
         #[arg(long)]
         resume_latest: bool,
         /// Run in shadow mode: write to shadow targets instead of production


### PR DESCRIPTION
## Summary

Make explicit resume requests fail closed instead of silently becoming fresh or partially fresh executions.

Closes #1543.

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [x] Cross-project (CI, scripts, root docs)

## Changes

- Resolve an explicitly requested replication checkpoint before discovery or warehouse setup, preserving state-read errors and rejecting missing run IDs/latest checkpoints.
- Reject resume flags on transformation, model-only, and mixed replication/model execution paths that do not provide compatible checkpoint coverage.
- Require authoritative state for recovery, so a missing or failed remote restore cannot authorize table skipping from stale local state.
- Preserve valid zero-progress checkpoints and record their `resumed_from` identity.
- Add unit and end-to-end regressions for missing/latest checkpoints, lookup errors, zero-progress state, unsupported dispatch, pre-mutation refusal, and indeterminate remote authority.
- Document the replication-only and authoritative-state resume contract in CLI help and reference/concept pages.

## Safety invariant

Supplying `--resume` or `--resume-latest` either resumes an existing replication checkpoint from authoritative state or exits before materialization. Starting fresh remains an explicit run without a resume flag.

## Test Plan

- GitHub Actions: all nine checks pass, including the all-feature test matrix, Clippy, formatting, adapter boundary, release-build smoke, codegen drift, docs, and credential-containment checks.
- `cargo nextest run --all-features --no-fail-fast`: 6,533 passed; two unrelated compile-contract tests failed only in the fully parallel run and both passed when rerun independently (`plan_writers_are_not_nameable_externally`, `the_raw_demotion_is_not_nameable_externally`).
- `cargo nextest run -p rocky-cli resume_specific_run_requires_an_existing_checkpoint`: passes; `scripts/mutation-check.sh` proves it fails when the old missing-checkpoint fallback is restored.
- `cargo clippy --all-targets --all-features -- -D warnings`: passes.
- `cargo fmt -- --check`: passes.
- `cargo test -p rocky-cli --lib commands::export_schemas`: 3 passed.
- `just codegen && just regen-fixtures`: passes with no generated drift.
- `cargo build --release --bin rocky`: passes; the release doctor smoke confirms the tiered cache backend builds.
- `npm run build` in `docs/`: 105 pages built.
- Adapter boundary: the canonical GitHub job passes. A local macOS invocation reported pre-existing test-only imports in untouched files; this PR adds none.

## Independent review

A GPT-5.5 red-team pass initially identified two gaps: remote state authority was not yet gating resume, and helper-only coverage did not prove pre-mutation behavior. Both were addressed with the authority guard and DuckDB/remote-state integration tests. A second pass found no actionable correctness gaps. `ModelIr` and public JSON contract semantics are unchanged.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/), scoped by subproject when relevant (e.g. `feat(engine/rocky-databricks): ...`, `fix(dagster): ...`)
- [x] No `Co-Authored-By` trailers
- [x] If this is a CLI JSON schema or DSL syntax change, all consumers (`integrations/dagster/`, `editors/vscode/`) are updated in this same PR (not applicable; codegen produced no schema drift)

### Engine (`engine/`)
- [x] `cargo test --all-targets` passes (the repository's all-feature nextest CI is green; local parallel-only compile-test flakes passed independently)
- [x] `cargo clippy --all-targets -- -D warnings` is clean
- [x] `cargo fmt --check` passes

### Dagster (`integrations/dagster/`)
- [ ] `uv run pytest` passes (not affected)
- [ ] `uv run ruff check` is clean (not affected)
- [ ] `uv run ruff format --check` passes (not affected)

### VS Code (`editors/vscode/`)
- [ ] `npm run compile` succeeds (not affected)
- [ ] `npm run test:unit` passes (not affected)
- [ ] `npm run lint` is clean (not affected)
