### PR TITLE
fix(engine/rocky-core): encode SQL string literals through the dialect at ten sinks

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Ten SQL string-literal sinks now encode through the dialect's own lexer rule, and the interim backslash refusal from #1595 is gone where they do.** A value in `accepted_values` (declarative checks and quarantine assertions), a seed cell, a `rocky load` cell on BigQuery's local-file `INSERT` path, a `rocky test` unit-test fixture string, `schema_pattern.prefix` in DuckDB and BigQuery discovery, the schema name DuckDB discovery reads back from the warehouse, a Snowflake tag value and the cross-source `_src` tag were each spliced into `'…'` by doubling quotes. On Snowflake, Databricks and BigQuery a value ending in `\` escaped the first quote of that pair and let the second one close the literal; #1595 refused any backslash at four of those sites, on every warehouse. Each sink now calls `rocky_core::sql_gen::string_literal(dialect, value)`, so a backslash stands for itself on DuckDB and Trino and is doubled, with the quote written as `\'`, on Snowflake, Databricks and BigQuery.
+
+  **On upgrade:** a backslash in `accepted_values` or in `schema_pattern.prefix` is accepted again and carried as a value. For a value with no quote, backslash or line break the generated SQL is byte-identical to 1.73.0. For a value that has one, it differs only on the three backslash-reading warehouses. Snowflake tag values were already escaped correctly and now share the one encoder. The dialect-less `generate_test_sql` API still refuses a backslash, because it has no lexer rule to ask; every `rocky` command passes a dialect.
+
+  **Still not routed:** a string literal written in a `.rocky` model (`rocky-lang` lowers to SQL before any dialect is chosen); `regex_match.pattern`, where a backslash is regex syntax and Snowflake and Databricks read it as an escape before the regex engine sees it; a Databricks tag value and a lakehouse `COMMENT` or `TBLPROPERTIES` value, which refuse a quote but still let a trailing backslash break the statement. (Refs #1596, #1524)
+
 ## [1.73.0] — 2026-09-03
 
 ### Added

--- a/engine/crates/rocky-bigquery/src/discovery.rs
+++ b/engine/crates/rocky-bigquery/src/discovery.rs
@@ -22,10 +22,12 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use rocky_core::source::{DiscoveredConnector, DiscoveredTable, DiscoveryResult};
+use rocky_core::sql_gen::string_literal;
 use rocky_core::traits::{AdapterError, AdapterResult, DiscoveryAdapter, WarehouseAdapter};
 use rocky_sql::validation::{validate_gcp_project_id, validate_identifier};
 
 use crate::connector::BigQueryAdapter;
+use crate::dialect::BigQueryDialect;
 
 /// BigQuery discovery adapter that lists datasets matching a prefix.
 pub struct BigQueryDiscoveryAdapter {
@@ -59,6 +61,23 @@ impl BigQueryDiscoveryAdapter {
     }
 }
 
+/// The `INFORMATION_SCHEMA.SCHEMATA` query for every dataset whose name
+/// starts with `schema_prefix`.
+///
+/// `project` and `region` are validated by the caller. The prefix is user
+/// text from `schema_pattern.prefix`, encoded by BigQuery's own lexer rule
+/// (it reads backslash escapes, and `''` is a syntax error there rather
+/// than an escaped quote). `STARTS_WITH` reads the result as plain text, so
+/// `_` and `%` need no `LIKE` treatment.
+fn schemata_sql(project: &str, region: &str, schema_prefix: &str) -> String {
+    let prefix_lit = string_literal(&BigQueryDialect, schema_prefix);
+    format!(
+        "SELECT schema_name FROM `{project}.{region}.INFORMATION_SCHEMA.SCHEMATA` \
+         WHERE STARTS_WITH(schema_name, {prefix_lit}) \
+         ORDER BY schema_name"
+    )
+}
+
 #[async_trait]
 impl DiscoveryAdapter for BigQueryDiscoveryAdapter {
     async fn discover(&self, schema_prefix: &str) -> AdapterResult<DiscoveryResult> {
@@ -66,21 +85,7 @@ impl DiscoveryAdapter for BigQueryDiscoveryAdapter {
         validate_gcp_project_id(project).map_err(AdapterError::new)?;
         let region = self.region_qualifier()?;
 
-        // SQL string-literal escape. The prefix is user input; `'`
-        // would otherwise close the literal. `STARTS_WITH` makes
-        // wildcard characters (`_`, `%`) safe — they're treated as
-        // literals. Doubling is not enough on its own: BigQuery also honours
-        // a backslash escape, so a prefix ending in `\` would escape the first
-        // quote of the pair and let the second close the literal (#1524).
-        rocky_sql::validation::reject_unquotable_literal("schema_pattern `prefix`", schema_prefix)
-            .map_err(AdapterError::new)?;
-        let prefix_lit = schema_prefix.replace('\'', "''");
-
-        let schemas_sql = format!(
-            "SELECT schema_name FROM `{project}.{region}.INFORMATION_SCHEMA.SCHEMATA` \
-             WHERE STARTS_WITH(schema_name, '{prefix_lit}') \
-             ORDER BY schema_name"
-        );
+        let schemas_sql = schemata_sql(project, &region, schema_prefix);
 
         let schema_result = self.adapter.execute_query(&schemas_sql).await?;
 
@@ -151,6 +156,31 @@ mod tests {
                 "test-token".to_string(),
             )),
         ))
+    }
+
+    /// The prefix is encoded by BigQuery's own lexer rule (issue #1596):
+    /// its lexer reads backslash escapes, so a backslash is doubled and a
+    /// quote is `\'` — and, per the GoogleSQL lexical spec, `''` would be a
+    /// syntax error there rather than an escaped quote.
+    #[test]
+    fn schemata_sql_encodes_the_prefix_by_bigquerys_lexer_rule() {
+        assert_eq!(
+            schemata_sql("p", "region-eu", r"raw\"),
+            r"SELECT schema_name FROM `p.region-eu.INFORMATION_SCHEMA.SCHEMATA` WHERE STARTS_WITH(schema_name, 'raw\\') ORDER BY schema_name"
+        );
+        assert!(
+            schemata_sql("p", "region-eu", "it's").contains(r"STARTS_WITH(schema_name, 'it\'s')")
+        );
+    }
+
+    /// A prefix without a quote or a backslash is spliced byte-identically to
+    /// the pre-encoder form.
+    #[test]
+    fn schemata_sql_plain_prefix_is_byte_identical() {
+        assert_eq!(
+            schemata_sql("p", "region-eu", "src__"),
+            "SELECT schema_name FROM `p.region-eu.INFORMATION_SCHEMA.SCHEMATA` WHERE STARTS_WITH(schema_name, 'src__') ORDER BY schema_name"
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-core/src/arrow_loader.rs
+++ b/engine/crates/rocky-core/src/arrow_loader.rs
@@ -244,15 +244,15 @@ pub fn read_csv_batches(path: &Path, batch_size: usize) -> Result<Vec<RowBatch>,
 /// Cell values are formatted using the same rules as [`crate::seeds`]:
 /// - Empty cells become `NULL`.
 /// - Numeric-looking values are emitted bare.
-/// - Everything else is single-quoted with internal quotes escaped.
+/// - Everything else is a single-quoted string literal encoded by
+///   `dialect`'s own lexer rule.
 ///
-/// The `dialect` parameter is used to format the target table reference via
-/// [`SqlDialect`]; if the caller already has a fully-qualified target string,
-/// pass it directly — this function accepts `&str` for the target.
+/// `target` is spliced as given: the caller formats the table reference
+/// (normally via [`SqlDialect::format_table_ref`]) before calling.
 pub fn generate_batch_insert_sql(
     batch: &RowBatch,
     target: &str,
-    _dialect: &dyn SqlDialect,
+    dialect: &dyn SqlDialect,
 ) -> Result<String, BatchLoaderError> {
     if batch.rows.is_empty() {
         return Err(BatchLoaderError::EmptyBatch);
@@ -274,7 +274,7 @@ pub fn generate_batch_insert_sql(
         .rows
         .iter()
         .map(|row| {
-            let cells: Vec<String> = row.iter().map(|cell| format_cell(cell)).collect();
+            let cells: Vec<String> = row.iter().map(|cell| format_cell(cell, dialect)).collect();
             format!("({})", cells.join(", "))
         })
         .collect();
@@ -292,8 +292,9 @@ pub fn generate_batch_insert_sql(
 /// - Parseable as `i64` → bare integer
 /// - Parseable as `f64` → bare float
 /// - Boolean (`true`/`false`, case-insensitive) → bare boolean
-/// - Everything else → single-quoted with `'` escaped to `''`
-fn format_cell(value: &str) -> String {
+/// - Everything else → a single-quoted string literal encoded by `dialect`'s
+///   own lexer rule
+fn format_cell(value: &str, dialect: &dyn SqlDialect) -> String {
     let trimmed = value.trim();
     if trimmed.is_empty() {
         return "NULL".to_string();
@@ -315,8 +316,8 @@ fn format_cell(value: &str) -> String {
         return trimmed.to_string();
     }
 
-    // Default: single-quoted string
-    format!("'{}'", trimmed.replace('\'', "''"))
+    // Default: a string literal encoded by the dialect's own lexer rule.
+    crate::sql_gen::string_literal(dialect, trimmed)
 }
 
 // ---------------------------------------------------------------------------
@@ -671,32 +672,59 @@ mod tests {
 
     #[test]
     fn format_cell_empty_is_null() {
-        assert_eq!(format_cell(""), "NULL");
-        assert_eq!(format_cell("   "), "NULL");
+        assert_eq!(format_cell("", &TestDialect), "NULL");
+        assert_eq!(format_cell("   ", &TestDialect), "NULL");
     }
 
     #[test]
     fn format_cell_integer() {
-        assert_eq!(format_cell("42"), "42");
-        assert_eq!(format_cell("-7"), "-7");
+        assert_eq!(format_cell("42", &TestDialect), "42");
+        assert_eq!(format_cell("-7", &TestDialect), "-7");
     }
 
     #[test]
     fn format_cell_float() {
-        assert_eq!(format_cell("3.14"), "3.14");
-        assert_eq!(format_cell("-0.5"), "-0.5");
+        assert_eq!(format_cell("3.14", &TestDialect), "3.14");
+        assert_eq!(format_cell("-0.5", &TestDialect), "-0.5");
     }
 
     #[test]
     fn format_cell_boolean() {
-        assert_eq!(format_cell("true"), "true");
-        assert_eq!(format_cell("False"), "false");
+        assert_eq!(format_cell("true", &TestDialect), "true");
+        assert_eq!(format_cell("False", &TestDialect), "false");
     }
 
     #[test]
     fn format_cell_string_escaping() {
-        assert_eq!(format_cell("hello"), "'hello'");
-        assert_eq!(format_cell("it's"), "'it''s'");
+        assert_eq!(format_cell("hello", &TestDialect), "'hello'");
+        assert_eq!(format_cell("it's", &TestDialect), "'it''s'");
+    }
+
+    /// A loader cell holding a backslash or a quote is encoded by the
+    /// dialect's own lexer rule (issue #1596): verbatim backslash and doubled
+    /// quote under `Standard` (DuckDB, Trino); doubled backslash
+    /// and `\'` under `Backslash`.
+    #[test]
+    fn format_cell_encodes_a_backslash_and_a_quote_per_dialect() {
+        use crate::traits::LiteralEscape;
+        use crate::traits::test_dialects::StubDialect;
+
+        assert_eq!(
+            format_cell(r"C:\tmp\", &StubDialect(LiteralEscape::Standard)),
+            r"'C:\tmp\'"
+        );
+        assert_eq!(
+            format_cell("it's", &StubDialect(LiteralEscape::Standard)),
+            "'it''s'"
+        );
+        assert_eq!(
+            format_cell(r"C:\tmp\", &StubDialect(LiteralEscape::Backslash)),
+            r"'C:\\tmp\\'"
+        );
+        assert_eq!(
+            format_cell("it's", &StubDialect(LiteralEscape::Backslash)),
+            r"'it\'s'"
+        );
     }
 
     // -- generate_batch_insert_sql --------------------------------------------

--- a/engine/crates/rocky-core/src/checks.rs
+++ b/engine/crates/rocky-core/src/checks.rs
@@ -281,11 +281,13 @@ pub fn generate_cross_source_overlap_sql(
             union.push_str("\n  UNION ALL\n  ");
         }
         // Tag each row with its source table as a string literal so the outer
-        // query can count distinct contributing sources per key.
-        let src_lit = ref_str.replace('\'', "''");
+        // query can count distinct contributing sources per key. The ref is
+        // built from validated identifiers, so this encodes nothing today; it
+        // goes through the dialect so that stays true if the ref format grows.
+        let src_lit = crate::sql_gen::string_literal(dialect, &ref_str);
         let _ = write!(
             union,
-            "SELECT {key_list}, '{src_lit}' AS _src FROM {ref_str} WHERE {not_null}"
+            "SELECT {key_list}, {src_lit} AS _src FROM {ref_str} WHERE {not_null}"
         );
     }
     Ok(format!(

--- a/engine/crates/rocky-core/src/quarantine.rs
+++ b/engine/crates/rocky-core/src/quarantine.rs
@@ -321,17 +321,9 @@ fn lower_valid_predicate(
                     name: label.to_string(),
                 });
             }
-            // Same quote-doubling limit as `generate_test_sql_inner` — see
-            // `reject_unquotable_literal`.
-            for v in values {
-                validation::reject_unquotable_literal(
-                    &format!("quarantine assertion '{label}' accepted_values value"),
-                    v,
-                )?;
-            }
             let in_list = values
                 .iter()
-                .map(|v| format!("'{}'", v.replace('\'', "''")))
+                .map(|v| crate::sql_gen::string_literal(dialect, v))
                 .collect::<Vec<_>>()
                 .join(", ");
             Ok(format!("({col} IS NULL OR {col} IN ({in_list}))"))
@@ -1109,23 +1101,59 @@ mod unit_tests {
         }));
     }
 
-    // ----- Statement-terminator refusal (issue #1524) -----
+    // ----- Dialect-owned literal encoding (issue #1596) -----
 
+    /// Each `accepted_values` entry is encoded by the dialect's own lexer
+    /// rule: a backslash stands for itself under `Standard` (DuckDB, Trino)
+    /// and is doubled under `Backslash` (Snowflake, Databricks, BigQuery),
+    /// where the quote is `\'` rather than `''`.
     #[test]
-    fn quarantine_accepted_values_refuses_a_backslash_in_a_value() {
+    fn quarantine_accepted_values_encodes_a_backslash_and_a_quote_per_dialect() {
+        use crate::traits::LiteralEscape;
+        use crate::traits::test_dialects::StubDialect;
+
         let cfg = split_config();
         let assertions = vec![assertion(
             None,
             TestType::AcceptedValues {
-                values: vec!["ok".into(), "trailing_backslash\\".into()],
+                values: vec!["ok".into(), r"trailing\".into(), "it's".into()],
             },
             Some("status"),
             TestSeverity::Error,
         )];
-        let err = compile_quarantine_sql(&assertions, "orders", &table(), &TestDialect, &cfg)
-            .unwrap_err();
-        assert!(err.to_string().contains("backslash"), "{err}");
+
+        let standard = compile_quarantine_sql(
+            &assertions,
+            "orders",
+            &table(),
+            &StubDialect(LiteralEscape::Standard),
+            &cfg,
+        )
+        .unwrap()
+        .unwrap();
+        let sql = &standard.statements[1].sql;
+        assert!(
+            sql.contains(r"(status IS NULL OR status IN ('ok', 'trailing\', 'it''s'))"),
+            "{sql}"
+        );
+
+        let backslash = compile_quarantine_sql(
+            &assertions,
+            "orders",
+            &table(),
+            &StubDialect(LiteralEscape::Backslash),
+            &cfg,
+        )
+        .unwrap()
+        .unwrap();
+        let sql = &backslash.statements[1].sql;
+        assert!(
+            sql.contains(r"(status IS NULL OR status IN ('ok', 'trailing\\', 'it\'s'))"),
+            "{sql}"
+        );
     }
+
+    // ----- Statement-terminator refusal (issue #1524) -----
 
     #[test]
     fn quarantine_expression_refuses_a_statement_terminator() {

--- a/engine/crates/rocky-core/src/seeds.rs
+++ b/engine/crates/rocky-core/src/seeds.rs
@@ -519,7 +519,7 @@ pub fn generate_insert_sql(
                     .get(i)
                     .map(|c| c.data_type.as_str())
                     .unwrap_or("STRING");
-                format_value(trimmed, col_type)
+                format_value(trimmed, col_type, dialect)
             })
             .collect();
 
@@ -553,9 +553,9 @@ pub fn generate_insert_sql(
 
 /// Format a cell value for a SQL VALUES clause.
 ///
-/// Numeric and boolean types are emitted bare; everything else is
-/// single-quoted with internal quotes escaped.
-fn format_value(value: &str, col_type: &str) -> String {
+/// Numeric and boolean types are emitted bare; everything else is a
+/// single-quoted string literal encoded by `dialect`'s own lexer rule.
+fn format_value(value: &str, col_type: &str, dialect: &dyn SqlDialect) -> String {
     let upper = col_type.to_uppercase();
     if upper == "BIGINT"
         || upper == "INTEGER"
@@ -575,8 +575,8 @@ fn format_value(value: &str, col_type: &str) -> String {
             return lower;
         }
     }
-    // Default: single-quoted string with escaped quotes.
-    format!("'{}'", value.replace('\'', "''"))
+    // Default: a string literal encoded by the dialect's own lexer rule.
+    crate::sql_gen::string_literal(dialect, value)
 }
 
 // ---------------------------------------------------------------------------
@@ -1057,26 +1057,53 @@ post_hook = ["ANALYZE main.seeds.dim_date"]
 
     #[test]
     fn format_value_numerics_bare() {
-        assert_eq!(format_value("42", "BIGINT"), "42");
-        assert_eq!(format_value("3.14", "DOUBLE"), "3.14");
-        assert_eq!(format_value("-1", "INTEGER"), "-1");
+        assert_eq!(format_value("42", "BIGINT", &TestDialect), "42");
+        assert_eq!(format_value("3.14", "DOUBLE", &TestDialect), "3.14");
+        assert_eq!(format_value("-1", "INTEGER", &TestDialect), "-1");
     }
 
     #[test]
     fn format_value_boolean() {
-        assert_eq!(format_value("true", "BOOLEAN"), "true");
-        assert_eq!(format_value("False", "BOOLEAN"), "false");
+        assert_eq!(format_value("true", "BOOLEAN", &TestDialect), "true");
+        assert_eq!(format_value("False", "BOOLEAN", &TestDialect), "false");
     }
 
     #[test]
     fn format_value_string_escaping() {
-        assert_eq!(format_value("hello", "STRING"), "'hello'");
-        assert_eq!(format_value("it's", "STRING"), "'it''s'");
+        assert_eq!(format_value("hello", "STRING", &TestDialect), "'hello'");
+        assert_eq!(format_value("it's", "STRING", &TestDialect), "'it''s'");
+    }
+
+    /// A seed cell holding a backslash or a quote is encoded by the
+    /// dialect's own lexer rule (issue #1596): verbatim backslash and doubled
+    /// quote under `Standard` (DuckDB, Trino); doubled backslash
+    /// and `\'` under `Backslash`.
+    #[test]
+    fn format_value_encodes_a_backslash_and_a_quote_per_dialect() {
+        use crate::traits::LiteralEscape;
+        use crate::traits::test_dialects::StubDialect;
+
+        assert_eq!(
+            format_value(r"C:\tmp\", "STRING", &StubDialect(LiteralEscape::Standard)),
+            r"'C:\tmp\'"
+        );
+        assert_eq!(
+            format_value("it's", "STRING", &StubDialect(LiteralEscape::Standard)),
+            "'it''s'"
+        );
+        assert_eq!(
+            format_value(r"C:\tmp\", "STRING", &StubDialect(LiteralEscape::Backslash)),
+            r"'C:\\tmp\\'"
+        );
+        assert_eq!(
+            format_value("it's", "STRING", &StubDialect(LiteralEscape::Backslash)),
+            r"'it\'s'"
+        );
     }
 
     #[test]
     fn format_value_non_numeric_in_numeric_col_is_quoted() {
         // If a "numeric" column has a non-parseable value, quote it safely.
-        assert_eq!(format_value("abc", "BIGINT"), "'abc'");
+        assert_eq!(format_value("abc", "BIGINT", &TestDialect), "'abc'");
     }
 }

--- a/engine/crates/rocky-core/src/tests.rs
+++ b/engine/crates/rocky-core/src/tests.rs
@@ -474,19 +474,10 @@ fn generate_test_sql_inner(
             if values.is_empty() {
                 return Err(TestGenError::EmptyAcceptedValues);
             }
-            // Each value is wrapped in a `'...'` literal by doubling quotes.
-            // That is only safe where `''` is the sole escape; a backslash makes
-            // three of the five dialects read the closing quote differently.
-            for v in values {
-                validation::reject_unquotable_literal(
-                    &format!("accepted_values test value on {table}"),
-                    v,
-                )?;
-            }
             let in_list = values
                 .iter()
-                .map(|v| format!("'{}'", v.replace('\'', "''")))
-                .collect::<Vec<_>>()
+                .map(|v| accepted_value_literal(v, dialect, table))
+                .collect::<Result<Vec<_>, _>>()?
                 .join(", ");
             Ok(format!(
                 "SELECT DISTINCT {col} FROM {table} WHERE {}{col} NOT IN ({in_list})",
@@ -730,6 +721,35 @@ pub fn validate_regex_pattern(pattern: &str) -> Result<(), TestGenError> {
         }
     }
     Ok(())
+}
+
+/// Encodes one `accepted_values` entry as a complete `'…'` literal.
+///
+/// With a dialect in hand, that dialect's own lexer rule does the encoding
+/// ([`crate::sql_gen::string_literal`]), and any value round-trips. Without
+/// one — the dialect-less [`generate_test_sql`] — only quote-doubling is
+/// available, and three of the five warehouses read a backslash differently
+/// under it, so a backslash is refused there rather than guessed at. Every
+/// production caller passes a dialect; the refusal is the only defence left
+/// on the dialect-less path.
+fn accepted_value_literal(
+    value: &str,
+    dialect: Option<&dyn crate::traits::SqlDialect>,
+    table: &str,
+) -> Result<String, TestGenError> {
+    match dialect {
+        Some(dialect) => Ok(crate::sql_gen::string_literal(dialect, value)),
+        None => {
+            validation::reject_unquotable_literal(
+                &format!("accepted_values test value on {table}"),
+                value,
+            )?;
+            Ok(rocky_sql::literal::encode_string_literal(
+                rocky_sql::literal::LiteralEscape::Standard,
+                value,
+            ))
+        }
+    }
 }
 
 /// Extracts the required column from a test declaration, returning an error
@@ -1611,12 +1631,13 @@ value = "0"
     // fragment would let the author's text end that statement and start
     // another. `generate_test_sql*` refuses it at generation time.
 
+    /// The dialect-less `generate_test_sql` has no lexer rule to ask, so it
+    /// keeps the interim refusal: quote-doubling is all it can do, and a
+    /// trailing backslash would let three of the five warehouses read the
+    /// closing quote differently. With a dialect the value is encoded
+    /// instead — see `accepted_values_encodes_a_backslash_and_a_quote_per_dialect`.
     #[test]
     fn accepted_values_refuses_a_backslash_in_a_value() {
-        // The value is wrapped in a `'...'` literal by doubling quotes. On
-        // Snowflake / DuckDB / BigQuery a trailing backslash escapes the first
-        // quote of that pair, so the second closes the literal and the rest of
-        // the value becomes live SQL. Quote-doubling alone cannot contain it.
         let decl = TestDecl {
             test_type: TestType::AcceptedValues {
                 values: vec!["pending".into(), "trailing_backslash\\".into()],
@@ -1631,6 +1652,72 @@ value = "0"
         assert!(
             msg.contains("accepted_values test value on db.sc.orders"),
             "{msg}"
+        );
+    }
+
+    // ----- Dialect-owned literal encoding (issue #1596) -----
+
+    fn accepted(values: &[&str]) -> TestDecl {
+        TestDecl {
+            test_type: TestType::AcceptedValues {
+                values: values.iter().map(|v| (*v).to_string()).collect(),
+            },
+            column: Some("status".into()),
+            severity: TestSeverity::Error,
+            filter: None,
+        }
+    }
+
+    /// With a dialect in hand, each value is encoded by that dialect's own
+    /// lexer rule. Under `Standard` (DuckDB, Trino) a backslash
+    /// stands for itself and a quote is doubled. Under `Backslash` the
+    /// backslash is doubled and the quote is `\'` — a doubled quote there
+    /// would let a trailing `\` escape the first quote of the pair and free
+    /// the second one to close the literal.
+    #[test]
+    fn accepted_values_encodes_a_backslash_and_a_quote_per_dialect() {
+        use crate::traits::LiteralEscape;
+        use crate::traits::test_dialects::StubDialect;
+
+        let decl = accepted(&["pending", r"trailing\", "it's"]);
+
+        let standard =
+            generate_test_sql_with_dialect(&decl, "orders", &StubDialect(LiteralEscape::Standard))
+                .unwrap();
+        assert_eq!(
+            standard,
+            r"SELECT DISTINCT status FROM orders WHERE status NOT IN ('pending', 'trailing\', 'it''s')"
+        );
+
+        let backslash =
+            generate_test_sql_with_dialect(&decl, "orders", &StubDialect(LiteralEscape::Backslash))
+                .unwrap();
+        assert_eq!(
+            backslash,
+            r"SELECT DISTINCT status FROM orders WHERE status NOT IN ('pending', 'trailing\\', 'it\'s')"
+        );
+    }
+
+    /// A value without a quote or a backslash encodes to the same bytes under
+    /// both rules, and to the same bytes the dialect-less path emits.
+    #[test]
+    fn accepted_values_plain_values_are_byte_identical_under_both_rules() {
+        use crate::traits::LiteralEscape;
+        use crate::traits::test_dialects::StubDialect;
+
+        let decl = accepted(&["pending", "shipped"]);
+        let expected =
+            "SELECT DISTINCT status FROM orders WHERE status NOT IN ('pending', 'shipped')";
+        assert_eq!(generate_test_sql(&decl, "orders").unwrap(), expected);
+        assert_eq!(
+            generate_test_sql_with_dialect(&decl, "orders", &StubDialect(LiteralEscape::Standard))
+                .unwrap(),
+            expected
+        );
+        assert_eq!(
+            generate_test_sql_with_dialect(&decl, "orders", &StubDialect(LiteralEscape::Backslash))
+                .unwrap(),
+            expected
         );
     }
 

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -2147,3 +2147,101 @@ mod tests {
         }
     }
 }
+
+/// A stub dialect for this crate's own literal-encoding tests.
+///
+/// A real adapter dialect cannot stand in here: a dev-dependency on an
+/// adapter crate links a second instance of `rocky-core`, so its dialect
+/// implements that instance's `SqlDialect`, not this one's. The stub answers
+/// the lexer fact it is built with and the handful of methods a SQL
+/// generator calls; the real dialects are exercised in the adapter crates.
+#[cfg(test)]
+pub(crate) mod test_dialects {
+    use super::{AdapterError, AdapterResult, LiteralEscape, SqlDialect};
+
+    /// A dialect that answers exactly the lexer rule it carries.
+    pub(crate) struct StubDialect(pub(crate) LiteralEscape);
+
+    impl SqlDialect for StubDialect {
+        fn literal_escape(&self) -> LiteralEscape {
+            self.0
+        }
+
+        fn format_table_ref(
+            &self,
+            catalog: &str,
+            schema: &str,
+            table: &str,
+        ) -> AdapterResult<String> {
+            rocky_sql::validation::format_table_ref(catalog, schema, table)
+                .map_err(AdapterError::new)
+        }
+
+        fn create_table_as(&self, target: &str, select_sql: &str) -> String {
+            format!("CREATE OR REPLACE TABLE {target} AS\n{select_sql}")
+        }
+
+        fn insert_into(&self, target: &str, select_sql: &str) -> String {
+            format!("INSERT INTO {target}\n{select_sql}")
+        }
+
+        fn merge_into(
+            &self,
+            _target: &str,
+            _source_sql: &str,
+            _keys: &[std::sync::Arc<str>],
+            _update_cols: &rocky_ir::ColumnSelection,
+        ) -> AdapterResult<String> {
+            unimplemented!("not reached by literal-encoding tests")
+        }
+
+        fn select_clause(
+            &self,
+            _columns: &rocky_ir::ColumnSelection,
+            _metadata: &[rocky_ir::MetadataColumn],
+        ) -> AdapterResult<String> {
+            unimplemented!("not reached by literal-encoding tests")
+        }
+
+        fn watermark_where(
+            &self,
+            _timestamp_col: &str,
+            _last_watermark: Option<&chrono::DateTime<chrono::Utc>>,
+        ) -> AdapterResult<String> {
+            unimplemented!("not reached by literal-encoding tests")
+        }
+
+        fn describe_table_sql(&self, table_ref: &str) -> String {
+            format!("DESCRIBE TABLE {table_ref}")
+        }
+
+        fn drop_table_sql(&self, table_ref: &str) -> String {
+            format!("DROP TABLE IF EXISTS {table_ref}")
+        }
+
+        fn create_catalog_sql(&self, _name: &str) -> Option<AdapterResult<String>> {
+            None
+        }
+
+        fn create_schema_sql(
+            &self,
+            _catalog: &str,
+            _schema: &str,
+        ) -> Option<AdapterResult<String>> {
+            None
+        }
+
+        fn tablesample_clause(&self, _percent: u32) -> Option<String> {
+            None
+        }
+
+        fn insert_overwrite_partition(
+            &self,
+            _target: &str,
+            _partition_filter: &str,
+            _select_sql: &str,
+        ) -> AdapterResult<Vec<String>> {
+            unimplemented!("not reached by literal-encoding tests")
+        }
+    }
+}

--- a/engine/crates/rocky-core/src/unit_test.rs
+++ b/engine/crates/rocky-core/src/unit_test.rs
@@ -30,6 +30,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
+use crate::traits::SqlDialect;
+
 /// A unit test definition from a model sidecar.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct UnitTestDef {
@@ -103,22 +105,23 @@ pub enum MismatchKind {
     ValueDiff,
 }
 
-/// Render a JSON scalar to a DuckDB SQL literal.
+/// Render a JSON scalar to a SQL literal for `dialect`.
 ///
-/// Strings are single-quote escaped; numbers and bools pass through their
-/// canonical text form; anything else (including `null`, arrays, objects) is
-/// rendered as `NULL`. Shared by [`fixture_to_sql`] and the unit-test runner's
-/// expected-table builder so both stringify values identically.
-pub fn json_to_sql_literal(value: &JsonValue) -> String {
+/// Strings become a single-quoted literal encoded by the dialect's own lexer
+/// rule; numbers and bools pass through their canonical text form; anything
+/// else (including `null`, arrays, objects) is rendered as `NULL`. Shared by
+/// [`fixture_to_sql`] and the unit-test runner's expected-table builder so
+/// both stringify values identically.
+pub fn json_to_sql_literal(value: &JsonValue, dialect: &dyn SqlDialect) -> String {
     match value {
-        JsonValue::String(s) => format!("'{}'", s.replace('\'', "''")),
+        JsonValue::String(s) => crate::sql_gen::string_literal(dialect, s),
         JsonValue::Number(n) => n.to_string(),
         JsonValue::Bool(b) => b.to_string(),
         _ => "NULL".to_string(),
     }
 }
 
-/// Generate DuckDB SQL to create a temporary table from fixture rows.
+/// Generate SQL for `dialect` to create a temporary table from fixture rows.
 ///
 /// Returns a `CREATE TABLE <ref> AS SELECT ... UNION ALL ...` statement
 /// that the test runner can execute before running the model.
@@ -131,7 +134,7 @@ pub fn json_to_sql_literal(value: &JsonValue) -> String {
 /// omitted by the dbt-import emitter because its value was JSON `null`)
 /// materializes as SQL `NULL` rather than dropping the column or skewing the
 /// `SELECT` width. (FR-045)
-pub fn fixture_to_sql(fixture: &TestFixture) -> Option<String> {
+pub fn fixture_to_sql(fixture: &TestFixture, dialect: &dyn SqlDialect) -> Option<String> {
     if fixture.rows.is_empty() {
         return None;
     }
@@ -157,7 +160,7 @@ pub fn fixture_to_sql(fixture: &TestFixture) -> Option<String> {
             .map(|col| {
                 let lit = table
                     .get(*col)
-                    .map_or_else(|| "NULL".to_string(), json_to_sql_literal);
+                    .map_or_else(|| "NULL".to_string(), |v| json_to_sql_literal(v, dialect));
                 format!("{lit} AS {col}")
             })
             .collect();
@@ -174,6 +177,27 @@ pub fn fixture_to_sql(fixture: &TestFixture) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::traits::LiteralEscape;
+    use crate::traits::test_dialects::StubDialect;
+
+    fn standard() -> StubDialect {
+        StubDialect(LiteralEscape::Standard)
+    }
+
+    /// A fixture string holding a backslash or a quote is encoded by the
+    /// dialect's own lexer rule (issue #1596): verbatim backslash and doubled
+    /// quote under `Standard` (DuckDB, the dialect the runner passes); doubled
+    /// backslash and `\'` under `Backslash`.
+    #[test]
+    fn json_to_sql_literal_encodes_a_backslash_and_a_quote_per_dialect() {
+        let backslash = StubDialect(LiteralEscape::Backslash);
+        let bs = serde_json::json!(r"C:\tmp\");
+        let quote = serde_json::json!("it's");
+        assert_eq!(json_to_sql_literal(&bs, &standard()), r"'C:\tmp\'");
+        assert_eq!(json_to_sql_literal(&quote, &standard()), "'it''s'");
+        assert_eq!(json_to_sql_literal(&bs, &backslash), r"'C:\\tmp\\'");
+        assert_eq!(json_to_sql_literal(&quote, &backslash), r"'it\'s'");
+    }
 
     #[test]
     fn test_fixture_to_sql_basic() {
@@ -185,7 +209,7 @@ mod tests {
             ],
         };
 
-        let sql = fixture_to_sql(&fixture).unwrap();
+        let sql = fixture_to_sql(&fixture, &standard()).unwrap();
         assert!(sql.starts_with("CREATE OR REPLACE TABLE orders AS"));
         assert!(sql.contains("UNION ALL"));
         assert!(sql.contains("1 AS id"));
@@ -197,7 +221,7 @@ mod tests {
             model_ref: "empty".into(),
             rows: vec![],
         };
-        assert!(fixture_to_sql(&fixture).is_none());
+        assert!(fixture_to_sql(&fixture, &standard()).is_none());
     }
 
     #[test]
@@ -233,7 +257,7 @@ mod tests {
             model_ref: "names".into(),
             rows: vec![serde_json::json!({ "name": "O'Brien" })],
         };
-        let sql = fixture_to_sql(&fixture).unwrap();
+        let sql = fixture_to_sql(&fixture, &standard()).unwrap();
         assert!(sql.contains("O''Brien")); // escaped single quote
     }
 
@@ -249,7 +273,7 @@ mod tests {
                 serde_json::json!({ "id": 2, "email": "a@b.com" }),
             ],
         };
-        let sql = fixture_to_sql(&fixture).unwrap();
+        let sql = fixture_to_sql(&fixture, &standard()).unwrap();
 
         // Union column order is sorted: email before id.
         let selects: Vec<&str> = sql.split("UNION ALL").collect();
@@ -275,7 +299,7 @@ mod tests {
             model_ref: "users".into(),
             rows: vec![serde_json::json!({ "id": 1, "email": serde_json::Value::Null })],
         };
-        let sql = fixture_to_sql(&fixture).unwrap();
+        let sql = fixture_to_sql(&fixture, &standard()).unwrap();
         assert!(sql.contains("NULL AS email"));
         assert!(sql.contains("1 AS id"));
     }
@@ -286,6 +310,6 @@ mod tests {
             model_ref: "empty".into(),
             rows: vec![serde_json::json!({})],
         };
-        assert!(fixture_to_sql(&fixture).is_none());
+        assert!(fixture_to_sql(&fixture, &standard()).is_none());
     }
 }

--- a/engine/crates/rocky-duckdb/src/discovery.rs
+++ b/engine/crates/rocky-duckdb/src/discovery.rs
@@ -12,9 +12,11 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 
 use rocky_core::source::{DiscoveredConnector, DiscoveredTable, DiscoveryResult};
+use rocky_core::sql_gen::string_literal;
 use rocky_core::traits::{AdapterError, AdapterResult, DiscoveryAdapter};
 
 use crate::DuckDbConnector;
+use crate::dialect::DuckDbSqlDialect;
 
 /// DuckDB discovery adapter that lists schemas + tables matching a prefix.
 pub struct DuckDbDiscoveryAdapter {
@@ -35,16 +37,16 @@ impl DiscoveryAdapter for DuckDbDiscoveryAdapter {
             .lock()
             .map_err(|e| AdapterError::msg(format!("mutex poisoned: {e}")))?;
 
-        // 1. Find schemas matching the prefix. Quote-doubling alone only holds
-        // where `''` is the sole escape; refuse a backslash rather than rely on
-        // DuckDB staying in its standard-SQL default (#1524).
-        rocky_sql::validation::reject_unquotable_literal("schema_pattern `prefix`", schema_prefix)
-            .map_err(AdapterError::new)?;
+        // 1. Find schemas matching the prefix. The prefix is user text from
+        // `schema_pattern.prefix`, encoded by this dialect's own lexer rule.
+        // `%` is the LIKE wildcard; a backslash is a plain character in
+        // DuckDB's LIKE (there is no default ESCAPE), so it needs no second
+        // encoding for the pattern.
         let schema_sql = format!(
             "SELECT schema_name FROM information_schema.schemata \
-             WHERE schema_name LIKE '{}%' \
+             WHERE schema_name LIKE {} \
              ORDER BY schema_name",
-            schema_prefix.replace('\'', "''")
+            string_literal(&DuckDbSqlDialect, &format!("{schema_prefix}%"))
         );
         let schema_result = conn.execute_sql(&schema_sql).map_err(AdapterError::new)?;
 
@@ -56,12 +58,14 @@ impl DiscoveryAdapter for DuckDbDiscoveryAdapter {
                 .ok_or_else(|| AdapterError::msg("schema_name not a string"))?
                 .to_string();
 
-            // 2. Find tables in this schema.
+            // 2. Find tables in this schema. The name came back from the
+            // warehouse and can hold any character, so it is encoded the
+            // same way.
             let table_sql = format!(
                 "SELECT table_name FROM information_schema.tables \
-                 WHERE table_schema = '{}' AND table_type = 'BASE TABLE' \
+                 WHERE table_schema = {} AND table_type = 'BASE TABLE' \
                  ORDER BY table_name",
-                schema.replace('\'', "''")
+                string_literal(&DuckDbSqlDialect, &schema)
             );
             let table_result = conn.execute_sql(&table_sql).map_err(AdapterError::new)?;
 
@@ -96,16 +100,36 @@ impl DiscoveryAdapter for DuckDbDiscoveryAdapter {
 mod tests {
     use super::*;
 
+    /// Executed proof, not a string assertion: the prefix and each schema
+    /// name are encoded by DuckDB's own lexer rule (issue #1596). A schema
+    /// whose name ends in a backslash, and one holding a quote, are both
+    /// found; a backslash in the prefix matches only itself, because
+    /// DuckDB's `LIKE` has no default escape character.
     #[tokio::test]
-    async fn discover_refuses_a_backslash_in_the_schema_prefix() {
-        // `schema_pattern.prefix` reaches this literal from `rocky.toml`.
-        // Doubling quotes alone does not contain a backslash — see
-        // `rocky_sql::validation::reject_unquotable_literal` (#1524).
+    async fn discover_finds_schemas_whose_names_hold_a_backslash_or_a_quote() {
         let connector = Arc::new(Mutex::new(DuckDbConnector::in_memory().unwrap()));
+        {
+            let conn = connector.lock().unwrap();
+            for stmt in [
+                r#"CREATE SCHEMA "raw\""#,
+                r#"CREATE SCHEMA "raw\x""#,
+                r#"CREATE SCHEMA "rawx""#,
+                r#"CREATE SCHEMA "it's""#,
+                r#"CREATE TABLE "it's".t (id INTEGER)"#,
+            ] {
+                conn.execute_sql(stmt).unwrap();
+            }
+        }
         let adapter = DuckDbDiscoveryAdapter::new(connector);
-        let err = adapter.discover(r"raw\").await.unwrap_err();
-        assert!(err.to_string().contains("backslash"), "{err}");
-        assert!(err.to_string().contains("schema_pattern `prefix`"), "{err}");
+
+        let found = adapter.discover(r"raw\").await.unwrap();
+        let names: Vec<&str> = found.connectors.iter().map(|c| c.schema.as_str()).collect();
+        assert_eq!(names, [r"raw\", r"raw\x"]);
+
+        let found = adapter.discover("it'").await.unwrap();
+        let names: Vec<&str> = found.connectors.iter().map(|c| c.schema.as_str()).collect();
+        assert_eq!(names, ["it's"]);
+        assert_eq!(found.connectors[0].tables[0].name, "t");
     }
 
     #[tokio::test]

--- a/engine/crates/rocky-engine/src/test_runner.rs
+++ b/engine/crates/rocky-engine/src/test_runner.rs
@@ -12,6 +12,7 @@ use rocky_core::unit_test::{
     MismatchKind, RowMismatch, UnitTestDef, UnitTestResult, fixture_to_sql, json_to_sql_literal,
 };
 use rocky_duckdb::DuckDbConnector;
+use rocky_duckdb::dialect::DuckDbSqlDialect;
 use rocky_sql::validation::validate_identifier;
 use tracing::info;
 
@@ -312,7 +313,7 @@ fn run_one_unit_test(model: &str, compiled_sql: &str, test: &UnitTestDef) -> Uni
                 Vec::new(),
             );
         }
-        if let Some(sql) = fixture_to_sql(fx)
+        if let Some(sql) = fixture_to_sql(fx, &DuckDbSqlDialect)
             && let Err(e) = db.execute_statement(&sql)
         {
             return fail(
@@ -432,9 +433,10 @@ fn expected_table_sql(rows: &[serde_json::Value], cols: &[String]) -> String {
             let vals: Vec<String> = cols
                 .iter()
                 .map(|c| {
-                    let lit = obj
-                        .and_then(|o| o.get(c))
-                        .map_or_else(|| "NULL".to_string(), json_to_sql_literal);
+                    let lit = obj.and_then(|o| o.get(c)).map_or_else(
+                        || "NULL".to_string(),
+                        |v| json_to_sql_literal(v, &DuckDbSqlDialect),
+                    );
                     format!("{lit} AS {c}")
                 })
                 .collect();

--- a/engine/crates/rocky-snowflake/src/governance.rs
+++ b/engine/crates/rocky-snowflake/src/governance.rs
@@ -23,11 +23,13 @@ use async_trait::async_trait;
 use tracing::debug;
 
 use rocky_core::retention::RetentionPolicy;
+use rocky_core::sql_gen::string_literal;
 use rocky_core::traits::{AdapterError, AdapterResult, GovernanceAdapter, TagTarget};
 use rocky_ir::{Grant, GrantTarget, Permission, TableRef};
 use rocky_sql::validation;
 
 use crate::connector::SnowflakeConnector;
+use crate::dialect::SnowflakeSqlDialect;
 
 /// Snowflake governance adapter for tags and grants.
 ///
@@ -248,13 +250,11 @@ fn format_set_tags_sql(
         .iter()
         .map(|(k, v)| {
             validation::validate_identifier(k).map_err(AdapterError::new)?;
-            // Snowflake string literals honor backslash escapes by default, so
-            // doubling quotes alone is bypassable: a leading `\` escapes the
-            // first quote of a `''` pair, letting the second close the literal.
-            // Escape backslashes FIRST (so we don't double-escape the ones we
-            // add), then single quotes — closing the quote-doubling bypass.
-            let escaped = v.replace('\\', "\\\\").replace('\'', "''");
-            Ok(format!("{k} = '{escaped}'"))
+            // Snowflake's lexer reads backslash escapes, so the value goes
+            // through the dialect's own rule (`\\` and `\'`). Doubling the
+            // quote alone is bypassable there: a leading `\` escapes the
+            // first quote of the pair and the second closes the literal.
+            Ok(format!("{k} = {}", string_literal(&SnowflakeSqlDialect, v)))
         })
         .collect::<AdapterResult<Vec<_>>>()?;
 
@@ -469,18 +469,27 @@ mod tests {
         );
     }
 
+    /// Snowflake's lexer reads backslash escapes, so the value is encoded
+    /// by the dialect's own rule (issue #1596): `\` becomes `\\` and `'`
+    /// becomes `\'`. A doubled `''` would be split by a leading `\` and
+    /// the literal terminated early.
     #[test]
-    fn test_set_tags_escapes_backslash_before_quote() {
-        // Snowflake honors backslash escapes, so `\'` would otherwise let a
-        // doubled `''` be split and the literal terminated early. Escaping
-        // backslashes first neutralizes the bypass: `\` → `\\`, `'` → `''`.
+    fn test_set_tags_encodes_a_backslash_quote_pair_by_the_dialect_rule() {
         let mut tags = BTreeMap::new();
-        tags.insert("note".into(), "\\'; DROP TABLE x; --".into());
+        tags.insert("note".into(), r"\'; DROP TABLE x; --".into());
         let sql = format_set_tags_sql(&TagTarget::Catalog("db".into()), &tags).unwrap();
         assert_eq!(
             sql,
-            "ALTER DATABASE db SET TAG note = '\\\\''; DROP TABLE x; --'"
+            r"ALTER DATABASE db SET TAG note = '\\\'; DROP TABLE x; --'"
         );
+    }
+
+    #[test]
+    fn test_set_tags_encodes_a_trailing_backslash() {
+        let mut tags = BTreeMap::new();
+        tags.insert("path".into(), r"C:\data\".into());
+        let sql = format_set_tags_sql(&TagTarget::Catalog("db".into()), &tags).unwrap();
+        assert_eq!(sql, r"ALTER DATABASE db SET TAG path = 'C:\\data\\'");
     }
 
     #[test]
@@ -532,7 +541,7 @@ mod tests {
         let mut tags = BTreeMap::new();
         tags.insert("desc".into(), "Hugo's pipeline".into());
         let sql = format_set_tags_sql(&TagTarget::Catalog("db".into()), &tags).unwrap();
-        assert_eq!(sql, "ALTER DATABASE db SET TAG desc = 'Hugo''s pipeline'");
+        assert_eq!(sql, r"ALTER DATABASE db SET TAG desc = 'Hugo\'s pipeline'");
     }
 
     // ---- Grant SQL generation ----

--- a/engine/crates/rocky-sql/src/validation.rs
+++ b/engine/crates/rocky-sql/src/validation.rs
@@ -378,21 +378,20 @@ pub fn reject_statement_terminator(context: &str, sql: &str) -> Result<(), Valid
 
 /// Refuses a value Rocky cannot safely wrap in a `'…'` SQL literal.
 ///
-/// Rocky encodes a config-supplied string constant — a declarative check's
-/// `accepted_values`, for instance — by doubling single quotes. That is enough
-/// only where `''` is the *only* escape. Snowflake, DuckDB and BigQuery also
-/// honour a backslash escape, so a value ending in `\` escapes the first quote
-/// of the `''` pair Rocky emits and the second quote closes the literal — the
-/// bypass `rocky-snowflake/src/governance.rs` documents for tag values.
+/// Doubling single quotes encodes a string constant correctly only where `''`
+/// is the *only* escape. Snowflake, Databricks and BigQuery also read a
+/// backslash escape, so a value ending in `\` escapes the first quote of the
+/// `''` pair and the second quote closes the literal.
 ///
-/// Escaping backslashes as well closes the bypass on those three but changes the
-/// *value* on Trino and standard-SQL DuckDB, where a doubled backslash is two
-/// literal backslashes. No single encoding is correct everywhere, and these call
-/// sites have no dialect to ask. So a backslash is refused and the author is
-/// told which value to change.
+/// Escaping backslashes as well would change the *value* on Trino and DuckDB,
+/// where a backslash stands for itself. No single encoding is correct without
+/// knowing the dialect, so a caller that has none refuses a backslash and
+/// tells the author which value to change.
 ///
-/// The proper fix is dialect-owned literal encoding or parameter binding at
-/// these call sites; this is the cheap, sound guard until that lands.
+/// Every sink with a dialect in hand encodes through
+/// [`crate::literal::encode_string_literal`] instead and needs no guard. The
+/// one remaining caller is the dialect-less `generate_test_sql` in
+/// `rocky-core`, kept for callers that cannot name a dialect.
 ///
 /// # Errors
 ///


### PR DESCRIPTION
Ten SQL string-literal sinks now encode through the dialect's own lexer rule (`rocky_core::sql_gen::string_literal`, the encoder #1605 added). Where a sink is routed, the interim backslash refusal from #1595 is deleted. A backslash in `accepted_values` or `schema_pattern.prefix` is accepted again and carried as a value.

Generated SQL for a value without a quote, backslash or line break is byte-identical to `main`. This is proven below, not assumed.

## Sink table

| Sink | Dialect source | State |
|---|---|---|
| `rocky-core/src/tests.rs` `accepted_values` (with a dialect) | `generate_test_sql_with_dialect` argument (`adapter.dialect()` in `rocky test` / `rocky run`) | **routed**, guard deleted |
| `rocky-core/src/tests.rs` `accepted_values` (dialect-less `generate_test_sql`) | none by construction | **guarded** (refuses a backslash) — no `rocky` command reaches it |
| `rocky-core/src/quarantine.rs` `accepted_values` | `lower_valid_predicate` argument | **routed**, guard deleted |
| `rocky-core/src/seeds.rs` seed cells | `generate_insert_sql` argument | **routed** |
| `rocky-core/src/arrow_loader.rs` loader cells (BigQuery local-file `INSERT` path) | `generate_batch_insert_sql` argument — was `_dialect`, unused | **routed** |
| `rocky-core/src/unit_test.rs` fixture strings | `rocky-engine/src/test_runner.rs` passes `DuckDbSqlDialect` (the only runner) | **routed** |
| `rocky-core/src/checks.rs` cross-source `_src` tag | `generate_cross_source_overlap_sql` argument | **routed** — validated identifiers, so byte-identical |
| `rocky-duckdb/src/discovery.rs` `schema_pattern.prefix` (inside `LIKE`) | `DuckDbSqlDialect` (the crate's own) | **routed**, guard deleted |
| `rocky-duckdb/src/discovery.rs` schema name read back | `DuckDbSqlDialect` | **routed** |
| `rocky-bigquery/src/discovery.rs` `schema_pattern.prefix` (inside `STARTS_WITH`) | `BigQueryDialect` | **routed**, guard deleted |
| `rocky-snowflake/src/governance.rs` tag values | `SnowflakeSqlDialect` | **routed** — was already escaped correctly by hand; now one encoder |
| `rocky-lang/src/lower.rs` DSL string literal | none — lowers to SQL before a dialect exists | **remaining** |
| `regex_match.pattern` (`regex_match_predicate` on DuckDB / Snowflake / Databricks / BigQuery) | each dialect's own | **remaining** — a backslash is regex syntax; routing it changes today's Snowflake / Databricks behaviour (see below) |
| `rocky-core/src/catalog.rs` Databricks tag values | none (Unity Catalog SQL, no dialect argument) | **guarded** (refuses a quote); a trailing backslash still breaks the statement |
| `rocky-core/src/lakehouse.rs` `COMMENT` / `TBLPROPERTIES` | none | **guarded** (refuses a quote); same backslash gap |
| Snowflake stage URI / path, Databricks `COPY INTO` path, CSV delimiters | n/a | **guarded** (refuse quote, backslash and newline) |

Not a seam, verified: `WHERE table_schema = '{schema}'` and similar in the adapters splice `validate_identifier`-checked names only.

## Evidence

Tests were written first, against the unfixed code, and failed for the real reason. Then the bodies were routed.

| Sink | Fail-before (unfixed code) | Pass-after |
|---|---|---|
| `accepted_values` (`tests.rs`, `quarantine.rs`) with a dialect | `unwrap()` on the #1595 refusal — the guard fired although a dialect was in hand | `NOT IN ('pending', 'trailing\', 'it''s')` on `Standard`; `NOT IN ('pending', 'trailing\\', 'it\'s')` on `Backslash` |
| seed cell, loader cell, fixture string | `Backslash` dialect emitted `'C:\tmp\'` — the trailing `\'` escapes the closing quote | `'C:\\tmp\\'` and `'it\'s'`; `Standard` unchanged: `'C:\tmp\'`, `'it''s'` |
| DuckDB discovery | `discover(r"raw\")` returned the guard's error | executed in-process: schemas `raw\`, `raw\x` found for prefix `raw\` (`rawx` correctly not), `it's` found for prefix `it'`, with its table |
| BigQuery discovery | emitted `STARTS_WITH(schema_name, 'raw\')` — on BigQuery `\'` escapes the closing quote | `STARTS_WITH(schema_name, 'raw\\')`, `'it\'s'` |
| Snowflake tags | emitted `'\\''; DROP TABLE x; --'` — hand-escaped and valid on Snowflake; this sink was already sound | `'\\\'; DROP TABLE x; --'`, `'Hugo\'s pipeline'` — the one encoder |

**Live DuckDB probe** (the branch's own `rocky` binary, a scratch transformation project, DuckDB 1.x file):

- `accepted_values = ["plain", "it's", "C:\\tmp\\"]` on a column holding `plain`, `it's`, `C:\tmp\`, `other`. `rocky test --declarative` generated `SELECT DISTINCT kind FROM probe.demo.items_mart WHERE kind NOT IN ('plain', 'it''s', 'C:\tmp\')`, DuckDB executed it, and the check reported exactly `1 unexpected value(s)` — the quote and the trailing backslash round-tripped. On `main` this config is refused before any SQL is built.
- `rocky seed` on a CSV whose `note` cells are `plain`, `it's`, `C:\tmp\`: 3 rows loaded into `probe.seeds.notes`; read back with `SELECT note, length(note), note = 'C:\tmp\', note = 'it''s'` — lengths 5 / 4 / 7 and both equality tests true, so both values round-tripped byte-exact.

**Byte-identical for plain values.** Unchanged, still-passing assertions on exact SQL: `tests.rs` `NOT IN ('pending', 'shipped')`, `seeds.rs` `'it''s fine'`, `arrow_loader.rs` `'hello'`, `checks.rs` `'cat.s1.orders' AS _src`, `governance.rs` `managed_by = 'rocky'` and friends, `rocky-duckdb` `test_discover_matching_schemas`. New: `accepted_values_plain_values_are_byte_identical_under_both_rules` (dialect-less, `Standard` and `Backslash` all equal the pre-existing string) and `schemata_sql_plain_prefix_is_byte_identical`. Under `Standard` the encoder *is* quote-doubling, so DuckDB and Trino output cannot differ for any value.

**Gates** (`cargo +1.98.0`, exit codes captured directly, tree hash checked before and after): `fmt --all --check` 0; `test -p rocky-sql -p rocky-core -p rocky-duckdb -p rocky-bigquery -p rocky-snowflake -p rocky-engine` 0 (45 suites, 2078 rocky-core lib tests, 0 failed); `clippy --all-targets` on those six with `-D warnings` 0; `check --workspace --all-targets` 0.

**Mutation check** (`scripts/mutation-check.sh`, clean tree enforced): the `Backslash` arm of `encode_string_literal` reverted to plain quote-doubling — the exact defect this PR closes, applied at the one point every routed sink goes through. Five tests fail, one per sink, and nothing else moves:

```
arrow_loader::tests::format_cell_encodes_a_backslash_and_a_quote_per_dialect
quarantine::unit_tests::quarantine_accepted_values_encodes_a_backslash_and_a_quote_per_dialect
seeds::tests::format_value_encodes_a_backslash_and_a_quote_per_dialect
tests::unit_tests::accepted_values_encodes_a_backslash_and_a_quote_per_dialect
unit_test::tests::json_to_sql_literal_encodes_a_backslash_and_a_quote_per_dialect

test result: FAILED. 2073 passed; 5 failed
```

The two discovery sinks carry their own dialect-specific assertions rather than routing through this arm, so they are covered by the fail-before evidence above instead.

## Not in this PR

- `rocky-lang/src/lower.rs`: the DSL lowers to a SQL string before any dialect is chosen. Routing it needs the dialect at lowering time, which is a design change, not a call-site fix.
- `regex_match.pattern`: a backslash is regex syntax. On Snowflake and Databricks the lexer consumes it today, so `\d` reaches the regex engine as `d`, and a user who worked around that by writing `\\d` would see the encoder double it again. That is a behaviour change for a config that works today on those two warehouses, so it is a separate PR for the owner to judge.
- Databricks tag values (`rocky-core/src/catalog.rs`) and lakehouse `COMMENT` / `TBLPROPERTIES` (`rocky-core/src/lakehouse.rs`): both refuse a quote, neither refuses a backslash, and neither takes a dialect. A trailing backslash breaks the statement rather than escaping the literal (a quote cannot follow it). Follow-up.

## Red team

Codex review in progress — reviewer, rounds and the disposition of each finding are posted as one comment and summarised here when done.

## The two standing questions

**Least confident:** that the dialect-less `generate_test_sql` path is unreachable from a `rocky` command with user values. I grepped every caller: the only non-test caller is `rocky-core/tests/integration.rs`, and both production callers (`commands/test.rs`, `commands/run_local.rs`) use `generate_test_sql_with_dialect`. The guard stays there, so the direction of harm if I am wrong is a refusal, not a bypass. Second: the DuckDB `LIKE` fact (a backslash is a plain character, no default `ESCAPE`) is proven by the executed test on the DuckDB version the crate links; a future DuckDB default could change it, and the test would fail loudly.

**Most important thing I might be missing:** the encoder's `Backslash` rule is one rule for three warehouses, and Databricks can turn backslash reading off (`spark.sql.parser.escapedStringLiterals=true`, noted in #1605). Under that session flag every routed Databricks sink would now emit `\'`, which is a parse error there, where `''` used to work. This PR does not add a policy for that flag; it inherits #1605's position that the default parser is the supported one.

Refs #1596 (not closed: four sinks remain, listed above). Refs #1524.

