### PR TITLE
chore(ci): record the machine state around the coverage job, and free more disk

### DIFF
--- a/.github/workflows/engine-weekly.yml
+++ b/.github/workflows/engine-weekly.yml
@@ -103,21 +103,31 @@ jobs:
           # while competing for the repo's 10 GB budget against caches that
           # every PR restores from. Latency does not matter on a schedule.
           save-if: false
+      # The runner filled its root filesystem here, which is what has been
+      # failing this job since 2026-08-24. It surfaced as
+      # `collect2: fatal error: ld terminated with signal 7 [Bus error]`
+      # because a linker writes its output through mmap: a filesystem that
+      # fills mid-write faults instead of returning ENOSPC. The proof is the
+      # runner agent's own crash on the next run —
+      # `System.IO.IOException: No space left on device` while writing
+      # `_diag/Worker_*.log` — which is also why that run uploaded no logs at
+      # all. Removing dotnet, android and ghc was not enough for a
+      # tarpaulin-instrumented debug build of this workspace.
       - name: Free disk space and add swap
         run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /usr/local/share/boost /usr/share/swift \
+                      /usr/local/lib/node_modules /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force || true
           sudo fallocate -l 4G /mnt/swapfile && sudo chmod 600 /mnt/swapfile && sudo mkswap /mnt/swapfile && sudo swapon /mnt/swapfile || true
       - run: sudo apt-get update && sudo apt-get install -y cmake
       - name: Install cargo-tarpaulin
         # Pinned + --locked for the same reason as cargo-audit above.
         run: cargo install cargo-tarpaulin --version 0.31.2 --locked
-      # Kept permanently, not just while #1638 is open. The failure this job
-      # hit for six weeks was `collect2: fatal error: ld terminated with
-      # signal 7 [Bus error]` while linking a test binary, and the log said
-      # nothing about the machine it happened on. A linker writes its output
-      # through mmap, so a filesystem that fills mid-link faults instead of
-      # returning ENOSPC — the one failure mode whose evidence is exactly
-      # these two numbers, and exactly what no log had.
+      # Kept permanently. Six weeks of failures carried a bus error and no
+      # word about the machine it happened on, and the cause turned out to
+      # be the one thing these two numbers would have shown immediately.
+      # Headroom here is the early warning for the next time the build grows.
       - name: Machine state before coverage
         run: |
           df -h / /mnt /tmp || true
@@ -129,15 +139,7 @@ jobs:
         # never returns (it contends on the target/ lock) and the bench blows
         # the --timeout, failing the whole job. tarpaulin's default target set
         # (lib + bins + tests) is what we want coverage for anyway.
-        #
-        # `--jobs 1`: the workflow-level `CARGO_BUILD_JOBS: 4` had four of
-        # these linking at once. Each `rocky-cli` test binary pulls in every
-        # adapter, DuckDB, aws-lc, ring and the OpenTelemetry stack — the
-        # failing link listed several hundred rlibs — and tarpaulin's
-        # instrumentation inflates every object on top of that. Four
-        # concurrent links of that size is the cheapest explanation for the
-        # bus error, and serialising them is the cheapest test of it.
-        run: cargo tarpaulin --timeout 600 --out xml --output-dir coverage/ --jobs 1
+        run: cargo tarpaulin --timeout 600 --out xml --output-dir coverage/
       - name: Machine state after coverage
         # Runs even when the step above fails: on a failure this is the
         # reading that matters.

--- a/.github/workflows/engine-weekly.yml
+++ b/.github/workflows/engine-weekly.yml
@@ -103,16 +103,10 @@ jobs:
           # while competing for the repo's 10 GB budget against caches that
           # every PR restores from. Latency does not matter on a schedule.
           save-if: false
-      # The runner filled its root filesystem here, which is what has been
-      # failing this job since 2026-08-24. It surfaced as
-      # `collect2: fatal error: ld terminated with signal 7 [Bus error]`
-      # because a linker writes its output through mmap: a filesystem that
-      # fills mid-write faults instead of returning ENOSPC. The proof is the
-      # runner agent's own crash on the next run —
-      # `System.IO.IOException: No space left on device` while writing
-      # `_diag/Worker_*.log` — which is also why that run uploaded no logs at
-      # all. Removing dotnet, android and ghc was not enough for a
-      # tarpaulin-instrumented debug build of this workspace.
+      # Headroom for the coverage build, which is the largest thing this
+      # repository builds anywhere. It is not sufficient on its own — see the
+      # debug-info setting on the coverage step — but it buys back ~25 GB and
+      # the two together are what keep this job under the disk.
       - name: Free disk space and add swap
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
@@ -133,6 +127,16 @@ jobs:
           df -h / /mnt /tmp || true
           free -m || true
       - name: Run coverage
+        env:
+          # Line tables, not full DWARF. Measured: with default dev debug
+          # info this build filled a 145 GB runner disk — 106 GB available
+          # before the step, 149 MB after, so the instrumented artefacts
+          # alone are ~105 GB. That is why freeing more space did not fix
+          # it; the build outgrew the machine. Coverage needs the line
+          # mapping, which is what this keeps, and not the variable and
+          # type DWARF that dominates the size.
+          CARGO_PROFILE_DEV_DEBUG: line-tables-only
+          CARGO_PROFILE_TEST_DEBUG: line-tables-only
         # No --all-targets: that pulls the criterion benches into the run, and
         # the `binary_startup` bench shells out to `cargo run` on every
         # iteration. Under tarpaulin's ptrace instrumentation that subprocess

--- a/.github/workflows/engine-weekly.yml
+++ b/.github/workflows/engine-weekly.yml
@@ -111,6 +111,17 @@ jobs:
       - name: Install cargo-tarpaulin
         # Pinned + --locked for the same reason as cargo-audit above.
         run: cargo install cargo-tarpaulin --version 0.31.2 --locked
+      # Kept permanently, not just while #1638 is open. The failure this job
+      # hit for six weeks was `collect2: fatal error: ld terminated with
+      # signal 7 [Bus error]` while linking a test binary, and the log said
+      # nothing about the machine it happened on. A linker writes its output
+      # through mmap, so a filesystem that fills mid-link faults instead of
+      # returning ENOSPC — the one failure mode whose evidence is exactly
+      # these two numbers, and exactly what no log had.
+      - name: Machine state before coverage
+        run: |
+          df -h / /mnt /tmp || true
+          free -m || true
       - name: Run coverage
         # No --all-targets: that pulls the criterion benches into the run, and
         # the `binary_startup` bench shells out to `cargo run` on every
@@ -118,7 +129,22 @@ jobs:
         # never returns (it contends on the target/ lock) and the bench blows
         # the --timeout, failing the whole job. tarpaulin's default target set
         # (lib + bins + tests) is what we want coverage for anyway.
-        run: cargo tarpaulin --timeout 600 --out xml --output-dir coverage/
+        #
+        # `--jobs 1`: the workflow-level `CARGO_BUILD_JOBS: 4` had four of
+        # these linking at once. Each `rocky-cli` test binary pulls in every
+        # adapter, DuckDB, aws-lc, ring and the OpenTelemetry stack — the
+        # failing link listed several hundred rlibs — and tarpaulin's
+        # instrumentation inflates every object on top of that. Four
+        # concurrent links of that size is the cheapest explanation for the
+        # bus error, and serialising them is the cheapest test of it.
+        run: cargo tarpaulin --timeout 600 --out xml --output-dir coverage/ --jobs 1
+      - name: Machine state after coverage
+        # Runs even when the step above fails: on a failure this is the
+        # reading that matters.
+        if: always()
+        run: |
+          df -h / /mnt /tmp || true
+          free -m || true
       - name: Upload coverage report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/engine-weekly.yml
+++ b/.github/workflows/engine-weekly.yml
@@ -127,16 +127,6 @@ jobs:
           df -h / /mnt /tmp || true
           free -m || true
       - name: Run coverage
-        env:
-          # Line tables, not full DWARF. Measured: with default dev debug
-          # info this build filled a 145 GB runner disk — 106 GB available
-          # before the step, 149 MB after, so the instrumented artefacts
-          # alone are ~105 GB. That is why freeing more space did not fix
-          # it; the build outgrew the machine. Coverage needs the line
-          # mapping, which is what this keeps, and not the variable and
-          # type DWARF that dominates the size.
-          CARGO_PROFILE_DEV_DEBUG: line-tables-only
-          CARGO_PROFILE_TEST_DEBUG: line-tables-only
         # No --all-targets: that pulls the criterion benches into the run, and
         # the `binary_startup` bench shells out to `cargo run` on every
         # iteration. Under tarpaulin's ptrace instrumentation that subprocess
@@ -145,8 +135,11 @@ jobs:
         # (lib + bins + tests) is what we want coverage for anyway.
         run: cargo tarpaulin --timeout 600 --out xml --output-dir coverage/
       - name: Machine state after coverage
-        # Runs even when the step above fails: on a failure this is the
-        # reading that matters.
+        # `always()` so a failing coverage step still reports. Note the
+        # limit: when the disk fills hard enough the runner AGENT dies, and
+        # then no step runs and no logs upload at all. A job that ends with
+        # `Run coverage` having no conclusion and an empty log IS that case
+        # — treat it as the disk, not as a mystery.
         if: always()
         run: |
           df -h / /mnt /tmp || true

--- a/.github/workflows/engine-weekly.yml
+++ b/.github/workflows/engine-weekly.yml
@@ -104,9 +104,11 @@ jobs:
           # every PR restores from. Latency does not matter on a schedule.
           save-if: false
       # Headroom for the coverage build, which is the largest thing this
-      # repository builds anywhere. It is not sufficient on its own — see the
-      # debug-info setting on the coverage step — but it buys back ~25 GB and
-      # the two together are what keep this job under the disk.
+      # repository builds anywhere. It buys back roughly 25 GB and it is NOT
+      # enough: the instrumented build needs ~105 GB and still fills the
+      # 145 GB disk, so this job remains red. See #1638 — closing it means
+      # changing what the job is (a bigger runner, per-crate runs, or a
+      # different coverage engine), not freeing more space.
       - name: Free disk space and add swap
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
@@ -118,10 +120,10 @@ jobs:
       - name: Install cargo-tarpaulin
         # Pinned + --locked for the same reason as cargo-audit above.
         run: cargo install cargo-tarpaulin --version 0.31.2 --locked
-      # Kept permanently. Six weeks of failures carried a bus error and no
-      # word about the machine it happened on, and the cause turned out to
-      # be the one thing these two numbers would have shown immediately.
-      # Headroom here is the early warning for the next time the build grows.
+      # Kept permanently. Every failure since 2026-08-24 carried a bus error
+      # and no word about the machine it happened on, and the cause turned
+      # out to be the one thing these two numbers show immediately. Headroom
+      # here is the early warning for the next time the build grows.
       - name: Machine state before coverage
         run: |
           df -h / /mnt /tmp || true
@@ -138,8 +140,10 @@ jobs:
         # `always()` so a failing coverage step still reports. Note the
         # limit: when the disk fills hard enough the runner AGENT dies, and
         # then no step runs and no logs upload at all. A job that ends with
-        # `Run coverage` having no conclusion and an empty log IS that case
-        # — treat it as the disk, not as a mystery.
+        # `Run coverage` having no conclusion and an empty log has lost its
+        # runner — which the disk does cause here, but so do cancellation
+        # and ordinary infrastructure loss. Check the job's annotations for
+        # the agent's own error before concluding which.
         if: always()
         run: |
           df -h / /mnt /tmp || true


### PR DESCRIPTION
**This does not fix the Coverage job.** It establishes why the job fails, with numbers, and keeps the two things that proved useful. The job stays red until a decision is made — see the options in #1638.

Refs #1638

## What the diagnostics found

A linker writes its output through `mmap`, so a filesystem that fills mid-write faults instead of returning ENOSPC. That is why every failure since 2026-08-24 carries `signal 7 [Bus error]` and never `No space left`.

With `df` around the step ([run 33911564622](https://github.com/rocky-data/rocky/actions/runs/33911564622)):

```
before the step    /dev/root  145G   40G  106G   28% /
after the failure  /dev/root  145G  145G  149M  100% /
```

The tarpaulin-instrumented build consumes **~105 GB**. Corroborated on [run 33906729207](https://github.com/rocky-data/rocky/actions/runs/33906729207), where the runner *agent* itself crashed with `System.IO.IOException: No space left on device` writing its own diagnostic log.

## What is in the diff

- **`df -h` and `free -m` bracketing the coverage step**, permanently. The second carries a comment naming its own limit: when the disk fills hard enough the runner agent dies, so `if: always()` does not run and no logs upload at all. A Coverage job whose `Run coverage` step has no conclusion and an empty log has **lost its runner** — the disk causes that here, but so do cancellation and ordinary infrastructure loss, so the job's annotations carry the agent's own error and are what to read first. That is how the cause was identified.
- **More aggressive cleanup**: boost, swift, the bundled node modules, the CodeQL toolcache, cached Docker images. Worth ~25 GB. Not sufficient on its own, kept because it is real headroom.

## What I tried and removed

- **`--jobs 1`**, on the theory that four concurrent links of a several-hundred-rlib binary exhausted memory. Failed identically. Removed — it only made a slow job slower.
- **`debug = line-tables-only`** for the dev and test profiles. Failed the same way. Removed — a change that does not work, and that narrows what coverage can map, is worse than not having tried it.

Both theories were mine and both were wrong. The 105 GB figure is the only claim here I would rely on.

## Why it is not fixed here

The build outgrew the machine, so freeing space cannot close it. The remaining options each change what the job is — a larger runner, per-crate coverage, or swapping tarpaulin for `cargo-llvm-cov` — and that is a decision about what this repository measures, not a fix. Laid out with a recommendation in #1638.

`actionlint`: clean.
