### PR TITLE
fix(ci): close the fail-open holes in the change-detection job

### DIFF
--- a/.github/workflows/codegen-drift.yml
+++ b/.github/workflows/codegen-drift.yml
@@ -54,9 +54,10 @@ jobs:
   # beyond the runner spin-up.
   #
   # Fail closed: the answer is "false" only when the diff was computed AND
-  # grep itself reported a clean non-match (exit 1). A failed diff, a grep
-  # error, or a step that never ran all keep it "true" and the drift check
-  # runs.
+  # grep itself reported a clean non-match (exit 1). A failed diff or a grep
+  # error still writes "true". A step that never ran writes nothing, so the
+  # job output is empty; the `drift` job tests `!= 'false'`, and an empty
+  # answer runs the check.
   changes:
     name: Detect codegen changes
     runs-on: ubuntu-latest

--- a/.github/workflows/codegen-drift.yml
+++ b/.github/workflows/codegen-drift.yml
@@ -85,14 +85,20 @@ jobs:
           # --no-renames: a rename lists BOTH its old and its new path. Plain
           # `git diff` folds a rename into the destination alone, so a file
           # renamed out of a watched tree never matched and the check skipped.
-          if git diff --no-renames --name-only HEAD^1 HEAD > "$files"; then
+          # -z: NUL-terminated paths, and no quoting. Without it git QUOTES a
+          # pathname holding an unusual byte, so a file named with a newline
+          # in it lists as `"engine/...` — the leading double quote defeats
+          # the `^` anchor and a real codegen change read as no-match.
+          if git diff --no-renames --name-only -z HEAD^1 HEAD > "$files"; then
             # grep reads a file, not a pipe. `printf | grep -q` let grep quit
             # on the first match while printf was still writing; past the
             # pipe buffer printf died of SIGPIPE, pipefail made the pipeline
             # non-zero, and a real match read as "false". Branch on grep's
-            # own exit code instead: only a clean 1 means no match.
+            # own exit code instead: only a clean 1 means no match. `-z` here
+            # matches the `-z` above: one record per NUL, so `^` and `$` still
+            # anchor per path.
             status=0
-            grep -qE "$CODEGEN_PATHS_RE" "$files" || status=$?
+            grep -zqE "$CODEGEN_PATHS_RE" "$files" || status=$?
             case "$status" in
               0) codegen=true ;;
               1) codegen=false ;;

--- a/.github/workflows/codegen-drift.yml
+++ b/.github/workflows/codegen-drift.yml
@@ -48,43 +48,66 @@ env:
 
 jobs:
   # Computes whether this PR touches any codegen input or output. The list
-  # below must stay in sync with the `push` trigger's `paths:` above. On push
-  # events the trigger's own filter already matched, so the answer is yes.
+  # below must stay in sync with the `push` trigger's `paths:` above. On any
+  # other event the trigger's own filter already matched, so the `trigger`
+  # step answers yes without a checkout — a push to main pays nothing here
+  # beyond the runner spin-up.
   #
-  # Fail closed: the answer is "false" only when the diff was computed and no
-  # relevant path matched. Any error keeps it "true" and the drift check runs.
+  # Fail closed: the answer is "false" only when the diff was computed AND
+  # grep itself reported a clean non-match (exit 1). A failed diff, a grep
+  # error, or a step that never ran all keep it "true" and the drift check
+  # runs.
   changes:
     name: Detect codegen changes
     runs-on: ubuntu-latest
     outputs:
-      codegen: ${{ steps.diff.outputs.codegen }}
+      # Exactly one of the two steps runs per event; a skipped step's output
+      # is empty, and `||` picks the one that wrote.
+      codegen: ${{ steps.diff.outputs.codegen || steps.trigger.outputs.codegen }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: github.event_name == 'pull_request'
         with:
           persist-credentials: false
           # The PR merge commit plus both of its parents.
           fetch-depth: 2
       - name: Diff the merge commit against its base parent
         id: diff
+        if: github.event_name == 'pull_request'
         env:
           # Mirrors the push trigger paths above.
           CODEGEN_PATHS_RE: ^(engine/|schemas/|docs/public/openapi\.json$|sdk/python/src/rocky_sdk/types_generated/|integrations/dagster/tests/fixtures_generated/|editors/vscode/src/types/generated/|editors/vscode/schemas/rocky-project\.schema\.json$|examples/playground/pocs/|scripts/regen_fixtures\.sh$|scripts/_normalize_fixture\.py$|scripts/copy_project_schema\.py$|justfile$|\.github/workflows/codegen-drift\.yml$)
         run: |
           set -uo pipefail
           codegen=true
-          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            if files=$(git diff --name-only HEAD^1 HEAD); then
-              if printf '%s\n' "$files" | grep -qE "$CODEGEN_PATHS_RE"; then
-                codegen=true
-              else
-                codegen=false
-              fi
-            else
-              echo "::warning::could not diff the merge commit; running the drift check to fail closed"
-            fi
+          files=$(mktemp)
+          # --no-renames: a rename lists BOTH its old and its new path. Plain
+          # `git diff` folds a rename into the destination alone, so a file
+          # renamed out of a watched tree never matched and the check skipped.
+          if git diff --no-renames --name-only HEAD^1 HEAD > "$files"; then
+            # grep reads a file, not a pipe. `printf | grep -q` let grep quit
+            # on the first match while printf was still writing; past the
+            # pipe buffer printf died of SIGPIPE, pipefail made the pipeline
+            # non-zero, and a real match read as "false". Branch on grep's
+            # own exit code instead: only a clean 1 means no match.
+            status=0
+            grep -qE "$CODEGEN_PATHS_RE" "$files" || status=$?
+            case "$status" in
+              0) codegen=true ;;
+              1) codegen=false ;;
+              *) echo "::warning::grep exited $status while matching the changed paths; running the drift check to fail closed" ;;
+            esac
+          else
+            echo "::warning::could not diff the merge commit; running the drift check to fail closed"
           fi
           echo "codegen=$codegen" >> "$GITHUB_OUTPUT"
           echo "codegen=$codegen"
+      - name: Trust the trigger's own paths filter
+        id: trigger
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "codegen=true" >> "$GITHUB_OUTPUT"
+          echo "codegen=true"
 
   drift:
     name: Check codegen is up to date

--- a/.github/workflows/engine-ci.yml
+++ b/.github/workflows/engine-ci.yml
@@ -59,9 +59,10 @@ jobs:
   # beyond the runner spin-up.
   #
   # Fail closed: the answer is "false" only when the diff was computed AND
-  # grep itself reported a clean non-match (exit 1). A failed diff, a grep
-  # error, or a step that never ran all keep it "true" and the full suite
-  # runs.
+  # grep itself reported a clean non-match (exit 1). A failed diff or a grep
+  # error still writes "true". A step that never ran writes nothing, so the
+  # job output is empty; the gates below test `!= 'false'`, and an empty
+  # answer runs the full suite.
   changes:
     name: Detect engine changes
     runs-on: ubuntu-latest

--- a/.github/workflows/engine-ci.yml
+++ b/.github/workflows/engine-ci.yml
@@ -53,24 +53,32 @@ defaults:
 
 jobs:
   # Computes whether this PR touches any path engine CI cares about. The list
-  # below must stay in sync with the `push` trigger's `paths:` above. On push
-  # events the trigger's own filter already matched, so the answer is yes.
+  # below must stay in sync with the `push` trigger's `paths:` above. On any
+  # other event the trigger's own filter already matched, so the `trigger`
+  # step answers yes without a checkout — a push to main pays nothing here
+  # beyond the runner spin-up.
   #
-  # Fail closed: the answer is "false" only when the diff was computed and no
-  # relevant path matched. Any error keeps it "true" and the full suite runs.
+  # Fail closed: the answer is "false" only when the diff was computed AND
+  # grep itself reported a clean non-match (exit 1). A failed diff, a grep
+  # error, or a step that never ran all keep it "true" and the full suite
+  # runs.
   changes:
     name: Detect engine changes
     runs-on: ubuntu-latest
     outputs:
-      engine: ${{ steps.diff.outputs.engine }}
+      # Exactly one of the two steps runs per event; a skipped step's output
+      # is empty, and `||` picks the one that wrote.
+      engine: ${{ steps.diff.outputs.engine || steps.trigger.outputs.engine }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: github.event_name == 'pull_request'
         with:
           persist-credentials: false
           # The PR merge commit plus both of its parents.
           fetch-depth: 2
       - name: Diff the merge commit against its base parent
         id: diff
+        if: github.event_name == 'pull_request'
         env:
           # Mirrors the push trigger paths: engine/**, schemas/**, the skill
           # compiled into the binary (#1557), and this workflow itself.
@@ -78,19 +86,37 @@ jobs:
         run: |
           set -uo pipefail
           engine=true
-          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            if files=$(git diff --name-only HEAD^1 HEAD); then
-              if printf '%s\n' "$files" | grep -qE "$ENGINE_PATHS_RE"; then
-                engine=true
-              else
-                engine=false
-              fi
-            else
-              echo "::warning::could not diff the merge commit; running engine CI to fail closed"
-            fi
+          files=$(mktemp)
+          # --no-renames: a rename lists BOTH its old and its new path. Plain
+          # `git diff` folds a rename into the destination alone, so a file
+          # renamed out of engine/ never matched and the suite skipped.
+          if git diff --no-renames --name-only HEAD^1 HEAD > "$files"; then
+            # grep reads a file, not a pipe. `printf | grep -q` let grep quit
+            # on the first match while printf was still writing; past the
+            # pipe buffer printf died of SIGPIPE, pipefail made the pipeline
+            # non-zero, and a real match read as "false". Branch on grep's
+            # own exit code instead: only a clean 1 means no match.
+            status=0
+            grep -qE "$ENGINE_PATHS_RE" "$files" || status=$?
+            case "$status" in
+              0) engine=true ;;
+              1) engine=false ;;
+              *) echo "::warning::grep exited $status while matching the changed paths; running engine CI to fail closed" ;;
+            esac
+          else
+            echo "::warning::could not diff the merge commit; running engine CI to fail closed"
           fi
           echo "engine=$engine" >> "$GITHUB_OUTPUT"
           echo "engine=$engine"
+      - name: Trust the trigger's own paths filter
+        id: trigger
+        if: github.event_name != 'pull_request'
+        # Nothing is checked out on this path, so the workflow-level
+        # `working-directory: engine` does not exist yet; run at the root.
+        working-directory: .
+        run: |
+          echo "engine=true" >> "$GITHUB_OUTPUT"
+          echo "engine=true"
 
   test:
     name: Test

--- a/.github/workflows/engine-ci.yml
+++ b/.github/workflows/engine-ci.yml
@@ -91,14 +91,20 @@ jobs:
           # --no-renames: a rename lists BOTH its old and its new path. Plain
           # `git diff` folds a rename into the destination alone, so a file
           # renamed out of engine/ never matched and the suite skipped.
-          if git diff --no-renames --name-only HEAD^1 HEAD > "$files"; then
+          # -z: NUL-terminated paths, and no quoting. Without it git QUOTES a
+          # pathname holding an unusual byte, so a file named with a newline
+          # in it lists as `"engine/...` — the leading double quote defeats
+          # the `^` anchor and a real engine change read as no-match.
+          if git diff --no-renames --name-only -z HEAD^1 HEAD > "$files"; then
             # grep reads a file, not a pipe. `printf | grep -q` let grep quit
             # on the first match while printf was still writing; past the
             # pipe buffer printf died of SIGPIPE, pipefail made the pipeline
             # non-zero, and a real match read as "false". Branch on grep's
-            # own exit code instead: only a clean 1 means no match.
+            # own exit code instead: only a clean 1 means no match. `-z` here
+            # matches the `-z` above: one record per NUL, so `^` and `$` still
+            # anchor per path.
             status=0
-            grep -qE "$ENGINE_PATHS_RE" "$files" || status=$?
+            grep -zqE "$ENGINE_PATHS_RE" "$files" || status=$?
             case "$status" in
               0) engine=true ;;
               1) engine=false ;;

--- a/.github/workflows/scripts-ci.yml
+++ b/.github/workflows/scripts-ci.yml
@@ -10,11 +10,19 @@ on:
     paths:
       - "scripts/**"
       - ".github/workflows/scripts-ci.yml"
+      # The change-detector self-test replays these two workflows' own `run:`
+      # blocks. Without them here, a PR that edits only a detector block runs
+      # engine-ci and codegen-drift but not the test that guards them — the
+      # guard absent for exactly the change that needs it (#1557, #1563).
+      - ".github/workflows/engine-ci.yml"
+      - ".github/workflows/codegen-drift.yml"
   push:
     branches: [main]
     paths:
       - "scripts/**"
       - ".github/workflows/scripts-ci.yml"
+      - ".github/workflows/engine-ci.yml"
+      - ".github/workflows/codegen-drift.yml"
 
 permissions:
   contents: read
@@ -43,6 +51,21 @@ jobs:
         # Uses stub commands in scratch repos, so no Rust toolchain is needed.
         run: bash scripts/tests/mutation-check.test.sh
 
+  ci-change-detector:
+    name: CI change detector
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Replay the detector blocks against scratch repos
+        # Extracts each workflow's own `run:` block and replays it, so no
+        # toolchain and no second copy of the logic are needed. This is also
+        # where the fix runs under the runner's GNU grep rather than a
+        # developer's.
+        run: bash scripts/tests/ci-change-detector.test.sh
+
   shellcheck:
     name: Shellcheck scripts
     runs-on: ubuntu-latest
@@ -54,7 +77,7 @@ jobs:
       - name: Shellcheck the soak harness (full severity)
         # The scripts this workflow exists to protect hold the full bar and
         # already meet it.
-        run: shellcheck scripts/soak-scheduler.sh
+        run: shellcheck scripts/soak-scheduler.sh scripts/tests/ci-change-detector.test.sh
       - name: Shellcheck everything else (error severity)
         # Six pre-existing scripts carry SC2155/SC2012/SC2015 warnings today
         # (release.sh, the vendor_* pair, regen_fixtures.sh, build_rocky_linux.sh).

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4325,6 +4325,7 @@ dependencies = [
  "arrow",
  "async-trait",
  "chrono",
+ "regex",
  "rmcp",
  "rocky-ai",
  "rocky-cli",

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -54,6 +54,9 @@ rocky-snowflake = { path = "../rocky-snowflake" }
 rocky-ai = { path = "../rocky-ai" }
 tempfile = "3"
 serde_json = { workspace = true }
+# The engine-ci guard test compiles ENGINE_PATHS_RE from the workflow and runs
+# it against the out-of-tree include paths, the way `grep -E` does in CI.
+regex = { workspace = true }
 # The scripted round-trip test drives the stdio server in-process with an rmcp
 # client over a duplex pipe, so it needs the client side of rmcp too.
 rmcp = { version = "3.0", features = ["server", "macros", "transport-io", "client"] }

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -5974,6 +5974,18 @@ mod tests {
         lists
     }
 
+    /// Whether `alternative` appears in `regex` as a whole alternation
+    /// branch: preceded by `(` or `|` and followed by `|` or `)`. A bare
+    /// substring test is satisfied by a glued prefix (`|x\.claude/...$|`)
+    /// that matches no real path.
+    fn is_delimited_alternative(regex: &str, alternative: &str) -> bool {
+        regex.match_indices(alternative).any(|(at, hit)| {
+            let before = regex[..at].chars().next_back();
+            let after = regex[at + hit.len()..].chars().next();
+            matches!(before, Some('(' | '|')) && matches!(after, Some('|' | ')'))
+        })
+    }
+
     /// `include_str!` reaches OUT of `engine/` for the AI-workflow skill, so
     /// that file is part of the engine build: editing it changes what `rocky
     /// mcp` serves, and renaming or deleting it fails compilation.
@@ -6042,14 +6054,18 @@ mod tests {
             );
             // The PR side: the detection regex must name the file as an
             // exact-file alternative — the path with its dots escaped, then
-            // `$`. Prefix alternatives like `engine/` do not cover it.
+            // `$` — standing on its own between alternation delimiters.
+            // Prefix alternatives like `engine/` do not cover it, and a
+            // substring hit does not either: `|x\.claude/...$|` contains the
+            // text and matches nothing.
             let exact_alternative = format!("{}$", repo_relative.replace('.', "\\."));
             assert!(
-                engine_paths_re.contains(&exact_alternative),
+                is_delimited_alternative(engine_paths_re, &exact_alternative),
                 "`{repo_relative}` is compiled into the engine but \
                  ENGINE_PATHS_RE in engine-ci.yml does not carry \
-                 `{exact_alternative}`. A PR touching it would skip the \
-                 required engine jobs (#1557, #1563)."
+                 `{exact_alternative}` as its own `(`- or `|`-delimited \
+                 alternative. A PR touching it would skip the required \
+                 engine jobs (#1557, #1563)."
             );
             checked += 1;
         }

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -5974,18 +5974,6 @@ mod tests {
         lists
     }
 
-    /// Whether `alternative` appears in `regex` as a whole alternation
-    /// branch: preceded by `(` or `|` and followed by `|` or `)`. A bare
-    /// substring test is satisfied by a glued prefix (`|x\.claude/...$|`)
-    /// that matches no real path.
-    fn is_delimited_alternative(regex: &str, alternative: &str) -> bool {
-        regex.match_indices(alternative).any(|(at, hit)| {
-            let before = regex[..at].chars().next_back();
-            let after = regex[at + hit.len()..].chars().next();
-            matches!(before, Some('(' | '|')) && matches!(after, Some('|' | ')'))
-        })
-    }
-
     /// `include_str!` reaches OUT of `engine/` for the AI-workflow skill, so
     /// that file is part of the engine build: editing it changes what `rocky
     /// mcp` serves, and renaming or deleting it fails compilation.
@@ -6018,6 +6006,14 @@ mod tests {
                  move with it",
             )
             .trim();
+        // The workflow hands that line to `grep -E`, so it is a POSIX ERE. It
+        // uses only anchors (`^`, `$`), one group, alternation (`|`) and
+        // escaped dots (`\.`). The `regex` crate reads that subset the same
+        // way, so matching here reruns the CI check instead of guessing at
+        // it from the regex's text.
+        let engine_paths_re = regex::Regex::new(engine_paths_re).unwrap_or_else(|err| {
+            panic!("ENGINE_PATHS_RE in engine-ci.yml does not compile: {err}\n{engine_paths_re}")
+        });
 
         // Paths that climb above `engine/` — `src/` is three levels below the
         // repo root, so four or more `../` escapes the engine tree.
@@ -6052,20 +6048,16 @@ mod tests {
                  from engine-ci.yml's push `paths:` list. A push touching it \
                  would run no engine CI (#1557)."
             );
-            // The PR side: the detection regex must name the file as an
-            // exact-file alternative — the path with its dots escaped, then
-            // `$` — standing on its own between alternation delimiters.
-            // Prefix alternatives like `engine/` do not cover it, and a
-            // substring hit does not either: `|x\.claude/...$|` contains the
-            // text and matches nothing.
-            let exact_alternative = format!("{}$", repo_relative.replace('.', "\\."));
+            // The PR side: run the regex against the path, the way the
+            // `changes` job does. Searching the regex's text for the path
+            // proved nothing — `|x\.claude/...$|` and `|\|\.claude/...$|`
+            // both contain it and neither matches it.
             assert!(
-                is_delimited_alternative(engine_paths_re, &exact_alternative),
+                engine_paths_re.is_match(repo_relative),
                 "`{repo_relative}` is compiled into the engine but \
-                 ENGINE_PATHS_RE in engine-ci.yml does not carry \
-                 `{exact_alternative}` as its own `(`- or `|`-delimited \
-                 alternative. A PR touching it would skip the required \
-                 engine jobs (#1557, #1563)."
+                 ENGINE_PATHS_RE in engine-ci.yml does not match it. A PR \
+                 touching it would skip the required engine jobs (#1557, \
+                 #1563). ENGINE_PATHS_RE: {engine_paths_re}"
             );
             checked += 1;
         }

--- a/justfile
+++ b/justfile
@@ -297,3 +297,7 @@ soak-verdict-selftest:
 # Pin mutation-check.sh's three verdicts (killed / survived / inconclusive).
 mutation-check-selftest:
     bash scripts/tests/mutation-check.test.sh
+
+# Replay engine-ci and codegen-drift's change detectors against scratch repos.
+ci-change-detector-selftest:
+    bash scripts/tests/ci-change-detector.test.sh

--- a/scripts/tests/ci-change-detector.test.sh
+++ b/scripts/tests/ci-change-detector.test.sh
@@ -135,6 +135,17 @@ build_non_match_first() {
     commit_change
 }
 
+# A path that only a `$`-anchored alternative can match. `^` and `$` have to
+# anchor to the same NUL record; if `$` anchored to the end of the whole
+# listing instead, every one of these single-file watches would go dark —
+# including a PR that touches only the workflow file itself.
+build_dollar_anchored() {
+    mkdir -p "$(dirname "$DOLLAR_PATH")"
+    : > "$DOLLAR_PATH"
+    : > docs/guide.md
+    commit_change
+}
+
 build_grep_error() {
     : > docs/guide.md
     commit_change
@@ -229,11 +240,13 @@ run_case() {
 }
 
 # $1 workflow file   $2 regex env var   $3 output key   $4 dir the step runs in
+# $5 a watched path this regex matches only through a `$`-anchored alternative
 run_suite() {
     WORKFLOW="$ROOT/.github/workflows/$1"
     REGEX_VAR="$2"
     OUT_KEY="$3"
     RUNDIR="$4"
+    DOLLAR_PATH="$5"
 
     echo "$1 (${REGEX_VAR}, working directory: $RUNDIR):"
 
@@ -267,6 +280,7 @@ run_suite() {
     run_case "a path renamed out of the tree runs"     build_renamed_out     true
     run_case "a match early in a huge listing runs"    build_long_list       true
     run_case "a match after a non-match runs"          build_non_match_first true
+    run_case "$DOLLAR_PATH runs (\$-anchored)"         build_dollar_anchored true
     run_case "a newline in a pathname runs"            build_newline_name    true
     run_case "a grep error runs and warns"             build_grep_error      true warn
     run_case "a failed diff runs and warns"            build_no_parent       true warn
@@ -275,8 +289,10 @@ run_suite() {
     echo
 }
 
-run_suite engine-ci.yml      ENGINE_PATHS_RE  engine  engine
-run_suite codegen-drift.yml  CODEGEN_PATHS_RE codegen .
+run_suite engine-ci.yml      ENGINE_PATHS_RE  engine  engine \
+    .claude/skills/rocky-ai-workflow/SKILL.md
+run_suite codegen-drift.yml  CODEGEN_PATHS_RE codegen . \
+    justfile
 
 if [ "$fail" -gt 0 ]; then
     echo "$pass passed, $fail FAILED"

--- a/scripts/tests/ci-change-detector.test.sh
+++ b/scripts/tests/ci-change-detector.test.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# Pin the change-detection blocks in engine-ci.yml and codegen-drift.yml.
+#
+# Both workflows run their required jobs unfiltered on `pull_request`, and a
+# `changes` job decides whether each job does real work (#1563). A wrong "no
+# match" there skips the required jobs while still satisfying the merge gate,
+# so the PR merges having run no CI at all. Three fail-open holes have shipped
+# in that one block:
+#
+#   * a rename folded into its destination path, so a file moved OUT of
+#     engine/ never matched;
+#   * `printf | grep -q` past the pipe buffer — grep quit on the first match,
+#     printf died of SIGPIPE, and pipefail read a real match as no-match;
+#   * `git diff` QUOTING a pathname that holds a newline, so the listing line
+#     starts with a double quote and the `^`-anchored regex misses it.
+#
+# Each case below replays the workflow's own `run:` block, extracted verbatim,
+# against a scratch git repo. Nothing is reimplemented: a block that stops
+# matching the workflow stops being tested.
+#
+#   scripts/tests/ci-change-detector.test.sh
+#
+# Set DETECTOR_TEST_ROOT to a copy of the repo to replay modified workflows —
+# that is how fix-sensitivity is shown without dirtying the worktree.
+set -uo pipefail
+
+ROOT="${DETECTOR_TEST_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+pass=0
+fail=0
+
+# --- extraction -------------------------------------------------------------
+
+# The regex the detector matches changed paths against, e.g.
+# `ENGINE_PATHS_RE: ^(engine/|...)` -> everything after the colon.
+extract_regex() {
+    # $1 workflow file   $2 env var name
+    awk -v pat="^ *$2: " 'sub(pat, "") { print; exit }' "$1"
+}
+
+# The `run:` block of the step with `id: $2`, dedented to column 0. The block
+# scalar ends at the first line indented less than its own body.
+extract_run_block() {
+    # $1 workflow file   $2 step id
+    # shellcheck disable=SC2016  # $0/$1/$2 below are awk fields, not shell args
+    awk -v want="$2" '
+        $1 == "id:" { step = $2 }
+        step == want && $0 ~ /^ *run: \|$/ { collect = 1; next }
+        collect {
+            if ($0 ~ /^[[:space:]]*$/) { print ""; next }
+            here = match($0, /[^ ]/)
+            if (!indent) indent = here
+            if (here < indent) exit
+            print substr($0, indent)
+        }
+    ' "$1"
+}
+
+# --- scratch repos ----------------------------------------------------------
+
+# A repo whose base commit already holds an engine file, so a case can rename
+# it away, plus a `docs/` tree and an `engine/` directory that survives every
+# case (engine-ci's block runs under `working-directory: engine`).
+new_repo() {
+    git init -q "$CASE_REPO"
+    git -C "$CASE_REPO" config user.email test@example.invalid
+    git -C "$CASE_REPO" config user.name detector-test
+    git -C "$CASE_REPO" config commit.gpgsign false
+    # Pinned, not inherited: with `diff.renames=false` the rename case is
+    # vacuous, and with `diff.relative=true` engine-ci's block would see paths
+    # already stripped of their `engine/` prefix.
+    git -C "$CASE_REPO" config diff.renames true
+    git -C "$CASE_REPO" config diff.relative false
+    git -C "$CASE_REPO" config core.quotePath true
+
+    mkdir -p "$CASE_REPO/docs" "$CASE_REPO/engine/crates/rocky-core/src"
+    : > "$CASE_REPO/engine/.keep"
+    : > "$CASE_REPO/docs/.keep"
+    # Distinct lines, so rename detection is confident about the move.
+    seq 1 40 > "$CASE_REPO/engine/crates/rocky-core/src/lib.rs"
+
+    git -C "$CASE_REPO" add -A
+    git -C "$CASE_REPO" commit -qm base
+}
+
+commit_change() {
+    git add -A
+    git commit -qm change
+}
+
+# --- the changes each case commits ------------------------------------------
+
+build_engine_path() {
+    : > engine/crates/rocky-core/src/added.rs
+    commit_change
+}
+
+build_non_engine_path() {
+    : > docs/guide.md
+    commit_change
+}
+
+build_renamed_out() {
+    git mv engine/crates/rocky-core/src/lib.rs docs/lib.rs
+    commit_change
+    # Exhibit the condition: with rename detection on, plain `git diff` folds
+    # the move into its destination and the engine path disappears.
+    git diff --name-only HEAD^1 HEAD > "$CASE_SCRATCH/list"
+    if grep -q '^engine/' "$CASE_SCRATCH/list"; then
+        echo "setup: the rename was not folded into its destination" >&2
+        return 1
+    fi
+}
+
+# A listing past the 64 KiB pipe buffer with the match near its FRONT — the
+# shape that let grep quit early and SIGPIPE the writer. `git diff` sorts by
+# path, so the padding has to sort after `engine/`; `zz/` matches neither
+# workflow's regex.
+build_long_list() {
+    local wide i
+    wide="$(printf 'x%.0s' {1..90})"
+    mkdir -p zz/pad
+    : > engine/crates/rocky-core/src/added.rs
+    for i in {1..800}; do
+        : > "zz/pad/${wide}$(printf '%04d' "$i").md"
+    done
+    commit_change
+}
+
+# The match is NOT the first record. If an implementation matched `^` against
+# the whole listing instead of per record, only this case would fail.
+build_non_match_first() {
+    : > docs/guide.md
+    : > engine/crates/rocky-core/src/added.rs
+    commit_change
+}
+
+build_grep_error() {
+    : > docs/guide.md
+    commit_change
+    cat > "$CASE_BIN/grep" <<'STUB'
+#!/usr/bin/env bash
+echo "grep: stubbed failure" >&2
+exit 2
+STUB
+    chmod +x "$CASE_BIN/grep"
+}
+
+build_newline_name() {
+    local target
+    target="$(printf 'engine/crates/rocky-core/tests/bad\nname.rs')"
+    mkdir -p engine/crates/rocky-core/tests
+    : > "$target"
+    commit_change
+    # Exhibit the condition: git quotes the pathname, so the line starts with
+    # a double quote rather than `engine/`.
+    git diff --no-renames --name-only HEAD^1 HEAD > "$CASE_SCRATCH/list"
+    if ! grep -q '^"engine/' "$CASE_SCRATCH/list"; then
+        echo "setup: git did not quote the newline pathname" >&2
+        return 1
+    fi
+}
+
+# No second commit at all: `HEAD^1` does not resolve, so the diff fails.
+build_no_parent() {
+    :
+}
+
+# --- the runner -------------------------------------------------------------
+
+# Echo a failing block's own output, indented under the verdict line.
+indent_output() {
+    local line
+    while IFS= read -r line; do
+        printf '          %s\n' "$line"
+    done <<< "$1"
+}
+
+# $1 label   $2 builder function   $3 expected output value
+# $4 "warn" when the block must also print a ::warning::
+run_case() {
+    local label="$1" builder="$2" want="$3" warn="${4:-}"
+    local out status got
+
+    CASE_SCRATCH="$(mktemp -d)" || {
+        echo "  FAIL  $label — mktemp failed"
+        fail=$((fail + 1))
+        return
+    }
+    CASE_REPO="$CASE_SCRATCH/repo"
+    CASE_BIN="$CASE_SCRATCH/bin"
+    mkdir -p "$CASE_BIN"
+
+    new_repo > /dev/null 2>&1
+    if ! ( cd "$CASE_REPO" && "$builder" ) > /dev/null; then
+        echo "  FAIL  $label — the scratch repo did not reach the state under test"
+        fail=$((fail + 1))
+        rm -rf "$CASE_SCRATCH"
+        return
+    fi
+
+    : > "$CASE_SCRATCH/github_output"
+    out="$( cd "$CASE_REPO/$RUNDIR" \
+        && PATH="$CASE_BIN:$PATH" \
+           GITHUB_OUTPUT="$CASE_SCRATCH/github_output" \
+           env "$REGEX_VAR=$REGEX" bash "$BLOCK" 2>&1 )"
+    status=$?
+    got="$(awk -v key="$OUT_KEY=" 'index($0, key) == 1 { v = substr($0, length(key) + 1) } END { print v }' \
+        "$CASE_SCRATCH/github_output")"
+
+    if [ "$status" != 0 ]; then
+        echo "  FAIL  $label — the detector block exited $status"
+        indent_output "$out"
+        fail=$((fail + 1))
+    elif [ "$got" != "$want" ]; then
+        echo "  FAIL  $label — wanted $OUT_KEY=$want, got $OUT_KEY=${got:-<empty>}"
+        indent_output "$out"
+        fail=$((fail + 1))
+    elif [ "$warn" = warn ] && ! printf '%s' "$out" | grep -q '::warning::'; then
+        echo "  FAIL  $label — no ::warning:: was emitted"
+        indent_output "$out"
+        fail=$((fail + 1))
+    else
+        echo "  ok    $label ($OUT_KEY=$got)"
+        pass=$((pass + 1))
+    fi
+
+    rm -rf "$CASE_SCRATCH"
+}
+
+# $1 workflow file   $2 regex env var   $3 output key   $4 dir the step runs in
+run_suite() {
+    WORKFLOW="$ROOT/.github/workflows/$1"
+    REGEX_VAR="$2"
+    OUT_KEY="$3"
+    RUNDIR="$4"
+
+    echo "$1 (${REGEX_VAR}, working directory: $RUNDIR):"
+
+    if [ ! -f "$WORKFLOW" ]; then
+        echo "  FAIL  no such workflow: $WORKFLOW"
+        fail=$((fail + 1))
+        return
+    fi
+
+    REGEX="$(extract_regex "$WORKFLOW" "$REGEX_VAR")"
+    if [ -z "$REGEX" ]; then
+        echo "  FAIL  $1 no longer defines $REGEX_VAR — the detector moved, and this suite must move with it"
+        fail=$((fail + 1))
+        return
+    fi
+
+    BLOCK="$(mktemp)"
+    extract_run_block "$WORKFLOW" diff > "$BLOCK"
+    # Sanity-check the extraction, never the fix: asserting on the fix here
+    # would make a reverted fix fail as a bad extraction instead of as the
+    # wrong verdict.
+    if ! grep -q 'git diff' "$BLOCK" || ! grep -q 'GITHUB_OUTPUT' "$BLOCK"; then
+        echo "  FAIL  could not extract the \`id: diff\` run block from $1"
+        fail=$((fail + 1))
+        rm -f "$BLOCK"
+        return
+    fi
+
+    run_case "an engine path runs the jobs"            build_engine_path     true
+    run_case "an unwatched path skips them"            build_non_engine_path false
+    run_case "a path renamed out of the tree runs"     build_renamed_out     true
+    run_case "a match early in a huge listing runs"    build_long_list       true
+    run_case "a match after a non-match runs"          build_non_match_first true
+    run_case "a newline in a pathname runs"            build_newline_name    true
+    run_case "a grep error runs and warns"             build_grep_error      true warn
+    run_case "a failed diff runs and warns"            build_no_parent       true warn
+
+    rm -f "$BLOCK"
+    echo
+}
+
+run_suite engine-ci.yml      ENGINE_PATHS_RE  engine  engine
+run_suite codegen-drift.yml  CODEGEN_PATHS_RE codegen .
+
+if [ "$fail" -gt 0 ]; then
+    echo "$pass passed, $fail FAILED"
+    exit 1
+fi
+echo "$pass passed"

--- a/scripts/tests/ci-change-detector.test.sh
+++ b/scripts/tests/ci-change-detector.test.sh
@@ -83,9 +83,13 @@ new_repo() {
     git -C "$CASE_REPO" commit -qm base
 }
 
+# Every builder ends by committing. A silent failure here would leave the repo
+# with no second commit, the block would take its diff-failed branch, and a
+# case expecting "true" would pass for the wrong reason — so callers must stop
+# on a non-zero return.
 commit_change() {
-    git add -A
-    git commit -qm change
+    git add -A || return 1
+    git commit -qm change || return 1
 }
 
 # --- the changes each case commits ------------------------------------------
@@ -102,10 +106,10 @@ build_non_engine_path() {
 
 build_renamed_out() {
     git mv engine/crates/rocky-core/src/lib.rs docs/lib.rs
-    commit_change
+    commit_change || return 1
     # Exhibit the condition: with rename detection on, plain `git diff` folds
     # the move into its destination and the engine path disappears.
-    git diff --name-only HEAD^1 HEAD > "$CASE_SCRATCH/list"
+    git diff --name-only HEAD^1 HEAD > "$CASE_SCRATCH/list" || return 1
     if grep -q '^engine/' "$CASE_SCRATCH/list"; then
         echo "setup: the rename was not folded into its destination" >&2
         return 1
@@ -148,7 +152,7 @@ build_dollar_anchored() {
 
 build_grep_error() {
     : > docs/guide.md
-    commit_change
+    commit_change || return 1
     cat > "$CASE_BIN/grep" <<'STUB'
 #!/usr/bin/env bash
 echo "grep: stubbed failure" >&2
@@ -162,10 +166,10 @@ build_newline_name() {
     target="$(printf 'engine/crates/rocky-core/tests/bad\nname.rs')"
     mkdir -p engine/crates/rocky-core/tests
     : > "$target"
-    commit_change
+    commit_change || return 1
     # Exhibit the condition: git quotes the pathname, so the line starts with
     # a double quote rather than `engine/`.
-    git diff --no-renames --name-only HEAD^1 HEAD > "$CASE_SCRATCH/list"
+    git diff --no-renames --name-only HEAD^1 HEAD > "$CASE_SCRATCH/list" || return 1
     if ! grep -q '^"engine/' "$CASE_SCRATCH/list"; then
         echo "setup: git did not quote the newline pathname" >&2
         return 1


### PR DESCRIPTION
## Summary

Independent red team (Codex) reviewed merged #1571 and found two fail-OPEN holes in the change-detection job, both reproduced and verified. This closes them, in both `engine-ci.yml` and `codegen-drift.yml`.

```
 rename OUT of engine/  ->  --name-only prints only the destination  ->  engine=false
 diff list > ~64 KB     ->  printf | grep -q dies of SIGPIPE (141)   ->  engine=false
```

## Changes

- `git diff --no-renames --name-only HEAD^1 HEAD` — a rename source now counts as a touched path.
- No early-exit pipe. The diff goes to a temp file; grep's exit code is branched explicitly: 0 → run, 1 → skip, anything else → run with a `::warning::` (fail closed).
- The detector's checkout and diff only run on `pull_request`; a push writes `true` from a plain step. Corrects #1571's "main-branch cost is unchanged" claim, which was strictly false (~10 s per push).
- The rocky-mcp guard test now compiles `ENGINE_PATHS_RE` with the `regex` crate and asserts it matches each out-of-tree `include_str!` path — the previous substring/delimiter checks accepted regexes that do not match (glued-`x` and escaped-pipe mutants both slipped through; both now kill the test).

## Test plan

- Byte-for-byte replays of the detector step in scratch repos: rename case and 5001-path SIGPIPE case both flip from `false` to `true`; bad-regex case warns and runs; single-commit repo warns and runs.
- `check_credential_containment.py` passed; its 110-test suite passed; `actionlint` clean on both workflows.
- `cargo test -p rocky-mcp --lib every_out_of_tree_include_is_watched_by_engine_ci`, clippy `-D warnings`, fmt — clean. Mutation-checked via `scripts/mutation-check.sh`.

## On the record (per AGENTS.md)

**Red team:** Codex (`codex-rescue`), two rounds; every finding cross-verified by two independent lenses against the real code before implementation. A final pass over this exact delta is running; its disposition lands as a comment before merge.

**Least confident:** Rust `regex` and GNU `grep -E` agree on the current pattern subset (`^ ( | ) $ \.` and literals); a future edit using `\b`/`\d`/`{n,m}` could diverge. The test comment names the subset.

**Most important thing possibly missing:** live proof of the skip path under the new `${{ steps.diff.outputs.engine || steps.trigger.outputs.engine }}` expression — the first non-engine PR after merge settles it (a skipped step's output is empty; the gate treats empty as run-everything).
