### PR TITLE
docs(engine/rocky-compiler): make the I003 grep hint runnable

### DIFF
--- a/engine/crates/rocky-compiler/src/diagnostic.rs
+++ b/engine/crates/rocky-compiler/src/diagnostic.rs
@@ -266,8 +266,12 @@ pub const I002: &str = "I002";
 /// nothing clears this code under them today. `rocky test` and `rocky ci`
 /// are the two that matter here (`rocky_engine::test_runner`,
 /// `rocky_engine::ci`); `rocky emit-sql`, `rocky preview-rows` and
-/// `rocky retention-status` do the same. Grep for `source_schemas:
-/// HashMap::new()` for the current list.
+/// `rocky retention-status` do the same. For the current list, run
+/// `rg 'source_schemas:\s*(std::collections::)?HashMap::new\(\)'` — the
+/// three commands above spell it `std::collections::HashMap::new()`, so a
+/// search for the short form alone finds none of them. It matches explicit
+/// initializers only; a caller that builds the map elsewhere and passes it in
+/// empty will not show up.
 ///
 /// A `CAST` is *not* a general fix. `refine_casts` in `typecheck.rs` refines a
 /// cast column only when the cast's input type is already known, so


### PR DESCRIPTION
The `I003` doc comment told the reader to grep `source_schemas: HashMap::new()` for the current list of commands that compile with no source schemas.

That search finds none of the three commands the same paragraph names. `emit-sql`, `preview-rows` and `retention-status` all spell it `std::collections::HashMap::new()`.

It now gives a pattern that matches both spellings, and says what it does not match — a caller that builds the map elsewhere and passes it in empty.

```
rg 'source_schemas:\s*(std::collections::)?HashMap::new\(\)'
```

Verified: the new pattern returns `emit_sql.rs`, `preview_rows.rs`, `retention_status.rs`, `test_runner.rs`, `executor.rs`, `plan.rs`, `lineage.rs`, `bench.rs`, `fulfill_api.rs`, `lsp.rs` and the two test/bench files. The old one returned none of the first three.

Doc comment only. No behaviour change.

Gates: `cargo fmt --all -- --check` clean, `cargo clippy --all-targets --all-features -- -D warnings` exit 0, `cargo test -p rocky-compiler` 456 + 23 passed / 0 failed, `just codegen` and `./scripts/regen_fixtures.sh` no drift.

Found by the independent red team (Codex, `codex exec --sandbox read-only`, reasoning effort high) on #1615, after that PR had already merged. It was the only finding left standing in that round.

Follow-up to #1240.