### PR TITLE
test(engine/rocky-cli): pin the order a degraded brief bails in

### DIFF
--- a/engine/crates/rocky-cli/src/commands/brief.rs
+++ b/engine/crates/rocky-cli/src/commands/brief.rs
@@ -1663,6 +1663,47 @@ fn section_status(availability: &SectionAvailability, note: &Option<String>) -> 
 
 #[cfg(test)]
 mod tests {
+    /// #1727. A degraded digest must not consume the `--since last` window.
+    ///
+    /// `run_brief` emits, then bails on `config_error`, then advances the
+    /// cursor. The order is the whole behaviour: if the bail moved below the
+    /// advance, a project with a broken `rocky.toml` would consume its window
+    /// on every run, and the six sections it COULD render would be silently
+    /// skipped for the next reader too — the exact silent-skip #1727 exists to
+    /// stop.
+    ///
+    /// Asserted over this file's own source because `run_brief` reads the
+    /// process cwd and prints to stdout, so no unit test reaches it — the same
+    /// shape `run.rs` uses for its stamp-ordering guards. The claim was a
+    /// comment with nothing behind it until this test.
+    ///
+    /// Every `find` takes the FIRST occurrence, which is the production site.
+    #[test]
+    fn a_degraded_digest_bails_before_the_cursor_advances() {
+        let source = include_str!("brief.rs");
+        let emit = source
+            .find("emit(&output, json)?;")
+            .expect("run_brief no longer emits before deciding; re-anchor this test");
+        let bail = source
+            .find("if let Some(err) = &output.config_error {")
+            .expect("the degraded-digest refusal is gone — see #1727");
+        let advance = source
+            .find(".set_last_brief_at(now)")
+            .expect("the cursor advance moved; re-anchor this test");
+
+        assert!(
+            emit < bail,
+            "the digest must be emitted BEFORE the refusal, or a wrapper parsing \
+             stdout loses the six sections that did render (#1727)"
+        );
+        assert!(
+            bail < advance,
+            "a degraded digest must not advance the `--since last` cursor: the \
+             sections it could not render would be silently skipped for the next \
+             reader too (#1727)"
+        );
+    }
+
     use super::*;
     use chrono::TimeZone;
     use rocky_core::config::PolicyCapability;


### PR DESCRIPTION
Found while verifying my own CHANGELOG claims from today against the merged code, rather than against what I remembered writing.

#1727 claims — **in a comment** — that a degraded digest must not consume the `--since last` window. Nothing was behind that claim.

`run_brief` does three things in order:

```
emit(&output, json)?                     the six sections that rendered
bail on output.config_error              exit non-zero
set_last_brief_at(now)                   advance the cursor
```

If the bail moved below the advance, every run on a broken `rocky.toml` would consume its window — so the six sections it *could* render would be silently skipped for the next reader too. That is the exact silent-skip #1727 exists to stop, reintroduced by an edit nothing would catch.

`run_brief` reads the process cwd and prints to stdout, so no unit test reaches it. Asserted over the file's own source instead — the shape `run.rs` already uses for its stamp-ordering guards, and the same reason: the site is unreachable from a unit test, so the choice is a source-order assertion or nothing.

Mutation-checked: moving the bail below the cursor advance fails the test.

The guard asserts both orderings, not just the one the issue names — `emit < bail` matters too, because emitting after the refusal would lose the digest for a wrapper parsing stdout.

Gates: `cargo test -p rocky-cli --lib` 1827 pass; `cargo fmt --check` clean.

## What I am least confident about

**Whether a source-order guard is worth its brittleness here.** Three `find` anchors on literal source text; a refactor that renames `set_last_brief_at` or restructures `run_brief` fails this test for no behavioural reason. I think it is worth it — the alternative is a claim with nothing behind it, and this file already had one — but a reader hitting a spurious failure should re-anchor rather than delete, and the doc comment says which invariant to preserve.

## Review

Reviewed by me at high effort, and **not** by an independent model: same-model review, which does not satisfy the `AGENTS.md` independence requirement. Flagging rather than skipping silently.

Refs #1727.