### PR TITLE
fix(engine/ui): widen the journal's `when` column, so a timestamp stops wrapping on some rows and not others

### DIFF
--- a/engine/ui/src/governor/ProductsScreen.tsx
+++ b/engine/ui/src/governor/ProductsScreen.tsx
@@ -177,7 +177,13 @@ function JournalTable({ rows }: { rows: ProductJournalEntry[] }) {
       <table className="w-full table-fixed text-left text-sm">
         <colgroup>
           <col className="w-10" />
-          <col className="w-40" />
+          {/* `when` holds a fixed-width string — "2026-09-06 20:44:26 UTC" —
+              and w-40 sat within a few pixels of it, so some rows wrapped
+              "UTC" onto a second line and others did not, for no reason a
+              reader could see. w-44 clears it with room to spare. It cannot
+              be `whitespace-nowrap`: under `table-fixed` that overflows the
+              cell rather than widening it. */}
+          <col className="w-44" />
           <col />
           <col className="w-44" />
           <col className="w-48" />


### PR DESCRIPTION
Spotted while auditing frames of the U3-A3 screencast (#1751), and requested by the owner.

**Review: the authoring model itself, at max effort, standing in for Codex on the owner's instruction while its credits are out until 2026-09-07. Same-model with the author, not independent — no independent review exists for this change yet.**

## What was wrong

The journal's `when` column holds a fixed-width string — `2026-09-06 20:44:26 UTC` — and `w-40` (160px) sat within a few pixels of what it needs:

| | |
|---|---|
| widest text | **144px** |
| cell padding (`px-2`) | 16px |
| needed | **160px** |
| column was | **160px** (`w-40`) |

Zero margin. So some rows rendered the timestamp on one line and others pushed `UTC` onto a second, for no reason a reader could see. `w-44` (176px) clears it.

It cannot be `whitespace-nowrap`: under `table-fixed` that overflows the cell rather than widening it, which is exactly why #1746 removed the nowrap in the first place. The comment in the colgroup says so, so the next person does not re-add it.

## The first measurement was wrong, instructively

Counting each `<td>`'s bounding-box height reported **20 of 34 cells wrapped** — after the fix. That is not a wrapping measurement at all: **a `<td>`'s box is the row's height.** A cell sitting in a row made tall by a long repair-round event measures "tall" even when its own text is a single line.

Counting the line boxes of the text itself — the distinct client-rect tops of a `Range` over the cell's contents — gives the real answer:

```
{ "columnWidthPx": 176, "whenCellsOnOneLine": 34, "whenCellsWrapped": 0 }
```

34 of 34 on one line. Worth writing down, because the wrong measurement was plausible and disagreed with the screenshot, which is the shape of an afternoon lost.

28 governor vitest cases pass, `tsc --noEmit` clean, eslint clean.

## The two questions

**Least confident.** Whether `w-44` holds for every timestamp this column can show. `formatInstant` renders a fixed `YYYY-MM-DD HH:MM:SS UTC`, so the width is constant — unless the locale or the font changes underneath it. The failure mode is soft (a wrap, not a clip), and it is now measured rather than assumed, which is the most this can be without a layout test the toolchain cannot run.

**Most likely missing.** A test. There is none, and there cannot be a useful one here: jsdom has no layout, so no vitest assertion in this repo can see whether text wraps. The measurement above came from Playwright against a real server — that capability now exists in `cli-recording/browser/`, but wiring it into CI as a layout-regression suite is its own package, not a rider on a column width.
