### PR TITLE
fix(engine): persist the verify_after verdict, so a resume cannot report Success over an unverified migration

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -18087,6 +18087,10 @@
             "minimum": 0.0,
             "type": "integer"
           },
+          "verify_after_failed": {
+            "description": "`true` when this run auto-applied additive schema drift whose post-apply `verify_after` gate did not confirm it.\n\nThe gate runs after the run record exists, because it reads that record's check outcomes. It yields `Err` when a required check failed **or did not run at all** — a required check that is absent from `RunRecord::check_outcomes` fails it closed. There is no rollback substrate on a plain warehouse target, so the migration stands until a human reverts it.\n\n# Why this is its own field and not `check_gate_failed`\n\nThe two verdicts do not imply one another, and the absent-check case is exactly where they diverge:\n\n```text a required check is ABSENT      -> verify_after fails closed -> nothing failed, so the check gate has nothing to gate on: false fail_on_error = false           -> every check is advisory, so the check gate is always false, while verify_after can still fail ```\n\nIn both, `check_gate_failed` is `false` while an auto-applied migration stands unverified. Deriving one from the other would fail open on the two shapes that matter most (#1732).\n\n# What reads it\n\n[`crate::commands::run`]'s resume gate, beside `check_gate_failed`. A run that copied every table it planned and could not verify its own migration has no copy work left for a resume to do, but it does carry a synthetic `<verify_after>` entry in `models_executed` — and the resume gate admits a run \"because a model failed, and the model phase re-runs\". That entry is not a model, nothing re-runs, and the resume recorded `Success` over an unconfirmed migration.\n\nLike `check_gate_failed`, an admitted resume inherits it: the resume re-runs `verify_after` only for drift IT auto-applies, so an earlier unverified migration is never re-examined. Omitted from the JSON when `false`, so a run that verified cleanly is unchanged on the wire.",
+            "type": "boolean"
+          },
           "version": {
             "type": "string"
           }

--- a/editors/vscode/src/types/generated/run.ts
+++ b/editors/vscode/src/types/generated/run.ts
@@ -212,6 +212,26 @@ export interface RunOutput {
    */
   tables_failed: number;
   tables_skipped?: number;
+  /**
+   * `true` when this run auto-applied additive schema drift whose post-apply `verify_after` gate did not confirm it.
+   *
+   * The gate runs after the run record exists, because it reads that record's check outcomes. It yields `Err` when a required check failed **or did not run at all** — a required check that is absent from `RunRecord::check_outcomes` fails it closed. There is no rollback substrate on a plain warehouse target, so the migration stands until a human reverts it.
+   *
+   * # Why this is its own field and not `check_gate_failed`
+   *
+   * The two verdicts do not imply one another, and the absent-check case is exactly where they diverge:
+   *
+   * ```text a required check is ABSENT      -> verify_after fails closed -> nothing failed, so the check gate has nothing to gate on: false fail_on_error = false           -> every check is advisory, so the check gate is always false, while verify_after can still fail ```
+   *
+   * In both, `check_gate_failed` is `false` while an auto-applied migration stands unverified. Deriving one from the other would fail open on the two shapes that matter most (#1732).
+   *
+   * # What reads it
+   *
+   * [`crate::commands::run`]'s resume gate, beside `check_gate_failed`. A run that copied every table it planned and could not verify its own migration has no copy work left for a resume to do, but it does carry a synthetic `<verify_after>` entry in `models_executed` — and the resume gate admits a run "because a model failed, and the model phase re-runs". That entry is not a model, nothing re-runs, and the resume recorded `Success` over an unconfirmed migration.
+   *
+   * Like `check_gate_failed`, an admitted resume inherits it: the resume re-runs `verify_after` only for drift IT auto-applies, so an earlier unverified migration is never re-examined. Omitted from the JSON when `false`, so a run that verified cleanly is unchanged on the wire.
+   */
+  verify_after_failed?: boolean;
   version: string;
   [k: string]: unknown;
 }

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -54,6 +54,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **On upgrade:** the state store schema moves v23 → v24. No table is added and no blob migration runs; a v23 store upgrades on the next read-write open. The bump is load-bearing: `observed_failing` is a new variant of the `fulfill_state` record's tagged enum, and a 1.73.0 binary cannot read a blob that carries it. **Rolling back is the part to plan for.** Remote state keys are qualified by schema version (`v23/state.redb` on an object store, `…v23:…` on Valkey), so a 1.73.0 binary never reads a v24 remote object. It reads whatever is under its own v23 key, which may be stale, and it cannot see progress recorded under v24. The incompatible-blob hazard is a **local** `state.redb` this version wrote. A 1.73.0 binary opening it either stops with a schema-mismatch error or, on the paths that honour `[state] on_schema_mismatch`, deletes the file and starts fresh under the default `recreate`. Do not point a 1.73.0 binary at a local state file written by this version, and do not share one local file between versions. `rocky doctor --check state_schema` reports the mismatch and exits 3. Which commands honour the key and which refuse is being pinned down in #1679. `fulfill_state` is local-only, so a re-run rebuilds the loop's position; see #1525 before relying on that loss being harmless.
 
 ### Fixed
+- **A resume could report `Success` over a schema migration whose verification failed.**
+
+  `rocky run` auto-applies additive schema drift under a policy rule, then verifies it with the rule's `verify_after` checks. When that verification fails there is no rollback on a warehouse target — the migration stands, and the run halts so a human can look at it.
+
+  The failure was recorded as a synthetic `<verify_after>` entry in the run record's `models_executed`, with `status: "failed"`. The resume gate reads any failed entry as "a model failed, and the model phase re-runs on a resume". That entry is not a model. Nothing re-ran:
+
+  ```
+  run 1   copies every table, auto-applies drift, verify_after FAILS -> exit 2
+  resume  skips every Success key -> copies nothing, verifies nothing -> Success
+  ```
+
+  `latest_successful_run` matches on exactly `Success`, so every downstream `after` demand then fired on a schema change nobody confirmed.
+
+  **Why #1720's fix did not already cover it.** That one persists the *check gate*, and the two verdicts diverge on exactly the shapes that matter here. `verify_after` fails **closed** on a required check that is ABSENT from the record — and an absent check is not a failing check, so the check gate has nothing to gate on and stays `false`. Under `[pipeline.<name>.checks] fail_on_error = false` the check gate is always `false` while `verify_after` can still fail. Deriving one from the other would fail open on both.
+
+  The verdict is now persisted in its own right, as `RunOutput.verify_after_failed` on the wire and `RunRecord::verify_after_failed` in the state store, and read by the resume gate beside the check gate. An admitted resume — one where a table really did fail to copy — inherits it too, because `verify_after` only ever verifies drift the current invocation applied.
+
+  **On upgrade:** the state store schema moves v25 → v26. No table is added and no blob migration runs; a v25 store upgrades on the next read-write open, and its existing records read back `verify_after_failed = false`. That default is lossy in one direction — a run that failed verification under an older binary has no persisted verdict, so a resume of it is admitted exactly as before. Rolling back has the same shape as v25: the blob itself is backward-safe, but the OPEN-time version check engages `[state] on_schema_mismatch` first, and `recreate` discards the run history along with every persisted verdict.
+
+  **On the wire:** `verify_after_failed` is omitted from `--output json` when `false`, so a run that verified cleanly is unchanged. (#1732)
+
 - **A `DATE` read back from DuckDB was the driver's `Debug` string, so it was unreadable in `rocky preview rows` and unparseable by a content-addressed write.**
 
   `rocky-duckdb` maps each `duckdb::types::Value` to JSON with an arm per type and a wildcard for the rest. There was no arm for `Date32`, so a date arrived as `Date32(20701)`. Two consequences. `rocky preview rows` — and the review screen's sample panel, which is the same bytes — showed that string to a person deciding whether to approve a plan. And `run_content_addressed` parses a date cell back with `%Y-%m-%d` to build its `Date32Array`, so a content-addressed write of any model with a `DATE` column failed at `failed to parse date "Date32(20701)"`.

--- a/engine/crates/rocky-cli/src/api.rs
+++ b/engine/crates/rocky-cli/src/api.rs
@@ -3613,6 +3613,7 @@ mod tests {
                 pipeline: None,
                 submission_id: None,
                 check_gate_failed: false,
+                verify_after_failed: false,
             })
             .expect("run recorded");
         store

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -9840,6 +9840,7 @@ schema_template = "s__{source}"
             pipeline: None,
             submission_id: None,
             check_gate_failed: false,
+            verify_after_failed: false,
         };
         store.record_run(&record).unwrap();
     }

--- a/engine/crates/rocky-cli/src/commands/brief.rs
+++ b/engine/crates/rocky-cli/src/commands/brief.rs
@@ -1681,6 +1681,7 @@ mod tests {
             pipeline: None,
             submission_id: None,
             check_gate_failed: false,
+            verify_after_failed: false,
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/catalog.rs
+++ b/engine/crates/rocky-cli/src/commands/catalog.rs
@@ -1231,6 +1231,7 @@ mod tests {
                 pipeline: None,
                 submission_id: None,
                 check_gate_failed: false,
+                verify_after_failed: false,
             }
         }
 

--- a/engine/crates/rocky-cli/src/commands/cost.rs
+++ b/engine/crates/rocky-cli/src/commands/cost.rs
@@ -562,6 +562,7 @@ mod tests {
             pipeline: None,
             submission_id: None,
             check_gate_failed: false,
+            verify_after_failed: false,
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/drift_governance.rs
+++ b/engine/crates/rocky-cli/src/commands/drift_governance.rs
@@ -864,6 +864,7 @@ mod tests {
             pipeline: None,
             submission_id: None,
             check_gate_failed: false,
+            verify_after_failed: false,
         }
     }
 
@@ -891,6 +892,42 @@ mod tests {
         assert_eq!(rows.len(), 1, "one verification outcome row");
         assert_eq!(rows[0].effect, PolicyEffect::Allow);
         assert_eq!(rows[0].verify_after, vec!["row_count".to_string()]);
+    }
+
+    /// #1732, the discriminating case. `verify_after` fails **closed** on a
+    /// required check that is ABSENT from the run record — and absence is not
+    /// a failing check, so the run's own check gate has nothing to gate on and
+    /// stays `false`.
+    ///
+    /// That is why `verify_after_failed` is its own persisted verdict rather
+    /// than a reading of `check_gate_failed`: on this shape, the one the
+    /// resume gate would consult says the run was fine while an auto-applied
+    /// migration stands unconfirmed.
+    #[test]
+    fn an_absent_required_check_fails_verify_after_while_the_check_gate_stays_false() {
+        let (store, _d) = temp_store();
+        let policy = granting_policy(&["row_count"], None);
+        store
+            .record_policy_decision(&applied_decision("run-1", "wh.raw.orders"))
+            .unwrap();
+        // The run recorded NO check outcome at all — `row_count` never ran.
+        let record = run_with_checks("run-1", &[]);
+        assert!(
+            !record.check_gate_failed,
+            "nothing failed, so the check gate has nothing to gate on"
+        );
+        store.record_run(&record).unwrap();
+
+        let err = finalize_drift_verify_after(Some(&store), "run-1", Some(&policy))
+            .expect_err("an absent required check must fail the gate closed");
+        assert!(
+            err.to_string().contains("absent — did not run"),
+            "the refusal names the absence rather than a failure: {err}"
+        );
+
+        let rows = verify_rows(&store, "run-1");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].effect, PolicyEffect::Deny);
     }
 
     #[test]

--- a/engine/crates/rocky-cli/src/commands/gc.rs
+++ b/engine/crates/rocky-cli/src/commands/gc.rs
@@ -2348,6 +2348,7 @@ auto_create_schemas = true
                 pipeline: None,
                 submission_id: None,
                 check_gate_failed: false,
+                verify_after_failed: false,
             })
             .unwrap();
     }

--- a/engine/crates/rocky-cli/src/commands/history.rs
+++ b/engine/crates/rocky-cli/src/commands/history.rs
@@ -652,6 +652,7 @@ mod tests {
             pipeline: None,
             submission_id: None,
             check_gate_failed: false,
+            verify_after_failed: false,
         }
     }
 
@@ -742,6 +743,7 @@ mod tests {
             pipeline: None,
             submission_id: None,
             check_gate_failed: false,
+            verify_after_failed: false,
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/preview.rs
+++ b/engine/crates/rocky-cli/src/commands/preview.rs
@@ -2943,6 +2943,7 @@ mod tests {
             pipeline: None,
             submission_id: None,
             check_gate_failed: false,
+            verify_after_failed: false,
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/replay.rs
+++ b/engine/crates/rocky-cli/src/commands/replay.rs
@@ -2089,6 +2089,7 @@ mod tests {
             pipeline: None,
             submission_id: None,
             check_gate_failed: false,
+            verify_after_failed: false,
         }
     }
 
@@ -2821,6 +2822,7 @@ mod tests {
                 pipeline: None,
                 submission_id: None,
                 check_gate_failed: false,
+                verify_after_failed: false,
             };
             store.record_run(&record).unwrap();
 

--- a/engine/crates/rocky-cli/src/commands/restore.rs
+++ b/engine/crates/rocky-cli/src/commands/restore.rs
@@ -1426,6 +1426,7 @@ mod tests {
                     pipeline: None,
                     submission_id: None,
                     check_gate_failed: false,
+                    verify_after_failed: false,
                 })
                 .unwrap();
         }
@@ -2488,6 +2489,7 @@ mod tests {
                         pipeline: None,
                         submission_id: None,
                         check_gate_failed: false,
+                        verify_after_failed: false,
                     })
                     .unwrap();
 

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -21881,6 +21881,52 @@ backend = "local"
         );
     }
 
+    /// #1732. The stamp must exist, and it must land BEFORE the re-persist
+    /// that writes the record the resume gate later reads.
+    ///
+    /// This is a source-order guard for the same reason as
+    /// `the_inherited_gate_is_stamped_before_the_interrupt_path_persists`
+    /// above: no behavioural unit test reaches the site. Getting there needs a
+    /// real warehouse, a real additive drift, a policy rule with
+    /// `verify_after`, and a required check that does not run. Deleting
+    /// `output.verify_after_failed = true;` passes the entire
+    /// `commands::run::` suite — 1819 tests — because every test that asserts
+    /// the verdict sets it by hand.
+    ///
+    /// The ordering half matters as much as the existence half. There are two
+    /// `persist_run_record` calls around this branch: one before the gate runs
+    /// (the gate reads the record it writes) and one inside the failure branch.
+    /// The first necessarily writes `verify_after_failed: false`. If the stamp
+    /// landed after the second, the `false` would stand and the resume gate
+    /// would read it.
+    ///
+    /// Every `find` takes the FIRST occurrence, which is the production site;
+    /// the copies inside these tests are thousands of lines later.
+    #[test]
+    fn the_verify_after_verdict_is_stamped_before_the_failure_branch_repersists() {
+        let source = include_str!("run.rs");
+        let push = source
+            .find("asset_key: vec![\"<verify_after>\".to_string()],")
+            .expect("the <verify_after> error push is gone — re-anchor this test");
+        let stamp = source
+            .find("output.verify_after_failed = true;")
+            .expect("the verify_after verdict is never stamped — see #1732");
+        let repersist = source[push..]
+            .find("persist_run_record(")
+            .map(|i| push + i)
+            .expect("the failure branch no longer re-persists; re-anchor this test");
+        assert!(
+            push < stamp,
+            "the stamp belongs with the failure it records, right after the error push"
+        );
+        assert!(
+            stamp < repersist,
+            "the verdict must be stamped BEFORE the failure branch re-persists, or the \
+             record the resume gate reads carries the `false` written by the persist that \
+             ran before the gate (#1732)"
+        );
+    }
+
     /// Control (#1720). A resume with nothing inherited is unchanged: the
     /// verdict is the run's own, so an honest recovery from a copy failure
     /// still reaches `Success` and still records `check_gate_failed = false`.

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1838,6 +1838,28 @@ fn ensure_the_resume_would_do_work(
             progress.run_id
         );
     }
+    // The post-apply verification did not confirm an auto-applied migration,
+    // and no copy work remains (#1732). Refused here, beside the check gate
+    // and AHEAD of the `models_executed` branch below — that branch is what
+    // admits this run today, because the failure was recorded as a synthetic
+    // `<verify_after>` entry with `status: "failed"` and the branch reads any
+    // failed entry as a model the resume re-runs. It is not a model. The
+    // resume would skip every `Success` key, copy nothing, verify nothing,
+    // and derive `Success` over a schema change nobody confirmed.
+    //
+    // A separate verdict from `check_gate_failed` on purpose: `verify_after`
+    // fails closed on a required check that is ABSENT, which the check gate
+    // cannot see, and `fail_on_error = false` keeps the check gate `false`
+    // while this one still trips.
+    if record.verify_after_failed {
+        anyhow::bail!(
+            "nothing to resume: run {} auto-applied schema drift that its verify_after gate \
+             could not confirm, and it copied every table it planned to copy — so a resume \
+             would copy nothing and would re-run no verification. There is no rollback on a \
+             warehouse target: review the applied change, then re-run the pipeline",
+            progress.run_id
+        );
+    }
     if record
         .models_executed
         .iter()
@@ -1895,6 +1917,31 @@ fn inherited_check_gate(
     let progress = progress?;
     let record = state_store.get_run(&progress.run_id).ok().flatten()?;
     record.check_gate_failed.then(|| progress.run_id.clone())
+}
+
+/// The prior run whose still-standing `verify_after` failure an admitted
+/// resume inherits (#1732).
+///
+/// Same shape and same reason as [`inherited_check_gate`], for a verdict that
+/// gate cannot carry. [`ensure_the_resume_would_do_work`] refuses only the
+/// EMPTY resume of an unverified run. The commoner shape still resumes: run N
+/// auto-applied additive drift, its `verify_after` gate could not confirm it,
+/// AND a table failed to copy. That resume is admitted on the failed table —
+/// legitimately, there is real work — but `finalize_drift_verify_after` only
+/// verifies drift THIS invocation auto-applied, so the earlier unconfirmed
+/// migration is never re-examined. Left alone, the resume derives `Success`
+/// and `StateStore::latest_successful_run` starts matching it.
+///
+/// `None` when this is not a resume, when the prior record is gone, or when
+/// the record predates state schema v26 — an unrecorded verdict reads `false`,
+/// so a pre-v26 run resumes exactly as it does today.
+fn inherited_verify_after(
+    state_store: &StateStore,
+    progress: Option<&RunProgress>,
+) -> Option<String> {
+    let progress = progress?;
+    let record = state_store.get_run(&progress.run_id).ok().flatten()?;
+    record.verify_after_failed.then(|| progress.run_id.clone())
 }
 
 fn resolve_resume_progress(
@@ -3214,6 +3261,10 @@ pub async fn run(
     // `resume_progress` is still in scope (it is consumed below). `None` for a
     // non-resume run, so a plain run is byte-identical to before (#1720).
     let inherited_gate = inherited_check_gate(&state_store, resume_progress.as_ref());
+    // The same read for the post-apply verification verdict (#1732). Kept as
+    // its own value, not folded into `inherited_gate`: the two carry different
+    // messages and a run can stand under either alone.
+    let inherited_verify = inherited_verify_after(&state_store, resume_progress.as_ref());
 
     // Suppress both the periodic and the end-of-run upload when either:
     // - the on-disk state was forward-incompatible (newer schema than this
@@ -3327,6 +3378,10 @@ pub async fn run(
     // no check has run yet. Written through the same helper as the stamp
     // below so the two sites cannot drift apart.
     output.check_gate_failed = resolved_check_gate(false, inherited_gate.as_ref());
+    // Same early stamp, same reason, for the inherited verification verdict:
+    // an interrupted resume must persist it too, or a resume of THAT run
+    // inherits nothing and can go green (#1732).
+    output.verify_after_failed = resolved_check_gate(false, inherited_verify.as_ref());
     if let Some(ctx) = &idempotency_ctx {
         output.idempotency_key = Some(ctx.key.clone());
     }
@@ -5225,6 +5280,24 @@ pub async fn run(
     // `latest_successful_run` starts matching it — the laundering path. `None`
     // on every run that is not a resume of a gated run, so nothing else moves.
     output.check_gate_failed = resolved_check_gate(this_run_gated, inherited_gate.as_ref());
+    // The inherited verification verdict rides alongside. This run's OWN
+    // `verify_after` has not run yet — it runs after the record is persisted,
+    // because it reads that record — so the failure branch there ORs itself in
+    // afterwards. Here the inheritance alone is enough to stop a resume of an
+    // unverified run from reporting green (#1732).
+    output.verify_after_failed =
+        resolved_check_gate(output.verify_after_failed, inherited_verify.as_ref());
+    if let Some(prior) = &inherited_verify {
+        warn!(
+            resumed_from = prior.as_str(),
+            "resumed run inherits an unconfirmed verify_after migration"
+        );
+        crate::status_line!(
+            "Verification: run {prior} auto-applied schema drift its verify_after gate could \
+             not confirm, and this resume re-ran no verification — so it still stands and this \
+             run cannot report success. Review the applied change, then re-run the pipeline."
+        );
+    }
     if let Some(prior) = &inherited_gate {
         warn!(
             resumed_from = prior.as_str(),
@@ -5577,6 +5650,19 @@ pub async fn run(
             failure_kind: crate::output::FailureKind::Unknown,
             cooldown_seconds: None,
         });
+        // Stamp the verdict BEFORE the re-persist below, so the record the
+        // resume gate reads carries it. The `<verify_after>` entry pushed
+        // above is what the gate would otherwise read, and it reads a failed
+        // entry as "a model failed, so the model phase re-runs on a resume" —
+        // but that entry is not a model, nothing re-runs, and the resume
+        // recorded `Success` over a migration this run could not confirm
+        // (#1732).
+        //
+        // Not folded into `check_gate_failed`: this gate fails CLOSED on a
+        // required check that is absent from the record, and absence is not a
+        // failing check, so the check gate stays `false` on exactly the shape
+        // that matters most.
+        output.verify_after_failed = true;
         // Re-persist so `rocky history` records a Failure (status is derived
         // from the now-failed tallies), and finalize idempotency as failed.
         persist_run_record(
@@ -17381,6 +17467,7 @@ auto_create_schemas = true
             tables_copied: 0,
             tables_failed: 0,
             check_gate_failed: false,
+            verify_after_failed: false,
             tables_skipped: 0,
             excluded_tables: vec![],
             resumed_from: None,
@@ -21554,6 +21641,178 @@ backend = "local"
             super::inherited_check_gate(&store, Some(&progress2)).as_deref(),
             Some("run-2"),
             "a resume of the resume inherits the same standing gate"
+        );
+    }
+
+    /// #1732. The empty resume of a run whose `verify_after` gate could not
+    /// confirm an auto-applied migration.
+    ///
+    /// FAILS ON `main`: the failure is recorded as a synthetic
+    /// `<verify_after>` entry in `models_executed` with `status: "failed"`,
+    /// and the resume gate reads any failed entry as "a model failed, and the
+    /// model phase re-runs on a resume". That entry is not a model. The resume
+    /// skips every `Success` key, copies nothing, verifies nothing, and
+    /// derives `Success` over a schema change nobody confirmed.
+    ///
+    /// `check_gate_failed` is `false` throughout, on purpose: this is the
+    /// shape #1720's refusal cannot see (see
+    /// `drift_governance::tests::an_absent_required_check_fails_verify_after_while_the_check_gate_stays_false`).
+    #[test]
+    fn an_empty_resume_of_an_unverified_run_is_refused() {
+        use rocky_core::state::{RunStatus, StateStore, TableStatus};
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = StateStore::open(&dir.path().join("state.redb")).unwrap();
+        let now = chrono::Utc::now();
+
+        // One table, copied. The run then auto-applied additive drift whose
+        // verify_after could not be confirmed.
+        let mut out = RunOutput::new(String::new(), 0, 1);
+        out.tables_copied = 1;
+        out.tables_failed += 1;
+        out.errors.push(crate::output::TableErrorOutput {
+            asset_key: vec!["<verify_after>".to_string()],
+            error: "verify_after FAILED: row_count (absent — did not run)".to_string(),
+            failure_kind: crate::output::FailureKind::Unknown,
+            cooldown_seconds: None,
+        });
+        out.verify_after_failed = true;
+        assert!(
+            !out.check_gate_failed,
+            "the check gate cannot see an absent required check"
+        );
+
+        let record = out.to_run_record(
+            "run-1",
+            now,
+            now,
+            "cfg".to_string(),
+            rocky_core::state::RunTrigger::Manual,
+            out.derive_run_status(),
+            crate::output::RunRecordAudit::test_sentinels(),
+        );
+        assert!(
+            record.verify_after_failed,
+            "the verdict must reach the record the resume gate reads"
+        );
+        assert!(
+            record
+                .models_executed
+                .iter()
+                .any(|m| m.status.as_str() == "failed"),
+            "precondition: the synthetic entry is what admits the resume today"
+        );
+        store.record_run(&record).unwrap();
+        store.init_run_progress("run-1", 1, None).unwrap();
+        store
+            .record_table_progress(
+                "run-1",
+                &rocky_core::state::TableProgress {
+                    index: 0,
+                    table_key: "wh.raw.orders".to_string(),
+                    asset_key: vec!["wh".to_string(), "orders".to_string()],
+                    status: TableStatus::Success,
+                    error: None,
+                    duration_ms: 1,
+                    completed_at: now,
+                },
+            )
+            .unwrap();
+        let progress = store.get_run_progress("run-1").unwrap().unwrap();
+
+        let err = super::ensure_the_resume_would_do_work(&record, &progress)
+            .expect_err("a resume that would copy nothing and verify nothing must be refused");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("verify_after") && msg.contains("re-run no verification"),
+            "the refusal says what the resume would NOT do: {msg}"
+        );
+
+        // The control: the SAME record without the verdict is still admitted,
+        // which is exactly the behaviour on `main`.
+        let mut ungated = record.clone();
+        ungated.verify_after_failed = false;
+        assert!(
+            super::ensure_the_resume_would_do_work(&ungated, &progress).is_ok(),
+            "without the persisted verdict the synthetic entry admits the resume"
+        );
+
+        assert!(!matches!(record.status, RunStatus::Success));
+    }
+
+    /// #1732, the other half. A resume that IS legitimately admitted — a table
+    /// failed to copy, so real work remains — must not launder the standing
+    /// verification failure into a green record.
+    ///
+    /// `finalize_drift_verify_after` verifies only the drift the CURRENT
+    /// invocation auto-applied, so the earlier unconfirmed migration is never
+    /// re-examined. Without the carry-forward the resume has no failed table
+    /// of its own, derives `Success`, and `latest_successful_run` starts
+    /// matching it.
+    #[test]
+    fn a_resume_of_an_unverified_run_cannot_record_success() {
+        use rocky_core::state::{RunStatus, StateStore};
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = StateStore::open(&dir.path().join("state.redb")).unwrap();
+        let now = chrono::Utc::now();
+
+        // Run 1: two of three tables copied, one failed, and the post-apply
+        // verification of an auto-applied migration could not be confirmed.
+        let mut first = RunOutput::new(String::new(), 0, 3);
+        first.tables_copied = 2;
+        first.tables_failed = 1;
+        first.verify_after_failed = true;
+        let first_record = first.to_run_record(
+            "run-1",
+            now,
+            now,
+            "cfg".to_string(),
+            rocky_core::state::RunTrigger::Manual,
+            first.derive_run_status(),
+            crate::output::RunRecordAudit::test_sentinels(),
+        );
+        assert!(first_record.verify_after_failed);
+        store.record_run(&first_record).unwrap();
+        store.init_run_progress("run-1", 3, None).unwrap();
+        let progress = store.get_run_progress("run-1").unwrap().unwrap();
+
+        // The resume copies the one failed table. It auto-applies no drift, so
+        // it runs no verification at all.
+        let inherited = super::inherited_verify_after(&store, Some(&progress));
+        assert_eq!(inherited.as_deref(), Some("run-1"));
+
+        let mut resumed = RunOutput::new(String::new(), 0, 1);
+        resumed.tables_copied = 1;
+        resumed.resumed_from = Some("run-1".to_string());
+        resumed.verify_after_failed =
+            super::resolved_check_gate(resumed.verify_after_failed, inherited.as_ref());
+
+        assert!(
+            !matches!(resumed.derive_run_status(), RunStatus::Success),
+            "a resume that re-ran no verification must not report Success"
+        );
+
+        let resumed_record = resumed.to_run_record(
+            "run-2",
+            now,
+            now,
+            "cfg".to_string(),
+            rocky_core::state::RunTrigger::Manual,
+            resumed.derive_run_status(),
+            crate::output::RunRecordAudit::test_sentinels(),
+        );
+        assert!(
+            resumed_record.verify_after_failed,
+            "the standing verdict must survive onto the resumed run's own record"
+        );
+        store.record_run(&resumed_record).unwrap();
+        store.init_run_progress("run-2", 1, None).unwrap();
+        let progress2 = store.get_run_progress("run-2").unwrap().unwrap();
+        assert_eq!(
+            super::inherited_verify_after(&store, Some(&progress2)).as_deref(),
+            Some("run-2"),
+            "a resume of the resume inherits it in turn instead of clearing it by depth"
         );
     }
 
@@ -27237,6 +27496,7 @@ auto_create_schemas = true
             pipeline: None,
             submission_id: None,
             check_gate_failed: false,
+            verify_after_failed: false,
         };
         state.record_run(&failed).unwrap();
 
@@ -28566,6 +28826,7 @@ auto_create_schemas = true
             pipeline: None,
             submission_id: None,
             check_gate_failed: false,
+            verify_after_failed: false,
         };
         store.record_run(&run).unwrap();
         // The prior build's LIVE artifact — the ledger row the liveness gate
@@ -28763,6 +29024,7 @@ auto_create_schemas = true
             pipeline: None,
             submission_id: None,
             check_gate_failed: false,
+            verify_after_failed: false,
         };
         store.record_run(&base_run).unwrap();
         store
@@ -28891,6 +29153,7 @@ auto_create_schemas = true
             pipeline: None,
             submission_id: None,
             check_gate_failed: false,
+            verify_after_failed: false,
         };
         store.record_run(&run).unwrap();
 
@@ -29876,6 +30139,7 @@ auto_create_schemas = true
                 pipeline: None,
                 submission_id: None,
                 check_gate_failed: false,
+                verify_after_failed: false,
             };
             store.record_run(&run).unwrap();
             // The prior build's LIVE artifact row — the liveness gate resolves
@@ -30179,6 +30443,7 @@ auto_create_schemas = true
                     pipeline: None,
                     submission_id: None,
                     check_gate_failed: false,
+                    verify_after_failed: false,
                 })
                 .unwrap();
             // The prior live_d build's LIVE artifact-ledger row — the liveness

--- a/engine/crates/rocky-cli/src/commands/state.rs
+++ b/engine/crates/rocky-cli/src/commands/state.rs
@@ -438,6 +438,7 @@ mod retention_sweep_config_tests {
         let at = chrono::Utc::now() - chrono::Duration::days(days_old);
         RunRecord {
             check_gate_failed: false,
+            verify_after_failed: false,
             run_id: id.to_string(),
             started_at: at,
             finished_at: at,

--- a/engine/crates/rocky-cli/src/commands/trace.rs
+++ b/engine/crates/rocky-cli/src/commands/trace.rs
@@ -288,6 +288,7 @@ mod tests {
             pipeline: None,
             submission_id: None,
             check_gate_failed: false,
+            verify_after_failed: false,
         }
     }
 

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -289,6 +289,50 @@ pub struct RunOutput {
     /// "may I treat the run as green?" — the answer there is no.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub check_gate_failed: bool,
+    /// `true` when this run auto-applied additive schema drift whose
+    /// post-apply `verify_after` gate did not confirm it.
+    ///
+    /// The gate runs after the run record exists, because it reads that
+    /// record's check outcomes. It yields `Err` when a required check failed
+    /// **or did not run at all** — a required check that is absent from
+    /// `RunRecord::check_outcomes` fails it closed. There is no rollback
+    /// substrate on a plain warehouse target, so the migration stands until a
+    /// human reverts it.
+    ///
+    /// # Why this is its own field and not `check_gate_failed`
+    ///
+    /// The two verdicts do not imply one another, and the absent-check case is
+    /// exactly where they diverge:
+    ///
+    /// ```text
+    ///   a required check is ABSENT      -> verify_after fails closed
+    ///                                   -> nothing failed, so the check gate
+    ///                                      has nothing to gate on: false
+    ///   fail_on_error = false           -> every check is advisory, so the
+    ///                                      check gate is always false, while
+    ///                                      verify_after can still fail
+    /// ```
+    ///
+    /// In both, `check_gate_failed` is `false` while an auto-applied migration
+    /// stands unverified. Deriving one from the other would fail open on the
+    /// two shapes that matter most (#1732).
+    ///
+    /// # What reads it
+    ///
+    /// [`crate::commands::run`]'s resume gate, beside `check_gate_failed`. A
+    /// run that copied every table it planned and could not verify its own
+    /// migration has no copy work left for a resume to do, but it does carry a
+    /// synthetic `<verify_after>` entry in `models_executed` — and the resume
+    /// gate admits a run "because a model failed, and the model phase re-runs".
+    /// That entry is not a model, nothing re-runs, and the resume recorded
+    /// `Success` over an unconfirmed migration.
+    ///
+    /// Like `check_gate_failed`, an admitted resume inherits it: the resume
+    /// re-runs `verify_after` only for drift IT auto-applies, so an earlier
+    /// unverified migration is never re-examined. Omitted from the JSON when
+    /// `false`, so a run that verified cleanly is unchanged on the wire.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub verify_after_failed: bool,
     #[serde(default, skip_serializing_if = "is_zero")]
     pub tables_skipped: usize,
     /// Tables that the discovery adapter reported as enabled but that do not
@@ -4898,6 +4942,7 @@ impl RunOutput {
             tables_copied: 0,
             tables_failed: 0,
             check_gate_failed: false,
+            verify_after_failed: false,
             tables_skipped: 0,
             excluded_tables: vec![],
             resumed_from: None,
@@ -5272,6 +5317,13 @@ impl RunOutput {
             // or guessing from `models_executed` (which is orthogonal to it).
             // The resume gate reads exactly this field (#1720).
             check_gate_failed: self.check_gate_failed,
+            // The post-apply verification verdict, persisted for the same
+            // reason and read by the same refusal. Deliberately NOT derived
+            // from `check_gate_failed`: the two diverge on exactly the shapes
+            // that matter (a required check that is absent, and
+            // `fail_on_error = false`), so deriving one from the other fails
+            // open (#1732).
+            verify_after_failed: self.verify_after_failed,
         }
     }
 
@@ -5326,7 +5378,16 @@ impl RunOutput {
     /// meaning is a count of tables and models.
     pub fn derive_run_status(&self) -> rocky_core::state::RunStatus {
         let has_progress = self.tables_copied > 0 || !self.materializations.is_empty();
-        let has_problem = self.interrupted || self.tables_failed > 0 || self.check_gate_failed;
+        // `verify_after_failed` joins the gate for the same reason it exists: a
+        // resume that INHERITS it has `tables_failed == 0` of its own, so
+        // without this it derives `Success` and `latest_successful_run` starts
+        // matching a run whose auto-applied migration nobody confirmed
+        // (#1732). On the run that raised it, `tables_failed` was already
+        // incremented, so this changes nothing there.
+        let has_problem = self.interrupted
+            || self.tables_failed > 0
+            || self.check_gate_failed
+            || self.verify_after_failed;
         match (has_progress, has_problem) {
             (_, false) => rocky_core::state::RunStatus::Success,
             (true, true) => rocky_core::state::RunStatus::PartialFailure,

--- a/engine/crates/rocky-core/src/schedule/reconcile.rs
+++ b/engine/crates/rocky-core/src/schedule/reconcile.rs
@@ -1850,6 +1850,7 @@ cron = "also invalid"
             pipeline: Some(pipeline.to_string()),
             submission_id: submission_id.map(String::from),
             check_gate_failed: false,
+            verify_after_failed: false,
         }
     }
 

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -713,7 +713,38 @@ const SNAPSHOT_MEMORY_WARN_BYTES: u64 = 128 * 1024 * 1024;
 ///   and with it every persisted gate verdict, so a rolled-back binary
 ///   resumes a check-gated run the old way. Rolling back is not a way to
 ///   clear a gate; re-running the pipeline is.
-const CURRENT_SCHEMA_VERSION: u32 = 25;
+///
+/// - **v26** — persists the post-apply verification verdict beside the check
+///   gate: a new serde-additive [`RunRecord::verify_after_failed`] flag. Same
+///   shape as v25 in every respect — no table change, no blob walk, and a v25
+///   blob forward-deserializes with it `false`, guarded by
+///   `test_v25_run_record_forward_deserializes_verify_after_failed_false`.
+///
+///   **Why a second flag and not a wider `check_gate_failed` (#1732).** The
+///   two verdicts do not imply one another, and they diverge on exactly the
+///   shapes that matter. `verify_after` fails **closed** on a required check
+///   that is ABSENT from `check_outcomes`; absence is not a failing check, so
+///   the check gate has nothing to gate on and stays `false`. And under
+///   `[pipeline.<name>.checks] fail_on_error = false` every check is
+///   advisory, so the check gate is *always* `false` while `verify_after` can
+///   still fail. In both, an auto-applied migration stands unverified while
+///   `check_gate_failed` says the run was fine. Folding the two would fail
+///   open on precisely the runs this flag exists to catch.
+///
+///   **What it buys.** The resume gate can refuse a run that copied every
+///   table it planned and could not verify its own migration. Before this,
+///   that run carried a synthetic `<verify_after>` entry in
+///   `models_executed`, and the resume gate reads a failed entry as "a model
+///   failed, and the model phase re-runs on a resume" — but that entry is not
+///   a model, nothing re-runs, and the resume recorded `Success` over an
+///   unconfirmed schema migration.
+///
+///   **On upgrade and rollback.** Identical to v25: a v25 store is stamped
+///   v26 in place, existing records read back `false` (honest but lossy for
+///   runs recorded before this binary), and the blob is backward-safe while
+///   the OPEN-time version check is what actually engages
+///   `[state] on_schema_mismatch`.
+const CURRENT_SCHEMA_VERSION: u32 = 26;
 
 /// Errors from the embedded redb state store.
 #[derive(Debug, Error)]
@@ -2387,6 +2418,31 @@ pub struct RunRecord {
     /// `test_v24_run_record_forward_deserializes_check_gate_failed_false`.
     #[serde(default)]
     pub check_gate_failed: bool,
+    /// `true` when this run auto-applied additive schema drift whose
+    /// post-apply `verify_after` gate did not confirm it. The persisted twin
+    /// of `RunOutput::verify_after_failed`, written by `to_run_record`.
+    ///
+    /// **Why it is not [`Self::check_gate_failed`].** The gate fails **closed**
+    /// on a required check that is ABSENT from [`Self::check_outcomes`], and
+    /// absence is not a failing check — so the check gate has nothing to gate
+    /// on and stays `false`. Under `fail_on_error = false` the check gate is
+    /// always `false` while this one can still trip. In both, a migration
+    /// stands unverified while `check_gate_failed` reports the run was fine
+    /// (#1732).
+    ///
+    /// **Why it is not re-derived at read time.** The verdict depends on the
+    /// policy in force when the run executed, on which checks that policy
+    /// required, and on which of them the run recorded — a later reader has
+    /// the last of those and not the first two.
+    ///
+    /// `false` on pre-v26 records and on every run that verified cleanly or
+    /// auto-applied no drift at all.
+    ///
+    /// Serde-defaulted so a v25 blob forward-deserializes with it `false`;
+    /// guarded by
+    /// `test_v25_run_record_forward_deserializes_verify_after_failed_false`.
+    #[serde(default)]
+    pub verify_after_failed: bool,
 }
 
 /// One executed data-quality check's pass/fail outcome, captured on a
@@ -7005,6 +7061,7 @@ mod tests {
             pipeline: None,
             submission_id: None,
             check_gate_failed: false,
+            verify_after_failed: false,
         }
     }
 
@@ -7076,6 +7133,49 @@ mod tests {
             serde_json::from_slice(&serde_json::to_vec(&stamped).unwrap()).unwrap();
         assert_eq!(round.pipeline.as_deref(), Some("raw"));
         assert_eq!(round.submission_id.as_deref(), Some("sub-123"));
+    }
+
+    /// v25 → v26 (#1732). A v25 `RunRecord` blob has no `verify_after_failed`
+    /// key at all. It must forward-deserialize with the field `false`, for the
+    /// same reason and with the same bounded fail-open as the v25 bump below:
+    /// a v25 record carries no verification verdict to honour, so refusing its
+    /// resume would refuse every legitimate pre-upgrade resume.
+    ///
+    /// The pair matters as much as either field: a record can carry
+    /// `check_gate_failed = false` and `verify_after_failed = true` at once,
+    /// and that combination is the whole point — `verify_after` fails closed
+    /// on a required check that is ABSENT, which the check gate cannot see.
+    #[test]
+    fn test_v25_run_record_forward_deserializes_verify_after_failed_false() {
+        let mut value = serde_json::to_value(minimal_run_record("run-v25", vec![]))
+            .expect("serialize run record");
+        let obj = value.as_object_mut().expect("record is an object");
+        assert!(
+            obj.remove("verify_after_failed").is_some(),
+            "precondition: the field is serialized, so removing it models a v25 blob"
+        );
+        let blob = serde_json::to_vec(&value).expect("reserialize without the field");
+
+        let record: RunRecord =
+            serde_json::from_slice(&blob).expect("a v25 RunRecord must forward-deserialize");
+        assert_eq!(record.run_id, "run-v25");
+        assert!(
+            !record.verify_after_failed,
+            "a pre-v26 record reads as no verification verdict recorded"
+        );
+
+        // A v26 record carrying the flag round-trips, and carries it
+        // INDEPENDENTLY of the check gate.
+        let mut unverified = minimal_run_record("run-v26", vec![]);
+        unverified.verify_after_failed = true;
+        assert!(!unverified.check_gate_failed);
+        let round: RunRecord =
+            serde_json::from_slice(&serde_json::to_vec(&unverified).unwrap()).unwrap();
+        assert!(round.verify_after_failed);
+        assert!(
+            !round.check_gate_failed,
+            "the two verdicts are separate on the wire, not derived from each other"
+        );
     }
 
     /// v24 → v25 (#1720). A v24 `RunRecord` blob has no `check_gate_failed`
@@ -12038,7 +12138,11 @@ mod tests {
         // field. NO table change — `EXPECTED_TABLES` is deliberately
         // unchanged below — so this stanza moves the version only; guarded by
         // `test_v24_run_record_forward_deserializes_check_gate_failed_false`.
-        const EXPECTED_VERSION: u32 = 25;
+        // v26 adds `RunRecord::verify_after_failed` (#1732), the same
+        // serde-additive shape. NO table change either — so this stanza moves
+        // the version only; guarded by
+        // `test_v25_run_record_forward_deserializes_verify_after_failed_false`.
+        const EXPECTED_VERSION: u32 = 26;
         const EXPECTED_TABLES: &[&str] = &[
             "branches",
             "check_history",

--- a/engine/crates/rocky-core/tests/e2e.rs
+++ b/engine/crates/rocky-core/tests/e2e.rs
@@ -516,6 +516,7 @@ fn test_run_history_flow() {
         pipeline: None,
         submission_id: None,
         check_gate_failed: false,
+        verify_after_failed: false,
     };
 
     store.record_run(&run).unwrap();

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -4267,6 +4267,7 @@ fn seed_run_history(models_dir: &Path) {
         pipeline: None,
         submission_id: None,
         check_gate_failed: false,
+        verify_after_failed: false,
     };
     store.record_run(&run).expect("record run");
 

--- a/engine/rocky/tests/replay_check.rs
+++ b/engine/rocky/tests/replay_check.rs
@@ -169,6 +169,7 @@ fn record_run(store: &StateStore, models: &[&str]) {
             pipeline: None,
             submission_id: None,
             check_gate_failed: false,
+            verify_after_failed: false,
         })
         .expect("record run");
 }

--- a/engine/rocky/tests/replay_dag.rs
+++ b/engine/rocky/tests/replay_dag.rs
@@ -191,6 +191,7 @@ fn record_run(store: &StateStore, models: &[&str]) {
             pipeline: None,
             submission_id: None,
             check_gate_failed: false,
+            verify_after_failed: false,
         })
         .expect("record run");
 }

--- a/engine/rocky/tests/replay_execute.rs
+++ b/engine/rocky/tests/replay_execute.rs
@@ -173,6 +173,7 @@ fn record_run(store: &StateStore, models: &[&str]) {
             pipeline: None,
             submission_id: None,
             check_gate_failed: false,
+            verify_after_failed: false,
         })
         .expect("record run");
 }

--- a/integrations/dagster/tests/fixtures_generated/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor.json
@@ -17,7 +17,7 @@
     {
       "name": "state_schema",
       "status": "healthy",
-      "message": "state schema v25 matches this binary",
+      "message": "state schema v26 matches this binary",
       "duration_ms": 0
     },
     {

--- a/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
@@ -17,7 +17,7 @@
     {
       "name": "state_schema",
       "status": "healthy",
-      "message": "no on-disk state schema (binary supports v25)",
+      "message": "no on-disk state schema (binary supports v26)",
       "duration_ms": 0
     },
     {

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 25,
-  "schema_version_on_disk": 25
+  "schema_version_supported": 26,
+  "schema_version_on_disk": 26
 }

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 25,
-  "schema_version_on_disk": 25
+  "schema_version_supported": 26,
+  "schema_version_on_disk": 26
 }

--- a/integrations/dagster/tests/fixtures_generated/state.json
+++ b/integrations/dagster/tests/fixtures_generated/state.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 25,
-  "schema_version_on_disk": 25
+  "schema_version_supported": 26,
+  "schema_version_on_disk": 26
 }

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -1368,6 +1368,10 @@
       "minimum": 0.0,
       "type": "integer"
     },
+    "verify_after_failed": {
+      "description": "`true` when this run auto-applied additive schema drift whose post-apply `verify_after` gate did not confirm it.\n\nThe gate runs after the run record exists, because it reads that record's check outcomes. It yields `Err` when a required check failed **or did not run at all** — a required check that is absent from `RunRecord::check_outcomes` fails it closed. There is no rollback substrate on a plain warehouse target, so the migration stands until a human reverts it.\n\n# Why this is its own field and not `check_gate_failed`\n\nThe two verdicts do not imply one another, and the absent-check case is exactly where they diverge:\n\n```text a required check is ABSENT      -> verify_after fails closed -> nothing failed, so the check gate has nothing to gate on: false fail_on_error = false           -> every check is advisory, so the check gate is always false, while verify_after can still fail ```\n\nIn both, `check_gate_failed` is `false` while an auto-applied migration stands unverified. Deriving one from the other would fail open on the two shapes that matter most (#1732).\n\n# What reads it\n\n[`crate::commands::run`]'s resume gate, beside `check_gate_failed`. A run that copied every table it planned and could not verify its own migration has no copy work left for a resume to do, but it does carry a synthetic `<verify_after>` entry in `models_executed` — and the resume gate admits a run \"because a model failed, and the model phase re-runs\". That entry is not a model, nothing re-runs, and the resume recorded `Success` over an unconfirmed migration.\n\nLike `check_gate_failed`, an admitted resume inherits it: the resume re-runs `verify_after` only for drift IT auto-applies, so an earlier unverified migration is never re-examined. Omitted from the JSON when `false`, so a run that verified cleanly is unchanged on the wire.",
+      "type": "boolean"
+    },
     "version": {
       "type": "string"
     }

--- a/sdk/python/src/rocky_sdk/types.py
+++ b/sdk/python/src/rocky_sdk/types.py
@@ -466,6 +466,14 @@ class RunResult(BaseModel):
     #: and when ``fail_on_error = false``. Count :attr:`check_results` for the
     #: number of failed checks. Omitted from the wire when ``False``.
     check_gate_failed: bool = False
+    #: ``True`` when the run auto-applied additive schema drift whose post-apply
+    #: ``verify_after`` gate did not confirm it. A separate verdict from
+    #: :attr:`check_gate_failed`, not derivable from it: ``verify_after`` fails
+    #: closed on a required check that is *absent* from the run record, and an
+    #: absent check is not a failing one, so the check gate stays ``False``.
+    #: There is no rollback on a warehouse target — the migration stands until a
+    #: human reverts it. Omitted from the wire when ``False``.
+    verify_after_failed: bool = False
     #: Tables short-circuited via the idempotency key. Defaults to 0.
     tables_skipped: int = 0
     materializations: list[MaterializationInfo]

--- a/sdk/python/src/rocky_sdk/types_generated/run_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/run_schema.py
@@ -868,4 +868,24 @@ class RunOutput(BaseModel):
     Total number of failed tables/models for the run, **including** pre-execution compile failures: a model that fails to type-check is counted here even though it never reached the execution phase. This is the authoritative failure count — consumers should key overall pass/fail on the top-level `tables_failed` / `status` / `errors`, not on `execution.tables_failed`, which counts only execution-phase (copy / runtime) failures and excludes models excluded before execution.
     """
     tables_skipped: conint(ge=0) | None = None
+    verify_after_failed: bool | None = None
+    """
+    `true` when this run auto-applied additive schema drift whose post-apply `verify_after` gate did not confirm it.
+
+    The gate runs after the run record exists, because it reads that record's check outcomes. It yields `Err` when a required check failed **or did not run at all** — a required check that is absent from `RunRecord::check_outcomes` fails it closed. There is no rollback substrate on a plain warehouse target, so the migration stands until a human reverts it.
+
+    # Why this is its own field and not `check_gate_failed`
+
+    The two verdicts do not imply one another, and the absent-check case is exactly where they diverge:
+
+    ```text a required check is ABSENT      -> verify_after fails closed -> nothing failed, so the check gate has nothing to gate on: false fail_on_error = false           -> every check is advisory, so the check gate is always false, while verify_after can still fail ```
+
+    In both, `check_gate_failed` is `false` while an auto-applied migration stands unverified. Deriving one from the other would fail open on the two shapes that matter most (#1732).
+
+    # What reads it
+
+    [`crate::commands::run`]'s resume gate, beside `check_gate_failed`. A run that copied every table it planned and could not verify its own migration has no copy work left for a resume to do, but it does carry a synthetic `<verify_after>` entry in `models_executed` — and the resume gate admits a run "because a model failed, and the model phase re-runs". That entry is not a model, nothing re-runs, and the resume recorded `Success` over an unconfirmed migration.
+
+    Like `check_gate_failed`, an admitted resume inherits it: the resume re-runs `verify_after` only for drift IT auto-applies, so an earlier unverified migration is never re-examined. Omitted from the JSON when `false`, so a run that verified cleanly is unchanged on the wire.
+    """
     version: str


### PR DESCRIPTION
A resume could report `Success` over a schema migration whose verification failed.

`rocky run` auto-applies additive schema drift under a policy rule, then verifies it with that rule's `verify_after` checks. When the verification fails there is no rollback on a warehouse target: the migration stands and the run halts so a human can look at it.

The failure was recorded as a synthetic `<verify_after>` entry in `models_executed` with `status: "failed"`. The resume gate reads any failed entry as "a model failed, and the model phase re-runs on a resume". That entry is not a model, so nothing re-ran:

```
run 1   copies every table, applies drift, verify_after FAILS  -> exit 2
resume  skips every Success key -> copies nothing, verifies nothing
        -> derives Success
```

`latest_successful_run` matches on exactly `Success`, so every downstream `after` demand then fired on a schema change nobody confirmed.

## Why #1720's fix did not already cover it

#1720 persists the **check gate**. The two verdicts diverge on exactly the shapes that matter here:

| shape | `verify_after` | `check_gate_failed` |
|---|---|---|
| a required check is **absent** from the record | fails **closed** on it | an absent check is not a failing check, so there is nothing to gate on: `false` |
| `fail_on_error = false` | can still fail | **always** `false` — every check is advisory |

Deriving one from the other fails open on both. So this is its own verdict: `RunOutput::verify_after_failed` on the wire, `RunRecord::verify_after_failed` in the store, read by the resume gate beside `check_gate_failed` and **ahead of** the `models_executed` branch that admits the run today.

## Both halves, as #1720 did

The **refusal** covers the empty resume — the issue's case.

The **carry-forward** covers the admitted one: run N applied drift, failed verification, *and* a table failed to copy. That resume is legitimately admitted on the failed table, but `finalize_drift_verify_after` verifies only the drift the current invocation applied, so the earlier unconfirmed migration is never re-examined. Left alone it derives `Success` one level up and the hole is unchanged.

I verified this half is reachable rather than assuming it: the `verify_after` call site sits on the linear path after the copy errors are merged into the output, not behind a success branch.

`derive_run_status` reads the flag for the same reason — an inheriting resume has `tables_failed == 0` of its own, so without it the carry-forward would be cosmetic. On the run that *raised* the verdict `tables_failed` was already incremented, so nothing moves there.

## Evidence

The coverage probe is the part worth reading.

**Mutation 1 — delete the refusal.** `an_empty_resume_of_an_unverified_run_is_refused` fails. Fix-sensitive.

**Mutation 2 — delete the stamp** (`output.verify_after_failed = true;`). **All 1819 rocky-cli tests passed.** Every test that asserted the verdict set it by hand, so nothing proved the runner sets it at all. That is a real hole, found by probing rather than by confirming.

No behavioural unit test can reach that site: it needs a real warehouse, real additive drift, a policy rule with `verify_after`, and a required check that does not run. So the claim is asserted over the file's own source — the shape `the_inherited_gate_is_stamped_before_the_interrupt_path_persists` already uses for the same reason. Re-running mutation 2 now fails, as it should.

The ordering half matters as much as the existence half: two `persist_run_record` calls bracket that branch, and the first necessarily writes `false`. A stamp landing after the second would leave that `false` standing in the record the resume gate reads. The guard asserts `push < stamp < re-persist`.

Tests added:

- `an_empty_resume_of_an_unverified_run_is_refused` — the issue's case, with the control: the same record without the verdict is still admitted, which is `main`'s behaviour.
- `a_resume_of_an_unverified_run_cannot_record_success` — the carry-forward, including a resume-of-the-resume so the verdict is not cleared by depth.
- `an_absent_required_check_fails_verify_after_while_the_check_gate_stays_false` — the discriminating case, in `drift_governance`. This is the one that cannot pass for the wrong reason.
- `the_verify_after_verdict_is_stamped_before_the_failure_branch_repersists` — the source-order guard above.
- `test_v25_run_record_forward_deserializes_verify_after_failed_false` — and that a record can carry `check_gate_failed: false` with `verify_after_failed: true`, which is the whole point.

Gates: `cargo test -p rocky-cli -p rocky-core --lib` 1820 + 2133 pass; SDK 256 pass; dagster 766 pass; clippy `--all-targets --all-features` clean; `cargo fmt --check` clean; `just codegen` re-run is a no-op.

## State schema v25 → v26

Serde-additive, no table change, no blob walk. A v25 blob forward-deserializes with the field `false` — the same bounded fail-open v25 itself chose, because a record that carries no verdict has none to honour. `EXPECTED_VERSION` and the doctor/state fixtures move with it.

## Codegen

`RunOutput` gained a field, so `just codegen` regenerated `schemas/run.schema.json`, the Pydantic model, the TypeScript interface and `docs/public/openapi.json`, and `just regen-fixtures` recaptured the dagster corpus (the v25 → v26 strings in `doctor.json` and `state.json`). `skip_serializing_if` mirrors `check_gate_failed`, so a run that verified cleanly is unchanged on the wire. The hand-written `rocky_sdk/types.py` model carries the field too — `test_schema_parity.py` guards only top-level shape.

`editors/vscode/package-lock.json` is **deliberately not** in this PR: `just codegen` runs `npm install`, and my npm strips the `libc` platform fields CI's npm writes. That diff is an npm-version artifact, not part of the cascade.

## What I am least confident about

**The carry-forward's stopping condition.** Once `verify_after_failed` is set it is only ever OR-ed forward, exactly like `check_gate_failed`, so a project cannot clear it by resuming — only by re-running the pipeline. That is deliberate and matches #1720, and it is the right direction for an unverified migration. But `check_gate_failed` clears when the data is fixed and the checks re-run; an unverified *migration* has no equivalent "it's fine now" signal short of a human reverting it, so in practice this flag is stickier than its sibling. If that turns out to be wrong for real operators, the clearing rule is the thing to revisit, not the refusal.

**Second:** I did not exercise the real `rocky run` path end-to-end. Mutation 2 is precisely why I am saying so — the site is unreachable from a unit test, and a source-order guard proves the stamp is *there*, not that the surrounding branch behaves as I read it.

## The most important thing I might be missing

**Whether `verify_after_failed` belongs in `derive_run_status` at all.** I put it there because the carry-forward is otherwise cosmetic, and I checked it changes nothing for the run that raises it (`tables_failed` was already incremented). What I have not traced is every consumer of `RunStatus` for a run that *inherits* it — a resume that copies its tables cleanly now reports `PartialFailure` where it used to report `Success`. That is the intended behaviour and it mirrors `check_gate_failed` exactly, but "mirrors the sibling" is a claim about the sibling's consumers, not this one's.

## Review

Reviewed by me at high effort, and **not** by an independent model: same-model review, which does not satisfy the `AGENTS.md` independence requirement. Flagging rather than skipping silently.

Refs #1732, #1720, #1598.
