### PR TITLE
fix(dagster): a check-gated Rocky run must not finish as a green step

### DIFF
--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -3308,6 +3308,17 @@ def _log_run_diagnostics(
     """
     for err in result.errors:
         context.log.error(f"Table failed: {err.error}")
+    # The engine's own verdict on its checks. Nothing in this package read it
+    # before #1728: `RockyClient.run` passes `allow_partial=True`, so a
+    # check-gated exit 2 comes back as a parsed result rather than raising, and
+    # the step finished successful while the engine said it had failed the run.
+    if result.check_gate_failed:
+        context.log.error(
+            "Rocky failed this run on its checks (check_gate_failed): at least one "
+            "error-severity check failed or could not be evaluated while fail_on_error "
+            "was on. A resumed run can also inherit a standing gate from the run it "
+            "resumed, in which case this run's own check_results are clean."
+        )
 
 
 #: Metadata key stamped on the :class:`dg.AssetObservation` that carries a
@@ -3526,9 +3537,32 @@ def _emit_results(
         )
 
     yielded_checks: set[tuple[dg.AssetKey, str]] = set(extra_yielded_checks or ())
+    # Failing checks this step could not report as checks, for the gate
+    # backstop at the end. A cross_source_overlap verdict is a GROUP check the
+    # engine attaches to one sibling in materialization order, so the carrier
+    # is not knowable when specs are built — a partial selection that spans
+    # every source but omits the carrier drops the whole result (#1728).
+    unreported_failures: list[str] = []
+    failing_checks_yielded = False
     for table_check in table_checks:
         asset_key = remap(table_check.asset_key)
         if asset_key not in selected_keys:
+            # Dropped by the selection filter, which runs BEFORE the
+            # declaration filter below — so `_undeclared_check_observation`
+            # never saw it and #1709's fix did not reach this path. An
+            # observation is not available either: Dagster rejects an event on
+            # an asset outside the step. Name it in the log and remember it, so
+            # a gated run cannot finish green on silence (#1728).
+            failing = [c for c in table_check.checks if not c.passed]
+            for check in failing:
+                unreported_failures.append(f"{asset_key.to_user_string()}:{check.name}")
+                (log or _log).warning(
+                    "Rocky reported a FAILED check '%s' on %s, which this step did not "
+                    "select — it cannot be recorded as an asset check here. %s",
+                    check.name,
+                    asset_key.to_user_string(),
+                    check.not_evaluated or "",
+                )
             continue
         for check in table_check.checks:
             # Sanitize the engine name (it may carry ``:`` / ``.`` separators,
@@ -3558,6 +3592,10 @@ def _emit_results(
                 )
                 continue
             yielded_checks.add(spec_key)
+            if not check.passed:
+                # The gate backstop below stays quiet while a failing check is
+                # visible as a check.
+                failing_checks_yielded = True
             yield dg.AssetCheckResult(
                 asset_key=asset_key,
                 check_name=check_name,
@@ -3707,6 +3745,44 @@ def _emit_results(
         instance=instance,
         log=log or _log,
     )
+
+    # THE BACKSTOP (#1728). Raised after every event above is yielded, the same
+    # ordering `_emit_derived_model_results` uses for containment: the step's
+    # real results are recorded first, then it fails.
+    #
+    # The engine failed this run on its checks. `RockyClient.run` passes
+    # `allow_partial=True`, so that exit 2 comes back as a parsed result rather
+    # than raising — and if the failing check could not be reported as an asset
+    # check, the step finished GREEN while the engine said it had failed.
+    #
+    # Deliberately narrow, so it never fires on the ordinary shape: if any
+    # failing AssetCheckResult was yielded, the gate is already visible in the
+    # UI and on the asset's health, and this stays quiet. It fires only when the
+    # gate stands and nothing in this step explains it — a group check whose
+    # carrier sibling is outside the selection, a check whose spec was never
+    # declared, or a resume that inherited a standing gate with clean
+    # check_results of its own (#1720).
+    gated = [r for r in results if r.check_gate_failed]
+    if gated and not failing_checks_yielded:
+        detail = (
+            "\n\nFailing checks this step could not report as asset checks:\n  "
+            + "\n  ".join(unreported_failures)
+            if unreported_failures
+            else (
+                "\n\nNo failing check reached this step at all. Either the failing "
+                "check's asset is outside this step's selection, its spec was never "
+                "declared, or this run inherited a standing gate from the run it "
+                "resumed (its own check_results are clean in that case)."
+            )
+        )
+        raise dg.Failure(
+            description=(
+                "Rocky failed this run on its checks (check_gate_failed), but no failing "
+                "asset check in this step explains it — so the step would otherwise have "
+                "finished successfully. Refusing to report green on a run the engine "
+                "gated." + detail
+            ),
+        )
 
 
 def _empty_output_results(

--- a/integrations/dagster/tests/test_check_gate_backstop.py
+++ b/integrations/dagster/tests/test_check_gate_backstop.py
@@ -1,0 +1,175 @@
+"""A check-gated Rocky run must not finish as a green Dagster step (#1728).
+
+Two filters run in ``_emit_results``, in this order:
+
+    1. selection    `asset_key not in selected_keys`  -> the whole result dropped
+    2. declaration  `spec_key not in declared_checks` -> observation (#1709)
+
+#1709 fixed the second. The first still dropped everything — no check, no
+observation, no log — and it is the one a ``cross_source_overlap`` verdict
+lands behind, because the engine attaches that group check to one sibling in
+materialization order, so the carrier is not knowable when specs are built.
+
+Underneath sat the run-level twin: nothing in this package read
+``check_gate_failed``. ``RockyClient.run`` passes ``allow_partial=True``, so a
+check-gated exit 2 comes back parsed rather than raising. The engine said "I
+failed this run on a check" and the step finished successful.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import dagster as dg
+import pytest
+
+from dagster_rocky.component import _emit_results
+from dagster_rocky.types import (
+    CheckResult,
+    DriftInfo,
+    ExecutionSummary,
+    PermissionInfo,
+    RunResult,
+    TableCheckResult,
+)
+
+CARRIER = dg.AssetKey(["fivetran", "acme", "us_west", "shopify", "orders"])
+SIBLING = dg.AssetKey(["fivetran", "acme", "us_east", "shopify", "orders"])
+CARRIER_ROCKY = ("fivetran", "acme", "us_west", "shopify", "orders")
+SIBLING_ROCKY = ("fivetran", "acme", "us_east", "shopify", "orders")
+MAPPING = {CARRIER_ROCKY: CARRIER, SIBLING_ROCKY: SIBLING}
+OVERLAP = "cross_source_overlap:fivetran.orders"
+
+
+def _run_result(
+    *,
+    check_results: list[TableCheckResult] | None = None,
+    check_gate_failed: bool = False,
+) -> RunResult:
+    return RunResult(
+        version="0.3.0",
+        command="run",
+        filter="tenant=acme",
+        duration_ms=1000,
+        tables_copied=0,
+        tables_failed=0,
+        check_gate_failed=check_gate_failed,
+        materializations=[],
+        check_results=check_results or [],
+        execution=ExecutionSummary(concurrency=4, tables_processed=0, tables_failed=0),
+        permissions=PermissionInfo(
+            grants_added=0, grants_revoked=0, catalogs_created=0, schemas_created=0
+        ),
+        drift=DriftInfo(tables_checked=0, tables_drifted=0, actions_taken=[]),
+        anomalies=[],
+        errors=[],
+    )
+
+
+def _failing_overlap_on_carrier() -> TableCheckResult:
+    return TableCheckResult(
+        asset_key=list(CARRIER_ROCKY),
+        checks=[CheckResult(name=OVERLAP, passed=False)],
+    )
+
+
+def test_a_gated_run_whose_failing_check_is_outside_the_selection_fails_the_step(caplog):
+    """The shape #1669 was filed for, still live after #1709.
+
+    The selection spans the group but omits the carrier sibling — an ordinary
+    partial selection. Before #1728 this produced NO event of any kind and a
+    successful step.
+    """
+    result = _run_result(
+        check_results=[_failing_overlap_on_carrier()],
+        check_gate_failed=True,
+    )
+
+    with caplog.at_level(logging.WARNING), pytest.raises(dg.Failure) as excinfo:
+        list(
+            _emit_results(
+                results=[result],
+                check_specs=[],
+                # The carrier is NOT selected.
+                selected_keys={SIBLING},
+                rocky_key_to_dagster_key=MAPPING,
+            )
+        )
+
+    description = excinfo.value.description or ""
+    assert "check_gate_failed" in description
+    assert "Refusing to report green" in description
+    # The refusal names what it could not report, not just that something went
+    # wrong — the operator has to know which check to go look at.
+    assert OVERLAP in description
+    assert OVERLAP in caplog.text, caplog.text
+
+
+def test_a_gated_run_with_a_visible_failing_check_does_not_double_report(caplog):
+    """The control. A failing check the step CAN report is already visible in
+    the UI and on the asset's health, so the backstop stays quiet — otherwise
+    every ordinary check failure would become a step-level exception too."""
+    result = _run_result(
+        check_results=[_failing_overlap_on_carrier()],
+        check_gate_failed=True,
+    )
+
+    events = list(
+        _emit_results(
+            results=[result],
+            check_specs=[
+                dg.AssetCheckSpec(name="cross_source_overlap_fivetran_orders", asset=CARRIER)
+            ],
+            selected_keys={CARRIER, SIBLING},
+            rocky_key_to_dagster_key=MAPPING,
+        )
+    )
+
+    failed = [e for e in events if isinstance(e, dg.AssetCheckResult) and not e.passed]
+    assert len(failed) == 1, f"the check is reported as a check: {events}"
+
+
+def test_an_ungated_run_with_an_unselected_check_still_does_not_fail_the_step(caplog):
+    """The other control, and the reason this is not just 'raise on any drop'.
+
+    A check outside the selection with no gate is not this step's problem — it
+    is warned about and nothing more. Only the engine's own gate verdict turns
+    it into a failure.
+    """
+    result = _run_result(
+        check_results=[_failing_overlap_on_carrier()],
+        check_gate_failed=False,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        events = list(
+            _emit_results(
+                results=[result],
+                check_specs=[],
+                selected_keys={SIBLING},
+                rocky_key_to_dagster_key=MAPPING,
+            )
+        )
+
+    assert not [e for e in events if isinstance(e, dg.AssetCheckResult)]
+    assert "FAILED check" in caplog.text, caplog.text
+
+
+def test_an_inherited_gate_with_clean_checks_still_fails_the_step():
+    """A resume can inherit a standing gate from the run it resumed, so its own
+    ``check_results`` are clean (#1720). Nothing in this step explains the gate
+    — which is exactly when reporting green would be wrong."""
+    result = _run_result(check_results=[], check_gate_failed=True)
+
+    with pytest.raises(dg.Failure) as excinfo:
+        list(
+            _emit_results(
+                results=[result],
+                check_specs=[],
+                selected_keys={CARRIER},
+                rocky_key_to_dagster_key=MAPPING,
+            )
+        )
+
+    description = excinfo.value.description or ""
+    assert "inherited a standing gate" in description


### PR DESCRIPTION
Items 1 and 2 of #1728. Together they let a run the engine **failed on its checks** complete as a green Dagster step with no failed check anywhere.

## 1. The selection filter dropped everything, silently

`_emit_results` filters by selection **before** it filters by declaration:

```
asset_key not in selected_keys   -> continue      (no check, no observation, no log)
spec_key  not in declared_checks -> observation   (#1709 fixed this one)
```

#1709 fixed the second. The first still discarded the whole `TableCheckResult` — and it is the one a `cross_source_overlap` verdict lands behind, because the engine attaches that **group** check to one sibling in materialization order, so the carrier is not knowable when specs are built.

A partial selection that spans every source but omits the carrier is an ordinary shape. It threw the result away. That is #1669 verbatim, still live after the PR that closed it.

An observation is not available on this path — Dagster rejects an event on an asset outside the step — so the drop is now **named in the log** and remembered for the backstop below.

## 2. Nothing read `check_gate_failed`

The field appeared exactly twice across `sdk/python/src` and `integrations/dagster/src`, both times as a model field with no reader.

`RockyClient.run` passes `allow_partial=True`, so a check-gated exit 2 comes back as a parsed result rather than raising, and `_log_run_diagnostics` logged only table failures. The engine said *"I failed this run on a check"* and the step finished successful.

It is now logged, and backed by a step-level refusal: if the gate stands and no failing `AssetCheckResult` in this step explains it, `_emit_results` raises `dg.Failure` **after** yielding every other event — the ordering `_emit_derived_model_results` already uses for containment, so the step's real results are recorded first.

## Why this does not fire on the ordinary shape

If any failing check *was* reported as a check, the gate is already visible in the UI and on the asset's health, and the backstop stays quiet. Otherwise every ordinary check failure would become a step-level exception on top of its own check result.

It fires only when the gate stands and nothing in the step explains it:

- a group check whose carrier sibling is outside the selection,
- a check whose spec was never declared,
- a resume that inherited a standing gate, whose own `check_results` are clean (#1720).

## Evidence

`tests/test_check_gate_backstop.py` — four tests, two of them controls.

Mutation-checked: deleting the `dg.Failure` block fails 2 of the 4 and leaves both controls passing, which is the shape you want — the controls assert the backstop stays *quiet*, so a mutation that removes it must not flip them.

The issue named the missing test explicitly ("a selection that spans all sources while omitting the carrier"); `test_a_gated_run_whose_failing_check_is_outside_the_selection_fails_the_step` is it.

Gates: 770 pytest pass, `ruff check` and `ruff format --check` clean.

## Deliberately not in this PR

Items **3**, **4** and **5** of #1728, so the issue stays open:

- **3** — a `not_applicable` check renders green with `overlap_count: 0`, which reads as "measured, found nothing". Needs the placeholder numerics suppressed and the reason moved into `AssetCheckResult(description=...)`, plus the stale comment at `checks.py:166` corrected.
- **4** — the SKIPPED claim in `AGENTS.md` / `CHANGELOG.md` is wrong at the consumer, and the direction is stuck red. That one needs a *decision* (a result per sibling, one deterministic carrier, or documenting that a per-sibling badge is not meaningful for a group check), not just a fix.
- **5** — the engine's pipes emitter hardcodes `PipesCheckSeverity::Error`, so `severity = "warning"` reads WARNING in streaming and DEGRADED in pipes. That is an engine-side change (`run.rs:7038`), not a component one.

## What I am least confident about

**Whether `dg.Failure` is the right primitive, versus a failing `AssetCheckResult` on some selected asset.** A `Failure` fails the step but attaches to no asset, so the check's own health badge does not move — an alert on that check key still does not fire. Attaching a synthetic result to an arbitrary selected sibling would move a badge, but it would be a verdict about a table the engine did not evaluate, which is the fabrication #1706 and #1709 both worked to remove. I chose the honest-but-blunt option. If item 4's "one deterministic carrier" decision lands, this backstop should probably become a real result on that carrier instead.

## The most important thing I might be missing

**The Pipes path.** `_PipesHandlerProxy.handle_message` discards an out-of-`include_keys` `report_asset_check` with the comment "Silent by design" (`resource.py:409`), one layer earlier than the filter I fixed. My backstop lives in `_emit_results`, which Pipes mode does not reach — so a check-gated run in `execution_mode="pipes"` is still green. I did not extend it there because the Pipes path never sees the parsed `RunResult` that carries `check_gate_failed`, and wiring one in is a different change. That gap is real and I would rather name it than let the PR title imply more coverage than it has.

## Review

Reviewed by me at high effort, and **not** by an independent model: same-model review, which does not satisfy the `AGENTS.md` independence requirement. Flagging rather than skipping silently.

Refs #1728, #1709, #1669, #1671, #1720.
