### PR TITLE
fix(engine): refuse when the policy cannot be read, instead of allowing

### DIFF
--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -1148,6 +1148,18 @@ pub enum PolicyGate {
     /// (AiAuthored → require a review marker; Run/Promote → ungated), so
     /// absent-`[policy]` behaviour is byte-identical to today.
     NotConfigured,
+    /// The config could not be READ, so whether a `[policy]` block exists is
+    /// unknown. Distinct from [`PolicyGate::NotConfigured`] on purpose: "there
+    /// is no policy" and "we could not find out" are different answers, and
+    /// only the first is permission.
+    ///
+    /// Every consumer must refuse on this. Collapsing it into the
+    /// `NotConfigured | Allow` arm is what let a configured `deny` stop denying
+    /// when an unrelated `${VAR}` was unset (#1559).
+    Unloadable {
+        /// Why the config could not be read, for the refusal message.
+        reason: String,
+    },
     /// Every touched model resolved to `allow`. Proceed without a marker.
     Allow,
     /// The most-restrictive effect is `require_review`. A human review marker
@@ -1508,9 +1520,10 @@ pub fn evaluate_apply_policy(
     // the pre-gate sync decision, so the sync-guard and this gate can never
     // disagree about whether `[policy]` is configured (finding A — config-snapshot
     // TOCTOU).
-    let policy = rocky_core::config::load_rocky_config(config_path)
-        .ok()
-        .and_then(|cfg| cfg.policy);
+    let policy = match load_policy_for_gate(config_path) {
+        Ok(policy) => policy,
+        Err(reason) => return PolicyGate::Unloadable { reason },
+    };
     evaluate_apply_policy_with_policy(
         policy.as_ref(),
         plan_id,
@@ -1581,6 +1594,28 @@ pub(crate) fn evaluate_apply_policy_with_policy_matching(
     )
 }
 
+/// Load the `[policy]` block for a gate decision, distinguishing "no config
+/// file" from "the config could not be read".
+///
+/// `Ok(None)` means there is genuinely no project config — the standalone case,
+/// which keeps the pre-policy-plane posture. `Err` means the file exists and
+/// did not load, so any `[policy]` block in it is unknown and unenforceable.
+///
+/// This is the shape `rocky gc` already uses at its own seam (`gc.rs:1661`),
+/// with the comment that says why: a config-load error "would otherwise
+/// silently unenforce a possibly-configured `[policy]` block". That reasoning
+/// was never applied to the shared gate, which swallowed the error with `.ok()`
+/// and reported `NotConfigured` — indistinguishable from permission (#1559).
+fn load_policy_for_gate(
+    config_path: &Path,
+) -> Result<Option<rocky_core::config::PolicyConfig>, String> {
+    match rocky_core::config::load_rocky_config(config_path) {
+        Ok(cfg) => Ok(cfg.policy),
+        Err(rocky_core::config::ConfigError::FileNotFound { .. }) => Ok(None),
+        Err(e) => Err(format!("{e}")),
+    }
+}
+
 /// [`evaluate_apply_policy`] evaluated over BOTH the pre-image and the
 /// post-image classification state, returning the most restrictive verdict.
 ///
@@ -1607,9 +1642,10 @@ pub fn evaluate_apply_policy_with_extra_classifications(
     marker_freezes: &[rocky_core::freeze_marker::ActiveMarkerFreeze],
     prior_classifications: &BTreeMap<String, Vec<String>>,
 ) -> PolicyGate {
-    let policy = rocky_core::config::load_rocky_config(config_path)
-        .ok()
-        .and_then(|cfg| cfg.policy);
+    let policy = match load_policy_for_gate(config_path) {
+        Ok(policy) => policy,
+        Err(reason) => return PolicyGate::Unloadable { reason },
+    };
     evaluate_apply_policy_with_policy_matching_dual(
         policy.as_ref(),
         plan_id,
@@ -2096,6 +2132,10 @@ fn gate_rank(gate: &PolicyGate) -> u8 {
         PolicyGate::Allow => policy::effect_rank(PolicyEffect::Allow),
         PolicyGate::RequireReview { .. } => policy::effect_rank(PolicyEffect::RequireReview),
         PolicyGate::Deny { .. } => policy::effect_rank(PolicyEffect::Deny),
+        // Above `Deny`: an unreadable config might have denied, and the
+        // aggregate keeps the MOST restrictive outcome. Ranking it any lower
+        // would let a readable `allow` on another model out-vote it.
+        PolicyGate::Unloadable { .. } => u8::MAX,
     }
 }
 
@@ -3166,6 +3206,14 @@ pub(crate) async fn gate_maintenance_apply(
 pub(crate) fn apply_policy_gate(root: &Path, plan_id: &str, gate: PolicyGate) -> Result<()> {
     match gate {
         PolicyGate::NotConfigured | PolicyGate::Allow => Ok(()),
+        // NOT grouped with the arm above. A config that would not load may well
+        // carry a `[policy]` block that denies this exact plan; proceeding
+        // would enforce nothing while reporting success (#1559).
+        PolicyGate::Unloadable { reason } => Err(anyhow::anyhow!(
+            "refusing to apply plan '{plan_id}': the project config failed to load, so any \
+             configured [policy] rules cannot be enforced (fail-closed). Fix the config and \
+             re-run. Cause: {reason}"
+        )),
         PolicyGate::RequireReview {
             model,
             rule_id,
@@ -4719,6 +4767,96 @@ pub async fn run_apply_inline_for_run(
 
 #[cfg(test)]
 mod tests {
+
+    // ---- the policy gate fails closed on an unreadable config (#1559) ----
+
+    /// A config that EXISTS but does not load must not read as "no policy
+    /// configured". Those are different answers and only the first is
+    /// permission — a configured `deny` used to stop denying when an unrelated
+    /// `${VAR}` was unset.
+    #[test]
+    fn an_unreadable_config_is_unloadable_not_notconfigured() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = dir.path().join("rocky.toml");
+        // Parses as a file, fails to LOAD: the variable is not set.
+        std::fs::write(
+            &cfg,
+            "[adapter]\ntype = \"databricks\"\nhost = \"${ROCKY_T_UNSET_1559}\"\n\
+             \n[policy]\nversion = 1\ndefault_agent_effect = \"deny\"\n",
+        )
+        .unwrap();
+
+        let gate = evaluate_apply_policy(
+            &cfg,
+            "plan-1",
+            PolicyPrincipal::Agent,
+            &BTreeMap::new(),
+            dir.path(),
+            &dir.path().join("state.redb"),
+            &[],
+        );
+        assert!(
+            matches!(gate, PolicyGate::Unloadable { .. }),
+            "an unreadable config must be Unloadable, not {gate:?}"
+        );
+
+        // And the gate must refuse it rather than proceeding.
+        let refused = apply_policy_gate(dir.path(), "plan-1", gate);
+        assert!(
+            refused.is_err(),
+            "an unreadable policy must refuse the apply"
+        );
+    }
+
+    /// A genuinely ABSENT config keeps the pre-policy-plane posture. Without
+    /// this, failing closed on an unreadable config would also break every
+    /// standalone `rocky compile --models …` project that has no rocky.toml.
+    #[test]
+    fn a_missing_config_is_still_notconfigured() {
+        let dir = tempfile::tempdir().unwrap();
+        let gate = evaluate_apply_policy(
+            &dir.path().join("does-not-exist.toml"),
+            "plan-1",
+            PolicyPrincipal::Agent,
+            &BTreeMap::new(),
+            dir.path(),
+            &dir.path().join("state.redb"),
+            &[],
+        );
+        assert!(
+            matches!(gate, PolicyGate::NotConfigured),
+            "an absent config must stay NotConfigured, not {gate:?}"
+        );
+        assert!(apply_policy_gate(dir.path(), "plan-1", gate).is_ok());
+    }
+
+    /// Aggregation must not lose an `Unloadable`. It ranks above `Deny`, so a
+    /// readable `allow` on another model cannot out-vote it.
+    #[test]
+    fn unloadable_outranks_every_other_gate() {
+        let unloadable = PolicyGate::Unloadable {
+            reason: "boom".to_string(),
+        };
+        for other in [
+            PolicyGate::NotConfigured,
+            PolicyGate::Allow,
+            PolicyGate::RequireReview {
+                model: "m".into(),
+                rule_id: None,
+                reason: "r".into(),
+            },
+            PolicyGate::Deny {
+                model: "m".into(),
+                rule_id: None,
+                reason: "r".into(),
+            },
+        ] {
+            assert!(
+                gate_rank(&unloadable) > gate_rank(&other),
+                "Unloadable must outrank {other:?}"
+            );
+        }
+    }
     use super::*;
     use crate::output::{ReplicationTableSnapshot, RunPlan};
     use crate::plan_store::write_plan;

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -1606,14 +1606,21 @@ pub(crate) fn evaluate_apply_policy_with_policy_matching(
 /// silently unenforce a possibly-configured `[policy]` block". That reasoning
 /// was never applied to the shared gate, which swallowed the error with `.ok()`
 /// and reported `NotConfigured` — indistinguishable from permission (#1559).
-fn load_policy_for_gate(
+pub(crate) fn load_config_for_gate(
     config_path: &Path,
-) -> Result<Option<rocky_core::config::PolicyConfig>, String> {
+) -> Result<Option<rocky_core::config::RockyConfig>, String> {
     match rocky_core::config::load_rocky_config(config_path) {
-        Ok(cfg) => Ok(cfg.policy),
+        Ok(cfg) => Ok(Some(cfg)),
         Err(rocky_core::config::ConfigError::FileNotFound { .. }) => Ok(None),
         Err(e) => Err(format!("{e}")),
     }
+}
+
+/// [`load_config_for_gate`], narrowed to the `[policy]` block.
+fn load_policy_for_gate(
+    config_path: &Path,
+) -> Result<Option<rocky_core::config::PolicyConfig>, String> {
+    Ok(load_config_for_gate(config_path)?.and_then(|cfg| cfg.policy))
 }
 
 /// [`evaluate_apply_policy`] evaluated over BOTH the pre-image and the

--- a/engine/crates/rocky-cli/src/commands/fulfill_api.rs
+++ b/engine/crates/rocky-cli/src/commands/fulfill_api.rs
@@ -142,6 +142,13 @@ pub enum ProposeError {
     /// reason).
     #[error("failed to list durable freeze markers before the policy gate: {0}")]
     MarkerList(String),
+    /// The project config exists but could not be read, so any configured
+    /// `[policy]` rules cannot be evaluated (fail-closed).
+    #[error(
+        "the project config failed to load, so any configured [policy] rules cannot be \
+         enforced (fail-closed). Fix the config and re-run. Cause: {0}"
+    )]
+    PolicyUnreadable(String),
     /// Persisting the gated plan failed.
     #[error("failed to write AI-authored plan: {0}")]
     PlanWrite(String),
@@ -378,7 +385,16 @@ pub async fn propose_governed_run_plan(
     // freeze-gate sync decision and the policy gate, so a `rocky.toml`
     // swap between the two can't let the guard skip the sync while the
     // gate then reads stale local decisions.
-    let cfg = rocky_core::config::load_rocky_config(config_path).ok();
+    //
+    // Fail-closed on a load ERROR. `.ok()` here discarded it, so an unreadable
+    // config produced `None`, the gate below saw no `[policy]`, and a plan a
+    // configured `deny` forbids was persisted anyway. The gate's own
+    // `Unloadable` arm does NOT catch this: `evaluate_apply_policy_with_policy`
+    // is handed the policy directly and never loads a config, so it can never
+    // report `Unloadable` itself. The refusal has to happen HERE, at the read.
+    // A genuinely absent config still yields `None` and the pre-policy posture.
+    let cfg =
+        super::apply::load_config_for_gate(config_path).map_err(ProposeError::PolicyUnreadable)?;
     // Pull the authoritative remote freeze/budget ledger BEFORE the
     // policy gate reads it, so an active cross-pod freeze denies the
     // propose instead of persisting a plan a later apply would refuse.
@@ -854,6 +870,57 @@ pub use crate::plan_store::EmbeddedCapabilities as ProposeCapabilities;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A propose must refuse when the config exists but cannot be read: any
+    /// `[policy]` block in it is then unenforceable, and writing an
+    /// AI-authored plan under an unknown policy is the fail-open #1559 is
+    /// about.
+    ///
+    /// This does NOT go through the gate's `Unloadable` arm.
+    /// `evaluate_apply_policy_with_policy` is handed the policy directly and
+    /// never loads a config, so it can never report `Unloadable` itself — the
+    /// refusal has to happen at the read. That is exactly why the first
+    /// version of this fix was inert: it added the arm and left the `.ok()`.
+    #[tokio::test]
+    async fn propose_refuses_when_the_config_cannot_be_read() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let models_dir = root.join("models");
+        write_file(&models_dir.join("orders.sql"), b"SELECT 1 AS id\n");
+        write_file(
+            &models_dir.join("orders.toml"),
+            b"[strategy]\ntype = \"full_refresh\"\n[target]\ncatalog = \"\"\nschema = \"main\"\n",
+        );
+        // Parses as TOML, fails to LOAD: the variable is not set.
+        let config_path = root.join("rocky.toml");
+        write_file(
+            &config_path,
+            b"[adapter]\ntype = \"duckdb\"\npath = \"${ROCKY_T_UNSET_1559_PROPOSE}\"\n\
+              \n[policy]\nversion = 1\ndefault_agent_effect = \"deny\"\n",
+        );
+
+        let outcome = propose_governed_run_plan(ProposeRequest {
+            root,
+            config_path: &config_path,
+            models_dir: &models_dir,
+            state_path: &root.join("state.redb"),
+            model: Some("orders".to_string()),
+            product: None,
+            idempotency_key: None,
+        })
+        .await;
+
+        assert!(
+            matches!(outcome, Err(ProposeError::PolicyUnreadable(_))),
+            "an unreadable config must refuse the propose, got: {outcome:?}"
+        );
+        // And nothing may be persisted.
+        let plans = root.join(".rocky").join("plans");
+        let written = std::fs::read_dir(&plans)
+            .map(|d| d.filter_map(std::result::Result::ok).count())
+            .unwrap_or(0);
+        assert_eq!(written, 0, "a refused propose must not persist a plan");
+    }
 
     fn write_file(path: &Path, bytes: &[u8]) {
         if let Some(parent) = path.parent() {

--- a/engine/crates/rocky-cli/src/commands/fulfill_api.rs
+++ b/engine/crates/rocky-cli/src/commands/fulfill_api.rs
@@ -426,6 +426,13 @@ pub async fn propose_governed_run_plan(
     };
 
     match gate {
+        // Separate from the permissive arm: an unreadable config leaves any
+        // configured `[policy]` unenforceable, and a propose that writes a plan
+        // under an unknown policy is exactly the fail-open #1559 describes.
+        super::PolicyGate::Unloadable { reason } => Err(ProposeError::PlanWrite(format!(
+            "the project config failed to load, so any configured [policy] rules cannot be \
+             enforced (fail-closed). Fix the config and re-run. Cause: {reason}"
+        ))),
         super::PolicyGate::NotConfigured | super::PolicyGate::Allow => {
             let plan_id = write_plan()?;
             Ok(ProposeOutcome::Written {

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -2485,7 +2485,8 @@ impl RockyMcpServer {
                 Err(ToolError::policy_denied(
                     format!(
                         "the project config failed to load, so any configured [policy] rules \
-                         cannot be enforced (fail-closed). The draft was not kept. Cause: {reason}"
+                         cannot be enforced (fail-closed). The draft was rolled back. Cause: \
+                         {reason}"
                     ),
                     "Fix the project config so its policy can be read, then retry. Rocky refuses \
                      to author under a policy it cannot evaluate."
@@ -2621,7 +2622,8 @@ impl RockyMcpServer {
                 Err(ToolError::policy_denied(
                     format!(
                         "the project config failed to load, so any configured [policy] rules \
-                         cannot be enforced (fail-closed). The draft was not kept. Cause: {reason}"
+                         cannot be enforced (fail-closed). The draft was rolled back. Cause: \
+                         {reason}"
                     ),
                     "Fix the project config so its policy can be read, then retry. Rocky refuses \
                      to author under a policy it cannot evaluate."
@@ -2774,7 +2776,8 @@ impl RockyMcpServer {
                 Err(ToolError::policy_denied(
                     format!(
                         "the project config failed to load, so any configured [policy] rules \
-                         cannot be enforced (fail-closed). The draft was not kept. Cause: {reason}"
+                         cannot be enforced (fail-closed). The draft was rolled back. Cause: \
+                         {reason}"
                     ),
                     "Fix the project config so its policy can be read, then retry. Rocky refuses \
                      to author under a policy it cannot evaluate."
@@ -2991,7 +2994,8 @@ impl RockyMcpServer {
                 Err(ToolError::policy_denied(
                     format!(
                         "the project config failed to load, so any configured [policy] rules \
-                         cannot be enforced (fail-closed). The draft was not kept. Cause: {reason}"
+                         cannot be enforced (fail-closed). The draft was rolled back. Cause: \
+                         {reason}"
                     ),
                     "Fix the project config so its policy can be read, then retry. Rocky refuses \
                      to author under a policy it cannot evaluate."
@@ -3132,6 +3136,22 @@ impl RockyMcpServer {
                 return Err(ToolError::internal(
                     format!("failed to compute plan id: {inner}"),
                     "Retry the propose; if it persists, verify the project compiles cleanly.",
+                ));
+            }
+            Err(ProposeError::PolicyUnreadable(inner)) => {
+                // policy_denied, not internal: the propose was REFUSED by the
+                // policy plane's fail-closed rule, and the agent must be told
+                // that plainly rather than reading it as a transient fault to
+                // retry (#1559).
+                return Err(ToolError::policy_denied(
+                    format!(
+                        "the project config failed to load, so any configured [policy] rules \
+                         cannot be enforced (fail-closed). No plan was written. Cause: {inner}"
+                    ),
+                    "Fix the project config so its policy can be read, then retry. Rocky refuses \
+                     to propose under a policy it cannot evaluate."
+                        .to_string(),
+                    None,
                 ));
             }
             Err(ProposeError::LedgerDownload(inner)) => {

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -2206,9 +2206,10 @@ impl RockyMcpServer {
     /// frozen agent must not keep minting drafts, so the draft tools consult
     /// the same marker set the propose/apply gates enforce. Bounded by the
     /// shared gate guard (no `[policy]` ⇒ no LIST ⇒ zero behavior change; an
-    /// unloadable config resolves to `NotConfigured` in the gate, so it reads
-    /// no markers either). Fail-closed on a transport failure, mirroring the
-    /// governed apply seams.
+    /// unloadable config resolves to `PolicyGate::Unloadable`, which every
+    /// draft gate refuses — it used to resolve to `NotConfigured` and read no
+    /// markers, which is the fail-open #1559 fixed). Fail-closed on a transport
+    /// failure, mirroring the governed apply seams.
     async fn draft_marker_freezes(
         &self,
         stem: &str,
@@ -2436,6 +2437,9 @@ impl RockyMcpServer {
         // agent authoring into a governed scope gets a structured verdict WITH
         // the write, not later at apply. Absent a `[policy]` block this resolves
         // to `NotConfigured` and behaviour is byte-identical to no policy plane.
+        // A config that EXISTS but fails to load is `Unloadable` instead, and
+        // is refused — "no policy" and "could not read the policy" are
+        // different answers, and only the first is permission (#1559).
         let state_path = self.state_path();
         let touched: std::collections::BTreeMap<String, rocky_core::config::PolicyCapability> =
             std::iter::once((
@@ -2472,6 +2476,23 @@ impl RockyMcpServer {
         );
 
         match gate {
+            // NOT grouped with NotConfigured. A config that failed to LOAD may
+            // carry a `[policy]` block denying exactly this write; treating it
+            // as "no policy configured" is what let a configured deny stop
+            // denying (#1559). The rollback is deliberately NOT defused, so the
+            // draft is removed — matching the `Deny` arm below.
+            rocky_cli::commands::PolicyGate::Unloadable { reason } => {
+                Err(ToolError::policy_denied(
+                    format!(
+                        "the project config failed to load, so any configured [policy] rules \
+                         cannot be enforced (fail-closed). The draft was not kept. Cause: {reason}"
+                    ),
+                    "Fix the project config so its policy can be read, then retry. Rocky refuses \
+                     to author under a policy it cannot evaluate."
+                        .to_string(),
+                    None,
+                ))
+            }
             rocky_cli::commands::PolicyGate::NotConfigured
             | rocky_cli::commands::PolicyGate::Allow => {
                 rollback.defuse();
@@ -2591,6 +2612,23 @@ impl RockyMcpServer {
         // synchronous). Fail-closed; no `[policy]` ⇒ no LIST.
         let marker_freezes = self.draft_marker_freezes(&paths.stem).await?;
         match self.evaluate_draft_policy(&paths.stem, &decision_id, &marker_freezes) {
+            // NOT grouped with NotConfigured. A config that failed to LOAD may
+            // carry a `[policy]` block denying exactly this write; treating it
+            // as "no policy configured" is what let a configured deny stop
+            // denying (#1559). The rollback is deliberately NOT defused, so the
+            // draft is removed — matching the `Deny` arm below.
+            rocky_cli::commands::PolicyGate::Unloadable { reason } => {
+                Err(ToolError::policy_denied(
+                    format!(
+                        "the project config failed to load, so any configured [policy] rules \
+                         cannot be enforced (fail-closed). The draft was not kept. Cause: {reason}"
+                    ),
+                    "Fix the project config so its policy can be read, then retry. Rocky refuses \
+                     to author under a policy it cannot evaluate."
+                        .to_string(),
+                    None,
+                ))
+            }
             rocky_cli::commands::PolicyGate::NotConfigured
             | rocky_cli::commands::PolicyGate::Allow => {
                 rollback.defuse();
@@ -2727,6 +2765,23 @@ impl RockyMcpServer {
         // synchronous). Fail-closed; no `[policy]` ⇒ no LIST.
         let marker_freezes = self.draft_marker_freezes(&paths.stem).await?;
         match self.evaluate_draft_policy(&paths.stem, &decision_id, &marker_freezes) {
+            // NOT grouped with NotConfigured. A config that failed to LOAD may
+            // carry a `[policy]` block denying exactly this write; treating it
+            // as "no policy configured" is what let a configured deny stop
+            // denying (#1559). The rollback is deliberately NOT defused, so the
+            // draft is removed — matching the `Deny` arm below.
+            rocky_cli::commands::PolicyGate::Unloadable { reason } => {
+                Err(ToolError::policy_denied(
+                    format!(
+                        "the project config failed to load, so any configured [policy] rules \
+                         cannot be enforced (fail-closed). The draft was not kept. Cause: {reason}"
+                    ),
+                    "Fix the project config so its policy can be read, then retry. Rocky refuses \
+                     to author under a policy it cannot evaluate."
+                        .to_string(),
+                    None,
+                ))
+            }
             rocky_cli::commands::PolicyGate::NotConfigured
             | rocky_cli::commands::PolicyGate::Allow => {
                 rollback.defuse();
@@ -2927,6 +2982,23 @@ impl RockyMcpServer {
         let decision_id = format!("draft-metadata:{}", paths.stem);
         let marker_freezes = self.draft_marker_freezes(&paths.stem).await?;
         match self.evaluate_draft_policy(&paths.stem, &decision_id, &marker_freezes) {
+            // NOT grouped with NotConfigured. A config that failed to LOAD may
+            // carry a `[policy]` block denying exactly this write; treating it
+            // as "no policy configured" is what let a configured deny stop
+            // denying (#1559). The rollback is deliberately NOT defused, so the
+            // draft is removed — matching the `Deny` arm below.
+            rocky_cli::commands::PolicyGate::Unloadable { reason } => {
+                Err(ToolError::policy_denied(
+                    format!(
+                        "the project config failed to load, so any configured [policy] rules \
+                         cannot be enforced (fail-closed). The draft was not kept. Cause: {reason}"
+                    ),
+                    "Fix the project config so its policy can be read, then retry. Rocky refuses \
+                     to author under a policy it cannot evaluate."
+                        .to_string(),
+                    None,
+                ))
+            }
             rocky_cli::commands::PolicyGate::NotConfigured
             | rocky_cli::commands::PolicyGate::Allow => {
                 rollback.defuse();


### PR DESCRIPTION
A `[policy]` block that could not be **loaded** was reported as "no policy configured", and every consumer treated that the same as `Allow`. A configured **deny** therefore stopped denying.

```rust
// engine/crates/rocky-cli/src/commands/apply.rs
let policy = load_rocky_config(config_path)
    .ok()                      // <- ANY load error becomes None
    .and_then(|cfg| cfg.policy);
```

`None` yields `PolicyGate::NotConfigured`, and the MCP draft tools match `NotConfigured | Allow` in one arm and defuse the rollback — so an agent write a deny rule forbids was **kept on disk**.

```
 configured deny -> config fails to load -> .ok() -> None
                                         -> NotConfigured
                                         -> same arm as Allow -> write persists
```

Reaching it needs only a config that parses but does not load. An unset `${VAR}` will do.

## The fix already existed, at one seam

`rocky gc` had the right shape (`gc.rs:1661`) with a comment saying exactly why:

> a config-load ERROR would otherwise silently unenforce a possibly-configured `[policy]` block. Bail instead. A genuinely-missing config file keeps the NotConfigured posture.

That reasoning was never applied to the shared gate. Both `.ok()` sites now go through one helper with gc's semantics:

| config state | before | after |
|---|---|---|
| no file at all | `NotConfigured` → proceed | **unchanged** — `NotConfigured` → proceed |
| exists, fails to load | `NotConfigured` → **proceed** | `Unloadable` → **refuse** |
| loads, no `[policy]` | `NotConfigured` → proceed | unchanged |

The standalone `rocky compile --models …` case with no `rocky.toml` is deliberately untouched.

## Why a new variant, not a bool

`PolicyGate::Unloadable` makes the compiler name every consumer, because the enum has no `_` arms. It found seven: two apply seams, the fulfill propose seam, and all four MCP draft tools. Every one now refuses.

The draft tools deliberately do **not** defuse the rollback, so the artifact is removed — matching the existing `Deny` arm.

`Unloadable` also ranks above `Deny` in `gate_rank`. An unreadable config might have denied, and the aggregate keeps the most restrictive outcome, so a readable `allow` on another model must not out-vote it.

## Two comments that documented the bug as a feature

`rocky-mcp` carried these, both now corrected:

> an unloadable config resolves to `NotConfigured` in the gate, so it reads no markers either

## Evidence

Three tests: an unreadable config is `Unloadable` and its apply refuses; a genuinely absent config is still `NotConfigured` and still proceeds; `Unloadable` outranks every other gate.

**Fix-sensitive**, checked with `scripts/mutation-check.sh`. Reverting both loads to `.ok()` fails exactly `an_unreadable_config_is_unloadable_not_notconfigured`.

111 apply tests and 32 MCP tests pass. Clippy and fmt clean across the workspace.

## Provenance

Found by independent adversarial review (Codex, a different model) while reviewing #1558, and verified against both call sites before filing. Pre-existing on `main` — the `.ok()` and the shared match arm both predate that PR. **#1558 is blocked on this.**

Closes #1559