### PR TITLE
fix(engine/rocky-mcp): write and roll back drafts no-follow, and refuse a redirected models directory

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4325,6 +4325,7 @@ dependencies = [
  "arrow",
  "async-trait",
  "chrono",
+ "libc",
  "rmcp",
  "rocky-ai",
  "rocky-cli",

--- a/engine/crates/rocky-core/src/product/commit.rs
+++ b/engine/crates/rocky-core/src/product/commit.rs
@@ -384,6 +384,52 @@ fn create_new_no_follow(path: &Path, mode: Option<u32>) -> std::io::Result<std::
     }
 }
 
+/// Write `bytes` to `path` in place, refusing to follow a symlink at the
+/// leaf.
+///
+/// The counterpart of [`write_new_no_follow`] for a file the caller MEANS
+/// to overwrite — an existing model's SQL or sidecar under a redraft. The
+/// file is truncated in place (same inode, same mode) or created when
+/// absent, so a legitimate overwrite keeps the semantics of
+/// `std::fs::write`. What changes is the leaf: on unix the open carries
+/// `O_NOFOLLOW`, so a link swapped in AFTER a path-based pre-check fails
+/// (`ELOOP`) instead of being written through to its target, and
+/// `O_NONBLOCK`, so a FIFO swapped in cannot park the open waiting for a
+/// reader. The regular-file check is on the DESCRIPTOR — the thing already
+/// opened cannot be swapped underneath it — so a FIFO, socket, or device is
+/// refused before a byte is written.
+///
+/// Windows `OpenOptions` has no `O_NOFOLLOW` equivalent, so there this is a
+/// plain create-or-truncate write and the caller's pre-check is the only
+/// leaf guard: the same stated gap as [`read_no_follow`].
+///
+/// # Errors
+///
+/// Any error from the open, the descriptor's metadata, the truncate, or the
+/// write; `InvalidInput` when what was opened is not a regular file.
+pub fn write_no_follow(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    use std::io::Write as _;
+    let mut options = std::fs::OpenOptions::new();
+    // `truncate(false)`: the truncate happens below, once the descriptor is
+    // known to be a regular file.
+    options.write(true).create(true).truncate(false);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    }
+    let mut file = options.open(path)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("refusing to write {} — not a regular file", path.display()),
+        ));
+    }
+    file.set_len(0)?;
+    file.write_all(bytes)
+}
+
 /// Read `path` whole, refusing to follow a symlink at the leaf, and hand
 /// back its mode alongside the bytes.
 ///
@@ -2636,6 +2682,22 @@ mod tests {
         assert_eq!(mode & 0o777, 0o755, "the ordinary permission bits carry");
     }
 
+    /// Create a FIFO at `path` for the non-regular-file probes.
+    #[cfg(unix)]
+    fn make_fifo(path: &Path) {
+        let c_path = std::ffi::CString::new(path.as_os_str().as_encoded_bytes())
+            .expect("path has no interior nul");
+        // SAFETY: `mkfifo` with a valid NUL-terminated path and a mode is
+        // sound; the worst case is a failure return, asserted below.
+        let made = unsafe { libc::mkfifo(c_path.as_ptr(), 0o644) };
+        assert_eq!(
+            made,
+            0,
+            "mkfifo failed: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+
     /// A non-regular source is refused, and refused WITHOUT blocking.
     ///
     /// `std::fs::copy` rejected non-regular sources; reading by hand has to
@@ -2649,17 +2711,7 @@ mod tests {
         let project = seeded_project(dir.path());
         let final_path = project.join("models/revenue_daily.contract.toml");
         std::fs::remove_file(&final_path).ok();
-        let c_path = std::ffi::CString::new(final_path.as_os_str().as_encoded_bytes())
-            .expect("path has no interior nul");
-        // SAFETY: `mkfifo` with a valid NUL-terminated path and a mode is
-        // sound; the worst case is a failure return, asserted below.
-        let made = unsafe { libc::mkfifo(c_path.as_ptr(), 0o644) };
-        assert_eq!(
-            made,
-            0,
-            "mkfifo failed: {}",
-            std::io::Error::last_os_error()
-        );
+        make_fifo(&final_path);
         let prev = prev_sibling(&final_path);
 
         // The assertion is that this RETURNS. Before O_NONBLOCK it would
@@ -2671,6 +2723,131 @@ mod tests {
             "expected the regular-file refusal, got: {error}"
         );
         assert!(!prev.exists(), "a refused copy must leave no backup behind");
+    }
+
+    /// The in-place write refuses a symlink at the leaf — resolving or
+    /// dangling — by the open itself, and leaves the link and its target
+    /// alone. This is the draft tools' race guard: a link swapped in at a
+    /// draft path after the path-based pre-check meets this open, not a
+    /// follow.
+    #[cfg(unix)]
+    #[test]
+    fn write_no_follow_refuses_a_symlinked_leaf_and_leaves_the_target_untouched() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let secret = dir.path().join("outside-secret");
+        std::fs::write(&secret, b"bytes the write must not replace").expect("write");
+        let resolving = dir.path().join("resolving.toml");
+        plant_symlink(&resolving, &secret);
+        let dangling = dir.path().join("dangling.toml");
+        let nowhere = dir.path().join("nowhere.toml");
+        plant_symlink(&dangling, &nowhere);
+
+        for link in [&resolving, &dangling] {
+            let error = write_no_follow(link, b"draft").expect_err("a symlinked leaf is refused");
+            assert_eq!(
+                error.raw_os_error(),
+                Some(libc::ELOOP),
+                "refused by the no-follow open itself: {error}"
+            );
+            assert!(
+                std::fs::symlink_metadata(link)
+                    .expect("still there")
+                    .file_type()
+                    .is_symlink(),
+                "the link is left in place"
+            );
+        }
+        assert_eq!(
+            std::fs::read(&secret).expect("still there"),
+            b"bytes the write must not replace"
+        );
+        assert!(
+            !nowhere.exists(),
+            "the dangling link's target was not created"
+        );
+    }
+
+    /// The in-place write keeps the file's identity: an existing regular
+    /// file is truncated and rewritten under the same inode and mode, and an
+    /// absent path is created. (`write_new_no_follow` unlinks and recreates;
+    /// a redraft of a user's own model must not.)
+    #[cfg(unix)]
+    #[test]
+    fn write_no_follow_rewrites_an_existing_file_in_place_and_creates_an_absent_one() {
+        use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let existing = dir.path().join("orders.toml");
+        std::fs::write(
+            &existing,
+            "name = \"orders\"\n\n[strategy]\ntype = \"full_refresh\"\n",
+        )
+        .expect("write");
+        std::fs::set_permissions(&existing, std::fs::Permissions::from_mode(0o640)).expect("chmod");
+        let before = std::fs::metadata(&existing).expect("metadata");
+
+        write_no_follow(&existing, b"name = \"orders\"\n").expect("in-place write");
+
+        let after = std::fs::metadata(&existing).expect("metadata");
+        assert_eq!(
+            std::fs::read(&existing).expect("read"),
+            b"name = \"orders\"\n",
+            "truncated to the new bytes, not appended"
+        );
+        assert_eq!(after.ino(), before.ino(), "the same inode");
+        assert_eq!(after.mode() & 0o777, 0o640, "the same mode");
+
+        let fresh = dir.path().join("fresh.sql");
+        write_no_follow(&fresh, b"SELECT 1 AS id\n").expect("create");
+        assert_eq!(std::fs::read(&fresh).expect("read"), b"SELECT 1 AS id\n");
+    }
+
+    /// A non-regular leaf is refused WITHOUT blocking. A FIFO with no reader
+    /// would park a blocking write-open forever; with a reader the open
+    /// succeeds and the DESCRIPTOR check refuses it. A directory is refused
+    /// by the open. Nothing is written in any case.
+    #[cfg(unix)]
+    #[test]
+    fn write_no_follow_refuses_a_fifo_and_a_directory_instead_of_blocking() {
+        use std::os::unix::fs::{FileTypeExt as _, OpenOptionsExt as _};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let fifo = dir.path().join("orders.sql");
+        make_fifo(&fifo);
+
+        // No reader: the assertion is that this RETURNS.
+        assert!(
+            write_no_follow(&fifo, b"SELECT 1").is_err(),
+            "a FIFO with no reader is refused"
+        );
+
+        // A reader present: the open succeeds, the descriptor check refuses.
+        let _reader = std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NONBLOCK)
+            .open(&fifo)
+            .expect("open the read end");
+        let error =
+            write_no_follow(&fifo, b"SELECT 1").expect_err("a FIFO with a reader is refused");
+        assert!(
+            error.to_string().contains("not a regular file"),
+            "expected the regular-file refusal, got: {error}"
+        );
+        assert!(
+            std::fs::symlink_metadata(&fifo)
+                .expect("still there")
+                .file_type()
+                .is_fifo(),
+            "the FIFO is left in place"
+        );
+
+        let directory = dir.path().join("orders.toml");
+        std::fs::create_dir(&directory).expect("mkdir");
+        assert!(
+            write_no_follow(&directory, b"name = \"orders\"").is_err(),
+            "a directory is refused"
+        );
+        assert!(directory.is_dir(), "the directory is left in place");
     }
 
     #[cfg(unix)]

--- a/engine/crates/rocky-core/src/product/commit.rs
+++ b/engine/crates/rocky-core/src/product/commit.rs
@@ -430,6 +430,40 @@ pub fn write_no_follow(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     file.write_all(bytes)
 }
 
+/// The largest artifact read whole through the no-follow read helpers.
+///
+/// The files copied here are a lowered contract, sidecar, SQL model, and
+/// manifest — kilobytes. `std::fs::copy` streamed, so it could not be made
+/// to exhaust memory; reading whole can be, which is why the size is
+/// bounded rather than trusted. [`read_no_follow_bytes`] shares the bound,
+/// for the same reason and over the same kind of file.
+const MAX_BACKUP_BYTES: u64 = 16 * 1024 * 1024;
+
+/// Read `path` whole, refusing to follow a symlink at the leaf, and hand
+/// back just the bytes.
+///
+/// The read counterpart of [`write_no_follow`], for a caller that must
+/// capture a file's CURRENT content before overwriting it — the draft
+/// tools' rollback snapshot. `std::fs::read` resolves the path again, so a
+/// link swapped in after a path-based pre-check is read through to its
+/// target and a FIFO parks the read until a writer appears. This opens
+/// once with `O_NOFOLLOW | O_NONBLOCK`, checks the DESCRIPTOR is a regular
+/// file, and reads from that same descriptor — never a second path lookup.
+/// The read is bounded by [`MAX_BACKUP_BYTES`].
+///
+/// Windows `OpenOptions` has no `O_NOFOLLOW` equivalent, so there the read
+/// still follows a symlink or junction and the caller's pre-check is the
+/// only leaf guard: the same stated gap as [`write_no_follow`].
+///
+/// # Errors
+///
+/// Any error from the open or the read — `NotFound` when nothing is at the
+/// path, `ELOOP` for a symlinked leaf on unix; `InvalidInput` when what was
+/// opened is not a regular file, or is over the size bound.
+pub fn read_no_follow_bytes(path: &Path) -> std::io::Result<Vec<u8>> {
+    read_no_follow(path).map(|(bytes, _)| bytes)
+}
+
 /// Read `path` whole, refusing to follow a symlink at the leaf, and hand
 /// back its mode alongside the bytes.
 ///
@@ -443,14 +477,6 @@ pub fn write_no_follow(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
 ///
 /// The mode comes off the DESCRIPTOR, not a second path lookup, so it
 /// describes the same file the bytes came from.
-/// The largest artifact this module will back up.
-///
-/// The files copied here are a lowered contract, sidecar, SQL model, and
-/// manifest — kilobytes. `std::fs::copy` streamed, so it could not be made
-/// to exhaust memory; reading whole can be, which is why the size is
-/// bounded rather than trusted.
-const MAX_BACKUP_BYTES: u64 = 16 * 1024 * 1024;
-
 fn read_no_follow(path: &Path) -> std::io::Result<(Vec<u8>, std::fs::Permissions)> {
     use std::io::Read as _;
     let mut options = std::fs::OpenOptions::new();
@@ -2848,6 +2874,127 @@ mod tests {
             "a directory is refused"
         );
         assert!(directory.is_dir(), "the directory is left in place");
+    }
+
+    /// The pub read counterpart: a regular file reads back verbatim, an
+    /// absent path is `NotFound` (the caller's "absent" arm), and a
+    /// symlinked leaf — resolving or dangling — is refused by the open
+    /// itself rather than read through to its target.
+    #[cfg(unix)]
+    #[test]
+    fn read_no_follow_bytes_reads_a_regular_file_and_refuses_a_symlinked_leaf() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let regular = dir.path().join("orders.toml");
+        std::fs::write(&regular, b"name = \"orders\"\n").expect("write");
+        assert_eq!(
+            read_no_follow_bytes(&regular).expect("a regular file reads"),
+            b"name = \"orders\"\n"
+        );
+        assert_eq!(
+            read_no_follow_bytes(&dir.path().join("absent.toml"))
+                .expect_err("an absent path is NotFound")
+                .kind(),
+            std::io::ErrorKind::NotFound,
+            "the caller maps NotFound to \"absent\"; nothing else may take that arm"
+        );
+
+        let secret = dir.path().join("outside-secret");
+        std::fs::write(&secret, b"bytes the read must not capture").expect("write");
+        let resolving = dir.path().join("resolving.toml");
+        plant_symlink(&resolving, &secret);
+        let dangling = dir.path().join("dangling.toml");
+        plant_symlink(&dangling, &dir.path().join("nowhere.toml"));
+
+        for link in [&resolving, &dangling] {
+            let error = read_no_follow_bytes(link).expect_err("a symlinked leaf is refused");
+            assert_eq!(
+                error.raw_os_error(),
+                Some(libc::ELOOP),
+                "refused by the no-follow open itself: {error}"
+            );
+            assert_ne!(
+                error.kind(),
+                std::io::ErrorKind::NotFound,
+                "a dangling link must not read as \"absent\""
+            );
+        }
+    }
+
+    /// A non-regular leaf is refused WITHOUT blocking. A FIFO with no writer
+    /// would park a blocking read-open forever — the shape that hung the
+    /// draft snapshot; with a writer the open succeeds and the DESCRIPTOR
+    /// check refuses it. A directory is refused either by the open (Linux)
+    /// or by the same descriptor check (macOS).
+    #[cfg(unix)]
+    #[test]
+    fn read_no_follow_bytes_refuses_a_fifo_and_a_directory_instead_of_blocking() {
+        use std::io::Write as _;
+        use std::os::unix::fs::{FileTypeExt as _, OpenOptionsExt as _};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let fifo = dir.path().join("orders.sql");
+        make_fifo(&fifo);
+
+        // No writer: a blocking read-open parks here until one appears.
+        // `O_NONBLOCK` returns instead, and the descriptor check refuses.
+        let error = read_no_follow_bytes(&fifo).expect_err("a FIFO with no writer is refused");
+        assert!(
+            error.to_string().contains("not a regular file"),
+            "expected the regular-file refusal, got: {error}"
+        );
+
+        // Bytes waiting in the pipe do not make it a file either: a reader
+        // must exist before the write end can be opened at all.
+        let _reader = std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NONBLOCK)
+            .open(&fifo)
+            .expect("open the read end");
+        let mut writer = std::fs::OpenOptions::new()
+            .write(true)
+            .custom_flags(libc::O_NONBLOCK)
+            .open(&fifo)
+            .expect("open the write end");
+        writer.write_all(b"not the model").expect("feed the FIFO");
+        let error = read_no_follow_bytes(&fifo).expect_err("a FIFO with a writer is refused");
+        assert!(
+            error.to_string().contains("not a regular file"),
+            "expected the regular-file refusal, got: {error}"
+        );
+        assert!(
+            std::fs::symlink_metadata(&fifo)
+                .expect("still there")
+                .file_type()
+                .is_fifo(),
+            "the FIFO is left in place"
+        );
+
+        let directory = dir.path().join("orders.toml");
+        std::fs::create_dir(&directory).expect("mkdir");
+        let error = read_no_follow_bytes(&directory).expect_err("a directory is refused");
+        assert_ne!(
+            error.kind(),
+            std::io::ErrorKind::NotFound,
+            "a directory must not read as \"absent\": {error}"
+        );
+        assert!(directory.is_dir(), "the directory is left in place");
+    }
+
+    /// The read is bounded, not trusted: a file over `MAX_BACKUP_BYTES`
+    /// refuses instead of being buffered whole. The bound covers the draft
+    /// snapshot too, so a redraft of a model larger than the limit refuses
+    /// where a plain `std::fs::read` would have loaded it.
+    #[test]
+    fn read_no_follow_bytes_refuses_a_file_over_the_size_bound() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let oversized = dir.path().join("huge.sql");
+        std::fs::write(&oversized, vec![b'x'; MAX_BACKUP_BYTES as usize + 1]).expect("write");
+
+        let error = read_no_follow_bytes(&oversized).expect_err("an oversized file is refused");
+        assert!(
+            error.to_string().contains("exceeds the"),
+            "expected the size refusal, got: {error}"
+        );
     }
 
     #[cfg(unix)]

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -54,6 +54,10 @@ rocky-snowflake = { path = "../rocky-snowflake" }
 rocky-ai = { path = "../rocky-ai" }
 tempfile = "3"
 serde_json = { workspace = true }
+# The mid-flight mutation probes in roundtrip.rs hold the draft handler on a
+# FIFO between its write and its verdict: `O_NONBLOCK` for the write-end open
+# and `ENXIO` for "no reader yet".
+libc = { workspace = true }
 # The scripted round-trip test drives the stdio server in-process with an rmcp
 # client over a duplex pipe, so it needs the client side of rmcp too.
 rmcp = { version = "3.0", features = ["server", "macros", "transport-io", "client"] }

--- a/engine/crates/rocky-mcp/src/error.rs
+++ b/engine/crates/rocky-mcp/src/error.rs
@@ -110,12 +110,12 @@ pub struct ToolError {
     /// helpers).
     #[serde(flatten)]
     pub recorded_plan: Option<Box<RecordedPlanHandoff>>,
-    /// The project-relative paths a refused draft's rollback FAILED to clean
-    /// up — each is an artifact still on disk that the refusal `message` says
-    /// to remove or restore (#1561). Set only by
-    /// [`ToolError::policy_denied_after_rollback`] when the rollback reported
-    /// failures; absent (nothing on the wire) on every other error, a clean
-    /// rollback included.
+    /// The project-relative paths a refused draft's rollback FAILED to put
+    /// back (#1561) — each is either a refused artifact still on disk or a
+    /// prior file that is now absent; the refusal `message` says which, per
+    /// path. Set only by [`ToolError::policy_denied_after_rollback`] when the
+    /// rollback reported failures; absent (nothing on the wire) on every
+    /// other error, a clean rollback included.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rollback_failed_paths: Option<Vec<String>>,
 }
@@ -393,7 +393,18 @@ mod tests {
                 "`{field}` is an always-present envelope field; required = {required:?}"
             );
         }
-        for field in ["plan_id", "product_id", "spec_digest", "policy_rule"] {
+        for field in [
+            "plan_id",
+            "product_id",
+            "spec_digest",
+            "policy_rule",
+            "rollback_failed_paths",
+        ] {
+            assert!(
+                properties.contains_key(field),
+                "`{field}` must be a property of the ToolError schema; got properties {:?}",
+                properties.keys().collect::<Vec<_>>()
+            );
             assert!(
                 !required.contains(&field),
                 "`{field}` must stay OPTIONAL on the wire; required = {required:?}"

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -2166,24 +2166,15 @@ impl RockyMcpServer {
         let sidecar_path = self.models_dir.join(format!("{stem}.toml"));
         let contract_path = self.models_dir.join(format!("{stem}.contract.toml"));
 
-        // Symlink defense-in-depth: if a target already exists, confirm it
-        // resolves under the (canonicalized) models directory before we write
-        // through it. A not-yet-existing path passed the syntactic check above.
+        // NO-FOLLOW. `std::fs::write` follows a symlink, so a link planted at
+        // a draft path carried the write out of the models directory, and the
+        // rollback's `remove_file` then unlinked only the link — the refusal
+        // claimed a clean rollback while the written-through file kept the
+        // draft. The canonicalize check this replaces skipped a DANGLING link
+        // (`exists()` follows it and reports false). Any symlink at any draft
+        // path now refuses, dangling or not, before a snapshot or a write.
         for p in [&sql_path, &sidecar_path, &contract_path] {
-            if p.exists() {
-                let base = self.models_dir.canonicalize().map_err(|e| {
-                    bad(format!("failed to canonicalize the models directory: {e}"))
-                })?;
-                let canon = p
-                    .canonicalize()
-                    .map_err(|e| bad(format!("failed to canonicalize {}: {e}", p.display())))?;
-                if !canon.starts_with(&base) {
-                    return Err(bad(format!(
-                        "draft path {} resolves outside the models directory",
-                        p.display()
-                    )));
-                }
-            }
+            refuse_symlinked_draft_target(&self.root, p)?;
         }
 
         Ok(DraftPaths {
@@ -2326,33 +2317,19 @@ impl RockyMcpServer {
         // artifact — a draft the policy plane refuses must not linger on disk
         // (mirrors the propose gate's deny → no plan written). A drop-guard,
         // not a manual closure: unwinding restores too.
+        //
+        // An EXISTS-but-unreadable file REFUSES here, for the SQL and the
+        // sidecar alike, mirroring the unparseable-sidecar refusal below. Read
+        // as "absent", the draft would treat the model as NEW — overwriting
+        // the sidecar's spec-owned metadata, evaluating policy with no prior
+        // classifications, and, on a deny or a failed compile, "restoring"
+        // the absent prior by DELETING the file. The sidecar used to have a
+        // guard for that shape after the snapshot; the SQL file had none, so
+        // the snapshot itself now refuses (#1572 follow-up).
         let rollback =
             DraftRollback::snapshot_async(vec![paths.sql_path.clone(), paths.sidecar_path.clone()])
-                .await;
-
-        // FF-WP1 fix round 2 (item 2): an EXISTS-but-unreadable sidecar must
-        // REFUSE, mirroring the unparseable refusal below. The snapshot
-        // converts read errors to "absent", so without this guard the draft
-        // would treat the model as NEW — overwriting the sidecar's spec-owned
-        // metadata, evaluating policy with no prior classifications, and, on
-        // a deny, "restoring" the absent prior by DELETING the file. Checked
-        // against the same snapshot read the merge decision uses. Nothing has
-        // been written yet, so the guard is defused rather than dropped — a
-        // drop would perform exactly the deletion this refusal prevents.
-        if rollback.prior(&paths.sidecar_path).is_none()
-            && std::fs::metadata(&paths.sidecar_path).is_ok()
-        {
-            rollback.defuse();
-            return Err(ToolError::invalid_argument(
-                format!(
-                    "the sidecar at {} exists but cannot be read; refusing to rewrite it",
-                    rel_display(&self.root, &paths.sidecar_path)
-                ),
-                "Fix the sidecar file's permissions (it must be readable so its spec-owned \
-                 metadata can be preserved), then retry. draft_model never overwrites a sidecar \
-                 it cannot read.",
-            ));
-        }
+                .await
+                .map_err(|e| e.into_tool_error(&self.root))?;
 
         // FF-WP1 fix round (finding 2): build the sidecar to write, and
         // collect the PRIOR sidecar's classifications for the policy
@@ -2640,7 +2617,9 @@ impl RockyMcpServer {
         // Snapshot so a policy DENY (or a write/compile failure, or a panic
         // before the verdict) rolls back to leave NO new artifact — mirrors
         // `draft_model` and the propose gate. Drop-guard: unwinding restores.
-        let rollback = DraftRollback::snapshot_async(vec![paths.contract_path.clone()]).await;
+        let rollback = DraftRollback::snapshot_async(vec![paths.contract_path.clone()])
+            .await
+            .map_err(|e| e.into_tool_error(&self.root))?;
 
         if let Err(e) = std::fs::write(&paths.contract_path, ensure_trailing_newline(&spec)) {
             return Err(ToolError::internal(
@@ -2795,8 +2774,11 @@ impl RockyMcpServer {
         // Snapshot the sidecar so a DENY (or a failure/panic before the
         // verdict) restores the model's PRIOR sidecar (the name/intent
         // draft_model wrote), never deletes it — the check is what rolls back,
-        // not the model. A model with no sidecar yet snapshots None.
-        let rollback = DraftRollback::snapshot_async(vec![paths.sidecar_path.clone()]).await;
+        // not the model. A model with no sidecar yet snapshots None; a sidecar
+        // that exists but cannot be read refuses.
+        let rollback = DraftRollback::snapshot_async(vec![paths.sidecar_path.clone()])
+            .await
+            .map_err(|e| e.into_tool_error(&self.root))?;
 
         // Merge: append the `[[tests]]` block(s) to the existing sidecar, or seed
         // a minimal sidecar (`name = "<stem>"`) when the model is a bare `.sql`.
@@ -2971,7 +2953,10 @@ impl RockyMcpServer {
 
         // Snapshot the sidecar so a DENY (or a write/compile failure, or a
         // panic before the verdict) restores the model's PRIOR sidecar bytes.
-        let rollback = DraftRollback::snapshot_async(vec![paths.sidecar_path.clone()]).await;
+        // A sidecar that exists but cannot be read refuses.
+        let rollback = DraftRollback::snapshot_async(vec![paths.sidecar_path.clone()])
+            .await
+            .map_err(|e| e.into_tool_error(&self.root))?;
 
         // Parse-merge, never string-append: the existing sidecar must parse as
         // TOML or the call fails naming it — an unparseable sidecar is never
@@ -4857,6 +4842,61 @@ fn restore_or_remove(path: &Path, prior: Option<&[u8]>) -> std::io::Result<()> {
     }
 }
 
+/// Refuse a draft path occupied by a symlink — dangling or not — before
+/// anything is snapshotted or written through it. Every draft tool resolves
+/// its paths through this (via `resolve_draft_paths`): the up-front half of
+/// the no-follow guard, beside the O_EXCL / `O_NOFOLLOW` guards on the product
+/// commit path. `symlink_metadata` does not follow, so a dangling link is seen
+/// as what it is. An absent path is fine; any other inspection failure refuses
+/// too, because the write would land somewhere the tool could not inspect.
+fn refuse_symlinked_draft_target(root: &Path, path: &Path) -> Result<(), Json<ToolError>> {
+    match std::fs::symlink_metadata(path) {
+        Ok(meta) if meta.file_type().is_symlink() => Err(ToolError::invalid_argument(
+            format!(
+                "draft target {} is a symlink; refusing to write through it",
+                rel_display(root, path)
+            ),
+            "Replace the symlink with a regular file, or remove it, so the draft lands inside \
+             the models directory, then retry. The draft tools never write through a link, \
+             dangling or not.",
+        )),
+        Ok(_) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(ToolError::internal(
+            format!(
+                "failed to inspect draft target {}: {e}",
+                rel_display(root, path)
+            ),
+            "Ensure the models directory is readable, then retry.",
+        )),
+    }
+}
+
+/// A path [`DraftRollback::snapshot`] found on disk but could not read.
+/// Refused before anything is written: the draft tools never overwrite a file
+/// they cannot read back, because its content is what the rollback would have
+/// to restore.
+#[derive(Debug)]
+struct UnreadablePrior {
+    path: PathBuf,
+    error: std::io::Error,
+}
+
+impl UnreadablePrior {
+    fn into_tool_error(self, root: &Path) -> Json<ToolError> {
+        ToolError::invalid_argument(
+            format!(
+                "the file at {} exists but cannot be read ({}); refusing to draft over it",
+                rel_display(root, &self.path),
+                self.error
+            ),
+            "Fix the file's permissions (it must be readable so its prior content can be \
+             preserved and restored), then retry. The draft tools never overwrite a file they \
+             cannot read back.",
+        )
+    }
+}
+
 /// Panic-safe rollback guard for the `draft_*` write tools.
 ///
 /// Snapshots each path's prior bytes at construction and restores them (via
@@ -4877,33 +4917,39 @@ struct DraftRollback {
 }
 
 impl DraftRollback {
-    /// Snapshot `paths` before the draft writes them.
-    fn snapshot<I, P>(paths: I) -> Self
+    /// Snapshot `paths` before the draft writes them. Only a NotFound read is
+    /// "absent" (`None`). Any other read error — permission denied, a
+    /// directory at the path — refuses the whole snapshot: a path that EXISTS
+    /// but cannot be read back has no prior to restore, so the rollback would
+    /// take the remove arm and delete it (#1572 follow-up).
+    fn snapshot<I, P>(paths: I) -> Result<Self, UnreadablePrior>
     where
         I: IntoIterator<Item = P>,
         P: Into<PathBuf>,
     {
-        let entries = paths
-            .into_iter()
-            .map(|p| {
-                let path = p.into();
-                let prior = std::fs::read(&path).ok();
-                (path, prior)
-            })
-            .collect();
-        Self {
+        let mut entries = Vec::new();
+        for p in paths {
+            let path: PathBuf = p.into();
+            let prior = match std::fs::read(&path) {
+                Ok(bytes) => Some(bytes),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+                Err(error) => return Err(UnreadablePrior { path, error }),
+            };
+            entries.push((path, prior));
+        }
+        Ok(Self {
             entries,
             defused: false,
-        }
+        })
     }
 
     /// Async wrapper over [`snapshot`](Self::snapshot) that runs the prior-bytes
     /// reads on the blocking pool. The async draft handlers use this so the
     /// snapshot reads don't block the tokio worker; the sync `snapshot` stays
     /// for the `catch_unwind`-based restore-on-panic unit test.
-    async fn snapshot_async(paths: Vec<PathBuf>) -> Self {
-        // `snapshot` only ever reads with `.ok()`, so the closure can't panic
-        // and the `JoinError` arm is unreachable in practice.
+    async fn snapshot_async(paths: Vec<PathBuf>) -> Result<Self, UnreadablePrior> {
+        // `snapshot` returns every read error, so the closure can't panic and
+        // the `JoinError` arm is unreachable in practice.
         tokio::task::spawn_blocking(move || Self::snapshot(paths))
             .await
             .expect("DraftRollback::snapshot does not panic")
@@ -4957,11 +5003,14 @@ impl Drop for DraftRollback {
             if let Err(error) = restore_or_remove(path, prior.as_deref()) {
                 // The unwind path cannot return the outcome; the deliberate
                 // refusal arms use `rollback` for that. Log so the leftover
-                // is at least visible to the operator.
+                // is at least visible to the operator — checked, not assumed:
+                // a failed restore can leave the path gone.
+                let on_disk = std::fs::symlink_metadata(path).is_ok();
                 tracing::warn!(
                     path = %path.display(),
                     %error,
-                    "draft rollback failed; the artifact remains on disk"
+                    on_disk,
+                    "draft rollback failed"
                 );
             }
         }
@@ -4979,12 +5028,18 @@ struct RollbackFailure {
 
 /// Roll a refused draft back and word the outcome for the refusal message:
 /// `clean` verbatim when every snapshotted path restored, or a sentence
-/// naming each artifact still on disk (with its I/O cause) when the cleanup
-/// FAILED — a refusal must never claim a rollback it did not perform (#1561).
-/// `failed_lead` opens the failure sentence so it reads in the arm's grammar
-/// (e.g. "but rolling it back FAILED" mid-sentence). A failure also returns
-/// the project-relative paths for the envelope's `rollback_failed_paths`
-/// field.
+/// naming each path the cleanup FAILED on (with its I/O cause) and what that
+/// left behind — a refusal must never claim a rollback it did not perform
+/// (#1561). `failed_lead` opens the failure sentence so it reads in the arm's
+/// grammar (e.g. "but rolling it back FAILED" mid-sentence). A failure also
+/// returns the project-relative paths for the envelope's
+/// `rollback_failed_paths` field.
+///
+/// What was left behind is CHECKED, not assumed: a failed restore can leave
+/// the path gone (the prior file removed, then its parent unwritable), and
+/// "remove it" then points at nothing while the prior content is what was
+/// lost. `symlink_metadata` does not follow a link, so a leftover link counts
+/// as on disk.
 fn rollback_disposition(
     root: &Path,
     rollback: DraftRollback,
@@ -5011,11 +5066,35 @@ fn rollback_disposition(
         .iter()
         .map(|f| rel_display(root, &f.path))
         .collect();
+    let (on_disk, absent): (Vec<&RollbackFailure>, Vec<&RollbackFailure>) = failures
+        .iter()
+        .partition(|f| std::fs::symlink_metadata(&f.path).is_ok());
+    let mut outcome = Vec::new();
+    if !on_disk.is_empty() {
+        outcome.push(
+            "the refused artifact is STILL ON DISK, remove it or restore its prior content \
+             manually"
+                .to_string(),
+        );
+    }
+    if !absent.is_empty() {
+        let names = absent
+            .iter()
+            .map(|f| rel_display(root, &f.path))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let (path_word, is_are) = if absent.len() == 1 {
+            ("path", "is")
+        } else {
+            ("paths", "are")
+        };
+        outcome.push(format!(
+            "the prior content of {names} could not be restored and the {path_word} {is_are} \
+             now absent, recover it from version control or a backup"
+        ));
+    }
     (
-        format!(
-            "{failed_lead} — {listed}; the refused artifact is STILL ON DISK, remove it or \
-             restore its prior content manually."
-        ),
+        format!("{failed_lead} — {listed}; {}.", outcome.join("; ")),
         Some(paths),
     )
 }
@@ -5593,7 +5672,7 @@ mod tests {
         std::fs::write(&existing, "original").unwrap();
         let fresh = dir.path().join("fresh.sql");
 
-        let guard = DraftRollback::snapshot([&existing, &fresh]);
+        let guard = DraftRollback::snapshot([&existing, &fresh]).expect("snapshot");
         let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let _guard = guard;
             std::fs::write(&existing, "clobbered").unwrap();
@@ -5617,7 +5696,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let fresh = dir.path().join("fresh.sql");
         {
-            let _guard = DraftRollback::snapshot([&fresh]);
+            let _guard = DraftRollback::snapshot([&fresh]).expect("snapshot");
             std::fs::write(&fresh, "draft body").unwrap();
             // The guard drops here without defuse, as on an Err return.
         }
@@ -5632,7 +5711,7 @@ mod tests {
         let sidecar = dir.path().join("model.toml");
         std::fs::write(&sidecar, "name = \"m\"").unwrap();
 
-        let guard = DraftRollback::snapshot([&sidecar]);
+        let guard = DraftRollback::snapshot([&sidecar]).expect("snapshot");
         assert_eq!(
             guard.prior(&sidecar),
             Some("name = \"m\"".as_bytes()),
@@ -5661,7 +5740,7 @@ mod tests {
     fn rollback_disposition_clean_keeps_the_claim() {
         let dir = tempfile::tempdir().unwrap();
         let fresh = dir.path().join("fresh.sql");
-        let guard = DraftRollback::snapshot([&fresh]);
+        let guard = DraftRollback::snapshot([&fresh]).expect("snapshot");
         std::fs::write(&fresh, "draft body").unwrap();
 
         let (disposition, failed) = rollback_disposition(
@@ -5689,7 +5768,7 @@ mod tests {
         let fresh = root.join("models").join("shadow.sql");
         std::fs::create_dir_all(fresh.parent().unwrap()).unwrap();
 
-        let guard = DraftRollback::snapshot([&fresh]);
+        let guard = DraftRollback::snapshot([&fresh]).expect("snapshot");
         std::fs::create_dir_all(fresh.join("occupied")).unwrap();
 
         let (disposition, failed) = rollback_disposition(
@@ -5732,7 +5811,7 @@ mod tests {
         let fresh = models.join("shadow.sql");
         let probe = models.join("probe");
 
-        let guard = DraftRollback::snapshot([&fresh]);
+        let guard = DraftRollback::snapshot([&fresh]).expect("snapshot");
         std::fs::write(&fresh, "SELECT 1 AS id").unwrap();
         std::fs::write(&probe, "x").unwrap();
         std::fs::set_permissions(&models, std::fs::Permissions::from_mode(0o555)).unwrap();
@@ -5750,6 +5829,154 @@ mod tests {
         assert_eq!(failures[0].path, fresh);
         assert_eq!(failures[0].action, "removed");
         assert!(fresh.exists(), "the artifact really is still on disk");
+    }
+
+    /// The snapshot refuses a path that EXISTS but cannot be read, instead of
+    /// recording it as absent — the shape that had the rollback DELETE a
+    /// user's file (the remove arm, for a path with "no prior"). A directory
+    /// at the path is the root-proof way to make the read fail; an absent
+    /// sibling still snapshots as `None`.
+    #[test]
+    fn draft_rollback_snapshot_refuses_an_existing_path_it_cannot_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let occupied = root.join("models").join("orders.sql");
+        std::fs::create_dir_all(&occupied).unwrap();
+        let absent = root.join("models").join("fresh.sql");
+
+        let refused = DraftRollback::snapshot([&absent, &occupied])
+            .err()
+            .expect("an existing path that cannot be read refuses the snapshot");
+        assert_eq!(refused.path, occupied);
+        let err = refused.into_tool_error(root);
+        assert_eq!(err.0.code, crate::error::ToolErrorCode::InvalidArgument);
+        assert!(
+            err.0.message.contains("models/orders.sql") && err.0.message.contains("cannot be read"),
+            "the refusal names the path: {}",
+            err.0.message
+        );
+        assert!(occupied.is_dir(), "nothing touched the path");
+
+        let guard = DraftRollback::snapshot([&absent]).expect("an absent path is a None prior");
+        assert_eq!(guard.prior(&absent), None);
+        guard.defuse();
+    }
+
+    /// A failed restore whose target is GONE says so: the prior file was
+    /// removed and its parent went with it, so `std::fs::write` cannot put
+    /// the bytes back and there is nothing on disk to "remove". Before the
+    /// fix the refusal asserted "STILL ON DISK" for every failure.
+    #[test]
+    fn rollback_disposition_says_the_path_is_absent_when_the_restore_target_is_gone() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let models = root.join("models");
+        std::fs::create_dir_all(&models).unwrap();
+        let sidecar = models.join("orders.toml");
+        std::fs::write(&sidecar, "name = \"orders\"\n").unwrap();
+
+        let guard = DraftRollback::snapshot([&sidecar]).expect("snapshot");
+        std::fs::remove_dir_all(&models).unwrap();
+
+        let (disposition, failed) = rollback_disposition(
+            root,
+            guard,
+            "so the check was not kept.",
+            "but rolling it back FAILED",
+        );
+        assert_eq!(failed, Some(vec!["models/orders.toml".to_string()]));
+        assert!(
+            disposition.contains("models/orders.toml could not be restored to its prior content"),
+            "the refusal names the path and what failed: {disposition}"
+        );
+        assert!(
+            disposition.contains(
+                "the prior content of models/orders.toml could not be restored and the path is \
+                 now absent"
+            ),
+            "the refusal says the path is gone: {disposition}"
+        );
+        assert!(
+            !disposition.contains("STILL ON DISK"),
+            "nothing is on disk; the refusal must not claim otherwise: {disposition}"
+        );
+        assert!(
+            !disposition.contains("not kept"),
+            "a failed rollback must not read as a clean refusal: {disposition}"
+        );
+        assert!(
+            std::fs::symlink_metadata(&sidecar).is_err(),
+            "the path really is absent"
+        );
+    }
+
+    /// Mixed outcome: a path still on disk and a path now gone are each
+    /// reported in their own words, and both ride `rollback_failed_paths`.
+    #[test]
+    fn rollback_disposition_reports_on_disk_and_absent_paths_separately() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let leftover = root.join("models").join("shadow.sql");
+        std::fs::create_dir_all(leftover.parent().unwrap()).unwrap();
+        let gone = root.join("elsewhere").join("orders.toml");
+        std::fs::create_dir_all(gone.parent().unwrap()).unwrap();
+        std::fs::write(&gone, "name = \"orders\"\n").unwrap();
+
+        let guard = DraftRollback::snapshot([&leftover, &gone]).expect("snapshot");
+        std::fs::create_dir_all(leftover.join("occupied")).unwrap();
+        std::fs::remove_dir_all(gone.parent().unwrap()).unwrap();
+
+        let (disposition, failed) =
+            rollback_disposition(root, guard, "clean", "but rolling it back FAILED");
+        assert_eq!(
+            failed,
+            Some(vec![
+                "models/shadow.sql".to_string(),
+                "elsewhere/orders.toml".to_string()
+            ])
+        );
+        assert!(
+            disposition.contains("models/shadow.sql could not be removed")
+                && disposition.contains("STILL ON DISK"),
+            "the leftover is reported as on disk: {disposition}"
+        );
+        assert!(
+            disposition.contains(
+                "the prior content of elsewhere/orders.toml could not be restored and the path \
+                 is now absent"
+            ),
+            "the missing file is reported as absent: {disposition}"
+        );
+    }
+
+    /// The no-follow guard: a symlink at a draft path refuses — dangling or
+    /// resolving — naming the path; a regular file and an absent path pass.
+    #[cfg(unix)]
+    #[test]
+    fn refuse_symlinked_draft_target_refuses_links_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let models = root.join("models");
+        std::fs::create_dir_all(&models).unwrap();
+        let regular = models.join("orders.sql");
+        std::fs::write(&regular, "SELECT 1 AS id\n").unwrap();
+        let dangling = models.join("shadow.sql");
+        std::os::unix::fs::symlink(root.join("nowhere.sql"), &dangling).unwrap();
+        let resolving = models.join("alias.sql");
+        std::os::unix::fs::symlink(&regular, &resolving).unwrap();
+
+        assert!(refuse_symlinked_draft_target(root, &regular).is_ok());
+        assert!(refuse_symlinked_draft_target(root, &models.join("absent.sql")).is_ok());
+        for link in [&dangling, &resolving] {
+            let err = refuse_symlinked_draft_target(root, link).expect_err("a symlink refuses");
+            assert_eq!(err.0.code, crate::error::ToolErrorCode::InvalidArgument);
+            assert!(
+                err.0.message.contains(&rel_display(root, link))
+                    && err.0.message.contains("symlink"),
+                "the refusal names the link: {}",
+                err.0.message
+            );
+        }
     }
 
     // --- validate_check_spec (draft_check structural gate) ---

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -20,6 +20,7 @@ use rmcp::{
 
 use rocky_cli::commands;
 use rocky_compiler::compile::{self, CompileResult as CompilerResult, CompilerConfig};
+use rocky_core::product::commit::write_no_follow;
 
 use crate::error::{ToolError, ToolResult};
 use crate::result_types::*;
@@ -2127,10 +2128,14 @@ impl RockyMcpServer {
     ///
     /// Mirrors the import-dbt `safe_join_under` path guard (the traversal fix
     /// that hardened untrusted `model-paths`): reject an absolute name or any
-    /// path-traversal component syntactically, and — when a target path already
-    /// exists — canonicalize it and confirm it stays under the models directory,
-    /// catching a pre-existing symlink that would redirect the write. A draft
-    /// name is a bare identifier, so a separator, `..`, or extension is refused.
+    /// path-traversal component syntactically. A draft name is a bare
+    /// identifier, so a separator, `..`, or extension is refused. Then the
+    /// two up-front halves of the no-follow guard run, before any snapshot or
+    /// write: the models directory must resolve inside the project root
+    /// ([`Self::refuse_redirected_models_dir`]), and each draft path must be
+    /// absent or a regular file ([`refuse_non_regular_draft_target`]). What
+    /// appears at a leaf AFTER these checks meets the no-follow open on every
+    /// write and rollback (`write_no_follow`), not a follow.
     fn resolve_draft_paths(&self, name: &str) -> Result<DraftPaths, Json<ToolError>> {
         use std::path::Component;
 
@@ -2162,19 +2167,25 @@ impl RockyMcpServer {
             )));
         }
 
+        // The ancestor half of the no-follow guard: `models/` itself reached
+        // through a link would redirect every draft write with no race at
+        // all, and neither the leaf check below nor the no-follow writes look
+        // above the leaf.
+        self.refuse_redirected_models_dir()?;
+
         let sql_path = self.models_dir.join(format!("{stem}.sql"));
         let sidecar_path = self.models_dir.join(format!("{stem}.toml"));
         let contract_path = self.models_dir.join(format!("{stem}.contract.toml"));
 
-        // NO-FOLLOW. `std::fs::write` follows a symlink, so a link planted at
-        // a draft path carried the write out of the models directory, and the
-        // rollback's `remove_file` then unlinked only the link — the refusal
-        // claimed a clean rollback while the written-through file kept the
-        // draft. The canonicalize check this replaces skipped a DANGLING link
-        // (`exists()` follows it and reports false). Any symlink at any draft
-        // path now refuses, dangling or not, before a snapshot or a write.
+        // The leaf half, up front: a symlink at any draft path — dangling or
+        // not; `symlink_metadata` does not follow, where the `exists()` of the
+        // canonicalize check this replaced did — or anything else that is not
+        // a regular file refuses before a snapshot or a write. A FIFO would
+        // park the snapshot's read until a writer appeared. A link swapped in
+        // AFTER this check meets the no-follow open on every write and on the
+        // rollback's restore (`write_no_follow`), never a follow.
         for p in [&sql_path, &sidecar_path, &contract_path] {
-            refuse_symlinked_draft_target(&self.root, p)?;
+            refuse_non_regular_draft_target(&self.root, p)?;
         }
 
         Ok(DraftPaths {
@@ -2183,6 +2194,84 @@ impl RockyMcpServer {
             sidecar_path,
             contract_path,
         })
+    }
+
+    /// Refuse to draft while `models/` resolves outside the project root.
+    ///
+    /// The leaf guard and the no-follow writes only look at the final path
+    /// component, so `proj/models -> <outside>/models_real` redirected every
+    /// draft write with no race at all. Both directories are canonicalized
+    /// here and the models directory must sit under the root. A models
+    /// directory that does not exist yet passes — `draft_model` creates it
+    /// under the root just resolved — unless its name is taken by a dangling
+    /// link. This is a check at one point in time: a link swapped into an
+    /// ANCESTOR after it cannot be closed by path-based syscalls at all, only
+    /// by dirfd-relative opens — the residual #1500 records.
+    fn refuse_redirected_models_dir(&self) -> Result<(), Json<ToolError>> {
+        let resolved_root = match self.root.canonicalize() {
+            Ok(resolved) => resolved,
+            // No root on disk means nothing under it either: there is nothing
+            // to resolve yet, and `draft_model` creates the models directory
+            // under the root as before.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(e) => {
+                return Err(ToolError::internal(
+                    format!(
+                        "failed to resolve the project root {}: {e}",
+                        self.root.display()
+                    ),
+                    "Ensure the project directory is readable, then retry.",
+                ));
+            }
+        };
+        let resolved_models = match self.models_dir.canonicalize() {
+            Ok(resolved) => resolved,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return match std::fs::symlink_metadata(&self.models_dir) {
+                    Ok(meta) if meta.file_type().is_symlink() => Err(ToolError::invalid_argument(
+                        format!(
+                            "the models directory {}/ is a symlink whose target does not \
+                             exist; refusing to draft through it",
+                            rel_display(&self.root, &self.models_dir)
+                        ),
+                        "Replace the link with a real models directory inside the project, \
+                         then retry. Drafts are written only under the project root.",
+                    )),
+                    Ok(_) => Ok(()),
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                    Err(e) => Err(ToolError::internal(
+                        format!(
+                            "failed to inspect the models directory {}: {e}",
+                            self.models_dir.display()
+                        ),
+                        "Ensure the project directory is readable, then retry.",
+                    )),
+                };
+            }
+            Err(e) => {
+                return Err(ToolError::internal(
+                    format!(
+                        "failed to resolve the models directory {}: {e}",
+                        self.models_dir.display()
+                    ),
+                    "Ensure the models directory is readable, then retry.",
+                ));
+            }
+        };
+        if !resolved_models.starts_with(&resolved_root) {
+            return Err(ToolError::invalid_argument(
+                format!(
+                    "the models directory {}/ resolves to {}, outside the project root {}; \
+                     refusing to draft through it",
+                    rel_display(&self.root, &self.models_dir),
+                    resolved_models.display(),
+                    resolved_root.display()
+                ),
+                "Make models/ a real directory inside the project (or a link that stays inside \
+                 it), then retry. Drafts are written only under the project root.",
+            ));
+        }
+        Ok(())
     }
 
     /// Whether the model `stem` already has a source file under `models/`
@@ -2400,7 +2489,11 @@ impl RockyMcpServer {
             };
 
         // Write the draft: the SQL body verbatim + the sidecar built above.
-        if let Err(e) = std::fs::write(&paths.sql_path, ensure_trailing_newline(&args.sql)) {
+        // No-follow at the leaf (`write_no_follow`): a link swapped in at a
+        // draft path after `resolve_draft_paths` looked fails the write
+        // instead of carrying it out of the models directory.
+        let sql = ensure_trailing_newline(&args.sql);
+        if let Err(e) = write_no_follow(&paths.sql_path, sql.as_bytes()) {
             return Err(ToolError::internal(
                 format!(
                     "failed to write draft SQL to {}: {e}",
@@ -2409,7 +2502,7 @@ impl RockyMcpServer {
                 "Ensure the models directory is writable.",
             ));
         }
-        if let Err(e) = std::fs::write(&paths.sidecar_path, sidecar_bytes) {
+        if let Err(e) = write_no_follow(&paths.sidecar_path, sidecar_bytes.as_bytes()) {
             return Err(ToolError::internal(
                 format!(
                     "failed to write draft sidecar to {}: {e}",
@@ -2621,7 +2714,8 @@ impl RockyMcpServer {
             .await
             .map_err(|e| e.into_tool_error(&self.root))?;
 
-        if let Err(e) = std::fs::write(&paths.contract_path, ensure_trailing_newline(&spec)) {
+        let contract = ensure_trailing_newline(&spec);
+        if let Err(e) = write_no_follow(&paths.contract_path, contract.as_bytes()) {
             return Err(ToolError::internal(
                 format!(
                     "failed to write draft contract to {}: {e}",
@@ -2793,7 +2887,8 @@ impl RockyMcpServer {
             }
             None => format!("name = {}\n\n{}", toml_basic_string(&paths.stem), spec),
         };
-        if let Err(e) = std::fs::write(&paths.sidecar_path, ensure_trailing_newline(&merged)) {
+        let merged = ensure_trailing_newline(&merged);
+        if let Err(e) = write_no_follow(&paths.sidecar_path, merged.as_bytes()) {
             return Err(ToolError::internal(
                 format!(
                     "failed to write draft check to {}: {e}",
@@ -3024,7 +3119,8 @@ impl RockyMcpServer {
                 "Retry; if it persists this is an internal TOML serialization bug.",
             )
         })?;
-        if let Err(e) = std::fs::write(&paths.sidecar_path, ensure_trailing_newline(&serialized)) {
+        let serialized = ensure_trailing_newline(&serialized);
+        if let Err(e) = write_no_follow(&paths.sidecar_path, serialized.as_bytes()) {
             return Err(ToolError::internal(
                 format!(
                     "failed to write patched sidecar to {}: {e}",
@@ -4831,10 +4927,15 @@ struct DraftPaths {
 /// model is restored to the model's prior content, so a deny never corrupts nor
 /// leaves a new artifact. Removing an already-absent file is success (the
 /// desired end state holds); any other failure comes back to the caller — the
-/// artifact is still on disk and the refusal must say so (#1561).
+/// refusal must say what it left behind (#1561).
+///
+/// Neither arm follows a link at the leaf. `remove_file` unlinks the leaf
+/// itself; the restore goes through `write_no_follow`, so a link swapped in
+/// at the path since the snapshot fails the restore — reported by the caller
+/// — instead of receiving the prior bytes at its target.
 fn restore_or_remove(path: &Path, prior: Option<&[u8]>) -> std::io::Result<()> {
     match prior {
-        Some(bytes) => std::fs::write(path, bytes),
+        Some(bytes) => write_no_follow(path, bytes),
         None => match std::fs::remove_file(path) {
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
             other => other,
@@ -4842,34 +4943,79 @@ fn restore_or_remove(path: &Path, prior: Option<&[u8]>) -> std::io::Result<()> {
     }
 }
 
-/// Refuse a draft path occupied by a symlink — dangling or not — before
+/// Refuse a draft path occupied by anything but a regular file — a symlink
+/// (dangling or not), a directory, a FIFO, a socket, a device — before
 /// anything is snapshotted or written through it. Every draft tool resolves
-/// its paths through this (via `resolve_draft_paths`): the up-front half of
-/// the no-follow guard, beside the O_EXCL / `O_NOFOLLOW` guards on the product
-/// commit path. `symlink_metadata` does not follow, so a dangling link is seen
-/// as what it is. An absent path is fine; any other inspection failure refuses
-/// too, because the write would land somewhere the tool could not inspect.
-fn refuse_symlinked_draft_target(root: &Path, path: &Path) -> Result<(), Json<ToolError>> {
-    match std::fs::symlink_metadata(path) {
-        Ok(meta) if meta.file_type().is_symlink() => Err(ToolError::invalid_argument(
-            format!(
-                "draft target {} is a symlink; refusing to write through it",
-                rel_display(root, path)
-            ),
-            "Replace the symlink with a regular file, or remove it, so the draft lands inside \
-             the models directory, then retry. The draft tools never write through a link, \
-             dangling or not.",
-        )),
-        Ok(_) => Ok(()),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(e) => Err(ToolError::internal(
-            format!(
-                "failed to inspect draft target {}: {e}",
-                rel_display(root, path)
-            ),
-            "Ensure the models directory is readable, then retry.",
-        )),
+/// its paths through this (via `resolve_draft_paths`): the up-front leaf half
+/// of the no-follow guard. `symlink_metadata` does not follow, so a dangling
+/// link is seen as what it is; a FIFO is refused here because the snapshot's
+/// read would otherwise block until a writer appeared. An absent path is
+/// fine; any other inspection failure refuses too, because the write would
+/// land somewhere the tool could not inspect. What appears AFTER this check
+/// meets the no-follow open on every write and rollback (`write_no_follow`).
+fn refuse_non_regular_draft_target(root: &Path, path: &Path) -> Result<(), Json<ToolError>> {
+    let meta = match std::fs::symlink_metadata(path) {
+        Ok(meta) => meta,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => {
+            return Err(ToolError::internal(
+                format!(
+                    "failed to inspect draft target {}: {e}",
+                    rel_display(root, path)
+                ),
+                "Ensure the models directory is readable, then retry.",
+            ));
+        }
+    };
+    let file_type = meta.file_type();
+    if file_type.is_file() {
+        return Ok(());
     }
+    let (what, remedy) = if file_type.is_symlink() {
+        (
+            "is a symlink; refusing to write through it".to_string(),
+            "Replace the symlink with a regular file, or remove it,",
+        )
+    } else {
+        (
+            format!(
+                "is a {}, not a regular file; refusing to write to it",
+                describe_non_regular(file_type)
+            ),
+            "Remove it,",
+        )
+    };
+    Err(ToolError::invalid_argument(
+        format!("draft target {} {what}", rel_display(root, path)),
+        format!(
+            "{remedy} so the draft lands in a regular file inside the models directory, then \
+             retry. Every draft path is checked before the write, and on unix each write and \
+             rollback opens the leaf without following a link, so a link swapped in after this \
+             check fails the write instead of redirecting it (elsewhere this check is the only \
+             leaf guard)."
+        ),
+    ))
+}
+
+/// Name a non-regular file type for a refusal message.
+fn describe_non_regular(file_type: std::fs::FileType) -> &'static str {
+    if file_type.is_dir() {
+        return "directory";
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::FileTypeExt as _;
+        if file_type.is_fifo() {
+            return "FIFO";
+        }
+        if file_type.is_socket() {
+            return "socket";
+        }
+        if file_type.is_block_device() || file_type.is_char_device() {
+            return "device";
+        }
+    }
+    "non-regular file"
 }
 
 /// A path [`DraftRollback::snapshot`] found on disk but could not read.
@@ -4980,13 +5126,13 @@ impl DraftRollback {
             .iter()
             .filter_map(|(path, prior)| {
                 let error = restore_or_remove(path, prior.as_deref()).err()?;
-                let action = match prior {
-                    Some(_) => "restored to its prior content",
-                    None => "removed",
+                let arm = match prior {
+                    Some(_) => RollbackArm::Restore,
+                    None => RollbackArm::Remove,
                 };
                 Some(RollbackFailure {
                     path: path.clone(),
-                    action,
+                    arm,
                     error,
                 })
             })
@@ -5004,12 +5150,12 @@ impl Drop for DraftRollback {
                 // The unwind path cannot return the outcome; the deliberate
                 // refusal arms use `rollback` for that. Log so the leftover
                 // is at least visible to the operator — checked, not assumed:
-                // a failed restore can leave the path gone.
-                let on_disk = std::fs::symlink_metadata(path).is_ok();
+                // a failed restore can leave the path gone, or uninspectable.
+                let left_behind = LeftBehind::inspect(path);
                 tracing::warn!(
                     path = %path.display(),
                     %error,
-                    on_disk,
+                    %left_behind,
                     "draft rollback failed"
                 );
             }
@@ -5017,13 +5163,100 @@ impl Drop for DraftRollback {
     }
 }
 
-/// One path a [`DraftRollback::rollback`] could not clean up: the artifact
-/// still on disk, what the rollback tried (reads as "could not be
-/// `{action}`"), and the I/O cause.
+/// Which arm a snapshotted path's rollback took.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RollbackArm {
+    /// The path had no prior content: the draft is unlinked.
+    Remove,
+    /// The path had prior content: it is written back, no-follow.
+    Restore,
+}
+
+impl RollbackArm {
+    /// Completes "could not be …" in the refusal message.
+    fn failed_verb(self) -> &'static str {
+        match self {
+            RollbackArm::Remove => "removed",
+            RollbackArm::Restore => "restored to its prior content",
+        }
+    }
+}
+
+/// One path a [`DraftRollback::rollback`] could not clean up: the path, the
+/// arm that failed, and the I/O cause.
 struct RollbackFailure {
     path: PathBuf,
-    action: &'static str,
+    arm: RollbackArm,
     error: std::io::Error,
+}
+
+/// What a failed rollback left at a path — CHECKED, never assumed.
+enum LeftBehind {
+    /// Something is at the path. `symlink_metadata` does not follow, so a
+    /// link swapped in at the leaf is reported as the link it is.
+    Present { symlink: bool },
+    /// Nothing is at the path.
+    Absent,
+    /// The path could not be inspected at all — an unsearchable parent, say —
+    /// so whether anything is there is unknown. Before this state existed,
+    /// every inspection error read as "absent".
+    Uninspectable(std::io::Error),
+}
+
+impl LeftBehind {
+    fn inspect(path: &Path) -> Self {
+        match std::fs::symlink_metadata(path) {
+            Ok(meta) => LeftBehind::Present {
+                symlink: meta.file_type().is_symlink(),
+            },
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => LeftBehind::Absent,
+            Err(e) => LeftBehind::Uninspectable(e),
+        }
+    }
+
+    /// The operator-facing sentence for `name` after `arm` failed, worded by
+    /// what the arm was trying to do and by what is actually there now.
+    fn sentence(&self, name: &str, arm: RollbackArm) -> String {
+        match (arm, self) {
+            (RollbackArm::Remove, LeftBehind::Present { symlink }) => format!(
+                "{name} is STILL ON DISK{}, remove it manually",
+                link_note(*symlink)
+            ),
+            (RollbackArm::Restore, LeftBehind::Present { symlink }) => format!(
+                "{name} is STILL ON DISK{} without its prior content, put that content back \
+                 manually from version control or a backup",
+                link_note(*symlink)
+            ),
+            (RollbackArm::Remove, LeftBehind::Absent) => format!(
+                "{name} could not be removed yet is now absent, check the models directory by \
+                 hand"
+            ),
+            (RollbackArm::Restore, LeftBehind::Absent) => format!(
+                "the prior content of {name} could not be restored and the path is now absent, \
+                 recover it from version control or a backup"
+            ),
+            (RollbackArm::Remove | RollbackArm::Restore, LeftBehind::Uninspectable(e)) => {
+                format!(
+                    "{name} could not be inspected after the failed rollback ({e}), so whether \
+                     it is on disk is unknown; check the models directory by hand"
+                )
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for LeftBehind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LeftBehind::Present { symlink } => write!(f, "present{}", link_note(*symlink)),
+            LeftBehind::Absent => f.write_str("absent"),
+            LeftBehind::Uninspectable(e) => write!(f, "uninspectable ({e})"),
+        }
+    }
+}
+
+fn link_note(symlink: bool) -> &'static str {
+    if symlink { " (a symlink)" } else { "" }
 }
 
 /// Roll a refused draft back and word the outcome for the refusal message:
@@ -5035,11 +5268,12 @@ struct RollbackFailure {
 /// returns the project-relative paths for the envelope's
 /// `rollback_failed_paths` field.
 ///
-/// What was left behind is CHECKED, not assumed: a failed restore can leave
-/// the path gone (the prior file removed, then its parent unwritable), and
-/// "remove it" then points at nothing while the prior content is what was
-/// lost. `symlink_metadata` does not follow a link, so a leftover link counts
-/// as on disk.
+/// What was left behind is CHECKED, not assumed, and has three states, each
+/// worded by the arm that failed: present (a leftover to remove, or a path
+/// whose prior content is not back — a swapped-in link is named as one),
+/// absent (a failed restore whose target is gone: the prior content is what
+/// was lost), and uninspectable (the check itself failed, so nothing is
+/// claimed either way and the error is named).
 fn rollback_disposition(
     root: &Path,
     rollback: DraftRollback,
@@ -5056,7 +5290,7 @@ fn rollback_disposition(
             format!(
                 "{} could not be {} ({})",
                 rel_display(root, &f.path),
-                f.action,
+                f.arm.failed_verb(),
                 f.error
             )
         })
@@ -5066,37 +5300,12 @@ fn rollback_disposition(
         .iter()
         .map(|f| rel_display(root, &f.path))
         .collect();
-    let (on_disk, absent): (Vec<&RollbackFailure>, Vec<&RollbackFailure>) = failures
+    let outcome = failures
         .iter()
-        .partition(|f| std::fs::symlink_metadata(&f.path).is_ok());
-    let mut outcome = Vec::new();
-    if !on_disk.is_empty() {
-        outcome.push(
-            "the refused artifact is STILL ON DISK, remove it or restore its prior content \
-             manually"
-                .to_string(),
-        );
-    }
-    if !absent.is_empty() {
-        let names = absent
-            .iter()
-            .map(|f| rel_display(root, &f.path))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let (path_word, is_are) = if absent.len() == 1 {
-            ("path", "is")
-        } else {
-            ("paths", "are")
-        };
-        outcome.push(format!(
-            "the prior content of {names} could not be restored and the {path_word} {is_are} \
-             now absent, recover it from version control or a backup"
-        ));
-    }
-    (
-        format!("{failed_lead} — {listed}; {}.", outcome.join("; ")),
-        Some(paths),
-    )
+        .map(|f| LeftBehind::inspect(&f.path).sentence(&rel_display(root, &f.path), f.arm))
+        .collect::<Vec<_>>()
+        .join("; ");
+    (format!("{failed_lead} — {listed}; {outcome}."), Some(paths))
 }
 
 /// Filter the pending review queue to plans whose payload carries
@@ -5827,7 +6036,7 @@ mod tests {
         std::fs::set_permissions(&models, std::fs::Permissions::from_mode(0o755)).unwrap();
         assert_eq!(failures.len(), 1, "the failed unlink is reported");
         assert_eq!(failures[0].path, fresh);
-        assert_eq!(failures[0].action, "removed");
+        assert_eq!(failures[0].arm, RollbackArm::Remove);
         assert!(fresh.exists(), "the artifact really is still on disk");
     }
 
@@ -5949,11 +6158,242 @@ mod tests {
         );
     }
 
-    /// The no-follow guard: a symlink at a draft path refuses — dangling or
-    /// resolving — naming the path; a regular file and an absent path pass.
+    /// Put a directory's mode back on every exit path, so the tempdir cleans
+    /// up and a byte comparison can read it again.
+    #[cfg(unix)]
+    struct RestoreMode(PathBuf, u32);
+
+    #[cfg(unix)]
+    impl Drop for RestoreMode {
+        fn drop(&mut self) {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&self.0, std::fs::Permissions::from_mode(self.1));
+        }
+    }
+
+    /// Create a FIFO at `path`.
+    #[cfg(unix)]
+    fn make_fifo(path: &Path) {
+        let status = std::process::Command::new("mkfifo")
+            .arg(path)
+            .status()
+            .expect("mkfifo runs");
+        assert!(status.success(), "mkfifo {}", path.display());
+    }
+
+    /// The third disposition state: the leftover could not even be
+    /// inspected. The parent is unsearchable (mode 000), so the unlink fails
+    /// AND the after-the-fact `symlink_metadata` fails; before the fix any
+    /// inspection error read as "absent". Root ignores directory modes, so
+    /// the fault probes itself and stands down when it cannot arm.
     #[cfg(unix)]
     #[test]
-    fn refuse_symlinked_draft_target_refuses_links_only() {
+    fn rollback_disposition_says_the_leftover_could_not_be_inspected() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let models = root.join("models");
+        std::fs::create_dir(&models).unwrap();
+        let fresh = models.join("shadow.sql");
+
+        let guard = DraftRollback::snapshot([&fresh]).expect("snapshot");
+        std::fs::write(&fresh, "SELECT 1 AS id").unwrap();
+        std::fs::set_permissions(&models, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let restore = RestoreMode(models.clone(), 0o755);
+        if std::fs::symlink_metadata(&fresh).is_ok() {
+            // This process ignores the directory mode; the fault cannot arm.
+            drop(restore);
+            guard.defuse();
+            return;
+        }
+
+        let (disposition, failed) = rollback_disposition(
+            root,
+            guard,
+            "so the draft was not kept.",
+            "but rolling it back FAILED",
+        );
+        drop(restore);
+        assert_eq!(failed, Some(vec!["models/shadow.sql".to_string()]));
+        assert!(
+            disposition.contains("models/shadow.sql could not be removed"),
+            "the refusal names the path and what failed: {disposition}"
+        );
+        assert!(
+            disposition
+                .contains("models/shadow.sql could not be inspected after the failed rollback")
+                && disposition.contains("Permission denied"),
+            "the refusal says the check itself failed, and why: {disposition}"
+        );
+        assert!(
+            !disposition.contains("STILL ON DISK") && !disposition.contains("now absent"),
+            "an uninspectable path is claimed neither present nor absent: {disposition}"
+        );
+        assert!(
+            fresh.exists(),
+            "the artifact really is still there once the directory is searchable again"
+        );
+    }
+
+    /// The restore arm meets a link swapped in at the leaf after the
+    /// snapshot — the race the up-front check cannot close. `std::fs::write`
+    /// followed it and put the PRIOR bytes at the link's target, outside the
+    /// models directory, while the refusal claimed a clean rollback. The
+    /// no-follow restore fails instead: the target is untouched, the
+    /// disposition names the path, and it says a symlink is what is on disk.
+    #[cfg(unix)]
+    #[test]
+    fn rollback_disposition_never_restores_through_a_swapped_in_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let models = root.join("models");
+        std::fs::create_dir(&models).unwrap();
+        let sidecar = models.join("orders.toml");
+        std::fs::write(&sidecar, "name = \"orders\"\n").unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let leak = outside.path().join("leak.toml");
+
+        let guard = DraftRollback::snapshot([&sidecar]).expect("snapshot");
+        std::fs::write(&sidecar, "name = \"orders\"\nintent = \"draft\"\n").unwrap();
+        std::fs::remove_file(&sidecar).unwrap();
+        std::os::unix::fs::symlink(&leak, &sidecar).unwrap();
+
+        let (disposition, failed) = rollback_disposition(
+            root,
+            guard,
+            "so the draft was not kept.",
+            "but rolling it back FAILED",
+        );
+        assert!(
+            !leak.exists(),
+            "the prior bytes were written through the link to {}",
+            leak.display()
+        );
+        assert_eq!(failed, Some(vec!["models/orders.toml".to_string()]));
+        assert!(
+            disposition.contains("models/orders.toml could not be restored to its prior content"),
+            "the refusal names the path and what failed: {disposition}"
+        );
+        assert!(
+            disposition.contains("models/orders.toml is STILL ON DISK (a symlink)"),
+            "the refusal says a link is what is on disk: {disposition}"
+        );
+        assert!(
+            !disposition.contains("not kept"),
+            "a failed rollback must not read as a clean refusal: {disposition}"
+        );
+        assert!(
+            std::fs::symlink_metadata(&sidecar)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "the swapped-in link is left for the operator to see, not replaced"
+        );
+    }
+
+    /// Every draft write and the rollback's restore go through the no-follow
+    /// helper — this guards the WIRE; `rocky-core` proves the helper. The
+    /// banned and required strings are assembled at runtime so this test's
+    /// own source cannot satisfy the search it performs.
+    #[test]
+    fn every_draft_write_and_the_restore_use_the_no_follow_helper() {
+        let source = include_str!("tools.rs");
+        let banned = format!("std::fs::{}(&paths.", "write");
+        assert!(
+            !source.contains(&banned),
+            "a draft write uses a plain std::fs::write, which follows a link swapped in at \
+             the leaf"
+        );
+        let banned = format!("Some(bytes) => std::fs::{}(path, bytes)", "write");
+        assert!(
+            !source.contains(&banned),
+            "the rollback restore uses a plain std::fs::write"
+        );
+        let required = format!("write_no_{}(&paths.", "follow");
+        assert_eq!(
+            source.matches(&required).count(),
+            5,
+            "the five draft write sites (draft_model SQL + sidecar, draft_contract, \
+             draft_check, draft_metadata) call write_no_follow"
+        );
+        let required = format!("Some(bytes) => write_no_{}(path, bytes)", "follow");
+        assert!(
+            source.contains(&required),
+            "the rollback restore calls write_no_follow"
+        );
+    }
+
+    /// The ancestor guard: `models/` resolving outside the project root
+    /// refuses, naming both ends; a link that stays inside the root, a real
+    /// directory, and a models directory that does not exist yet pass; a
+    /// dangling link where the models directory would go refuses.
+    #[cfg(unix)]
+    #[test]
+    fn refuse_redirected_models_dir_refuses_a_models_link_that_leaves_the_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("proj");
+        std::fs::create_dir(&root).unwrap();
+        let server = RockyMcpServer::new(root.join("rocky.toml"));
+        let models = root.join("models");
+
+        assert!(
+            server.refuse_redirected_models_dir().is_ok(),
+            "an absent models directory has nothing to redirect"
+        );
+
+        let outside = dir.path().join("elsewhere");
+        std::fs::create_dir(&outside).unwrap();
+        std::os::unix::fs::symlink(&outside, &models).unwrap();
+        let err = server
+            .refuse_redirected_models_dir()
+            .expect_err("a models link that leaves the root refuses");
+        assert_eq!(err.0.code, crate::error::ToolErrorCode::InvalidArgument);
+        let resolved_outside = outside.canonicalize().unwrap().display().to_string();
+        let resolved_root = root.canonicalize().unwrap().display().to_string();
+        assert!(
+            err.0.message.contains("models/ resolves to")
+                && err.0.message.contains(&resolved_outside)
+                && err.0.message.contains(&resolved_root),
+            "the refusal names where models/ resolves and the root it left: {}",
+            err.0.message
+        );
+
+        std::fs::remove_file(&models).unwrap();
+        std::os::unix::fs::symlink(root.join("gone"), &models).unwrap();
+        let err = server
+            .refuse_redirected_models_dir()
+            .expect_err("a dangling models link refuses");
+        assert!(
+            err.0.message.contains("target does not exist"),
+            "the refusal says the link dangles: {}",
+            err.0.message
+        );
+
+        std::fs::remove_file(&models).unwrap();
+        let inside = root.join("src").join("models_real");
+        std::fs::create_dir_all(&inside).unwrap();
+        std::os::unix::fs::symlink(&inside, &models).unwrap();
+        assert!(
+            server.refuse_redirected_models_dir().is_ok(),
+            "a models link that stays inside the root passes"
+        );
+
+        std::fs::remove_file(&models).unwrap();
+        std::fs::create_dir(&models).unwrap();
+        assert!(
+            server.refuse_redirected_models_dir().is_ok(),
+            "a real models directory passes"
+        );
+    }
+
+    /// The up-front leaf guard: a symlink at a draft path refuses — dangling
+    /// or resolving — naming the path, and so does any other non-regular
+    /// file (a directory, a FIFO — which would park the snapshot's read); a
+    /// regular file and an absent path pass.
+    #[cfg(unix)]
+    #[test]
+    fn refuse_non_regular_draft_target_refuses_links_and_non_regular_files() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
         let models = root.join("models");
@@ -5964,16 +6404,32 @@ mod tests {
         std::os::unix::fs::symlink(root.join("nowhere.sql"), &dangling).unwrap();
         let resolving = models.join("alias.sql");
         std::os::unix::fs::symlink(&regular, &resolving).unwrap();
+        let directory = models.join("nested.sql");
+        std::fs::create_dir(&directory).unwrap();
+        let fifo = models.join("pipe.sql");
+        make_fifo(&fifo);
 
-        assert!(refuse_symlinked_draft_target(root, &regular).is_ok());
-        assert!(refuse_symlinked_draft_target(root, &models.join("absent.sql")).is_ok());
+        assert!(refuse_non_regular_draft_target(root, &regular).is_ok());
+        assert!(refuse_non_regular_draft_target(root, &models.join("absent.sql")).is_ok());
         for link in [&dangling, &resolving] {
-            let err = refuse_symlinked_draft_target(root, link).expect_err("a symlink refuses");
+            let err = refuse_non_regular_draft_target(root, link).expect_err("a symlink refuses");
             assert_eq!(err.0.code, crate::error::ToolErrorCode::InvalidArgument);
             assert!(
                 err.0.message.contains(&rel_display(root, link))
                     && err.0.message.contains("symlink"),
                 "the refusal names the link: {}",
+                err.0.message
+            );
+        }
+        for (path, kind) in [(&directory, "directory"), (&fifo, "FIFO")] {
+            let err = refuse_non_regular_draft_target(root, path)
+                .expect_err("a non-regular file refuses");
+            assert_eq!(err.0.code, crate::error::ToolErrorCode::InvalidArgument);
+            assert!(
+                err.0.message.contains(&rel_display(root, path))
+                    && err.0.message.contains(kind)
+                    && err.0.message.contains("not a regular file"),
+                "the refusal names the path and its kind: {}",
                 err.0.message
             );
         }

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -20,7 +20,7 @@ use rmcp::{
 
 use rocky_cli::commands;
 use rocky_compiler::compile::{self, CompileResult as CompilerResult, CompilerConfig};
-use rocky_core::product::commit::write_no_follow;
+use rocky_core::product::commit::{read_no_follow_bytes, write_no_follow};
 
 use crate::error::{ToolError, ToolResult};
 use crate::result_types::*;
@@ -2134,8 +2134,9 @@ impl RockyMcpServer {
     /// write: the models directory must resolve inside the project root
     /// ([`Self::refuse_redirected_models_dir`]), and each draft path must be
     /// absent or a regular file ([`refuse_non_regular_draft_target`]). What
-    /// appears at a leaf AFTER these checks meets the no-follow open on every
-    /// write and rollback (`write_no_follow`), not a follow.
+    /// appears at a leaf AFTER these checks meets a no-follow open on both
+    /// sides — the snapshot's read (`read_no_follow_bytes`) and every write
+    /// and rollback (`write_no_follow`) — not a follow.
     fn resolve_draft_paths(&self, name: &str) -> Result<DraftPaths, Json<ToolError>> {
         use std::path::Component;
 
@@ -2180,10 +2181,10 @@ impl RockyMcpServer {
         // The leaf half, up front: a symlink at any draft path — dangling or
         // not; `symlink_metadata` does not follow, where the `exists()` of the
         // canonicalize check this replaced did — or anything else that is not
-        // a regular file refuses before a snapshot or a write. A FIFO would
-        // park the snapshot's read until a writer appeared. A link swapped in
-        // AFTER this check meets the no-follow open on every write and on the
-        // rollback's restore (`write_no_follow`), never a follow.
+        // a regular file refuses before a snapshot or a write. A link swapped
+        // in AFTER this check meets a no-follow open on both sides: the
+        // snapshot's read (`read_no_follow_bytes`) and every write and
+        // rollback restore (`write_no_follow`), never a follow.
         for p in [&sql_path, &sidecar_path, &contract_path] {
             refuse_non_regular_draft_target(&self.root, p)?;
         }
@@ -4948,11 +4949,16 @@ fn restore_or_remove(path: &Path, prior: Option<&[u8]>) -> std::io::Result<()> {
 /// anything is snapshotted or written through it. Every draft tool resolves
 /// its paths through this (via `resolve_draft_paths`): the up-front leaf half
 /// of the no-follow guard. `symlink_metadata` does not follow, so a dangling
-/// link is seen as what it is; a FIFO is refused here because the snapshot's
-/// read would otherwise block until a writer appeared. An absent path is
+/// link is seen as what it is; a FIFO is refused here so the refusal names
+/// its kind rather than surfacing as an unreadable prior. An absent path is
 /// fine; any other inspection failure refuses too, because the write would
 /// land somewhere the tool could not inspect. What appears AFTER this check
-/// meets the no-follow open on every write and rollback (`write_no_follow`).
+/// meets a no-follow open on both sides — the snapshot's read
+/// (`read_no_follow_bytes`) and every write and rollback (`write_no_follow`).
+///
+/// Residual: the refusal's own remediation text still describes only the
+/// write half. It is one of the pinned wire strings, so it is left as it
+/// stands rather than reworded here.
 fn refuse_non_regular_draft_target(root: &Path, path: &Path) -> Result<(), Json<ToolError>> {
     let meta = match std::fs::symlink_metadata(path) {
         Ok(meta) => meta,
@@ -5068,6 +5074,16 @@ impl DraftRollback {
     /// directory at the path — refuses the whole snapshot: a path that EXISTS
     /// but cannot be read back has no prior to restore, so the rollback would
     /// take the remove arm and delete it (#1572 follow-up).
+    ///
+    /// The read goes through `read_no_follow_bytes`, the read counterpart of
+    /// the no-follow writes. `std::fs::read` re-resolved the path, so a link
+    /// or FIFO swapped in at a leaf between `resolve_draft_paths` and here
+    /// was read through — the prior content could come from OUTSIDE the
+    /// project and then ride the merge and the rollback — or parked the
+    /// request forever. The open now carries `O_NOFOLLOW | O_NONBLOCK` on
+    /// unix, the regular-file check is on the DESCRIPTOR, and the read is
+    /// bounded: a file over `MAX_BACKUP_BYTES` (16 MiB) refuses rather than
+    /// being buffered whole.
     fn snapshot<I, P>(paths: I) -> Result<Self, UnreadablePrior>
     where
         I: IntoIterator<Item = P>,
@@ -5076,7 +5092,7 @@ impl DraftRollback {
         let mut entries = Vec::new();
         for p in paths {
             let path: PathBuf = p.into();
-            let prior = match std::fs::read(&path) {
+            let prior = match read_no_follow_bytes(&path) {
                 Ok(bytes) => Some(bytes),
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
                 Err(error) => return Err(UnreadablePrior { path, error }),
@@ -6071,6 +6087,86 @@ mod tests {
         guard.defuse();
     }
 
+    /// The snapshot's read is guarded at the DESCRIPTOR, like every draft
+    /// write: a leaf swapped for a symlink AFTER the up-front check — the
+    /// window `resolve_draft_paths` cannot close, because a path syscall
+    /// re-traverses the path — refuses instead of being read through. Before
+    /// the fix `std::fs::read` followed it, so a file OUTSIDE the project
+    /// became the "prior content" that the merge folds into the user's
+    /// sidecar and the rollback would restore.
+    #[cfg(unix)]
+    #[test]
+    fn draft_rollback_snapshot_refuses_a_leaf_swapped_for_a_symlink_out_of_the_project() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("proj");
+        let models = root.join("models");
+        std::fs::create_dir_all(&models).unwrap();
+        let outside = dir.path().join("outside.toml");
+        std::fs::write(&outside, "marker = \"OUTSIDE-SECRET\"\n").unwrap();
+        let sidecar = models.join("orders.toml");
+        std::os::unix::fs::symlink(&outside, &sidecar).unwrap();
+
+        let refused = DraftRollback::snapshot([&sidecar])
+            .err()
+            .expect("a symlinked leaf refuses the snapshot instead of being read through");
+        assert_eq!(refused.path, sidecar);
+        let err = refused.into_tool_error(&root);
+        assert_eq!(err.0.code, crate::error::ToolErrorCode::InvalidArgument);
+        assert!(
+            err.0.message.contains("models/orders.toml")
+                && err.0.message.contains("cannot be read"),
+            "the refusal names the path: {}",
+            err.0.message
+        );
+        assert!(
+            !err.0.message.contains("OUTSIDE-SECRET"),
+            "the outside file's content never reaches the caller: {}",
+            err.0.message
+        );
+        assert_eq!(
+            std::fs::read_to_string(&outside).unwrap(),
+            "marker = \"OUTSIDE-SECRET\"\n",
+            "the file outside the project is untouched"
+        );
+    }
+
+    /// A FIFO swapped in at a snapshot path is refused, and refused without
+    /// blocking. Before the fix the snapshot's `std::fs::read` opened it and
+    /// waited for a writer that never comes, parking the draft request
+    /// forever. The read now carries `O_NONBLOCK` with `O_NOFOLLOW` and
+    /// checks the descriptor. The timeout turns a regression into a failure
+    /// instead of a hung suite.
+    #[cfg(unix)]
+    #[test]
+    fn draft_rollback_snapshot_refuses_a_fifo_instead_of_blocking() {
+        let dir = tempfile::tempdir().unwrap();
+        let models = dir.path().join("models");
+        std::fs::create_dir_all(&models).unwrap();
+        let sidecar = models.join("orders.toml");
+        make_fifo(&sidecar);
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let probe = sidecar.clone();
+        std::thread::spawn(move || {
+            let refused = match DraftRollback::snapshot([&probe]) {
+                Ok(guard) => {
+                    guard.defuse();
+                    false
+                }
+                Err(_) => true,
+            };
+            let _ = tx.send(refused);
+        });
+        let refused = rx
+            .recv_timeout(std::time::Duration::from_secs(10))
+            .expect("the snapshot returned instead of parking on the FIFO");
+        assert!(refused, "a FIFO at a snapshot path refuses");
+        assert!(
+            std::fs::symlink_metadata(&sidecar).is_ok(),
+            "the FIFO is left in place, neither read nor replaced"
+        );
+    }
+
     /// A failed restore whose target is GONE says so: the prior file was
     /// removed and its parent went with it, so `std::fs::write` cannot put
     /// the bytes back and there is nothing on disk to "remove". Before the
@@ -6321,6 +6417,17 @@ mod tests {
         assert!(
             source.contains(&required),
             "the rollback restore calls write_no_follow"
+        );
+        let banned = format!("match std::fs::{}(&path)", "read");
+        assert!(
+            !source.contains(&banned),
+            "the snapshot reads a prior with a plain std::fs::read, which follows a link \
+             swapped in at the leaf and parks on a FIFO"
+        );
+        let required = format!("read_no_follow_{}(&path)", "bytes");
+        assert!(
+            source.contains(&required),
+            "the snapshot reads each prior through read_no_follow_bytes"
         );
     }
 

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -4610,3 +4610,511 @@ async fn draft_contract_deny_with_a_failed_remove_says_the_draft_is_still_on_dis
         "the refused draft really is still on disk"
     );
 }
+
+/// The leaf-swap race the up-front check cannot close: the draft is on disk
+/// when the loader blocks, and there the drafted contract is replaced by a
+/// symlink to a file OUTSIDE the project. The deny's rollback takes the
+/// restore arm (the contract existed before the redraft), and before the fix
+/// `std::fs::write` followed the link and put the PRIOR contract at its target
+/// while the refusal claimed a clean rollback. The no-follow restore fails
+/// instead: nothing lands outside, the failure rides the envelope, and the
+/// message says a symlink is what is on disk.
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn draft_contract_deny_never_restores_through_a_leaf_swapped_for_a_symlink() {
+    let dir = TempDir::new().unwrap();
+    write_project_with_policy(
+        dir.path(),
+        &dir.path().join("test.duckdb"),
+        DENY_AGENT_AUTHORING,
+    );
+    let models = dir.path().join("models");
+    let contract = models.join("orders.contract.toml");
+    std::fs::write(
+        &contract,
+        "[[columns]]\nname = \"id\"\ntype = \"Int64\"\nnullable = true\n",
+    )
+    .unwrap();
+    let outside = TempDir::new().unwrap();
+    let leak = outside.path().join("leak.toml");
+
+    let spec = "[[columns]]\nname = \"status\"\ntype = \"String\"\nnullable = true\n";
+    let args = object(serde_json::json!({ "model": "orders", "spec": spec }));
+    let (contract_at_mutation, leak_at_mutation) = (contract.clone(), leak.clone());
+    let result = call_with_midflight_mutation(dir.path(), "draft_contract", args, move || {
+        assert!(
+            std::fs::read_to_string(&contract_at_mutation)
+                .expect("the draft is on disk when the loader blocks")
+                .contains("status"),
+            "the loader blocked before the draft was written"
+        );
+        std::fs::remove_file(&contract_at_mutation).unwrap();
+        std::os::unix::fs::symlink(&leak_at_mutation, &contract_at_mutation).unwrap();
+        true
+    })
+    .await
+    .expect("the swap arms for every user");
+
+    // THE PIN: the prior contract did not land outside the project.
+    assert!(
+        !leak.exists(),
+        "the rollback wrote the prior contract through the link to {}: {:?}",
+        leak.display(),
+        std::fs::read_to_string(&leak)
+    );
+    assert_eq!(result.is_error, Some(true), "the deny is an error");
+    let err = result.structured_content.expect("envelope");
+    assert_eq!(err["code"], serde_json::json!("policy_denied"), "{err:?}");
+    assert_eq!(
+        err["rollback_failed_paths"],
+        serde_json::json!(["models/orders.contract.toml"]),
+        "the failed restore rides the envelope as a typed field: {err:?}"
+    );
+    let message = err["message"].as_str().unwrap();
+    assert!(
+        message.contains("models/orders.contract.toml could not be restored to its prior content"),
+        "the refusal names the path and what failed: {message}"
+    );
+    assert!(
+        message.contains("models/orders.contract.toml is STILL ON DISK (a symlink)"),
+        "the refusal says a link is what is on disk: {message}"
+    );
+    assert!(
+        !message.contains("not kept"),
+        "a failed rollback must not read as a clean refusal: {message}"
+    );
+    assert!(
+        std::fs::symlink_metadata(&contract)
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "the swapped-in link is left in place, neither followed nor replaced"
+    );
+}
+
+/// `models/` itself reached through a symlink redirected every draft write
+/// out of the project with no race at all: the leaf check and the no-follow
+/// writes look only at the final path component, and `root.join("models")`
+/// was never resolved. Every draft tool now refuses up front — naming where
+/// the models directory resolves and the root it left — and writes nothing.
+#[cfg(unix)]
+#[tokio::test]
+async fn draft_tools_refuse_a_models_directory_that_resolves_outside_the_project() {
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    let outside = TempDir::new().unwrap();
+    let real_models = outside.path().join("models_real");
+    let models = dir.path().join("models");
+    std::fs::rename(&models, &real_models).expect("move the models directory out of the project");
+    std::os::unix::fs::symlink(&real_models, &models).unwrap();
+    write_target_defaults(dir.path());
+    let sidecar_before = std::fs::read(real_models.join("orders.toml")).unwrap();
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+
+    let contract_spec = "[[columns]]\nname = \"id\"\ntype = \"Int64\"\nnullable = true\n";
+    let check_spec = "[[tests]]\ntype = \"not_null\"\ncolumn = \"id\"\n";
+    let cases = vec![
+        (
+            "draft_model",
+            draft_args("shadow", "SELECT 1 AS id", "through a linked directory"),
+        ),
+        (
+            "draft_contract",
+            object(serde_json::json!({ "model": "orders", "spec": contract_spec })),
+        ),
+        (
+            "draft_check",
+            object(serde_json::json!({ "model": "orders", "spec": check_spec })),
+        ),
+        (
+            "draft_metadata",
+            object(serde_json::json!({ "model": "orders", "classifications": { "id": "pii" } })),
+        ),
+    ];
+    let resolved_models = real_models.canonicalize().unwrap().display().to_string();
+    let resolved_root = dir.path().canonicalize().unwrap().display().to_string();
+    for (tool, args) in cases {
+        let result = client
+            .call_tool(CallToolRequestParams::new(tool).with_arguments(args))
+            .await
+            .unwrap_or_else(|e| panic!("{tool} returns a result: {e}"));
+        assert_eq!(
+            result.is_error,
+            Some(true),
+            "{tool}: a models directory outside the project refuses"
+        );
+        let err = result.structured_content.expect("envelope");
+        assert_eq!(
+            err["code"],
+            serde_json::json!("invalid_argument"),
+            "{tool}: refused up front: {err:?}"
+        );
+        let message = err["message"].as_str().unwrap();
+        assert!(
+            message.contains("models/ resolves to")
+                && message.contains(&resolved_models)
+                && message.contains(&resolved_root),
+            "{tool}: the refusal names where models/ resolves and the root it left: {message}"
+        );
+    }
+    client.cancel().await.unwrap();
+
+    assert!(
+        !real_models.join("shadow.sql").exists() && !real_models.join("shadow.toml").exists(),
+        "draft_model wrote through the linked directory"
+    );
+    assert!(
+        !real_models.join("orders.contract.toml").exists(),
+        "draft_contract wrote through the linked directory"
+    );
+    assert_eq!(
+        std::fs::read(real_models.join("orders.toml")).unwrap(),
+        sidecar_before,
+        "draft_check / draft_metadata rewrote the sidecar through the linked directory"
+    );
+}
+
+/// A FIFO at a draft path is refused, and refused without blocking. Before
+/// the fix the leaf check let anything but a symlink through, and the
+/// snapshot's `std::fs::read` then parked a blocking-pool thread in the
+/// FIFO's open until a writer appeared — which never happens — so the call
+/// hung. The timeout turns a regression into a failure instead of a hung
+/// suite, and the runtime is shut down without waiting because that parked
+/// thread can never be joined.
+#[cfg(unix)]
+#[test]
+fn draft_model_refuses_a_fifo_at_the_draft_path_without_hanging() {
+    use std::os::unix::fs::FileTypeExt;
+
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    write_target_defaults(dir.path());
+    let models = dir.path().join("models");
+    let fifo = models.join("shadow.sql");
+    let status = std::process::Command::new("mkfifo")
+        .arg(&fifo)
+        .status()
+        .expect("mkfifo runs");
+    assert!(status.success(), "mkfifo {}", fifo.display());
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+    let config = dir.path().join("rocky.toml");
+    let outcome = runtime.block_on(async move {
+        let client = connect(RockyMcpServer::new(config)).await;
+        let call = client.call_tool(
+            CallToolRequestParams::new("draft_model").with_arguments(draft_args(
+                "shadow",
+                "SELECT 1 AS id",
+                "into a FIFO",
+            )),
+        );
+        match tokio::time::timeout(std::time::Duration::from_secs(10), call).await {
+            Ok(result) => {
+                client.cancel().await.unwrap();
+                Some(result.expect("draft_model returns a result"))
+            }
+            Err(_elapsed) => None,
+        }
+    });
+    runtime.shutdown_background();
+    let Some(result) = outcome else {
+        panic!("draft_model hung on the FIFO at models/shadow.sql instead of refusing it");
+    };
+
+    assert_eq!(
+        result.is_error,
+        Some(true),
+        "a FIFO at the draft path refuses"
+    );
+    let err = result.structured_content.expect("envelope");
+    assert_eq!(
+        err["code"],
+        serde_json::json!("invalid_argument"),
+        "refused up front: {err:?}"
+    );
+    let message = err["message"].as_str().unwrap();
+    assert!(
+        message.contains("models/shadow.sql")
+            && message.contains("FIFO")
+            && message.contains("not a regular file"),
+        "the refusal names the path and its kind: {message}"
+    );
+    assert!(
+        std::fs::symlink_metadata(&fifo)
+            .unwrap()
+            .file_type()
+            .is_fifo(),
+        "the FIFO is left in place"
+    );
+    assert!(
+        !models.join("shadow.toml").exists(),
+        "the sidecar was written before the refusal"
+    );
+}
+
+/// The `Unloadable` arm driven through a rollback that REALLY fails. The
+/// project config is broken between the compile (which holds its parsed copy)
+/// and the policy gate (which reloads it), and the models directory is made
+/// read-only, so the gate cannot read its policy and the fail-closed
+/// refusal's rollback cannot unlink the draft. The refusal must report both:
+/// the cause, and the leftover it could not remove.
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn draft_contract_unloadable_policy_with_a_failed_remove_reports_the_leftover() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    let models = dir.path().join("models");
+    let contract = models.join("orders.contract.toml");
+    let config = dir.path().join("rocky.toml");
+    let restore = RestorePerms(models.clone(), std::fs::Permissions::from_mode(0o755));
+
+    let spec = "[[columns]]\nname = \"id\"\ntype = \"Int64\"\nnullable = true\n";
+    let args = object(serde_json::json!({ "model": "orders", "spec": spec }));
+    let (models_at_mutation, contract_at_mutation) = (models.clone(), contract.clone());
+    let result = call_with_midflight_mutation(dir.path(), "draft_contract", args, move || {
+        assert!(
+            contract_at_mutation.is_file(),
+            "the loader blocked before the draft was written"
+        );
+        std::fs::write(&config, "this is not = [toml\n").unwrap();
+        make_models_read_only(&models_at_mutation)
+    })
+    .await;
+    let Some(result) = result else {
+        eprintln!(
+            "skipping: a read-only models directory does not block unlink here (running as root?)"
+        );
+        return;
+    };
+
+    assert_eq!(result.is_error, Some(true), "an unloadable policy refuses");
+    let err = result.structured_content.expect("envelope");
+    assert_eq!(err["code"], serde_json::json!("policy_denied"), "{err:?}");
+    assert_eq!(
+        err["rollback_failed_paths"],
+        serde_json::json!(["models/orders.contract.toml"]),
+        "the leftover rides the envelope as a typed field: {err:?}"
+    );
+    let message = err["message"].as_str().unwrap();
+    assert!(
+        message.contains("the project config failed to load") && message.contains("Cause:"),
+        "the refusal is the fail-closed one and names its cause: {message}"
+    );
+    assert!(
+        message.contains("Rolling it back FAILED")
+            && message.contains("models/orders.contract.toml could not be removed")
+            && message.contains("STILL ON DISK"),
+        "the refusal names the leftover and what failed: {message}"
+    );
+    assert!(
+        !message.contains("The draft was rolled back."),
+        "a failed rollback must not read as a clean refusal: {message}"
+    );
+    drop(restore);
+    assert!(
+        contract.is_file(),
+        "the refused draft really is still on disk"
+    );
+}
+
+/// Drive `tool` with a mutation AFTER the compile and BEFORE the policy gate
+/// — the window [`call_with_midflight_mutation`] cannot reach, because the
+/// loader opens its FIFO before it reads the models, so a fault that breaks
+/// reads under `models/` there breaks the compile too.
+///
+/// `rocky.toml` is a FIFO here as well, so every config read is a handshake
+/// this test answers: `config` verbatim while the compile runs, and
+/// `post_compile_config` from the first config read after the loader's
+/// handshake — the marker LIST's; the gate's follows it — where `mutate`
+/// runs, when nothing reads `models/` again before the verdict. Returns
+/// `None` when the fault did not arm.
+#[cfg(unix)]
+async fn call_with_post_compile_mutation(
+    dir: &Path,
+    tool: &str,
+    args: serde_json::Map<String, serde_json::Value>,
+    config: &str,
+    post_compile_config: &str,
+    mutate: impl FnOnce() -> bool,
+) -> Option<rmcp::model::CallToolResult> {
+    use std::io::Write as _;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let config_fifo = dir.join("rocky.toml");
+    std::fs::remove_file(&config_fifo).unwrap();
+    let loader_fifo = dir.join("models").join("test_definitions.toml");
+    for fifo in [&config_fifo, &loader_fifo] {
+        let status = std::process::Command::new("mkfifo")
+            .arg(fifo)
+            .status()
+            .expect("mkfifo runs");
+        assert!(status.success(), "mkfifo {}", fifo.display());
+    }
+
+    let server = RockyMcpServer::new(config_fifo.clone());
+    let client = connect(server).await;
+    let tool = tool.to_string();
+    let call = tokio::spawn(async move {
+        let result = client
+            .call_tool(CallToolRequestParams::new(tool).with_arguments(args))
+            .await;
+        (client, result)
+    });
+
+    let open_writer = |fifo: &Path| {
+        std::fs::OpenOptions::new()
+            .write(true)
+            .custom_flags(libc::O_NONBLOCK)
+            .open(fifo)
+    };
+    let mut mutate = Some(mutate);
+    let mut armed = None;
+    let mut loader_seen = false;
+    while !call.is_finished() {
+        match open_writer(&loader_fifo) {
+            Ok(writer) => {
+                loader_seen = true;
+                drop(writer);
+            }
+            Err(e) if e.raw_os_error() == Some(libc::ENXIO) => {}
+            // `mutate` may make `models/` unsearchable; then nothing — the
+            // handler included — can open this FIFO, so it cannot block on it.
+            Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {}
+            Err(e) => panic!("opening {} for writing: {e}", loader_fifo.display()),
+        }
+        match open_writer(&config_fifo) {
+            Ok(mut writer) => {
+                let feed = if loader_seen {
+                    if let Some(mutate) = mutate.take() {
+                        armed = Some(mutate());
+                    }
+                    post_compile_config
+                } else {
+                    config
+                };
+                writer.write_all(feed.as_bytes()).expect("feed the config");
+                drop(writer);
+                // Let the reader drain to EOF and close before the FIFO is
+                // opened again, or the next feed is appended to this read.
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+            Err(e) if e.raw_os_error() == Some(libc::ENXIO) => {
+                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            }
+            Err(e) => panic!("opening {} for writing: {e}", config_fifo.display()),
+        }
+    }
+    let (client, result) = call.await.expect("the call task completes");
+    client.cancel().await.unwrap();
+
+    let armed = armed.expect(
+        "the handler never read rocky.toml after the loader's handshake, so the mutation had \
+         no post-compile point to run",
+    );
+    if !armed {
+        return None;
+    }
+    Some(result.expect("the tool returns a result"))
+}
+
+/// The third disposition state, end to end: the leftover could not even be
+/// inspected. After the compile, the models directory is made unsearchable
+/// (mode 000) and the config broken, so the gate refuses fail-closed, its
+/// rollback cannot unlink the draft, and the after-the-fact check cannot see
+/// whether the draft is there. Before the fix that inspection error read as
+/// "absent" — the refusal claimed the path was gone while the draft sat on
+/// disk. Root ignores directory modes, so the fault stands down there.
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn draft_contract_unloadable_policy_with_an_uninspectable_leftover_says_so() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    let models = dir.path().join("models");
+    let contract = models.join("orders.contract.toml");
+    let config = std::fs::read_to_string(dir.path().join("rocky.toml")).unwrap();
+    let restore = RestorePerms(models.clone(), std::fs::Permissions::from_mode(0o755));
+
+    let spec = "[[columns]]\nname = \"id\"\ntype = \"Int64\"\nnullable = true\n";
+    let args = object(serde_json::json!({ "model": "orders", "spec": spec }));
+    let (models_at_mutation, contract_at_mutation) = (models.clone(), contract.clone());
+    let result = call_with_post_compile_mutation(
+        dir.path(),
+        "draft_contract",
+        args,
+        &config,
+        "this is not = [toml\n",
+        move || {
+            assert!(
+                contract_at_mutation.is_file(),
+                "the post-compile handshake came before the draft was written"
+            );
+            std::fs::set_permissions(&models_at_mutation, std::fs::Permissions::from_mode(0o000))
+                .unwrap();
+            if std::fs::symlink_metadata(&contract_at_mutation).is_ok() {
+                // This process ignores the directory mode; the fault cannot arm.
+                std::fs::set_permissions(
+                    &models_at_mutation,
+                    std::fs::Permissions::from_mode(0o755),
+                )
+                .unwrap();
+                return false;
+            }
+            true
+        },
+    )
+    .await;
+    let Some(result) = result else {
+        eprintln!(
+            "skipping: an unsearchable models directory does not block inspection here (running \
+             as root?)"
+        );
+        return;
+    };
+
+    assert_eq!(result.is_error, Some(true), "an unloadable policy refuses");
+    let err = result.structured_content.expect("envelope");
+    assert_eq!(err["code"], serde_json::json!("policy_denied"), "{err:?}");
+    assert_eq!(
+        err["rollback_failed_paths"],
+        serde_json::json!(["models/orders.contract.toml"]),
+        "the failed path rides the envelope as a typed field: {err:?}"
+    );
+    let message = err["message"].as_str().unwrap();
+    assert!(
+        message.contains("the project config failed to load") && message.contains("Cause:"),
+        "the refusal is the fail-closed one and names its cause: {message}"
+    );
+    assert!(
+        message.contains("Rolling it back FAILED")
+            && message.contains("models/orders.contract.toml could not be removed"),
+        "the refusal names the path and what failed: {message}"
+    );
+    assert!(
+        message.contains(
+            "models/orders.contract.toml could not be inspected after the failed rollback"
+        ) && message.contains("Permission denied"),
+        "the refusal says the check itself failed, and why: {message}"
+    );
+    assert!(
+        !message.contains("STILL ON DISK") && !message.contains("now absent"),
+        "an uninspectable path is claimed neither present nor absent: {message}"
+    );
+    assert!(
+        !message.contains("The draft was rolled back."),
+        "a failed rollback must not read as a clean refusal: {message}"
+    );
+    drop(restore);
+    assert!(
+        contract.is_file(),
+        "the refused draft really is still on disk once the directory is searchable again"
+    );
+}

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -4729,7 +4729,7 @@ fn draft_model_with_a_pre_snapshot_swap(
         .build()
         .expect("build a runtime with exactly one blocking thread");
 
-    runtime.block_on(async move {
+    let outcome: Result<rmcp::model::CallToolResult, &str> = runtime.block_on(async move {
         let (release, held) = std::sync::mpsc::channel::<()>();
         let (hogging, hogged) = tokio::sync::oneshot::channel();
         let hog = tokio::task::spawn_blocking(move || {
@@ -4754,23 +4754,34 @@ fn draft_model_with_a_pre_snapshot_swap(
             }
         })
         .await;
-        assert!(
-            reached.is_ok(),
-            "draft_model never created the models directory, so the leaf check never passed \
-             and there was no window to plant into"
-        );
+        if reached.is_err() {
+            return Err(
+                "draft_model never created the models directory, so the leaf check never \
+                 passed and there was no window to plant into",
+            );
+        }
 
         plant();
         drop(release);
         hog.await.expect("the hog task finishes");
 
-        let (client, result) = tokio::time::timeout(std::time::Duration::from_secs(30), call)
-            .await
-            .expect("draft_model parked on the planted leaf instead of refusing it")
-            .expect("the call task completes");
+        let Ok(joined) = tokio::time::timeout(std::time::Duration::from_secs(30), call).await
+        else {
+            return Err("draft_model parked on the planted leaf instead of refusing it");
+        };
+        let (client, result) = joined.expect("the call task completes");
         client.cancel().await.unwrap();
-        result.expect("the tool returns a result")
-    })
+        Ok(result.expect("the tool returns a result"))
+    });
+
+    // The verdict is carried out of the runtime, not panicked inside it. A
+    // path-based read parks on a planted FIFO forever, wedging the one
+    // blocking thread; dropping the runtime WAITS for that thread, so a
+    // panic in `block_on` would hang the suite instead of failing it.
+    // `shutdown_timeout(0)` hands the test back and leaks the wedged thread
+    // deliberately — the process is about to fail anyway.
+    runtime.shutdown_timeout(std::time::Duration::from_secs(0));
+    outcome.unwrap_or_else(|why| panic!("{why}"))
 }
 
 /// The READ half of the leaf race, end to end. Between the up-front leaf

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -1667,12 +1667,6 @@ async fn draft_model_refuses_an_existing_but_unreadable_sidecar() {
     // exit path so cleanup (and the byte comparison) can read it again.
     let readable = std::fs::Permissions::from_mode(0o644);
     std::fs::set_permissions(&sidecar_path, std::fs::Permissions::from_mode(0o000)).unwrap();
-    struct RestorePerms(std::path::PathBuf, std::fs::Permissions);
-    impl Drop for RestorePerms {
-        fn drop(&mut self) {
-            let _ = std::fs::set_permissions(&self.0, self.1.clone());
-        }
-    }
     let _restore = RestorePerms(sidecar_path.clone(), readable);
 
     // Probe the condition the test needs: running as root (e.g. a container
@@ -4141,4 +4135,478 @@ async fn suggest_freshness_block_returns_null_without_api_key() {
     );
 
     client.cancel().await.unwrap();
+}
+
+/// The policy the draft-tool refusal probes below run under: a hard deny on
+/// agent authorship, so every draft tool takes the DENY arm — the one that
+/// rolls its write back — instead of keeping the draft for review.
+const DENY_AGENT_AUTHORING: &str = r#"[policy]
+version = 1
+default_agent_effect = "require_review"
+
+[[policy.rules]]
+principal = "agent"
+capability = "propose"
+scope = { any = true }
+effect = "deny"
+"#;
+
+/// Restore a path's permissions on every exit path, so the tempdir cleans up
+/// and a byte comparison can read the file again.
+#[cfg(unix)]
+struct RestorePerms(std::path::PathBuf, std::fs::Permissions);
+
+#[cfg(unix)]
+impl Drop for RestorePerms {
+    fn drop(&mut self) {
+        let _ = std::fs::set_permissions(&self.0, self.1.clone());
+    }
+}
+
+fn object(value: serde_json::Value) -> serde_json::Map<String, serde_json::Value> {
+    let serde_json::Value::Object(map) = value else {
+        panic!("a JSON object, got {value}");
+    };
+    map
+}
+
+/// A symlink at a draft path refuses BEFORE anything is written — dangling or
+/// not, in every draft tool. `std::fs::write` follows a link, so a dangling
+/// link planted at `models/shadow.sql` carried a DENIED draft out of the
+/// models directory: the SQL landed at the link's target, the rollback's
+/// `remove_file` unlinked only the link, and the refusal reported a clean
+/// rollback while the outside file kept the SQL. `exists()` follows the link
+/// too, so the canonicalize check that guarded existing targets never saw a
+/// dangling one. Every draft tool resolves its paths through the same guard,
+/// so each is driven here, under the deny policy that produced the leak.
+#[cfg(unix)]
+#[tokio::test]
+async fn draft_tools_refuse_a_symlink_at_the_draft_path_before_writing() {
+    let dir = TempDir::new().unwrap();
+    write_project_with_policy(
+        dir.path(),
+        &dir.path().join("test.duckdb"),
+        DENY_AGENT_AUTHORING,
+    );
+    write_target_defaults(dir.path());
+    let models = dir.path().join("models");
+    // A sidecar-less model (inline frontmatter) for the sidecar-writing tools,
+    // so the link can sit at its sidecar path while `orders` keeps its fixture
+    // sidecar for the contract case.
+    std::fs::write(
+        models.join("bare.sql"),
+        "---toml\nname = \"bare\"\n---\nSELECT 1 AS id\n",
+    )
+    .unwrap();
+    let outside = TempDir::new().unwrap();
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+
+    let contract_spec = "[[columns]]\nname = \"id\"\ntype = \"Int64\"\nnullable = true\n";
+    let check_spec = "[[tests]]\ntype = \"not_null\"\ncolumn = \"id\"\n";
+    // (tool, arguments, the planted link, a sibling artifact that must stay
+    // unwritten)
+    let cases = vec![
+        (
+            "draft_model",
+            draft_args("shadow", "SELECT 1 AS id", "through a link"),
+            "shadow.sql",
+            Some("shadow.toml"),
+        ),
+        (
+            "draft_model",
+            draft_args("shade", "SELECT 1 AS id", "through a link"),
+            "shade.toml",
+            Some("shade.sql"),
+        ),
+        (
+            "draft_contract",
+            object(serde_json::json!({ "model": "orders", "spec": contract_spec })),
+            "orders.contract.toml",
+            None,
+        ),
+        (
+            "draft_check",
+            object(serde_json::json!({ "model": "bare", "spec": check_spec })),
+            "bare.toml",
+            None,
+        ),
+        (
+            "draft_metadata",
+            object(serde_json::json!({ "model": "bare", "classifications": { "id": "pii" } })),
+            "bare.toml",
+            None,
+        ),
+    ];
+    for (tool, args, link, sibling) in cases {
+        let link_path = models.join(link);
+        let target = outside.path().join(link);
+        if std::fs::symlink_metadata(&link_path).is_err() {
+            std::os::unix::fs::symlink(&target, &link_path).unwrap();
+        }
+        assert!(!target.exists(), "fixture: the planted link is dangling");
+
+        let result = client
+            .call_tool(CallToolRequestParams::new(tool).with_arguments(args))
+            .await
+            .unwrap_or_else(|e| panic!("{tool} returns a result: {e}"));
+        assert!(
+            !target.exists(),
+            "{tool}: the draft was written through the link to {} (response: {:?})",
+            target.display(),
+            result.structured_content
+        );
+        assert_eq!(
+            result.is_error,
+            Some(true),
+            "{tool}: a symlinked draft path refuses"
+        );
+        let err = result.structured_content.expect("envelope");
+        assert_eq!(
+            err["code"],
+            serde_json::json!("invalid_argument"),
+            "{tool}: refused up front, not denied after a write-through: {err:?}"
+        );
+        let message = err["message"].as_str().unwrap();
+        assert!(
+            message.contains(&format!("models/{link}")) && message.contains("symlink"),
+            "{tool}: the refusal names the link: {message}"
+        );
+        assert!(
+            std::fs::symlink_metadata(&link_path)
+                .map(|m| m.file_type().is_symlink())
+                .unwrap_or(false),
+            "{tool}: the planted link was replaced or removed"
+        );
+        if let Some(sibling) = sibling {
+            assert!(
+                !models.join(sibling).exists(),
+                "{tool}: the sibling artifact {sibling} was written before the refusal"
+            );
+        }
+    }
+
+    client.cancel().await.unwrap();
+}
+
+/// An EXISTS-but-unreadable SQL file refuses the redraft; before the fix it
+/// was DELETED. `DraftRollback::snapshot` turned every read error into
+/// "absent", so with `models/orders.sql` at mode 0200 the draft overwrote it
+/// (0200 is writable), the compile failed on the unreadable file, and the
+/// rollback took the remove arm for a path that had existed — the user's
+/// model was gone and the response said `compile_failed`. The sidecar had a
+/// guard for this shape; the SQL path had none. The snapshot itself now
+/// refuses any read error but NotFound, for every path, before anything is
+/// written.
+#[cfg(unix)]
+#[tokio::test]
+async fn draft_model_refuses_an_existing_but_unreadable_sql_instead_of_deleting_it() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    let sql_path = dir.path().join("models").join("orders.sql");
+    let sql_before = std::fs::read(&sql_path).unwrap();
+    let sidecar_path = dir.path().join("models").join("orders.toml");
+    let sidecar_before = std::fs::read(&sidecar_path).unwrap();
+
+    std::fs::set_permissions(&sql_path, std::fs::Permissions::from_mode(0o200)).unwrap();
+    let restore = RestorePerms(sql_path.clone(), std::fs::Permissions::from_mode(0o644));
+    if std::fs::read(&sql_path).is_ok() {
+        eprintln!("skipping: chmod 0o200 does not make files unreadable here (running as root?)");
+        return;
+    }
+
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("draft_model").with_arguments(draft_args(
+                "orders",
+                "SELECT 2 AS id",
+                "must not land",
+            )),
+        )
+        .await
+        .expect("draft_model returns a result");
+    assert_eq!(
+        result.is_error,
+        Some(true),
+        "an existing-but-unreadable SQL file refuses"
+    );
+    let err = result.structured_content.expect("envelope");
+    assert_eq!(
+        err["code"],
+        serde_json::json!("invalid_argument"),
+        "refused up front, not compile_failed after a write: {err:?}"
+    );
+    let message = err["message"].as_str().unwrap();
+    assert!(
+        message.contains("models/orders.sql") && message.contains("cannot be read"),
+        "the refusal names the unreadable file: {message}"
+    );
+    client.cancel().await.unwrap();
+
+    drop(restore);
+    assert_eq!(
+        std::fs::read(&sql_path)
+            .expect("the SQL file still exists: neither overwritten nor deleted"),
+        sql_before,
+        "the unreadable SQL file is byte-identical"
+    );
+    assert_eq!(
+        std::fs::read(&sidecar_path).unwrap(),
+        sidecar_before,
+        "the sidecar is untouched"
+    );
+}
+
+/// Drive `tool` with a mid-flight mutation of the project tree — a
+/// deterministic stand-in for "something on the machine changed the artifact
+/// between the draft's write and the policy verdict", the #1561 shape.
+///
+/// `models/test_definitions.toml` is a FIFO. The compile's model loader opens
+/// it right after the draft is written and blocks until this test opens the
+/// write end, so the FIRST handshake is a point where the draft is on disk
+/// and the verdict has not run: `mutate` runs there and returns whether its
+/// fault armed (a fault root bypasses returns false; the call is then fed to
+/// completion and `None` comes back so the caller can stand down). Every
+/// later handshake feeds the loader an empty — valid — definitions file. The
+/// loop ends when the call returns.
+///
+/// Needs a multi-thread runtime: the handler blocks a worker inside `open`.
+#[cfg(unix)]
+async fn call_with_midflight_mutation(
+    dir: &Path,
+    tool: &str,
+    args: serde_json::Map<String, serde_json::Value>,
+    mutate: impl FnOnce() -> bool,
+) -> Option<rmcp::model::CallToolResult> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let fifo = dir.join("models").join("test_definitions.toml");
+    let status = std::process::Command::new("mkfifo")
+        .arg(&fifo)
+        .status()
+        .expect("mkfifo runs");
+    assert!(status.success(), "mkfifo {}", fifo.display());
+
+    let server = RockyMcpServer::new(dir.join("rocky.toml"));
+    let client = connect(server).await;
+    let tool = tool.to_string();
+    let call = tokio::spawn(async move {
+        let result = client
+            .call_tool(CallToolRequestParams::new(tool).with_arguments(args))
+            .await;
+        (client, result)
+    });
+
+    let mut mutate = Some(mutate);
+    let mut armed = None;
+    while !call.is_finished() {
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .custom_flags(libc::O_NONBLOCK)
+            .open(&fifo)
+        {
+            Ok(writer) => {
+                if let Some(mutate) = mutate.take() {
+                    armed = Some(mutate());
+                }
+                drop(writer);
+            }
+            Err(e) if e.raw_os_error() == Some(libc::ENXIO) => {
+                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            }
+            Err(e) => panic!("opening {} for writing: {e}", fifo.display()),
+        }
+    }
+    let (client, result) = call.await.expect("the call task completes");
+    client.cancel().await.unwrap();
+
+    let armed = armed.expect(
+        "the handler never opened models/test_definitions.toml between its write and its \
+         verdict, so the mutation had no deterministic point to run",
+    );
+    if !armed {
+        return None;
+    }
+    Some(result.expect("the tool returns a result"))
+}
+
+/// Make `models` read-only so the rollback's unlink or create fails, and
+/// probe it: root creates files in a read-only directory, so the fault
+/// cannot arm there and the caller stands down. Returns whether it armed.
+#[cfg(unix)]
+fn make_models_read_only(models: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::set_permissions(models, std::fs::Permissions::from_mode(0o555)).unwrap();
+    let probe = models.join(".probe");
+    match std::fs::write(&probe, b"") {
+        Ok(()) => {
+            std::fs::remove_file(&probe).unwrap();
+            std::fs::set_permissions(models, std::fs::Permissions::from_mode(0o755)).unwrap();
+            false
+        }
+        Err(_) => true,
+    }
+}
+
+/// #1561's refusal arm driven end to end through a rollback that REALLY
+/// fails and leaves the path ABSENT. `orders` already has a contract; the
+/// redraft snapshots it, and between the write and the verdict the contract
+/// is deleted and the models directory made read-only, so the deny's
+/// rollback cannot recreate the prior file. The refusal must say so: before
+/// the fix every failed rollback claimed the artifact was "STILL ON DISK",
+/// which here is false — nothing is on disk, and the prior content is what
+/// was lost.
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn draft_contract_deny_with_a_failed_restore_says_the_prior_file_is_absent() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = TempDir::new().unwrap();
+    write_project_with_policy(
+        dir.path(),
+        &dir.path().join("test.duckdb"),
+        DENY_AGENT_AUTHORING,
+    );
+    let models = dir.path().join("models");
+    let contract = models.join("orders.contract.toml");
+    std::fs::write(
+        &contract,
+        "[[columns]]\nname = \"id\"\ntype = \"Int64\"\nnullable = true\n",
+    )
+    .unwrap();
+    // The ledger the deny records into must exist before the directory goes
+    // read-only: nothing can be created in models/ after the mutation.
+    let state_path = rocky_core::state::resolve_state_path(None, &models).path;
+    drop(rocky_core::state::StateStore::open(&state_path).expect("pre-create the ledger"));
+    let restore = RestorePerms(models.clone(), std::fs::Permissions::from_mode(0o755));
+
+    let spec = "[[columns]]\nname = \"status\"\ntype = \"String\"\nnullable = true\n";
+    let args = object(serde_json::json!({ "model": "orders", "spec": spec }));
+    let (models_at_mutation, contract_at_mutation) = (models.clone(), contract.clone());
+    let result = call_with_midflight_mutation(dir.path(), "draft_contract", args, move || {
+        assert!(
+            std::fs::read_to_string(&contract_at_mutation)
+                .expect("the draft is on disk when the loader blocks")
+                .contains("status"),
+            "the loader blocked before the draft was written"
+        );
+        std::fs::remove_file(&contract_at_mutation).unwrap();
+        make_models_read_only(&models_at_mutation)
+    })
+    .await;
+    let Some(result) = result else {
+        eprintln!(
+            "skipping: a read-only models directory does not block file creation here (running \
+             as root?)"
+        );
+        return;
+    };
+
+    assert_eq!(result.is_error, Some(true), "the deny is an error");
+    let err = result.structured_content.expect("envelope");
+    assert_eq!(
+        err["code"],
+        serde_json::json!("policy_denied"),
+        "the class stays policy_denied: {err:?}"
+    );
+    assert_eq!(err["policy_rule"], serde_json::json!("0"));
+    assert_eq!(
+        err["rollback_failed_paths"],
+        serde_json::json!(["models/orders.contract.toml"]),
+        "the leftover rides the envelope as a typed field: {err:?}"
+    );
+    let message = err["message"].as_str().unwrap();
+    assert!(
+        message.contains("models/orders.contract.toml could not be restored to its prior content"),
+        "the refusal names the path and what failed: {message}"
+    );
+    assert!(
+        message.contains("now absent"),
+        "the refusal says the path is gone: {message}"
+    );
+    assert!(
+        !message.contains("STILL ON DISK"),
+        "nothing is on disk; the refusal must not claim otherwise: {message}"
+    );
+    assert!(
+        !message.contains("not kept"),
+        "a failed rollback must not read as a clean refusal: {message}"
+    );
+    drop(restore);
+    assert!(
+        std::fs::symlink_metadata(&contract).is_err(),
+        "the prior contract really is absent"
+    );
+}
+
+/// The sibling shape: the artifact is NEW, the rollback's unlink fails, and
+/// the artifact really is still on disk — the wording that was previously
+/// asserted for every failure is right here, and the typed field names the
+/// path.
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn draft_contract_deny_with_a_failed_remove_says_the_draft_is_still_on_disk() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = TempDir::new().unwrap();
+    write_project_with_policy(
+        dir.path(),
+        &dir.path().join("test.duckdb"),
+        DENY_AGENT_AUTHORING,
+    );
+    let models = dir.path().join("models");
+    let contract = models.join("orders.contract.toml");
+    let state_path = rocky_core::state::resolve_state_path(None, &models).path;
+    drop(rocky_core::state::StateStore::open(&state_path).expect("pre-create the ledger"));
+    let restore = RestorePerms(models.clone(), std::fs::Permissions::from_mode(0o755));
+
+    let spec = "[[columns]]\nname = \"id\"\ntype = \"Int64\"\nnullable = true\n";
+    let args = object(serde_json::json!({ "model": "orders", "spec": spec }));
+    let (models_at_mutation, contract_at_mutation) = (models.clone(), contract.clone());
+    let result = call_with_midflight_mutation(dir.path(), "draft_contract", args, move || {
+        assert!(
+            contract_at_mutation.is_file(),
+            "the loader blocked before the draft was written"
+        );
+        make_models_read_only(&models_at_mutation)
+    })
+    .await;
+    let Some(result) = result else {
+        eprintln!(
+            "skipping: a read-only models directory does not block unlink here (running as root?)"
+        );
+        return;
+    };
+
+    assert_eq!(result.is_error, Some(true), "the deny is an error");
+    let err = result.structured_content.expect("envelope");
+    assert_eq!(err["code"], serde_json::json!("policy_denied"), "{err:?}");
+    assert_eq!(
+        err["rollback_failed_paths"],
+        serde_json::json!(["models/orders.contract.toml"]),
+        "{err:?}"
+    );
+    let message = err["message"].as_str().unwrap();
+    assert!(
+        message.contains("models/orders.contract.toml could not be removed"),
+        "the refusal names the path and what failed: {message}"
+    );
+    assert!(
+        message.contains("STILL ON DISK"),
+        "the artifact remains, and the refusal says so: {message}"
+    );
+    assert!(
+        !message.contains("not kept"),
+        "a failed rollback must not read as a clean refusal: {message}"
+    );
+    drop(restore);
+    assert!(
+        contract.is_file(),
+        "the refused draft really is still on disk"
+    );
 }

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -4692,6 +4692,203 @@ async fn draft_contract_deny_never_restores_through_a_leaf_swapped_for_a_symlink
     );
 }
 
+/// Drive `draft_model` for `name` with `plant` running in the window between
+/// the up-front leaf check and the rollback snapshot — the window
+/// [`call_with_midflight_mutation`] cannot reach, because the loader's FIFO
+/// handshake only happens after both writes.
+///
+/// The runtime is built with ONE blocking thread and a hog holds it, so the
+/// handler's `snapshot_async` (a `spawn_blocking`) queues instead of running.
+/// `models/` is removed first, and `draft_model` creates it AFTER
+/// `resolve_draft_paths` returns, so the directory appearing is the handler's
+/// own proof that the leaf check has already passed. `plant` runs there;
+/// releasing the hog then lets the snapshot meet what `plant` left at the
+/// leaf.
+///
+/// ```text
+///  handler: resolve_draft_paths ─► create_dir_all ─► snapshot_async ┄┄┄┄► reads the leaf
+///  test:                            (sees models/) ─► plant ─► release hog ┘
+/// ```
+///
+/// Both timeouts turn a regression into a failure instead of a hung suite: a
+/// path-based read parks on a planted FIFO forever.
+#[cfg(unix)]
+fn draft_model_with_a_pre_snapshot_swap(
+    dir: &Path,
+    name: &str,
+    plant: impl FnOnce(),
+) -> rmcp::model::CallToolResult {
+    let dir = dir.to_path_buf();
+    let models = dir.join("models");
+    std::fs::remove_dir_all(&models).expect("clear the models directory");
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .max_blocking_threads(1)
+        .enable_all()
+        .build()
+        .expect("build a runtime with exactly one blocking thread");
+
+    runtime.block_on(async move {
+        let (release, held) = std::sync::mpsc::channel::<()>();
+        let (hogging, hogged) = tokio::sync::oneshot::channel();
+        let hog = tokio::task::spawn_blocking(move || {
+            let _ = hogging.send(());
+            let _ = held.recv();
+        });
+        hogged.await.expect("the hog holds the blocking thread");
+
+        let server = RockyMcpServer::new(dir.join("rocky.toml"));
+        let client = connect(server).await;
+        let args = draft_args(name, "SELECT 3 AS id", "a draft racing the leaf");
+        let call = tokio::spawn(async move {
+            let result = client
+                .call_tool(CallToolRequestParams::new("draft_model").with_arguments(args))
+                .await;
+            (client, result)
+        });
+
+        let reached = tokio::time::timeout(std::time::Duration::from_secs(30), async {
+            while !models.is_dir() {
+                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            }
+        })
+        .await;
+        assert!(
+            reached.is_ok(),
+            "draft_model never created the models directory, so the leaf check never passed \
+             and there was no window to plant into"
+        );
+
+        plant();
+        drop(release);
+        hog.await.expect("the hog task finishes");
+
+        let (client, result) = tokio::time::timeout(std::time::Duration::from_secs(30), call)
+            .await
+            .expect("draft_model parked on the planted leaf instead of refusing it")
+            .expect("the call task completes");
+        client.cancel().await.unwrap();
+        result.expect("the tool returns a result")
+    })
+}
+
+/// The READ half of the leaf race, end to end. Between the up-front leaf
+/// check and the snapshot, `models/orders.toml` becomes a symlink to a file
+/// OUTSIDE the project. Before the fix the snapshot's `std::fs::read`
+/// followed it: the outside file became the "prior sidecar" the merge folds
+/// into the draft, the policy read its classifications, and the rollback
+/// would have written it back. The no-follow read refuses the draft instead,
+/// before anything is written. The planted target is valid TOML, so a
+/// followed read would MERGE it rather than refuse for parsing — the bug
+/// cannot hide behind a parse error.
+#[cfg(unix)]
+#[test]
+fn draft_model_never_snapshots_through_a_leaf_swapped_for_an_outside_symlink() {
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    let outside_dir = TempDir::new().unwrap();
+    let outside = outside_dir.path().join("outside.toml");
+    std::fs::write(&outside, "marker = \"OUTSIDE-SECRET\"\n").unwrap();
+
+    let sidecar = dir.path().join("models").join("orders.toml");
+    let (link_at, target) = (sidecar.clone(), outside.clone());
+    let result = draft_model_with_a_pre_snapshot_swap(dir.path(), "orders", move || {
+        std::os::unix::fs::symlink(&target, &link_at).unwrap();
+    });
+
+    assert_eq!(
+        result.is_error,
+        Some(true),
+        "a leaf swapped for a symlink refuses the draft"
+    );
+    let err = result.structured_content.expect("envelope");
+    assert_eq!(
+        err["code"],
+        serde_json::json!("invalid_argument"),
+        "refused by the snapshot's no-follow read, not by a later write: {err:?}"
+    );
+    let message = err["message"].as_str().unwrap();
+    assert!(
+        message.contains("models/orders.toml") && message.contains("cannot be read"),
+        "the refusal names the path: {message}"
+    );
+    assert!(
+        !message.contains("OUTSIDE-SECRET"),
+        "the outside file's content never reaches the caller: {message}"
+    );
+
+    // THE PIN: nothing outside the project was read in, and nothing was written.
+    assert_eq!(
+        std::fs::read_to_string(&outside).unwrap(),
+        "marker = \"OUTSIDE-SECRET\"\n",
+        "the file outside the project is untouched"
+    );
+    assert!(
+        !dir.path().join("models").join("orders.sql").exists(),
+        "the draft refused before any write"
+    );
+    assert!(
+        std::fs::symlink_metadata(&sidecar)
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "the planted link is left in place, neither followed nor replaced"
+    );
+}
+
+/// The same window with a FIFO. Before the fix the snapshot's `std::fs::read`
+/// opened it and waited for a writer that never comes, parking the request —
+/// and the tool call — forever. The harness's timeout turns that regression
+/// into a failure instead of a hung suite; the no-follow read refuses
+/// promptly.
+#[cfg(unix)]
+#[test]
+fn draft_model_refuses_a_leaf_swapped_for_a_fifo_before_the_snapshot_without_hanging() {
+    use std::os::unix::fs::FileTypeExt as _;
+
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+
+    let sidecar = dir.path().join("models").join("orders.toml");
+    let fifo_at = sidecar.clone();
+    let result = draft_model_with_a_pre_snapshot_swap(dir.path(), "orders", move || {
+        let status = std::process::Command::new("mkfifo")
+            .arg(&fifo_at)
+            .status()
+            .expect("mkfifo runs");
+        assert!(status.success(), "mkfifo {}", fifo_at.display());
+    });
+
+    assert_eq!(
+        result.is_error,
+        Some(true),
+        "a leaf swapped for a FIFO refuses the draft"
+    );
+    let err = result.structured_content.expect("envelope");
+    assert_eq!(
+        err["code"],
+        serde_json::json!("invalid_argument"),
+        "refused by the snapshot's no-follow read: {err:?}"
+    );
+    let message = err["message"].as_str().unwrap();
+    assert!(
+        message.contains("models/orders.toml") && message.contains("cannot be read"),
+        "the refusal names the path: {message}"
+    );
+    assert!(
+        !dir.path().join("models").join("orders.sql").exists(),
+        "the draft refused before any write"
+    );
+    assert!(
+        std::fs::symlink_metadata(&sidecar)
+            .unwrap()
+            .file_type()
+            .is_fifo(),
+        "the planted FIFO is left in place, neither read nor replaced"
+    );
+}
+
 /// `models/` itself reached through a symlink redirected every draft write
 /// out of the project with no race at all: the leaf check and the no-follow
 /// writes look only at the final path component, and `root.join("models")`


### PR DESCRIPTION
## Summary

Independent red team (Codex) attacked #1572's rollback contract and won three times; a second round against the first fix won again. All reproduced end-to-end over the rmcp harness and verified before fixing. This branch closes the class.

```
 dangling symlink at models/x.sql  ->  deny "kept no file"  ->  bytes landed OUTSIDE the project
 unreadable existing x.sql (0200)  ->  refusal DELETED the user's file
 check-then-write                  ->  mid-flight link swap redirected the rollback restore
 models/ -> elsewhere (symlink)    ->  every draft wrote outside, no race needed
 FIFO at the draft path            ->  request hung forever
```

## Changes

- Draft writes and the rollback restore go through a no-follow write (the #1570 helper, lifted into rocky-core with an in-place variant). The check-then-write window is gone: a swapped-in link makes the write fail and the refusal reports it.
- `resolve_draft_paths` canonicalizes the models directory and refuses when it resolves outside the project root. The dirfd-level residual stays with #1500.
- The pre-write guard refuses any non-regular file (symlink, FIFO, device), not just symlinks.
- Snapshot distinguishes NotFound from unreadable: drafting over an existing-but-unreadable file refuses up front; the remove arm can no longer delete a file that existed.
- `rollback_disposition` reports three honest states — still on disk / now absent / could not inspect (with the error) — worded by the failing arm (restore vs remove).
- Clean-path refusal texts are byte-identical; the wire-parity goldens pin that.

## Test plan

`cargo test -p rocky-mcp`: 48 lib + 73 roundtrip + 3 wire-parity, 0 failed. New end-to-end tests: mid-flight symlink swap under deny, ancestor-symlink refusal, FIFO refusal (timeout-bounded), unreadable-SQL refusal, a `PolicyGate::Unloadable` arm driven through a real rollback failure, and the disposition wording states. Clippy `-D warnings` and fmt clean. Every guard shown fix-sensitive (test fails with the guard reverted).

## On the record (per AGENTS.md)

**Red team:** Codex (`codex-rescue`), two rounds, findings cross-verified by two independent lenses. A final pass over this delta is running; its disposition lands as a comment before merge.

**Least confident:** the mid-flight FIFO test harness assumes the compile loader's read ordering; if that changes the tests fail loudly rather than silently pass. Verified on macOS/APFS only.

**Most important thing possibly missing:** syscall-level containment for a hostile parent directory swapped mid-flight (dirfd/openat) — the same class #1500 tracks for the product path.
