### PR TITLE
docs(skills): sdk and dagster releases carry four assets, not two

### DIFF
--- a/.agents/skills/rocky-release/SKILL.md
+++ b/.agents/skills/rocky-release/SKILL.md
@@ -223,7 +223,7 @@ Path-filtered workflows in `.github/workflows/`:
 
 ## Post-release checklist
 
-- [ ] `gh release view <tag>` shows all expected artifacts (**11 for engine**: 10 archives + `checksums.txt`; 2 for sdk; 2 for dagster; 1 for vscode)
+- [ ] `gh release view <tag>` shows all expected artifacts (**11 for engine**: 10 archives + `checksums.txt`; **4 for sdk and 4 for dagster**: wheel, sdist and one `.publish.attestation` for each, uploaded by the PyPI trusted-publisher step; 1 for vscode)
 - [ ] Install script (`engine/install.sh` or `install.ps1`) resolves and installs the new version on a clean machine
 - [ ] Downstream consumers that vendor the binary + Python wheel atomically have been updated — see `scripts/vendor_rocky.sh` for the vendoring workflow
 - [ ] Changelog is on `main` (it merged with the release PR, but double-check)

--- a/.claude/skills/rocky-release/SKILL.md
+++ b/.claude/skills/rocky-release/SKILL.md
@@ -223,7 +223,7 @@ Path-filtered workflows in `.github/workflows/`:
 
 ## Post-release checklist
 
-- [ ] `gh release view <tag>` shows all expected artifacts (**11 for engine**: 10 archives + `checksums.txt`; 2 for sdk; 2 for dagster; 1 for vscode)
+- [ ] `gh release view <tag>` shows all expected artifacts (**11 for engine**: 10 archives + `checksums.txt`; **4 for sdk and 4 for dagster**: wheel, sdist and one `.publish.attestation` for each, uploaded by the PyPI trusted-publisher step; 1 for vscode)
 - [ ] Install script (`engine/install.sh` or `install.ps1`) resolves and installs the new version on a clean machine
 - [ ] Downstream consumers that vendor the binary + Python wheel atomically have been updated — see `scripts/vendor_rocky.sh` for the vendoring workflow
 - [ ] Changelog is on `main` (it merged with the release PR, but double-check)


### PR DESCRIPTION
The post-release checklist in the `rocky-release` skill says an SDK or dagster release has 2 assets. It has 4: the PyPI trusted-publisher step attaches a `.publish.attestation` beside the wheel and the sdist (`sdk-v0.13.0`, `sdk-v0.14.0`, `dagster-v1.64.0`, `dagster-v1.65.0` all show 4).

A guarded tag script written from the checklist stopped the 1.73.0 cycle after the SDK tag on that false mismatch. Mechanical doc correction, both skill mirrors, byte-identical.