### PR TITLE
fix(ci): make required engine and codegen contexts always report

### DIFF
--- a/.github/SECURITY_ENVIRONMENTS.md
+++ b/.github/SECURITY_ENVIRONMENTS.md
@@ -68,14 +68,15 @@ choice. Require branches to be up to date before merging, do not grant ordinary
 bypass access, and keep any emergency override limited to named maintainers.
 
 Requiring these two checks is not optional hardening, and the repository's other
-required checks are not a substitute. Every other required context is
-path-filtered on `engine/**`, so a pull request that bundles any engine source
-edit with a hostile `.github` edit reports all of them green. If the containment
-check is merely present-and-red rather than required, GitHub returns a mergeable
-state and the change lands with no override and no administrator involvement. The
-absence of an engine change is likewise not a barrier: a `.github`-only pull
-request leaves the engine contexts pending, which is the same state that ordinary
-docs-only work produces, so it is routinely cleared rather than investigated.
+required checks are not a substitute. The engine contexts run real work only for
+changes that touch engine paths (since #1563 their workflows always report — a
+change-detection job skips the expensive jobs on other changes, so the contexts
+read green either way). A pull request that bundles any engine source edit with
+a hostile `.github` edit therefore reports all of them green, and a `.github`-only
+pull request reports them green as skipped. Only the containment check examines
+the `.github` tree itself. If it is merely present-and-red rather than required,
+GitHub returns a mergeable state and the change lands with no override and no
+administrator involvement.
 
 Verify the rule with a disposable pull request that makes a policy regression:
 the first check must fail from trusted `main` tooling, the candidate regression

--- a/.github/workflows/codegen-drift.yml
+++ b/.github/workflows/codegen-drift.yml
@@ -21,22 +21,15 @@ on:
       - 'scripts/copy_project_schema.py'
       - 'justfile'
       - '.github/workflows/codegen-drift.yml'
+  # No `paths:` filter on pull_request — deliberately. "Check codegen is up
+  # to date" is a required merge context. A workflow-level path filter leaves
+  # it ABSENT on a PR that does not match, and an absent required check
+  # blocks the merge forever (#1563). Instead the `changes` job below detects
+  # whether codegen inputs were touched, and the drift job skips itself — a
+  # job skipped by an `if:` conditional still reports, and satisfies the
+  # required check.
   pull_request:
     branches: [main]
-    paths:
-      - 'engine/**'
-      - 'schemas/**'
-      - 'docs/public/openapi.json'
-      - 'sdk/python/src/rocky_sdk/types_generated/**'
-      - 'integrations/dagster/tests/fixtures_generated/**'
-      - 'editors/vscode/src/types/generated/**'
-      - 'editors/vscode/schemas/rocky-project.schema.json'
-      - 'examples/playground/pocs/**'
-      - 'scripts/regen_fixtures.sh'
-      - 'scripts/_normalize_fixture.py'
-      - 'scripts/copy_project_schema.py'
-      - 'justfile'
-      - '.github/workflows/codegen-drift.yml'
 
 # CI only reads the repo; restrict the token to the minimum (CodeQL ql-for-actions).
 permissions:
@@ -54,8 +47,51 @@ env:
   CARGO_BUILD_JOBS: 4
 
 jobs:
+  # Computes whether this PR touches any codegen input or output. The list
+  # below must stay in sync with the `push` trigger's `paths:` above. On push
+  # events the trigger's own filter already matched, so the answer is yes.
+  #
+  # Fail closed: the answer is "false" only when the diff was computed and no
+  # relevant path matched. Any error keeps it "true" and the drift check runs.
+  changes:
+    name: Detect codegen changes
+    runs-on: ubuntu-latest
+    outputs:
+      codegen: ${{ steps.diff.outputs.codegen }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # The PR merge commit plus both of its parents.
+          fetch-depth: 2
+      - name: Diff the merge commit against its base parent
+        id: diff
+        env:
+          # Mirrors the push trigger paths above.
+          CODEGEN_PATHS_RE: ^(engine/|schemas/|docs/public/openapi\.json$|sdk/python/src/rocky_sdk/types_generated/|integrations/dagster/tests/fixtures_generated/|editors/vscode/src/types/generated/|editors/vscode/schemas/rocky-project\.schema\.json$|examples/playground/pocs/|scripts/regen_fixtures\.sh$|scripts/_normalize_fixture\.py$|scripts/copy_project_schema\.py$|justfile$|\.github/workflows/codegen-drift\.yml$)
+        run: |
+          set -uo pipefail
+          codegen=true
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            if files=$(git diff --name-only HEAD^1 HEAD); then
+              if printf '%s\n' "$files" | grep -qE "$CODEGEN_PATHS_RE"; then
+                codegen=true
+              else
+                codegen=false
+              fi
+            else
+              echo "::warning::could not diff the merge commit; running the drift check to fail closed"
+            fi
+          fi
+          echo "codegen=$codegen" >> "$GITHUB_OUTPUT"
+          echo "codegen=$codegen"
+
   drift:
     name: Check codegen is up to date
+    needs: changes
+    # Skip only on a positive "false" from the detection job. An empty output
+    # (the detection job itself failed) runs the check — fail closed.
+    if: ${{ !cancelled() && needs.changes.outputs.codegen != 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/engine-ci.yml
+++ b/.github/workflows/engine-ci.yml
@@ -13,18 +13,15 @@ on:
       # run and the PR cannot merge at all (#1557).
       - '.claude/skills/rocky-ai-workflow/SKILL.md'
       - '.github/workflows/engine-ci.yml'
+  # No `paths:` filter on pull_request — deliberately. Four required merge
+  # contexts live in this workflow (Test, Clippy, Format, Adapter boundary).
+  # A workflow-level path filter leaves those contexts ABSENT on a PR that
+  # does not match, and an absent required check blocks the merge forever
+  # (#1563). Instead the `changes` job below detects whether engine paths
+  # were touched, and each job skips itself — a job skipped by an `if:`
+  # conditional still reports, and satisfies the required check.
   pull_request:
     branches: [main]
-    paths:
-      - 'engine/**'
-      - 'schemas/**'
-      # Compiled INTO the binary: rocky-mcp `include_str!`s this skill as the
-      # MCP `instructions` (crates/rocky-mcp/src/tools.rs). Editing it changes
-      # what `rocky mcp` serves, and renaming or deleting it fails the build —
-      # so it needs engine CI, and without it the five required contexts never
-      # run and the PR cannot merge at all (#1557).
-      - '.claude/skills/rocky-ai-workflow/SKILL.md'
-      - '.github/workflows/engine-ci.yml'
 
 # CI only reads the repo; restrict the token to the minimum (CodeQL ql-for-actions).
 permissions:
@@ -55,8 +52,52 @@ defaults:
     working-directory: engine
 
 jobs:
+  # Computes whether this PR touches any path engine CI cares about. The list
+  # below must stay in sync with the `push` trigger's `paths:` above. On push
+  # events the trigger's own filter already matched, so the answer is yes.
+  #
+  # Fail closed: the answer is "false" only when the diff was computed and no
+  # relevant path matched. Any error keeps it "true" and the full suite runs.
+  changes:
+    name: Detect engine changes
+    runs-on: ubuntu-latest
+    outputs:
+      engine: ${{ steps.diff.outputs.engine }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # The PR merge commit plus both of its parents.
+          fetch-depth: 2
+      - name: Diff the merge commit against its base parent
+        id: diff
+        env:
+          # Mirrors the push trigger paths: engine/**, schemas/**, the skill
+          # compiled into the binary (#1557), and this workflow itself.
+          ENGINE_PATHS_RE: ^(engine/|schemas/|\.claude/skills/rocky-ai-workflow/SKILL\.md$|\.github/workflows/engine-ci\.yml$)
+        run: |
+          set -uo pipefail
+          engine=true
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            if files=$(git diff --name-only HEAD^1 HEAD); then
+              if printf '%s\n' "$files" | grep -qE "$ENGINE_PATHS_RE"; then
+                engine=true
+              else
+                engine=false
+              fi
+            else
+              echo "::warning::could not diff the merge commit; running engine CI to fail closed"
+            fi
+          fi
+          echo "engine=$engine" >> "$GITHUB_OUTPUT"
+          echo "engine=$engine"
+
   test:
     name: Test
+    needs: changes
+    # Skip only on a positive "false" from the detection job. An empty output
+    # (the detection job itself failed) runs the suite — fail closed.
+    if: ${{ !cancelled() && needs.changes.outputs.engine != 'false' }}
     runs-on: ubuntu-latest
     # CI-only: emit `line-tables-only` debuginfo on the dev+test profiles
     # instead of full debuginfo. Linking the workspace's test binaries with
@@ -109,6 +150,8 @@ jobs:
 
   clippy:
     name: Clippy
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.engine != 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -138,6 +181,8 @@ jobs:
 
   fmt:
     name: Format
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.engine != 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -151,6 +196,8 @@ jobs:
 
   adapter-boundary:
     name: Adapter boundary
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.engine != 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -172,6 +219,8 @@ jobs:
   # `failed to build [adapter.fivetran.cache] backend` (gold-dev 2026-05-20).
   release-build-smoke:
     name: Release-build smoke (valkey feature)
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.engine != 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -5736,10 +5736,12 @@ mod tests {
     /// that file is part of the engine build: editing it changes what `rocky
     /// mcp` serves, and renaming or deleting it fails compilation.
     ///
-    /// `engine-ci.yml` must watch every such path. A check that never runs is
-    /// never satisfied — and because `Test`, `Clippy`, `Format`, `Adapter
-    /// boundary` and the codegen check are REQUIRED contexts, a path the filter
-    /// misses does not merely skip CI, it blocks the merge outright (#1557).
+    /// `engine-ci.yml` must watch every such path, in BOTH places that route
+    /// it since #1563: the `push` trigger still carries a `paths:` filter,
+    /// while `pull_request` runs unfiltered and the `changes` job's
+    /// `ENGINE_PATHS_RE` decides whether the required jobs do real work. A
+    /// path the regex misses skips engine CI for exactly the change that
+    /// needs it — #1557's failure mode, moved one level down (#1557, #1563).
     #[test]
     fn every_out_of_tree_include_is_watched_by_engine_ci() {
         let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -5750,6 +5752,18 @@ mod tests {
         let src = std::fs::read_to_string(manifest.join("src/tools.rs")).expect("read tools.rs");
         let workflow = std::fs::read_to_string(repo_root.join(".github/workflows/engine-ci.yml"))
             .expect("read engine-ci.yml");
+
+        // The change-detection regex the `changes` job matches PR diffs
+        // against. One line, `ENGINE_PATHS_RE: <regex>`.
+        let engine_paths_re = workflow
+            .lines()
+            .find_map(|line| line.trim().strip_prefix("ENGINE_PATHS_RE:"))
+            .expect(
+                "engine-ci.yml no longer defines ENGINE_PATHS_RE — the \
+                 change-detection mechanism moved, and this guard needs to \
+                 move with it",
+            )
+            .trim();
 
         // Paths that climb above `engine/` — `src/` is three levels below the
         // repo root, so four or more `../` escapes the engine tree.
@@ -5765,30 +5779,36 @@ mod tests {
                 repo_root.join(repo_relative).exists(),
                 "include_str! names a file that does not exist: {repo_relative}"
             );
-            // EVERY `paths:` list, not merely one of them. `engine-ci.yml`
-            // carries two — `push` and `pull_request` — and a path present in
-            // only one still misses half the trigger. `contains` over the whole
-            // file would pass on a single occurrence; mutation-checking this
-            // test by deleting one of the two proved exactly that.
+            // The `push` trigger's `paths:` list is the only one left since
+            // #1563 removed the pull_request filter. Pin that count so a
+            // reintroduced or dropped list changes this guard deliberately.
             let lists = workflow_path_lists(&workflow);
             assert_eq!(
                 lists.len(),
-                2,
-                "expected engine-ci.yml to carry a `paths:` list for both `push` \
-                 and `pull_request`; found {}. If the triggers changed, this \
-                 guard needs to change with them.",
+                1,
+                "expected engine-ci.yml to carry exactly one `paths:` list \
+                 (push — pull_request is deliberately unfiltered since #1563); \
+                 found {}. If the triggers changed, this guard needs to change \
+                 with them.",
                 lists.len()
             );
-            for (n, list) in lists.iter().enumerate() {
-                assert!(
-                    list.iter().any(|entry| entry == repo_relative),
-                    "`{repo_relative}` is compiled into the engine but is missing \
-                     from engine-ci.yml `paths:` list {n}. The required checks \
-                     would never run for a change to it, so the change gets no \
-                     engine CI AND cannot merge (#1557). It must be in BOTH the \
-                     push and pull_request lists."
-                );
-            }
+            assert!(
+                lists[0].iter().any(|entry| entry == repo_relative),
+                "`{repo_relative}` is compiled into the engine but is missing \
+                 from engine-ci.yml's push `paths:` list. A push touching it \
+                 would run no engine CI (#1557)."
+            );
+            // The PR side: the detection regex must name the file as an
+            // exact-file alternative — the path with its dots escaped, then
+            // `$`. Prefix alternatives like `engine/` do not cover it.
+            let exact_alternative = format!("{}$", repo_relative.replace('.', "\\."));
+            assert!(
+                engine_paths_re.contains(&exact_alternative),
+                "`{repo_relative}` is compiled into the engine but \
+                 ENGINE_PATHS_RE in engine-ci.yml does not carry \
+                 `{exact_alternative}`. A PR touching it would skip the \
+                 required engine jobs (#1557, #1563)."
+            );
             checked += 1;
         }
 


### PR DESCRIPTION
## Summary

Every non-engine PR is permanently unmergeable today (#1563). Four required contexts (`Test`, `Clippy`, `Format`, `Adapter boundary`) live in `engine-ci.yml` and one (`Check codegen is up to date`) in `codegen-drift.yml`, and both workflows path-filter their `pull_request` trigger. A filtered-out workflow never reports. An absent required check blocks the merge forever.

This PR makes both workflows always run on PRs. A cheap `changes` job diffs the merge commit against its base parent. Each real job skips itself when no relevant path was touched. A job skipped by an `if:` conditional still reports, and satisfies the required check (``[GitHub docs: handling skipped but required checks](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks)).``

```
 before   non-engine PR -> workflow never runs -> 5 contexts ABSENT -> blocked forever
 after    non-engine PR -> changes job says "false" -> jobs skip -> contexts report -> mergeable
          engine PR     -> changes job says "true"  -> jobs run exactly as before
```

Unblocks #1555, #1552, #1554.

Closes #1563

## Subproject(s) touched

- [x] Cross-project (CI, scripts, root docs)

## Changes

- `engine-ci.yml`: drop the `pull_request` `paths:` filter; add a `changes` job (merge-commit diff, `fetch-depth: 2`); gate `test`, `clippy`, `fmt`, `adapter-boundary`, `release-build-smoke` on its output.
- `codegen-drift.yml`: same shape for the `drift` job, with its own path list.
- `SECURITY_ENVIRONMENTS.md`: the rationale paragraph described the old pending-context behavior; reworded for always-report.

Design points:

- **Fails closed twice.** A diff error keeps the answer `true`. The gate is `engine != 'false'` with `!cancelled()`, so a failed detection job (empty output) runs everything instead of skipping it.
- **The detection regexes mirror the old filters exactly** — verified against sample paths, including anchored single files (`justfile` matches, `justfile.bak` does not).
- **`push` triggers keep their filters.** Main-branch cost is unchanged. Non-engine PRs pay one near-instant detection job per workflow.
- **No new action sources.** The detection job reuses the pinned `actions/checkout` already in the file and plain `git diff`, so the credential-containment allow-list is untouched.

## Test Plan

- `python3 .github/scripts/check_credential_containment.py` → passed on the modified tree.
- `.github/tests/test_credential_containment.py` → 110 tests, all pass.
- `actionlint` v1.7.7 on both workflows → clean.
- Regex simulation for both path lists against engine, scripts, docs, vscode, schemas, and near-miss paths (`.bak` suffixes) → matches the old filter semantics exactly.
- The live proof is this PR itself once merged: #1555 (scripts-only) should flip from `BLOCKED` to mergeable with the four contexts reporting as skipped.

## Open questions, on the record (per AGENTS.md)

**Least confident about:** the ruleset treating a `skipped` required context as satisfied. GitHub's own docs say a job skipped by a conditional reports and does not block, and this is the documented pattern for path-filtered required checks — but the definitive test is the first non-engine PR after this merges. If it stays blocked, the fallback is letting each gated job run and short-circuit its steps to a real `success` conclusion.

**Most important thing possibly missing:** the issue's suggested durable form — a CI check that every ruleset-named context is produced by an unconditionally-running workflow. Reading rulesets needs API access the unprivileged CI token may not have, so it is left as follow-up rather than widening this PR.

**Red team:** the repo's designated independent red team (Codex) is not available in this session. Flagging that here per AGENTS.md instead of skipping silently.

