### PR TITLE
fix(engine/rocky-cli): build both sides of the execution fingerprint with one derivation

### DIFF
--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -2409,6 +2409,40 @@ pub(crate) struct ExecutionExtras {
     effective_masks: BTreeMap<String, rocky_ir::MaskStrategy>,
 }
 
+/// The surrogate-key map both sides of the execution fingerprint must hash.
+///
+/// Filtered to the COMPILED model set and strict on a malformed spec — the
+/// derivation the apply-side choke-point already used. The plan side used
+/// `load_surrogate_keys_from_tree(models_dir).unwrap_or_default()` instead:
+/// unfiltered, and emptied on any `ModelError`. Two sides of one fingerprint,
+/// built by different functions over different sets (#1730).
+///
+/// What that cost:
+///
+/// - A `.sql` under `models/` that is not a compiled model is in the plan's
+///   map and not in the apply's, so the digests differ and `rocky apply`
+///   refuses a legitimate plan. Constructible: `load_models_from_dir_filtered`
+///   skips a file whose NAME is not valid UTF-8, while the surrogate-key load
+///   checks only the extension.
+/// - A malformed spec on such a file collapsed the plan side to an EMPTY map,
+///   so the plan was persisted with no surrogate key in its fingerprint at all
+///   — the fail-open direction, and the one the justifying comment claimed
+///   could not happen because the gate "must keep hashing the resolved whole".
+///   `.unwrap_or_default()` already made that false in the strongest way.
+pub(crate) fn resolved_surrogate_keys(
+    models_dir: &std::path::Path,
+    models: &[rocky_core::models::Model],
+) -> anyhow::Result<std::collections::HashMap<String, Vec<rocky_core::models::SurrogateKeySpec>>> {
+    let selected: std::collections::HashSet<std::path::PathBuf> = models
+        .iter()
+        .map(|m| std::path::PathBuf::from(&m.file_path))
+        .collect();
+    rocky_core::models::load_surrogate_keys_from_tree_filtered(models_dir, |path| {
+        selected.contains(path)
+    })
+    .context("invalid surrogate_key configuration")
+}
+
 impl ExecutionExtras {
     /// Assemble the extras from the already-loaded surrogate-key map, the
     /// compiled models (for `contract_path`s + classification tags), and the
@@ -4794,6 +4828,89 @@ pub async fn run_apply_inline_for_run(
 
 #[cfg(test)]
 mod tests {
+    /// #1730. Both sides of the execution fingerprint must build the
+    /// surrogate-key map with the SAME function over the SAME set.
+    ///
+    /// The plan side used `load_surrogate_keys_from_tree(models_dir)
+    /// .unwrap_or_default()`: unfiltered, and emptied on any `ModelError`. The
+    /// apply-side choke-point used the filtered, strict load. So a malformed
+    /// spec collapsed the plan side to an empty map — the plan was persisted
+    /// with no surrogate key in its fingerprint at all — while the apply side
+    /// refused. Fail-open on the side that writes the plan.
+    #[test]
+    fn a_malformed_surrogate_key_spec_refuses_instead_of_emptying_the_map() {
+        let dir = tempfile::tempdir().unwrap();
+        let models = dir.path().join("models");
+        std::fs::create_dir_all(&models).unwrap();
+        std::fs::write(models.join("orders.sql"), "SELECT 1 AS id\n").unwrap();
+        std::fs::write(
+            models.join("orders.toml"),
+            "name = \"orders\"\ntarget = { catalog = \"c\", schema = \"s\", table = \"orders\" }\n[[surrogate_key]]\nname = \"sk\"\ncolumns = [\"id\"]\n",
+        )
+        .unwrap();
+
+        let compiled =
+            rocky_core::models::load_models_from_dir(&models, None).expect("the fixture loads");
+
+        // Control: a well-formed spec resolves, and the key is IN the map.
+        let ok = super::resolved_surrogate_keys(&models, &compiled)
+            .expect("a well-formed spec resolves");
+        assert!(
+            ok.contains_key("orders"),
+            "precondition: the map is what carries the key into the fingerprint: {ok:?}"
+        );
+
+        // Now break the spec. `.unwrap_or_default()` used to swallow this to an
+        // EMPTY map on the plan side and fingerprint the plan without it.
+        std::fs::write(
+            models.join("orders.toml"),
+            "name = \"orders\"\ntarget = { catalog = \"c\", schema = \"s\", table = \"orders\" }\n[[surrogate_key]]\nname = \"sk\"\ncolumns = \"not-a-list\"\n",
+        )
+        .unwrap();
+        let err = super::resolved_surrogate_keys(&models, &compiled)
+            .expect_err("a malformed spec must refuse, not empty the fingerprint");
+        assert!(
+            format!("{err:#}").contains("surrogate_key"),
+            "the refusal names what it could not read: {err:#}"
+        );
+    }
+
+    /// #1730, the other half of "the same set": the map is FILTERED to the
+    /// compiled models. A `.sql` under `models/` that is not a compiled model
+    /// was in the plan side's map and not in the apply side's, so the two
+    /// digests differed and `rocky apply` refused a legitimate plan.
+    #[test]
+    fn the_resolved_map_is_filtered_to_the_compiled_models() {
+        let dir = tempfile::tempdir().unwrap();
+        let models = dir.path().join("models");
+        std::fs::create_dir_all(&models).unwrap();
+        for name in ["orders", "shipments"] {
+            std::fs::write(models.join(format!("{name}.sql")), "SELECT 1 AS id\n").unwrap();
+            std::fs::write(
+                models.join(format!("{name}.toml")),
+                format!(
+                    "name = \"{name}\"\ntarget = {{ catalog = \"c\", schema = \"s\", table = \"{name}\" }}\n[[surrogate_key]]\nname = \"sk\"\ncolumns = [\"id\"]\n"
+                ),
+            )
+            .unwrap();
+        }
+        let all =
+            rocky_core::models::load_models_from_dir(&models, None).expect("the fixture loads");
+        assert_eq!(all.len(), 2);
+
+        // Hand it ONE of the two, as a narrowed compile would.
+        let one: Vec<_> = all
+            .iter()
+            .filter(|m| m.config.name == "orders")
+            .cloned()
+            .collect();
+        let map = super::resolved_surrogate_keys(&models, &one).expect("resolves");
+        assert!(map.contains_key("orders"));
+        assert!(
+            !map.contains_key("shipments"),
+            "a model outside the compiled set must not enter the fingerprint: {map:?}"
+        );
+    }
 
     // ---- the policy gate fails closed on an unreadable config (#1559) ----
 

--- a/engine/crates/rocky-cli/src/commands/backfill.rs
+++ b/engine/crates/rocky-cli/src/commands/backfill.rs
@@ -285,7 +285,7 @@ pub(crate) fn run_backfill_in(
     // apply-time TOCTOU gate rejects a post-plan swap of any, built from the SAME
     // `models_dir` the apply choke-point re-reads.
     let extras = crate::commands::apply::ExecutionExtras::build(
-        &rocky_core::models::load_surrogate_keys_from_tree(models_dir).unwrap_or_default(),
+        &crate::commands::apply::resolved_surrogate_keys(models_dir, &compiled.project.models)?,
         &compiled.project.models,
         &resolved_mask,
     );

--- a/engine/crates/rocky-cli/src/commands/fulfill_api.rs
+++ b/engine/crates/rocky-cli/src/commands/fulfill_api.rs
@@ -401,7 +401,11 @@ pub async fn propose_governed_run_plan(
         // so the apply never reaches the mask-reconciling model leg — the
         // mask is never bound, `false` on both sides.
         false,
-    );
+    )
+    // A malformed surrogate-key spec must refuse rather than fingerprint the
+    // plan without it (#1730). `Compile` is the closest existing variant: the
+    // spec lives beside the model and this is a project that does not load.
+    .map_err(|e| ProposeError::Compile(format!("{e:#}")))?;
 
     // Gate on the models the apply will EXECUTE: the freshly-compiled
     // project narrowed by the plan's `--model` selection — mirroring how

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -1243,7 +1243,7 @@ fn build_and_persist_run_plan(
         Some(state_path),
         env,
         bind_masks,
-    );
+    )?;
     let plan_id = write_plan_governed(&cwd, PlanKind::Run, &run_plan, principal, capabilities)
         .context("failed to write run plan")?;
 
@@ -1279,7 +1279,14 @@ pub fn compute_embedded_capabilities(
     // does not reach the mask leg never checks the gate, so a wrong-`true` is
     // harmless; a wrong-`false` would false-refuse).
     bind_masks: bool,
-) -> EmbeddedCapabilities {
+    // Returns `Result` since #1730: the surrogate-key map folded into the
+    // execution fingerprint is now loaded by the SAME filtered, strict
+    // derivation the apply-side choke-point uses. A malformed spec used to
+    // collapse this side to an empty map through `.unwrap_or_default()`, so
+    // the plan was persisted with no surrogate key in its fingerprint at all —
+    // and the comment below claimed the gate "must keep hashing the resolved
+    // whole" while that call made it false.
+) -> anyhow::Result<EmbeddedCapabilities> {
     use crate::plan_store::CURRENT_FINGERPRINT_VERSION;
     use rocky_compiler::compile::{self, CompilerConfig};
 
@@ -1329,7 +1336,7 @@ pub fn compute_embedded_capabilities(
     };
 
     if !models_dir.is_dir() {
-        return failed(config_identity); // fail-closed
+        return Ok(failed(config_identity)); // fail-closed
     }
 
     let identity = config_identity.clone().unwrap_or_default();
@@ -1370,7 +1377,7 @@ pub fn compute_embedded_capabilities(
         };
         match compile::compile(&config) {
             Ok(r) => r,
-            Err(_) => return failed(config_identity),
+            Err(_) => return Ok(failed(config_identity)),
         }
     };
     // Capture the REVIEWED source-schema snapshot (finding #2) — the exact
@@ -1394,7 +1401,7 @@ pub fn compute_embedded_capabilities(
     // swap of either is refused even though `config`+`sql` are byte-identical —
     // built from the SAME `models_dir` the apply choke-point re-reads.
     let extras = crate::commands::apply::ExecutionExtras::build(
-        &rocky_core::models::load_surrogate_keys_from_tree(models_dir).unwrap_or_default(),
+        &crate::commands::apply::resolved_surrogate_keys(models_dir, &head.project.models)?,
         &head.project.models,
         &resolved_mask,
     );
@@ -1412,14 +1419,14 @@ pub fn compute_embedded_capabilities(
         // per-model classification (fail-closed to breaking). Keep the
         // fingerprint so the TOCTOU gate still binds.
         Err(_) => {
-            return EmbeddedCapabilities {
+            return Ok(EmbeddedCapabilities {
                 diff_available: false,
                 changed: std::collections::BTreeMap::new(),
                 models_fingerprint,
                 config_identity,
                 fingerprint_version: CURRENT_FINGERPRINT_VERSION,
                 reviewed_source_schemas,
-            };
+            });
         }
     };
 
@@ -1444,14 +1451,14 @@ pub fn compute_embedded_capabilities(
         }
     }
 
-    EmbeddedCapabilities {
+    Ok(EmbeddedCapabilities {
         diff_available: true,
         changed,
         models_fingerprint,
         config_identity,
         fingerprint_version: CURRENT_FINGERPRINT_VERSION,
         reviewed_source_schemas,
-    }
+    })
 }
 
 /// Build a canonical, sorted source-state snapshot from the discovered

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -23765,7 +23765,8 @@ backend = "local"
             None,
             None,
             false, // transformation pipeline → mask NOT bound (finding #4)
-        );
+        )
+        .expect("the fixture's surrogate-key specs load");
         // Apply side: the choke-point's routing + governance identity are the
         // loaded config's, resolved for the same (None) env. The POC pipeline is
         // a TRANSFORMATION pipeline (→ `run_local`), which reconciles no masks, so
@@ -23829,7 +23830,8 @@ backend = "local"
             None,
             None,
             true, // replication full run → mask BOUND (finding #4)
-        );
+        )
+        .expect("the fixture's surrogate-key specs load");
         // Apply side: `reconciles_masks = true` binds `gate.resolved_mask`, which
         // the choke-point restricts to the executed models' tags — mirror that.
         let cfg = rocky_core::config::load_rocky_config(&config_path).unwrap();
@@ -23855,7 +23857,8 @@ backend = "local"
             None,
             None,
             true, // replication full run → mask BOUND (finding #4)
-        );
+        )
+        .expect("the fixture's surrogate-key specs load");
         assert_ne!(
             caps.models_fingerprint, caps_redact.models_fingerprint,
             "a used [mask] change must move the replication plan fingerprint (#4/C bound)"


### PR DESCRIPTION
The second half of #1730 — the one reachable without a hand-crafted non-UTF-8 filename.

The plan side and the apply side of the TOCTOU execution fingerprint loaded the surrogate-key map with **different functions over different sets**:

```
plan.rs      load_surrogate_keys_from_tree(dir).unwrap_or_default()
backfill.rs  load_surrogate_keys_from_tree(dir).unwrap_or_default()
run.rs       load_surrogate_keys_from_tree_filtered(dir, in_compiled_set)?
```

Unfiltered vs filtered, swallowed vs strict. Two consequences:

1. **A legitimate plan is refused.** A `.sql` under `models/` that is not a compiled model is in the plan's map and not in the apply's, so the digests differ. Constructible: `load_models_from_dir_filtered` skips a file whose *name* is not valid UTF-8, while the surrogate-key load checks only the extension.

2. **A plan is fingerprinted without its key at all.** A malformed spec collapsed the plan side to an empty map — the fail-open direction, on the side that *writes* the plan.

The justifying comment argued the gate "must keep hashing the resolved whole". `.unwrap_or_default()` already made that false in the strongest way.

## The change

All three sites go through one `resolved_surrogate_keys()` helper carrying the apply side's derivation: filtered to the compiled set, strict on a malformed spec. One function, so they cannot drift again — which is the actual invariant, not "both happen to be correct today".

`compute_embedded_capabilities` returns `anyhow::Result` as a consequence. A malformed spec has to refuse *somewhere*, and emptying the map was the bug. One production caller, plus `fulfill_api`, which maps it onto its existing `ProposeError::Compile` — the spec lives beside the model, and this is a project that does not load.

## Evidence

- `a_malformed_surrogate_key_spec_refuses_instead_of_emptying_the_map` — with a control asserting the well-formed key **is** in the map first, so the test cannot pass by the map being empty for an unrelated reason.
- `the_resolved_map_is_filtered_to_the_compiled_models` — two models, one handed in, the other must not enter the fingerprint.

Gates: `cargo test -p rocky-cli -p rocky-core --lib` 1826 + 2140 pass; clippy `--all-targets` clean; `cargo fmt --check` clean.

## Not in this PR, deliberately

The `Model::file_path: String → PathBuf` half. I measured it rather than guessing: **129 non-test call sites**. That deserves its own PR.

Its reachability is also narrower — non-UTF-8 path components are Linux-only and need a filename someone went out of their way to create, where this half is reachable with an ordinary malformed spec. #1730 stays open for it, and the issue's own interim (compare on the same lossy form on both sides) remains available if the type change stays too wide.

## What I am least confident about

**`ProposeError::Compile` as the variant for a malformed surrogate-key spec.** It is the closest existing one and the message reads correctly, but it is not literally a compile failure, and a caller branching on that variant now sees a case it did not before. A dedicated variant would be cleaner; I did not add one because `ProposeError` is part of the fulfillment API surface and widening it is a bigger decision than this fix.

## The most important thing I might be missing

**Whether the other `ExecutionExtras::build` inputs have the same split.** I fixed the surrogate-key argument because that is what the issue names and what #1703 changed. `build` also takes the model set and the resolved mask, and I checked those are passed from the same compile on both sides — but I did *not* audit the contract-presence input the doc comment mentions as extras item #3. If that one is loaded differently on the two sides, it has this bug too and this PR does not touch it.

## Review

Reviewed by me at high effort, and **not** by an independent model: same-model review, which does not satisfy the `AGENTS.md` independence requirement. Flagging rather than skipping silently.

Refs #1730, #1703, #1556.
