### PR TITLE
fix(bigquery): collect all paginated query results

### DIFF
--- a/engine/crates/rocky-bigquery/src/connector.rs
+++ b/engine/crates/rocky-bigquery/src/connector.rs
@@ -1,5 +1,6 @@
 //! BigQuery REST API connector — jobs.query + jobs.getQueryResults.
 
+use std::collections::HashSet;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -501,6 +502,134 @@ impl BigQueryAdapter {
         })
     }
 
+    /// Fetch every remaining page for a completed query response.
+    ///
+    /// BigQuery's `maxResults` is a per-page limit. A non-empty
+    /// `pageToken` means the response is incomplete even when
+    /// `jobComplete=true`, so returning the first page would silently
+    /// truncate callers such as content-addressed materialization.
+    async fn collect_query_pages(
+        &self,
+        mut response: BigQueryResponse,
+    ) -> Result<BigQueryResponse, BigQueryError> {
+        let Some(mut page_token) = response.page_token.take().filter(|t| !t.is_empty()) else {
+            return response.validate_row_count();
+        };
+        let job_id = response
+            .job_reference
+            .as_ref()
+            .map(|r| r.job_id.clone())
+            .ok_or_else(|| BigQueryError::ApiError {
+                status: "missing jobReference".into(),
+                message: "BigQuery returned a pageToken without a jobReference; cannot fetch the remaining query results".into(),
+            })?;
+        let token = self.auth.get_token(&self.client).await?;
+        let url = format!(
+            "{}/bigquery/v2/projects/{}/queries/{job_id}",
+            self.base_url(),
+            self.project_id,
+        );
+        let mut seen = HashSet::new();
+
+        loop {
+            if !seen.insert(page_token.clone()) {
+                return Err(BigQueryError::ApiError {
+                    status: "repeated pageToken".into(),
+                    message: "BigQuery repeated a query-results pageToken; refusing to loop or return an incomplete result".into(),
+                });
+            }
+
+            let mut page = self
+                .fetch_query_result_page(&url, &token, &page_token)
+                .await?;
+            if !page.job_complete {
+                return Err(BigQueryError::ApiError {
+                    status: "incomplete query-results page".into(),
+                    message: "BigQuery returned jobComplete=false while paging a completed query"
+                        .into(),
+                });
+            }
+            page.check_job_error()?;
+            if response.schema.is_none() {
+                response.schema = page.schema.take();
+            }
+            if let Some(mut rows) = page.rows.take() {
+                response.rows.get_or_insert_with(Vec::new).append(&mut rows);
+            }
+
+            match page.page_token.take().filter(|t| !t.is_empty()) {
+                Some(next) => page_token = next,
+                None => return response.validate_row_count(),
+            }
+        }
+    }
+
+    /// Fetch one result page with the connector's bounded transient retry
+    /// policy. A flaky page must not force a full query resubmission, which is
+    /// especially important for content-addressed model runs.
+    async fn fetch_query_result_page(
+        &self,
+        url: &str,
+        token: &str,
+        page_token: &str,
+    ) -> Result<BigQueryResponse, BigQueryError> {
+        for attempt in 0..=self.retry.max_retries {
+            let result = async {
+                let resp = self
+                    .client
+                    .get(url)
+                    .bearer_auth(token)
+                    .query(&[
+                        ("location", self.location.as_str()),
+                        ("maxResults", "10000"),
+                        ("pageToken", page_token),
+                    ])
+                    .send()
+                    .await?;
+
+                if !resp.status().is_success() {
+                    let status = resp.status().to_string();
+                    let body = resp.text().await.unwrap_or_default();
+                    return Err(BigQueryError::ApiError {
+                        status,
+                        message: body,
+                    });
+                }
+
+                Ok(resp.json().await?)
+            }
+            .await;
+
+            match result {
+                Ok(page) => {
+                    if attempt > 0 {
+                        rocky_observe::metrics::METRICS.inc_retries_succeeded();
+                    }
+                    return Ok(page);
+                }
+                Err(err) if attempt < self.retry.max_retries && is_transient(&err) => {
+                    if !self.retry_budget.try_consume() {
+                        let limit = self.retry_budget.total().unwrap_or(0);
+                        return Err(BigQueryError::RetryBudgetExhausted { limit });
+                    }
+                    rocky_observe::metrics::METRICS.inc_retries_attempted();
+                    let backoff_ms = compute_backoff(&self.retry, attempt);
+                    warn!(
+                        attempt = attempt + 1,
+                        max_retries = self.retry.max_retries,
+                        backoff_ms,
+                        error = %err,
+                        "transient BigQuery result-page error, retrying"
+                    );
+                    tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+
+        unreachable!("retry loop should always return")
+    }
+
     /// Fetch the full `Job` resource for a completed job ID and return
     /// its `configuration.query.destinationTable` reference.
     ///
@@ -939,6 +1068,10 @@ impl WarehouseAdapter for BigQueryAdapter {
 
     async fn execute_query(&self, sql: &str) -> AdapterResult<QueryResult> {
         let response = self.run_query(sql).await.map_err(AdapterError::new)?;
+        let response = self
+            .collect_query_pages(response)
+            .await
+            .map_err(AdapterError::new)?;
 
         let columns: Vec<String> = response
             .schema
@@ -1573,6 +1706,10 @@ struct BigQueryResponse {
     #[allow(dead_code)]
     #[serde(default)]
     total_rows: Option<String>,
+    /// Token for the next page of query rows. A non-empty token means this
+    /// response is incomplete even when `jobComplete=true`.
+    #[serde(default)]
+    page_token: Option<String>,
     /// Top-level `totalBytesProcessed` from the `jobs.query` /
     /// `jobs.getQueryResults` response shape (decimal-encoded int64).
     /// Set on every successful query job. **Note:** the synchronous
@@ -1613,6 +1750,28 @@ struct BigQueryResponse {
 }
 
 impl BigQueryResponse {
+    /// Refuse a response whose advertised total does not match the rows
+    /// collected after pagination. BigQuery encodes `totalRows` as a decimal
+    /// string; an absent or malformed value remains best-effort metadata.
+    fn validate_row_count(self) -> Result<Self, BigQueryError> {
+        if let Some(expected) = self
+            .total_rows
+            .as_deref()
+            .and_then(|value| value.parse::<u64>().ok())
+        {
+            let actual = self.rows.as_ref().map_or(0, |rows| rows.len() as u64);
+            if actual != expected {
+                return Err(BigQueryError::ApiError {
+                    status: "incomplete query result".into(),
+                    message: format!(
+                        "BigQuery advertised {expected} total row(s), but Rocky received {actual}"
+                    ),
+                });
+            }
+        }
+        Ok(self)
+    }
+
     /// Map a top-level `errors[]` on a completed job to a
     /// [`BigQueryError::JobError`], so an async job failure surfaces as an
     /// error instead of an empty result set. No-op when `errors` is absent

--- a/engine/crates/rocky-bigquery/tests/wiremock_tests.rs
+++ b/engine/crates/rocky-bigquery/tests/wiremock_tests.rs
@@ -182,6 +182,316 @@ async fn happy_path_inline_result_parses_values() {
     assert_eq!(result.rows[1][2], json!("hi"));
 }
 
+/// `maxResults` is a per-page limit, not a whole-query limit. A successful
+/// inline response with `pageToken` must be followed through
+/// `jobs.getQueryResults` before `execute_query` returns.
+#[tokio::test]
+async fn inline_query_collects_all_result_pages() {
+    let server = MockServer::start().await;
+    let first_page: Vec<Value> = (0..10_000)
+        .map(|id| json!({"f": [{"v": id.to_string()}]}))
+        .collect();
+
+    Mock::given(method("POST"))
+        .and(path(QUERIES_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "jobReference": {"projectId": "test-project", "jobId": "job-paged"},
+            "schema": {"fields": [{"name": "id", "type": "INTEGER"}]},
+            "rows": first_page,
+            "totalRows": "10001",
+            "pageToken": "page-2"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/bigquery/v2/projects/test-project/queries/job-paged"))
+        .and(query_param("location", "EU"))
+        .and(query_param("maxResults", "10000"))
+        .and(query_param("pageToken", "page-2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "rows": [{"f": [{"v": "10000"}]}]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let result = test_adapter(&server)
+        .execute_query("SELECT id FROM large_table")
+        .await
+        .expect("all query-result pages should be returned");
+
+    assert_eq!(result.columns, vec!["id"]);
+    assert_eq!(result.rows.len(), 10_001);
+    assert_eq!(result.rows[0][0], json!("0"));
+    assert_eq!(result.rows[10_000][0], json!("10000"));
+    server.verify().await;
+}
+
+/// Pagination composes with the deferred-job poll path: the first completed
+/// poll may itself be only page one.
+#[tokio::test]
+async fn deferred_query_collects_all_result_pages() {
+    let server = MockServer::start().await;
+    let poll_path = "/bigquery/v2/projects/test-project/queries/job-deferred-paged";
+
+    Mock::given(method("POST"))
+        .and(path(QUERIES_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": false,
+            "jobReference": {"projectId": "test-project", "jobId": "job-deferred-paged"}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(poll_path))
+        .and(query_param("timeoutMs", "10000"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "jobReference": {"projectId": "test-project", "jobId": "job-deferred-paged"},
+            "schema": {"fields": [{"name": "id", "type": "INTEGER"}]},
+            "rows": [{"f": [{"v": "1"}]}],
+            "totalRows": "2",
+            "pageToken": "last-page"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(poll_path))
+        .and(query_param("pageToken", "last-page"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "rows": [{"f": [{"v": "2"}]}]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let result = test_adapter(&server)
+        .execute_query("SELECT id FROM slow_large_table")
+        .await
+        .expect("a completed poll should fetch its remaining pages");
+
+    assert_eq!(result.rows, vec![vec![json!("1")], vec![json!("2")]]);
+    server.verify().await;
+}
+
+/// A token without a job reference cannot be followed. Returning the first
+/// page would be silent truncation, so this malformed response fails closed.
+#[tokio::test]
+async fn page_token_without_job_reference_errors_cleanly() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path(QUERIES_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "rows": [{"f": [{"v": "1"}]}],
+            "totalRows": "2",
+            "pageToken": "unreachable-page"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let err = test_adapter(&server)
+        .execute_query("SELECT id FROM malformed_result")
+        .await
+        .expect_err("an unpageable response must not return partial success");
+
+    match as_bq_error(&err) {
+        BigQueryError::ApiError { status, message } => {
+            assert_eq!(status, "missing jobReference");
+            assert!(message.contains("remaining query results"));
+        }
+        other => panic!("expected ApiError(missing jobReference), got: {other:?}"),
+    }
+}
+
+/// A later-page failure must surface as an error rather than returning the
+/// rows collected so far as a successful result.
+#[tokio::test]
+async fn later_page_error_is_not_partial_success() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path(QUERIES_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "jobReference": {"projectId": "test-project", "jobId": "job-page-error"},
+            "rows": [{"f": [{"v": "1"}]}],
+            "totalRows": "2",
+            "pageToken": "page-error"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(
+            "/bigquery/v2/projects/test-project/queries/job-page-error",
+        ))
+        .and(query_param("pageToken", "page-error"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("page unavailable"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let err = test_adapter(&server)
+        .execute_query("SELECT id FROM unavailable_page")
+        .await
+        .expect_err("a later-page failure must fail the whole query result");
+
+    match as_bq_error(&err) {
+        BigQueryError::ApiError { status, message } => {
+            assert!(status.contains("503"));
+            assert!(message.contains("page unavailable"));
+        }
+        other => panic!("expected ApiError(503), got: {other:?}"),
+    }
+}
+
+/// Later pages use the same bounded transient retry policy as query
+/// submission, so a one-off API outage does not fail an otherwise completed
+/// content-addressed query.
+#[tokio::test]
+async fn later_page_transient_error_is_retried() {
+    let server = MockServer::start().await;
+    let page_path = "/bigquery/v2/projects/test-project/queries/job-page-retry";
+
+    Mock::given(method("POST"))
+        .and(path(QUERIES_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "jobReference": {"projectId": "test-project", "jobId": "job-page-retry"},
+            "rows": [{"f": [{"v": "1"}]}],
+            "totalRows": "2",
+            "pageToken": "page-2"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(page_path))
+        .and(query_param("pageToken", "page-2"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("try again"))
+        .up_to_n_times(1)
+        .with_priority(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(page_path))
+        .and(query_param("pageToken", "page-2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "rows": [{"f": [{"v": "2"}]}]
+        })))
+        .with_priority(2)
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let result = retrying_adapter(&server, 1)
+        .execute_query("SELECT id FROM transient_page")
+        .await
+        .expect("a transient later-page error should be retried");
+
+    assert_eq!(result.rows, vec![vec![json!("1")], vec![json!("2")]]);
+    server.verify().await;
+}
+
+/// `totalRows` describes the complete result set. If BigQuery supplies no
+/// continuation token for fewer rows, fail closed instead of committing a
+/// silently truncated result.
+#[tokio::test]
+async fn row_count_mismatch_without_page_token_errors() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path(QUERIES_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "jobReference": {"projectId": "test-project", "jobId": "job-short-result"},
+            "rows": [{"f": [{"v": "1"}]}],
+            "totalRows": "2"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let err = test_adapter(&server)
+        .execute_query("SELECT id FROM short_result")
+        .await
+        .expect_err("a row-count mismatch must not return partial success");
+
+    match as_bq_error(&err) {
+        BigQueryError::ApiError { status, message } => {
+            assert_eq!(status, "incomplete query result");
+            assert!(message.contains("advertised 2 total row(s)"));
+            assert!(message.contains("received 1"));
+        }
+        other => panic!("expected incomplete-result ApiError, got: {other:?}"),
+    }
+}
+
+/// A repeated token would otherwise spin forever. Refuse it after the first
+/// page instead of returning incomplete rows or issuing an unbounded request
+/// loop.
+#[tokio::test]
+async fn repeated_page_token_errors_cleanly() {
+    let server = MockServer::start().await;
+    let page_path = "/bigquery/v2/projects/test-project/queries/job-token-loop";
+
+    Mock::given(method("POST"))
+        .and(path(QUERIES_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "jobReference": {"projectId": "test-project", "jobId": "job-token-loop"},
+            "rows": [{"f": [{"v": "1"}]}],
+            "totalRows": "3",
+            "pageToken": "same-token"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(page_path))
+        .and(query_param("pageToken", "same-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "rows": [{"f": [{"v": "2"}]}],
+            "pageToken": "same-token"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let err = test_adapter(&server)
+        .execute_query("SELECT id FROM looping_pages")
+        .await
+        .expect_err("a repeated page token must be refused");
+
+    match as_bq_error(&err) {
+        BigQueryError::ApiError { status, message } => {
+            assert_eq!(status, "repeated pageToken");
+            assert!(message.contains("refusing to loop"));
+        }
+        other => panic!("expected repeated-page-token ApiError, got: {other:?}"),
+    }
+    server.verify().await;
+}
+
 /// `execute_statement` ignores the result body and just confirms success —
 /// the bearer token rides in the Authorization header.
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fetch every BigQuery `jobs.getQueryResults` page before returning an `execute_query` result. This prevents successful content-addressed model runs, restores, and query consumers from silently using only the first 10,000-row page.

Fixes #1650.

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Changes

- Deserialize and follow BigQuery `pageToken` values for both inline and deferred query completions.
- Preserve schema and row order while accumulating pages, then validate the accumulated count against `totalRows`.
- Fail closed on missing job references, repeated tokens, incomplete later pages, and later-page API/job errors.
- Apply the adapter's bounded transient retry, backoff, and shared retry budget to later-page requests.
- Add wire-level coverage for 10,001-row pagination, deferred pagination, transient recovery, partial-failure refusal, malformed tokens, and row-count mismatch.

## Test Plan

- `cargo nextest run --all-features` — 6,828 passed; 115 credential/measurement tests skipped by the repository.
- `cargo test` — passed, including doctests; credential-gated live tests remained ignored.
- `cargo test -p rocky-bigquery --all-features --test wiremock_tests -- --nocapture` — 36 passed.
- `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- `cargo fmt -- --check` — passed.
- `scripts/mutation-check.sh ... inline_query_collects_all_result_pages` — passed; removing the page collection makes the assertion fail at 10,000 versus 10,001 rows.
- Monorepo unaffected-consumer checks: SDK 241 passed, Dagster 724 passed, VS Code 208 passed.

`cargo test --all-targets` cannot complete on current `main`: its `rocky-cli` `binary_startup` benchmark starts a nested `cargo run` against the target directory locked by the parent Cargo process. The run was stopped at that pre-existing deadlock after all preceding tests passed. The CI-equivalent nextest and all-target clippy commands above completed successfully.

## Adversarial review

Fermat (independent GPT-5 Codex) initially found that later-page requests bypassed transient retry handling. The patch now uses the bounded adapter retry policy and includes a 503-then-success regression. Fermat's second-pass disposition is **accept**, with no blocking findings and ModelIr/contract semantics preserved.

- **Least confidence:** rare live BigQuery response shapes around optional `jobReference` behavior are mocked, not exercised against a real project.
- **Most important missing evidence:** a live BigQuery content-addressed run above 10,000 rows that verifies the final committed Parquet artifact end to end. The adapter boundary and content-addressed caller were traced, and the wire contract is covered locally.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/), scoped by subproject when relevant
- [x] No `Co-Authored-By` trailers
- [x] This does not change CLI JSON schema or DSL syntax

### Engine (`engine/`)

- [x] All engine tests pass under `cargo nextest run --all-features` and `cargo test`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo fmt --check` passes
