### PR TITLE
fix(engine): make Model::file_path a PathBuf, so the incremental typecheck stops missing a changed model (#1730)

### DIFF
--- a/engine/crates/rocky-ai/src/explain.rs
+++ b/engine/crates/rocky-ai/src/explain.rs
@@ -77,15 +77,28 @@ pub async fn explain_model(
 /// surface the message to the user, who is expected to fix or remove
 /// the file before retrying.
 pub fn save_intent_to_config(model: &Model, intent: &str) -> Result<(), std::io::Error> {
-    let toml_path = if model.file_path.ends_with(".rocky") {
-        format!("{}.toml", model.file_path)
-    } else if model.file_path.ends_with(".sql") {
-        model.file_path.replace(".sql", ".toml")
+    // Built on the path itself rather than on a rendered string (#1730): the
+    // result is opened for writing, so a lossy round-trip would write to a
+    // different file than the one the model came from.
+    //
+    // The `.sql` arm now uses `with_extension`, which is the derivation the
+    // loader itself uses (`project.rs:629`, `models.rs:1603`). The previous
+    // `replace(".sql", ".toml")` rewrote EVERY occurrence, so a model under a
+    // directory whose name contains `.sql` was redirected into a sibling tree.
+    //
+    // The two appending arms are preserved exactly as they were. The `.rocky`
+    // arm is wrong — it writes `flow.rocky.toml` while the loader reads
+    // `flow.toml` — but that is a separate defect with a user-visible output
+    // path, tracked on its own rather than folded into this change.
+    let toml_path = if model.file_path.extension().is_some_and(|e| e == "sql") {
+        model.file_path.with_extension("toml")
     } else {
-        format!("{}.toml", model.file_path)
+        let mut appended = model.file_path.clone().into_os_string();
+        appended.push(".toml");
+        std::path::PathBuf::from(appended)
     };
 
-    let path = std::path::Path::new(&toml_path);
+    let path = toml_path.as_path();
 
     // Read existing config or start fresh. Refuse to clobber a sidecar
     // that exists but doesn't parse — overwriting it would delete the
@@ -131,10 +144,10 @@ mod save_intent_tests {
     use rocky_core::models::{Model, ModelConfig, StrategyConfig, TargetConfig};
     use std::io::Write;
 
-    fn make_model(file_path: String) -> Model {
+    fn make_model(file_path: impl Into<std::path::PathBuf>) -> Model {
         Model {
             sql: String::new(),
-            file_path,
+            file_path: file_path.into(),
             contract_path: None,
             config: ModelConfig {
                 name: "test_model".to_string(),

--- a/engine/crates/rocky-ai/src/generate.rs
+++ b/engine/crates/rocky-ai/src/generate.rs
@@ -423,7 +423,7 @@ fn build_generated_model(
         } else {
             source.to_string()
         },
-        file_path: format!("generated/{name}.{format}"),
+        file_path: format!("generated/{name}.{format}").into(),
         contract_path: None,
     }
 }
@@ -536,7 +536,7 @@ mod tests {
                 target_table_declared: String::new(),
             },
             sql: sql.to_string(),
-            file_path: format!("upstream/{name}.sql"),
+            file_path: format!("upstream/{name}.sql").into(),
             contract_path: None,
         }
     }

--- a/engine/crates/rocky-cli/src/api.rs
+++ b/engine/crates/rocky-cli/src/api.rs
@@ -1079,7 +1079,7 @@ async fn get_model(
         sql,
         sql_truncated,
         sql_bytes: model.sql.len(),
-        file_path: model.file_path.clone(),
+        file_path: model.file_path.display().to_string(),
         columns: schema
             .columns
             .iter()

--- a/engine/crates/rocky-cli/src/commands/ai.rs
+++ b/engine/crates/rocky-cli/src/commands/ai.rs
@@ -21,8 +21,8 @@ const ANTHROPIC_API_KEY_VAR: &str = "ANTHROPIC_API_KEY";
 
 /// Pick the validation format for a model from its source file path: `.rocky`
 /// files are Rocky DSL, everything else (notably `.sql`) is raw SQL.
-fn proposed_source_format(file_path: &str) -> &'static str {
-    if std::path::Path::new(file_path)
+fn proposed_source_format(file_path: &std::path::Path) -> &'static str {
+    if file_path
         .extension()
         .is_some_and(|ext| ext.eq_ignore_ascii_case("rocky"))
     {
@@ -417,7 +417,7 @@ pub async fn run_ai_sync(
                         );
                     }
                     std::fs::write(&model.file_path, &proposal.proposed_source)?;
-                    println!("Updated: {}", model.file_path);
+                    println!("Updated: {}", model.file_path.display());
                 }
             }
         } else if !proposals.is_empty() {
@@ -589,10 +589,22 @@ mod tests {
 
     #[test]
     fn proposed_source_format_detects_rocky_and_sql() {
-        assert_eq!(proposed_source_format("models/orders.rocky"), "rocky");
-        assert_eq!(proposed_source_format("models/orders.ROCKY"), "rocky");
-        assert_eq!(proposed_source_format("models/orders.sql"), "sql");
-        assert_eq!(proposed_source_format("models/orders"), "sql");
+        assert_eq!(
+            proposed_source_format(std::path::Path::new("models/orders.rocky")),
+            "rocky"
+        );
+        assert_eq!(
+            proposed_source_format(std::path::Path::new("models/orders.ROCKY")),
+            "rocky"
+        );
+        assert_eq!(
+            proposed_source_format(std::path::Path::new("models/orders.sql")),
+            "sql"
+        );
+        assert_eq!(
+            proposed_source_format(std::path::Path::new("models/orders")),
+            "sql"
+        );
     }
 
     /// `ai-sync --apply` must validate a proposal before writing. An
@@ -605,7 +617,7 @@ mod tests {
         std::fs::write(&model_path, original).unwrap();
 
         let bad_proposal = "this is not sql at all ;;;";
-        let format = proposed_source_format(model_path.to_str().unwrap());
+        let format = proposed_source_format(&model_path);
 
         // Mirror the apply gate: validate first, only write on success.
         let validation =

--- a/engine/crates/rocky-cli/src/commands/compile.rs
+++ b/engine/crates/rocky-cli/src/commands/compile.rs
@@ -210,7 +210,7 @@ fn compile_inner(
                 }
                 result.diagnostics.push(build_p001_diagnostic(
                     &model.config.name,
-                    &model.file_path,
+                    &model.file_path.display().to_string(),
                     &issue,
                 ));
                 portability_errors = true;
@@ -367,7 +367,7 @@ fn compile_inner(
             .models
             .iter()
             .filter(|model| in_scope(&model.config.name))
-            .map(|m| (m.file_path.clone(), m.sql.clone()))
+            .map(|m| (m.file_path.display().to_string(), m.sql.clone()))
             .collect(),
     };
 

--- a/engine/crates/rocky-cli/src/commands/compliance.rs
+++ b/engine/crates/rocky-cli/src/commands/compliance.rs
@@ -306,7 +306,7 @@ mod tests {
                 target_table_declared: String::new(),
             },
             sql: "SELECT 1".to_string(),
-            file_path: format!("models/{name}.sql"),
+            file_path: format!("models/{name}.sql").into(),
             contract_path: None,
         }
     }

--- a/engine/crates/rocky-cli/src/commands/imports_check.rs
+++ b/engine/crates/rocky-cli/src/commands/imports_check.rs
@@ -466,7 +466,7 @@ mod tests {
                 target_table_declared: String::new(),
             },
             sql: sql.to_string(),
-            file_path: "models/shipments.sql".to_string(),
+            file_path: "models/shipments.sql".into(),
             contract_path: None,
         }
     }

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -24637,7 +24637,7 @@ auto_create_schemas = true
             Model {
                 config: toml::from_str(&toml).expect("model config"),
                 sql: "SELECT 1".into(),
-                file_path: String::new(),
+                file_path: std::path::PathBuf::new(),
                 contract_path: None,
             }
         };

--- a/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
+++ b/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
@@ -551,14 +551,17 @@ pub(super) fn load_transformation_models(
                      models sharing a name cannot both be built — rename one.",
                     model.config.name,
                     first,
-                    model.file_path,
+                    model.file_path.display(),
                 );
             }
 
-            seen_here.insert(model.config.name.clone(), model.file_path.clone());
+            seen_here.insert(
+                model.config.name.clone(),
+                model.file_path.display().to_string(),
+            );
             file_of_name.insert(
                 model.config.name.clone(),
-                (canonical, model.file_path.clone()),
+                (canonical, model.file_path.display().to_string()),
             );
             models.push(model);
         }

--- a/engine/crates/rocky-cli/src/commands/validate.rs
+++ b/engine/crates/rocky-cli/src/commands/validate.rs
@@ -1469,7 +1469,7 @@ fn lint_config(
                     "model '{}' declares name='{}' which matches its filename — you can omit it",
                     model.config.name, model.config.name
                 ),
-                file: Some(model.file_path.clone()),
+                file: Some(model.file_path.display().to_string()),
                 field: Some("name".into()),
             });
         }
@@ -1490,7 +1490,7 @@ fn lint_config(
                     "model '{}' declares target.table='{}' which matches name — you can omit it",
                     model.config.name, model.config.target.table
                 ),
-                file: Some(model.file_path.clone()),
+                file: Some(model.file_path.display().to_string()),
                 field: Some("target.table".into()),
             });
         }

--- a/engine/crates/rocky-compiler/src/blast_radius.rs
+++ b/engine/crates/rocky-compiler/src/blast_radius.rs
@@ -146,7 +146,7 @@ mod tests {
                 target_table_declared: String::new(),
             },
             sql: sql.to_string(),
-            file_path: format!("models/{name}.sql"),
+            file_path: format!("models/{name}.sql").into(),
             contract_path: None,
         }
     }
@@ -154,7 +154,7 @@ mod tests {
     fn file_paths_for(models: &[Model]) -> HashMap<String, String> {
         models
             .iter()
-            .map(|m| (m.config.name.clone(), m.file_path.clone()))
+            .map(|m| (m.config.name.clone(), m.file_path.display().to_string()))
             .collect()
     }
 

--- a/engine/crates/rocky-compiler/src/compile.rs
+++ b/engine/crates/rocky-compiler/src/compile.rs
@@ -926,8 +926,8 @@ mod tests {
         let edited = models_dir.join("m00.sql");
         std::fs::write(&edited, "SELECT 1 AS id, 2 AS qty\n").expect("rewrite m00");
 
-        let incremental =
-            compile_incremental(&config, &[edited.clone()], &first).expect("incremental");
+        let incremental = compile_incremental(&config, std::slice::from_ref(&edited), &first)
+            .expect("incremental");
         let scratch = compile(&config).expect("from-scratch compile");
 
         assert_eq!(
@@ -983,11 +983,12 @@ mod tests {
         // component as U+FFFD and the round-trip cannot recover it.
         let models_dir = tmp.path().join(OsString::from_vec(b"models_\xff".to_vec()));
         if let Err(e) = std::fs::create_dir_all(&models_dir) {
-            assert!(
-                !cfg!(target_os = "linux"),
-                "linux must be able to create a non-UTF-8 directory; without it \
-                 this test asserts nothing: {e}"
-            );
+            if cfg!(target_os = "linux") {
+                panic!(
+                    "linux must be able to create a non-UTF-8 directory; \
+                     without it this test asserts nothing: {e}"
+                );
+            }
             return;
         }
 
@@ -1019,8 +1020,8 @@ mod tests {
         let edited = models_dir.join("m00.sql");
         std::fs::write(&edited, "SELECT 1 AS id, 2 AS qty\n").expect("rewrite m00");
 
-        let incremental =
-            compile_incremental(&config, &[edited.clone()], &first).expect("incremental");
+        let incremental = compile_incremental(&config, std::slice::from_ref(&edited), &first)
+            .expect("incremental");
         let scratch = compile(&config).expect("from-scratch compile");
 
         assert_eq!(

--- a/engine/crates/rocky-compiler/src/compile.rs
+++ b/engine/crates/rocky-compiler/src/compile.rs
@@ -4,7 +4,7 @@
 //! type check → validate contracts → produce `CompileResult`.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
@@ -417,7 +417,10 @@ pub fn compile_project(
     let file_paths: HashMap<String, String> = project
         .models
         .iter()
-        .map(|m| (m.config.name.clone(), m.file_path.clone()))
+        // Rendered, not compared: this map feeds a diagnostic's `file` field.
+        // The lossy conversion is correct HERE and is now visible, instead of
+        // being baked into the type every consumer shares (#1730).
+        .map(|m| (m.config.name.clone(), m.file_path.display().to_string()))
         .collect();
     let blast_radius_diagnostics =
         blast_radius::detect_select_star_blast_radius(&semantic_graph, &file_paths);
@@ -537,10 +540,17 @@ pub fn compile_incremental(
     //    graph so we catch upstream shifts and newly-added models.
     let mut affected: HashSet<String> = HashSet::new();
 
-    let changed_paths: HashSet<PathBuf> = changed_files.iter().cloned().collect();
+    // #1730. This comparison is why `Model::file_path` is a `PathBuf`. It was
+    // a `String` built with `display()`, rebuilt here into a `PathBuf` and
+    // compared against the watcher's real path — so on a path component that
+    // is not valid UTF-8 the two could never be equal, the model was never
+    // marked affected, and its stale typed result and `reference_map` survived
+    // the edit. That breaks the invariant AGENT_REVIEW.md names as priority 3:
+    // incremental output must equal from-scratch output for the same final
+    // state. Both sides are now the bytes the filesystem gave us.
+    let changed_paths: HashSet<&Path> = changed_files.iter().map(PathBuf::as_path).collect();
     for m in &project.models {
-        let path = PathBuf::from(&m.file_path);
-        if changed_paths.contains(&path) {
+        if changed_paths.contains(m.file_path.as_path()) {
             affected.insert(m.config.name.clone());
         }
     }
@@ -641,7 +651,10 @@ pub fn compile_incremental(
     let file_paths: HashMap<String, String> = project
         .models
         .iter()
-        .map(|m| (m.config.name.clone(), m.file_path.clone()))
+        // Rendered, not compared: this map feeds a diagnostic's `file` field.
+        // The lossy conversion is correct HERE and is now visible, instead of
+        // being baked into the type every consumer shares (#1730).
+        .map(|m| (m.config.name.clone(), m.file_path.display().to_string()))
         .collect();
     let blast_radius_diagnostics =
         blast_radius::detect_select_star_blast_radius(&semantic_graph, &file_paths);

--- a/engine/crates/rocky-compiler/src/compile.rs
+++ b/engine/crates/rocky-compiler/src/compile.rs
@@ -866,6 +866,177 @@ fn decimal_family_type(upper: &str) -> RockyType {
 mod tests {
     use super::*;
 
+    /// Write `count` independent single-column models into `dir`.
+    ///
+    /// Independent on purpose: nothing but the changed-path comparison may
+    /// mark one affected, so there is no upstream shift and no transitive
+    /// dependent to do it instead.
+    #[cfg(test)]
+    fn write_flat_models(dir: &std::path::Path, count: usize) {
+        // Directory-level target defaults, so each sidecar stays one line.
+        std::fs::write(
+            dir.join("_defaults.toml"),
+            "[target]\ncatalog = \"analytics\"\nschema = \"marts\"\n",
+        )
+        .expect("write _defaults.toml");
+        for i in 0..count {
+            let name = format!("m{i:02}");
+            std::fs::write(
+                dir.join(format!("{name}.toml")),
+                format!("name = \"{name}\"\n"),
+            )
+            .expect("write sidecar");
+            std::fs::write(dir.join(format!("{name}.sql")), "SELECT 1 AS id\n")
+                .expect("write model");
+        }
+    }
+
+    /// The companion to the non-UTF-8 test below, on an ordinary ASCII path so
+    /// it runs on every platform.
+    ///
+    /// It exists because the Linux-only test cannot be executed on macOS or
+    /// Windows, and an unrunnable test is an unverified one. This pins
+    /// everything that test depends on except the invalid byte: that twelve
+    /// models clear the `total < 10` guardrail, that one edited model keeps
+    /// `affected.len() * 2 <= total` so the incremental path is actually
+    /// taken, and that the equality assertion detects a stale typed result.
+    ///
+    /// There were no tests over `compile_incremental` before this.
+    #[test]
+    fn an_edited_model_is_re_typechecked_on_the_incremental_path() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir_all(&models_dir).expect("create models dir");
+
+        const TOTAL: usize = 12;
+        write_flat_models(&models_dir, TOTAL);
+
+        let config = CompilerConfig {
+            models_dir: models_dir.clone(),
+            ..Default::default()
+        };
+
+        let first = compile(&config).expect("first compile");
+        assert_eq!(
+            first.type_check.typed_models.len(),
+            TOTAL,
+            "twelve models, so `total < 10` cannot send this to a full compile"
+        );
+
+        let edited = models_dir.join("m00.sql");
+        std::fs::write(&edited, "SELECT 1 AS id, 2 AS qty\n").expect("rewrite m00");
+
+        let incremental =
+            compile_incremental(&config, &[edited.clone()], &first).expect("incremental");
+        let scratch = compile(&config).expect("from-scratch compile");
+
+        assert_eq!(
+            incremental.type_check.typed_models["m00"], scratch.type_check.typed_models["m00"],
+            "incremental output must equal from-scratch output"
+        );
+        assert_eq!(incremental.type_check.typed_models["m00"].len(), 2);
+
+        // The untouched models still carry their typed result, which is the
+        // reuse the incremental path exists for. If this were a full compile
+        // in disguise it would still hold — the point is that it must not
+        // REGRESS while the edited model is refreshed.
+        assert_eq!(incremental.type_check.typed_models["m11"].len(), 1);
+    }
+
+    /// 🔴 #1730. A model under a directory whose name is not valid UTF-8 must
+    /// still be marked affected when the watcher reports it changed.
+    ///
+    /// Asserted as the invariant `AGENT_REVIEW.md` calls priority 3 —
+    /// incremental output must equal from-scratch output for the same final
+    /// state — rather than by reaching into the affected set, so the test pins
+    /// the property and not the implementation.
+    ///
+    /// Before the fix, `Model::file_path` was a `String` built with
+    /// `display()`. The seed rebuilt a `PathBuf` from it and compared against
+    /// the watcher's real path; the lossy round-trip replaced the invalid byte
+    /// with U+FFFD, so the two could never be equal, the model was never
+    /// affected, and its stale typed columns survived the edit.
+    ///
+    /// **Twelve models, not one, and that is load-bearing.** `compile_incremental`
+    /// has a guardrail — `if total < 10 || affected.len() * 2 > total { return
+    /// compile(config) }` — so a small project falls through to a FULL compile
+    /// and would produce the correct answer whether or not the seed matched.
+    /// A one-model version of this test passes with the bug still in place.
+    /// Twelve independent models with one edited keeps `1 * 2 <= 12`, which is
+    /// the only shape that actually reaches the incremental path.
+    ///
+    /// Compiled on every unix so it cannot rot unnoticed, but only Linux can
+    /// create the directory: a component that is not valid UTF-8 is
+    /// representable there, while macOS APFS and Windows NTFS reject it at
+    /// creation. The defect is unreachable on those targets for the same
+    /// reason the test is. The skip is fail-closed on Linux — if creation
+    /// fails THERE the test panics rather than passing quietly.
+    #[cfg(unix)]
+    #[test]
+    fn a_changed_model_under_a_non_utf8_dir_is_re_typechecked() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+
+        // 0xFF is not valid UTF-8 in any position, so `display()` renders this
+        // component as U+FFFD and the round-trip cannot recover it.
+        let models_dir = tmp.path().join(OsString::from_vec(b"models_\xff".to_vec()));
+        if let Err(e) = std::fs::create_dir_all(&models_dir) {
+            assert!(
+                !cfg!(target_os = "linux"),
+                "linux must be able to create a non-UTF-8 directory; without it \
+                 this test asserts nothing: {e}"
+            );
+            return;
+        }
+
+        // Twelve independent models — see the guardrail note above. Independent
+        // so that nothing but the path comparison can mark `m00` affected: no
+        // upstream shift, no transitive dependent.
+        const TOTAL: usize = 12;
+        write_flat_models(&models_dir, TOTAL);
+
+        let config = CompilerConfig {
+            models_dir: models_dir.clone(),
+            ..Default::default()
+        };
+
+        let first = compile(&config).expect("first compile");
+        assert_eq!(
+            first.type_check.typed_models.len(),
+            TOTAL,
+            "precondition: every model typed, so the guardrail's `total` is 12"
+        );
+        assert_eq!(
+            first.type_check.typed_models["m00"].len(),
+            1,
+            "precondition: m00 starts with one column"
+        );
+
+        // Edit one, then hand the incremental path the watcher's REAL path —
+        // the same bytes on disk, not a rendering of them.
+        let edited = models_dir.join("m00.sql");
+        std::fs::write(&edited, "SELECT 1 AS id, 2 AS qty\n").expect("rewrite m00");
+
+        let incremental =
+            compile_incremental(&config, &[edited.clone()], &first).expect("incremental");
+        let scratch = compile(&config).expect("from-scratch compile");
+
+        assert_eq!(
+            incremental.type_check.typed_models["m00"], scratch.type_check.typed_models["m00"],
+            "incremental output must equal from-scratch output for the same \
+             final state; a stale typed result here means the edit was never \
+             seen (#1730)"
+        );
+        assert_eq!(
+            incremental.type_check.typed_models["m00"].len(),
+            2,
+            "and the new column is really there, so the assertion above cannot \
+             pass by both sides being stale"
+        );
+    }
+
     /// Contract diagnostics are serialized into `rocky compile --output json`
     /// and the dagster fixture corpus is byte-diffed in CI, so two runs of the
     /// same project must order them the same way. `HashMap` iteration does not

--- a/engine/crates/rocky-compiler/src/cost_check.rs
+++ b/engine/crates/rocky-compiler/src/cost_check.rs
@@ -198,7 +198,7 @@ mod tests {
                 target_table_declared: String::new(),
             },
             sql: "SELECT 1 AS x".to_string(),
-            file_path: format!("models/{name}.sql"),
+            file_path: format!("models/{name}.sql").into(),
             contract_path: None,
         }
     }

--- a/engine/crates/rocky-compiler/src/import/dbt.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt.rs
@@ -4827,7 +4827,7 @@ FROM {{ ref('stg_events') }}
             .map(|im| Model {
                 config: im.config.clone(),
                 sql: im.sql.clone(),
-                file_path: format!("models/{}.sql", im.name),
+                file_path: format!("models/{}.sql", im.name).into(),
                 contract_path: None,
             })
             .collect();

--- a/engine/crates/rocky-compiler/src/project.rs
+++ b/engine/crates/rocky-compiler/src/project.rs
@@ -696,7 +696,10 @@ fn load_single_rocky_model_with_db(
     Ok(Model {
         config,
         sql,
-        file_path: path.display().to_string(),
+        // The second of the two lossy constructions #1730 names. Both are
+        // now the bytes the filesystem gave us; rendering happens where a
+        // diagnostic needs a string, not here.
+        file_path: path.to_path_buf(),
         contract_path,
     })
 }
@@ -734,7 +737,7 @@ mod tests {
                 target_table_declared: String::new(),
             },
             sql: sql.to_string(),
-            file_path: format!("models/{name}.sql"),
+            file_path: format!("models/{name}.sql").into(),
             contract_path: None,
         }
     }

--- a/engine/crates/rocky-compiler/src/resolve.rs
+++ b/engine/crates/rocky-compiler/src/resolve.rs
@@ -357,7 +357,7 @@ mod tests {
                 target_table_declared: String::new(),
             },
             sql: sql.to_string(),
-            file_path: format!("models/{name}.sql"),
+            file_path: format!("models/{name}.sql").into(),
             contract_path: None,
         }
     }

--- a/engine/crates/rocky-compiler/src/semantic.rs
+++ b/engine/crates/rocky-compiler/src/semantic.rs
@@ -509,7 +509,7 @@ mod tests {
                 target_table_declared: String::new(),
             },
             sql: sql.to_string(),
-            file_path: format!("models/{name}.sql"),
+            file_path: format!("models/{name}.sql").into(),
             contract_path: None,
         }
     }

--- a/engine/crates/rocky-compiler/src/typecheck.rs
+++ b/engine/crates/rocky-compiler/src/typecheck.rs
@@ -438,7 +438,11 @@ fn compute_model_typecheck(
 
     // Extract references from this model's SQL if available.
     let ref_map = if let Some(model) = model_by_name.get(model_name) {
-        collect_references(&model.sql, &model.file_path, model_names)
+        collect_references(
+            &model.sql,
+            &model.file_path.display().to_string(),
+            model_names,
+        )
     } else {
         ReferenceMap::default()
     };
@@ -607,7 +611,10 @@ fn compute_model_typecheck(
     // Step 6: Enrich diagnostics with the model's file path as a SourceSpan
     // when they don't already have one. This gives miette a file to render.
     if let Some(model) = model_by_name.get(model_name) {
-        let file_path = &model.file_path;
+        // `SourceSpan.file` is what miette renders, so a lossy string is the
+        // right type at this seam — unlike the affected-set comparison in
+        // `compile.rs`, nothing here is matched against a real path (#1730).
+        let file_path = model.file_path.display().to_string();
         for diag in &mut diagnostics {
             if diag.span.is_none() {
                 diag.span = Some(SourceSpan {
@@ -2491,7 +2498,7 @@ mod tests {
                 target_table_declared: String::new(),
             },
             sql: sql.to_string(),
-            file_path: format!("models/{name}.sql"),
+            file_path: format!("models/{name}.sql").into(),
             contract_path: None,
         }
     }
@@ -4228,7 +4235,7 @@ mod tests {
             sql: format!(
                 "SELECT {time_column} FROM upstream WHERE {time_column} >= @start_date AND {time_column} < @end_date"
             ),
-            file_path: format!("models/{name}.sql"),
+            file_path: format!("models/{name}.sql").into(),
             contract_path: None,
         }
     }

--- a/engine/crates/rocky-core/src/cross_engine.rs
+++ b/engine/crates/rocky-core/src/cross_engine.rs
@@ -257,9 +257,16 @@ pub fn validate_cross_engine_config(
             && !config.adapters.contains_key(adapter_name)
         {
             // Find which pipeline this model belongs to (best effort).
+            // Walk real path components rather than splitting a rendered
+            // string on '/': that separator is wrong on Windows, and on a
+            // component that is not valid UTF-8 the rendered form cannot match
+            // any configured pipeline name. `filter_map` skips such a
+            // component instead of mangling it — a pipeline name is always
+            // UTF-8, so a component that is not one can never be the match.
             let pipeline_name = model
                 .file_path
-                .split('/')
+                .components()
+                .filter_map(|c| c.as_os_str().to_str())
                 .find(|seg| config.pipelines.contains_key(*seg))
                 .unwrap_or("unknown")
                 .to_owned();
@@ -1026,7 +1033,7 @@ mod tests {
                 target_table_declared: String::new(),
             },
             sql: format!("SELECT * FROM upstream_{name}"),
-            file_path: format!("models/{name}.sql"),
+            file_path: format!("models/{name}.sql").into(),
             contract_path: None,
         }
     }

--- a/engine/crates/rocky-core/src/models.rs
+++ b/engine/crates/rocky-core/src/models.rs
@@ -1222,8 +1222,15 @@ pub(crate) fn extract_declared_fields(raw_toml: &str) -> DeclaredModelFields {
 pub struct Model {
     pub config: ModelConfig,
     pub sql: String,
-    /// Path to the source file (for diagnostics).
-    pub file_path: String,
+    /// Path to the source file.
+    ///
+    /// A `PathBuf` rather than a `String` because four sites join against it
+    /// by comparing to a real filesystem path, and a `String` built with
+    /// `display()` is lossy: on a path component that is not valid UTF-8 the
+    /// two can never be equal, and every miss is silent (#1730). The worst of
+    /// them seeds the incremental typecheck's affected set, so a model edited
+    /// under such a directory kept its stale typed result.
+    pub file_path: std::path::PathBuf,
     /// Path to an auto-discovered `<stem>.contract.toml` file, if present
     /// alongside the model's `.sql` file. The contract itself is parsed by
     /// the compiler crate — we only stash the path here to avoid a
@@ -1453,7 +1460,10 @@ pub fn load_model_pair_with_context(
     Ok(Model {
         config,
         sql,
-        file_path: sql_path.display().to_string(),
+        // The whole point of #1730: `display().to_string()` here is
+        // `to_string_lossy`, and four sites downstream compare the result to a
+        // real filesystem path. Keep the bytes.
+        file_path: sql_path.to_path_buf(),
         contract_path,
     })
 }
@@ -1516,7 +1526,10 @@ pub fn parse_model_inline_with_context(
     Ok(Model {
         config,
         sql: sql.to_string(),
-        file_path: file_path.to_string(),
+        // Lossless: this parser's `file_path` is a `&str` label supplied by
+        // the caller (a synthetic name like "fct_orders.sql"), never a path
+        // read off the filesystem, so widening it cannot lose bytes.
+        file_path: std::path::PathBuf::from(file_path),
         contract_path,
     })
 }

--- a/engine/crates/rocky-core/src/plan_partition.rs
+++ b/engine/crates/rocky-core/src/plan_partition.rs
@@ -437,7 +437,7 @@ mod tests {
                 target_table_declared: String::new(),
             },
             sql: "SELECT d FROM x WHERE d >= @start_date AND d < @end_date".into(),
-            file_path: format!("models/{name}.sql"),
+            file_path: format!("models/{name}.sql").into(),
             contract_path: None,
         }
     }
@@ -710,7 +710,7 @@ mod tests {
                 target_table_declared: String::new(),
             },
             sql: String::new(),
-            file_path: String::new(),
+            file_path: std::path::PathBuf::new(),
             contract_path: None,
         };
         let (state, _dir) = temp_state();

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -1607,7 +1607,7 @@ mod tests {
                 target_table_declared: String::new(),
             },
             sql: format!("SELECT * FROM upstream_{name}"),
-            file_path: format!("models/{name}.sql"),
+            file_path: format!("models/{name}.sql").into(),
             contract_path: None,
         }
     }

--- a/engine/crates/rocky-server/src/lsp.rs
+++ b/engine/crates/rocky-server/src/lsp.rs
@@ -5333,6 +5333,66 @@ mod tests {
         assert_eq!(parsed.upstream_models, vec!["upstream".to_string()]);
     }
 
+    /// The sibling of `ai_action_skipped_on_rocky_dsl_file`, for the OTHER
+    /// `.rocky` skip. `build_contract_quickfix` had no test naming this branch
+    /// at all, so when the `PathBuf` migration turned its `ends_with(".rocky")`
+    /// from a substring test into a whole-component one — silently, with no
+    /// compile error — the whole suite stayed green (#1730).
+    ///
+    /// A `.rocky` model must get no textual quick-fix: the DSL has its own
+    /// auto-fix path, and appending a SQL projection column to it would emit
+    /// syntactically invalid source.
+    #[test]
+    fn contract_quickfix_skipped_on_rocky_dsl_file() {
+        let model = synth_model(
+            "downstream",
+            "from upstream\nselect { id }\n",
+            "/tmp/m/downstream.rocky",
+            vec!["upstream".into()],
+        );
+        let mut typed: indexmap::IndexMap<String, Vec<rocky_compiler::types::TypedColumn>> =
+            indexmap::IndexMap::new();
+        typed.insert(
+            "upstream".to_string(),
+            vec![rocky_compiler::types::TypedColumn {
+                name: "email".to_string(),
+                data_type: rocky_ir::types::RockyType::Unknown,
+                nullable: true,
+            }],
+        );
+
+        assert!(
+            build_contract_quickfix(
+                "E010",
+                "required column 'email' missing from model output",
+                &model,
+                &typed,
+            )
+            .is_none(),
+            "a .rocky model must take the DSL auto-fix path, not a SQL text edit"
+        );
+
+        // The control: the identical case on a `.sql` model DOES produce a fix,
+        // so the assertion above cannot pass because the inputs were wrong.
+        let sql_model = synth_model(
+            "downstream",
+            "SELECT id FROM upstream\n",
+            "/tmp/m/downstream.sql",
+            vec!["upstream".into()],
+        );
+        assert!(
+            build_contract_quickfix(
+                "E010",
+                "required column 'email' missing from model output",
+                &sql_model,
+                &typed,
+            )
+            .is_some(),
+            "precondition: this input yields a quick-fix on a .sql model, so \
+             the skip above is about the extension and nothing else"
+        );
+    }
+
     #[test]
     fn ai_action_skipped_on_rocky_dsl_file() {
         let model = synth_model(

--- a/engine/crates/rocky-server/src/lsp.rs
+++ b/engine/crates/rocky-server/src/lsp.rs
@@ -5344,9 +5344,14 @@ mod tests {
     /// syntactically invalid source.
     #[test]
     fn contract_quickfix_skipped_on_rocky_dsl_file() {
+        // Deliberately VALID SQL in a file named `.rocky`. A DSL body would
+        // fail the SQL parse further down and return `None` for that reason
+        // instead, which is what made the pre-existing test — and the first
+        // draft of this one — pass with the skip broken. The extension must be
+        // the only thing that can produce `None` here.
         let model = synth_model(
             "downstream",
-            "from upstream\nselect { id }\n",
+            "SELECT id FROM upstream\n",
             "/tmp/m/downstream.rocky",
             vec!["upstream".into()],
         );
@@ -5369,7 +5374,8 @@ mod tests {
                 &typed,
             )
             .is_none(),
-            "a .rocky model must take the DSL auto-fix path, not a SQL text edit"
+            "a .rocky model must take the DSL auto-fix path even when its body \
+             happens to parse as SQL — the extension decides"
         );
 
         // The control: the identical case on a `.sql` model DOES produce a fix,

--- a/engine/crates/rocky-server/src/lsp.rs
+++ b/engine/crates/rocky-server/src/lsp.rs
@@ -606,9 +606,9 @@ impl RockyLsp {
     /// sidecar is fine: the AI edit creates the `[freshness]` block in a
     /// fresh file via [`end_of_document_position`] on the empty text.
     async fn load_model_sidecar(
-        model_file_path: &str,
+        model_file_path: &std::path::Path,
     ) -> Option<(tower_lsp::lsp_types::Url, String)> {
-        let sidecar_path = std::path::Path::new(model_file_path).with_extension("toml");
+        let sidecar_path = model_file_path.with_extension("toml");
         let text = tokio::fs::read_to_string(&sidecar_path)
             .await
             .unwrap_or_default();
@@ -709,7 +709,7 @@ impl RockyLsp {
 
         for d in &result.diagnostics {
             let file = if let Some(model) = result.project.model(&d.model) {
-                model.file_path.clone()
+                model.file_path.display().to_string()
             } else {
                 continue;
             };
@@ -1314,7 +1314,7 @@ impl LanguageServer for RockyLsp {
                     let mut diags_by_file: HashMap<String, Vec<Diagnostic>> = HashMap::new();
                     for d in &result.diagnostics {
                         let file = if let Some(model) = result.project.model(&d.model) {
-                            model.file_path.clone()
+                            model.file_path.display().to_string()
                         } else {
                             continue;
                         };

--- a/engine/crates/rocky-server/src/lsp.rs
+++ b/engine/crates/rocky-server/src/lsp.rs
@@ -757,7 +757,7 @@ impl RockyLsp {
             .project
             .models
             .iter()
-            .find(|m| std::path::Path::new(&m.file_path) == file_path)
+            .find(|m| m.file_path == file_path)
     }
 
     /// Get the word at a cursor position in document text.
@@ -2985,7 +2985,11 @@ pub(crate) fn build_contract_quickfix(
     typed_models: &indexmap::IndexMap<String, Vec<rocky_compiler::types::TypedColumn>>,
 ) -> Option<(TextEdit, String)> {
     // 1. `.rocky` DSL files use a different syntax — skip.
-    if model.file_path.ends_with(".rocky") {
+    // `extension()`, not `ends_with`: on a `Path` the latter compares whole
+    // COMPONENTS, so `.ends_with(".rocky")` is false for
+    // `downstream.rocky` and this skip would silently stop firing
+    // (#1730). It was a substring check while `file_path` was a String.
+    if model.file_path.extension().is_some_and(|e| e == "rocky") {
         return None;
     }
 
@@ -3152,7 +3156,11 @@ pub(crate) fn build_ai_contract_action(
     uri: &tower_lsp::lsp_types::Url,
     diag: &Diagnostic,
 ) -> Option<CodeAction> {
-    if model.file_path.ends_with(".rocky") {
+    // `extension()`, not `ends_with`: on a `Path` the latter compares whole
+    // COMPONENTS, so `.ends_with(".rocky")` is false for
+    // `downstream.rocky` and this skip would silently stop firing
+    // (#1730). It was a substring check while `file_path` was a String.
+    if model.file_path.extension().is_some_and(|e| e == "rocky") {
         return None;
     }
 


### PR DESCRIPTION
`Model::file_path` is now a `PathBuf`. This closes part 1 of #1730 — part 2 landed in #1761.

The field was a `String` built with `path.display().to_string()`, which is `to_string_lossy`. Four sites joined against it by rebuilding a `PathBuf` and comparing to a real filesystem path. On a path component that is not valid UTF-8 the two can never be equal, and every miss is silent.

```
  before                          after
  ------                          -----
  fs path (OsStr bytes)           fs path (OsStr bytes)
      |                               |
      v  display()  <- LOSSY          v  to_path_buf()
  file_path: String               file_path: PathBuf
      |                               |
      v  PathBuf::from()              v
  compare to a real path          compare to a real path
  -> never equal, silently        -> equal
```

The one that matters seeds the incremental typecheck, and the LSP passes the file watcher's real `PathBuf` straight through. A model edited under such a directory was never marked affected, so its previous typed result and `reference_map` survived the edit — breaking the invariant `AGENT_REVIEW.md` names as priority 3: **incremental output must equal from-scratch output for the same final state.**

The type now carries the bytes, and each consumer that wants a rendered string says so at its own call site. Those are all genuine display surfaces — a diagnostic's `file`, a JSON output field, a `println!`, an LSP URI key. That distinction is the point: rendering is correct at a display seam and wrong at a comparison, and it was invisible while the type was a `String`.

## Three defects the change surfaced

**Fixed here, because the compiler would not let them stand:**

- `cross_engine.rs` split the rendered path on `'/'` to find a pipeline name. Wrong separator on Windows, and a non-UTF-8 component could never match. Now walks real path components.
- `explain.rs` derived a sidecar path with `replace(".sql", ".toml")`, which rewrites **every** occurrence — a model under a directory whose name contains `.sql` was redirected into a sibling tree. Now uses `with_extension`, the derivation the loader itself uses (`project.rs:629`, `models.rs:1603`).

**Fixed here because the migration caused it:**

- Both LSP `.rocky` skips used `file_path.ends_with(".rocky")`. On a `String` that is a substring test; on a `Path` it compares whole **components**, so it is `false` for `downstream.rocky`. Both skips silently stopped firing, with no compile error. Now `extension()`.

  This is the hazard of the migration rather than of the original bug — the two types share a method name whose semantics differ. Every other `ends_with` / `starts_with` / `contains` on a `file_path` in the workspace was checked; the rest belong to different structs still typed `String` (iceberg writers, replay records, restore).

**Filed separately, not fixed here:** the same `explain.rs` function's `.rocky` arm appends, producing `flow.rocky.toml`, while the loader reads `flow.toml` — so `rocky ai-explain` on a `.rocky` model has been writing its intent to a file nothing reads. That is a user-visible output path and unrelated to UTF-8, so the arm is preserved byte-for-byte and the defect is tracked on its own.

## Tests, and two false guards found along the way

There were **no tests over `compile_incremental`** before this. Two are added:

| Test | Runs |
|---|---|
| `an_edited_model_is_re_typechecked_on_the_incremental_path` | everywhere |
| `a_changed_model_under_a_non_utf8_dir_is_re_typechecked` | Linux only |

**Twelve models in both, and that is load-bearing.** `compile_incremental` short-circuits on `total < 10 || affected.len() * 2 > total` and returns a **full** compile, which produces the right answer whether or not the seed matched. A one-model version of either test passes with the bug still in place — I wrote that version first and caught it before committing. Twelve independent models with one edited keeps `1 * 2 <= 12`, the only shape that reaches the incremental path at all.

Both assert the property rather than the affected set, and each carries a control so it cannot pass by both sides being stale.

The ASCII companion exists because an unrunnable test is an unverified one — macOS APFS and Windows NTFS reject a non-UTF-8 filename at creation, so I cannot execute the Linux test here. It earned its place immediately: it failed on first run because the models needed directory-level target defaults, a scaffolding defect that would otherwise have surfaced in CI on the Linux-only test.

**Two false guards, both found by mutation probe:**

1. The pre-existing `test_contract_quickfix_skipped_on_rocky_dsl_file` does **not** guard its branch. Reverting the skip to the always-false `ends_with` left all 101 rocky-server tests green.
2. My replacement for it was a false guard too, for the same reason — a `.rocky` DSL body fails the SQL parse further down and returns `None` regardless. The fixture is now deliberately **valid SQL in a file named `.rocky`**, so the extension is the only thing that can produce `None`. It now fails under the mutation while the pre-existing test still passes.

## Evidence

`scripts/mutation-check.sh`, three probes:

| Mutation | Result |
|---|---|
| Affected-set seed never matches (the pre-fix effect) | **caught** — stale 1-column schema vs 2 from scratch |
| First `.rocky` skip reverted to `ends_with` | **caught** by the new test; the pre-existing one passes |
| — before the fixture fix — | not caught, which is how the false guard was found |

Local: engine workspace `cargo test --all-features` green, 165 test binaries. Clippy `--all-targets --all-features -D warnings` clean, `cargo fmt --check` clean.

One test is excluded from that number: `init_adapter_scaffold_compiles` fails on my machine with `E0053` "expected `rocky_ir::ir::ColumnSelection`, found `ColumnSelection`" — two rlibs of the same crate. That is the inconsistent `target/debug/deps` state the test's own error path describes, left by repeated mutation-check rebuilds. It passes in CI, which builds clean.

Refs #1730, #1761, #1703.

---

**Review disclosure.** Same-model adversarial pass, not an independent red team — per `AGENTS.md` that does not meet the independence bar; none was available at authoring time. This is a wide mechanical change with one silent-semantics trap already found in it, so it is a good candidate for the independent pass.
