### PR TITLE
fix(dagster): a declared check the engine did not produce stops reporting as passed

### DIFF
--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -213,6 +213,18 @@ DEFAULT_CHECK_NAMES: tuple[str, ...] = (
     ANOMALY_CHECK_NAME,
 )
 
+#: The checks for which "the engine reported nothing" genuinely means "nothing
+#: is wrong". Both are EVENT checks: the engine emits a result only when it has
+#: an anomaly or an exception to report, so silence is the clean verdict and a
+#: passing placeholder states the truth.
+#:
+#: Every other check is a MEASUREMENT. Silence there means the measurement was
+#: not taken, which is not the same as taking it and finding nothing — so its
+#: placeholder reports ``passed=False`` (#1645). This is the same rule the
+#: engine settled in #1741 one layer down: a check that did not run is not a
+#: check that passed.
+PASS_BY_ABSENCE_CHECK_NAMES: frozenset[str] = frozenset({ANOMALY_CHECK_NAME, COMPLIANCE_CHECK_NAME})
+
 
 @dataclass(frozen=True)
 class RockyTableProps:
@@ -4096,17 +4108,35 @@ def _emit_placeholder_checks(
             continue
 
         materialized = cs.asset_key in materialized_keys
-        if materialized:
-            reason = f"not produced by rocky (check type: {cs.name})"
-            severity = dg.AssetCheckSeverity.ERROR
-        else:
+        if not materialized:
             reason = "table not materialized"
             severity = dg.AssetCheckSeverity.WARN
+            passed = False
+        elif cs.name in PASS_BY_ABSENCE_CHECK_NAMES:
+            # An event check. No event means no anomaly, so silence IS the
+            # clean verdict and the placeholder states it.
+            reason = f"no {cs.name} reported by rocky"
+            severity = dg.AssetCheckSeverity.WARN
+            passed = True
+        else:
+            # A measurement the engine did not take. This used to report
+            # `passed=True` on a materialized table, so a `row_count` switched
+            # off in `rocky.toml` — or one the engine simply never emitted —
+            # showed a green badge for a measurement nobody made (#1645). The
+            # `status` metadata was already honest; the verdict was not, and
+            # the badge shows the verdict.
+            #
+            # WARN, not ERROR: a missing measurement is a gap in evidence, not
+            # a detected fault, and an unproduced check should not fail a run
+            # that was otherwise fine.
+            reason = f"not produced by rocky (check type: {cs.name})"
+            severity = dg.AssetCheckSeverity.WARN
+            passed = False
 
         yield dg.AssetCheckResult(
             asset_key=cs.asset_key,
             check_name=cs.name,
-            passed=materialized,
+            passed=passed,
             severity=severity,
             metadata={"status": dg.MetadataValue.text(reason)},
         )

--- a/integrations/dagster/tests/test_empty_outputs.py
+++ b/integrations/dagster/tests/test_empty_outputs.py
@@ -31,7 +31,12 @@ import dagster as dg
 import pytest
 
 from dagster_rocky import EMPTY_FOR_PARTITION_METADATA_KEY, RockyResource, TenantConfig
-from dagster_rocky.component import RockyComponent, _emit_results
+from dagster_rocky.component import (
+    RockyComponent,
+    _emit_placeholder_checks,
+    _emit_results,
+)
+from dagster_rocky.observability import ANOMALY_CHECK_NAME
 from dagster_rocky.types import RunResult
 
 
@@ -694,7 +699,18 @@ def test_pruned_placeholder_carries_prior_failure_end_to_end(tmp_path):
                         "passed": False,
                         "source_count": 100,
                         "target_count": 90,
-                    }
+                    },
+                    # A REAL passing verdict, so the carry-forward assertion
+                    # below rests on an evaluation the engine actually made.
+                    # It used to rest on the placeholder's green, which was
+                    # #1645 itself: `column_match` was never produced, and
+                    # `passed=materialized` reported it as passing anyway.
+                    {
+                        "name": "column_match",
+                        "passed": True,
+                        "source_columns": ["id"],
+                        "target_columns": ["id"],
+                    },
                 ],
             }
         ],
@@ -746,8 +762,90 @@ def test_pruned_placeholder_carries_prior_failure_end_to_end(tmp_path):
     # `column_match`, not `freshness`: this discover payload declares no
     # `[checks.freshness]`, so the `freshness` spec is not declared at all
     # (#1645). Any other declared default check proves the same carry-forward.
+    assert _checks_by_name(result_1)["column_match"].passed is True  # Monday: real pass
     assert tuesday_checks["column_match"].passed is True
     assert tuesday_checks["column_match"].metadata["rocky/pruned_unchanged"].value is True
+
+    # And the other half of #1645, visible in the same story: `row_count_anomaly`
+    # is declared on every asset and the engine reported none, on either day.
+    # It is an EVENT check, so silence is the clean verdict and it stays green.
+    assert tuesday_checks[ANOMALY_CHECK_NAME].passed is True
+
+
+def test_an_unproduced_measurement_check_does_not_report_passed():
+    """#1645. A declared check the engine did not produce is NOT a passing
+    check on a materialized table.
+
+    `_build_check_specs` declares `row_count` and `column_match` on every
+    asset, and both can be switched off in `rocky.toml` — so the engine
+    routinely emits no result for a check Dagster has declared. The
+    placeholder reported `passed=materialized`, which on a table that copied
+    fine meant a green badge for a measurement nobody made. The `status`
+    metadata said "not produced by rocky"; the verdict said pass, and the
+    badge shows the verdict.
+
+    The two EVENT checks are the deliberate exception: the engine emits
+    `row_count_anomaly` / `compliance_exception` only when it has one to
+    report, so silence there really is the clean verdict.
+
+    Same rule as #1741 one layer down in the engine: a check that did not run
+    is not a check that passed.
+    """
+    orders = dg.AssetKey(["orders"])
+    specs = [
+        dg.AssetCheckSpec(name="row_count", asset=orders),
+        dg.AssetCheckSpec(name="column_match", asset=orders),
+        dg.AssetCheckSpec(name=ANOMALY_CHECK_NAME, asset=orders),
+    ]
+
+    results = {
+        r.check_name: r
+        for r in _emit_placeholder_checks(
+            check_specs=specs,
+            selected_keys={orders},
+            yielded_checks=set(),
+            materialized_keys={orders},
+        )
+    }
+
+    assert set(results) == {"row_count", "column_match", ANOMALY_CHECK_NAME}
+
+    # The table materialized, so these are not "not materialized" — the engine
+    # simply produced no measurement, and that is not a pass.
+    for name in ("row_count", "column_match"):
+        assert results[name].passed is False, name
+        assert results[name].severity == dg.AssetCheckSeverity.WARN, name
+        assert "not produced by rocky" in results[name].metadata["status"].value
+
+    # No anomaly reported means no anomaly. This one stays green.
+    assert results[ANOMALY_CHECK_NAME].passed is True
+
+
+def test_an_unproduced_check_on_an_unmaterialized_table_is_unchanged():
+    """The other arm, so the fix above is not read as covering it: a table
+    that did not materialize keeps its own WARN placeholder and its own
+    reason. That includes the event checks — nothing was copied, so silence
+    says nothing about anomalies either."""
+    orders = dg.AssetKey(["orders"])
+    specs = [
+        dg.AssetCheckSpec(name="row_count", asset=orders),
+        dg.AssetCheckSpec(name=ANOMALY_CHECK_NAME, asset=orders),
+    ]
+
+    results = {
+        r.check_name: r
+        for r in _emit_placeholder_checks(
+            check_specs=specs,
+            selected_keys={orders},
+            yielded_checks=set(),
+            materialized_keys=set(),
+        )
+    }
+
+    for name in ("row_count", ANOMALY_CHECK_NAME):
+        assert results[name].passed is False, name
+        assert results[name].severity == dg.AssetCheckSeverity.WARN, name
+        assert results[name].metadata["status"].value == "table not materialized", name
 
 
 def test_prune_without_satisfy_empty_outputs_warns(caplog):


### PR DESCRIPTION
`_emit_placeholder_checks` ended with `passed=materialized`. On a table that copied fine, a declared check the engine never produced reported **`passed=True`** — a green badge for a measurement nobody made. The `status` metadata already said "not produced by rocky"; the verdict said pass, and the badge shows the verdict.

This is the ordinary case, not an edge one: `_build_check_specs` declares `row_count` and `column_match` on every asset, and both can be switched off in `rocky.toml`.

## The rule, named once

```
event check    row_count_anomaly, compliance_exception
               the engine emits a result only when it HAS one to report,
               so silence is the clean verdict                  -> passes

measurement    everything else
               silence means the measurement was not taken, which is not
               the same as taking it and finding nothing        -> does not pass
```

`PASS_BY_ABSENCE_CHECK_NAMES` holds exactly the two event checks. Everything else now reports `passed=False`.

**WARN, not ERROR.** A missing measurement is a gap in evidence, not a detected fault, and an unproduced check should not fail a run that was otherwise fine.

This is the same rule the engine settled in #1741 one layer down, where an unevaluated `CheckResult` stopped inheriting the configured severity so it could no longer clear the gate. Fixing it in the engine and leaving the orchestrator reporting green on the same absence would have been odd.

## An existing test caught the defect propagating

`test_pruned_placeholder_carries_prior_failure_end_to_end` failed, and it is worth reading why rather than just repairing it.

It proves "a green Monday verdict carries forward through Tuesday's prune". It used `column_match` as the green one — but Monday's `column_match` was green *only because it was never produced*. So the false pass was not just a bad badge for one run: the prune path carried it forward as though it were a real evaluation, and the test depended on that.

Monday now emits a **real** passing `column_match`, so the carry-forward assertion rests on an evaluation the engine actually made. The test also now pins that `row_count_anomaly` stays green across both days, since it is the deliberate exception.

## New tests, both arms

- `test_an_unproduced_measurement_check_does_not_report_passed` — on a materialized table, `row_count` and `column_match` report `passed=False` at WARN with "not produced by rocky", while `row_count_anomaly` stays green.
- `test_an_unproduced_check_on_an_unmaterialized_table_is_unchanged` — the other arm is untouched: an unmaterialized table keeps its own "table not materialized" placeholder, event checks included, because nothing was copied and silence says nothing about anomalies either.

## Evidence

```
pytest        772 passed, 0 failed
ruff check    All checks passed!
ruff format   clean
```

Mutation-probed by collapsing the branch back to the old verdict:

```
mutation-check: OK — the test failed under mutation, so it is fix-sensitive.
```

Exactly the new test failed; the other 22 in that file passed, so the probe is pointed at the change.

## Not fixed here, and why

A check switched **off** in `rocky.toml` still has a spec declared, so it now shows a warning instead of a false green. That is a better failure than the one it replaces — a visible gap rather than a false assurance — but it is not the end state.

Closing it needs the other option from the issue, and that option is **not implementable today**: `ChecksConfigOutput` (`engine/crates/rocky-cli/src/output.rs:140`) carries only `freshness` and `configured_checks`, and `configured_checks` explicitly excludes the four defaults. So there is nothing to gate on. It needs a new field on the engine's discover projection plus `just codegen` and `just regen-fixtures` — a cross-project PR. Written up on #1645.

That ordering is deliberate: this PR is the correctness half and needs no schema change; the follow-up is the noise half.

## What I am least confident about

**Whether WARN is loud enough.** A warning on a check nobody looks at is close to no fix at all, and the reason this shipped as a false green for so long is that nothing surfaced it. ERROR would be the honest severity for "you declared this check and it did not run" — but it would fail runs on the day it lands, for a condition that has been silently true all along. WARN first is the conservative order, not the obviously right answer.

**What I may be missing:** whether any user relies on the current pass-by-absence for `row_count`/`column_match` — an asset where checks are deliberately off and green is the expected steady state. Those users see a new warning after this change. The follow-up (not declaring the spec at all) is what actually serves them, which is the argument for not leaving it as an indefinite follow-up.

## Review

No independent red team — the `codex:codex-rescue` plugin cannot return a verdict to this session (it dispatches a background task whose status command is human-invocation-only, and refuses an inline pass). Stating that per AGENTS.md rather than skipping it silently. Refs #1645, #1619, #1642.
