### PR TITLE
fix(engine): a check that could not run is never advisory, so a failed query stops clearing the gate

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -68,6 +68,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
      after    not_evaluated, severity=Error    ->  error bucket    ->  gate fires  ->  exit 2
   ```
 
+  The **quality pipeline's `row_count`** had the same defect a fourth time, and worse: its failure arm was hand-built rather than going through a constructor, so it set `not_evaluated: None` — telling every consumer the check had run — and described a row-count check as `CheckDetails::Custom` with a fabricated `result_value: 0, threshold: 1`. It now uses `row_count_not_evaluated`, which gets all three right.
+
   **Breaking:** a project with an advisory check whose query has been failing will start failing the run. That is the point — the previous exit code said the data was fine when nothing had been read. `cross_source_overlap_not_applicable` is unchanged: a keyless sibling passes, and a passing check never reaches the severity buckets. Refs #1741.
 
 - **A model sidecar that was a dangling symlink read as absent, so the model compiled against defaults — different strategy, possibly a different target table, silently.**

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -56,6 +56,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **On upgrade:** the state store schema moves v23 → v24. No table is added and no blob migration runs; a v23 store upgrades on the next read-write open. The bump is load-bearing: `observed_failing` is a new variant of the `fulfill_state` record's tagged enum, and a 1.73.0 binary cannot read a blob that carries it. **Rolling back is the part to plan for.** Remote state keys are qualified by schema version (`v23/state.redb` on an object store, `…v23:…` on Valkey), so a 1.73.0 binary never reads a v24 remote object. It reads whatever is under its own v23 key, which may be stale, and it cannot see progress recorded under v24. The incompatible-blob hazard is a **local** `state.redb` this version wrote. A 1.73.0 binary opening it either stops with a schema-mismatch error or, on the paths that honour `[state] on_schema_mismatch`, deletes the file and starts fresh under the default `recreate`. Do not point a 1.73.0 binary at a local state file written by this version, and do not share one local file between versions. `rocky doctor --check state_schema` reports the mismatch and exits 3. Which commands honour the key and which refuse is being pinned down in #1679. `fulfill_state` is local-only, so a re-run rebuilds the loop's position; see #1525 before relying on that loss being harmless.
 
 ### Fixed
+- **A check the engine could not run kept the severity you declared, so a `severity = "warning"` check that failed to execute cleared the gate and the run exited 0.**
+
+  Severity grades a *measurement*: it says how bad three null rows are, or how bad this much overlap is. A check whose query failed produced no measurement to grade, but `assertion_not_evaluated` and `cross_source_overlap_not_evaluated` carried the declared severity through anyway. `check_failures_by_severity` then filed the failure in the warning bucket, `replication_check_gate_failed` reads only the error bucket, and a run that verified nothing about a column reported success.
+
+  The declared severity is now ignored for a check that did not run — every `*_not_evaluated` constructor is `TestSeverity::Error`, matching the four (`row_count`, `freshness`, `null_rate`, `custom`) that already were. A measured violation is unaffected and still grades at the severity you set.
+
+  ```
+  severity = "warning", query fails
+     before   not_evaluated, severity=Warning  ->  warning bucket  ->  gate clear  ->  exit 0
+     after    not_evaluated, severity=Error    ->  error bucket    ->  gate fires  ->  exit 2
+  ```
+
+  **Breaking:** a project with an advisory check whose query has been failing will start failing the run. That is the point — the previous exit code said the data was fine when nothing had been read. `cross_source_overlap_not_applicable` is unchanged: a keyless sibling passes, and a passing check never reaches the severity buckets. Refs #1741.
+
 - **A model sidecar that was a dangling symlink read as absent, so the model compiled against defaults — different strategy, possibly a different target table, silently.**
 
   `Path::exists()` is `std::fs::metadata(..).is_ok()`, and `metadata` **follows** a symlink. A file that is a symlink to a deleted target therefore answers `false`, and every caller that gated a read on that probe read a present file as absent and took its "there is none of this" branch.

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -21654,20 +21654,24 @@ backend = "local"
             Some("email".to_string()),
             "the assertion query failed: no such column: emial",
         );
-        assert_eq!(
-            never_ran.severity,
-            TestSeverity::Error,
-            "an unevaluated check is never advisory"
-        );
-
+        // The gate first, deliberately: this test has to fail on the EXIT
+        // CODE when the fix is reverted, not on a severity field a reader
+        // could dismiss as cosmetic.
         let mut gated = RunOutput::new(String::new(), 0, 1);
         gated.tables_copied = 1;
-        gated.check_results.push(failing_check_bag(never_ran));
+        gated
+            .check_results
+            .push(failing_check_bag(never_ran.clone()));
         gated.check_gate_failed = super::replication_check_gate_failed(&gated, &config);
         assert!(gated.check_gate_failed, "a check that never ran gates");
         assert!(
             matches!(gated.derive_run_status(), RunStatus::PartialFailure),
             "and the run does not exit 0"
+        );
+        assert_eq!(
+            never_ran.severity,
+            TestSeverity::Error,
+            "an unevaluated check is never advisory"
         );
 
         // Measured, violated, advisory: still does not gate.

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -6792,7 +6792,6 @@ async fn run_batched_checks(
                                     name,
                                     contributing,
                                     e.clone(),
-                                    overlap_cfg.severity,
                                 ),
                             );
                             continue;
@@ -6837,7 +6836,6 @@ async fn run_batched_checks(
                                 name,
                                 contributing,
                                 reason,
-                                overlap_cfg.severity,
                             )
                         } else {
                             // Exactly one carrier. A single table cannot
@@ -6904,7 +6902,6 @@ async fn run_batched_checks(
                                     name,
                                     contributing,
                                     e.to_string(),
-                                    overlap_cfg.severity,
                                 ),
                             );
                             continue;
@@ -6983,7 +6980,6 @@ async fn run_batched_checks(
                                     name,
                                     contributing,
                                     e.to_string(),
-                                    overlap_cfg.severity,
                                 ),
                             );
                         }
@@ -21568,12 +21564,16 @@ backend = "local"
         use rocky_core::tests::TestSeverity;
 
         let failed_error = rocky_core::checks::check_row_count(10, 7);
-        let failed_warning = rocky_core::checks::assertion_not_evaluated(
+        // A MEASURED violation the user declared advisory. Before #1741 this
+        // row used `assertion_not_evaluated`, which could no longer produce a
+        // warning: a check that never ran is always an error now.
+        let failed_warning = rocky_core::checks::check_assertion(
             "not_null:name",
             "not_null",
             Some("name".to_string()),
+            3,
+            false,
             TestSeverity::Warning,
-            "the assertion query failed",
         );
         // Hard-coded error severity: a check the engine could not evaluate
         // gates exactly as a violated one does (#1602).
@@ -21624,6 +21624,72 @@ backend = "local"
                 "{why}"
             );
         }
+    }
+
+    /// #1741, walked to the exit code. A `not_null` test the user declared
+    /// `severity = "warning"` whose QUERY FAILED. The run measured nothing
+    /// about that column, so it must not clear the gate.
+    ///
+    /// Before this fix `assertion_not_evaluated` carried the declared
+    /// `Warning` through: `check_failures_by_severity` bucketed it as a
+    /// warning, `replication_check_gate_failed` reads only the error bucket,
+    /// the gate stayed clear, and `derive_run_status` returned `Success` —
+    /// exit 0 on a run whose check never ran. The advisory grade belongs to a
+    /// measured violation, and this one had no measurement to grade.
+    ///
+    /// The second half is the discriminator: the SAME assertion, measured and
+    /// violated at warning severity, still does not gate. The fix separates
+    /// "you told me 3 nulls are tolerable" from "I never counted".
+    #[test]
+    fn an_advisory_assertion_that_could_not_run_still_gates() {
+        use rocky_core::state::RunStatus;
+        use rocky_core::tests::TestSeverity;
+
+        let config = checks_config("row_count = true");
+
+        // Declared advisory, but the query failed: nothing was measured.
+        let never_ran = rocky_core::checks::assertion_not_evaluated(
+            "not_null:email",
+            "not_null",
+            Some("email".to_string()),
+            "the assertion query failed: no such column: emial",
+        );
+        assert_eq!(
+            never_ran.severity,
+            TestSeverity::Error,
+            "an unevaluated check is never advisory"
+        );
+
+        let mut gated = RunOutput::new(String::new(), 0, 1);
+        gated.tables_copied = 1;
+        gated.check_results.push(failing_check_bag(never_ran));
+        gated.check_gate_failed = super::replication_check_gate_failed(&gated, &config);
+        assert!(gated.check_gate_failed, "a check that never ran gates");
+        assert!(
+            matches!(gated.derive_run_status(), RunStatus::PartialFailure),
+            "and the run does not exit 0"
+        );
+
+        // Measured, violated, advisory: still does not gate.
+        let measured_warning = rocky_core::checks::check_assertion(
+            "not_null:email",
+            "not_null",
+            Some("email".to_string()),
+            3,
+            false,
+            TestSeverity::Warning,
+        );
+        let mut advisory = RunOutput::new(String::new(), 0, 1);
+        advisory.tables_copied = 1;
+        advisory
+            .check_results
+            .push(failing_check_bag(measured_warning));
+        advisory.check_gate_failed = super::replication_check_gate_failed(&advisory, &config);
+        assert!(
+            !advisory.check_gate_failed,
+            "a measured violation keeps the severity the user declared"
+        );
+        assert!(matches!(advisory.derive_run_status(), RunStatus::Success));
     }
 
     /// #1720, the higher-frequency shape — and the one the tool's own advice
@@ -32461,6 +32527,12 @@ table = "fct_events"
     /// A target whose reference cannot be formatted used to have its
     /// assertions and custom checks skipped without a trace. Each is reported
     /// as not evaluated instead.
+    ///
+    /// The config declares `severity = "warning"`, and this is #1741 end to
+    /// end: the assertion still comes back at ERROR severity, because Rocky
+    /// never addressed the table and so measured nothing to grade. Until this
+    /// fix the declared `Warning` survived, the error bucket stayed empty,
+    /// and a run that checked nothing exited 0.
     #[cfg(feature = "duckdb")]
     #[tokio::test]
     async fn assertions_and_custom_checks_on_an_unaddressable_table_are_not_evaluated() {
@@ -32489,7 +32561,11 @@ table = "fct_events"
                 .is_some_and(|r| r.starts_with("could not address the table: ")),
             "{assertion:?}"
         );
-        assert_eq!(assertion.severity, rocky_core::tests::TestSeverity::Warning);
+        assert_eq!(
+            assertion.severity,
+            rocky_core::tests::TestSeverity::Error,
+            "declared advisory, but never evaluated: it gates (#1741)"
+        );
         let custom = the_result(&pending, &key, "no_dupes");
         assert!(!custom.passed, "{custom:?}");
         assert!(

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -385,6 +385,59 @@ pub async fn run_transformation(
     super::run::run_status_exit_result(&output, run_id)
 }
 
+/// Builds the quality pipeline's `row_count` check from the count query's
+/// outcome.
+///
+/// Extracted so the failure arm is reachable from a test: `run_quality` does
+/// not return its `RunOutput`, and the persisted `CheckOutcome` carries no
+/// severity, so the distinction this function exists to make was not
+/// observable anywhere.
+///
+/// The rule (#1741, and #1719/#1735 before it): `severity` grades a
+/// MEASUREMENT. A count the engine obtained is graded at the configured
+/// severity; a query that FAILED measured nothing and takes the
+/// `TestSeverity::Error` `row_count_not_evaluated` chose, so it still gates.
+///
+/// The failure arm used to be built by hand with `not_evaluated: None` and the
+/// configured severity — so a `severity = "warning"` quality pipeline whose
+/// count query failed stayed out of the error bucket and exited 0, while every
+/// consumer read `not_evaluated: None` as "this check ran". It also described a
+/// row-count check as `CheckDetails::Custom` with a fabricated
+/// `result_value: 0, threshold: 1`.
+fn quality_row_count_check(
+    queried: rocky_core::traits::AdapterResult<rocky_core::traits::QueryResult>,
+    configured: rocky_core::tests::TestSeverity,
+) -> rocky_core::checks::CheckResult {
+    use rocky_core::checks::{CheckDetails, CheckResult};
+
+    match queried {
+        Ok(result) => {
+            let count: u64 = result
+                .rows
+                .first()
+                .and_then(|r| r.first())
+                .and_then(|v| {
+                    v.as_u64()
+                        .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+                })
+                .unwrap_or(0);
+            CheckResult {
+                name: "row_count".into(),
+                passed: count > 0,
+                severity: configured,
+                not_evaluated: None,
+                details: CheckDetails::RowCount {
+                    source_count: count,
+                    target_count: count,
+                },
+            }
+        }
+        Err(e) => {
+            rocky_core::checks::row_count_not_evaluated(format!("the row count query failed: {e}"))
+        }
+    }
+}
+
 /// Execute `rocky run` for a quality pipeline.
 ///
 /// Runs data quality checks against the specified tables without any data movement.
@@ -412,8 +465,6 @@ pub async fn run_quality(
     // the reconciler can answer `after`/`freshness` demands on this pipeline.
     pipeline_name: &str,
 ) -> Result<()> {
-    use rocky_core::checks::{CheckDetails, CheckResult};
-
     let start = Instant::now();
 
     let pipes = crate::pipes::PipesEmitter::detect();
@@ -488,46 +539,13 @@ pub async fn run_quality(
 
                 // Row count check
                 if pipeline.checks.row_count.enabled() {
-                    match warehouse_adapter
+                    let queried = warehouse_adapter
                         .execute_query(&format!("SELECT COUNT(*) FROM {full_table}"))
-                        .await
-                    {
-                        Ok(result) => {
-                            let count: u64 = result
-                                .rows
-                                .first()
-                                .and_then(|r| r.first())
-                                .and_then(|v| {
-                                    v.as_u64()
-                                        .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
-                                })
-                                .unwrap_or(0);
-                            checks.push(CheckResult {
-                                name: "row_count".into(),
-                                passed: count > 0,
-                                severity: row_count_severity,
-                                not_evaluated: None,
-                                details: CheckDetails::RowCount {
-                                    source_count: count,
-                                    target_count: count,
-                                },
-                            });
-                        }
-                        Err(e) => {
-                            checks.push(CheckResult {
-                                name: "row_count".into(),
-                                passed: false,
-                                severity: row_count_severity,
-                                not_evaluated: None,
-                                details: CheckDetails::Custom {
-                                    query: format!("SELECT COUNT(*) FROM {full_table}"),
-                                    result_value: 0,
-                                    threshold: 1,
-                                },
-                            });
-                            warn!(error = %e, table = %full_table, "row count query failed");
-                        }
+                        .await;
+                    if let Err(e) = &queried {
+                        warn!(error = %e, table = %full_table, "row count query failed");
                     }
+                    checks.push(quality_row_count_check(queried, row_count_severity));
                 }
 
                 // Custom checks — shared with the replication runner (run.rs)
@@ -2420,6 +2438,76 @@ auto_create_schemas = true
         );
         assert!(results[1].passed, "a genuine 0 <= threshold still passes");
         assert!(results[1].not_evaluated.is_none());
+    }
+
+    /// FAILS ON `main` before #1741, the same shape a fourth time, in the
+    /// QUALITY pipeline's `row_count`. Its failure arm was hand-built with
+    /// `not_evaluated: None` and the configured severity, so a
+    /// `severity = "warning"` quality pipeline whose `SELECT COUNT(*)` failed
+    /// produced a warning-severity failure that never reached the error
+    /// bucket, and the run exited 0. Consumers read `not_evaluated: None` as
+    /// "this check ran", and the details said `CheckDetails::Custom` with a
+    /// fabricated `result_value: 0, threshold: 1` for a row-count check.
+    ///
+    /// The query is failed the way it fails in production: the table named in
+    /// the config is not in the database.
+    #[tokio::test]
+    async fn a_quality_row_count_query_that_failed_keeps_error_severity() {
+        use rocky_core::checks::CheckDetails;
+        use rocky_core::tests::TestSeverity;
+
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("quality.duckdb");
+        {
+            let a = DuckDbWarehouseAdapter::open(&db).expect("open");
+            a.execute_statement("CREATE SCHEMA IF NOT EXISTS main")
+                .await
+                .unwrap();
+            a.execute_statement("CREATE TABLE main.present AS SELECT 1 AS id")
+                .await
+                .unwrap();
+        }
+        let warehouse = DuckDbWarehouseAdapter::open(&db).expect("reopen");
+
+        // The table the config names does not exist, so the count query errors.
+        let failed = warehouse
+            .execute_query("SELECT COUNT(*) FROM main.absent")
+            .await;
+        assert!(failed.is_err(), "the fixture must actually fail the query");
+        let check = super::quality_row_count_check(failed, TestSeverity::Warning);
+
+        assert!(!check.passed, "{check:?}");
+        assert_eq!(
+            check.severity,
+            TestSeverity::Error,
+            "declared advisory, but nothing was counted: it gates (#1741): {check:?}"
+        );
+        assert!(
+            check
+                .not_evaluated
+                .as_deref()
+                .is_some_and(|r| r.starts_with("the row count query failed: ")),
+            "carries the reason instead of claiming it ran: {check:?}"
+        );
+        assert!(
+            matches!(check.details, CheckDetails::RowCount { .. }),
+            "a row-count check reports row-count details, not a fabricated \
+             Custom result: {check:?}"
+        );
+
+        // The other half, unchanged: a MEASURED count still reports at the
+        // configured severity.
+        let measured = warehouse
+            .execute_query("SELECT COUNT(*) FROM main.present")
+            .await;
+        let check = super::quality_row_count_check(measured, TestSeverity::Warning);
+        assert!(check.passed, "one row is a pass: {check:?}");
+        assert!(check.not_evaluated.is_none(), "{check:?}");
+        assert_eq!(
+            check.severity,
+            TestSeverity::Warning,
+            "a measured result takes the configured severity: {check:?}"
+        );
     }
 
     /// FAILS ON `main` before #1735: `severity = "warning"` on a

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -805,7 +805,6 @@ pub(crate) fn table_assertions_not_evaluated(
                 assertion.resolved_name(),
                 rocky_core::tests::test_type_kind(&assertion.test.test_type),
                 assertion.test.column.clone(),
-                assertion.test.severity,
                 reason,
             )
         })
@@ -847,7 +846,6 @@ pub(crate) async fn run_table_assertions(
                     name,
                     kind,
                     test.column.clone(),
-                    test.severity,
                     format!("could not generate the assertion SQL: {e}"),
                 ));
                 continue;
@@ -876,7 +874,6 @@ pub(crate) async fn run_table_assertions(
                         name,
                         kind,
                         test.column.clone(),
-                        test.severity,
                         "the assertion query returned no readable count",
                     ));
                 }
@@ -887,7 +884,6 @@ pub(crate) async fn run_table_assertions(
                     name,
                     kind,
                     test.column.clone(),
-                    test.severity,
                     format!("the assertion query failed: {e}"),
                 ));
             }
@@ -2584,7 +2580,6 @@ auto_create_schemas = true
                 "cross_source_overlap_duckdb_t",
                 vec!["cat.s1.t".into(), "cat.s2.t".into()],
                 "key expression refused",
-                rocky_core::tests::TestSeverity::Error,
             )],
         });
 

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -6892,30 +6892,42 @@ mod run_record_tests {
         assert!(matches!(out.derive_run_status(), RunStatus::Success));
     }
 
-    /// A check the engine could not evaluate (#1595 / #1602) is a failure in
-    /// its OWN severity bucket: `not_evaluated` always carries
-    /// `passed: false`, and a check the user declared advisory does not become
-    /// gating by failing to run.
+    /// Severity grades a MEASUREMENT, so it only ever reaches the buckets from
+    /// a check that ran (#1741). A `not_evaluated` failure is always an error;
+    /// only a measured violation can land in the warning bucket.
+    ///
+    /// This replaces `..._buckets_not_evaluated_by_its_own_severity`, whose
+    /// name asserted the behaviour #1741 removes: a declared-advisory check
+    /// used to stay advisory when it failed to run, so a broken query cleared
+    /// the gate on a run that had measured nothing.
     #[test]
-    fn check_failures_by_severity_buckets_not_evaluated_by_its_own_severity() {
+    fn check_failures_by_severity_buckets_every_unevaluated_check_as_an_error() {
         use rocky_core::tests::TestSeverity;
         let mut out = RunOutput::new(String::new(), 0, 1);
         out.check_results.push(checks_for(
             "orders",
             vec![
-                // Hard-coded error severity, so a broken row_count gates.
+                // Neither ran. Both gate, whatever the config declared.
                 rocky_core::checks::row_count_not_evaluated("the source query failed"),
                 rocky_core::checks::assertion_not_evaluated(
                     "not_null:name",
                     "not_null",
                     Some("name".to_string()),
-                    TestSeverity::Warning,
                     "the assertion query failed",
+                ),
+                // Ran, violated, declared advisory: the one warning.
+                rocky_core::checks::check_assertion(
+                    "not_null:email",
+                    "not_null",
+                    Some("email".to_string()),
+                    3,
+                    false,
+                    TestSeverity::Warning,
                 ),
                 rocky_core::checks::check_row_count(10, 10),
             ],
         ));
-        assert_eq!(out.check_failures_by_severity(), (1, 1));
+        assert_eq!(out.check_failures_by_severity(), (2, 1));
     }
 
     /// The whole point of the gate being a separate field: the persisted

--- a/engine/crates/rocky-core/src/checks.rs
+++ b/engine/crates/rocky-core/src/checks.rs
@@ -333,18 +333,22 @@ pub fn check_cross_source_overlap(
 /// evaluated — a refused key expression, a `keys`/`key_expr`
 /// misconfiguration, or a query that failed.
 ///
-/// Always fails. A check Rocky declined to run must stay in the tally and must
-/// not report a zero overlap count as if it had measured one.
+/// Always fails, and always at [`TestSeverity::Error`] (#1741). A check Rocky
+/// declined to run must stay in the tally and must not report a zero overlap
+/// count as if it had measured one. The configured severity grades a
+/// *measurement* — how bad is this much overlap — so it has nothing to say
+/// about a group that was never measured. Honouring it here meant a
+/// `severity = "warning"` group whose key expression was refused never
+/// reached the error bucket, so the run exited 0.
 pub fn cross_source_overlap_not_evaluated(
     name: impl Into<String>,
     contributing_tables: Vec<String>,
     reason: impl Into<String>,
-    severity: TestSeverity,
 ) -> CheckResult {
     CheckResult {
         name: name.into(),
         passed: false,
-        severity,
+        severity: TestSeverity::Error,
         not_evaluated: Some(reason.into()),
         details: CheckDetails::CrossSourceOverlap {
             overlap_count: 0,
@@ -567,17 +571,22 @@ pub fn check_assertion(
 /// A row-level assertion the engine could not evaluate: the SQL could not be
 /// generated, the query failed, it returned no readable count, or the table
 /// could not be addressed. Always fails; `failing_rows` is a placeholder.
+///
+/// Always [`TestSeverity::Error`] (#1741). The declared severity grades a
+/// *measured* violation — how bad are N failing rows — and says nothing about
+/// an assertion that never ran. Reading it here made a `severity = "warning"`
+/// assertion silently non-gating whenever its query failed, which is the one
+/// case where the run learned nothing at all.
 pub fn assertion_not_evaluated(
     name: impl Into<String>,
     kind: impl Into<String>,
     column: Option<String>,
-    severity: TestSeverity,
     reason: impl Into<String>,
 ) -> CheckResult {
     CheckResult {
         name: name.into(),
         passed: false,
-        severity,
+        severity: TestSeverity::Error,
         not_evaluated: Some(reason.into()),
         details: CheckDetails::Assertion {
             kind: kind.into(),
@@ -1057,7 +1066,6 @@ mod tests {
             "x",
             vec!["cat.s1.t".into()],
             "key expression refused",
-            TestSeverity::Error,
         );
         assert!(!skipped.passed, "a check that did not run must not pass");
         assert_eq!(
@@ -1074,7 +1082,9 @@ mod tests {
     }
 
     /// `not_evaluated` is one field for every check kind, and it is absent
-    /// from the wire form of a check that ran (#1602).
+    /// from the wire form of a check that ran (#1602). Every such constructor
+    /// is also hard-coded to [`TestSeverity::Error`] (#1741) — none of them
+    /// takes a severity, so a check that did not run cannot be advisory.
     #[test]
     fn not_evaluated_constructors_fail_and_round_trip_through_json() {
         let cases: Vec<CheckResult> = vec![
@@ -1085,7 +1095,6 @@ mod tests {
                 "not_null:id",
                 "not_null",
                 Some("id".into()),
-                TestSeverity::Warning,
                 "the assertion query returned no readable count",
             ),
             custom_not_evaluated("no_dupes", "SELECT 1", 0, "custom check query failed: boom"),
@@ -1093,13 +1102,18 @@ mod tests {
                 "cross_source_overlap:shopify.orders",
                 vec!["cat.s1.orders".into()],
                 "key expression refused",
-                TestSeverity::Error,
             ),
         ];
         for check in &cases {
             assert!(
                 !check.passed,
                 "{}: a check that did not run must not pass",
+                check.name
+            );
+            assert_eq!(
+                check.severity,
+                TestSeverity::Error,
+                "{}: a check that did not run is never advisory (#1741)",
                 check.name
             );
             let reason = check


### PR DESCRIPTION
Severity grades a **measurement**. It says how bad three null rows are, or how bad this much overlap is. A check whose query failed produced no measurement to grade — but two constructors carried the declared severity through anyway.

So a test declared `severity = "warning"` whose query failed came back as a warning-severity failure. `check_failures_by_severity` filed it in the warning bucket, `replication_check_gate_failed` reads only the error bucket, and the run exited 0 having verified nothing about that column.

```
severity = "warning", the query fails
  before   not_evaluated, severity=Warning  ->  warning bucket  ->  gate clear  ->  exit 0
  after    not_evaluated, severity=Error    ->  error bucket    ->  gate fires  ->  exit 2
```

## The change

`assertion_not_evaluated` and `cross_source_overlap_not_evaluated` drop the `severity` parameter and hard-code `TestSeverity::Error`. That matches the four constructors that already did it — `row_count_not_evaluated`, `freshness_not_evaluated`, `null_rate_not_evaluated`, `custom_not_evaluated`. 14 call sites lose the argument.

One rule, stated once: **severity governs a measured result, and only a measured result.**

`cross_source_overlap_not_applicable` is deliberately untouched. It sets `passed: true` for a keyless sibling, and `check_failures_by_severity` skips passing checks, so its severity never reaches a bucket at all.

## This was live, not theoretical

Three existing tests asserted the old behaviour. The first is the strongest evidence:

- **`assertions_and_custom_checks_on_an_unaddressable_table_are_not_evaluated`** (`run.rs`) runs a real DuckDB fixture with `severity = "warning"` and a table whose hyphen fails identifier validation. It asserted the result came back `Warning` — a real end-to-end path producing a non-gating failure on a table Rocky never addressed. It now asserts `Error`.
- **`check_failures_by_severity_buckets_not_evaluated_by_its_own_severity`** (`output.rs`) — its *name* stated the defect. Renamed to `..._buckets_every_unevaluated_check_as_an_error` and given a measured warning, so both directions are pinned.
- **`the_check_gate_reads_severity_and_fail_on_error`** (`run.rs`) used `assertion_not_evaluated` as its warning-severity fixture, which can no longer produce one. It now uses `check_assertion` — a measured violation, which is what that row was always meant to represent.

## Evidence

New test `an_advisory_assertion_that_could_not_run_still_gates` walks the real chain, `replication_check_gate_failed` -> `derive_run_status`, for both halves of the rule. Its assertions are ordered so a revert fails on the **exit code**, not on a severity field.

`not_evaluated_constructors_fail_and_round_trip_through_json` now asserts `severity == Error` across all six constructors, so a seventh added later is covered by construction.

Both halves mutation-probed with `scripts/mutation-check.sh` (flipping the hard-coded `Error` back to `Warning`):

```
mut_assertion.py  -> an_advisory_assertion_that_could_not_run_still_gates
   FAILED at "a check that never ran gates"   <- the gate, not the field
mut_overlap.py    -> not_evaluated_constructors_fail_and_round_trip_through_json
   FAILED: left: Warning, right: Error
both: "mutation-check: OK - the test failed under mutation, so it is fix-sensitive."
```

Full suites green: `rocky-core` 2142 passed, `rocky-cli` 1840 passed, 0 failed. Clippy `--all-targets --all-features` clean.

## Breaking

A project with an advisory check whose query has been failing will start failing the run. That is the fix: the old exit code said the data was fine when nothing had been read. Changelog entry included, stated in those terms.

## What I am least confident about

**That `check_failures_by_severity` is the only consumer of a `not_evaluated` check's severity.** I grepped the field and found the bucketer plus the JSON output; if some other reader treats `severity` as "what the user configured" rather than "how this result grades", it now sees `Error` where the config said `warning`. The JSON `severity` field on a `not_evaluated` check is the visible surface of that, and it does change.

**What I may be missing:** whether anyone deliberately sets `severity = "warning"` on a check they expect to fail to evaluate — for example an assertion against a table that only exists in some environments. Under the old behaviour that was a silent pass; under this one it fails the run. The honest answer is that such a config was already broken, since the check was never verifying anything, but the failure will surface as new.

## Review

Red-teamed by the `codex:codex-rescue` plugin — findings and disposition in a comment below. Refs #1741.
