### PR TITLE
chore: release pre-flight — bump h2 (RUSTSEC-2026-0258) and fix the checkpoint-resume POC

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -122,7 +122,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -133,7 +133,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -768,9 +768,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1465,7 +1465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1828,9 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2815,7 +2815,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3475,7 +3475,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4533,7 +4533,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4546,7 +4546,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4605,7 +4605,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5030,7 +5030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5093,7 +5093,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5240,7 +5240,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5259,7 +5259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6114,7 +6114,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6187,15 +6187,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/examples/playground/pocs/05-orchestration/04-checkpoint-resume/README.md
+++ b/examples/playground/pocs/05-orchestration/04-checkpoint-resume/README.md
@@ -1,25 +1,44 @@
-# 04-checkpoint-resume — `rocky run --resume-latest` after a failure
+# 04-checkpoint-resume — `rocky run --resume-latest` after a partial failure
 
 > **Category:** 05-orchestration
 > **Credentials:** none (DuckDB)
 > **Runtime:** < 5s
-> **Rocky features:** `--resume-latest`, per-table run progress in the state store
+> **Rocky features:** `--resume-latest`, per-table run progress in the state store, pipeline-scoped checkpoints
 
 ## What it shows
 
-`rocky run` records per-table progress in the state store as it processes the
-pipeline. If a run stops before every table is copied, `rocky run
---resume-latest` reads the previous run's checkpoint and skips the tables that
-already succeeded rather than starting over.
+`rocky run` records per-table progress in the state store as it processes a
+replication pipeline. When a run fails partway, `rocky run --resume-latest`
+reads that run's checkpoint, skips the tables that already succeeded, and
+retries only the ones that did not.
+
+A checkpoint belongs to the scope that wrote it: the pipeline, its `--filter`,
+and where it writes. A `--resume-latest` from another scope is refused, and
+`--resume-latest` refuses when the latest run in scope succeeded. Both
+refusals are demonstrated here. (An explicit `--resume <run-id>` checks the
+scope but not whether that run succeeded.)
 
 ## How it works
 
-The replication run path (used by the DuckDB and Databricks adapters alike)
-initialises run progress up front and checkpoints each table as it finishes —
-success or failure — into the local state store (`.rocky-state.redb`). On
-`--resume-latest`, the next run loads the most recent run's progress, collects
-the table keys that reached `Success`, and drops them from the work list. The
-output records the replayed run under `resumed_from`.
+```
+run 1  (no filter)         orders ok, customers ok, products FAILS   exit 2
+                           checkpoint: orders + customers recorded as Success
+   |
+   +-- resume --filter source=orders   refused: different scope, no checkpoint visible
+   |
+run 2  --resume-latest     skips orders + customers, copies products   exit 0
+                           output carries resumed_from = <run 1 id>
+   |
+   +-- resume again        refused: the latest run succeeded
+```
+
+The failure is induced by occupying the `products` target with a view that
+Rocky did not create, with a column that matches the source so drift detection
+has nothing to alter. `full_refresh` then replaces the target table, and DuckDB
+refuses to replace a view with a table (`Existing object products is of type
+View, trying to replace with type Table`), so that one table fails while the
+other two copy. The script asserts that error, then drops the view before
+resuming.
 
 ## Layout
 
@@ -27,7 +46,7 @@ output records the replayed run under `resumed_from`.
 .
 ├── README.md
 ├── rocky.toml
-├── run.sh           Demonstrates the --resume-latest flag
+├── run.sh           Demonstrates the --resume-latest contract
 └── data/seed.sql
 ```
 
@@ -39,7 +58,12 @@ output records the replayed run under `resumed_from`.
 
 ## Expected output
 
-- `Run 1 (orders)` copies **1** table (`orders`) and checkpoints it.
-- `Run 2 (--resume-latest)` has all three sources in scope but skips the
-  already-completed `orders`, copying **2** tables (`customers`, `products`).
-  `expected/run2.json` carries a non-null `resumed_from` pointing at run 1.
+- `Run 1` exits 2 with `status = PartialFailure`, `tables_copied = 2`,
+  `tables_failed = 1`, and the recorded error names the view.
+- A resume with `--filter source=orders` is refused with `no progress found`:
+  the filter makes it a different scope, and the checkpoint is not visible
+  from there.
+- `Run 2 (--resume-latest)` exits 0 with `tables_skipped = 2`,
+  `tables_copied = 1`, and a `resumed_from` naming run 1.
+- A third `--resume-latest` is refused: `nothing to resume: run <run 2 id>
+  already succeeded`.

--- a/examples/playground/pocs/05-orchestration/04-checkpoint-resume/run.sh
+++ b/examples/playground/pocs/05-orchestration/04-checkpoint-resume/run.sh
@@ -1,24 +1,101 @@
 #!/usr/bin/env bash
+# 04-checkpoint-resume — `rocky run --resume-latest` after a partial failure.
+#
+# A replication pipeline with three sources. One target is occupied by a VIEW
+# that Rocky did not create, so the first run copies two tables and fails the
+# third. This script PROVES the resume contract:
+#   1. the failed run exits NON-ZERO and checkpoints the tables that succeeded
+#   2. `--resume-latest` from a DIFFERENT scope (here, with a `--filter`) is
+#      refused — a checkpoint belongs to the scope that wrote it
+#   3. `--resume-latest` from the SAME scope skips the two copied tables and
+#      retries only the failed one, recording `resumed_from`
+#   4. once that run succeeds, `--resume-latest` is refused again — the
+#      latest run succeeded, so it has nothing to resume
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$HERE"
 mkdir -p expected
-rm -f .rocky-state.redb poc.duckdb
+rm -f .rocky-state.redb .rocky-state.redb.lock poc.duckdb
+
+# Read one top-level field out of a `rocky -o json run` result.
+field() { python3 -c 'import json,sys; v=json.load(open(sys.argv[1]))[sys.argv[2]]; print("null" if v is None else v)' "$1" "$2"; }
+expect() { # expect <file> <field> <value>
+    local got; got="$(field "$1" "$2")"
+    if [ "$got" != "$3" ]; then echo "FAIL: $1 $2 = $got, expected $3" >&2; exit 1; fi
+    echo "OK: $2 = $got"
+}
 
 duckdb poc.duckdb < data/seed.sql
+# Occupy the `products` target with a view whose column matches the source, so
+# drift detection has nothing to alter. `full_refresh` then replaces the target
+# table, and DuckDB refuses to replace a view with a table, so this one table
+# fails while the other two copy.
+duckdb poc.duckdb "CREATE SCHEMA staging__products; CREATE VIEW staging__products.products AS SELECT 0::BIGINT AS id"
 
 rocky -c rocky.toml validate
 
-# First run — replicate just the `orders` source. The replication run path
-# records per-table progress in the state store as each table completes.
-rocky -c rocky.toml -o json run --filter source=orders > expected/run1.json
-echo "Run 1 (orders) ok — progress checkpointed to the state store"
-
-# Resume — no filter, so all three sources are in scope, but --resume-latest
-# reads the previous run's checkpoint and skips `orders` (already succeeded),
-# copying only customers + products.
-rocky -c rocky.toml -o json run --resume-latest > expected/run2.json
-echo "Run 2 (--resume-latest) ok — orders skipped, customers + products copied"
+echo
+echo "==== 1. run — two tables copy, one fails ===="
+# The run is EXPECTED to fail. Capture the exit code without tripping `set -e`.
+set +e
+rocky -c rocky.toml -o json run > expected/run1.json 2> expected/run1.log
+RUN1_EXIT=$?
+set -e
+# Exit 2 is the partial-failure contract: some tables copied, at least one did not.
+if [ "$RUN1_EXIT" -ne 2 ]; then echo "FAIL: run 1 exited $RUN1_EXIT, expected 2 (partial failure)" >&2; exit 1; fi
+echo "OK: run 1 exited 2 (partial failure)"
+expect expected/run1.json status PartialFailure
+expect expected/run1.json tables_copied 2
+expect expected/run1.json tables_failed 1
+grep -q "is of type View" expected/run1.json \
+    || { echo "FAIL: run 1 did not fail on the view collision (see expected/run1.json errors[])" >&2; exit 1; }
+echo "OK: the failure is the occupied target"
+# The run output does not carry its own id; the run record does.
+RUN1_ID="$(rocky -c rocky.toml -o json history | python3 -c '
+import json,sys
+runs=[r for r in json.load(sys.stdin)["runs"] if "partial" in r["status"].lower()]
+assert len(runs)==1, runs
+print(runs[0]["run_id"])')"
+echo "run 1 id: $RUN1_ID"
 
 echo
-echo "POC complete: --resume-latest replayed the latest run and skipped the already-completed table."
+echo "==== 2. a resume from a different scope is refused ===="
+# `--filter source=orders` is a different scope from the run that wrote the
+# checkpoint (no filter). The checkpoint is not visible from here, so the
+# resume refuses instead of skipping tables another scope copied.
+set +e
+rocky -c rocky.toml -o json run --resume-latest --filter source=orders \
+    > expected/run-other-scope.json 2> expected/run-other-scope.log
+OTHER_EXIT=$?
+set -e
+if [ "$OTHER_EXIT" -eq 0 ]; then echo "FAIL: a resume from another scope was accepted" >&2; exit 1; fi
+grep -q "no progress found" expected/run-other-scope.log \
+    || { echo "FAIL: expected 'no progress found' in expected/run-other-scope.log" >&2; exit 1; }
+echo "OK: refused — $(grep -m1 -o 'cannot resume.*' expected/run-other-scope.log)"
+
+echo
+echo "==== 3. repair the target, then resume from the same scope ===="
+duckdb poc.duckdb "DROP VIEW staging__products.products"
+rocky -c rocky.toml -o json run --resume-latest > expected/run2.json
+expect expected/run2.json status Success
+expect expected/run2.json resumed_from "$RUN1_ID"
+expect expected/run2.json tables_skipped 2
+expect expected/run2.json tables_copied 1
+expect expected/run2.json tables_failed 0
+PRODUCTS_ROWS="$(duckdb -noheader -list poc.duckdb 'SELECT count(*) FROM staging__products.products')"
+if [ "$PRODUCTS_ROWS" != "50" ]; then echo "FAIL: staging__products.products has ${PRODUCTS_ROWS:-no} rows, expected 50" >&2; exit 1; fi
+echo "OK: products rows = $PRODUCTS_ROWS (the failed table was copied on resume)"
+
+echo
+echo "==== 4. the latest run succeeded, so --resume-latest has nothing to resume ===="
+set +e
+rocky -c rocky.toml -o json run --resume-latest > expected/run3.json 2> expected/run3.log
+RUN3_EXIT=$?
+set -e
+if [ "$RUN3_EXIT" -eq 0 ]; then echo "FAIL: a succeeded run was resumed" >&2; exit 1; fi
+grep -q "already succeeded" expected/run3.log \
+    || { echo "FAIL: expected 'already succeeded' in expected/run3.log" >&2; exit 1; }
+echo "OK: refused — $(grep -m1 -Eo '(nothing to resume|cannot resume).*' expected/run3.log)"
+
+echo
+echo "POC complete: the failed table was retried, the copied tables were skipped, a cross-scope resume was refused, and a resume after success was refused."


### PR DESCRIPTION
Two things the weekly job has been reporting red since 2026-08-24, fixed before `engine-v1.73.0` is tagged.
Nothing here changes engine behaviour. The release PR follows this one.

## 1. `h2` 0.4.15 → 0.4.19, `chacha20` 0.10.1 → 0.10.2

`cargo audit` on main: one vulnerability, RUSTSEC-2026-0258 (`h2` accepts and queues empty DATA frames without limit — a denial-of-service, patched in 0.4.16). `chacha20` 0.10.1 is yanked. Both bumps are lockfile-only; `windows-sys` 0.59.0 drops out of the lock as a result. `cargo audit` after: no vulnerabilities; one allowed warning (`paste` unmaintained, RUSTSEC-2024-0436), with `RUSTSEC-2023-0071` still ignored per `engine/.cargo/audit.toml`.

## 2. The `checkpoint-resume` POC exercised the shape the engine now refuses

```
before   run --filter source=orders    succeeded
         run --resume-latest           no filter -> "no progress found"
```

Since #1573 a checkpoint is keyed by its resume scope — the pipeline, its `--filter`, and its target routing — and a run that succeeded is not resumable. The POC did both things the scope refuses, so the headline example of this release's own resume work has been red in `engine-weekly` for ten days.

It now demonstrates the contract as it is:

```
run 1  (no filter)         orders ok, customers ok, products FAILS   exit 2
                           checkpoint: 2 x Success, 1 x Failed
   +-- resume --filter source=orders   refused: no progress found (different scope)
run 2  --resume-latest     skips orders + customers, copies products   exit 0
                           resumed_from = <run 1 id>
   +-- resume again        refused: run 2 already succeeded
```

The failure is induced by occupying the `products` target with a view Rocky did not create; DuckDB refuses `CREATE OR REPLACE TABLE` over a view. Every count and both refusal messages are asserted, not just the exit codes. Run 1's id is read from `rocky -o json history`, because `RunOutput` does not carry its own id.

## Evidence

The full DuckDB smoke suite (`examples/playground/scripts/run-all-duckdb.sh`) against a release binary built from this branch: **84 passed, 0 failed, 16 skipped** — the same 16 credential- or docker-gated POCs the weekly job skips. The one non-environmental failure on main was this POC.

| gate | result |
|---|---|
| `cargo audit` (engine/) | 0 vulnerabilities, 1 allowed warning |
| `cargo deny check bans` | fails on main and on this branch with the same pre-existing duplicate list, one `windows-sys` copy fewer here; not a CI gate |
| POC `05-orchestration/04-checkpoint-resume` | passes against the branch binary, fails on `engine-v1.72.0`'s shape as described |
| `run-all-duckdb.sh` | 84 / 0 / 16 on macOS (branch binary); 85 / 0 / 16 on `ubuntu-latest` (weekly dispatch) |

## Red team

Independent review: Codex (`codex exec`, read-only sandbox, high reasoning), two blocking rounds against this branch.

**Round 1 — BLOCK, 14 findings.**

| # | finding | disposition |
|---|---|---|
| 1 | README said exit 1 and `status = partial_failure`; a partial run exits 2 and serialises `PartialFailure` | fixed |
| 2 | "a run that succeeded is not resumable" is too broad: only `--resume-latest` checks the run record; explicit `--resume <run-id>` does not | fixed in the README; the engine gap is filed as #1635 |
| 5 | the README named the wrong failure: with an `INTEGER` view column, drift detection issued `ALTER TABLE … TYPE` against the view first | fixed — the view column now matches the source (`BIGINT`), no drift, the failure is `CREATE OR REPLACE TABLE` over a view, and the script asserts that error text |
| 7 | "every outcome is checkpointed" overclaims: checkpoint writes are best-effort and the second run proves only the two `Success` entries | fixed — wording now says the tables that succeeded |
| 8 | "both out-of-scope resumes" — step 4 is in scope, refused because the latest run succeeded | fixed |
| 11 | a lockfile bump is not platform-neutral and the first Windows build is after the tag | rebutted in part: every unix-only reference added since 1.72.0 is under `#[cfg(unix)]` (six sites checked); the release is a draft until all five targets upload, so a Windows failure cannot publish; local cross-check from macOS stops at `ring` / `aws-lc-sys` build scripts. The missing lane is #1636 |
| 12 | "ready to tag" lacked evidence for audit, coverage, the POC suite, Windows; manifests still say 1.72.0 | rebutted: this is the pre-flight, the release PR carries the bumps; audit and the full POC suite are in the evidence table above; coverage was not run and is stated |
| 13 | DuckDB CLI 1.5.3 seeding files for a bundled 1.5.5 engine | rebutted with history: bundled 1.5.5 since 2026-07-27 (#1251); the weekly suite has passed on that pair on every run since |
| 3, 4, 6, 9, 10, 14 | concerns the reviewer raised and refuted itself (scope-keyed lookup, retention, no pre-drop, `PartialFailure` spelling, `resumed_from` semantics) | accepted, no change |

**Round 2 — BLOCK, 7 findings.** Every round-1 fix was verified as applied; the Windows rebuttal was accepted ("the Windows graph resolves, and a fresh-tag release remains draft until every matrix build succeeds"); rebuttals 12–13 were accepted on the condition that the release PR supplies the versions and changelog, which it does.

| # | finding | disposition |
|---|---|---|
| 1 | "this script PROVES exit 2" while accepting any non-zero exit | fixed — `RUN1_EXIT -eq 2` |
| 2 | `echo "products rows: $(duckdb …)"` could pass vacuously: an unchecked substitution under an `echo` that exits 0 | fixed — the count is captured and asserted equal to 50 |
| 3, 4 | the `is of type View` text is DuckDB's, prefixed and copied verbatim into `errors[].error`; both columns are `BIGINT`, drift is `Ignore`, the failing statement is the CTAS | accepted — this is the mechanism the README now names |
| — | "most important missing: an Ubuntu execution of the amended script" | done — `engine-weekly.yml` dispatched on this branch; result below |

**Round 3 — PASS.** Both round-2 fixes verified at their lines (`RUN1_EXIT -eq 2` matches the exit contract in `main.rs`; the row count is captured and asserted). The reviewer then tried to refute its own remaining concerns and could not: every assertion in `run.sh` fails closed (JSON parsing, substitutions, pipelines and checked greps; the two masked greps are display-only after hard gates); no sentence in the README exceeds the code (`run.rs` scope equality, latest-success refusal, explicit-resume behaviour, success-only skipping); locked dependency resolution, `bash -n`, ShellCheck and `git diff --check` pass. Its one open item was the Ubuntu execution, below.

**Ubuntu run of this branch (`engine-weekly.yml`, manual dispatch):** run `33811298534` on this branch — **POC Smoke Tests: 85 passed, 0 failed, 16 skipped** (`04-checkpoint-resume` among the passes); parse-validate 12 / 0 / 84; **Security Audit: 0 vulnerabilities, 1 allowed warning**; Coverage: failed, as it has on every run since 2026-08-24 — not caused here and not a release gate; diagnosed separately.


## Two standing questions

**Least confident:** that the induced failure stays deterministic if the DuckDB adapter's `full_refresh` write ever changes shape (a `DROP TABLE IF EXISTS` before the create would turn the view collision into a different error, or a success). The POC asserts the counts, so such a change would fail this POC loudly rather than pass it vacuously.

**Most important thing missing:** the weekly job's other two legs. `cargo audit` is covered here. Coverage (tarpaulin) has not run green since 2026-08-17, and nothing in this PR looks at it.
