### PR TITLE
fix(engine/ui): a truncated id now says it was truncated, and a compound key keeps the end that identifies it

### DIFF
--- a/engine/ui/src/estate/RunsPanel.tsx
+++ b/engine/ui/src/estate/RunsPanel.tsx
@@ -52,7 +52,7 @@ export function RunsPanel({ history, now }: { history: HistoryOutput; now?: numb
           {history.runs.map((run) => (
             <tr key={run.run_id} className="border-t border-zinc-100 dark:border-zinc-800">
               <td className="pr-3 font-mono" title={run.run_id}>
-                {shortId(run.run_id)}
+                <span title={run.run_id}>{shortId(run.run_id)}</span>
               </td>
               <td className="pr-3">{formatInstant(run.started_at, now)}</td>
               <td className={`pr-3 font-medium ${TONE_TEXT[statusTone(run.status)]}`}>

--- a/engine/ui/src/format.test.ts
+++ b/engine/ui/src/format.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { NOT_RECORDED, formatDuration, formatInstant, orNotRecorded, shortId } from "./format";
+import {
+  NOT_RECORDED,
+  elideMiddle,
+  formatDuration,
+  formatInstant,
+  orNotRecorded,
+  shortId,
+} from "./format";
 
 describe("orNotRecorded", () => {
   it("renders null, undefined and the empty string as the status, and values as text", () => {
@@ -41,8 +48,40 @@ describe("formatInstant", () => {
 });
 
 describe("shortId", () => {
-  it("keeps short ids and cuts long ones to twelve characters", () => {
+  it("keeps short ids whole and marks a cut with an ellipsis", () => {
     expect(shortId("run-1")).toBe("run-1");
-    expect(shortId("a".repeat(64))).toBe("a".repeat(12));
+    expect(shortId("a".repeat(64))).toBe(`${"a".repeat(12)}…`);
+  });
+
+  it("does not mark an id that was not cut", () => {
+    // Exactly at the limit: twelve characters are shown, nothing was dropped,
+    // so an ellipsis would claim a truncation that did not happen.
+    expect(shortId("a".repeat(12))).toBe("a".repeat(12));
+    expect(shortId("a".repeat(13))).toBe(`${"a".repeat(12)}…`);
+  });
+});
+
+describe("elideMiddle", () => {
+  it("keeps both ends of a compound identifier", () => {
+    // #1756: `shortId` renders every key for one product identically, because
+    // they all begin `product:<name>@`. The tail is what distinguishes them.
+    const key = "product:revenue_daily@sha256:5b1bf5c@21";
+    expect(elideMiddle(key)).toBe("product:re…1bf5c@21");
+    expect(elideMiddle(key)).toContain("@21");
+  });
+
+  it("distinguishes two keys that shortId renders identically", () => {
+    const a = "product:revenue_daily@sha256:5b1bf5c@21";
+    const b = "product:revenue_daily@sha256:5b1bf5c@22";
+    expect(shortId(a)).toBe(shortId(b));
+    expect(elideMiddle(a)).not.toBe(elideMiddle(b));
+  });
+
+  it("returns a value unchanged rather than rendering it longer", () => {
+    // head + tail + the ellipsis is 19 characters, so anything at or under
+    // that gains nothing from eliding.
+    expect(elideMiddle("a".repeat(19))).toBe("a".repeat(19));
+    expect(elideMiddle("a".repeat(20)).length).toBeLessThan(20);
+    expect(elideMiddle("short")).toBe("short");
   });
 });

--- a/engine/ui/src/format.ts
+++ b/engine/ui/src/format.ts
@@ -45,7 +45,34 @@ function formatAgo(deltaMs: number): string {
   return `${Math.round(hours / 24)} d ago`;
 }
 
-/** The first 12 characters of a long id, for a table cell; the full id goes in `title`. */
+/**
+ * The first 12 characters of a long id, for a table cell, with an ellipsis so
+ * a truncation reads as one. Put the full id in `title` at the call site.
+ *
+ * Right for an id whose HEAD identifies it — a hex digest, a run id. A
+ * compound id whose tail is the distinguishing part wants `elideMiddle`
+ * instead: every fulfillment idempotency key for one product begins
+ * `product:<name>@`, so twelve leading characters of it distinguish nothing
+ * (#1756).
+ */
 export function shortId(id: string): string {
-  return id.length > 12 ? id.slice(0, 12) : id;
+  return id.length > 12 ? `${id.slice(0, 12)}…` : id;
+}
+
+/**
+ * Keeps both ends of a compound identifier and elides the middle:
+ * `product:revenue_daily@sha256:5b1bf5c@21` renders as `product:re…1bf5c@21`,
+ * keeping the digest tail and the sequence number that tell two keys apart.
+ *
+ * Used where the tail carries the distinguishing part. It reads the string as
+ * text and knows nothing about any identifier's grammar, so a key whose shape
+ * changes still renders, just with a different slice shown.
+ *
+ * Returns the input unchanged when eliding would not make it shorter, so a
+ * value near the limit never renders LONGER than it is.
+ */
+export function elideMiddle(value: string, head = 10, tail = 8): string {
+  if (head < 0 || tail < 0) return value;
+  if (value.length <= head + tail + 1) return value;
+  return `${value.slice(0, head)}…${value.slice(value.length - tail)}`;
 }

--- a/engine/ui/src/governor/ProductsScreen.test.tsx
+++ b/engine/ui/src/governor/ProductsScreen.test.tsx
@@ -91,7 +91,66 @@ function loaders(overrides: Partial<ProductLoaders> = {}): ProductLoaders {
   };
 }
 
+/**
+ * Two journal rows whose idempotency keys differ ONLY in the trailing
+ * sequence number — the shape the engine really writes. The fixture above
+ * uses `key-abc`, which is under the truncation limit, so it never exercised
+ * the rendering at all (#1756).
+ */
+const REAL_KEY_JOURNAL: ProductJournalOutput = {
+  ...JOURNAL,
+  count: 2,
+  rows: [
+    {
+      seq: 1,
+      at: "2026-09-05T08:00:00Z",
+      event: "change proposed",
+      to_state: "proposed",
+      idempotency_key: "product:revenue_daily@sha256:5b1bf5c@21",
+    },
+    {
+      seq: 2,
+      at: "2026-09-05T09:00:00Z",
+      event: "change proposed",
+      to_state: "proposed",
+      idempotency_key: "product:revenue_daily@sha256:5b1bf5c@22",
+    },
+  ],
+};
+
 describe("ProductsScreen", () => {
+  it("renders two idempotency keys distinguishably (#1756)", async () => {
+    render(
+      <ProductsScreen
+        name="revenue_daily"
+        loaders={loaders({ journal: vi.fn(async () => REAL_KEY_JOURNAL) })}
+      />,
+    );
+
+    await screen.findAllByText("change proposed");
+
+    const full = [
+      "product:revenue_daily@sha256:5b1bf5c@21",
+      "product:revenue_daily@sha256:5b1bf5c@22",
+    ];
+
+    // The full key is always recoverable, which is what `shortId`'s own doc
+    // comment promised and no call site did.
+    for (const key of full) {
+      expect(document.querySelector(`[title="${key}"]`)).toBeTruthy();
+    }
+
+    // And the two rows do not read identically. Before the fix both rendered
+    // as `key product:reve` — cut mid-word, no ellipsis, and indistinguishable.
+    const rendered = Array.from(document.querySelectorAll("[title]"))
+      .filter((el) => full.includes(el.getAttribute("title") ?? ""))
+      .map((el) => el.textContent ?? "");
+    expect(rendered).toHaveLength(2);
+    expect(rendered[0]).not.toBe(rendered[1]);
+    expect(rendered[0]).toContain("@21");
+    expect(rendered[1]).toContain("@22");
+  });
+
   it("lists every product, including one whose spec file is gone", async () => {
     render(<ProductsScreen name={null} loaders={loaders()} />);
 

--- a/engine/ui/src/governor/ProductsScreen.tsx
+++ b/engine/ui/src/governor/ProductsScreen.tsx
@@ -5,7 +5,7 @@ import type { ProductStatusOutput } from "@rocky-types/product_status";
 import { apiGet } from "../api";
 import { StatusCard } from "../components";
 import { useResource } from "../estate/useResource";
-import { formatInstant, shortId } from "../format";
+import { elideMiddle, formatInstant, shortId } from "../format";
 import { navigateTo, pathForLane } from "../router";
 import { ResourceState } from "../review/ResourceState";
 import { reviewPath } from "../review/paths";
@@ -131,8 +131,15 @@ function JournalRow({ entry }: { entry: ProductJournalEntry }) {
       </td>
       <td className={`${cell} text-[11px] break-words text-zinc-500 dark:text-zinc-400`}>
         <div className="flex flex-wrap gap-x-3 gap-y-1">
-          {entry.spec_digest != null && <span>spec {shortId(entry.spec_digest)}</span>}
-          {entry.idempotency_key != null && <span>key {shortId(entry.idempotency_key)}</span>}
+          {entry.spec_digest != null && (
+            <span title={entry.spec_digest}>spec {shortId(entry.spec_digest)}</span>
+          )}
+          {entry.idempotency_key != null && (
+            // Not `shortId`: every key for this product begins
+            // `product:<name>@`, so a leading slice distinguishes nothing, and
+            // the product name is already the page title (#1756).
+            <span title={entry.idempotency_key}>key {elideMiddle(entry.idempotency_key)}</span>
+          )}
           {entry.plan_id != null && (
             <a
               href={reviewPath(entry.plan_id)}
@@ -141,6 +148,7 @@ function JournalRow({ entry }: { entry: ProductJournalEntry }) {
                 navigateTo(reviewPath(entry.plan_id as string));
               }}
               className="font-mono text-sky-700 underline-offset-2 hover:underline dark:text-sky-400"
+              title={entry.plan_id}
             >
               plan {shortId(entry.plan_id)}
             </a>
@@ -224,7 +232,13 @@ function Standing({ status }: { status: ProductStatusOutput }) {
         <StatusCard label="loop state" value={status.fulfill_state ?? "the loop has not run"} />
         <StatusCard
           label="working spec"
-          value={status.spec_digest ? shortId(status.spec_digest) : "not present"}
+          value={
+            status.spec_digest ? (
+              <span title={status.spec_digest}>{shortId(status.spec_digest)}</span>
+            ) : (
+              "not present"
+            )
+          }
           tone={status.spec_error ? "risk" : "muted"}
           sub={status.spec_error ?? undefined}
         />

--- a/engine/ui/src/review/PlanDetail.tsx
+++ b/engine/ui/src/review/PlanDetail.tsx
@@ -262,7 +262,7 @@ export function PlanDetail({
     return (
       <section aria-label="The plan" className="space-y-3">
         <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-          Plan {shortId(planId)}
+          Plan <span title={planId}>{shortId(planId)}</span>
         </h2>
         <ResourceState resource={status} loadingLine="reading the plan…" />
       </section>
@@ -298,7 +298,7 @@ export function PlanDetail({
     <div className="space-y-4">
       <section aria-label="The plan" className="space-y-2">
         <h2 className="font-mono text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-          {shortId(planId)}
+          <span title={planId}>{shortId(planId)}</span>
         </h2>
         <div className="grid gap-2 sm:grid-cols-3">
           <StatusCard label="kind" value={status.value.kind} />

--- a/engine/ui/src/review/QueuePanel.tsx
+++ b/engine/ui/src/review/QueuePanel.tsx
@@ -33,7 +33,7 @@ function QueueRow({ entry, now }: { entry: ReviewQueueEntry; now?: number }) {
           }}
           className="font-mono text-sm text-sky-700 underline-offset-2 hover:underline dark:text-sky-400"
         >
-          {shortId(entry.plan_id)}
+          <span title={entry.plan_id}>{shortId(entry.plan_id)}</span>
         </a>
         <span className="text-[11px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
           {entry.capability} · {entry.principal}


### PR DESCRIPTION
`shortId` sliced to 12 characters with no ellipsis. Its own doc comment said **"the full id goes in `title`"** — and no call site set a `title`. The promise of recoverability was documented and never implemented, which is what turns this from a style question into a bug.

For a hex digest the leading slice is a recognisable prefix and the missing ellipsis costs nothing. For the fulfillment journal's idempotency key it costs everything. The key is `product:<name>@<digest>@<seq>`, so every key for one product begins identically, and the product timeline rendered all of them as:

```
key product:reve
```

Cut mid-word, no ellipsis, and nothing shown distinguishes one row from the next.

## The change

**`shortId` marks a cut.** An ellipsis is appended when, and only when, something was actually dropped. A value at exactly 12 characters is returned unchanged — an ellipsis there would claim a truncation that did not happen.

**Every JSX call site sets `title`** with the full value, which is what the doc comment already promised. Two sites in `PlanDetail` build their text inside a template string, where an attribute is not available; those get the ellipsis only, and I have not contorted them to fit.

**The idempotency key uses a new `elideMiddle`,** which keeps both ends:

```
product:revenue_daily@sha256:5b1bf5c@21   ->   product:re…1bf5c@21
                                                          ^^^^^ ^^^
                                                          digest tail, and the
                                                          sequence number that
                                                          tells two keys apart
```

It reads the value as text and knows nothing about any identifier's grammar, so a key whose shape changes still renders — just with a different slice shown. It returns the input unchanged when eliding would not shorten it, so nothing ever renders longer than it is.

## Two things the issue got wrong, worth recording

**"Several tests assert the exact rendered string."** There was one. It is updated. The whole-UI style debate the issue anticipated did not materialise, which is why this is a PR and not another round of discussion.

**The rendering was never tested at all.** The existing `ProductsScreen` fixture used `idempotency_key: "key-abc"` — eight characters, under the truncation limit — so no test ever exercised the path that was broken. That is why jsdom "renders the string fine" and the defect was found by watching a screencast instead.

So the new component test uses two keys of the **real** shape, differing only in the trailing sequence number, and asserts both halves of the fix: the full value is recoverable from `title`, and the two rows do not read identically.

## Evidence

```
typecheck  clean
lint       clean
tests      18 files, 95 passed, 0 failed
```

Mutation-probed by restoring the old rendering (`shortId`, no `title`) at the key's call site:

```
mutation-check: OK — the test failed under mutation, so it is fix-sensitive.
```

Exactly the new test failed; the other nine in that file still passed, so the probe is pointed at the change rather than at the file.

## What I am least confident about

**Whether `elideMiddle`'s 10/8 split is right for keys other than this one.** I picked it against the one key shape the journal actually writes. A key with a longer product name pushes more of the digest out of view — still distinguishable, because the sequence number survives at the tail, but less informative. The `title` makes it recoverable either way, and the helper takes `head`/`tail` parameters if another site wants a different balance.

**What I may be missing:** whether any screenshot test, docs image, or screencast asserts the old rendered text outside `engine/ui`. I checked the UI test suite and the repo's TypeScript; I did not check the docs site's images, which nothing can verify automatically.

## Review

No independent red team on this one — the `codex:codex-rescue` plugin cannot return a verdict to this session (it dispatches a background task whose status command is human-invocation-only, and refuses an inline pass). Saying so per AGENTS.md rather than skipping it silently. Refs #1756.
