### PR TITLE
fix(engine/ui): tell a refused review queue from an empty one, and stop calling every wordy plan a backfill

### DIFF
--- a/engine/ui/src/review/PlanDetail.test.tsx
+++ b/engine/ui/src/review/PlanDetail.test.tsx
@@ -159,8 +159,62 @@ describe("PlanDetail", () => {
 
     await screen.findByText("no single model to sample");
     expect(screen.queryByRole("button", { name: /Show \d+ rows/ })).toBeNull();
-    // and it says which of the two reasons applies, quoting what it was given
+    // and it quotes what it was given, naming the capability the engine sent
     expect(screen.getByText(/backfill: 3 model\(s\)/)).toBeTruthy();
+  });
+
+  /// Backfill is not the only capability whose queue `model` holds a sentence:
+  /// gc and restore write one too. The card must not call those a backfill —
+  /// a restore covers one tombstoned model and a gc is a deletion.
+  it("does not describe a restore plan as a backfill", async () => {
+    const restore: ReviewQueueOutput = {
+      ...QUEUE,
+      pending: [
+        {
+          ...QUEUE.pending[0],
+          capability: "restore",
+          model: "restore: 1 tombstoned model",
+          blast_radius: undefined,
+        },
+      ],
+    };
+
+    render(
+      <PlanDetail
+        planId={PLAN}
+        loaders={loaders({
+          status: vi.fn(async () => ({ ...STATUS, product_id: undefined })),
+          queue: vi.fn(async () => restore),
+        })}
+      />,
+    );
+
+    await screen.findByText("no single model to sample");
+    expect(screen.getByText(/this restore plan/)).toBeTruthy();
+    expect(screen.queryByText(/a backfill covers/)).toBeNull();
+  });
+
+  /// "The queue does not name this plan" and "the queue could not be read" are
+  /// different facts. Collapsing them told a reader an escalation was resolved
+  /// when the server had refused the request.
+  it("says the queue was refused rather than claiming the plan is not in it", async () => {
+    render(
+      <PlanDetail
+        planId={PLAN}
+        loaders={loaders({
+          queue: vi.fn(async () => {
+            throw new ApiError(503, {
+              code: "state_unreadable",
+              message: "the state store could not be read",
+            });
+          }),
+        })}
+      />,
+    );
+
+    // The queue feeds several panels, so its refusal shows in more than one.
+    await screen.findAllByText(/state_unreadable/);
+    expect(screen.queryByText("not in the queue")).toBeNull();
   });
 
   it("shows the plan, its findings, the escalation and the approve command", async () => {

--- a/engine/ui/src/review/PlanDetail.tsx
+++ b/engine/ui/src/review/PlanDetail.tsx
@@ -5,7 +5,7 @@ import type { ReviewQueueEntry, ReviewQueueOutput } from "@rocky-types/review_qu
 import type { ReviewStatusOutput } from "@rocky-types/review_status";
 import { apiGet } from "../api";
 import { StatusCard } from "../components";
-import { useResource } from "../estate/useResource";
+import { type Resource, useResource } from "../estate/useResource";
 import { formatInstant, shortId } from "../format";
 import { CustodyLink } from "../governor/links";
 import { ResourceState } from "./ResourceState";
@@ -158,7 +158,29 @@ function SpecDrift({
   );
 }
 
-function Escalation({ entry, planId }: { entry: ReviewQueueEntry | null; planId: string }) {
+function Escalation({
+  entry,
+  queue,
+  planId,
+}: {
+  entry: ReviewQueueEntry | null;
+  queue: Resource<ReviewQueueOutput>;
+  planId: string;
+}) {
+  // "The queue does not name this plan" and "the queue could not be read" are
+  // different facts, and only the first is safe to state. Collapsing them told
+  // a reader that an escalation had been resolved when the server had in fact
+  // refused the request.
+  if (queue.kind !== "ready") {
+    return (
+      <section aria-label="Why it needs a human" className="space-y-2">
+        <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+          Why it needs a human
+        </h3>
+        <ResourceState resource={queue} loadingLine="reading the review queue…" />
+      </section>
+    );
+  }
   if (entry === null) {
     return (
       <StatusCard
@@ -325,7 +347,7 @@ export function PlanDetail({
         </section>
       )}
 
-      <Escalation entry={entry} planId={planId} />
+      <Escalation entry={entry} queue={queue} planId={planId} />
 
       {productId !== null &&
         (product.kind === "ready" ? (
@@ -344,15 +366,18 @@ export function PlanDetail({
       ) : (
         // Absent is not empty. A missing panel reads as "this plan touches no
         // data"; say instead that the screen could not work out which model to
-        // sample, which is a different thing and has a different fix. And say
-        // WHICH of the two reasons applies — a backfill has models, just not one
-        // this screen can name.
+        // sample, which is a different thing and has a different fix.
+        //
+        // Say only what the payload supports. Backfill is not the only
+        // capability whose `model` field holds a sentence — gc and restore
+        // write one too — so quote the sentence and name the capability the
+        // engine gave, rather than describing a backfill the plan may not be.
         <StatusCard
           label="sample rows"
           value="no single model to sample"
           sub={
             entry !== null
-              ? `The queue describes this plan as "${entry.model}", which names no single model — a backfill covers a set of them, and this panel reads one model at a time. Sample them from the estate screen instead.`
+              ? `The queue describes this ${entry.capability} plan as "${entry.model}", which is not a model name this panel can read rows from. Sample the models it touches from the estate screen instead.`
               : "Neither the review queue nor the product names a model for this plan, so there is nothing to read rows from. A plan that is not product-bound and no longer in the queue has no model on this screen."
           }
         />


### PR DESCRIPTION
Two defects in #1765, both found by **Codex's independent red-team pass** over it — the first outside review this work has had.

## 1. An unreadable queue read as an absent escalation

`entry` was derived from the queue resource like this:

```tsx
queue.kind === "ready" ? find(...) : null
```

So *every* non-ready state — refused, unreachable, still loading — produced `null`, and the escalation card then stated **"not in the queue"**.

```
  GET /api/v1/review/queue  ──▶  503 state_unreadable
                                        │
                                        ▼
                      the screen said:  "not in the queue"
                                        = no escalation names this plan
```

A refusal was rendered to the reviewer as a fact about the plan. On a screen whose entire job is that a human can trust it before approving something that changes data, that is the worst available direction to fail in.

The card now renders the refusal — the engine's own `code` and remediation hint, via the existing `ResourceState` — and says "not in the queue" only when the queue was actually read.

## 2. The sample card called a restore and a gc plan a backfill

Backfill is not the only capability whose queue `model` field holds a sentence rather than a name. `gc.rs` and `restore.rs` write one too, so both fell through the same guard and were told:

> The queue describes this plan as "…" — **a backfill covers a set of them.**

A restore covers one tombstoned model. A gc is a deletion. Neither is a backfill.

The copy now quotes the sentence and names the capability the engine sent, claiming nothing about what the plan does:

> The queue describes this **restore** plan as "restore: 1 tombstoned model", which is not a model name this panel can read rows from.

That is the shape of the original bug repeating one level up: #1765 generalised the *guard* correctly and then wrote copy for a single case.

## Tests

Both are fix-sensitive. Reverting each change fails exactly its own case and nothing else:

```
× does not describe a restore plan as a backfill
× says the queue was refused rather than claiming the plan is not in it
  Tests  2 failed | 11 passed
```

Restored: 24 review tests pass, `tsc --noEmit` clean, eslint clean.

## The two questions

**Least confident.** Whether any *other* capability writes a sentence into that field. I fixed the copy so it no longer needs to know — it quotes what it was given — but the underlying overload is still there and is tracked in #1766: `ReviewQueueEntry.model` is a graph lookup key **and** a human label, and the engine reads it as a key too (`blast_radius_of` looks it up by name and silently gets `None`).

**Most likely missing.** The same "absent vs unreadable" collapse almost certainly exists on other screens. Codex found three more in the same pass, all in #1740: an unparseable `products/*.toml` renders as "no spec file"; an unreadable state store renders as "the loop has not run", "approval none" and an empty journal; and a pending staging journal is reported by the producer but rendered nowhere. This PR does not touch those — they want their own change, and it is the shape rather than the instances that needs a rule.
