### PR TITLE
fix(engine): stop confirming a verify_after gate with a check that measured nothing (#1715)

### DIFF
--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -3414,35 +3414,24 @@ fn run_verify_after(
         .get_run(run_id)
         .with_context(|| format!("failed to read run '{run_id}' from state store"))?;
 
-    // AND-aggregate every occurrence of each check name: any `false` occurrence
-    // fails the name. Presence in the map ⇒ the check ran at least once.
-    let mut outcomes: BTreeMap<&str, bool> = BTreeMap::new();
-    if let Some(record) = run.as_ref() {
-        for c in &record.check_outcomes {
-            outcomes
-                .entry(c.name.as_str())
-                .and_modify(|passed| *passed &= c.passed)
-                .or_insert(c.passed);
-        }
-    }
-
     let mut failures: Vec<String> = Vec::new();
-    if run.is_none() {
+    match run.as_ref() {
         // The run this apply produced could not be found — treat every required
         // check as unverifiable and halt (fail closed).
-        for name in required {
-            failures.push(format!(
-                "{name} (apply run '{run_id}' not found — unverifiable)"
-            ));
-        }
-    } else {
-        for name in required {
-            match outcomes.get(name.as_str()) {
-                Some(true) => {}
-                Some(false) => failures.push(format!("{name} (failed)")),
-                // Fail closed: a named check that did not run cannot be confirmed.
-                None => failures.push(format!("{name} (absent — did not run)")),
+        None => {
+            for name in required {
+                failures.push(format!(
+                    "{name} (apply run '{run_id}' not found — unverifiable)"
+                ));
             }
+        }
+        // Fail closed on a check that did not run, failed, or ran and measured
+        // nothing. `unverified_required_checks` is the single implementation of
+        // that question — the drift-governance finalizer calls the same one, so
+        // the two gates cannot drift apart on what "confirmed" means.
+        Some(record) => {
+            failures =
+                rocky_core::state::unverified_required_checks(&record.check_outcomes, required);
         }
     }
     let passed = failures.is_empty();
@@ -9952,6 +9941,7 @@ schema_template = "s__{source}"
                 .map(|(n, p)| CheckOutcome {
                     name: n.to_string(),
                     passed: *p,
+                    not_evaluated: None,
                 })
                 .collect(),
             pipeline: None,
@@ -10030,6 +10020,80 @@ schema_template = "s__{source}"
         )
         .expect_err("an absent named check fails closed");
         assert!(err.to_string().contains("absent"), "{}", err);
+    }
+
+    /// Record a run whose single check PASSED but measured nothing — the
+    /// `cross_source_overlap_not_applicable` shape (#1706). Separate from
+    /// `record_run_with_checks` because the whole point is that `passed: true`
+    /// no longer settles the question.
+    fn record_run_with_unmeasured_check(state_path: &Path, name: &str, reason: &str) -> String {
+        use rocky_core::state::{CheckOutcome, StateStore};
+        let now = chrono::Utc::now();
+        let run_id = format!("run-{}", now.timestamp_nanos_opt().unwrap_or(0));
+        record_run_with_checks_id(state_path, &run_id, now, &[(name, true)]);
+
+        let store = StateStore::open(state_path).unwrap();
+        let mut record = store.get_run(&run_id).unwrap().expect("run was recorded");
+        record.check_outcomes = vec![CheckOutcome {
+            name: name.to_string(),
+            passed: true,
+            not_evaluated: Some(reason.to_string()),
+        }];
+        store.record_run(&record).unwrap();
+        run_id
+    }
+
+    /// 🔴 #1715. A check that ran, measured nothing, and passed is the ABSENT
+    /// case wearing `passed: true`. The gate is written fail-closed for absent
+    /// — "did not run, cannot be confirmed" — so it must refuse this too.
+    ///
+    /// Before v27 `CheckOutcome` carried only `{ name, passed }` and this
+    /// apply passed its gate on a reading nobody took.
+    #[test]
+    fn verify_after_fails_closed_when_named_check_measured_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = dir.path().join("state.redb");
+        let run_id = record_run_with_unmeasured_check(
+            &state,
+            "cross_source_overlap:duckdb.orders",
+            "only one contributing table carries the configured key",
+        );
+        let err = super::run_verify_after(
+            "plan-x",
+            PolicyPrincipal::Agent,
+            &["cross_source_overlap:duckdb.orders".to_string()],
+            &run_id,
+            &state,
+        )
+        .expect_err("a passing check that measured nothing cannot confirm the gate");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not evaluated") && msg.contains("only one contributing table"),
+            "the halt names why nothing was measured: {msg}"
+        );
+        // Still the halt-only posture — the migration has landed either way.
+        assert!(msg.contains("HAS ALREADY LANDED"), "halt-only state: {msg}");
+    }
+
+    /// The refusal above is not blanket: a check that measured something and
+    /// passed still confirms the gate. Without this, deleting the `passed`
+    /// arm entirely would look like a fix.
+    #[test]
+    fn verify_after_still_passes_a_check_that_measured_and_passed() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = dir.path().join("state.redb");
+        let run_id = record_run_with_checks(&state, &[("row_count", true)]);
+        assert!(
+            super::run_verify_after(
+                "plan-x",
+                PolicyPrincipal::Agent,
+                &["row_count".to_string()],
+                &run_id,
+                &state,
+            )
+            .is_ok(),
+            "a measured pass still confirms"
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-cli/src/commands/drift_governance.rs
+++ b/engine/crates/rocky-cli/src/commands/drift_governance.rs
@@ -495,23 +495,12 @@ pub(crate) fn finalize_drift_verify_after(
         return Ok(());
     }
 
-    // AND-aggregate this run's recorded check outcomes by name. A run recorded
-    // under this id must exist (the finalizer runs after `record_run`); an
-    // absent run leaves the map empty ⇒ every required check reads as "absent"
-    // ⇒ fail closed.
-    let outcomes = match store.get_run(run_id) {
-        Ok(Some(record)) => {
-            let mut map: std::collections::BTreeMap<&str, bool> = std::collections::BTreeMap::new();
-            for c in &record.check_outcomes {
-                map.entry(c.name.as_str())
-                    .and_modify(|p| *p &= c.passed)
-                    .or_insert(c.passed);
-            }
-            map.into_iter()
-                .map(|(k, v)| (k.to_string(), v))
-                .collect::<std::collections::BTreeMap<String, bool>>()
-        }
-        _ => std::collections::BTreeMap::new(),
+    // This run's recorded check outcomes. A run recorded under this id must
+    // exist (the finalizer runs after `record_run`); an absent run leaves the
+    // list empty ⇒ every required check reads as "absent" ⇒ fail closed.
+    let outcomes: Vec<rocky_core::state::CheckOutcome> = match store.get_run(run_id) {
+        Ok(Some(record)) => record.check_outcomes,
+        _ => Vec::new(),
     };
 
     let mut halted: Vec<String> = Vec::new();
@@ -530,14 +519,10 @@ pub(crate) fn finalize_drift_verify_after(
         if required.is_empty() {
             continue;
         }
-        let mut failures: Vec<String> = Vec::new();
-        for name in &required {
-            match outcomes.get(name) {
-                Some(true) => {}
-                Some(false) => failures.push(format!("{name} (failed)")),
-                None => failures.push(format!("{name} (absent — did not run)")),
-            }
-        }
+        // Fail closed on a check that did not run, failed, or ran and measured
+        // nothing — through the same implementation the two-step `rocky apply`
+        // gate calls, so the two cannot answer "confirmed" differently.
+        let failures = rocky_core::state::unverified_required_checks(&outcomes, &required);
         let passed = failures.is_empty();
         let reason = if passed {
             format!(
@@ -859,6 +844,7 @@ mod tests {
                 .map(|(n, p)| CheckOutcome {
                     name: n.to_string(),
                     passed: *p,
+                    not_evaluated: None,
                 })
                 .collect(),
             pipeline: None,
@@ -962,6 +948,71 @@ mod tests {
             .unwrap();
         store.record_run(&run_with_checks("run-3", &[])).unwrap();
         assert!(finalize_drift_verify_after(Some(&store), "run-3", Some(&policy)).is_err());
+    }
+
+    /// 🔴 #1715, the drift-governance half. A required check that ran,
+    /// measured nothing, and passed must fail the finalizer closed — the same
+    /// answer the two-step `rocky apply` gate gives, because both call
+    /// `unverified_required_checks`.
+    ///
+    /// This is the surface that matters most: the migration has ALREADY
+    /// landed when the finalizer runs, and before v27 an auto-applied schema
+    /// change was confirmed by a check with no reading behind it.
+    #[test]
+    fn a_required_check_that_measured_nothing_fails_verify_after_closed() {
+        let (store, _d) = temp_store();
+        let policy = granting_policy(&["cross_source_overlap:duckdb.orders"], None);
+        store
+            .record_policy_decision(&applied_decision("run-1715", "wh.raw.orders"))
+            .unwrap();
+
+        // The reachable shape (#1706): passes, measures nothing.
+        let mut record =
+            run_with_checks("run-1715", &[("cross_source_overlap:duckdb.orders", true)]);
+        record.check_outcomes[0].not_evaluated =
+            Some("only one contributing table carries the configured key".to_string());
+        assert!(
+            record.check_outcomes[0].passed,
+            "the shape under test is a PASSING outcome"
+        );
+        assert!(
+            !record.check_gate_failed,
+            "nothing failed, so the run's own check gate stays false — this is \
+             the same blind spot as the absent case"
+        );
+        store.record_run(&record).unwrap();
+
+        let err = finalize_drift_verify_after(Some(&store), "run-1715", Some(&policy))
+            .expect_err("a check that measured nothing cannot confirm the migration");
+        assert!(
+            err.to_string().contains("not evaluated")
+                && err.to_string().contains("only one contributing table"),
+            "the refusal names why nothing was measured: {err}"
+        );
+
+        let rows = verify_rows(&store, "run-1715");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].effect, PolicyEffect::Deny);
+    }
+
+    /// The companion to the above: a check that DID measure and passed still
+    /// confirms, so the refusal is about the reading and not about the check
+    /// name. Without this, deleting the passing arm would read as a fix.
+    #[test]
+    fn a_required_check_that_measured_and_passed_still_confirms() {
+        let (store, _d) = temp_store();
+        let policy = granting_policy(&["row_count"], None);
+        store
+            .record_policy_decision(&applied_decision("run-ok", "wh.raw.orders"))
+            .unwrap();
+        store
+            .record_run(&run_with_checks("run-ok", &[("row_count", true)]))
+            .unwrap();
+        assert!(
+            finalize_drift_verify_after(Some(&store), "run-ok", Some(&policy)).is_ok(),
+            "a measured pass still confirms the migration"
+        );
+        assert_eq!(verify_rows(&store, "run-ok")[0].effect, PolicyEffect::Allow);
     }
 
     #[test]

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -5282,6 +5282,11 @@ impl RunOutput {
         // Flatten every executed check's pass/fail across all tables so a later
         // reader (the `verify_after` policy gate) can confirm a named check ran
         // and passed without re-executing it.
+        //
+        // `not_evaluated` rides along because `passed` alone cannot tell a
+        // measured pass from a check that ran and measured nothing, and the
+        // gate would confirm the second (#1715). It is in scope here; before
+        // v27 it was dropped at this line.
         let check_outcomes = self
             .check_results
             .iter()
@@ -5289,6 +5294,7 @@ impl RunOutput {
             .map(|c| rocky_core::state::CheckOutcome {
                 name: c.name.clone(),
                 passed: c.passed,
+                not_evaluated: c.not_evaluated.clone(),
             })
             .collect();
 
@@ -6947,6 +6953,87 @@ mod run_record_tests {
         );
         assert_eq!(record.check_outcomes.len(), 1);
         assert!(!record.check_outcomes[0].passed);
+    }
+
+    /// The wire this fix exists to close (#1715). The REAL producer
+    /// (`to_run_record`) feeds the REAL consumer
+    /// (`unverified_required_checks`, which is what both `verify_after` gates
+    /// call), so a hand-built outcome cannot hide the drop.
+    ///
+    /// Before v27 the map at the construction site kept `{ name, passed }` and
+    /// discarded `not_evaluated`, so a passing-but-unmeasured overlap check
+    /// reached the gate indistinguishable from a real reading and confirmed a
+    /// rule requiring it.
+    ///
+    /// Deleting `not_evaluated: c.not_evaluated.clone()` from `to_run_record`
+    /// fails this test. Deleting the gate's `NotEvaluated` arm fails it too.
+    #[test]
+    fn an_unmeasured_passing_check_reaches_the_gate_as_unverifiable() {
+        use rocky_core::tests::TestSeverity;
+
+        let mut out = RunOutput::new(String::new(), 0, 1);
+        out.tables_copied = 1;
+        out.check_results.push(checks_for(
+            "orders",
+            vec![
+                // The reachable shape: passes, measures nothing (#1706).
+                rocky_core::checks::cross_source_overlap_not_applicable(
+                    "cross_source_overlap:duckdb.orders",
+                    vec!["duckdb.orders".to_string()],
+                    "only one contributing table carries the configured key",
+                    TestSeverity::Error,
+                ),
+                // A genuine reading, to prove the refusal is not blanket.
+                rocky_core::checks::check_row_count(10, 10),
+            ],
+        ));
+
+        let started = fixed_start();
+        let record = out.to_run_record(
+            "run-1715",
+            started,
+            started + chrono::Duration::seconds(1),
+            String::new(),
+            RunTrigger::Manual,
+            out.derive_run_status(),
+            RunRecordAudit::test_sentinels(),
+        );
+
+        // The reason survives the persist. `passed` alone still says "true".
+        let overlap = record
+            .check_outcomes
+            .iter()
+            .find(|c| c.name == "cross_source_overlap:duckdb.orders")
+            .expect("the overlap outcome is persisted");
+        assert!(overlap.passed, "the shape under test is a PASSING outcome");
+        assert_eq!(
+            overlap.not_evaluated.as_deref(),
+            Some("only one contributing table carries the configured key"),
+            "the reason must survive to_run_record — dropping it here is the bug"
+        );
+
+        // The gate refuses it, and names why.
+        let refused = rocky_core::state::unverified_required_checks(
+            &record.check_outcomes,
+            &["cross_source_overlap:duckdb.orders".to_string()],
+        );
+        assert_eq!(refused.len(), 1, "an unmeasured pass is not a confirmation");
+        assert!(
+            refused[0].contains("not evaluated")
+                && refused[0].contains("only one contributing table"),
+            "the refusal names the recorded reason, got {:?}",
+            refused[0]
+        );
+
+        // A measured pass is still confirmed — the gate did not become blanket.
+        assert!(
+            rocky_core::state::unverified_required_checks(
+                &record.check_outcomes,
+                &["row_count".to_string()],
+            )
+            .is_empty(),
+            "a check that measured something and passed still confirms"
+        );
     }
 
     /// The new field is omitted from the wire when the gate did not trip, so

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -744,7 +744,49 @@ const SNAPSHOT_MEMORY_WARN_BYTES: u64 = 128 * 1024 * 1024;
 ///   runs recorded before this binary), and the blob is backward-safe while
 ///   the OPEN-time version check is what actually engages
 ///   `[state] on_schema_mismatch`.
-const CURRENT_SCHEMA_VERSION: u32 = 26;
+///
+/// - **v27** — records whether each persisted check outcome actually measured
+///   anything: a new serde-additive [`CheckOutcome::not_evaluated`] reason.
+///   Not a table change — the redb table set is unchanged (`EXPECTED_TABLES`
+///   is untouched); no blob walk. A v26 blob (whose outcomes lack the key)
+///   forward-deserializes with it `None`, guarded by
+///   `test_v26_check_outcome_forward_deserializes_not_evaluated_none`.
+///
+///   **What it fixes (#1715).** `CheckOutcome` stored only `{ name, passed }`,
+///   and both `verify_after` gates read `Some(true)` as "ran and passed". The
+///   gates are written fail-closed for a check that is ABSENT — "did not run,
+///   cannot be confirmed". A check that ran and measured nothing is that same
+///   case, and it satisfied the gate. Since #1706 that outcome is reachable:
+///   `cross_source_overlap_not_applicable` passes with a reason and an
+///   `overlap_count: 0` placeholder, so a rule requiring that check was
+///   confirmed by a reading nobody took.
+///
+///   **Why on `CheckOutcome` and not `RunRecord`.** The distinction is
+///   per-check, not per-run. A run can record twenty outcomes of which one
+///   measured nothing, and only a rule naming THAT check should be refused.
+///   A run-level flag would refuse every rule on the run or none.
+///
+///   **This is the first bump to a NESTED record.** v25 and v26 added fields
+///   to `RunRecord` itself; this one adds to the elements of
+///   `RunRecord::check_outcomes`. The serde mechanism is the same, so the
+///   forward-read guard is written against a `RunRecord` blob whose OUTCOMES
+///   have the key stripped, not the record.
+///
+///   **On upgrade.** A v26 store is stamped v27 in place and every existing
+///   record is kept. Its outcomes read back `None` — honest, because a v26
+///   run's gates could not have consulted a field that did not exist, so
+///   nothing is being reinterpreted after the fact. Only runs recorded by
+///   this binary onward can carry a reason.
+///
+///   **On rollback.** The blob is backward-safe in the serde sense — a v27
+///   outcome carries at most one extra key and serde ignores unknown keys —
+///   but the read is NOT safe in meaning: a v26 binary parses an unevaluated
+///   pass and confirms it, which is the bug. It does not reach it, because
+///   the version check runs at OPEN and `[state] on_schema_mismatch` engages
+///   there. `Recreate` discards run history, so a rolled-back binary has no
+///   outcome to misread at all. Rolling back is not a way to clear this
+///   gate; re-running the pipeline with a real reading is.
+const CURRENT_SCHEMA_VERSION: u32 = 27;
 
 /// Errors from the embedded redb state store.
 #[derive(Debug, Error)]
@@ -2455,7 +2497,121 @@ pub struct CheckOutcome {
     /// lists.
     pub name: String,
     /// Whether the check passed.
+    ///
+    /// Read this to learn whether the check FAILED. It does not tell you the
+    /// check measured anything — see [`CheckOutcome::not_evaluated`].
     pub passed: bool,
+    /// Set when the run could not measure this check, carrying the reason.
+    /// Mirrors `rocky_core::checks::CheckResult::not_evaluated`, which is
+    /// where it is copied from.
+    ///
+    /// A `passed: true` outcome carrying this is a check that ran, measured
+    /// nothing, and declined to call that a failure. `passed` alone cannot
+    /// tell the two apart, so a gate that reads only `passed` confirms a
+    /// check it has no reading for (#1715).
+    ///
+    /// Almost always `None`: every `*_not_evaluated` constructor sets
+    /// `passed: false`, so an unevaluated outcome normally arrives as a plain
+    /// failure. The exception is the shape this field exists for —
+    /// `cross_source_overlap_not_applicable`, which passes because the
+    /// configuration does not apply to the group (#1654, #1706).
+    ///
+    /// `None` on pre-v27 records, which is the honest reading: a record
+    /// written before this field existed carries no unevaluated outcome to
+    /// find, because the gates that consume it also predate it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub not_evaluated: Option<String>,
+}
+
+/// Why a `verify_after` rule could not confirm one of the checks it requires.
+///
+/// Returned by [`unverified_required_checks`], which is the single place both
+/// `verify_after` gates — the two-step `rocky apply` gate and the post-apply
+/// drift-governance finalizer — decide what "confirmed" means. One
+/// implementation, so the two cannot drift apart on the question this type
+/// answers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UnverifiedCheck {
+    /// The run recorded the check and it failed.
+    Failed,
+    /// The run recorded the check as passing, but it measured nothing, so
+    /// there is no reading to confirm. Carries the recorded reason.
+    NotEvaluated(String),
+    /// No outcome under this name — the check did not run.
+    Absent,
+}
+
+impl UnverifiedCheck {
+    /// The operator-facing reason, rendered as `<name> (<reason>)`.
+    ///
+    /// Kept beside the variants so both gates report an unconfirmed check the
+    /// same way.
+    pub fn describe(&self, name: &str) -> String {
+        match self {
+            Self::Failed => format!("{name} (failed)"),
+            Self::NotEvaluated(reason) => {
+                format!("{name} (not evaluated: {reason} — nothing was measured)")
+            }
+            Self::Absent => format!("{name} (absent — did not run)"),
+        }
+    }
+}
+
+/// Resolve which of `required` a run's `outcomes` fail to confirm.
+///
+/// Returns one entry per unconfirmed check, in `required` order, already
+/// rendered by [`UnverifiedCheck::describe`]. An empty return means every
+/// required check ran, measured something, and passed.
+///
+/// **Aggregation.** A check name can appear once per table, so occurrences are
+/// folded together and the name is confirmed only if EVERY occurrence
+/// confirms. `Failed` outranks `NotEvaluated` in the report, because a
+/// measured failure is the more actionable thing to tell an operator.
+///
+/// **Why an unevaluated pass is not a pass.** The gate's contract is "confirm
+/// a named check ran and passed". It is written fail-closed for a check that
+/// is absent — "did not run, cannot be confirmed". A check that ran and
+/// measured nothing is that same case wearing `passed: true`, and before
+/// #1715 it satisfied the gate.
+pub fn unverified_required_checks(outcomes: &[CheckOutcome], required: &[String]) -> Vec<String> {
+    // Key present ⇒ the name ran at least once. `None` ⇒ every occurrence so
+    // far confirmed; `Some(v)` ⇒ one did not, and why.
+    let mut folded: std::collections::BTreeMap<&str, Option<UnverifiedCheck>> =
+        std::collections::BTreeMap::new();
+
+    for c in outcomes {
+        // `passed: false` stays a plain failure whether or not it also carries
+        // a reason — that is the pre-#1715 behaviour and this does not widen
+        // it. The one outcome that changes meaning is a PASSING one that
+        // measured nothing.
+        let verdict = if !c.passed {
+            Some(UnverifiedCheck::Failed)
+        } else {
+            c.not_evaluated
+                .as_ref()
+                .map(|r| UnverifiedCheck::NotEvaluated(r.clone()))
+        };
+        let slot = folded.entry(c.name.as_str()).or_insert(None);
+        match slot {
+            // A measured failure is the more actionable report, so it stands
+            // over an unevaluated sibling occurrence.
+            Some(UnverifiedCheck::Failed) => {}
+            _ => {
+                if verdict.is_some() {
+                    *slot = verdict;
+                }
+            }
+        }
+    }
+
+    required
+        .iter()
+        .filter_map(|name| match folded.get(name.as_str()) {
+            Some(Some(verdict)) => Some(verdict.describe(name)),
+            Some(None) => None,
+            None => Some(UnverifiedCheck::Absent.describe(name)),
+        })
+        .collect()
 }
 
 /// Default-value contract for `RunRecord.hostname` on v5→v6 upgrade.
@@ -7094,10 +7250,12 @@ mod tests {
             CheckOutcome {
                 name: "row_count".to_string(),
                 passed: true,
+                not_evaluated: None,
             },
             CheckOutcome {
                 name: "not_null:email".to_string(),
                 passed: false,
+                not_evaluated: None,
             },
         ];
         let round: RunRecord =
@@ -7133,6 +7291,184 @@ mod tests {
             serde_json::from_slice(&serde_json::to_vec(&stamped).unwrap()).unwrap();
         assert_eq!(round.pipeline.as_deref(), Some("raw"));
         assert_eq!(round.submission_id.as_deref(), Some("sub-123"));
+    }
+
+    /// v26 → v27 (#1715). A v26 `RunRecord` blob's check outcomes have no
+    /// `not_evaluated` key at all. They must forward-deserialize with it
+    /// `None`.
+    ///
+    /// `None` is the honest reading rather than a fail-open default: a v26 run
+    /// was gated by a binary that could not consult this field, so reading its
+    /// outcomes as "measured" reinterprets nothing that was ever decided
+    /// differently. Runs recorded by this binary onward carry the real reason.
+    ///
+    /// This is the first bump to a NESTED record, so the blob under test is a
+    /// `RunRecord` whose OUTCOMES have the key stripped — stripping it from
+    /// the record itself would test nothing.
+    #[test]
+    fn test_v26_check_outcome_forward_deserializes_not_evaluated_none() {
+        let mut v27 = minimal_run_record("run-v26", vec![]);
+        v27.check_outcomes = vec![CheckOutcome {
+            name: "cross_source_overlap:duckdb.orders".to_string(),
+            passed: true,
+            not_evaluated: Some("only one contributing table carries the key".to_string()),
+        }];
+
+        let mut value = serde_json::to_value(&v27).expect("serialize run record");
+        let outcomes = value
+            .get_mut("check_outcomes")
+            .and_then(|v| v.as_array_mut())
+            .expect("check_outcomes is an array");
+        assert!(
+            outcomes[0]
+                .as_object_mut()
+                .expect("an outcome is an object")
+                .remove("not_evaluated")
+                .is_some(),
+            "precondition: a v27 outcome carries the key this test strips"
+        );
+        let blob = serde_json::to_vec(&value).expect("reserialize without the key");
+
+        let record: RunRecord =
+            serde_json::from_slice(&blob).expect("a v26 RunRecord must forward-deserialize");
+        assert_eq!(record.run_id, "run-v26");
+        assert_eq!(record.check_outcomes.len(), 1);
+        assert!(
+            record.check_outcomes[0].not_evaluated.is_none(),
+            "a v26 outcome reads as no reason recorded"
+        );
+        assert!(record.check_outcomes[0].passed);
+
+        // A v27 outcome carrying the reason round-trips losslessly — the field
+        // survives redb's blob rather than being dropped on the way through.
+        let round: RunRecord = serde_json::from_slice(&serde_json::to_vec(&v27).unwrap()).unwrap();
+        assert_eq!(round.check_outcomes, v27.check_outcomes);
+
+        // An evaluated outcome emits no key at all, so a run whose checks all
+        // measured something serializes byte-identically to v26.
+        let mut plain = minimal_run_record("run-plain", vec![]);
+        plain.check_outcomes = vec![CheckOutcome {
+            name: "row_count".to_string(),
+            passed: true,
+            not_evaluated: None,
+        }];
+        let emitted = serde_json::to_value(&plain).unwrap();
+        assert!(
+            emitted["check_outcomes"][0].get("not_evaluated").is_none(),
+            "an evaluated outcome adds nothing to the wire"
+        );
+    }
+
+    /// The gate's own truth table, at the one function both `verify_after`
+    /// gates call. Each row is a shape the gate must answer, and the two
+    /// middle rows are the #1715 fix.
+    #[test]
+    fn unverified_required_checks_truth_table() {
+        let outcome = |name: &str, passed: bool, reason: Option<&str>| CheckOutcome {
+            name: name.to_string(),
+            passed,
+            not_evaluated: reason.map(str::to_string),
+        };
+        let req = |n: &str| vec![n.to_string()];
+
+        // Measured and passed ⇒ confirmed.
+        assert!(
+            unverified_required_checks(&[outcome("row_count", true, None)], &req("row_count"))
+                .is_empty()
+        );
+
+        // Measured and failed ⇒ refused as a failure.
+        let failed =
+            unverified_required_checks(&[outcome("row_count", false, None)], &req("row_count"));
+        assert_eq!(failed, vec!["row_count (failed)".to_string()]);
+
+        // 🔴 Passed but measured nothing ⇒ refused, naming the reason.
+        let unmeasured = unverified_required_checks(
+            &[outcome("overlap", true, Some("one carrier only"))],
+            &req("overlap"),
+        );
+        assert_eq!(unmeasured.len(), 1);
+        assert!(
+            unmeasured[0].contains("not evaluated") && unmeasured[0].contains("one carrier only"),
+            "{:?}",
+            unmeasured[0]
+        );
+
+        // Never ran ⇒ refused as absent (unchanged).
+        assert_eq!(
+            unverified_required_checks(&[], &req("row_count")),
+            vec!["row_count (absent — did not run)".to_string()]
+        );
+
+        // A failed occurrence outranks an unevaluated one under the same name:
+        // the measured failure is the more actionable thing to report.
+        let mixed = unverified_required_checks(
+            &[
+                outcome("overlap", true, Some("one carrier only")),
+                outcome("overlap", false, None),
+            ],
+            &req("overlap"),
+        );
+        assert_eq!(mixed, vec!["overlap (failed)".to_string()]);
+
+        // A measured pass does NOT rescue an unevaluated occurrence of the
+        // same name — every occurrence must confirm.
+        let partial = unverified_required_checks(
+            &[
+                outcome("overlap", true, None),
+                outcome("overlap", true, Some("one carrier only")),
+            ],
+            &req("overlap"),
+        );
+        assert_eq!(partial.len(), 1, "one blind occurrence blinds the name");
+        assert!(partial[0].contains("not evaluated"));
+
+        // …in either order.
+        let reversed = unverified_required_checks(
+            &[
+                outcome("overlap", true, Some("one carrier only")),
+                outcome("overlap", true, None),
+            ],
+            &req("overlap"),
+        );
+        assert_eq!(reversed.len(), 1, "order must not decide the verdict");
+
+        // A `passed: false` outcome that also carries a reason stays a plain
+        // failure — pre-#1715 behaviour, deliberately not widened.
+        assert_eq!(
+            unverified_required_checks(
+                &[outcome("row_count", false, Some("the query failed"))],
+                &req("row_count"),
+            ),
+            vec!["row_count (failed)".to_string()]
+        );
+
+        // Unrequired outcomes are ignored, however broken.
+        assert!(
+            unverified_required_checks(
+                &[outcome("something_else", true, Some("blind"))],
+                &req("row_count"),
+            ) == vec!["row_count (absent — did not run)".to_string()]
+        );
+
+        // Multiple required names report in `required` order.
+        let many = unverified_required_checks(
+            &[
+                outcome("a", false, None),
+                outcome("b", true, Some("blind")),
+                outcome("c", true, None),
+            ],
+            &[
+                "c".to_string(),
+                "b".to_string(),
+                "a".to_string(),
+                "d".to_string(),
+            ],
+        );
+        assert_eq!(many.len(), 3, "c confirms; b, a and d do not: {many:?}");
+        assert!(many[0].starts_with("b ("));
+        assert!(many[1].starts_with("a ("));
+        assert!(many[2].starts_with("d ("));
     }
 
     /// v25 → v26 (#1732). A v25 `RunRecord` blob has no `verify_after_failed`
@@ -12142,7 +12478,7 @@ mod tests {
         // serde-additive shape. NO table change either — so this stanza moves
         // the version only; guarded by
         // `test_v25_run_record_forward_deserializes_verify_after_failed_false`.
-        const EXPECTED_VERSION: u32 = 26;
+        const EXPECTED_VERSION: u32 = 27;
         const EXPECTED_TABLES: &[&str] = &[
             "branches",
             "check_history",

--- a/integrations/dagster/tests/fixtures_generated/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor.json
@@ -17,7 +17,7 @@
     {
       "name": "state_schema",
       "status": "healthy",
-      "message": "state schema v26 matches this binary",
+      "message": "state schema v27 matches this binary",
       "duration_ms": 0
     },
     {

--- a/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
@@ -17,7 +17,7 @@
     {
       "name": "state_schema",
       "status": "healthy",
-      "message": "no on-disk state schema (binary supports v26)",
+      "message": "no on-disk state schema (binary supports v27)",
       "duration_ms": 0
     },
     {

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 26,
-  "schema_version_on_disk": 26
+  "schema_version_supported": 27,
+  "schema_version_on_disk": 27
 }

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 26,
-  "schema_version_on_disk": 26
+  "schema_version_supported": 27,
+  "schema_version_on_disk": 27
 }

--- a/integrations/dagster/tests/fixtures_generated/state.json
+++ b/integrations/dagster/tests/fixtures_generated/state.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 26,
-  "schema_version_on_disk": 26
+  "schema_version_supported": 27,
+  "schema_version_on_disk": 27
 }


### PR DESCRIPTION
Both `verify_after` gates confirmed a check that measured nothing.

`CheckOutcome` stored `{ name, passed }`, so a gate reading `Some(true)` could not tell a measured pass from a check that ran and took no reading. The gates are written fail-closed for a check that is **absent** — "did not run, cannot be confirmed". A check that ran and measured nothing is that same case wearing `passed: true`.

## How it is reachable

Since #1706, `cross_source_overlap_not_applicable` passes with a reason and an `overlap_count: 0` placeholder. A policy rule with `verify_after = ["cross_source_overlap:duckdb.orders"]` on a group where one sibling carries no key column is confirmed by a reading nobody took.

On the drift-governance half the migration has **already landed** when the finalizer runs, and there is no rollback substrate.

## The fix is at a site that already had the data

`to_run_record` built each outcome from a `CheckResult` it was holding, and dropped `c.not_evaluated` on the floor.

```
  before                          after
  ------                          -----
  CheckResult                     CheckResult
    passed: true                    passed: true
    not_evaluated: Some(why)  ✂     not_evaluated: Some(why)
        |                               |
        v                               v
  CheckOutcome { name, passed }   CheckOutcome { name, passed, not_evaluated }
        |                               |
        v                               v
  gate: Some(true) => confirmed   gate: passed + unmeasured => refused
```

Both gates now call one function — `unverified_required_checks` — so they cannot answer "confirmed" differently. The two call sites had duplicated the aggregation, which is how they would have drifted.

A `passed: false` outcome stays a plain failure whether or not it carries a reason. That is the pre-fix behaviour and is deliberately not widened. **The only outcome that changes meaning is a passing one that measured nothing.**

## State schema v26 → v27

Serde-additive with `skip_serializing_if`, so a v26 blob forward-reads with `None` and a run whose checks all measured something serializes byte-identically to before.

This is the first bump to a **nested** record — v25 and v26 added fields to `RunRecord` itself, this adds to the elements of `RunRecord::check_outcomes` — so the forward-read guard strips the key from the *outcomes*, not from the record. Stripping it from the record would have tested nothing.

`None` on a v26 record is the honest reading rather than a fail-open default: a v26 run was gated by a binary that could not consult this field, so nothing decided earlier is being reinterpreted.

## Two corrections to the issue

The issue was written against `df506990` and is stale in two places. Both are recorded on the issue.

- It says the bump is v24 → v25. Main is at v26 (#1720, #1732), so it is v26 → v27. Those two bumps are also worked precedents for this exact shape, which makes it cheaper than the issue implies.
- It says that with #1705's mistyped-key shape "it passes on every group". #1717 fixed #1705 — a key no sibling carries now returns a *failing* `not_evaluated`. The remaining trigger is the genuine one-carrier case: one group, not all of them.

## Evidence

Four guards, each probed with `scripts/mutation-check.sh` against a mutation that removes exactly one half of the fix.

| Mutation | Result |
|---|---|
| Persist `not_evaluated: None` (break the wire, keep the gate) | **caught** — 1 of 1835 rocky-cli tests fails |
| Return `None` instead of `NotEvaluated` (break the gate, keep the wire) | **caught** — 3 rocky-cli tests + the rocky-core truth table fail |

The wire mutation being caught by exactly one test is the point: before this PR nothing read the persisted reason, so nothing could have caught it. The wire test runs the real producer (`to_run_record`) into the real consumer (`unverified_required_checks`) rather than a hand-built outcome.

Tests added:
- `an_unmeasured_passing_check_reaches_the_gate_as_unverifiable` — the wire, end to end
- `unverified_required_checks_truth_table` — every shape at the shared function: measured pass, measured
  failure, passing-but-unmeasured, never-ran, a failed occurrence outranking an unevaluated one, a measured
  pass failing to rescue an unevaluated occurrence of the same name (in both orderings), `passed: false`
  carrying a reason staying a plain failure, unrequired outcomes ignored, and reporting in `required` order
- `verify_after_fails_closed_when_named_check_measured_nothing` + `verify_after_still_passes_a_check_that_measured_and_passed` — the apply gate and its companion
- `a_required_check_that_measured_nothing_fails_verify_after_closed` + `a_required_check_that_measured_and_passed_still_confirms` — the drift-governance finalizer and its companion
- `test_v26_check_outcome_forward_deserializes_not_evaluated_none` — the forward read, plus that an evaluated outcome adds nothing to the wire

Each refusal test is paired with a companion proving a measured pass still confirms, so deleting the passing arm outright cannot read as a fix.

Full local run: engine workspace `cargo test --all-features` green (165 test binaries), clippy `--all-targets --all-features -D warnings` clean, `cargo fmt --check` clean, dagster 770 passed, sdk 258 passed.

`just codegen` produced no drift — `CheckOutcome` does not derive `JsonSchema`. `just regen-fixtures` moved the five dagster fixtures that carry the schema version number, committed separately.

### One local flake, not from this change

`commands::scheduler::tests::a_failed_run_climbs_the_consecutive_failure_gauge` failed once in a full run and then passed in isolation, three module runs, and two further full runs. It reads a process-global metrics gauge that a sibling test writes under the same `pipeline=raw` key. A deterministic code change cannot produce a failure that disappears on re-run, and there is no path from `CheckOutcome` to a scheduler gauge. Not addressed here.

Refs #1715, #1706, #1654, #1720, #1732, #1717.

---

**Review disclosure.** This was reviewed by a same-model adversarial pass, not an independent red team. Per `AGENTS.md` that does **not** meet the independence bar — an independent reviewer was unavailable at authoring time. The mutation probes above are the substitute evidence, and they are mechanical rather than a judgement about design.
