### PR TITLE
fix(engine/rocky-cli): an unreadable state store refuses, instead of reporting a healthy empty product

### DIFF
--- a/engine/crates/rocky-cli/src/commands/product.rs
+++ b/engine/crates/rocky-cli/src/commands/product.rs
@@ -1607,19 +1607,55 @@ pub(crate) fn product_status_in(
         .join(rocky_core::product::commit::STAGING_JOURNAL)
         .is_file();
 
+    // `Path::exists()` answers false for every metadata error, not just for a
+    // path that is not there — so a store the process may not stat produced a
+    // status reading "the loop has not run", "approval none" and an empty
+    // journal. On a screen a reviewer trusts before approving, an unreadable
+    // store must refuse, never render as a healthy empty one. `rocky-core`
+    // already owns the discriminator this needs (#1668, #1707).
     let store = match state_path {
-        Some(path) if path.exists() => Some(open_state_store_read_only(path)?),
-        _ => None,
+        Some(path) => match std::fs::metadata(path) {
+            Ok(_) => Some(open_state_store_read_only(path)?),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                match rocky_core::path_presence::classify_not_found(path) {
+                    // Genuinely nothing there: no store yet is the ordinary
+                    // case, and an empty status is the honest answer.
+                    rocky_core::path_presence::PathPresence::Absent => None,
+                    rocky_core::path_presence::PathPresence::Present { detail } => {
+                        anyhow::bail!("{} cannot be read: {detail}", path.display())
+                    }
+                }
+            }
+            Err(err) => anyhow::bail!("{} cannot be read: {err}", path.display()),
+        },
+        None => None,
     };
     if let Some(store) = store {
         if let Some(record) = store.product_approval_get(product_name)? {
+            // `snapshot_intact: false` is an accusation — it says the bytes a
+            // human approved no longer match. Only a snapshot that was READ
+            // may earn it. A snapshot that could not be read has proven
+            // nothing, and saying "not intact" there cries tampering over a
+            // permission bit. Absent still earns false: the approved bytes are
+            // genuinely gone, which is the thing the field exists to report.
             let snapshot_file = root.join(&record.snapshot_path);
-            let intact = if snapshot_file.is_file() {
-                std::fs::read(&snapshot_file)
-                    .map(|bytes| content_digest(&bytes) == record.spec_digest)
-                    .unwrap_or(false)
-            } else {
-                false
+            let intact = match std::fs::read(&snapshot_file) {
+                Ok(bytes) => content_digest(&bytes) == record.spec_digest,
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                    match rocky_core::path_presence::classify_not_found(&snapshot_file) {
+                        rocky_core::path_presence::PathPresence::Absent => false,
+                        rocky_core::path_presence::PathPresence::Present { detail } => {
+                            anyhow::bail!(
+                                "the approval snapshot {} cannot be read: {detail}",
+                                snapshot_file.display()
+                            )
+                        }
+                    }
+                }
+                Err(err) => anyhow::bail!(
+                    "the approval snapshot {} cannot be read: {err}",
+                    snapshot_file.display()
+                ),
             };
             output.snapshot_intact = Some(intact);
             output.spec_matches_approval = parsed
@@ -3901,5 +3937,52 @@ effect = "require_review"
         let status = product_status_in(&root, None, "revenue_daily").expect("status");
         assert!(status.staging_journal_present);
         assert!(journal.is_file(), "status never mutates");
+    }
+
+    /// No state store yet is the ordinary case: an empty status is honest.
+    #[test]
+    fn a_state_path_that_is_simply_absent_still_reports_a_status() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (root, config) = project_with_config(dir.path(), &passing_config());
+        product_compile_in(&root, &config, None, "revenue_daily").expect("phase A");
+
+        let missing = dir.path().join("no-store-here.redb");
+        let status =
+            product_status_in(&root, Some(&missing), "revenue_daily").expect("absent is fine");
+        assert!(status.approval.is_none());
+        assert_eq!(status.journal_rows, 0);
+    }
+
+    /// A store that IS there and cannot be read must refuse. `Path::exists()`
+    /// answered false for a metadata error, so the screen rendered "the loop
+    /// has not run", "approval none" and an empty journal over a store nobody
+    /// could open — a healthy-looking answer built on no evidence.
+    #[cfg(unix)]
+    #[test]
+    fn a_state_store_that_cannot_be_read_refuses_instead_of_reporting_an_empty_one() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (root, config) = project_with_config(dir.path(), &passing_config());
+        product_compile_in(&root, &config, None, "revenue_daily").expect("phase A");
+
+        // A directory the process may not search, with the store path inside.
+        let locked = dir.path().join("locked");
+        std::fs::create_dir(&locked).expect("mkdir");
+        let store = locked.join("state.redb");
+        std::fs::write(&store, b"not really a store").expect("write");
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).expect("chmod");
+
+        let result = product_status_in(&root, Some(&store), "revenue_daily");
+
+        // Restore before asserting, so a failure cannot leave an unremovable dir.
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).expect("restore");
+
+        let err = result.expect_err("an unreadable store must refuse");
+        let text = format!("{err:#}");
+        assert!(
+            text.contains("cannot be read"),
+            "the refusal must say the store could not be read, got: {text}"
+        );
     }
 }

--- a/engine/crates/rocky-core/src/path_presence.rs
+++ b/engine/crates/rocky-core/src/path_presence.rs
@@ -12,7 +12,7 @@
 use std::path::Path;
 
 /// What a `NotFound` from an operation on a path actually means.
-pub(crate) enum PathPresence {
+pub enum PathPresence {
     /// Nothing is at this path. The `NotFound` meant what it said, and the
     /// caller's ordinary "there is none of this yet" answer is correct.
     Absent,
@@ -40,7 +40,7 @@ pub(crate) enum PathPresence {
 ///
 /// The detail sentences are deliberately entry-neutral: the same helper backs
 /// a file read and a directory read, so nothing here says "file".
-pub(crate) fn classify_not_found(path: &Path) -> PathPresence {
+pub fn classify_not_found(path: &Path) -> PathPresence {
     match std::fs::symlink_metadata(path) {
         // Nothing at this path. Genuinely absent — unchanged behaviour, and
         // the case every caller depends on.


### PR DESCRIPTION
The second of Codex's three findings on #1740. Sibling of #1787, same class, different layer.

**Review: Codex, via the plugin, on the merged #1740. This follow-up is same-model self-review — no independent pass on the fix itself yet.**

## An empty world asserted over a store nobody could open

```rust
Some(path) if path.exists() => Some(open_state_store_read_only(path)?),
_ => None,
```

`Path::exists()` answers **false for every metadata error**, not only for a path that is not there. So a store the process could not stat produced a perfectly healthy status:

```
  chmod 000 on the store's parent
            │
            ▼
  path.exists() → false        (the error is swallowed)
            │
            ▼
  the governor screen says:
      loop state    the loop has not run
      approval      none
      journal rows  0
```

Every one of those is a claim about a store that was never read.

## The fix was already in the tree

`rocky-core` owns the discriminator for exactly this, written for #1668 and #1707:

```
  read(path) -> NotFound
       ├── symlink_metadata FAILS NotFound  → Absent   (ordinary: not created yet)
       └── otherwise                        → Present  (refuse: absence unproven)
```

`path_presence::classify_not_found` is fail-closed by construction and its module doc opens with *"Tell 'nothing is at this path' apart from 'an entry is here that cannot be read'."* It was `pub(crate)`; this makes it `pub` so the product verbs use **that** rule rather than inventing a second one.

Absent still means absent — no store yet is the ordinary case, and an empty status is the honest answer. Present-but-unreadable now refuses, and the UI already renders refusals properly through `ResourceState`. **No schema change.**

## The same block made a worse claim

```rust
let intact = if snapshot_file.is_file() {
    read(..).map(digest_matches).unwrap_or(false)
} else { false };
```

`snapshot_intact: false` is an **accusation** — it says the bytes a human approved no longer match. That was being raised over a permission bit. A snapshot that could not be read has proven nothing.

Only a snapshot that was actually read may earn `false` now. Absent still earns it: the approved bytes are genuinely gone, which is the thing the field exists to report.

## Tests

Mutation-checked. Reverting to `Path::exists()` fails exactly the new test:

```
failures:
    a_state_store_that_cannot_be_read_refuses_instead_of_reporting_an_empty_one
mutation-check: OK — the test failed under mutation, so it is fix-sensitive.
```

63 product tests pass, clippy `--all-targets` clean, fmt clean. The unreadable-directory test restores its permissions **before** asserting, so a failing run cannot leave an unremovable directory in a temp dir.

## The two questions

**Least confident.** Whether refusing is right for `product list`, which walks every product. One unreadable store now fails the whole listing rather than degrading that row. I judged fail-closed correct for a trust surface — a list that silently drops the one product whose store is broken is the same defect wearing a different hat — but a per-row refusal would be friendlier and is a defensible alternative.

**Most likely missing.** The remaining Codex finding on #1740: a pending staging journal is reported by the producer but rendered nowhere in either product view. That is a display gap rather than a false claim, so it is the least urgent of the three, and it is now the only one still open.

This is the **third** instance of "absent stands in for unreadable" fixed in two days (#1787, this, and the spool sites in the 09-06 drain), and Codex found two more in the same class elsewhere (#1708, #1710). The helper exists and is good; what is missing is anything that makes call sites use it. A lint, or a rule in `AGENT_REVIEW.md`, would be worth more than a fourth patch.
