### PR TITLE
fix(dagster): fail a contract check when the compile result is missing

### DIFF
--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A contract check now fails as "not verified" when there is no `rocky compile` output. Before, it passed.** `RockyComponent` caches `rocky compile` when it writes its state. That step is best-effort: if the binary is missing, the compile times out or crashes, or `models_dir` does not exist, the `compile` slot is left out of the state and the component keeps working. Contract checks read their verdict from that slot's diagnostics. A missing slot read as an empty list, and an empty list means "nothing to report", so every declared contract check went green with no compile behind it.
+
+  The two cases are now told apart. With a cached compile and no diagnostics for the model, the check passes as before. With no cached compile, each declared contract check reports `passed=False` at `WARN` severity, with `rocky/compile_missing = true` and a `status` that says why. The run logs a warning too. Refresh the state after `rocky compile` succeeds to clear it. (#1619)
+
+  For hand-rolled assets, `contract_check_results_from_diagnostics()` now accepts `diagnostics=None` to mean "no compile output". An empty list keeps its old meaning. `CONTRACT_COMPILE_MISSING_METADATA_KEY` is exported.
+
+- **In the default `streaming` mode, a source asset with a matching `.contract.toml` no longer fails its run with `returned an output ... multiple times`.** The placeholder pass that covers declared checks the engine did not produce also covered the contract checks, and reported each one as passing ("not produced by rocky"). The contract pass then reported the same check a second time, and Dagster failed the step. The contract results are now built first and the placeholder pass skips them, so each contract check is reported exactly once. Only `execution_mode="streaming"` was affected; `"pipes"` has no placeholder pass. (#1619)
+
 ## [1.65.0] — 2026-09-03
 
 Pairs with engine 1.73.0 and `rocky-sdk` 0.14.0. The `rocky-sdk>=0.13.0` floor is unchanged: nothing here reads a field that 0.13.0 lacks.

--- a/integrations/dagster/src/dagster_rocky/__init__.py
+++ b/integrations/dagster/src/dagster_rocky/__init__.py
@@ -26,6 +26,7 @@ from .component import (
 )
 from .contracts import (
     CONTRACT_COLUMN_CONSTRAINTS_CHECK,
+    CONTRACT_COMPILE_MISSING_METADATA_KEY,
     CONTRACT_PROTECTED_COLUMNS_CHECK,
     CONTRACT_REQUIRED_COLUMNS_CHECK,
     ContractParseError,
@@ -203,6 +204,7 @@ __all__ = [
     "CONTRACT_REQUIRED_COLUMNS_CHECK",
     "CONTRACT_PROTECTED_COLUMNS_CHECK",
     "CONTRACT_COLUMN_CONSTRAINTS_CHECK",
+    "CONTRACT_COMPILE_MISSING_METADATA_KEY",
     "ContractRules",
     "ContractParseError",
     "discover_contract_rules",

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -477,8 +477,11 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
     #: Limitation: until ``rocky run --model <name>`` lands on the engine
     #: side, derived-model multi-assets use ``can_subset=False`` (selecting
     #: any subset materializes the whole group). Per-model freshness,
-    #: optimize metadata, contract checks, and partition definitions all
-    #: still apply per-asset.
+    #: optimize metadata, and partition definitions all still apply
+    #: per-asset. Contract checks do not: they are declared only on source
+    #: assets whose table name matches a ``.contract.toml`` file
+    #: (``build_model_specs`` accepts ``contract_rules_by_model`` and
+    #: ignores it).
     surface_derived_models: bool = False
     #: When ``True``, use the DAG-driven asset builder that creates a
     #: single connected asset graph from ``rocky dag``. Every pipeline
@@ -2686,7 +2689,9 @@ def _make_rocky_asset(
         # declared spec — contract specs included — and would otherwise emit
         # a passing "not produced by rocky" placeholder for each contract
         # check, after which Dagster rejects the real result as an output
-        # returned twice (#1619).
+        # returned twice (#1619). Yielded in each branch BEFORE the
+        # quota-breach raise below, so the record survives the retriable
+        # failure the same way the materializations do.
         contract_results: list[dg.AssetCheckResult] = []
         if contract_rules_by_model:
             if not compile_state.compiled:
@@ -2719,6 +2724,7 @@ def _make_rocky_asset(
             # doesn't run — but we still need to yield the collected
             # governance events so the surfaces are wired in both modes.
             yield from governance_events
+            yield from contract_results
         else:
             results, quota_breach_cooldown = _run_filters(context, rocky, filters)
 
@@ -2744,6 +2750,7 @@ def _make_rocky_asset(
                 satisfy_empty_outputs=satisfy_empty_outputs,
                 instance=context.instance,
             )
+            yield from contract_results
 
             # If a filter surfaced the Fivetran-storm signal, raise the
             # retriable failure AFTER yielding materializations from
@@ -2752,8 +2759,6 @@ def _make_rocky_asset(
             # what was lost.
             if quota_breach_cooldown is not None:
                 raise _quota_breach_failure(quota_breach_cooldown)
-
-        yield from contract_results
 
     return _asset
 

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -313,16 +313,23 @@ class _GroupBuild:
 
 @dataclass
 class _CompileState:
-    """Compile diagnostics + error flag pulled from cached state."""
+    """Compile diagnostics + error flag pulled from cached state.
+
+    ``compiled`` is ``False`` when the state has no ``compile`` slot — the
+    compile failed, or never ran, when the state was written. Then
+    ``diagnostics`` is empty for lack of a compile, not for lack of
+    findings, and a consumer must not read it as "clean" (#1619).
+    """
 
     has_errors: bool = False
     diagnostics: list[Diagnostic] = field(default_factory=list)
+    compiled: bool = False
 
     @classmethod
     def from_result(cls, result: CompileResult | None) -> _CompileState:
         if result is None:
             return cls()
-        return cls(has_errors=result.has_errors, diagnostics=result.diagnostics)
+        return cls(has_errors=result.has_errors, diagnostics=result.diagnostics, compiled=True)
 
 
 # ---------------------------------------------------------------------------
@@ -2667,6 +2674,39 @@ def _make_rocky_asset(
                     # pass through unchanged.
                     governance_events.append(event)
 
+        # Contract check results — sourced from compile diagnostics, not
+        # from the run, so they are known before the run and emitted in
+        # both modes (Pipes doesn't carry a build-time signal). Each
+        # declared contract spec gets exactly one result; specs without
+        # a matching contract are skipped.
+        #
+        # Built BEFORE the run so their ``(asset_key, check_name)`` pairs can
+        # prime ``_emit_results``'s dedup set, the same way the compliance
+        # results do above. The streaming placeholder pass walks every
+        # declared spec — contract specs included — and would otherwise emit
+        # a passing "not produced by rocky" placeholder for each contract
+        # check, after which Dagster rejects the real result as an output
+        # returned twice (#1619).
+        contract_results: list[dg.AssetCheckResult] = []
+        if contract_rules_by_model:
+            if not compile_state.compiled:
+                context.log.warning(
+                    "No rocky compile output in the cached state (rocky compile "
+                    "failed, or did not run, when the state was written) — "
+                    "contract checks will report as not verified"
+                )
+            contract_results = list(
+                _emit_contract_check_results(
+                    group=group,
+                    selected_keys=selected_keys,
+                    compile_state=compile_state,
+                    contract_rules_by_model=contract_rules_by_model,
+                )
+            )
+        contract_yielded: set[tuple[dg.AssetKey, str]] = {
+            (r.asset_key, r.check_name) for r in contract_results
+        }
+
         if execution_mode == "pipes":
             yield from _run_filters_pipes(
                 context=context,
@@ -2699,7 +2739,7 @@ def _make_rocky_asset(
                 check_specs=check_specs,
                 selected_keys=selected_keys,
                 rocky_key_to_dagster_key=group.rocky_key_to_dagster_key,
-                extra_yielded_checks=compliance_yielded,
+                extra_yielded_checks=compliance_yielded | contract_yielded,
                 collapsed_key_by_table=group.collapsed_key_by_table or None,
                 satisfy_empty_outputs=satisfy_empty_outputs,
                 instance=context.instance,
@@ -2713,19 +2753,7 @@ def _make_rocky_asset(
             if quota_breach_cooldown is not None:
                 raise _quota_breach_failure(quota_breach_cooldown)
 
-        # Contract check results — sourced from compile diagnostics, not
-        # from the run. Each declared contract spec gets exactly one
-        # result (pass/fail) per materialization. Specs without
-        # corresponding rule entries are skipped. Emitted in both modes
-        # because compile diagnostics are a build-time signal Pipes
-        # doesn't carry.
-        if contract_rules_by_model:
-            yield from _emit_contract_check_results(
-                group=group,
-                selected_keys=selected_keys,
-                compile_state=compile_state,
-                contract_rules_by_model=contract_rules_by_model,
-            )
+        yield from contract_results
 
     return _asset
 
@@ -2858,7 +2886,12 @@ def _emit_contract_check_results(
     ``AssetCheckResult`` per declared rule kind by translating compile
     diagnostics. Skips specs that aren't in ``selected_keys`` so
     partial-subset runs don't emit results for unselected assets.
+
+    When ``compile_state.compiled`` is ``False`` there is no compile output
+    to translate, so ``None`` is passed through and every declared check
+    fails as "not verified" rather than passing on an empty list (#1619).
     """
+    diagnostics = compile_state.diagnostics if compile_state.compiled else None
     for spec in group.specs:
         if spec.key not in selected_keys:
             continue
@@ -2867,7 +2900,7 @@ def _emit_contract_check_results(
         if rules is None:
             continue
         yield from contract_check_results_from_diagnostics(
-            compile_state.diagnostics,
+            diagnostics,
             asset_key=spec.key,
             model_name=table_name,
             rules=rules,

--- a/integrations/dagster/src/dagster_rocky/contracts.py
+++ b/integrations/dagster/src/dagster_rocky/contracts.py
@@ -17,7 +17,10 @@ This module provides:
 
 * :func:`contract_check_results_from_diagnostics` — yields one
   :class:`AssetCheckResult` per check spec, mapping compiler diagnostics with
-  contract-related codes (E010-E013, W010) to pass/fail status.
+  contract-related codes (E010-E013, W010) to pass/fail status. Pass
+  ``diagnostics=None`` when there is no ``rocky compile`` output at all:
+  every declared check then fails as "not verified" instead of passing on
+  an empty list (#1619).
 
 Mapping from compiler diagnostic codes to dagster check names:
 
@@ -85,6 +88,12 @@ _CONTRACT_CODE_TO_CHECK: dict[str, str] = {
 _CONTRACT_UNVERIFIED_CODE_TO_CHECK: dict[str, str] = {
     "I003": CONTRACT_COLUMN_CONSTRAINTS_CHECK,
 }
+
+#: Metadata key stamped (``True``) on a contract check result that was not
+#: evaluated because there was no ``rocky compile`` output to read. The
+#: result also fails, so this key only tells a "not verified" failure apart
+#: from a real violation; it is never present on a passing result.
+CONTRACT_COMPILE_MISSING_METADATA_KEY: str = "rocky/compile_missing"
 
 
 @dataclass(frozen=True)
@@ -312,7 +321,7 @@ def configured_check_specs_for_model(
 
 
 def contract_check_results_from_diagnostics(
-    diagnostics: list[Diagnostic],
+    diagnostics: list[Diagnostic] | None,
     *,
     asset_key: dg.AssetKey,
     model_name: str,
@@ -333,10 +342,18 @@ def contract_check_results_from_diagnostics(
     * E010-E013 → ``AssetCheckSeverity.ERROR``
     * W010      → ``AssetCheckSeverity.WARN``
 
+    An empty list and ``None`` are different inputs. An empty list means the
+    compile ran and reported nothing for this model, so the checks pass.
+    ``None`` means there is no compile output at all (``rocky compile``
+    failed, or never ran), so nothing was checked: every declared check then
+    fails with ``AssetCheckSeverity.WARN`` and
+    :data:`CONTRACT_COMPILE_MISSING_METADATA_KEY` set, instead of passing
+    on the empty list (#1619).
+
     Args:
-        diagnostics: Compile-time diagnostics from :class:`CompileResult`.
-            Both contract codes and other codes are tolerated; non-contract
-            codes are ignored.
+        diagnostics: Compile-time diagnostics from :class:`CompileResult`,
+            or ``None`` when there is no compile result. Both contract codes
+            and other codes are tolerated; non-contract codes are ignored.
         asset_key: The Dagster asset key the checks belong to.
         model_name: The compiled model name to filter diagnostics by.
         rules: ContractRules — only check kinds with declared rules
@@ -346,6 +363,21 @@ def contract_check_results_from_diagnostics(
         ``dg.AssetCheckResult`` events. The number of yields equals the
         number of declared rule kinds in ``rules``.
     """
+    if diagnostics is None:
+        if rules.has_required:
+            yield _not_verified_result(
+                check_name=CONTRACT_REQUIRED_COLUMNS_CHECK, asset_key=asset_key
+            )
+        if rules.has_protected:
+            yield _not_verified_result(
+                check_name=CONTRACT_PROTECTED_COLUMNS_CHECK, asset_key=asset_key
+            )
+        if rules.has_column_constraints:
+            yield _not_verified_result(
+                check_name=CONTRACT_COLUMN_CONSTRAINTS_CHECK, asset_key=asset_key
+            )
+        return
+
     # Group diagnostics by which check they belong to
     by_check: dict[str, list[Diagnostic]] = {
         CONTRACT_REQUIRED_COLUMNS_CHECK: [],
@@ -389,6 +421,33 @@ def contract_check_results_from_diagnostics(
             diagnostics=by_check[CONTRACT_COLUMN_CONSTRAINTS_CHECK],
             unverified=unverified_by_check[CONTRACT_COLUMN_CONSTRAINTS_CHECK],
         )
+
+
+def _not_verified_result(*, check_name: str, asset_key: dg.AssetKey) -> dg.AssetCheckResult:
+    """Build the failing result for a contract check that could not be evaluated.
+
+    Used when there is no ``rocky compile`` output to read. The check fails
+    (the contract may be violated and nothing looked), at ``WARN`` severity
+    like the integration's other "not checked" placeholders, and carries
+    :data:`CONTRACT_COMPILE_MISSING_METADATA_KEY` so it can be told apart
+    from a real violation.
+    """
+    status = (
+        "not verified: no rocky compile output in the cached state (rocky compile "
+        "failed, or did not run, when the state was written), so this contract "
+        "was not checked — refresh the state after rocky compile succeeds"
+    )
+    return dg.AssetCheckResult(
+        asset_key=asset_key,
+        check_name=check_name,
+        passed=False,
+        severity=dg.AssetCheckSeverity.WARN,
+        description="contract not verified: no rocky compile output",
+        metadata={
+            "status": dg.MetadataValue.text(status),
+            CONTRACT_COMPILE_MISSING_METADATA_KEY: dg.MetadataValue.bool(True),
+        },
+    )
 
 
 def _result_for_check(

--- a/integrations/dagster/tests/test_component.py
+++ b/integrations/dagster/tests/test_component.py
@@ -17,12 +17,14 @@ from dagster_rocky import component as component_module
 from dagster_rocky.component import (
     _SUPPORTED_DAG_SCHEMA_VERSION,
     RockyComponent,
+    _CompileState,
     _load_state,
     _warn_discover_signals,
     _warn_if_dag_schema_newer,
 )
 from dagster_rocky.translator import RockyDagsterTranslator
 from dagster_rocky.types import (
+    CompileResult,
     DagResult,
     DiscoverResult,
     LineageEdge,
@@ -2004,3 +2006,26 @@ def test_dag_mode_build_warns_on_newer_schema_version(
 
     assert len(list(defs.assets or [])) > 0
     assert any("schema_version=2" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# _CompileState: a missing compile slot is not a clean compile (#1619)
+# ---------------------------------------------------------------------------
+
+
+def test_compile_state_from_missing_result_is_not_compiled():
+    """No cached compile result → ``compiled`` is False, so a consumer can
+    tell "no compile output" from "compiled with nothing to report"."""
+    state = _CompileState.from_result(None)
+
+    assert state.compiled is False
+    assert state.diagnostics == []
+    assert state.has_errors is False
+
+
+def test_compile_state_from_result_is_compiled(compile_json: str):
+    state = _CompileState.from_result(CompileResult.model_validate_json(compile_json))
+
+    assert state.compiled is True
+    assert state.has_errors is True
+    assert len(state.diagnostics) == 2

--- a/integrations/dagster/tests/test_contracts.py
+++ b/integrations/dagster/tests/test_contracts.py
@@ -9,6 +9,7 @@ import pytest
 
 from dagster_rocky.contracts import (
     CONTRACT_COLUMN_CONSTRAINTS_CHECK,
+    CONTRACT_COMPILE_MISSING_METADATA_KEY,
     CONTRACT_PROTECTED_COLUMNS_CHECK,
     CONTRACT_REQUIRED_COLUMNS_CHECK,
     ContractParseError,
@@ -551,3 +552,79 @@ def test_results_only_yield_for_declared_rules():
     assert len(results) == 1
     assert results[0].check_name == CONTRACT_REQUIRED_COLUMNS_CHECK
     assert results[0].passed is True
+
+
+# ---------------------------------------------------------------------------
+# No compile output at all (#1619)
+# ---------------------------------------------------------------------------
+
+
+def test_results_not_verified_when_there_is_no_compile_output():
+    """``diagnostics=None`` means ``rocky compile`` produced no output.
+
+    That is not the same as an empty diagnostics list: nothing was checked,
+    so every declared check must report a not-verified failure instead of
+    the green it reported before (#1619).
+    """
+    asset_key = dg.AssetKey(["orders"])
+    rules = ContractRules(has_required=True, has_protected=True, has_column_constraints=True)
+
+    results = list(
+        contract_check_results_from_diagnostics(
+            diagnostics=None,
+            asset_key=asset_key,
+            model_name="orders",
+            rules=rules,
+        )
+    )
+
+    assert [r.check_name for r in results] == [
+        CONTRACT_REQUIRED_COLUMNS_CHECK,
+        CONTRACT_PROTECTED_COLUMNS_CHECK,
+        CONTRACT_COLUMN_CONSTRAINTS_CHECK,
+    ]
+    for r in results:
+        assert r.passed is False, r.check_name
+        assert r.severity == dg.AssetCheckSeverity.WARN
+        assert r.asset_key == asset_key
+        assert r.metadata[CONTRACT_COMPILE_MISSING_METADATA_KEY].value is True
+        assert "not verified" in (r.description or "")
+        assert "not verified" in r.metadata["status"].value
+
+
+def test_results_not_verified_only_for_declared_rules():
+    """The not-verified result is still gated on the declared rule kinds."""
+    asset_key = dg.AssetKey(["orders"])
+    rules = ContractRules(has_required=True, has_protected=False, has_column_constraints=False)
+
+    results = list(
+        contract_check_results_from_diagnostics(
+            diagnostics=None,
+            asset_key=asset_key,
+            model_name="orders",
+            rules=rules,
+        )
+    )
+
+    assert len(results) == 1
+    assert results[0].check_name == CONTRACT_REQUIRED_COLUMNS_CHECK
+    assert results[0].passed is False
+
+
+def test_results_empty_diagnostics_still_pass_without_compile_missing_marker():
+    """An empty list is "compiled, nothing to report": green, and not marked."""
+    asset_key = dg.AssetKey(["orders"])
+    rules = ContractRules(has_required=True, has_protected=False, has_column_constraints=False)
+
+    results = list(
+        contract_check_results_from_diagnostics(
+            diagnostics=[],
+            asset_key=asset_key,
+            model_name="orders",
+            rules=rules,
+        )
+    )
+
+    assert len(results) == 1
+    assert results[0].passed is True
+    assert CONTRACT_COMPILE_MISSING_METADATA_KEY not in results[0].metadata

--- a/integrations/dagster/tests/test_execution.py
+++ b/integrations/dagster/tests/test_execution.py
@@ -1060,3 +1060,36 @@ def test_pipes_contract_checks_report_not_verified_when_compile_slot_is_missing(
     for ev in evals:
         assert ev.passed is False, ev.check_name
         assert ev.metadata[CONTRACT_COMPILE_MISSING_METADATA_KEY].value is True
+
+
+def test_streaming_contract_checks_are_recorded_before_a_quota_breach_raises(
+    discover_json: str, run_json: str, tmp_path: Path
+):
+    """A quota breach raises after the run; the contract record must land first.
+
+    The retriable failure is raised after the materializations so partial
+    progress is kept. The contract results are known before the run, so
+    they are yielded before that raise too: with no compile slot, the three
+    not-verified failures are on record even though the step fails.
+    """
+    from dagster_rocky.types import TableError  # noqa: PLC0415
+
+    defs = _build_defs_with_contracts(discover_json, tmp_path)
+    run_result = RunResult.model_validate_json(run_json)
+    run_result.errors = [
+        TableError(
+            asset_key=["fivetran", "acme", "us_west", "shopify", "payments"],
+            error="rate limited — retry after backoff",
+            failure_kind="quota-exceeded",
+        )
+    ]
+
+    exec_result = _materialize_subset(defs, run_result, [_ORDERS_KEY])
+
+    assert not exec_result.success, "quota-exceeded must still surface as a failure"
+    evals = _contract_evaluations(exec_result)
+    assert {ev.check_name for ev in evals} == _CONTRACT_CHECK_NAMES
+    assert len(evals) == 3
+    for ev in evals:
+        assert ev.passed is False, ev.check_name
+        assert ev.metadata[CONTRACT_COMPILE_MISSING_METADATA_KEY].value is True

--- a/integrations/dagster/tests/test_execution.py
+++ b/integrations/dagster/tests/test_execution.py
@@ -8,11 +8,17 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import dagster as dg
 
 from dagster_rocky.component import RockyComponent
+from dagster_rocky.contracts import (
+    CONTRACT_COLUMN_CONSTRAINTS_CHECK,
+    CONTRACT_COMPILE_MISSING_METADATA_KEY,
+    CONTRACT_PROTECTED_COLUMNS_CHECK,
+    CONTRACT_REQUIRED_COLUMNS_CHECK,
+)
 from dagster_rocky.resource import RockyResource
 from dagster_rocky.types import DiscoverResult, RunResult
 
@@ -926,3 +932,131 @@ def test_quota_exceeded_with_none_cooldown_falls_back_to_default(
         "None engine-supplied cooldown must fall back to "
         "_FIVETRAN_QUOTA_COOLDOWN_DEFAULT_SECONDS (300)"
     )
+
+
+# ---------------------------------------------------------------------------
+# Contract checks against the cached compile slot (#1619)
+# ---------------------------------------------------------------------------
+
+_ORDERS_KEY = dg.AssetKey(["fivetran", "acme", "us_west", "shopify", "orders"])
+_CONTRACT_CHECK_NAMES = {
+    CONTRACT_REQUIRED_COLUMNS_CHECK,
+    CONTRACT_PROTECTED_COLUMNS_CHECK,
+    CONTRACT_COLUMN_CONSTRAINTS_CHECK,
+}
+
+
+def _write_orders_contract(tmp_path: Path) -> Path:
+    """A contract for ``orders`` that declares all three rule kinds."""
+    contracts_dir = tmp_path / "contracts"
+    contracts_dir.mkdir()
+    (contracts_dir / "orders.contract.toml").write_text(
+        '[rules]\nrequired = ["id"]\nprotected = ["id"]\n\n'
+        '[[columns]]\nname = "id"\ntype = "Int64"\n',
+        encoding="utf-8",
+    )
+    return contracts_dir
+
+
+def _build_defs_with_contracts(
+    discover_json: str,
+    tmp_path: Path,
+    *,
+    compile_json: str | None = None,
+    execution_mode: str = "streaming",
+) -> dg.Definitions:
+    """Like :func:`_build_defs`, with a ``contracts_dir`` that matches ``orders``."""
+    state_file = tmp_path / "state.json"
+    state: dict = {"discover": json.loads(discover_json)}
+    if compile_json:
+        state["compile"] = json.loads(compile_json)
+    state_file.write_text(json.dumps(state))
+    component = RockyComponent(
+        config_path="rocky.toml",
+        contracts_dir=str(_write_orders_contract(tmp_path)),
+        execution_mode=execution_mode,  # type: ignore[arg-type]
+    )
+    return component.build_defs_from_state(context=None, state_path=state_file)
+
+
+def _contract_evaluations(exec_result: dg.ExecuteInProcessResult) -> list:
+    return [
+        ev
+        for ev in exec_result.get_asset_check_evaluations()
+        if ev.check_name in _CONTRACT_CHECK_NAMES
+    ]
+
+
+def test_streaming_contract_checks_report_not_verified_when_compile_slot_is_missing(
+    discover_json: str, run_json: str, tmp_path: Path
+):
+    """No ``compile`` slot in state → every contract check fails as not verified.
+
+    Before the fix this run did two wrong things: the placeholder pass
+    emitted each contract check as ``passed=True`` ("not produced by
+    rocky"), and the contract pass then emitted the same check again, so
+    Dagster failed the step with "returned an output multiple times".
+    """
+    defs = _build_defs_with_contracts(discover_json, tmp_path)
+    run_result = RunResult.model_validate_json(run_json)
+
+    exec_result = _materialize_subset(defs, run_result, [_ORDERS_KEY])
+
+    assert exec_result.success
+    evals = _contract_evaluations(exec_result)
+    assert {ev.check_name for ev in evals} == _CONTRACT_CHECK_NAMES
+    assert len(evals) == 3, "exactly one evaluation per declared contract check"
+    for ev in evals:
+        assert ev.asset_key == _ORDERS_KEY
+        assert ev.passed is False, ev.check_name
+        assert ev.severity == dg.AssetCheckSeverity.WARN
+        assert ev.metadata[CONTRACT_COMPILE_MISSING_METADATA_KEY].value is True
+
+
+def test_streaming_contract_checks_pass_when_compile_slot_is_clean_for_the_model(
+    discover_json: str, run_json: str, compile_json: str, tmp_path: Path
+):
+    """A cached compile with no diagnostics for ``orders`` → green, once each.
+
+    The compile fixture carries diagnostics for other models only, so this
+    is the "compiled, nothing to report" side of the distinction.
+    """
+    defs = _build_defs_with_contracts(discover_json, tmp_path, compile_json=compile_json)
+    run_result = RunResult.model_validate_json(run_json)
+
+    exec_result = _materialize_subset(defs, run_result, [_ORDERS_KEY])
+
+    assert exec_result.success
+    evals = _contract_evaluations(exec_result)
+    assert {ev.check_name for ev in evals} == _CONTRACT_CHECK_NAMES
+    assert len(evals) == 3, "exactly one evaluation per declared contract check"
+    for ev in evals:
+        assert ev.passed is True, ev.check_name
+        assert CONTRACT_COMPILE_MISSING_METADATA_KEY not in ev.metadata
+
+
+def test_pipes_contract_checks_report_not_verified_when_compile_slot_is_missing(
+    discover_json: str, tmp_path: Path
+):
+    """Pipes mode has no placeholder pass; the contract pass alone must not go green."""
+    defs = _build_defs_with_contracts(discover_json, tmp_path, execution_mode="pipes")
+
+    fake_invocation = MagicMock()
+    fake_invocation.get_results = MagicMock(
+        return_value=iter([dg.MaterializeResult(asset_key=_ORDERS_KEY)])
+    )
+    with patch.object(RockyResource, "run_pipes", return_value=fake_invocation):
+        exec_result = dg.materialize(
+            list(defs.assets or []),
+            resources={"rocky": RockyResource(config_path="rocky.toml")},
+            selection=[_ORDERS_KEY],
+            raise_on_error=False,
+        )
+
+    assert exec_result.success
+    evals = _contract_evaluations(exec_result)
+    assert {ev.check_name for ev in evals} == _CONTRACT_CHECK_NAMES
+    assert len(evals) == 3
+    for ev in evals:
+        assert ev.passed is False, ev.check_name
+        assert ev.metadata[CONTRACT_COMPILE_MISSING_METADATA_KEY].value is True


### PR DESCRIPTION
## Contract checks no longer pass green when the compile result is missing

A `RockyComponent` contract check now reports `passed=False` ("not verified") when the cached `rocky compile` slot is missing, instead of `passed=True`. On the way, the default `streaming` mode no longer fails the step with `returned an output ... multiple times` for a source asset that has a matching `.contract.toml`.

```
                          cached state
                     ┌──────────────────────┐
   rocky compile ───►│  compile slot ?      │
                     └──────────┬───────────┘
                present         │        missing (compile failed or skipped)
          ┌─────────────────────┴─────────────────────────┐
          ▼                                               ▼
  diagnostics for the model?             BEFORE: read as []  → passed=True
    none        → passed=True            AFTER:  None        → passed=False, WARN,
    E010..E014  → passed=False                                 rocky/compile_missing=true
```

### What changed

- `_CompileState.compiled` records whether a compile result was cached. `from_result(None)` gives `compiled=False`.
- `contract_check_results_from_diagnostics(diagnostics=None, ...)` means "no compile output": every declared check fails at `WARN` with `rocky/compile_missing = true`, a `status` and a `description`. An empty list keeps its meaning ("compiled, nothing to report") and passes. `CONTRACT_COMPILE_MISSING_METADATA_KEY` is exported.
- The run logs a warning when contract rules exist and the compile slot is missing.
- Streaming mode: the contract results are built before the run and prime the placeholder pass's dedup set, the same guard the compliance results already use. Before, the placeholder pass emitted each contract check as `passed=True` ("not produced by rocky") and the contract pass emitted it again, so Dagster failed the step. That second defect is fixed here because the #1619 fix cannot deliver a result in the default mode without it, and the placeholder's green is itself a green with no compile behind it. Both halves date from the initial commit.

Severity is `WARN`, matching the integration's other "not checked" results (unmaterialized table, failure containment). `passed=False` is what removes the false green; severity is presentation.

Not affected: DAG mode and derived-model assets declare no contract check specs (`build_dag_specs` and `build_model_specs` accept `contract_rules_by_model` and ignore it), so the only emit site is `_make_rocky_asset`, in both execution modes.

### Evidence

Fail-before, on `main`, end-to-end probe with `contracts_dir` set and no compile slot, streaming mode:

```
contract_required_columns   passed=True  meta={'status': 'not produced by rocky (check type: contract_required_columns)'}
contract_protected_columns  passed=True  ...
contract_column_constraints passed=True  ...
FAILURE: DagsterInvariantViolationError: Compute for op "rocky_acme" returned an output
         "fivetran__acme__us_west__shopify__orders_contract_required_columns" multiple times
```

The same probe with the compile slot present gives the same crash: the duplicate does not depend on the slot.

Pass-after: `uv run pytest -q` in `integrations/dagster` gives 732 passed (was 724). `ruff check .` and `ruff format --check .` are clean.

Mutation checks with `scripts/mutation-check.sh`, all three mutants killed:

| Mutation | Tests that fail under it |
|---|---|
| `diagnostics=None` falls through as `[]` (`contracts.py`) | 2 unit tests + streaming and pipes end-to-end "not verified" tests |
| `from_result(None)` returns `compiled=True` (`component.py`) | `_CompileState` test + streaming and pipes end-to-end "not verified" tests |
| contract pairs not primed into the placeholder pass (`component.py`) | both streaming end-to-end tests (step fails with the duplicate output) |

Closes #1619
