### PR TITLE
fix(engine): a quality run's JSON reports the status it actually reached

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -473,6 +473,36 @@ fn checks_for_unexpandable_target(
     });
 }
 
+/// Brings a quality run's `tables_failed` and `status` into agreement with the
+/// verdict its checks produced, before anything is emitted or persisted.
+///
+/// `RunOutput::derive_run_status` keys only on
+/// `tables_copied`/`tables_failed`/`interrupted` and IGNORES `check_results`,
+/// and nothing else in `run_quality` touches `tables_failed`. So a quality run
+/// with FAILING error-severity checks derived `Success`, and the schedule
+/// reconciler would treat a failed quality gate as a satisfied
+/// `after`/`freshness` demand. This maps the SAME condition the exit code uses
+/// (`error_failures > 0 && fail_on_error`) onto `tables_failed`.
+///
+/// It also stamps `status`, which `run_quality` never derived at all — the
+/// field kept the `RunStatus::Success` that `RunOutput::new` defaults it to,
+/// whatever the checks found.
+///
+/// **Call this before the JSON emit** (#1788). Doing the correction afterwards
+/// left the payload saying `"status": "success"` while the persisted record
+/// said `Failure` and the process exited non-zero — three signals, two of them
+/// right. `status`'s own doc comment promises consumers they "no longer need to
+/// re-derive status from counts themselves", and `rocky-sdk` and
+/// `dagster-rocky` are those consumers. `#1604` governs HOW the payload is
+/// printed (through `print_json`, so `COMPACT_JSON` is honoured), not when it
+/// is built, so nothing there depended on the stale value.
+fn finalize_quality_status(output: &mut RunOutput, error_failures: usize, fail_on_error: bool) {
+    if error_failures > 0 && fail_on_error {
+        output.tables_failed = error_failures;
+    }
+    output.status = output.derive_run_status();
+}
+
 /// Execute `rocky run` for a quality pipeline.
 ///
 /// Runs data quality checks against the specified tables without any data movement.
@@ -674,6 +704,9 @@ pub async fn run_quality(
 
     let (error_failures, warning_failures) = count_failures_by_severity(&output);
 
+    // Called BEFORE the JSON emit below, not after (#1788).
+    finalize_quality_status(&mut output, error_failures, pipeline.checks.fail_on_error);
+
     if output_json {
         // Through `print_json`, not the pretty serializer directly: the watch
         // loop sets `COMPACT_JSON` to promise one compact object per line,
@@ -699,21 +732,6 @@ pub async fn run_quality(
             output.check_results.len(),
             output.duration_ms
         );
-    }
-
-    // Quality status trap: `RunOutput::derive_run_status` keys only on
-    // `tables_copied`/`tables_failed`/`interrupted` and IGNORES `check_results`,
-    // and `run_quality` never touches `tables_failed` — so a quality run with
-    // FAILING error-severity checks would otherwise persist as `Success`, and the
-    // schedule reconciler would treat a failed quality gate as a satisfied
-    // `after`/`freshness` demand. Map the SAME condition the exit code uses
-    // (`error_failures > 0 && fail_on_error`) into `tables_failed` so the
-    // recorded status derives to `Failure` and AGREES with the non-zero exit
-    // below. Done after the JSON emit above so the `--output json` payload is
-    // unchanged — the persisted record, not the payload, carries the corrected
-    // status.
-    if error_failures > 0 && pipeline.checks.fail_on_error {
-        output.tables_failed = error_failures;
     }
 
     // Persist the canonical `RunRecord` (before the failure bail, so a failed
@@ -2555,6 +2573,88 @@ auto_create_schemas = true
             TestSeverity::Warning,
             "a measured result takes the configured severity: {check:?}"
         );
+    }
+
+    /// #1788. A quality run that fails its check gate emitted
+    /// `"status": "success"` in its JSON while the persisted record said
+    /// `Failure` and the process exited non-zero.
+    ///
+    /// Two faults composed. `run_quality` never derived `status` at all, so the
+    /// field kept the `RunStatus::Success` that `RunOutput::new` defaults it
+    /// to; and the `tables_failed` correction ran AFTER the payload was
+    /// already printed. `status`'s doc comment promises consumers they "no
+    /// longer need to re-derive status from counts themselves" — and
+    /// `rocky-sdk` and `dagster-rocky` are those consumers.
+    #[test]
+    fn a_failed_quality_gate_is_stamped_onto_the_payload_not_just_the_record() {
+        use crate::output::{RunOutput, TableCheckOutput};
+        use rocky_core::state::RunStatus;
+
+        let mut output = RunOutput::new(String::new(), 0, 1);
+        output.check_results.push(TableCheckOutput {
+            asset_key: vec!["cat".into(), "raw".into(), "orders".into()],
+            checks: vec![rocky_core::checks::row_count_not_evaluated(
+                "the row count query failed",
+            )],
+        });
+
+        // The default the payload used to ship, whatever the checks found.
+        assert!(matches!(output.status, RunStatus::Success));
+        let (error_failures, _) = super::count_failures_by_severity(&output);
+        assert_eq!(error_failures, 1);
+
+        super::finalize_quality_status(&mut output, error_failures, true);
+
+        assert_eq!(output.tables_failed, 1);
+        assert!(
+            matches!(output.status, RunStatus::Failure),
+            "the emitted payload agrees with the exit code: {:?}",
+            output.status
+        );
+        assert!(
+            matches!(output.derive_run_status(), RunStatus::Failure),
+            "and with what the persisted record derives"
+        );
+    }
+
+    /// The discriminator: `fail_on_error = false` is a documented escape hatch
+    /// that deliberately exits 0, so the payload must keep saying `success`.
+    /// Without this the fix could be "always report Failure when any check
+    /// failed", which would be a different and wrong change.
+    #[test]
+    fn fail_on_error_false_keeps_the_payload_successful() {
+        use crate::output::{RunOutput, TableCheckOutput};
+        use rocky_core::state::RunStatus;
+
+        let mut output = RunOutput::new(String::new(), 0, 1);
+        output.check_results.push(TableCheckOutput {
+            asset_key: vec!["cat".into(), "raw".into(), "orders".into()],
+            checks: vec![rocky_core::checks::row_count_not_evaluated(
+                "the row count query failed",
+            )],
+        });
+
+        super::finalize_quality_status(&mut output, 1, false);
+
+        assert_eq!(output.tables_failed, 0);
+        assert!(
+            matches!(output.status, RunStatus::Success),
+            "{:?}",
+            output.status
+        );
+    }
+
+    /// A clean quality run is unchanged: no failures, `Success`, and the
+    /// stamping does not invent a `tables_failed`.
+    #[test]
+    fn a_clean_quality_run_is_unchanged() {
+        use crate::output::RunOutput;
+        use rocky_core::state::RunStatus;
+
+        let mut output = RunOutput::new(String::new(), 0, 1);
+        super::finalize_quality_status(&mut output, 0, true);
+        assert_eq!(output.tables_failed, 0);
+        assert!(matches!(output.status, RunStatus::Success));
     }
 
     /// #1741 follow-up, found by the independent review of #1780. A

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -1236,6 +1236,14 @@ pub async fn run_snapshot(
 
     output.duration_ms = start.elapsed().as_millis() as u64;
 
+    // The same omission #1788 fixed in `run_quality`, at a third site. This
+    // runner does set `tables_failed` before the emit, so the COUNTS in the
+    // payload were right — but `status` was never derived, so it kept the
+    // `RunStatus::Success` that `RunOutput::new` defaults it to. A failed
+    // snapshot therefore emitted `"status": "success"` alongside
+    // `"tables_failed": 1`: a payload that contradicts itself.
+    output.status = output.derive_run_status();
+
     if let Some(p) = &pipes {
         super::run::emit_pipes_events(p, &output);
     }
@@ -2614,6 +2622,31 @@ auto_create_schemas = true
         assert!(
             matches!(output.derive_run_status(), RunStatus::Failure),
             "and with what the persisted record derives"
+        );
+    }
+
+    /// The same defect at a third site, checked because #1795 said it had not
+    /// been. `run_snapshot` DOES set `tables_failed` before it emits, so the
+    /// counts in its payload were right — but it never derived `status`, so a
+    /// failed snapshot emitted `"status": "success"` next to
+    /// `"tables_failed": 1`. A payload that contradicts itself.
+    #[test]
+    fn a_failed_snapshot_payload_does_not_contradict_its_own_counts() {
+        use crate::output::RunOutput;
+        use rocky_core::state::RunStatus;
+
+        let mut output = RunOutput::new(String::new(), 0, 1);
+        output.tables_failed = 1;
+
+        // What shipped: the constructor default, beside a non-zero failure count.
+        assert!(matches!(output.status, RunStatus::Success));
+
+        output.status = output.derive_run_status();
+
+        assert!(
+            matches!(output.status, RunStatus::Failure),
+            "status agrees with tables_failed: {:?}",
+            output.status
         );
     }
 


### PR DESCRIPTION
`rocky run --output json` on a quality pipeline **always** reported `"status": "success"` — including on a run that failed its check gate, exited non-zero, and persisted `Failure`.

```
a quality run with a failing error-severity check

  --output json     "status": "success",  "tables_failed": 0     wrong
  persisted record  RunStatus::Failure                            right
  process exit      non-zero                                      right
```

## Two faults composed

**1. `run_quality` never derived `status` at all.** `RunOutput::new` defaults the field to `RunStatus::Success`, and across the whole function there was no assignment to it — the only `output.status = output.derive_run_status()` in the file is in `run_transformation`. So the emitted value was the constructor default, whatever the checks found.

**2. The `tables_failed` correction ran after the payload was printed.** The comment above it said so, and treated the uncorrected payload as the thing to preserve:

> Done after the JSON emit above so the `--output json` payload is unchanged — the persisted record, not the payload, carries the corrected status.

Accurate about what the code did. The problem is that the payload it preserved was wrong.

## Why this matters

`status`'s own doc comment makes the opposite promise:

> Always populated — non-skipped runs derive this field from `tables_failed` / materialization counts, so **JSON consumers no longer need to re-derive status from counts themselves**.

`rocky-sdk` and `dagster-rocky` are exactly those consumers. Worse, the independent review of #1786 traced one more step: the SDK accepts a non-zero-exit payload under `allow_partial=True` (`client.py:827`) and returns that success-shaped `RunResult` — so a caller using that flag saw the wrong status **and** no exception.

## The change

The correction now runs before the emit and stamps `status`, exactly as `run_transformation` already did. Extracted as `finalize_quality_status` so the logic is testable and the ordering is one visible call site rather than two scattered blocks.

**The justification I checked before moving it:** `#1604` governs *how* the payload is printed — through `print_json`, so the watch loop's `COMPACT_JSON` promise of one compact object per line is honoured — not *when* it is built. Nothing there depended on the stale value. That was the only thing standing behind the old ordering, and it turned out not to be about ordering at all.

## Tests

| test | covers |
|---|---|
| `a_failed_quality_gate_is_stamped_onto_the_payload_not_just_the_record` | the defect: payload agrees with exit code and with the persisted derivation |
| `fail_on_error_false_keeps_the_payload_successful` | **the discriminator** |
| `a_clean_quality_run_is_unchanged` | no invented `tables_failed` on a clean run |

The middle one is the one that matters. `fail_on_error = false` is a documented escape hatch that deliberately exits 0, so the payload must keep saying `success`. Without that assertion the fix could have been "always report `Failure` when any check failed" — a different and wrong change that the first test alone would not have caught.

## Evidence

```
cargo test -p rocky-cli --features duckdb --lib     all green
cargo clippy --all-targets --all-features           clean
```

Mutation-probed by removing the `status` derivation:

```
mutation-check: OK — the test failed under mutation, so it is fix-sensitive.
```

## What I am least confident about

**Whether any consumer depends on the old value.** The change makes a previously-`success` payload report `failure` for runs that were already failing — visible to anyone parsing it. I traced the in-repo consumers (the SDK's `parse_rocky_output`, the Dagster resource) and neither switches on `status` in a way this breaks; both already treat a non-zero exit as the authority. But a user script that parses the JSON and ignores the exit code will start seeing failures it did not see before. That is the point of the fix, and it is still a behaviour change worth stating.

**What I may be missing:** whether `run_snapshot` — the third runner in this file, which also calls `print_json` at line ~1229 — has the same defect. I did not check it. If it does, it is the same fix and deserves the same treatment, but I would rather land this one and look than widen the change on a guess.

## Review

No independent red team on this PR. The defect itself came from the Codex review of #1786, read from the session rollout. Refs #1788.
