### PR TITLE
fix(engine/ui): show an interrupted commit, instead of dropping the pending staging journal

### DIFF
--- a/engine/ui/src/governor/ProductsScreen.test.tsx
+++ b/engine/ui/src/governor/ProductsScreen.test.tsx
@@ -300,6 +300,21 @@ describe("ProductsScreen", () => {
     expect(productPath("revenue daily")).toBe("/ui/governor/products/revenue%20daily");
   });
 
+  /// The engine reports a pending staging journal and deliberately does not
+  /// resolve it. A screen that drops it makes an interrupted compile look
+  /// like a finished one.
+  it("shows an interrupted commit in the standing panel and in the list", async () => {
+    render(
+      <ProductsScreen
+        name="revenue_daily"
+        loaders={loaders({
+          status: vi.fn(async () => ({ ...STATUS, staging_journal_present: true })),
+        })}
+      />,
+    );
+    await screen.findByText("a commit was interrupted");
+  });
+
   /// Only `spec-file-missing` means the file is gone. A spec that exists and
   /// cannot be read, or one that parses badly, must not be reported as a
   /// deletion — the reader would go looking for a removal that never happened.

--- a/engine/ui/src/governor/ProductsScreen.tsx
+++ b/engine/ui/src/governor/ProductsScreen.tsx
@@ -55,6 +55,14 @@ function ProductRow({ entry }: { entry: ProductListEntry }) {
           {entry.spec_error ?? "the loader gave no reason"}
         </p>
       )}
+      {entry.staging_journal_present && (
+        // Same fact as the standing panel's card: a compile was interrupted
+        // and its artifacts may be half applied. A row that hides it reads as
+        // a finished product.
+        <p className="mt-1 text-xs text-amber-700 dark:text-amber-400">
+          a commit was interrupted: a staging journal is still on disk
+        </p>
+      )}
       <dl className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-zinc-600 sm:grid-cols-4 dark:text-zinc-300">
         <div>
           <dt className="text-zinc-500 dark:text-zinc-400">journal rows</dt>
@@ -277,6 +285,20 @@ function Standing({ status }: { status: ProductStatusOutput }) {
           value="broken"
           tone="risk"
           sub="The approved snapshot's bytes no longer digest to the recorded value. The approval cannot be trusted to describe what was approved."
+        />
+      )}
+      {status.staging_journal_present && (
+        // The engine reports a pending staging journal and deliberately does
+        // NOT resolve it — the next compile does. Until then the committed
+        // artifacts may be a half-applied set, so a reviewer reading this page
+        // is looking at a product mid-commit. The producer has always said so;
+        // this screen used to drop it, which made an interrupted compile look
+        // like a finished one.
+        <StatusCard
+          label="staging journal"
+          value="a commit was interrupted"
+          tone="risk"
+          sub="A staging journal is still on disk, so the last compile did not finish applying its artifacts. Status only reports this — the next `rocky product compile` resolves it."
         />
       )}
       {status.artifact_problems !== undefined && status.artifact_problems.length > 0 && (


### PR DESCRIPTION
The last of Codex's three findings on #1740, closing that set. Siblings: #1787 (the spec code) and #1789 (the state store).

**Review: Codex, via the plugin, on the merged #1740. This follow-up is same-model self-review — no independent pass on the fix itself yet.**

## A field both payloads carry and neither view showed

`staging_journal_present` is in `ProductStatusOutput` **and** `ProductListEntry`. It was rendered in neither.

A staging journal on disk means the previous `rocky product compile` did not finish applying its artifacts, so the committed set may be half applied. `product_status_in` is documented to *report* that and deliberately not resolve it — the next compile does.

```
  compile interrupted after writing its staging journal
            │
            ▼
  the producer says:  staging_journal_present: true
            │
            ▼
  the screen showed:  (nothing)
                      = a finished product
```

## Both views now say it

- **Standing panel** — a risk-toned card: "a commit was interrupted".
- **List row** — a line, so a product mid-commit is visible without opening it.

The wording says what the reader can do ("the next `rocky product compile` resolves it") rather than only naming the state.

This one is a display gap rather than a false claim, which is why it was the least urgent of the three — but a screen that silently drops a field its producer sets is how the other two started.

## Test

Fix-sensitive: hiding the card fails exactly it.

```
× shows an interrupted commit in the standing panel and in the list
  Tests  1 failed | 13 passed
```

33 governor tests pass, `tsc --noEmit` clean, eslint clean.

## The two questions

**Least confident.** Whether the list row wants the same prominence as the standing card. I gave it a plain amber line rather than a card, matching how the list already reports a missing spec — but a product mid-commit is arguably worth more than a line, and that is a design call rather than a correctness one.

**Most likely missing.** Nothing in this change; it is small and its producer is a single boolean. The wider gap is the one all three of these share and none of them closes: nothing makes a new field, or a new call site, get rendered or classified correctly. Codex found five instances of "absent stands in for unreadable" across this batch (#1740 ×2, #1708, #1710, plus the spool sites fixed on 09-06), and `path_presence` — the helper that solves it — existed the whole time. A lint or an `AGENT_REVIEW.md` rule would be worth more than the next patch.