### PR TITLE
fix(engine): reject --dag with a resume flag instead of ignoring it

### DIFF
--- a/AGENT_REVIEW.md
+++ b/AGENT_REVIEW.md
@@ -132,8 +132,11 @@ it. That is the property to **preserve**, and it means the finding to look for i
 ### Executor (`rocky-core/src/{dag_executor.rs, unified_dag.rs, state.rs}`, `rocky-cli/src/commands/{run.rs, run_content_addressed.rs}`)
 - Execution respects the dependency DAG **topologically**; no node runs before its inputs
   (`rocky-ir/src/dag.rs::topological_sort` / `execution_layers`).
-- **Resume/retry is idempotent.** `rocky run --resume`/`--resume-latest` re-runs from a checkpoint; a
-  retried node must not double-apply an `INSERT`/`MERGE` or corrupt redb state.
+- **Resume/retry is idempotent, and replication-only.** `rocky run --resume`/`--resume-latest` re-runs
+  from a per-table replication checkpoint; a retried node must not double-apply an `INSERT`/`MERGE` or
+  corrupt redb state. Every path that records no such checkpoint refuses the flags rather than running
+  fresh — other pipeline types, `--all`/`--models`, `--model`, `--dag`, and non-authoritative remote
+  state. A resume that silently becomes a fresh run is the #1543 defect, not a convenience.
 - **Incremental-watermark soundness.** The runner reads the prior `MAX(ts)` from the redb state store,
   filters `WHERE ts > <watermark>`, then re-queries source to record the next watermark. For this
   SQL-executed path the **warehouse owns the data-write transaction**; Rocky owns only redb. Scrutinize the

--- a/ROCKY_EXPLAINED.md
+++ b/ROCKY_EXPLAINED.md
@@ -363,7 +363,7 @@ A **watermark** is the timestamp of the newest row Rocky has already loaded. It 
 
 Computing the new value from the target, rather than the source, prevents a race. New rows can land in the source while a run is in flight. The target holds only what Rocky actually wrote, so the watermark never moves past unprocessed data.
 
-**run_progress_entries + idempotency_keys** make runs resumable. If a run is interrupted, Rocky can skip the models that already completed. `rocky run --resume-latest` uses this.
+**run_progress_entries + idempotency_keys** make replication runs resumable. If a run is interrupted, Rocky can skip the *tables* that already copied. `rocky run --resume-latest` uses this. Transformation models record no per-table checkpoint, so a run that would execute models — another pipeline type, `--all`, `--models`, `--model`, or `--dag` — refuses the resume flags instead of ignoring them.
 
 ---
 
@@ -1309,7 +1309,7 @@ Resolved tags land on `rocky compile --output json` as `models_detail[].tags`, a
 | See what SQL will run | `rocky plan -c rocky.toml` |
 | Run the pipeline | `rocky run -c rocky.toml` |
 | Run only the sources matching one `key=value` | `rocky run -c rocky.toml --filter source=shopify` |
-| Resume a failed run | `rocky run -c rocky.toml --resume-latest` |
+| Resume a failed replication run | `rocky run -c rocky.toml --resume-latest` |
 | Run a single partition | `rocky run -c rocky.toml --partition 2024-01-15` |
 | Check watermark state | `rocky state -c rocky.toml` |
 | See run history | `rocky history` |

--- a/docs/src/content/docs/concepts/execution-flow.md
+++ b/docs/src/content/docs/concepts/execution-flow.md
@@ -251,12 +251,14 @@ A replication run can be interrupted mid-layer by a killed process or a network 
 
 Resume flags fail if the checkpoint is missing or unreadable. Every path that does not record per-table checkpoints refuses them instead of ignoring them: other pipeline types, mixed replication/model runs (`--all` or `--models`), and `--dag`. With a remote state backend, resume also requires an authoritative restore; an absent or unreachable remote state refuses recovery even if a stale local state file exists.
 
-To recover a run that used `--all` or `--dag`, resume the replication half on its own, then rebuild the models:
+There is no way to resume half of a combined run. `--all` and `--models` re-run the replication phase before the model phase, so a second command cannot pick up where a resumed replication left off — it copies the same tables again. If a `--all` or `--dag` run fails, either re-run it whole, or split the work: resume the replication pipeline on its own with `--resume-latest`, then build the models by naming their transformation pipeline, which runs no replication of its own.
 
 ```bash
 rocky run -c rocky.toml --pipeline <replication-pipeline> --resume-latest
-rocky run -c rocky.toml --all
+rocky run -c rocky.toml --pipeline <transformation-pipeline>
 ```
+
+That split needs the models to live in their own transformation pipeline. In a single pipeline driven by `--all`, they do not, and the whole run repeats.
 
 The state store records which tables completed in the `run_progress_entries` table, one entry per `run_id` plus table, with a `run_progress` header row per `run_id`. `rocky run --resume-latest` looks up the most recent `run_id`, reads which tables already completed, and skips them.
 

--- a/docs/src/content/docs/concepts/execution-flow.md
+++ b/docs/src/content/docs/concepts/execution-flow.md
@@ -249,7 +249,14 @@ Exit code:
 
 A replication run can be interrupted mid-layer by a killed process or a network failure. Rocky can resume it from the last successful checkpoint, but only when you ask for it. Pass `--resume-latest` or `--resume <run-id>`. Without one of those flags the next run starts fresh and rebuilds every selected table.
 
-Resume flags fail if the checkpoint is missing or unreadable. Other pipeline types and mixed replication/model runs reject them because they do not record compatible per-table resume checkpoints. With a remote state backend, resume also requires an authoritative restore; an absent or unreachable remote state refuses recovery even if a stale local state file exists.
+Resume flags fail if the checkpoint is missing or unreadable. Every path that does not record per-table checkpoints refuses them instead of ignoring them: other pipeline types, mixed replication/model runs (`--all` or `--models`), and `--dag`. With a remote state backend, resume also requires an authoritative restore; an absent or unreachable remote state refuses recovery even if a stale local state file exists.
+
+To recover a run that used `--all` or `--dag`, resume the replication half on its own, then rebuild the models:
+
+```bash
+rocky run -c rocky.toml --pipeline <replication-pipeline> --resume-latest
+rocky run -c rocky.toml --all
+```
 
 The state store records which tables completed in the `run_progress_entries` table, one entry per `run_id` plus table, with a `run_progress` header row per `run_id`. `rocky run --resume-latest` looks up the most recent `run_id`, reads which tables already completed, and skips them.
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -289,8 +289,8 @@ rocky run [--filter <key=value>] [flags]
 | `--governance-override <JSON>` | | Additional governance config as inline JSON or `@file.json`, merged with defaults. |
 | `--models <PATH>` | | Models directory for transformation execution. |
 | `--all` | | Execute both replication and compiled models. |
-| `--resume <RUN_ID>` | | Resume a specific previous replication run from its last checkpoint; mints a new `run_id` and records the prior one as `resumed_from`. |
-| `--resume-latest` | | Resume the most recent failed replication run from its last checkpoint; mints a new `run_id` and records the prior one as `resumed_from`. |
+| `--resume <RUN_ID>` | | Resume a specific previous replication run from its last checkpoint; mints a new `run_id` and records the prior one as `resumed_from`. Rejected with `--dag`, which does not replay the resume into its sub-runs (rejected at parse time). |
+| `--resume-latest` | | Resume the most recent failed replication run from its last checkpoint; mints a new `run_id` and records the prior one as `resumed_from`. Rejected with `--dag`, which does not replay the resume into its sub-runs (rejected at parse time). |
 | `--shadow` | | Run in shadow mode: write to shadow targets instead of production. |
 | `--shadow-suffix <SUFFIX>` | | Suffix appended to table names in shadow mode (default `_rocky_shadow`). |
 | `--shadow-schema <NAME>` | | Override schema for shadow tables (mutually exclusive with `--shadow-suffix`). |

--- a/docs/src/content/docs/reference/commands/core-pipeline.md
+++ b/docs/src/content/docs/reference/commands/core-pipeline.md
@@ -321,8 +321,8 @@ Rocky records the execution flags in the plan file, so `rocky apply` replays the
 | `--models <PATH>` | `PathBuf` | | Models directory for transformation execution. |
 | `--all` | `bool` | `false` | Plan both replication and compiled models. |
 | `--governance-override <JSON>` | `string` | | Additional governance config as inline JSON or `@file.json`, merged with the defaults. Resolved at plan time and stored in the plan. |
-| `--resume <RUN_ID>` | `string` | | Resume a specific previous replication run from its last checkpoint. Mints a new `run_id` and records the prior one as `resumed_from`. |
-| `--resume-latest` | `bool` | `false` | Resume the most recent failed replication run from its last checkpoint. Which run that is gets resolved at apply time, not plan time. |
+| `--resume <RUN_ID>` | `string` | | Resume a specific previous replication run from its last checkpoint. Mints a new `run_id` and records the prior one as `resumed_from`. Rejected with `--dag`, which does not replay the resume into its sub-runs (rejected at parse time). |
+| `--resume-latest` | `bool` | `false` | Resume the most recent failed replication run from its last checkpoint. Which run that is gets resolved at apply time, not plan time. Rejected with `--dag`, which does not replay the resume into its sub-runs (rejected at parse time). |
 | `--shadow` | `bool` | `false` | Write to shadow targets instead of production. |
 | `--shadow-suffix <SUFFIX>` | `string` | `_rocky_shadow` | Suffix appended to table names in shadow mode. |
 | `--shadow-schema <NAME>` | `string` | | Override the schema for shadow tables. Mutually exclusive with `--shadow-suffix`. |
@@ -334,7 +334,7 @@ Rocky records the execution flags in the plan file, so `rocky apply` replays the
 | `--missing` | `bool` | `false` | Plan the partitions missing from the state store, computed from the model's `first_partition` up to now. Errors if `first_partition` is unset. Resolved against the state store at apply time. |
 | `--lookback <N>` | `integer` | | Also recompute the previous N partitions. The flag overrides the model's TOML `lookback`. This is the standard handling for late-arriving data. |
 | `--parallel <N>` | `integer` | `1` | Run N partitions at a time. Warehouse-query parallelism only: state writes serialize through the state store. |
-| `--dag` | `bool` | `false` | Plan all pipelines as one DAG in dependency order. Each pipeline is a node, cross-pipeline `depends_on` edges set the order, and layers run in parallel. |
+| `--dag` | `bool` | `false` | Plan all pipelines as one DAG in dependency order. Each pipeline is a node, cross-pipeline `depends_on` edges set the order, and layers run in parallel. Mutually exclusive with `--resume` / `--resume-latest`: the DAG runner does not consume them, so a plan carrying both would apply as a fresh run of every pipeline. |
 | `--idempotency-key <KEY>` | `string` | `$ROCKY_IDEMPOTENCY_KEY` | Opaque caller-supplied key that dedups this run against prior runs with the same key. Supported on the `local`, `valkey`, and `tiered` state backends; an `s3`-only or `gcs`-only backend errors when the flag is parsed. Keys are stored verbatim, so never put a secret in one. |
 | `--env <NAME>` | `string` | | Scope the governance preview (`mask_actions`) to one environment, so `[mask.<env>]` overrides overlay the workspace `[mask]` defaults. Classification tagging and retention policies are the same in every environment and are previewed regardless. |
 | `--semantic` | `bool` | `false` | Also run the breaking-change classifier against `--base` and attach the change-impact verdict under `breaking_verdict`. Decision-support only — never gates the plan and never changes the exit code. |
@@ -549,8 +549,8 @@ rocky run [flags]
 | `--governance-override <JSON>` | `string` | | Additional governance config as inline JSON or `@file.json`, merged with defaults. |
 | `--models <PATH>` | `PathBuf` | | Models directory for transformation execution. |
 | `--all` | `bool` | `false` | Execute both replication and compiled models. |
-| `--resume <RUN_ID>` | `string` | | Resume a specific previous replication run from its last checkpoint; mints a new `run_id` and records the prior one as `resumed_from`. |
-| `--resume-latest` | `bool` | `false` | Resume the most recent failed replication run from its last checkpoint; mints a new `run_id` and records the prior one as `resumed_from`. |
+| `--resume <RUN_ID>` | `string` | | Resume a specific previous replication run from its last checkpoint; mints a new `run_id` and records the prior one as `resumed_from`. Rejected with `--dag`, which does not replay the resume into its sub-runs (rejected at parse time). |
+| `--resume-latest` | `bool` | `false` | Resume the most recent failed replication run from its last checkpoint; mints a new `run_id` and records the prior one as `resumed_from`. Rejected with `--dag`, which does not replay the resume into its sub-runs (rejected at parse time). |
 | `--shadow` | `bool` | `false` | Run in shadow mode: write to shadow targets instead of production. |
 | `--shadow-suffix <SUFFIX>` | `string` | `_rocky_shadow` | Suffix appended to table names in shadow mode. |
 | `--shadow-schema <NAME>` | `string` | | Override schema for shadow tables (mutually exclusive with `--shadow-suffix`). |

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -13,9 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Paths that record no per-table checkpoint used to accept the flags and ignore them. They now refuse: other pipeline types, mixed replication and model runs (`--all` or `--models`), `--model`, and `--dag`. `--dag` and the resume flags are rejected when the command is parsed, on both `rocky run` and `rocky plan`; a plan written by an older binary that carries both is refused at apply time, before the config is loaded.
 
+  `--resume <run-id>` and `--resume-latest` together are also rejected now, at parse time and on a persisted plan. Only one run can be resumed, and `--resume-latest` won — so passing both silently threw away the run id you named and recovered a different run.
+
   With a remote `[state]` backend, a resume now requires an authoritative restore. If the download fails and the run elects past it, the local file may be stale, so recovery refuses rather than skipping tables on state it could not confirm.
 
-  **On upgrade:** this is a behavior change for automation that passes a resume flag unconditionally. A command that used to exit 0 having rebuilt everything now exits non-zero. Starting fresh is still an explicit run with no resume flag. To recover a run that used `--all` or `--dag`, resume the replication pipeline on its own and then rebuild the models. (#1543, contributed in #1544; `--dag` and the plan/apply paths in #1546)
+  **On upgrade:** this is a behavior change for automation that passes a resume flag unconditionally. A command that used to exit 0 having rebuilt everything now exits non-zero. Starting fresh is still an explicit run with no resume flag. There is no partial recovery for a combined run: `--all` and `--models` re-run the replication phase before the model phase, so they cannot pick up after a resumed replication. Either re-run the whole thing, or split replication and models into their own pipelines and run each by name. (#1543, contributed in #1544; `--dag` and the plan/apply paths in #1546)
 
 ## [1.72.0] — 2026-08-26
 

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A resume that cannot resume now stops instead of running everything from scratch.** `rocky run --resume <run-id>` and `rocky run --resume-latest` used to fall back to an ordinary run when the checkpoint was missing or the state store could not be read. A typo, an empty state directory or an expired checkpoint therefore launched a full production run and reported success. Both flags now exit non-zero before anything is discovered or written, and a state-store read error is reported with its cause rather than swallowed. A valid checkpoint that recorded zero completed tables is still a valid resume, and now records its `resumed_from` identity.
+
+  Paths that record no per-table checkpoint used to accept the flags and ignore them. They now refuse: other pipeline types, mixed replication and model runs (`--all` or `--models`), `--model`, and `--dag`. `--dag` and the resume flags are rejected when the command is parsed, on both `rocky run` and `rocky plan`; a plan written by an older binary that carries both is refused at apply time, before the config is loaded.
+
+  With a remote `[state]` backend, a resume now requires an authoritative restore. If the download fails and the run elects past it, the local file may be stale, so recovery refuses rather than skipping tables on state it could not confirm.
+
+  **On upgrade:** this is a behavior change for automation that passes a resume flag unconditionally. A command that used to exit 0 having rebuilt everything now exits non-zero. Starting fresh is still an explicit run with no resume flag. To recover a run that used `--all` or `--dag`, resume the replication pipeline on its own and then rebuild the models. (#1543, contributed in #1544; `--dag` and the plan/apply paths in #1546)
+
 ## [1.72.0] — 2026-08-26
 
 ### Added

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -592,6 +592,18 @@ fn validate_run_plan_execution_shape(plan_id: &str, run_plan: &RunPlan) -> Resul
     // success. `rocky plan` now rejects the combination at parse time; this
     // check is what covers a plan written by an older binary, which is on-disk
     // JSON the gc apply path already treats as possibly hand-authored.
+    // Both resume selectors at once. `resolve_resume_progress` in `run.rs`
+    // checks `resume_latest` FIRST, so a plan carrying both silently discards
+    // the run id the operator named and recovers a different run. `rocky run`
+    // and `rocky plan` now reject the pair at parse time; this covers the
+    // persisted shape, same as the `--dag` pair below.
+    if run_plan.resume.is_some() && run_plan.resume_latest {
+        bail!(
+            "plan '{plan_id}' sets both --resume and --resume-latest; only one run can be \
+             resumed and --resume-latest would win, discarding the named run id. Re-plan with \
+             exactly one of them."
+        );
+    }
     if run_plan.dag && (run_plan.resume.is_some() || run_plan.resume_latest) {
         bail!(
             "plan '{plan_id}' sets both a resume flag and --dag; the DAG runner ignores \
@@ -8116,6 +8128,45 @@ autonomy_budget = { failures = 3, window = "7d" }
                 "{label}: the invalid plan must be rejected before state is opened or mutated"
             );
         }
+        Ok(())
+    }
+
+    /// The persisted half of the dual-selector rejection. `--resume` and
+    /// `--resume-latest` together never name one run: the resolver takes
+    /// `resume_latest` and drops the id. Parse time covers new invocations;
+    /// this covers a plan an older binary wrote.
+    #[tokio::test]
+    async fn persisted_dual_resume_selectors_are_refused_before_config_load() -> anyhow::Result<()>
+    {
+        let dir = tempfile::tempdir()?;
+        let mut rp = minimal_run_plan();
+        rp.resume = Some("run-20260101-000000-000".to_string());
+        rp.resume_latest = true;
+        let plan_id = write_plan(dir.path(), PlanKind::Run, &rp)?;
+        let state = dir.path().join("state.redb");
+
+        let err = super::run_apply_run_plan(
+            dir.path(),
+            &dir.path().join("rocky.toml"),
+            &plan_id,
+            &state,
+            PolicyPrincipal::Human,
+            true,
+        )
+        .await
+        .expect_err("a persisted dual-selector plan must be refused");
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "plan '{plan_id}' sets both --resume and --resume-latest; only one run can be \
+                 resumed and --resume-latest would win, discarding the named run id. Re-plan \
+                 with exactly one of them."
+            )
+        );
+        assert!(
+            !state.exists(),
+            "the invalid plan must be rejected before state is opened or mutated"
+        );
         Ok(())
     }
 

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -586,6 +586,19 @@ fn validate_run_plan_execution_shape(plan_id: &str, run_plan: &RunPlan) -> Resul
              the model selector. Re-plan without --dag."
         );
     }
+    // Same shape for resume (#1543 follow-up): the `run_plan.dag` arm below
+    // does not replay `resume` / `resume_latest` into its sub-runs, so a plan
+    // carrying both applied as a FRESH run of every pipeline and reported
+    // success. `rocky plan` now rejects the combination at parse time; this
+    // check is what covers a plan written by an older binary, which is on-disk
+    // JSON the gc apply path already treats as possibly hand-authored.
+    if run_plan.dag && (run_plan.resume.is_some() || run_plan.resume_latest) {
+        bail!(
+            "plan '{plan_id}' sets both a resume flag and --dag; the DAG runner ignores \
+             the resume flag and would rebuild every pipeline from scratch. Re-plan without \
+             --dag to resume a replication run."
+        );
+    }
     Ok(())
 }
 
@@ -3587,13 +3600,16 @@ async fn run_apply_ai_authored_plan(
 /// **Why this arm does not call [`validate_run_plan_execution_shape`]** (#1325).
 /// It is the third kind carrying a `RunPlan` payload, and the other two —
 /// `Run` and `AiAuthored` — do call it. The reason this one is safe is NOT
-/// that a backfill plan cannot carry the rejected `dag && model` shape:
-/// `build_run_plan` hardcodes `dag: false` / `model: None` today, but that is
+/// that a backfill plan cannot carry a rejected shape (`dag && model`, or
+/// `dag && resume`):
+/// `build_run_plan` hardcodes `dag: false` / `model: None` / no resume today,
+/// but that is
 /// the argument #1173 already rejected, since the check exists precisely for
 /// plans written by an OLDER binary, and a plan payload is on-disk JSON that
 /// the gc apply path already treats as possibly hand-authored.
 ///
-/// It is safe because this arm never READS `dag` or `model`. It consumes
+/// It is safe because this arm never READS `dag`, `model`, or either resume
+/// field. It consumes
 /// `models_dir`, `models`, `partition_from`, `partition_to`, `parallel`, and
 /// `env` — the last feeding the governance fingerprint gate, not model
 /// selection — so the DAG runner is never reached and DAG-precedence cannot
@@ -8052,6 +8068,54 @@ autonomy_budget = { failures = 3, window = "7d" }
             !state.exists(),
             "the invalid plan must be rejected before state is opened or mutated"
         );
+        Ok(())
+    }
+
+    /// #1543 follow-up, same shape as the `--model` case above: `rocky plan`
+    /// now rejects `--dag` with a resume flag at parse time, but a plan written
+    /// by an older binary is on-disk JSON. The DAG arm never replays the resume
+    /// into its sub-runs, so applying one rebuilt every pipeline from scratch
+    /// and reported success. Both spellings must refuse before config loading.
+    #[tokio::test]
+    async fn persisted_resume_and_dag_plan_is_refused_before_config_load() -> anyhow::Result<()> {
+        for label in ["--resume", "--resume-latest"] {
+            let dir = tempfile::tempdir()?;
+            let mut rp = minimal_run_plan();
+            rp.dag = true;
+            if label == "--resume" {
+                rp.resume = Some("run-20260101-000000-000".to_string());
+            } else {
+                rp.resume_latest = true;
+            }
+            let plan_id = write_plan(dir.path(), PlanKind::Run, &rp)?;
+            let state = dir.path().join("state.redb");
+
+            // No rocky.toml, exactly as above: the guard must fire ahead of the
+            // config load, not somewhere inside the DAG dispatch.
+            let err = super::run_apply_run_plan(
+                dir.path(),
+                &dir.path().join("rocky.toml"),
+                &plan_id,
+                &state,
+                PolicyPrincipal::Human,
+                true,
+            )
+            .await
+            .expect_err("a persisted resume + --dag plan must be refused");
+            assert_eq!(
+                err.to_string(),
+                format!(
+                    "plan '{plan_id}' sets both a resume flag and --dag; the DAG runner ignores \
+                     the resume flag and would rebuild every pipeline from scratch. Re-plan \
+                     without --dag to resume a replication run."
+                ),
+                "{label} must name the contradictory persisted flags"
+            );
+            assert!(
+                !state.exists(),
+                "{label}: the invalid plan must be rejected before state is opened or mutated"
+            );
+        }
         Ok(())
     }
 

--- a/engine/crates/rocky-cli/src/commands/backfill.rs
+++ b/engine/crates/rocky-cli/src/commands/backfill.rs
@@ -943,14 +943,15 @@ mod tests {
         assert!(!plan.run_all);
     }
 
-    /// #1325: a composed backfill never carries the `dag && model` shape that
-    /// `validate_run_plan_execution_shape` rejects (#1173).
+    /// #1325: a composed backfill never carries a shape that
+    /// `validate_run_plan_execution_shape` rejects — `dag && model` (#1173) or
+    /// `dag && resume` (#1543 follow-up).
     ///
     /// The backfill apply arm does NOT call that validation, and is safe only
-    /// because it never reads either field. This pins the plan-time half of
-    /// that argument: if backfill ever becomes DAG-aware or model-scoped at
-    /// compose time, this fails and points at the apply arm's doc comment,
-    /// which says to add the shape check there.
+    /// because it never reads those fields. This pins the plan-time half of
+    /// that argument: if backfill ever becomes DAG-aware, model-scoped, or
+    /// resume-aware at compose time, this fails and points at the apply arm's
+    /// doc comment, which says to add the shape check there.
     ///
     /// It does not — and cannot cheaply — pin the apply-time half, which stays
     /// a structural guarantee documented at `run_apply_backfill_plan`.
@@ -966,6 +967,12 @@ mod tests {
         assert!(
             !(plan.dag && plan.model.is_some()),
             "a composed backfill carries the contradictory dag+model shape that the \
+             backfill apply arm does not validate — add validate_run_plan_execution_shape \
+             to run_apply_backfill_plan"
+        );
+        assert!(
+            !(plan.dag && (plan.resume.is_some() || plan.resume_latest)),
+            "a composed backfill carries the contradictory dag+resume shape that the \
              backfill apply arm does not validate — add validate_run_plan_execution_shape \
              to run_apply_backfill_plan"
         );

--- a/engine/crates/rocky-cli/src/commands/backfill.rs
+++ b/engine/crates/rocky-cli/src/commands/backfill.rs
@@ -976,5 +976,11 @@ mod tests {
              backfill apply arm does not validate — add validate_run_plan_execution_shape \
              to run_apply_backfill_plan"
         );
+        assert!(
+            !(plan.resume.is_some() && plan.resume_latest),
+            "a composed backfill carries both resume selectors, the shape that the backfill \
+             apply arm does not validate — add validate_run_plan_execution_shape to \
+             run_apply_backfill_plan"
+        );
     }
 }

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -788,8 +788,11 @@ enum Command {
         #[arg(long, global = false)]
         all: bool,
         /// Resume a failed replication run; mints a new `run_id` and records the prior one as `resumed_from`.
+        /// Mutually exclusive with `--resume-latest`, for the same reason as on
+        /// `rocky run`: a plan carrying both would discard the named run id at
+        /// apply time.
         /// Applies to the default plan subcommand only.
-        #[arg(long, global = false)]
+        #[arg(long, conflicts_with = "resume_latest", global = false)]
         resume: Option<String>,
         /// Resume the most recent failed replication run; mints a new `run_id` and records the prior one as `resumed_from`.
         /// Resolved against the state store at apply time.
@@ -950,8 +953,11 @@ enum Command {
         /// Execute both replication and compiled models
         #[arg(long)]
         all: bool,
-        /// Resume a failed replication run; mints a new `run_id` and records the prior one as `resumed_from`
-        #[arg(long)]
+        /// Resume a failed replication run; mints a new `run_id` and records the prior one as `resumed_from`.
+        /// Mutually exclusive with `--resume-latest`: the resolver gives
+        /// `--resume-latest` precedence, so accepting both silently discarded
+        /// the run id the operator actually named.
+        #[arg(long, conflicts_with = "resume_latest")]
         resume: Option<String>,
         /// Resume the most recent failed replication run; mints a new `run_id` and records the prior one as `resumed_from`
         #[arg(long)]
@@ -5008,6 +5014,11 @@ mod tests {
     /// every pipeline from scratch — #1543's fail-open shape on the widest
     /// path. Both spellings, on both `run` and `plan`, must now fail at parse
     /// time; `--dag` on its own still parses.
+    ///
+    /// The same loop pins the dual-selector pair. `--resume <id>
+    /// --resume-latest` also parsed, and `resolve_resume_progress` checks
+    /// `resume_latest` first, so the run id the operator named was discarded
+    /// without a word.
     #[test]
     #[allow(
         clippy::disallowed_methods,
@@ -5020,6 +5031,11 @@ mod tests {
             vec!["rocky", "run", "--dag", "--resume", "run-1"],
             vec!["rocky", "plan", "--dag", "--resume-latest"],
             vec!["rocky", "plan", "--dag", "--resume", "run-1"],
+            // Both selectors at once: `resolve_resume_progress` checks
+            // `resume_latest` first, so this used to parse and silently
+            // discard `run-1`.
+            vec!["rocky", "run", "--resume", "run-1", "--resume-latest"],
+            vec!["rocky", "plan", "--resume", "run-1", "--resume-latest"],
         ] {
             let parsed = std::thread::scope(|s| {
                 let owned: Vec<String> = conflicting.iter().map(ToString::to_string).collect();

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -857,8 +857,13 @@ enum Command {
         /// Run all pipelines as a unified DAG, in dependency order.
         /// Each pipeline is a node; cross-pipeline `depends_on` edges define
         /// execution order. Layers run in parallel.
+        ///
+        /// Incompatible with `--resume` / `--resume-latest`, rejected at parse
+        /// time: a persisted `RunPlan` carrying both never replays the resume
+        /// into its DAG sub-runs (see the `run_plan.dag` arm in `apply.rs`), so
+        /// the plan would apply as a fresh run of every pipeline.
         /// Applies to the default plan subcommand only.
-        #[arg(long, global = false)]
+        #[arg(long, conflicts_with_all = ["resume", "resume_latest"], global = false)]
         dag: bool,
 
         /// Caller-supplied opaque key used to dedup this run against prior
@@ -1020,7 +1025,14 @@ enum Command {
         /// Run all pipelines as a unified DAG, in dependency order.
         /// Each pipeline is a node; cross-pipeline `depends_on` edges define
         /// execution order. Layers run in parallel.
-        #[arg(long)]
+        ///
+        /// Incompatible with `--resume` / `--resume-latest`, rejected at parse
+        /// time. `run_with_dag` takes no resume arguments and its sub-runner
+        /// passes `None` for both, so the combination used to run every
+        /// pipeline FRESH while reporting success — the #1543 fail-open shape,
+        /// on the widest-blast-radius path. Same reasoning as the `--var` and
+        /// `--models` bails below; `--watch` already names both flags.
+        #[arg(long, conflicts_with_all = ["resume", "resume_latest"])]
         dag: bool,
 
         /// Caller-supplied opaque key used to dedup this run against prior
@@ -4988,6 +5000,61 @@ mod tests {
                 .join()
                 .expect("parser thread panicked")
         })
+    }
+
+    /// `--dag` drops the resume flags on the floor: `run_with_dag` takes no
+    /// resume arguments and `default_sub_runner` passes `None` / `false` for
+    /// both, so `rocky run --dag --resume-latest` used to exit 0 having rebuilt
+    /// every pipeline from scratch — #1543's fail-open shape on the widest
+    /// path. Both spellings, on both `run` and `plan`, must now fail at parse
+    /// time; `--dag` on its own still parses.
+    #[test]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "expects a PARSE FAILURE, which the Cli-returning helper cannot express; the \
+                  call already runs on an 8 MB spawned thread"
+    )]
+    fn dag_conflicts_with_the_resume_flags() {
+        for conflicting in [
+            vec!["rocky", "run", "--dag", "--resume-latest"],
+            vec!["rocky", "run", "--dag", "--resume", "run-1"],
+            vec!["rocky", "plan", "--dag", "--resume-latest"],
+            vec!["rocky", "plan", "--dag", "--resume", "run-1"],
+        ] {
+            let parsed = std::thread::scope(|s| {
+                let owned: Vec<String> = conflicting.iter().map(ToString::to_string).collect();
+                std::thread::Builder::new()
+                    .stack_size(8 * 1024 * 1024)
+                    .spawn_scoped(s, move || Cli::try_parse_from(&owned).is_ok())
+                    .expect("spawn parser thread")
+                    .join()
+                    .expect("parser thread panicked")
+            });
+            assert!(!parsed, "{conflicting:?} must be a clap conflict");
+        }
+
+        // Positive control: the conflict must not have made `--dag` itself
+        // unusable, and a resume without `--dag` still parses.
+        let cli = try_parse_with_big_stack(&["rocky", "run", "--dag"]);
+        let Command::Run {
+            dag,
+            resume,
+            resume_latest,
+            ..
+        } = cli.command
+        else {
+            panic!("expected the run command");
+        };
+        assert!(dag && resume.is_none() && !resume_latest);
+
+        let cli = try_parse_with_big_stack(&["rocky", "run", "--resume-latest"]);
+        let Command::Run {
+            dag, resume_latest, ..
+        } = cli.command
+        else {
+            panic!("expected the run command");
+        };
+        assert!(resume_latest && !dag);
     }
 
     fn parse_run_idempotency_key(args: &[&str]) -> Option<String> {


### PR DESCRIPTION
## Summary

`--dag` accepted `--resume` / `--resume-latest` and dropped them on the floor. #1544 closed every other fail-open resume path in #1543; this closes the last one, on the widest-blast-radius path.

`run_with_dag` has no resume parameters, and `default_sub_runner` passes `None` / `false` for both. So the flags never reached a sub-run, and nothing rejected the combination.

Reproduced on `fef0da93` (the merged #1544), with the #1543 config verbatim:

```
$ rocky --state-path state.redb run --resume never-recorded
Error: cannot resume run 'never-recorded': no progress found      # exit 1, correct

$ rocky --state-path state.redb run --dag --resume never-recorded
Copied 1 tables in 0.1s (run_id: run-20260829-183807-871)          # exit 0, fail-open
```

The second command materialized `repro.staging__orders.one` as a fresh run. `--dag` runs every configured pipeline, so it was the widest path left open.

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [x] Cross-project (CI, scripts, root docs)

## Changes

- Reject `--dag` with either resume flag at parse time, on both `rocky run` and `rocky plan`. This mirrors the `--watch` declaration, which already names both flags for the same reason.
- Refuse a persisted `RunPlan` carrying both in `validate_run_plan_execution_shape`, ahead of the config load. Clap only covers new invocations; a plan is on-disk JSON an older binary may have written. Same shape as the `dag && model` rejection from #1173.
- Extend the backfill compose-time tripwire to the new shape, so `build_run_plan` growing a resume field fails the test that points at the apply arm.
- Reject `--resume <id>` together with `--resume-latest`, at parse time and on a persisted plan. `resolve_resume_progress` checks `resume_latest` first, so passing both silently discarded the run id the operator named and recovered a different run. Same two-sided treatment as the `--dag` pair, for the same reason.
- Correct the resume docs. The paragraph #1544 added said other pipeline types and mixed runs "reject them", which a reader takes to cover `--dag`. It now names `--dag`, and states the recovery constraint plainly: `--all` and `--models` both re-run the replication phase before the model phase, so there is no command that picks up after a resumed replication. The split recipe only works when models live in their own transformation pipeline, and the page now says so.
- Record the whole #1543 behavior change in `engine/CHANGELOG.md` under Unreleased, including the upgrade note: a command that used to exit 0 having rebuilt everything now exits non-zero.
- Correct two root-level docs that were already wrong. `ROCKY_EXPLAINED.md` said resume skips the *models* that already completed — it skips tables, and a transformation pipeline now refuses the flag. `AGENT_REVIEW.md`'s executor invariant described resume without saying it is replication-only, which is the property a reviewer has to check.

## Why the existing precedent settles this

The repo already treats "the DAG runner drops this flag" as a bug to reject:

| Flag | Dropped by `--dag`? | Rejected before this PR? |
|---|---|---|
| `--var` | yes | yes, runtime bail (`main.rs`) |
| `--models` | yes | yes, runtime bail (`main.rs`) |
| `--model` | yes | yes, plan + apply time (`apply.rs`) |
| `--resume` / `--resume-latest` | yes | **no** |

## Test Plan

- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt -- --check`: passes.
- `cargo nextest run --all-features` over every resume and dag-shape test: 23 passed, 0 failed. Includes the pre-existing `plan_accepts_resume_latest`, which proves the new conflict did not break a plain `--resume-latest`.
- Mutation-checked both new tests via `scripts/mutation-check.sh`, on a clean tree, baseline passing first:
  - remove `conflicts_with_all` from the `run` `dag` arg → `dag_conflicts_with_the_resume_flags` fails with `["rocky", "run", "--dag", "--resume-latest"] must be a clap conflict`.
  - short-circuit the apply guard to `false && …` → `persisted_resume_and_dag_plan_is_refused_before_config_load` fails with `--resume must name the contradictory persisted flags`.
- Rebuilt the binary and re-ran the repro end to end:

```
run --dag --resume-latest             -> exit 2, "the argument '--dag' cannot be used with '--resume-latest'"
run --dag --resume never-recorded     -> exit 2
plan --dag --resume-latest            -> exit 2
run --dag                (control)    -> exit 0, materializes normally
run --resume-latest      (control)    -> exit 1, "cannot resume the latest run: no progress found"
```

  Nothing was materialized by any of the three rejected forms.
- After the review fixes, re-verified on the rebuilt binary: `run --resume run-A --resume-latest` and `plan --resume run-A --resume-latest` both exit 2 with `the argument '--resume <RESUME>' cannot be used with '--resume-latest'`; each selector alone still parses through to the run; the `--dag` rejection still holds.
- No `JsonSchema`-deriving struct is touched, so no schema or binding drift is possible; `codegen-drift` confirms.

## What I am least confident about

Whether rejecting `FreshStart` state authority (from #1544, not changed here) is too strict for a remote `[state]` backend when a pod dies before its first periodic upload. Reading the code, `publish_merged`'s `Absent` arm already resets the replicated tables in the local file, so `run_progress` is empty by the time resume looks — the refusal changes the error message, not the outcome. That is worth a second pair of eyes.

Separately: #1549's colliding-target case is the one finding here I have **not** exercised end to end. I confirmed `TableProgress.table_key` is the target full name and that `RunProgress` carries no scope, which is what makes the collision reachable, but I did not build the two-pipeline fixture that would demonstrate the wrong tables being skipped. That fixture is the first thing to write on that issue.

## What I may be missing

Whether any caller intentionally relied on `--dag --resume-latest` as "resume what you can, rebuild the rest". Nothing in the repo, the SDK, or the docs uses that combination, and the SDK's `resume_run()` sends neither `--dag` nor `--models`. But an operator script would be invisible to that search, which is why the CHANGELOG carries the upgrade note and the docs give the two-command replacement.

## Independent review

Codex (GPT-5) reviewed the branch adversarially and returned BLOCK with five findings. I reproduced all five against the source and a built binary before acting on any of them — none is relayed on the reviewer's word.

Two were defects in this branch and are fixed above:

- **Both resume selectors accepted.** `rocky run --resume run-A --resume-latest` parsed and dropped `run-A`. Now rejected at parse time and on a persisted plan.
- **The recovery snippet I added was wrong.** It said to resume replication and then run `rocky run --all`. Measured on a DuckDB project: the resume reports `tables_skipped: 1, tables_copied: 0`, and the follow-up `--all` reports `tables_copied: 1` — it re-copied exactly what the resume had skipped. `--models <dir>` does the same. Snippet replaced with the constraint stated plainly.

Three are pre-existing and filed rather than folded in, to keep this diff to one defect class:

- **#1548** — `--resume-latest` selects the latest run by start time regardless of status, so resuming after a *successful* run skips every table and exits 0 having copied nothing. The help text says "most recent failed run".
- **#1549** — `RunProgress` records no pipeline scope, so `--resume-latest` is project-global. With disjoint targets that yields a misleading `resumed_from`; with colliding target templates it skips tables on another pipeline's progress.
- **#1550** — `rocky plan`'s default-subcommand args are accepted and dropped when a subcommand follows (`rocky plan --shadow promote <branch>` parses and promotes to production). Not resume-specific; the whole flag set is affected.

Two findings the reviewer raised survived: the backfill apply arm genuinely reads only `models_dir`, `models`, `partition_from`, `partition_to`, `parallel`, `env` — I enumerated them independently — and both new test loops exercise distinct fields.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/), scoped by subproject
- [x] No `Co-Authored-By` trailers
- [x] Not a CLI JSON schema or DSL syntax change

### Engine (`engine/`)

- [x] Tests pass. Locally this was a filtered run (`-E` over every resume and dag-shape test, 23 passed / 6626 skipped) plus a full `--all-targets --all-features` clippy compile; the unfiltered suite is the CI `Test` job, and this PR does not merge until it is green.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo fmt --check` passes
