### PR TITLE
chore(engine/rocky-mcp): pin rmcp exactly, so a caret range cannot downgrade the MCP protocol

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -107,7 +107,17 @@ tokio = { version = "1", features = ["full"] }
 # Transitively pulls schemars 1.x; the rest of the workspace uses schemars
 # 0.8. The dual-major is disjoint (rmcp's `#[tool]` param structs derive
 # schemars 1.x; Rocky's `*Output` structs derive 0.8) and compiles cleanly.
-rmcp = { version = "3.0", features = ["server", "macros", "transport-io"] }
+# PINNED EXACT, deliberately. `"3.0"` is a caret range, so it accepts 3.2.0,
+# and under 3.2.0 a client that asks for ProtocolVersion 2026-07-28 is handed
+# back 2024-11-05 — the server's FALLBACK — instead of its own request. That
+# is a silent protocol downgrade for every MCP client Rocky serves, and it
+# drops `resultType` from their results. rocky-mcp's
+# `result_type_reaches_a_2026_07_28_client_and_no_other` catches it; PR #1775
+# is the bump held on that failure. Only the lockfile was keeping 3.1.4, so
+# the range is now exact. Raise it after the negotiation change in 3.2.0 is
+# understood — NOT by narrowing `supported_protocol_versions`, which is the
+# very extreme that test was written to distinguish from a real fix.
+rmcp = { version = "=3.1.4", features = ["server", "macros", "transport-io"] }
 
 # HTTP
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "gzip", "http2"] }

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -67,4 +67,5 @@ libc = { workspace = true }
 regex = { workspace = true }
 # The scripted round-trip test drives the stdio server in-process with an rmcp
 # client over a duplex pipe, so it needs the client side of rmcp too.
-rmcp = { version = "3.0", features = ["server", "macros", "transport-io", "client"] }
+# Pinned exact to match the workspace pin — see the note in engine/Cargo.toml.
+rmcp = { version = "=3.1.4", features = ["server", "macros", "transport-io", "client"] }


### PR DESCRIPTION
## What

Pins `rmcp` to `=3.1.4` in the workspace and in `rocky-mcp`, replacing the caret range `"3.0"`.

## Why

`"3.0"` accepts 3.2.0. Under 3.2.0 a client that asks for `ProtocolVersion` **2026-07-28** is handed back **2024-11-05** — the server's *fallback* — instead of its own request:

```
assertion `left == right` failed
  left:  ProtocolVersion("2024-11-05")
  right: ProtocolVersion("2026-07-28")
```

That is a silent protocol downgrade for every MCP client Rocky serves, and it drops `resultType` from their results. `rocky mcp` is how agents drive Rocky, so it is a live product regression.

Only `Cargo.lock` was holding 3.1.4. A fresh resolve, a `cargo update`, or a consumer building without the lockfile picks up the downgrade with nothing failing. The range is now exact, so the barrier is **declared** rather than incidental.

## Blast radius

None today. `Cargo.lock` still reads `rmcp 3.1.4` after the change — verified with `cargo metadata`. This is behaviour-neutral now and only closes the future hole.

## Evidence

`result_type_reaches_a_2026_07_28_client_and_no_other` in `engine/crates/rocky-mcp/tests/roundtrip.rs` asserts the negotiated version on **both** peers before reading `result_type`. Under 3.1.4 the modern client is given 2026-07-28 and keeps `resultType`; under 3.2.0 the first assertion fails. The test was written to catch exactly this, and it did — on #1775.

## What raising the pin needs

The 3.2.0 negotiation change understood first — whether `negotiate_protocol_version` changed or 2026-07-28 left `KNOWN_VERSIONS`.

It must **not** be closed by narrowing `supported_protocol_versions`. `tools.rs` records that as a deliberate non-change ("a behaviour change to what this server speaks and is not made here"), and the same test names it as one of the two extremes a real fix has to be told apart from. Narrowing would make the downgrade permanent by design.

Refs #1775 — that bump stays held until then.
