### PR TITLE
fix(engine): a spec file that exists but cannot be read is not a missing one

### DIFF
--- a/engine/crates/rocky-core/src/product/spec.rs
+++ b/engine/crates/rocky-core/src/product/spec.rs
@@ -907,14 +907,32 @@ pub fn parse_spec_bytes(raw: &[u8], source_name: &str) -> SpecResult<ParsedSpec>
 ///
 /// # Errors
 ///
-/// Returns `spec-file-missing` when the path is not a readable file, plus any
+/// Returns `spec-file-missing` when the path does not exist,
+/// `spec-file-unreadable` when it exists but could not be read, plus any
 /// rejection from [`parse_spec_bytes`].
+///
+/// Those two are deliberately separate codes. A deleted spec and a spec the
+/// process may not open are different situations with different fixes, and
+/// every surface downstream — `rocky product status`, `product list`, the
+/// governor screen — words its refusal from this code. Reporting an
+/// unreadable file as "not found" tells a reviewer the product was removed
+/// when it is sitting right there.
 pub fn parse_spec_file(path: &std::path::Path) -> SpecResult<ParsedSpec> {
     let raw = std::fs::read(path).map_err(|err| {
-        SpecRejected::new(
-            "spec-file-missing",
-            format!("spec file not found: {} ({err})", path.display()),
-        )
+        if err.kind() == std::io::ErrorKind::NotFound {
+            SpecRejected::new(
+                "spec-file-missing",
+                format!("spec file not found: {} ({err})", path.display()),
+            )
+        } else {
+            SpecRejected::new(
+                "spec-file-unreadable",
+                format!(
+                    "spec file exists but could not be read: {} ({err})",
+                    path.display()
+                ),
+            )
+        }
     })?;
     parse_spec_bytes(&raw, &path.display().to_string())
 }
@@ -1271,5 +1289,48 @@ include = ["stripe.*"]"#,
         assert_eq!(freshness.max_lag_seconds().expect("parses"), 86_400);
         assert_eq!(freshness.severity, Some(FreshnessSeverity::Error));
         assert_eq!(product.trust.agent, "propose_only");
+    }
+
+    /// A path that does not exist is missing. Every surface downstream words
+    /// its refusal from this code, so it has to mean only the one thing.
+    #[test]
+    fn an_absent_spec_file_is_reported_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let reject =
+            parse_spec_file(&dir.path().join("products/nothing.toml")).expect_err("must reject");
+        assert_eq!(reject.code, "spec-file-missing");
+    }
+
+    /// A spec the process cannot open is NOT missing. Saying so tells a
+    /// reviewer the product was deleted when it is sitting right there.
+    #[cfg(unix)]
+    #[test]
+    fn a_spec_file_that_cannot_be_read_is_not_reported_missing() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("revenue_daily.toml");
+        std::fs::write(&path, VALID).expect("write");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).expect("chmod");
+
+        let reject = parse_spec_file(&path).expect_err("must reject");
+        // Root ignores the mode bits, so only assert when the read really failed.
+        assert_eq!(reject.code, "spec-file-unreadable");
+        assert!(
+            reject.message.contains("could not be read"),
+            "message must not claim absence: {}",
+            reject.message
+        );
+    }
+
+    /// A directory where a file belongs also exists — reporting it missing
+    /// sends the reader looking for a deletion that never happened.
+    #[test]
+    fn a_directory_in_the_specs_place_is_not_reported_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("revenue_daily.toml");
+        std::fs::create_dir(&path).expect("mkdir");
+        let reject = parse_spec_file(&path).expect_err("must reject");
+        assert_eq!(reject.code, "spec-file-unreadable");
     }
 }

--- a/engine/ui/src/governor/ProductsScreen.test.tsx
+++ b/engine/ui/src/governor/ProductsScreen.test.tsx
@@ -4,7 +4,12 @@ import type { ProductJournalOutput } from "@rocky-types/product_journal";
 import type { ProductListOutput } from "@rocky-types/product_list";
 import type { ProductStatusOutput } from "@rocky-types/product_status";
 import { ApiError } from "../api";
-import { ProductsScreen, type ProductLoaders, productPath } from "./ProductsScreen";
+import {
+  ProductsScreen,
+  type ProductLoaders,
+  describeSpecTrouble,
+  productPath,
+} from "./ProductsScreen";
 
 const PLAN = "d".repeat(64);
 
@@ -27,7 +32,9 @@ const LIST: ProductListOutput = {
     {
       name: "deleted_product",
       spec_present: false,
-      spec_error: "spec-file-missing",
+      // `SpecRejected`'s Display is `[<code>] <message>`; the code is what
+      // the screen words its label from, so the fixture must carry it.
+      spec_error: "[spec-file-missing] spec file not found: products/gone.toml",
       fulfill_state: null,
       journal_rows: 2,
       artifact_problems: 1,
@@ -159,7 +166,7 @@ describe("ProductsScreen", () => {
     // A deleted spec still lists, with the loader's own reason — hiding it
     // would make a removed product look like one that never existed.
     expect(screen.getByText("deleted_product")).toBeTruthy();
-    expect(screen.getByText(/no spec file: spec-file-missing/)).toBeTruthy();
+    expect(screen.getByText(/no spec file/)).toBeTruthy();
     expect(screen.getByText("the loop has not run")).toBeTruthy();
   });
 
@@ -291,5 +298,32 @@ describe("ProductsScreen", () => {
 
   it("builds a product path that survives an awkward name", () => {
     expect(productPath("revenue daily")).toBe("/ui/governor/products/revenue%20daily");
+  });
+
+  /// Only `spec-file-missing` means the file is gone. A spec that exists and
+  /// cannot be read, or one that parses badly, must not be reported as a
+  /// deletion — the reader would go looking for a removal that never happened.
+  describe("describeSpecTrouble", () => {
+    it("says the file is gone only when the loader said it was missing", () => {
+      expect(describeSpecTrouble("[spec-file-missing] spec file not found: a.toml")).toBe(
+        "no spec file",
+      );
+      expect(describeSpecTrouble(null)).toBe("no spec file");
+    });
+
+    it("does not call an unreadable spec a missing one", () => {
+      expect(
+        describeSpecTrouble("[spec-file-unreadable] spec file exists but could not be read: a.toml"),
+      ).toBe("spec file unreadable");
+    });
+
+    it("does not call a rejected spec a missing one", () => {
+      expect(describeSpecTrouble("[not-toml] products/a.toml is not valid TOML")).toBe(
+        "spec file unusable",
+      );
+      expect(describeSpecTrouble("[product-name-mismatch] declares product.name = 'x'")).toBe(
+        "spec file unusable",
+      );
+    });
   });
 });

--- a/engine/ui/src/governor/ProductsScreen.tsx
+++ b/engine/ui/src/governor/ProductsScreen.tsx
@@ -51,7 +51,8 @@ function ProductRow({ entry }: { entry: ProductListEntry }) {
         // A deleted spec still lists. Hiding it would make a product that was
         // removed look like one that never existed.
         <p className="mt-1 text-xs text-amber-700 dark:text-amber-400">
-          no spec file: {entry.spec_error ?? "the loader gave no reason"}
+          {describeSpecTrouble(entry.spec_error)}:{" "}
+          {entry.spec_error ?? "the loader gave no reason"}
         </p>
       )}
       <dl className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-zinc-600 sm:grid-cols-4 dark:text-zinc-300">
@@ -223,6 +224,22 @@ function JournalTable({ rows }: { rows: ProductJournalEntry[] }) {
       </table>
     </div>
   );
+}
+
+/**
+ * How to word a missing-or-broken spec.
+ *
+ * `spec_error` is `[<code>] <message>` (`SpecRejected`'s Display). The code
+ * discriminates: only `spec-file-missing` means the file is gone. Everything
+ * else — unreadable, not TOML, a rejected field — means the file is there and
+ * cannot be used, which has a different fix. Saying "no spec file" for all of
+ * them tells a reviewer a product was deleted when it is sitting right there.
+ */
+export function describeSpecTrouble(specError: string | null | undefined): string {
+  if (specError === null || specError === undefined) return "no spec file";
+  if (specError.startsWith("[spec-file-missing]")) return "no spec file";
+  if (specError.startsWith("[spec-file-unreadable]")) return "spec file unreadable";
+  return "spec file unusable";
 }
 
 function Standing({ status }: { status: ProductStatusOutput }) {


### PR DESCRIPTION
Codex's independent pass over #1740 reported that the governor screen labels an unparseable spec **"no spec file"**. Tracing it found the cause a layer down, in the engine.

**Review: Codex, via the plugin, on the merged #1740. This follow-up fix is same-model self-review — no independent pass on the fix itself yet.**

## The engine was reporting a lie

```rust
// before — every read error is a deletion
let raw = std::fs::read(path).map_err(|err| {
    SpecRejected::new("spec-file-missing", format!("spec file not found: {} ({err})", …))
})?;
```

A permission error, an I/O error, a directory where the file belongs — all reported as `spec-file-missing`, with the message "spec file not found". The doc comment conflated them too: *"when the path is not a readable file"*.

That code is the discriminator **every surface downstream words its refusal from** — `rocky product status`, `rocky product list`, the governor screen:

```
  chmod 000 products/revenue_daily.toml
            │
            ▼
  parse_spec_file → "spec-file-missing"
            │
            ▼
  the screen says:  "no spec file"
                    = this product was deleted
```

It is sitting right there. The reviewer goes looking for a removal that never happened.

`NotFound` now stays `spec-file-missing`. Anything else becomes **`spec-file-unreadable`**, whose message says the file exists.

## The screen reads the code instead of asserting

`SpecRejected`'s Display is already `[<code>] <message>`, so no payload or schema change was needed:

| code | label |
|---|---|
| `spec-file-missing` | no spec file |
| `spec-file-unreadable` | spec file unreadable |
| anything else — `not-toml`, `product-name-mismatch`, `unknown-key`… | spec file unusable |

## The fixture was wrong, and that is why the bug survived

The UI test set `spec_error: "spec-file-missing"`. The producer emits `[spec-file-missing] spec file not found: …`. A hand-built fixture that does not match its producer cannot catch a producer-shaped bug — it asserted against a format that never existed. Corrected to the real form.

## Tests

Three in `rocky-core`, four in the UI. The Rust ones are mutation-checked — reverting the discriminator to `if true` fails exactly the two that matter:

```
failures:
    a_directory_in_the_specs_place_is_not_reported_missing
    a_spec_file_that_cannot_be_read_is_not_reported_missing
mutation-check: OK — the test failed under mutation, so it is fix-sensitive.
```

`tempfile` is feature-gated in `rocky-core` rather than a dev-dependency, so the tests were verified to compile and pass **both** with and without default features.

## The two questions

**Least confident.** Whether `ErrorKind::NotFound` is the right sole test for "gone". A dangling symlink reports `NotFound` from `read`, and calling that "missing" is defensible — the target is gone — but a *dangling intermediate directory* symlink also reports `NotFound` while the spec may be fine underneath. Codex raised exactly that shape against #1710 for a different path (`symlink_metadata` cannot tell a missing leaf from a dangling intermediate). This change does not close that; it moves the common case from wrong to right.

**Most likely missing.** The other two findings Codex made on #1740, both untouched here: an unreadable **state store** still renders as "the loop has not run", "approval none" and an empty journal, because `Path::exists()` turns the metadata error into `false`; and a pending staging journal is reported by the producer but rendered nowhere. Those are the same class again, in `product.rs`, and want their own change. This is the third instance of "absent stands in for unreadable" found in two days — the shape needs a rule, not three more patches.
