### PR TITLE
fix(engine): a quality target whose schema cannot be listed stops reporting a clean run

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -438,6 +438,41 @@ fn quality_row_count_check(
     }
 }
 
+/// Records that a schema-wide quality target could not be EXPANDED, as a
+/// failing check the engine could not evaluate.
+///
+/// A `[[pipeline.x.tables]]` entry with no `table` names a whole schema, and
+/// Rocky enumerates it with `list_tables_sql`. When that SQL cannot be built or
+/// cannot be run, no table is known — so every check for that target is
+/// unevaluated.
+///
+/// Both arms used to `continue` after a `warn!`, emitting NO `CheckResult` at
+/// all. Nothing reached either severity bucket, `error_failures` stayed 0, and
+/// a run that had checked nothing persisted `Success` and exited 0. A dropped
+/// permission or a renamed schema read as a clean bill of health.
+///
+/// `custom_not_evaluated` is the right constructor rather than a
+/// convenience: the list-tables statement genuinely IS a query Rocky could not
+/// evaluate, and the constructor is hard-coded to `TestSeverity::Error`, so
+/// this lands in the error bucket and the existing
+/// `error_failures > 0 && fail_on_error` path fails the run (#1741).
+fn checks_for_unexpandable_target(
+    output: &mut RunOutput,
+    table_ref: &rocky_core::config::TableRef,
+    list_sql: &str,
+    reason: String,
+) {
+    output.check_results.push(TableCheckOutput {
+        asset_key: vec![table_ref.catalog.clone(), table_ref.schema.clone()],
+        checks: vec![rocky_core::checks::custom_not_evaluated(
+            "schema_expansion",
+            list_sql,
+            0,
+            reason,
+        )],
+    });
+}
+
 /// Execute `rocky run` for a quality pipeline.
 ///
 /// Runs data quality checks against the specified tables without any data movement.
@@ -500,7 +535,13 @@ pub async fn run_quality(
                             catalog = table_ref.catalog.as_str(),
                             schema = table_ref.schema.as_str(),
                             error = %e,
-                            "failed to build list-tables SQL — skipping"
+                            "failed to build list-tables SQL"
+                        );
+                        checks_for_unexpandable_target(
+                            &mut output,
+                            table_ref,
+                            "",
+                            format!("could not build the list-tables SQL: {e}"),
                         );
                         continue;
                     }
@@ -516,7 +557,13 @@ pub async fn run_quality(
                             catalog = table_ref.catalog.as_str(),
                             schema = table_ref.schema.as_str(),
                             error = %e,
-                            "failed to list tables in schema — skipping"
+                            "failed to list tables in schema"
+                        );
+                        checks_for_unexpandable_target(
+                            &mut output,
+                            table_ref,
+                            &list_sql,
+                            format!("could not list the tables in this schema: {e}"),
                         );
                         continue;
                     }
@@ -2507,6 +2554,63 @@ auto_create_schemas = true
             check.severity,
             TestSeverity::Warning,
             "a measured result takes the configured severity: {check:?}"
+        );
+    }
+
+    /// #1741 follow-up, found by the independent review of #1780. A
+    /// schema-wide quality target — a `[[pipeline.x.tables]]` entry with no
+    /// `table`, so Rocky enumerates the schema with `list_tables_sql` — used
+    /// to `continue` after a `warn!` when that enumeration failed.
+    ///
+    /// No `CheckResult` was emitted at all, so nothing reached either severity
+    /// bucket, `error_failures` stayed 0, and a run that had checked NOTHING
+    /// persisted `Success` and exited 0. A dropped permission or a renamed
+    /// schema read as a clean bill of health.
+    ///
+    /// Asserted through `check_failures_by_severity`, the same function
+    /// `run_quality` calls to decide `error_failures`, so this pins the number
+    /// that drives the exit code rather than the presence of a struct.
+    #[test]
+    fn a_schema_target_that_cannot_be_expanded_reaches_the_error_bucket() {
+        use crate::output::RunOutput;
+        use rocky_core::tests::TestSeverity;
+
+        let table_ref = rocky_core::config::TableRef {
+            catalog: "cat".into(),
+            schema: "raw".into(),
+            table: None,
+        };
+
+        let mut output = RunOutput::new(String::new(), 0, 0);
+        assert_eq!(
+            output.check_failures_by_severity(),
+            (0, 0),
+            "a run with no targets has nothing in either bucket"
+        );
+
+        super::checks_for_unexpandable_target(
+            &mut output,
+            &table_ref,
+            "SHOW TABLES IN cat.raw",
+            "could not list the tables in this schema: permission denied".to_string(),
+        );
+
+        assert_eq!(
+            output.check_failures_by_severity(),
+            (1, 0),
+            "an unexpandable target is an ERROR-bucket failure, which is what \
+             `error_failures > 0 && fail_on_error` reads to fail the run"
+        );
+
+        let bag = &output.check_results[0];
+        assert_eq!(bag.asset_key, vec!["cat".to_string(), "raw".to_string()]);
+        let check = &bag.checks[0];
+        assert!(!check.passed);
+        assert_eq!(check.severity, TestSeverity::Error);
+        assert_eq!(
+            check.not_evaluated.as_deref(),
+            Some("could not list the tables in this schema: permission denied"),
+            "carries the warehouse's own reason, not a summary"
         );
     }
 

--- a/engine/crates/rocky-core/src/checks.rs
+++ b/engine/crates/rocky-core/src/checks.rs
@@ -1085,6 +1085,11 @@ mod tests {
     /// from the wire form of a check that ran (#1602). Every such constructor
     /// is also hard-coded to [`TestSeverity::Error`] (#1741) — none of them
     /// takes a severity, so a check that did not run cannot be advisory.
+    ///
+    /// All SEVEN are listed below. Keep them in step with
+    /// `grep -c "^pub fn .*_not_evaluated" checks.rs`: this list said "every
+    /// constructor" while covering six, and the missing one
+    /// (`column_match_not_evaluated`) was found by review, not by the test.
     #[test]
     fn not_evaluated_constructors_fail_and_round_trip_through_json() {
         let cases: Vec<CheckResult> = vec![
@@ -1098,6 +1103,10 @@ mod tests {
                 "the assertion query returned no readable count",
             ),
             custom_not_evaluated("no_dupes", "SELECT 1", 0, "custom check query failed: boom"),
+            // Omitted until the independent review of #1780 caught it: the
+            // test's doc comment claimed to cover EVERY such constructor and
+            // covered six of seven.
+            column_match_not_evaluated("the column list could not be read"),
             cross_source_overlap_not_evaluated(
                 "cross_source_overlap:shopify.orders",
                 vec!["cat.s1.orders".into()],


### PR DESCRIPTION
Two defects the **independent Codex review of #1780** found and I did not. I had reported that review as unavailable; it had in fact run — 158 tool calls — and written its verdict to the session rollout, which is readable. That correction is on #1741 in full.

## 1. A schema-wide quality target that cannot be expanded checks nothing and exits 0

The more serious of the two, and a level up from #1741: not a check reported wrongly, but a check **never created**.

A `[[pipeline.x.tables]]` entry with no `table` names a whole schema, which Rocky enumerates with `list_tables_sql`. Both failure arms — SQL generation and execution — did `warn!` then `continue`, emitting no `CheckResult` at all:

```
list_tables_sql fails / the query fails
   -> warn! + continue
   -> no CheckResult
   -> neither severity bucket
   -> error_failures == 0
   -> tables_failed untouched
   -> RunStatus::Success, exit 0
```

A dropped permission or a renamed schema read as a clean bill of health, and the schedule reconciler would treat that run as a satisfied `after` / `freshness` demand.

Both arms now record a failing `custom_not_evaluated` named `schema_expansion` against the schema's asset key. That constructor is hard-coded to `TestSeverity::Error`, so the result lands in the error bucket and the **existing** `error_failures > 0 && fail_on_error` path does the rest — failing the run, setting `tables_failed`, and persisting `Failure`. No new control flow.

`custom_not_evaluated` is the honest constructor here rather than a convenience: the list-tables statement genuinely *is* a query the engine could not evaluate, and `CheckDetails::Custom` carries it so the reason and the SQL both survive.

The test asserts through `check_failures_by_severity` — the same function `run_quality` calls to compute `error_failures` — so it pins the number that drives the exit code, not the presence of a struct.

## 2. The "every constructor" test covered six of seven

`not_evaluated_constructors_fail_and_round_trip_through_json` claims in its doc comment to cover every `*_not_evaluated` constructor and to make a future one safe by construction. There are **seven**. It listed six. The omission is `column_match_not_evaluated` (`checks.rs:453`).

I also wrote "all six constructors" and "a seventh added later is covered by construction" on #1780. Both wrong, and the seventh was the one missing.

Added, and the doc comment now states the count with the `grep` that checks it:

```
grep -c "^pub fn .*_not_evaluated" checks.rs
```

so the next reader can verify the claim instead of trusting it. A claim about completeness that cannot be checked is how this one survived.

## Evidence

```
cargo test -p rocky-core -p rocky-cli --features duckdb   all green, 0 failures
cargo clippy --all-targets --all-features                 clean
cargo fmt --all                                           clean
```

## Filed, not fixed here

Two further review findings, both of which move a severity users actually see, and both of which belong with #1666's "should a measured result honour the configured severity" question rather than with a fail-open fix:

- **#1784** — Dagster Pipes passes `PipesCheckSeverity::Error` as a literal for every check (`run.rs:7327`), discarding the configured severity. `pipes.rs` threads severity properly and has a test expecting `"WARN"`; the call site never uses it. This is the **opposite** direction from #1741: a measured, deliberately-advisory violation escalated to a hard failure.
- **#1785** — `dagster_check_severity` maps severity without reading `passed` or `not_evaluated`, so `cross_source_overlap_not_applicable` reports `"severity": "warning"` for a group Rocky never measured. This is the finding that showed my #1780 claim — "severity has exactly one consumer, and it tests `passed` first" — was a Rust-only grep stated as a property of the system.

## What I am least confident about

**The check name `schema_expansion`.** It is a name no consumer pre-declares, so a Dagster user who has declared the four default specs will see this result dropped by `_emit_results` rather than surfaced. The engine's own gate is the primary consumer and it works, so the run does fail — but the orchestrator will not say why. Fixing that properly means declaring the name somewhere consumers can see it, which is the same projection question as #1645's second half.

**What I may be missing:** whether a schema that legitimately contains zero tables is now distinguishable from one that could not be listed. It is — an empty list yields no checks and no failure, while a failed list yields this result — but nothing tests the empty-schema case, and I have not added one because I could not tell from the config whether an empty schema is meant to be an error.

## Review

Reviewer: **Codex, independent**, via the plugin, read from the session rollout. Its findings on #1780 are dispositioned in full on #1741. This follow-up has not itself been re-reviewed. Refs #1741.
