### PR TITLE
fix: name the command that runs the declared assertions, and put the skill under engine CI

### DIFF
--- a/.agents/skills/rocky-ai-workflow/SKILL.md
+++ b/.agents/skills/rocky-ai-workflow/SKILL.md
@@ -28,7 +28,7 @@ Write models as **raw SQL** (`models/<name>.sql` + a `<name>.toml` sidecar for m
 
 5. **Preview the SQL.** Run `rocky plan` to see exactly what would execute. Read it. Confirm the generated SQL matches your intent.
 
-6. **Test.** Run `rocky test` to exercise assertions (uniqueness, not-null, accepted values, ranges). Add or strengthen assertions that encode what you learned from sampling — they become the contract that protects the model from future drift.
+6. **Test.** Run `rocky test` to compile, seed and materialize the models, and to run any `[[test]]` fixture blocks. Then run `rocky test --declarative` to evaluate the declared assertions (uniqueness, not-null, accepted values, ranges) — plain `rocky test` does not run those. Add or strengthen assertions that encode what you learned from sampling — they become the contract that protects the model from future drift.
 
 ## Shipping safely: propose → review → apply
 

--- a/.claude/skills/rocky-ai-workflow/SKILL.md
+++ b/.claude/skills/rocky-ai-workflow/SKILL.md
@@ -28,7 +28,7 @@ Write models as **raw SQL** (`models/<name>.sql` + a `<name>.toml` sidecar for m
 
 5. **Preview the SQL.** Run `rocky plan` to see exactly what would execute. Read it. Confirm the generated SQL matches your intent.
 
-6. **Test.** Run `rocky test` to exercise assertions (uniqueness, not-null, accepted values, ranges). Add or strengthen assertions that encode what you learned from sampling — they become the contract that protects the model from future drift.
+6. **Test.** Run `rocky test` to compile, seed and materialize the models, and to run any `[[test]]` fixture blocks. Then run `rocky test --declarative` to evaluate the declared assertions (uniqueness, not-null, accepted values, ranges) — plain `rocky test` does not run those. Add or strengthen assertions that encode what you learned from sampling — they become the contract that protects the model from future drift.
 
 ## Shipping safely: propose → review → apply
 

--- a/.github/workflows/engine-ci.yml
+++ b/.github/workflows/engine-ci.yml
@@ -6,12 +6,24 @@ on:
     paths:
       - 'engine/**'
       - 'schemas/**'
+      # Compiled INTO the binary: rocky-mcp `include_str!`s this skill as the
+      # MCP `instructions` (crates/rocky-mcp/src/tools.rs). Editing it changes
+      # what `rocky mcp` serves, and renaming or deleting it fails the build —
+      # so it needs engine CI, and without it the five required contexts never
+      # run and the PR cannot merge at all (#1557).
+      - '.claude/skills/rocky-ai-workflow/SKILL.md'
       - '.github/workflows/engine-ci.yml'
   pull_request:
     branches: [main]
     paths:
       - 'engine/**'
       - 'schemas/**'
+      # Compiled INTO the binary: rocky-mcp `include_str!`s this skill as the
+      # MCP `instructions` (crates/rocky-mcp/src/tools.rs). Editing it changes
+      # what `rocky mcp` serves, and renaming or deleting it fails the build —
+      # so it needs engine CI, and without it the five required contexts never
+      # run and the PR cannot merge at all (#1557).
+      - '.claude/skills/rocky-ai-workflow/SKILL.md'
       - '.github/workflows/engine-ci.yml'
 
 # CI only reads the repo; restrict the token to the minimum (CodeQL ql-for-actions).

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -5429,6 +5429,34 @@ mod tests {
     /// named as NOT available, the hand-off named as the ending) and serves
     /// the skill text below it UNCHANGED; the default profile serves the
     /// skill text verbatim, byte-identical to the compiled file.
+    /// Every `paths:` list in a workflow, as its quoted entries. Enough YAML
+    /// to check a trigger filter without taking a parser dependency: a
+    /// `paths:` line, then the `- '...'` entries indented under it.
+    fn workflow_path_lists(workflow: &str) -> Vec<Vec<String>> {
+        let mut lists = Vec::new();
+        let mut lines = workflow.lines().peekable();
+        while let Some(line) = lines.next() {
+            if line.trim() != "paths:" {
+                continue;
+            }
+            let mut entries = Vec::new();
+            while let Some(next) = lines.peek() {
+                let t = next.trim();
+                if t.starts_with('#') {
+                    lines.next();
+                    continue;
+                }
+                let Some(value) = t.strip_prefix("- ") else {
+                    break;
+                };
+                entries.push(value.trim_matches('\'').trim_matches('"').to_string());
+                lines.next();
+            }
+            lists.push(entries);
+        }
+        lists
+    }
+
     /// `include_str!` reaches OUT of `engine/` for the AI-workflow skill, so
     /// that file is part of the engine build: editing it changes what `rocky
     /// mcp` serves, and renaming or deleting it fails compilation.
@@ -5462,14 +5490,30 @@ mod tests {
                 repo_root.join(repo_relative).exists(),
                 "include_str! names a file that does not exist: {repo_relative}"
             );
-            assert!(
-                workflow.contains(repo_relative),
-                "`{repo_relative}` is compiled into the engine but is not in \
-                 engine-ci.yml's path filters. The required checks would never \
-                 run for a change to it, so the change gets no engine CI AND \
-                 cannot merge (#1557). Add it to BOTH the push and \
-                 pull_request `paths` lists."
+            // EVERY `paths:` list, not merely one of them. `engine-ci.yml`
+            // carries two — `push` and `pull_request` — and a path present in
+            // only one still misses half the trigger. `contains` over the whole
+            // file would pass on a single occurrence; mutation-checking this
+            // test by deleting one of the two proved exactly that.
+            let lists = workflow_path_lists(&workflow);
+            assert_eq!(
+                lists.len(),
+                2,
+                "expected engine-ci.yml to carry a `paths:` list for both `push` \
+                 and `pull_request`; found {}. If the triggers changed, this \
+                 guard needs to change with them.",
+                lists.len()
             );
+            for (n, list) in lists.iter().enumerate() {
+                assert!(
+                    list.iter().any(|entry| entry == repo_relative),
+                    "`{repo_relative}` is compiled into the engine but is missing \
+                     from engine-ci.yml `paths:` list {n}. The required checks \
+                     would never run for a change to it, so the change gets no \
+                     engine CI AND cannot merge (#1557). It must be in BOTH the \
+                     push and pull_request lists."
+                );
+            }
             checked += 1;
         }
 

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -5429,6 +5429,59 @@ mod tests {
     /// named as NOT available, the hand-off named as the ending) and serves
     /// the skill text below it UNCHANGED; the default profile serves the
     /// skill text verbatim, byte-identical to the compiled file.
+    /// `include_str!` reaches OUT of `engine/` for the AI-workflow skill, so
+    /// that file is part of the engine build: editing it changes what `rocky
+    /// mcp` serves, and renaming or deleting it fails compilation.
+    ///
+    /// `engine-ci.yml` must watch every such path. A check that never runs is
+    /// never satisfied — and because `Test`, `Clippy`, `Format`, `Adapter
+    /// boundary` and the codegen check are REQUIRED contexts, a path the filter
+    /// misses does not merely skip CI, it blocks the merge outright (#1557).
+    #[test]
+    fn every_out_of_tree_include_is_watched_by_engine_ci() {
+        let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let repo_root = manifest
+            .join("../../..")
+            .canonicalize()
+            .expect("repo root from the crate manifest");
+        let src = std::fs::read_to_string(manifest.join("src/tools.rs")).expect("read tools.rs");
+        let workflow = std::fs::read_to_string(repo_root.join(".github/workflows/engine-ci.yml"))
+            .expect("read engine-ci.yml");
+
+        // Paths that climb above `engine/` — `src/` is three levels below the
+        // repo root, so four or more `../` escapes the engine tree.
+        let mut checked = 0;
+        for (at, _) in src.match_indices("include_str!(\"") {
+            let rest = &src[at + "include_str!(\"".len()..];
+            let path = &rest[..rest.find('"').expect("unterminated include_str! path")];
+            if !path.starts_with("../../../../") {
+                continue;
+            }
+            let repo_relative = path.trim_start_matches("../");
+            assert!(
+                repo_root.join(repo_relative).exists(),
+                "include_str! names a file that does not exist: {repo_relative}"
+            );
+            assert!(
+                workflow.contains(repo_relative),
+                "`{repo_relative}` is compiled into the engine but is not in \
+                 engine-ci.yml's path filters. The required checks would never \
+                 run for a change to it, so the change gets no engine CI AND \
+                 cannot merge (#1557). Add it to BOTH the push and \
+                 pull_request `paths` lists."
+            );
+            checked += 1;
+        }
+
+        // A zero here would pass vacuously — the assertion above never runs if
+        // the scan finds nothing, which is exactly how this guard would rot.
+        assert!(
+            checked > 0,
+            "found no out-of-tree include_str! paths to check — the scan broke, \
+             or the coupling moved and this test now proves nothing"
+        );
+    }
+
     #[test]
     fn instructions_carry_the_worker_banner_and_stay_verbatim_by_default() {
         let default_info = server_with(McpProfile::Default).get_info();


### PR DESCRIPTION
Two coupled defects on the same file. The second was found because the first could not merge.

## 1. The skill named a command that does not run what it promises

`.claude/skills/rocky-ai-workflow/SKILL.md:31` (and its byte-identical `.agents/` mirror) said:

> **Test.** Run `rocky test` to exercise assertions (uniqueness, not-null, accepted values, ranges).

Those four are the **declarative** check types. Only `rocky test --declarative` runs them, through `run_declarative_tests`. The code says so at `engine/crates/rocky-cli/src/commands/test.rs:270`.

```
 rocky test                compile + seed + materialize + [[test]] fixtures
 rocky test --declarative  the declared checks: unique, not-null,
                           accepted values, row-count range
```

This file is `include_str!`d into `rocky-mcp` and served as the MCP `instructions`. An agent following it ran `rocky test`, saw green, and reported the assertions passed. They were never evaluated.

## 2. That same file was outside engine CI's path filter (#1557)

`engine-ci.yml` watched only `engine/**`, `schemas/**` and itself. The skill is compiled into the binary, so this broke both ways:

- **No engine check ran** on a change that alters the binary. A rename or delete would fail compilation with no PR check to catch it.
- **The PR could not merge.** `Test`, `Clippy`, `Format`, `Adapter boundary` and the codegen check are *required* contexts. A check that never runs is never satisfied, so this PR sat at `BLOCKED` with zero failures and zero pending.

The path now joins **both** the `push` and `pull_request` filters.

## The guard

A test in `rocky-mcp` scans `tools.rs` for `include_str!` paths that climb above `engine/`, and requires each to exist and to appear in every `paths:` list in the workflow. It refuses to pass vacuously: finding no such paths fails, because a scan that silently matches nothing is how this guard would rot.

**Mutation-checked, and the check earned its keep.** The first version of the test used `workflow.contains(...)`, which a single occurrence anywhere in the file satisfies. Deleting the path from just the `push` block left it green — its own message said "add it to BOTH lists" while the assertion checked neither specifically. The test now extracts each `paths:` list separately and pins that there are exactly two. Re-run after the fix: `mutation-check: OK — the test failed under mutation`.

## Note on the issue's warning

#1532 warned that the worker projection pins the edited line verbatim as a rewrite needle. That is stale — the worker profile now serves `WORKER_INSTRUCTIONS_BANNER` plus the instructions verbatim (`tools.rs:4188`), and a repo-wide search for the old sentence returns only the two `SKILL.md` files.

Closes #1532
Closes #1557