### PR TITLE
fix(engine/ui): stop offering to sample a backfill, whose queue entry names no single model

### DIFF
--- a/engine/ui/src/review/PlanDetail.test.tsx
+++ b/engine/ui/src/review/PlanDetail.test.tsx
@@ -127,8 +127,40 @@ describe("PlanDetail", () => {
       />,
     );
 
-    await screen.findByText("no model to sample");
+    await screen.findByText("no single model to sample");
     expect(screen.queryByRole("button", { name: /Show \d+ rows/ })).toBeNull();
+  });
+
+  /// A backfill escalation puts a display sentence in the queue's `model`
+  /// field — "backfill: 3 model(s)". Feeding that to the samples route earns a
+  /// 400 `invalid_model_name` on every click, so the offer must not be made.
+  it("does not offer to sample a backfill, whose queue entry names no single model", async () => {
+    const backfill: ReviewQueueOutput = {
+      ...QUEUE,
+      pending: [
+        {
+          ...QUEUE.pending[0],
+          capability: "backfill",
+          model: "backfill: 3 model(s)",
+          blast_radius: undefined,
+        },
+      ],
+    };
+
+    render(
+      <PlanDetail
+        planId={PLAN}
+        loaders={loaders({
+          status: vi.fn(async () => ({ ...STATUS, product_id: undefined })),
+          queue: vi.fn(async () => backfill),
+        })}
+      />,
+    );
+
+    await screen.findByText("no single model to sample");
+    expect(screen.queryByRole("button", { name: /Show \d+ rows/ })).toBeNull();
+    // and it says which of the two reasons applies, quoting what it was given
+    expect(screen.getByText(/backfill: 3 model\(s\)/)).toBeTruthy();
   });
 
   it("shows the plan, its findings, the escalation and the approve command", async () => {

--- a/engine/ui/src/review/PlanDetail.tsx
+++ b/engine/ui/src/review/PlanDetail.tsx
@@ -25,6 +25,12 @@ export const defaultPlanLoaders: PlanLoaders = {
   product: (name) => apiGet<ProductStatusOutput>(`products/${encodeURIComponent(name)}`),
 };
 
+/**
+ * What the samples route will accept as a model name — the same shape as
+ * `rocky_sql::validation::validate_identifier` (`^[a-zA-Z0-9_]+$`).
+ */
+const MODEL_NAME = /^[a-zA-Z0-9_]+$/;
+
 /** A `product:<name>` identity reduced to the name the products route takes. */
 export function productNameFromId(productId: string): string {
   return productId.startsWith("product:") ? productId.slice("product:".length) : productId;
@@ -276,8 +282,17 @@ export function PlanDetail({
   //
   // The product's own status carries `output_model`, and this screen already
   // reads it for the spec-drift card, so the fallback costs no request.
+  //
+  // The queue entry's `model` is not always a model name. A backfill escalation
+  // puts a display sentence there — "backfill: 3 model(s)" — and feeding that to
+  // the samples route earns a 400 `invalid_model_name` on every click. So take
+  // the field only when it could be a name. The server stays the authority
+  // (`rocky_sql::validation::validate_identifier`, `^[a-zA-Z0-9_]+$`); this only
+  // withholds an offer the server would refuse, so a drift here declines to ask
+  // rather than asking wrongly.
+  const named = entry?.model !== undefined && MODEL_NAME.test(entry.model) ? entry.model : null;
   const model =
-    entry?.model ?? (product.kind === "ready" ? (product.value.output_model ?? null) : null);
+    named ?? (product.kind === "ready" ? (product.value.output_model ?? null) : null);
 
   return (
     <div className="space-y-4">
@@ -329,11 +344,17 @@ export function PlanDetail({
       ) : (
         // Absent is not empty. A missing panel reads as "this plan touches no
         // data"; say instead that the screen could not work out which model to
-        // sample, which is a different thing and has a different fix.
+        // sample, which is a different thing and has a different fix. And say
+        // WHICH of the two reasons applies — a backfill has models, just not one
+        // this screen can name.
         <StatusCard
           label="sample rows"
-          value="no model to sample"
-          sub="Neither the review queue nor the product names a model for this plan, so there is nothing to read rows from. A plan that is not product-bound and no longer in the queue has no model on this screen."
+          value="no single model to sample"
+          sub={
+            entry !== null
+              ? `The queue describes this plan as "${entry.model}", which names no single model — a backfill covers a set of them, and this panel reads one model at a time. Sample them from the estate screen instead.`
+              : "Neither the review queue nor the product names a model for this plan, so there is nothing to read rows from. A plan that is not product-bound and no longer in the queue has no model on this screen."
+          }
         />
       )}
 


### PR DESCRIPTION
Found while probing whether the D4 approver task can be run on the fixture it names. The fixture is backfill plans — and every backfill plan's detail page offers a sample it cannot take.

**Review: the authoring model itself, at max effort, standing in for Codex on the owner's instruction. Same-model with the author, not independent — no independent review exists for this change yet.** Codex's credits return today at 10:07.

## What was wrong

The review queue's `model` field is not always a model name. A backfill escalation puts a display sentence there:

```
crates/rocky-cli/src/commands/backfill.rs:327
  &format!("backfill: {} model(s)", ordered.len()),
```

`PlanDetail` fed that straight to `SamplePanel`. Clicking **Show 20 rows** on any backfill plan:

```
REFUSED (400)  invalid_model_name
invalid model name 'backfill: 2 model(s)'
```

Measured against a live `rocky serve --ui` over a `rocky playground` scaffold with three pending backfill plans — not reasoned about.

It fails safe, and the screen reports the refusal honestly. But the offer should never have been made.

## The fix

Take the queue's field only when it could be a name.

```
                  entry.model
                       │
              ┌────────┴────────┐
     matches  │                 │  does not
  ^[a-zA-Z0-9_]+$              │
              │                 │
         SamplePanel      product.output_model, else a card
                          that says WHY there is no sample
```

The server stays the authority — `rocky_sql::validation::validate_identifier`, `^[a-zA-Z0-9_]+$`, the same rule this repo's own validation table publishes. The screen only withholds an offer the server would refuse, so if the two ever drift the screen declines to ask rather than asking wrongly. That is the safe direction, and it is why this is not a second copy of a gate.

The fallback card had to change too. It said *"Neither the review queue nor the product names a model"* — false for a backfill: the queue **has** an entry, and the plan **has** models, just not one this panel can read. It now says which of the two reasons applies and quotes what it was given.

## Test

One case, and it is fix-sensitive. Reverting the guard to `entry?.model ?? null` fails exactly it:

```
 Tests  1 failed | 10 passed (11)
   ❯ src/review/PlanDetail.test.tsx:160
     await screen.findByText("no single model to sample");
```

Restored: 22/22 green across the four review suites. `tsc --noEmit` clean, eslint clean.

## The two questions

**Least confident.** Whether any other producer writes a non-identifier into that field. I checked the one I hit — backfill — and it is the only `record_plan_review_escalation` call site that formats a sentence rather than passing a model name through. But the field's *type* still permits it, so the guard is the durable fix rather than repairing one call site: a future capability that labels its escalation will now be declined rather than 400ing.

**Most likely missing.** The deeper issue this is a symptom of: `blast_radius` is **`not computed`** for backfill plans, in the queue and on the detail page. That is the one field that would let a reviewer rank two backfills against each other, and it is absent. This PR does not touch it. It is the more consequential gap and it wants its own issue.
