### PR TITLE
test(engine/ui): hostile-value coverage for the review lane and the timeline

### DIFF
--- a/engine/ui/src/governor/ProductsScreen.test.tsx
+++ b/engine/ui/src/governor/ProductsScreen.test.tsx
@@ -207,6 +207,29 @@ describe("ProductsScreen", () => {
     expect(screen.getByText("engine_not_ready")).toBeTruthy();
   });
 
+  /// U2-P0's XSS row, the timeline half. A journal event is a string the
+  /// engine composed from a compiler error, a check failure or an agent's
+  /// output — none of it the operator's, and this screen renders it verbatim
+  /// on purpose, so verbatim has to mean text.
+  it("renders a hostile event and product name as text, never as markup", async () => {
+    const hostile = '<img src=x onerror="alert(1)">';
+    const { container } = render(
+      <ProductsScreen
+        name="revenue_daily"
+        loaders={loaders({
+          journal: vi.fn(async () => ({
+            ...JOURNAL,
+            count: 1,
+            rows: [{ seq: 1, at: "2026-09-05T08:00:00Z", event: hostile, to_state: "observing" }],
+          })),
+        })}
+      />,
+    );
+
+    expect(await screen.findByText(hostile)).toBeTruthy();
+    expect(container.querySelector("img")).toBeNull();
+  });
+
   it("builds a product path that survives an awkward name", () => {
     expect(productPath("revenue daily")).toBe("/ui/governor/products/revenue%20daily");
   });

--- a/engine/ui/src/review/PlanDetail.test.tsx
+++ b/engine/ui/src/review/PlanDetail.test.tsx
@@ -195,6 +195,44 @@ describe("PlanDetail", () => {
     expect(container.querySelector("form")).toBeNull();
   });
 
+  /// U2-P0's XSS row, the diff half — the sink that did not exist until this
+  /// lane did. A breaking finding names a model and a column, and neither is
+  /// the operator's: they come from whatever SQL an agent wrote.
+  it("renders a hostile model name, column and reason as text, never as markup", async () => {
+    const hostile = '<img src=x onerror="alert(1)">';
+    const { container } = render(
+      <PlanDetail
+        planId={PLAN}
+        loaders={loaders({
+          // Built from the typed finding above rather than written fresh, so
+          // the change's discriminant keeps its literal type.
+          diff: vi.fn(
+            async (): Promise<ReviewOutput> => ({
+              ...DIFF,
+              breaking_changes: (DIFF.breaking_changes ?? []).map((finding) => ({
+                ...finding,
+                change: { ...finding.change, model: hostile, column: hostile },
+              })),
+            }),
+          ),
+          queue: vi.fn(async () => ({
+            ...QUEUE,
+            pending: [{ ...QUEUE.pending[0], reason: `${hostile} needs a human` }],
+          })),
+        })}
+      />,
+    );
+
+    // Twice on the page: once as the escalation's reason, once inside the
+    // finding's description. Both are sinks; both must be text.
+    await screen.findByText(`${hostile} needs a human`);
+    const escaped = hostile.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    expect(screen.getAllByText(new RegExp(escaped)).length).toBeGreaterThanOrEqual(2);
+    // …and never as an element. React escapes by default; this fails loudly
+    // if anyone reaches for dangerouslySetInnerHTML in this lane.
+    expect(container.querySelector("img")).toBeNull();
+  });
+
   it("names a product from its identity, and describes every finding kind", () => {
     expect(productNameFromId("product:revenue_daily")).toBe("revenue_daily");
     expect(productNameFromId("revenue_daily")).toBe("revenue_daily");

--- a/engine/ui/src/review/SamplePanel.test.tsx
+++ b/engine/ui/src/review/SamplePanel.test.tsx
@@ -106,6 +106,31 @@ describe("SamplePanel", () => {
     }
   });
 
+  /// U2-P0's XSS row, the sample half. Every value here comes from a
+  /// warehouse: a column name, a cell, and the SQL the engine ran. None of it
+  /// is the operator's, so all of it is hostile input as far as this page is
+  /// concerned.
+  it("renders hostile column names, cells and SQL as text, never as markup", async () => {
+    const hostile = '<img src=x onerror="alert(1)">';
+    const load = vi.fn(async () => ({
+      ...SAMPLE,
+      columns: [hostile, "total"],
+      rows: [[hostile, 1]],
+      executed_sql: `SELECT '${hostile}' FROM t`,
+    }));
+    const { container } = render(<SamplePanel model="orders" load={load} />);
+
+    fireEvent.click(screen.getByRole("button", { name: `Show ${SAMPLE_LIMIT} rows` }));
+    await screen.findByRole("table");
+    // Present as text — dropping it would hide what is really in the column.
+    expect(screen.getAllByText(hostile).length).toBeGreaterThan(0);
+    expect(screen.getByText(new RegExp(`SELECT '${hostile.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}'`)))
+      .toBeTruthy();
+    // …and never as an element. React escapes by default; this fails loudly
+    // if anyone reaches for dangerouslySetInnerHTML here.
+    expect(container.querySelector("img")).toBeNull();
+  });
+
   it("carries no consent on a read that is not a sample", async () => {
     const fetchMock = vi.fn(async () => new Response("{}", { status: 200 }));
     await apiGet("review/queue", {


### PR DESCRIPTION
Closes the last open row of the **U2-P0 security slice**.

**Review: the authoring model itself, at max effort, standing in for Codex on the owner's instruction while its credits are out until 2026-09-07. Same-model with the author, not independent — no independent review exists for this change yet.**

## Why now

U2-P0's XSS row has read 🟡 *partial* since the screens shipped, for a stated reason:

> React text rendering escapes by default and the lint rule forbids `dangerouslySetInnerHTML`; the estate, governor, custody and audit screens render fail-closed on a bad payload. **The diff sink does not exist until U3 (after U1-P2b); its hostile-value row travels with U3-P1.**

U3-P1 (#1737) and U3-P2 (#1740) have landed. The row did not travel with them. This is it.

## The three sinks

None of these is the operator's text.

| Sink | Where the string comes from |
|---|---|
| A breaking finding's model and column | Whatever SQL an agent wrote |
| A sample's column names, cell values and `executed_sql` | A warehouse |
| A journal event | A string the engine composed from a compiler error, a check failure, or an agent's output — and this screen renders it **verbatim on purpose**, so verbatim has to mean text |

## The assertions

Each test asserts **both halves**:

- the hostile string **is** on the page — dropping it would hide what is really in the column, which is its own defect;
- and it is **not** an element (`container.querySelector("img")` is null).

| Test | File |
|---|---|
| `renders a hostile model name, column and reason as text, never as markup` | `PlanDetail.test.tsx` |
| `renders hostile column names, cells and SQL as text, never as markup` | `SamplePanel.test.tsx` |
| `renders a hostile event and product name as text, never as markup` | `ProductsScreen.test.tsx` |

## Are these worth anything?

They pass today because React escapes by default, which is the argument for skipping them. So I checked what they actually catch, by making the defect they describe:

```
scripts/mutation-check.sh engine/ui/src/review/SamplePanel.tsx <mutation> <tests>
  # mutation: render a cell as <span dangerouslySetInnerHTML={{ __html: String(cell) }} />
  → Tests  1 failed | 5 passed
  → mutation-check: OK — the test failed under mutation, so it is fix-sensitive
```

So the tests fail the moment anyone reaches for `dangerouslySetInnerHTML` in these lanes, which is the whole point of having them. The eslint rule forbids it too, but a lint rule is disabled with a comment and a test is not.

87 vitest cases pass, `tsc --noEmit` clean, eslint clean.

One thing `tsc` caught that vitest could not: the first draft built the hostile finding as a fresh object literal, which loses `kind`'s literal type and does not satisfy `BreakingFinding`. It now maps over the typed finding already in the fixture. **vitest does not type-check** — a reminder worth its own line.

## The two questions

**Least confident.** Whether `<img src=x onerror=…>` is the right probe for every sink. It catches an element being created, which is the failure mode that matters for `dangerouslySetInnerHTML`. It would **not** catch a `javascript:` URL reaching an `href`, which React does not sanitise. I checked that surface by hand instead: every `href` in the SPA is built from the fixed `UI_BASE` prefix plus `encodeURIComponent` (`reviewPath`, `custodyPath`, `productPath`, `pathForLane`), so no attacker-controlled value can choose the scheme. That is an argument from reading, not a test, and a helper that later returned a raw string would not be caught.

**Most likely missing.** The screens these tests do not cover. Estate and custody had hostile-value tests before this; brief, scorecard and audit do not, and they render engine-composed strings too. Adding them here would have made this PR about six screens rather than the one row U2-P0 names, so it is a follow-up — but the roll-call should say "the review lane and the timeline", not "the UI", and the INDEX update says exactly that.
