### PR TITLE
chore(ci): bump taiki-e/install-action and its allow-list entry together

### DIFF
--- a/.github/scripts/check_credential_containment.py
+++ b/.github/scripts/check_credential_containment.py
@@ -61,7 +61,7 @@ GH_RELEASE_SOURCE = (
     "softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228"
 )
 TAIKI_INSTALL_SOURCE = (
-    "taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1"
+    "taiki-e/install-action@fcf5432d9f50d67e37ee6e29bdb7a224ff67b4a7"
 )
 # Actions a job may run when it is not reachable from a pull request. Release,
 # publish and deployment workflows never execute candidate code, so the

--- a/.github/workflows/engine-ci.yml
+++ b/.github/workflows/engine-ci.yml
@@ -83,7 +83,7 @@ jobs:
           sudo fallocate -l 4G /mnt/swapfile && sudo chmod 600 /mnt/swapfile && sudo mkswap /mnt/swapfile && sudo swapon /mnt/swapfile || true
       - run: sudo apt-get update && sudo apt-get install -y cmake
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
+        uses: taiki-e/install-action@fcf5432d9f50d67e37ee6e29bdb7a224ff67b4a7 # v2.86.8
         with:
           tool: nextest
       # nextest runs all test binaries in one global scheduler instead of

--- a/.github/workflows/engine-release.yml
+++ b/.github/workflows/engine-release.yml
@@ -129,7 +129,7 @@ jobs:
         if: matrix.zigbuild
         # Prebuilt binary — avoids ~35s of `cargo install cargo-zigbuild
         # --locked` (compiles from source) per Linux target.
-        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
+        uses: taiki-e/install-action@fcf5432d9f50d67e37ee6e29bdb7a224ff67b4a7 # v2.86.8
         with:
           tool: cargo-zigbuild
 


### PR DESCRIPTION
Supersedes #1529, which could not pass its own security gate.

## Why Dependabot cannot land this alone

Dependabot bumps the `uses:` pin but not the **allow-list entry** the credential-containment policy checks against, so #1529 failed with:

```
.github/workflows/engine-release.yml: release step action source is not allow-listed
credential-containment policy: 1 violation(s)
```

The allow-list in `check_credential_containment.py` duplicates the SHA **on purpose** — it is the trust anchor. Deriving it from the workflow would make it constrain nothing. So the two have to move together, and Dependabot only knows about one of them.

All three sites move here:

```
 .github/workflows/engine-release.yml       uses: taiki-e/install-action@<sha>
 .github/workflows/engine-ci.yml            uses: taiki-e/install-action@<sha>
 .github/scripts/check_credential_containment.py   the allow-list entry
```

Verified the old SHA `82cd3e76` appears nowhere under `.github/` afterwards, and `check_credential_containment.py` passes locally.

## The pin was verified, not taken on trust

Rather than accepting Dependabot's `# v2.86.8` comment, checked it upstream:

```
$ gh api repos/taiki-e/install-action/git/ref/tags/v2.86.8
commit fcf5432d9f50d67e37ee6e29bdb7a224ff67b4a7
```

A lightweight tag pointing straight at that commit — which is the SHA being pinned.

## Swept for the same drift elsewhere

Compared all 15 allow-listed pins against the 16 distinct pins used across the workflows:

- allow-listed but unused by any workflow: **none**
- any action pinned at two different SHAs across the allow-list and the workflows: **none**

So this was the only drift.

Closes #1529