### PR TITLE
OWNER MERGE — fix(engine/rocky-cli): fail a replication run whose error-severity checks failed

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -189,6 +189,31 @@ pub struct RunFailed {
 /// JSON consumer reads regardless of exit code. This is what makes a
 /// compile-failed model a first-class run failure instead of a silently
 /// skipped no-op that still reported `status: "Success"`, exit 0.
+/// Fold failed error-severity checks into `tables_failed` so the replication
+/// path's exit code, recorded status and check results agree (#1598).
+///
+/// [`RunOutput::derive_run_status`] keys only on `tables_copied` /
+/// `tables_failed` / `interrupted` and ignores `check_results`, so a run whose
+/// assertions failed persisted as `Success` and exited 0. `[pipeline.X.checks]
+/// fail_on_error` already promised the opposite and defaults to `true`; it was
+/// never read on this path. The quality path folds the same condition in
+/// [`super::run_local::run_quality`].
+///
+/// A `not_evaluated` check counts as failed. It carries `passed: false` and its
+/// configured severity, and "the engine could not run this check" is not a
+/// pass — the reason #1595 gave it a state distinct from `overlap_count: 0`.
+///
+/// A warning-severity failure never folds, with or without the flag: severity
+/// is the author's statement about what a failure means, and the flag governs
+/// only whether an *error* is fatal.
+pub(crate) fn fold_failed_checks_into_tables_failed(output: &mut RunOutput, fail_on_error: bool) {
+    if !fail_on_error {
+        return;
+    }
+    let (error_failures, _) = super::run_local::count_failures_by_severity(output);
+    output.tables_failed += error_failures;
+}
+
 pub(crate) fn run_status_exit_result(output: &RunOutput, run_id: &str) -> Result<()> {
     match output.derive_run_status() {
         rocky_core::state::RunStatus::PartialFailure => Err(PartialFailure {
@@ -5743,6 +5768,30 @@ pub async fn run(
     if model_phase_clean {
         write_recipe_manifests(&output, governance_adapter.as_ref(), &run_id).await;
     }
+
+    // Replication check trap (#1598), the twin of the quality-path fold in
+    // `run_local::run_quality`. `RunOutput::derive_run_status` keys only on
+    // `tables_copied` / `tables_failed` / `interrupted` and IGNORES
+    // `check_results`, and nothing on this path folded a failed check into
+    // `tables_failed` — so a replication run whose error-severity assertions
+    // FAILED persisted as `Success` and exited 0. `[pipeline.X.checks]
+    // fail_on_error` already promised the opposite ("the run exits non-zero if
+    // any error-severity check fails") and defaults to true; it was simply
+    // never read here. This wires the documented control rather than inventing
+    // a policy.
+    //
+    // Placed BEFORE `persist_run_record` — unlike the quality path, which folds
+    // after its JSON emit — because this path persists first (below) and prints
+    // later (~`print_json`). Folding here keeps the recorded status, the
+    // reconciler's view and the exit code agreeing; the JSON payload is
+    // unaffected either way, since `tables_failed` already carries compile
+    // failures and the `check_results` array is unchanged.
+    //
+    // A `not_evaluated` check counts as failed: it carries `passed: false` and
+    // its configured severity, and "the engine could not run this check" is not
+    // a pass. That is the whole reason #1595 gave it a state distinct from
+    // `overlap_count: 0`.
+    fold_failed_checks_into_tables_failed(&mut output, pipeline.checks.fail_on_error);
 
     // Persist the RunRecord so `rocky history`, `rocky replay`,
     // `rocky trace`, and `rocky cost` have real data to read.
@@ -18426,6 +18475,80 @@ backend = "local"
             "[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"\"\nschema = \"main\"\n",
         )
         .expect("write model toml");
+    }
+
+    /// #1598: a replication run whose error-severity checks FAILED must not
+    /// exit 0. The fold is what makes `derive_run_status` — which reads only
+    /// the table tallies — see a failure that lives in `check_results`.
+    ///
+    /// The `not_evaluated` case is the one worth reading. #1595 gave a check
+    /// the engine could not run its own state precisely so it would stop
+    /// reading as a clean zero; folding it here is what makes that visible in
+    /// the exit code rather than only in the JSON.
+    #[test]
+    fn failed_error_checks_fold_into_the_replication_exit_contract() {
+        use rocky_core::checks::{CheckDetails, CheckResult};
+        use rocky_core::tests::TestSeverity;
+
+        let check = |passed: bool, severity: TestSeverity| CheckResult {
+            name: "c".to_string(),
+            passed,
+            severity,
+            details: CheckDetails::RowCount {
+                source_count: 1,
+                target_count: 1,
+            },
+        };
+        let with = |checks: Vec<CheckResult>| {
+            let mut o = RunOutput::new(String::new(), 0, 1);
+            o.tables_copied = 1;
+            o.check_results.push(crate::output::TableCheckOutput {
+                asset_key: vec!["t".to_string()],
+                checks,
+            });
+            o
+        };
+
+        // A failed error-severity check makes the run fail, and the exit
+        // contract maps it like any other partial failure.
+        let mut failed = with(vec![check(false, TestSeverity::Error)]);
+        super::fold_failed_checks_into_tables_failed(&mut failed, true);
+        assert_eq!(failed.tables_failed, 1, "an error failure must fold");
+        assert!(
+            super::run_status_exit_result(&failed, "r").is_err(),
+            "a failed error-severity check must not exit 0"
+        );
+
+        // `fail_on_error = false` is the documented opt-out.
+        let mut opted_out = with(vec![check(false, TestSeverity::Error)]);
+        super::fold_failed_checks_into_tables_failed(&mut opted_out, false);
+        assert_eq!(opted_out.tables_failed, 0);
+        assert!(super::run_status_exit_result(&opted_out, "r").is_ok());
+
+        // A warning failure never folds — severity is the author's statement.
+        let mut warned = with(vec![check(false, TestSeverity::Warning)]);
+        super::fold_failed_checks_into_tables_failed(&mut warned, true);
+        assert_eq!(warned.tables_failed, 0);
+
+        // A passing check folds nothing.
+        let mut clean = with(vec![check(true, TestSeverity::Error)]);
+        super::fold_failed_checks_into_tables_failed(&mut clean, true);
+        assert_eq!(clean.tables_failed, 0);
+
+        // A not-evaluated check is a failure, not a clean zero (#1595).
+        let mut not_evaluated = with(vec![
+            rocky_core::checks::cross_source_overlap_not_evaluated(
+                "overlap",
+                vec!["a".to_string(), "b".to_string()],
+                "the query could not run".to_string(),
+                TestSeverity::Error,
+            ),
+        ]);
+        super::fold_failed_checks_into_tables_failed(&mut not_evaluated, true);
+        assert_eq!(
+            not_evaluated.tables_failed, 1,
+            "a check the engine could not run is not a pass"
+        );
     }
 
     /// `run_status_exit_result` maps the derived run status onto the CLI

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -965,7 +965,7 @@ async fn count_rows(
 }
 
 /// Count failed checks bucketed by severity across every table result.
-fn count_failures_by_severity(output: &RunOutput) -> (usize, usize) {
+pub(crate) fn count_failures_by_severity(output: &RunOutput) -> (usize, usize) {
     use rocky_core::tests::TestSeverity;
     let mut error = 0usize;
     let mut warning = 0usize;


### PR DESCRIPTION
A replication run whose error-severity checks **failed** exited 0 and persisted as `Success`. It now fails, using the flag that already promised exactly that.

**This changes behaviour for every replication project on upgrade**, so it is marked for owner merge.

## What was wrong

`RunOutput::derive_run_status` keys only on `tables_copied` / `tables_failed` / `interrupted`. It ignores `check_results`. Nothing on the replication path folded a failed check into `tables_failed`.

```
  table copy failed    ->  tables_failed  ->  exit 1 / 2
  model compile failed ->  tables_failed  ->  exit 1 / 2
  error check failed   ->  check_results  ->  exit 0        <- this
```

## This is not a new policy

`[pipeline.<name>.checks] fail_on_error` already exists, defaults to `true`, and is documented as: *"the quality run exits non-zero if any error-severity check fails"*. The quality path honours it — `run_local.rs`, `error_failures > 0 && pipeline.checks.fail_on_error` folded into `tables_failed`. The replication path never read it.

So this wires a documented control that was not configured. That is the same class of gap several reviews found this week: a promise in the config reference that no code kept.

## Placement, and why it differs from the quality path

The quality path folds *after* its JSON emit, deliberately, so the payload is unchanged. Replication is the other way round: it calls `persist_run_record` **before** `print_json`. Folding after the emit would record `Success` and then exit non-zero — the record and the exit code would disagree, and the schedule reconciler reads the record.

So the fold sits immediately before `persist_run_record`. The JSON payload is unaffected either way: `tables_failed` already carries compile failures, and `check_results` is untouched.

## Two rules worth stating

- **A `not_evaluated` check counts as failed.** It carries `passed: false` and its configured severity. "The engine could not run this check" is not a pass — that is the whole reason #1595 gave it a state distinct from `overlap_count: 0`.
- **A warning-severity failure never folds**, with or without the flag. Severity is the author's statement about what a failure means; the flag governs only whether an *error* is fatal.

## Evidence

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --all-targets --all-features -- -D warnings` | pass |
| `cargo test --workspace --no-fail-fast` | **6919 passed, 0 failed** |
| `just codegen` + drift | clean |
| `./scripts/regen_fixtures.sh` + drift | clean |

`HEAD` and `git status --porcelain` were captured before and after the test run and were identical, so the run is not void.

Mutation check — the fold is neutered, the test kept:

```
assertion `left == right` failed: an error failure must fold
  left: 0
 right: 1
mutation-check: OK — the test failed under mutation, so it is fix-sensitive.
```

The test covers five cases: a failed error check folds and exits non-zero; `fail_on_error = false` opts out; a warning failure does not fold; a passing check folds nothing; and a `not_evaluated` check counts as failed.

While writing it I disabled a neighbouring test by inserting between its doc comment and its `#[test]`. Clippy caught it as "function is never used". Both attributes are correct now and the module runs 240 tests.

## Upgrade impact, stated plainly

A project whose error-severity checks have been failing quietly will start failing its pipeline. That is the intent, and it is still a change someone can be surprised by. The opt-out is one line:

```toml
[pipeline.<name>.checks]
fail_on_error = false
```

Worth a CHANGELOG entry under a clear heading before the next `engine-v*` tag.

## Not in scope, and filed

The Dagster component excludes `candidate` cross-source checks from its declared specs and then drops undeclared results, so a correctly recorded failure is still invisible there. That needs the matching change on the Dagster side; it is noted in #1598 rather than bundled here.

## Standing questions

**Least confident about:** whether folding into `tables_failed` is the right representation, as opposed to a separate `checks_failed` tally. Folding means `tables_failed` no longer means only "tables". I chose it because it is exactly what the quality path does, so both paths derive status the same way — but a reviewer who dislikes the overloading has a fair point, and the alternative is a wider change to `derive_run_status`.

**Most important thing I might be missing:** whether any consumer reads `tables_failed` as a count of tables rather than as a failure tally. I checked `derive_run_status`, `run_status_exit_result` and the persisted `RunRecord`; I did not audit every Dagster or SDK reader.

Closes #1598
