### PR TITLE
test(engine/rocky-cli): anchor the source-text guards on the test module, not the first #[cfg(test)]

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -13742,13 +13742,59 @@ mod tests {
     /// asymmetry from coming back: the singular `record_partition` cannot
     /// reappear in this file, because every use of it here would be a
     /// leading-key-only write.
+    /// This file's PRODUCTION half, whitespace-stripped, for the source-text
+    /// guards below.
+    ///
+    /// One helper because the anchor is the easy thing to get wrong, and
+    /// getting it wrong is silent. Cutting at the first `\n#[cfg(test)]` looks
+    /// right and is not: `build_replication_strategy` is a `#[cfg(test)]`
+    /// helper sitting ~1,600 lines ABOVE the test module, so that anchor ends
+    /// the scan there and every production line after it goes unread. A guard
+    /// that scans nothing passes (#1725).
+    ///
+    /// Whitespace is stripped so `cargo fmt` wrapping a call across lines
+    /// cannot silently zero a count. Write the needles without spaces to
+    /// match: `.record_partition(`, `batch_records(&record)`.
+    fn production_source() -> String {
+        let full = include_str!("run.rs");
+        let cut = full
+            .find("\n#[cfg(test)]\nmod tests {")
+            .expect("the test module header moved; re-anchor production_source()");
+        full[..cut].chars().filter(|c| !c.is_whitespace()).collect()
+    }
+
+    /// The anchor `production_source` does NOT use, and why. Pins the gap so a
+    /// later reader sees that the two differ and by how much, instead of
+    /// rediscovering it the way #1725 did.
+    #[test]
+    fn the_production_cut_reaches_past_the_mid_file_cfg_test_helper() {
+        let full = include_str!("run.rs");
+        let naive = full
+            .find("\n#[cfg(test)]")
+            .expect("a #[cfg(test)] attribute");
+        let anchored = full
+            .find("\n#[cfg(test)]\nmod tests {")
+            .expect("the test module header");
+        assert!(
+            naive < anchored,
+            "a #[cfg(test)] item sits above the test module — that is the whole \
+             reason production_source() anchors on the module header (#1725)"
+        );
+        let blind_spot = full[naive..anchored].lines().count();
+        assert!(
+            blind_spot > 100,
+            "the blind spot the naive anchor would create is {blind_spot} lines; if it \
+             has shrunk to nothing the mid-file #[cfg(test)] helper is gone and this \
+             test can go with it"
+        );
+    }
+
     #[test]
     fn every_partition_status_write_covers_the_whole_batch() {
         // PRODUCTION code only. This test's own body mentions the singular
         // form in its assertion message, and would otherwise match itself —
         // which it did on the first run.
-        let full = include_str!("run.rs");
-        let src = &full[..full.find("\n#[cfg(test)]").expect("a test module")];
+        let src = production_source();
         let singular = src.matches(".record_partition(").count();
         assert_eq!(
             singular, 0,
@@ -13758,7 +13804,7 @@ mod tests {
         );
         // And the batch helper is actually the thing being used.
         assert!(
-            src.contains("let batch_records ="),
+            src.contains("letbatch_records="),
             "the shared batch_records helper is gone — the three status writes can \
              drift apart again"
         );
@@ -33424,18 +33470,9 @@ timestamp_column = "ts"
     #[test]
     fn one_collector_consumes_every_materialized_table() {
         // PRODUCTION code only — the test module below calls the collector too.
-        // Anchored on the module header, not on a bare `#[cfg(test)]`: this
-        // file has a test-only helper (`build_replication_strategy`) sitting in
-        // the middle of the production half, so cutting at the first
-        // `#[cfg(test)]` would drop everything after it from the scan.
-        let full = include_str!("run.rs");
-        let src = &full[..full
-            .find("\n#[cfg(test)]\nmod tests {")
-            .expect("the test module header")];
-
-        // Whitespace-stripped, so `cargo fmt` wrapping a call across lines
-        // cannot silently zero either count.
-        let compact: String = src.chars().filter(|c| !c.is_whitespace()).collect();
+        // Through the shared helper, which owns both the anchor and the
+        // whitespace stripping (#1725).
+        let compact = production_source();
         assert_eq!(
             compact.matches(".assertion_targets.push(").count(),
             1,


### PR DESCRIPTION
`every_partition_status_write_covers_the_whole_batch` guards a real invariant — every partition-status write must cover the whole batch, never just the leading key (#1488 / #1496) — by scanning this file's own source.

It cut the production half at the **first** `\n#[cfg(test)]`. That is not the test module. A `#[cfg(test)] fn build_replication_strategy` sits well above it, so the scan ended there and never read the production code below.

```
line 12136   the first #[cfg(test)]  <- the old cut ended here
   ...       1,591 lines the guard never read
line 13727   #[cfg(test)] mod tests {  <- where it should end
```

## The measurement

Planting `.record_partition(` inside the blind spot:

```
old anchor  sees 0 occurrences  -> MISSED
new anchor  sees 1 occurrence   -> CAUGHT
```

The guard had been passing on code it could not read.

**No live violation today** — both anchors currently count 0. This restores coverage rather than fixing a bug, and I would rather say that plainly than dress it up: the value here is that the next `.record_partition(` added below line 12136 is now caught.

## The change

Both source-text guards in this file now go through one `production_source()` helper that owns the anchor **and** the whitespace stripping. #1718's guard already had both right; the older one had neither. Sharing the helper is the point — the anchor is the easy thing to get wrong and getting it wrong is silent, so a third guard should not get to choose again.

`the_production_cut_reaches_past_the_mid_file_cfg_test_helper` pins the gap between the two anchors and asserts it is non-trivial, so the reason the helper exists is visible in the test suite instead of waiting to be rediscovered. If the mid-file `#[cfg(test)]` helper is ever removed, that test says so and can go with it.

The partition guard also picks up the whitespace stripping it lacked: `.record_partition(` is a method call `cargo fmt` can split across lines, which would have zeroed the count silently. The needles are written without spaces to match (`letbatch_records=`).

Gates: `cargo test -p rocky-cli --lib` 1817 pass, clippy `--all-targets` clean, `cargo fmt --check` clean. No CHANGELOG entry — test-only, no user-visible behaviour change.

## What I am least confident about

**Whether a source-text guard is the right instrument at all here.** It cannot tell code from a comment or a string literal, so a doc comment mentioning `.record_partition(` would now fail the build in a way that reads as a false alarm. That is the trade the existing guards already made, and widening the scan widens the exposure. I kept the instrument because replacing it is a different change; if it starts crying wolf, the fix is a real lint, not a narrower anchor.

## The most important thing I might be missing

I asked whether other source-text guards share the anchor bug, and swept for it rather than leaving it as a worry. Every `include_str!` guard in `engine/crates/`, and how each scopes:

| guard | scoping | exposed? |
|---|---|---|
| `run.rs` partition + collector | cut at the `#[cfg(test)]` **module header** | fixed here |
| `rocky-mcp/tools.rs` | whole file; needle built with `format!` so the test's own text cannot self-match | no cut, immune |
| `rocky-core/product/commit.rs` | same `format!` technique | immune |
| `api.rs` | scoped to one function body, by exact signature | different anchor entirely |

After this change the only remaining bare `\n#[cfg(test)]` anchor in the workspace is the one inside `the_production_cut_reaches_past_the_mid_file_cfg_test_helper`, which uses it deliberately to measure the gap.

So the residual risk is not another file. It is the instrument itself, above.

Refs #1725, #1718, #1496.

## Review

Reviewed by me at high effort, and **not** by an independent model: same-model review, which does not satisfy the `AGENTS.md` independence requirement. Flagging rather than skipping silently.
