### PR TITLE
fix(engine): anomaly_threshold_pct = 0 disables detection, as it has always documented

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -4387,7 +4387,7 @@
         "properties": {
           "anomaly_threshold_pct": {
             "default": 50.0,
-            "description": "Row count anomaly detection threshold (percentage deviation from baseline). Default: 50.0 (50% deviation triggers anomaly). Set to 0 to disable.",
+            "description": "Row count anomaly detection threshold (percentage deviation from baseline). Default: 50.0 (50% deviation triggers anomaly).\n\n`0` disables detection. It used to do the opposite — the comparison is `deviation_pct > threshold_pct`, so `0` flagged every table whose count moved at all, and an operator following this sentence to turn detection off turned it maximally on. A negative value disables it too.",
             "format": "double",
             "type": "number"
           },

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -386,7 +386,7 @@ See [Data quality checks](/concepts/data-quality-checks/) for what each one mean
 | `freshness` | table | | `{ threshold_seconds = N, overrides = { ... } }`. |
 | `null_rate` | table | | `{ columns = [...], threshold = 0.0–1.0, sample_percent = 10 }`. |
 | `custom` | list | `[]` | Custom SQL checks. Each entry has `name`, `sql`, and optional `threshold`. |
-| `anomaly_threshold_pct` | float | `50.0` | Row count deviation percentage that triggers an anomaly. Set to 0 to disable. |
+| `anomaly_threshold_pct` | float | `50.0` | Row count deviation percentage that triggers an anomaly. Set to 0 (or a negative value) to disable detection. |
 | `quarantine` | table | | `{ mode = "split" \| "tag" \| "drop" }`. See below. |
 | `assertions` | list | `[]` | Repeated `[[assertions]]` blocks (DQX parity). See below. |
 | `cross_source_overlap` | table | | Flags the same business key appearing across sibling sources that feed one consolidation target. See [Cross-source duplicate detection](#cross-source-duplicate-detection). |

--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -580,7 +580,7 @@
       "properties": {
         "anomaly_threshold_pct": {
           "default": 50.0,
-          "description": "Row count anomaly detection threshold (percentage deviation from baseline). Default: 50.0 (50% deviation triggers anomaly). Set to 0 to disable.",
+          "description": "Row count anomaly detection threshold (percentage deviation from baseline). Default: 50.0 (50% deviation triggers anomaly).\n\n`0` disables detection. It used to do the opposite — the comparison is `deviation_pct > threshold_pct`, so `0` flagged every table whose count moved at all, and an operator following this sentence to turn detection off turned it maximally on. A negative value disables it too.",
           "format": "double",
           "type": "number"
         },

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -1208,7 +1208,9 @@ export interface ReplicationPipelineConfig {
  */
 export interface ChecksConfig {
   /**
-   * Row count anomaly detection threshold (percentage deviation from baseline). Default: 50.0 (50% deviation triggers anomaly). Set to 0 to disable.
+   * Row count anomaly detection threshold (percentage deviation from baseline). Default: 50.0 (50% deviation triggers anomaly).
+   *
+   * `0` disables detection. It used to do the opposite — the comparison is `deviation_pct > threshold_pct`, so `0` flagged every table whose count moved at all, and an operator following this sentence to turn detection off turned it maximally on. A negative value disables it too.
    */
   anomaly_threshold_pct?: number;
   /**

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -56,6 +56,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **On upgrade:** the state store schema moves v23 → v24. No table is added and no blob migration runs; a v23 store upgrades on the next read-write open. The bump is load-bearing: `observed_failing` is a new variant of the `fulfill_state` record's tagged enum, and a 1.73.0 binary cannot read a blob that carries it. **Rolling back is the part to plan for.** Remote state keys are qualified by schema version (`v23/state.redb` on an object store, `…v23:…` on Valkey), so a 1.73.0 binary never reads a v24 remote object. It reads whatever is under its own v23 key, which may be stale, and it cannot see progress recorded under v24. The incompatible-blob hazard is a **local** `state.redb` this version wrote. A 1.73.0 binary opening it either stops with a schema-mismatch error or, on the paths that honour `[state] on_schema_mismatch`, deletes the file and starts fresh under the default `recreate`. Do not point a 1.73.0 binary at a local state file written by this version, and do not share one local file between versions. `rocky doctor --check state_schema` reports the mismatch and exits 3. Which commands honour the key and which refuse is being pinned down in #1679. `fulfill_state` is local-only, so a re-run rebuilds the loop's position; see #1525 before relying on that loss being harmless.
 
 ### Fixed
+- **`anomaly_threshold_pct = 0` turned row-count anomaly detection fully ON instead of off, which is the opposite of what it documented.**
+
+  The field's doc comment and the published reference page both said "Set to 0 to disable". The comparison is `is_anomaly = deviation_pct > threshold_pct`, so `0` flagged every table whose row count moved at all — an operator following the documentation to silence anomaly detection got an anomaly on every run where anything changed.
+
+  ```
+  anomaly_threshold_pct = 0, a table whose count moved 1%
+     before   0 < 1        ->  anomaly  ->  warning on every run
+     after    disabled     ->  no anomaly, and the reason says so
+  ```
+
+  `0` (or any negative value) now disables detection, guarded inside `detect_anomaly` so every caller gets the documented behaviour rather than just the replication runner. Nothing had pinned the old behaviour — every existing test passes `50.0`.
+
+  **Breaking:** a project that set `0` and has been living with the resulting noise will stop seeing those anomalies. That is the setting doing what it always said it did. A project wanting maximum sensitivity should set a small positive value such as `0.1` rather than `0`.
+
 - **A check the engine could not run kept the severity you declared, so a `severity = "warning"` check that failed to execute cleared the gate and the run exited 0.**
 
   Severity grades a *measurement*: it says how bad three null rows are, or how bad this much overlap is. A check whose query failed produced no measurement to grade, but `assertion_not_evaluated` and `cross_source_overlap_not_evaluated` carried the declared severity through anyway. `check_failures_by_severity` then filed the failure in the warning bucket, `replication_check_gate_failed` reads only the error bucket, and a run that verified nothing about a column reported success.

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -1210,7 +1210,12 @@ pub struct ChecksConfig {
     #[serde(default)]
     pub quarantine: Option<QuarantineConfig>,
     /// Row count anomaly detection threshold (percentage deviation from baseline).
-    /// Default: 50.0 (50% deviation triggers anomaly). Set to 0 to disable.
+    /// Default: 50.0 (50% deviation triggers anomaly).
+    ///
+    /// `0` disables detection. It used to do the opposite — the comparison is
+    /// `deviation_pct > threshold_pct`, so `0` flagged every table whose count
+    /// moved at all, and an operator following this sentence to turn detection
+    /// off turned it maximally on. A negative value disables it too.
     #[serde(default = "default_anomaly_threshold_pct")]
     pub anomaly_threshold_pct: f64,
     /// When `true` (default), the quality run exits non-zero if any

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -6406,9 +6406,20 @@ pub fn detect_anomaly(
         100.0 // went from 0 to non-zero
     };
 
-    let is_anomaly = deviation_pct > threshold_pct;
+    // `threshold_pct <= 0` DISABLES detection, which is what the config field
+    // has always documented ("Set to 0 to disable") and the opposite of what
+    // this comparison did on its own: `deviation_pct > 0.0` flags every table
+    // whose count moved at all, so an operator following the documentation to
+    // turn anomaly detection OFF turned it maximally ON.
+    //
+    // Guarded here rather than at the call site so every caller of
+    // `detect_anomaly` gets the documented behaviour, not just the one in
+    // `run.rs`.
+    let is_anomaly = threshold_pct > 0.0 && deviation_pct > threshold_pct;
 
-    let reason = if is_anomaly {
+    let reason = if threshold_pct <= 0.0 {
+        "anomaly detection is disabled (anomaly_threshold_pct = 0)".to_string()
+    } else if is_anomaly {
         if (current_count as f64) < avg {
             format!(
                 "row count dropped {deviation_pct:.1}% (expected ~{avg:.0}, got {current_count})"
@@ -7178,6 +7189,69 @@ mod tests {
         let result = detect_anomaly("tbl", 500, &history, 50.0);
         assert!(result.is_anomaly);
         assert!(result.reason.contains("spiked"));
+    }
+
+    /// `anomaly_threshold_pct = 0` DISABLES detection. The config field has
+    /// documented that since it shipped, and the published reference page says
+    /// it too — but the comparison is `deviation_pct > threshold_pct`, so `0`
+    /// flagged every table whose row count moved at all.
+    ///
+    /// An operator following the documentation to turn anomaly detection OFF
+    /// turned it maximally ON, and got an anomaly on every run where anything
+    /// changed. Nothing pinned the behaviour: every existing test passes 50.0.
+    #[test]
+    fn a_zero_threshold_disables_detection_rather_than_flagging_everything() {
+        let history = vec![
+            CheckSnapshot {
+                timestamp: Utc::now(),
+                row_count: 100,
+            },
+            CheckSnapshot {
+                timestamp: Utc::now(),
+                row_count: 100,
+            },
+        ];
+
+        // A 400% spike — unmissable at any real threshold.
+        let spike = detect_anomaly("tbl", 500, &history, 0.0);
+        assert!(!spike.is_anomaly, "0 disables detection: {}", spike.reason);
+        assert!(
+            spike.reason.contains("disabled"),
+            "and says so, rather than implying it measured and cleared: {}",
+            spike.reason
+        );
+
+        // The discriminator: the SAME input at the default threshold IS an
+        // anomaly, so the test cannot pass because the fixture is uneventful.
+        let at_default = detect_anomaly("tbl", 500, &history, 50.0);
+        assert!(at_default.is_anomaly, "{}", at_default.reason);
+
+        // A negative threshold is disabled too, rather than flagging every
+        // table including unchanged ones.
+        let negative = detect_anomaly("tbl", 100, &history, -1.0);
+        assert!(!negative.is_anomaly, "{}", negative.reason);
+    }
+
+    /// The other side, so the guard is not a blanket off-switch: an ordinary
+    /// small positive threshold still detects, and still ignores noise below
+    /// it.
+    #[test]
+    fn a_small_positive_threshold_still_detects() {
+        let history = vec![
+            CheckSnapshot {
+                timestamp: Utc::now(),
+                row_count: 100,
+            },
+            CheckSnapshot {
+                timestamp: Utc::now(),
+                row_count: 100,
+            },
+        ];
+
+        // 5% move against a 1% threshold: an anomaly.
+        assert!(detect_anomaly("tbl", 105, &history, 1.0).is_anomaly);
+        // 5% move against a 10% threshold: not one.
+        assert!(!detect_anomaly("tbl", 105, &history, 10.0).is_anomaly);
     }
 
     #[test]

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -579,7 +579,7 @@
       "properties": {
         "anomaly_threshold_pct": {
           "default": 50.0,
-          "description": "Row count anomaly detection threshold (percentage deviation from baseline). Default: 50.0 (50% deviation triggers anomaly). Set to 0 to disable.",
+          "description": "Row count anomaly detection threshold (percentage deviation from baseline). Default: 50.0 (50% deviation triggers anomaly).\n\n`0` disables detection. It used to do the opposite — the comparison is `deviation_pct > threshold_pct`, so `0` flagged every table whose count moved at all, and an operator following this sentence to turn detection off turned it maximally on. A negative value disables it too.",
           "format": "double",
           "type": "number"
         },

--- a/sdk/python/src/rocky_sdk/types_generated/rocky_project_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/rocky_project_schema.py
@@ -2981,7 +2981,9 @@ class ChecksConfig(BaseModel):
     )
     anomaly_threshold_pct: float | None = 50.0
     """
-    Row count anomaly detection threshold (percentage deviation from baseline). Default: 50.0 (50% deviation triggers anomaly). Set to 0 to disable.
+    Row count anomaly detection threshold (percentage deviation from baseline). Default: 50.0 (50% deviation triggers anomaly).
+
+    `0` disables detection. It used to do the opposite — the comparison is `deviation_pct > threshold_pct`, so `0` flagged every table whose count moved at all, and an operator following this sentence to turn detection off turned it maximally on. A negative value disables it too.
     """
     assertions: (
         list[


### PR DESCRIPTION
The config field says one thing and the code does the opposite.

`anomaly_threshold_pct`'s doc comment says **"Set to 0 to disable"**, and so does the published reference page (`docs/src/content/docs/reference/configuration.md:389`). The comparison is:

```rust
let is_anomaly = deviation_pct > threshold_pct;
```

With `threshold_pct = 0`, every table whose row count moved at all is an anomaly. An operator who read the documentation and set `0` to silence anomaly detection turned it **maximally on**, and got a warning on every run where anything changed.

```
anomaly_threshold_pct = 0, a table whose count moved 1%
   before   0 < 1     ->  anomaly, every run
   after    disabled  ->  no anomaly, and the reason says so
```

## The change

`0` — or any negative value — now disables detection. The guard is inside `detect_anomaly` rather than at the call site, so every caller gets the documented behaviour and not just the one in `run.rs`. The `reason` string says detection is disabled, instead of implying a comparison ran and cleared the table.

The doc comment feeds `JsonSchema`, so `just codegen` propagated the corrected text to `schemas/`, the VS Code schema and its generated TypeScript, the SDK's generated Pydantic model, and the OpenAPI document. Those five files are prose-only.

## Why it survived

**Nothing pinned it.** Every existing `detect_anomaly` test passes `50.0` — the default. A value that had never done what it documented could sit there because no test asked it to.

So the new test's discriminator is the **same fixture at the default threshold**, which *is* an anomaly:

```rust
let spike = detect_anomaly("tbl", 500, &history, 0.0);
assert!(!spike.is_anomaly);                     // disabled

let at_default = detect_anomaly("tbl", 500, &history, 50.0);
assert!(at_default.is_anomaly);                 // and the fixture is not uneventful
```

Without that second assertion the test would pass on a fixture where nothing happened. A second test covers the other side — a `1.0` threshold still catches a 5% move, a `10.0` threshold still ignores it — so the guard is not a blanket off-switch.

## Evidence

```
cargo test -p rocky-core       all green, 0 failures
cargo clippy --all-targets --all-features   clean
just codegen                   clean, prose-only in the 5 generated files
```

Mutation-probed by removing the guard:

```
mutation-check: OK — the test failed under mutation, so it is fix-sensitive.
```

## Breaking

A project that set `0` and has been living with the resulting noise will stop seeing those anomalies. That is the setting doing what it always said it did. Maximum sensitivity is now a small positive value such as `0.1`, not `0`. Stated in the changelog in those terms.

## How this was found

Tracing #1790, which asks whether Dagster can distinguish "the anomaly detector ran and found nothing" from "it never ran". The answer turns on three conditions — `row_count` enabled, a state store present, and a threshold that does not disable — and the third one did not work. So #1790's analysis was resting on a fact that was not true.

## What I am least confident about

**That `0` should mean "disabled" rather than "flag any change".** I chose the documented meaning because it is the published contract on two surfaces and because "flag every table whose count moved by any amount" is not a setting anyone plausibly wants as the meaning of zero. But it is a judgement call: a strict operator could read `0` as "zero tolerance". If that reading is wanted, the fix should instead be to correct both docs and leave the code alone — which is the smaller change and the one I did not make.

**What I may be missing:** whether any project in use has `anomaly_threshold_pct = 0` today. If one does, it is currently getting anomaly warnings on every run with any change, which is loud enough that someone would likely have filed it — but I cannot check that from here.

## Review

No independent red team on this one yet. Refs #1790.
