### PR TITLE
fix(engine): an uncomparable landed type refuses the load instead of promoting it

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -16280,7 +16280,7 @@
             "type": "boolean"
           },
           "type": {
-            "description": "Expected type, written in warehouse vocabulary (e.g. `BIGINT`, `VARCHAR`, `NUMBER(38,0)`). It is normalized to a portable Rocky type before comparison, so the same contract ports across warehouses (DuckDB `VARCHAR` and Snowflake `STRING` both match). A type the normalizer does not recognise is never compared: the load gate reports the column in `ContractResult::warnings` instead, and the type check neither passes nor fails it — presence and nullability still apply.",
+            "description": "Expected type, written in warehouse vocabulary (e.g. `BIGINT`, `VARCHAR`, `NUMBER(38,0)`). It is normalized to a portable Rocky type before comparison, so the same contract ports across warehouses (DuckDB `VARCHAR` and Snowflake `STRING` both match). A type string here that the normalizer does not recognise is reported in `ContractResult::warnings` and not compared — it is yours to correct, and presence and nullability still apply. An unrecognised *landed* type is different: it refuses the load (#1721).",
             "type": "string"
           }
         },

--- a/docs/src/content/docs/concepts/capability-matrix.md
+++ b/docs/src/content/docs/concepts/capability-matrix.md
@@ -73,8 +73,10 @@ Two limits, stated plainly:
   that. `rocky test` and `rocky ci` always compile with no source schemas, so
   every column that takes its type from a source table is `Unknown` under
   them. And an expression whose result type depends on the warehouse — `AVG`
-  over a `DECIMAL` column — stays `Unknown` either way. A `CAST` only fixes
-  the column when the value it casts already has a known type.
+  over a `DECIMAL` column — stays `Unknown` either way. Do not add a `CAST`
+  to clear an `I003`. A cast takes its type from the target, not from the
+  value, so it reports whatever you cast to whether or not the data matches.
+  It silences the message and checks nothing.
 - A bare `Decimal` in a contract matches any precision and scale. A contract
   that names the digits — `Decimal(18,2)` — must match the inferred precision
   and scale exactly.

--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -3293,7 +3293,7 @@
           "type": "boolean"
         },
         "type": {
-          "description": "Expected type, written in warehouse vocabulary (e.g. `BIGINT`, `VARCHAR`, `NUMBER(38,0)`). It is normalized to a portable Rocky type before comparison, so the same contract ports across warehouses (DuckDB `VARCHAR` and Snowflake `STRING` both match). A type the normalizer does not recognise is never compared: the load gate reports the column in `ContractResult::warnings` instead, and the type check neither passes nor fails it — presence and nullability still apply.",
+          "description": "Expected type, written in warehouse vocabulary (e.g. `BIGINT`, `VARCHAR`, `NUMBER(38,0)`). It is normalized to a portable Rocky type before comparison, so the same contract ports across warehouses (DuckDB `VARCHAR` and Snowflake `STRING` both match). A type string here that the normalizer does not recognise is reported in `ContractResult::warnings` and not compared — it is yours to correct, and presence and nullability still apply. An unrecognised *landed* type is different: it refuses the load (#1721).",
           "type": "string"
         }
       },

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -1871,7 +1871,7 @@ export interface RequiredColumn {
   name: string;
   nullable?: boolean;
   /**
-   * Expected type, written in warehouse vocabulary (e.g. `BIGINT`, `VARCHAR`, `NUMBER(38,0)`). It is normalized to a portable Rocky type before comparison, so the same contract ports across warehouses (DuckDB `VARCHAR` and Snowflake `STRING` both match). A type the normalizer does not recognise is never compared: the load gate reports the column in `ContractResult::warnings` instead, and the type check neither passes nor fails it — presence and nullability still apply.
+   * Expected type, written in warehouse vocabulary (e.g. `BIGINT`, `VARCHAR`, `NUMBER(38,0)`). It is normalized to a portable Rocky type before comparison, so the same contract ports across warehouses (DuckDB `VARCHAR` and Snowflake `STRING` both match). A type string here that the normalizer does not recognise is reported in `ContractResult::warnings` and not compared — it is yours to correct, and presence and nullability still apply. An unrecognised *landed* type is different: it refuses the load (#1721).
    */
   type: string;
   [k: string]: unknown;

--- a/engine/crates/rocky-cli/src/commands/load.rs
+++ b/engine/crates/rocky-cli/src/commands/load.rs
@@ -1155,15 +1155,24 @@ required_columns = [
         );
     }
 
-    /// A column that lands with a type outside Rocky's type map (DuckDB sniffs
-    /// `12:34:56` as `TIME`, which `warehouse_type_to_rocky` does not know)
-    /// still promotes, and the gate result says the declared type was not
-    /// checked, naming the column and both types (#1614). Exercises the whole
-    /// path: COPY into staging, live `DESCRIBE`, `validate_contract_typed`,
-    /// promote.
+    /// A column that lands with a type outside Rocky's type map REFUSES the
+    /// load (#1721). DuckDB sniffs `12:34:56` as `TIME`, which
+    /// `warehouse_type_to_rocky` does not know, so the gate cannot say
+    /// whether it satisfies the declared `TIMESTAMP` — and an unanswered
+    /// question must not promote staging.
+    ///
+    /// This is the end-to-end proof for the whole change: COPY into staging,
+    /// live `DESCRIBE`, `validate_contract_typed`, then the refusal path that
+    /// drops staging and leaves the target absent. The unit tests in
+    /// `rocky-core` assert the verdict; this one asserts the DATA never
+    /// lands, which is the property that actually matters.
+    ///
+    /// Until #1614 the landed type was fabricated; #1614 stopped inventing
+    /// it and #1646 removed the last fabrication, which left this column
+    /// promoted on no comparison at all.
     #[cfg(feature = "duckdb")]
     #[tokio::test]
-    async fn test_contract_gate_reports_a_landed_type_it_cannot_compare() {
+    async fn test_contract_gate_refuses_a_landed_type_it_cannot_compare() {
         use rocky_core::contracts::ContractConfig;
         use rocky_duckdb::DuckDbConnector;
         use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
@@ -1206,23 +1215,36 @@ required_columns = [
             ..LoadOptions::default()
         };
 
-        let (rows, _bytes, result) =
-            load_with_contract_gate(&loader, &wh, &source, &target, &options, &contract)
-                .await
-                .expect("an uncomparable type is reported, not refused");
-        assert_eq!(rows, 1);
-        let result = result.expect("gate result should be present");
-        assert!(result.passed, "violations: {:?}", result.violations);
-        assert_eq!(
-            result.warnings.len(),
-            1,
-            "one warning for the one unchecked column: {:?}",
-            result.warnings
-        );
-        let w = &result.warnings[0];
+        let err = load_with_contract_gate(&loader, &wh, &source, &target, &options, &contract)
+            .await
+            .expect_err("an uncomparable landed type must refuse the load");
+
+        // The consequence first: no rows reached the target. A refusal that
+        // still promotes is the defect, so this fails before any message
+        // assertion can pass it.
+        let landed_target = wh.describe_table(&to_ir_table_ref(&target)).await;
         assert!(
-            w.contains("'at'") && w.contains("'TIME'") && w.contains("'TIMESTAMP'"),
-            "the warning must name the column, the landed type and the declared type: {w}"
+            landed_target.map(|c| c.is_empty()).unwrap_or(true),
+            "the gate refused, so the target must not have been created or promoted"
+        );
+
+        let gate = err
+            .downcast_ref::<ContractGateError>()
+            .expect("the refusal must be a contract-gate error");
+        assert!(!gate.0.passed);
+        let v = gate
+            .0
+            .violations
+            .iter()
+            .find(|v| v.column == "at")
+            .expect("violations: the uncomparable column must be named");
+        assert_eq!(v.rule, "unverifiable_landed_type");
+        assert!(
+            v.message.contains("'at'")
+                && v.message.contains("'TIME'")
+                && v.message.contains("'TIMESTAMP'"),
+            "the refusal must name the column, the landed type and the declared type: {}",
+            v.message
         );
     }
 

--- a/engine/crates/rocky-compiler/src/contracts.rs
+++ b/engine/crates/rocky-compiler/src/contracts.rs
@@ -163,12 +163,23 @@ pub fn validate_contract(
                                     contract_col.name, expected_type
                                 ),
                             )
+                            // Do NOT suggest a CAST here. `infer_expr_type`'s
+                            // cast arm takes the type purely from the target
+                            // (`sql_type_to_rocky(data_type)`, typecheck.rs);
+                            // only `nullable` reads the input expression. So a
+                            // CAST silences this diagnostic whatever the value
+                            // really is — and for a bare decimal target it
+                            // resolves to Decimal(38,0), the exact fabricated
+                            // type #1646 removed from the load gate. Advice
+                            // that manufactures the answer is worse than no
+                            // advice (#1721).
                             .with_suggestion(format!(
                                 "give `rocky compile` source schemas so `{0}`'s type resolves — \
                                  `rocky discover --with-schemas` fills the cache, or use \
                                  `rocky compile --with-seed`; `rocky test` and `rocky ci` always \
-                                 compile without them. A CAST to {1} only helps when the value it \
-                                 casts already has a known type",
+                                 compile without them. Do not add a CAST to silence this: a cast \
+                                 takes its type from the target, so it would report {1} whatever \
+                                 the column actually holds",
                                 contract_col.name, expected_type
                             )),
                         );

--- a/engine/crates/rocky-compiler/src/typecheck.rs
+++ b/engine/crates/rocky-compiler/src/typecheck.rs
@@ -2515,7 +2515,9 @@ mod tests {
             }
         );
         assert_eq!(
-            sql_type_to_rocky(&DataType::Numeric(ExactNumberInfo::PrecisionAndScale(38, 9))),
+            sql_type_to_rocky(&DataType::Numeric(ExactNumberInfo::PrecisionAndScale(
+                38, 9
+            ))),
             RockyType::Decimal {
                 precision: 38,
                 scale: 9

--- a/engine/crates/rocky-compiler/src/typecheck.rs
+++ b/engine/crates/rocky-compiler/src/typecheck.rs
@@ -1847,10 +1847,17 @@ fn sql_type_to_rocky(dt: &ast::DataType) -> RockyType {
                 precision: *p as u8,
                 scale: 0,
             },
-            ast::ExactNumberInfo::None => RockyType::Decimal {
-                precision: 38,
-                scale: 0,
-            },
+            // A bare `DECIMAL` / `NUMERIC` names no digits, so Rocky does
+            // not know the type — the same answer `warehouse_type_to_rocky`
+            // gives for the bare string since #1646. Guessing (38,0) here
+            // was the third normaliser reading one column differently from
+            // the other two, and it is what made a CAST able to manufacture
+            // a passing contract check (#1721).
+            //
+            // `Precision(p)` above is NOT a guess: SQL defines DECIMAL(p) as
+            // DECIMAL(p, 0), so the scale is stated by the standard rather
+            // than invented here.
+            ast::ExactNumberInfo::None => RockyType::Unknown,
         },
         ast::DataType::Varchar(_)
         | ast::DataType::Char(_)
@@ -2469,6 +2476,52 @@ mod tests {
     use crate::project::Project;
     use crate::semantic::build_semantic_graph;
     use rocky_core::models::{Model, ModelConfig, StrategyConfig, TargetConfig};
+
+    /// The decimal arms of the THIRD normaliser (#1721).
+    ///
+    /// Rocky has three type normalisers and this one had drifted: a bare
+    /// `DECIMAL` / `NUMERIC` became `Decimal(38,0)` here while
+    /// `warehouse_type_to_rocky` had returned `Unknown` for the same bare
+    /// string since #1646. One typecheck pass therefore read one column two
+    /// ways depending on which side it arrived from, and a `CAST(x AS
+    /// NUMERIC)` could manufacture a passing contract check.
+    ///
+    /// No test covered this arm before, which is why the drift survived two
+    /// issues about it. Stated as a table so a future edit has to disagree
+    /// with the standard explicitly.
+    #[test]
+    fn bare_decimal_is_unknown_while_stated_digits_stay_concrete() {
+        use sqlparser::ast::{DataType, ExactNumberInfo};
+
+        // A bare name states no digits, so it is not a type Rocky knows.
+        assert_eq!(
+            sql_type_to_rocky(&DataType::Numeric(ExactNumberInfo::None)),
+            RockyType::Unknown,
+            "bare NUMERIC must not become a made-up decimal"
+        );
+        assert_eq!(
+            sql_type_to_rocky(&DataType::Decimal(ExactNumberInfo::None)),
+            RockyType::Unknown,
+            "bare DECIMAL must not become a made-up decimal"
+        );
+
+        // DECIMAL(p) is DECIMAL(p, 0) by the SQL standard — stated, not
+        // guessed, so it stays concrete.
+        assert_eq!(
+            sql_type_to_rocky(&DataType::Decimal(ExactNumberInfo::Precision(10))),
+            RockyType::Decimal {
+                precision: 10,
+                scale: 0
+            }
+        );
+        assert_eq!(
+            sql_type_to_rocky(&DataType::Numeric(ExactNumberInfo::PrecisionAndScale(38, 9))),
+            RockyType::Decimal {
+                precision: 38,
+                scale: 9
+            }
+        );
+    }
 
     fn make_model(name: &str, sql: &str) -> Model {
         Model {

--- a/engine/crates/rocky-core/src/contracts.rs
+++ b/engine/crates/rocky-core/src/contracts.rs
@@ -867,35 +867,46 @@ mod tests {
         );
     }
 
-    /// The regression #1646 opened, stated as data rather than as types:
-    /// BigQuery reports a default-precision numeric as the bare string
-    /// `NUMERIC` while the column really holds (38,9). Before #1646 the
-    /// fabricated `Decimal(38,0)` refused this for the wrong reason; after
-    /// it, nothing refused it at all and staging was promoted.
+    /// Blast-radius control for #1721, at the GATE rather than the mapper.
+    ///
+    /// Refusing an uncomparable landed type widens what a refusal covers
+    /// from "does not fit" to "could not be read", so every type string the
+    /// normalizer does not know now blocks a load that used to promote. The
+    /// mapper-level control (`test_healthy_describe_decimals_stay_concrete`)
+    /// proves those strings parse; this one proves the GATE still passes
+    /// them, which is the property an ordinary run actually depends on.
+    ///
+    /// Strings are the ones the adapters really emit from a live `DESCRIBE`
+    /// — see that test's doc comment for the per-adapter sources.
     #[test]
-    fn test_typed_bare_bigquery_numeric_does_not_satisfy_a_narrower_contract() {
-        let contract = ContractConfig {
-            required_columns: vec![RequiredColumn {
-                name: "amount".into(),
-                data_type: "NUMERIC(10,2)".into(),
-                nullable: true,
-            }],
-            ..Default::default()
-        };
-        let landed = vec![col_n("amount", "NUMERIC", true)];
-        let result = validate_contract_typed(&contract, &landed);
-        assert!(
-            !result.passed,
-            "a bare NUMERIC must not satisfy NUMERIC(10,2): {result:?}"
-        );
-        assert!(
-            result
-                .violations
-                .iter()
-                .any(|v| v.rule == "unverifiable_landed_type" && v.column == "amount"),
-            "violations: {:?}",
-            result.violations
-        );
+    fn test_healthy_adapter_describe_output_still_passes_the_gate() {
+        for (landed, declared) in [
+            ("DECIMAL(10,2)", "DECIMAL(10,2)"),
+            ("decimal(10,2)", "DECIMAL(10,2)"),
+            ("NUMBER(38,0)", "NUMBER(38,0)"),
+            ("BIGINT", "BIGINT"),
+            ("INTEGER", "BIGINT"),
+            ("VARCHAR", "VARCHAR"),
+            ("STRING", "VARCHAR"),
+            ("BOOLEAN", "BOOLEAN"),
+            ("TIMESTAMP", "TIMESTAMP"),
+            ("DOUBLE", "DOUBLE"),
+        ] {
+            let contract = ContractConfig {
+                required_columns: vec![RequiredColumn {
+                    name: "c".into(),
+                    data_type: declared.into(),
+                    nullable: true,
+                }],
+                ..Default::default()
+            };
+            let result = validate_contract_typed(&contract, &[col_n("c", landed, true)]);
+            assert!(
+                result.passed,
+                "landed '{landed}' against '{declared}' must still pass: {:?}",
+                result.violations
+            );
+        }
     }
 
     /// The declared side has the same hole: a contract type string the
@@ -1024,15 +1035,27 @@ mod tests {
         }
     }
 
-    /// The bare BigQuery case (#1646). `INFORMATION_SCHEMA.COLUMNS.data_type`
-    /// reports a default-precision column as a bare `NUMERIC` — the live
-    /// sweep in `rocky-bigquery/tests/dialect_sweep_live.rs` asserts exactly
-    /// that string after an `ALTER ... SET DATA TYPE NUMERIC`. Read as
-    /// `DECIMAL(38,0)` it refused a correct load, because
-    /// `is_assignable(Decimal(38,0), Decimal(38,9))` fails on integer digits.
-    /// It is now unread, so the column is reported and the load promotes.
+    /// The bare BigQuery case (#1646), and the ACCEPTED COST of #1721.
+    ///
+    /// `INFORMATION_SCHEMA.COLUMNS.data_type` reports a default-precision
+    /// column as a bare `NUMERIC` — the live sweep in
+    /// `rocky-bigquery/tests/dialect_sweep_live.rs` asserts exactly that
+    /// string after an `ALTER ... SET DATA TYPE NUMERIC`.
+    ///
+    /// ```text
+    ///   before #1646   Decimal(38,0)  ->  38 > 29 integer digits  ->  REFUSED (wrong reason)
+    ///   after  #1646   Unknown        ->  warning                 ->  PROMOTED (no comparison)
+    ///   after  #1721   Unknown        ->  REFUSED (uncomparable)
+    /// ```
+    ///
+    /// This contract would have fitted, and it is refused anyway. That is
+    /// deliberate and is the price of the decision: the gate declines to
+    /// certify a column it could not compare, rather than guessing in
+    /// either direction. The remedy is nameable, which the fabricated
+    /// `Decimal(38,0)` never was — declare a type Rocky parses, or make the
+    /// source report a precise one.
     #[test]
-    fn test_typed_bare_numeric_is_reported_not_refused() {
+    fn test_typed_bare_numeric_refuses_even_where_the_data_would_have_fitted() {
         let contract = ContractConfig {
             required_columns: vec![RequiredColumn {
                 name: "amount".into(),
@@ -1044,25 +1067,26 @@ mod tests {
         let result = validate_contract_typed(&contract, &[col_n("amount", "NUMERIC", true)]);
 
         assert!(
-            result.passed,
-            "a bare NUMERIC must not refuse a NUMERIC(38,9) contract: {:?}",
-            result.violations
+            !result.passed,
+            "an uncomparable landed type refuses even when the data would fit: {result:?}"
         );
-        assert!(result.violations.is_empty());
-        assert_eq!(result.warnings.len(), 1, "{:?}", result.warnings);
-        let w = &result.warnings[0];
+        let v = &result.violations[0];
+        assert_eq!(v.rule, "unverifiable_landed_type");
         assert!(
-            w.contains("'amount'") && w.contains("'NUMERIC'") && w.contains("'NUMERIC(38,9)'"),
-            "the warning must name the column and both type strings: {w}"
+            v.message.contains("'amount'")
+                && v.message.contains("'NUMERIC'")
+                && v.message.contains("'NUMERIC(38,9)'"),
+            "the refusal must name the column and both type strings: {}",
+            v.message
         );
     }
 
-    /// The other half of #1646: a contract written `NUMERIC(38,0)` used to
-    /// accept a landed bare `NUMERIC`, which on BigQuery holds nine decimal
-    /// places. It is still not refused — `passed` is computed from
-    /// violations only — but it is no longer silent.
+    /// The other half of #1646, and the defect #1721 exists to close: a
+    /// contract written `NUMERIC(38,0)` accepted a landed bare `NUMERIC`,
+    /// which on BigQuery holds nine decimal places. #1646 made it noisy;
+    /// its own comment conceded "it is still not refused". Now it is.
     #[test]
-    fn test_typed_bare_numeric_against_narrow_contract_is_reported() {
+    fn test_typed_bare_numeric_against_narrow_contract_refuses() {
         let contract = ContractConfig {
             required_columns: vec![RequiredColumn {
                 name: "amount".into(),
@@ -1073,12 +1097,15 @@ mod tests {
         };
         let result = validate_contract_typed(&contract, &[col_n("amount", "NUMERIC", true)]);
 
-        assert!(result.violations.is_empty());
+        assert!(
+            !result.passed,
+            "a bare NUMERIC holding (38,9) must not satisfy NUMERIC(38,0): {result:?}"
+        );
         assert_eq!(
-            result.warnings.len(),
+            result.violations.len(),
             1,
-            "the landed bare NUMERIC must be reported, not accepted silently: {:?}",
-            result.warnings
+            "violations: {:?}",
+            result.violations
         );
     }
 

--- a/engine/crates/rocky-core/src/contracts.rs
+++ b/engine/crates/rocky-core/src/contracts.rs
@@ -27,10 +27,11 @@ pub struct RequiredColumn {
     /// Expected type, written in warehouse vocabulary (e.g. `BIGINT`,
     /// `VARCHAR`, `NUMBER(38,0)`). It is normalized to a portable Rocky type
     /// before comparison, so the same contract ports across warehouses
-    /// (DuckDB `VARCHAR` and Snowflake `STRING` both match). A type the
-    /// normalizer does not recognise is never compared: the load gate reports
-    /// the column in `ContractResult::warnings` instead, and the type check
-    /// neither passes nor fails it — presence and nullability still apply.
+    /// (DuckDB `VARCHAR` and Snowflake `STRING` both match). A type string
+    /// here that the normalizer does not recognise is reported in
+    /// `ContractResult::warnings` and not compared — it is yours to correct,
+    /// and presence and nullability still apply. An unrecognised *landed*
+    /// type is different: it refuses the load (#1721).
     #[serde(rename = "type")]
     pub data_type: String,
     #[serde(default = "default_true")]
@@ -179,10 +180,13 @@ pub fn validate_contract(
 ///   a violation is emitted only when both normalize to a *known* type and the
 ///   landed type is not assignable to (does not fit within) the expected type.
 ///   So a narrower landed type (`INT32`) satisfies a wider contract (`BIGINT`),
-///   but not the reverse. If either side normalizes to [`RockyType::Unknown`]
-///   the column cannot be compared: it is reported in `warnings`, naming the
-///   column and both raw type strings, and is neither a violation nor a
-///   silent pass (#1614).
+///   but not the reverse. When a side normalizes to [`RockyType::Unknown`] the
+///   column cannot be compared, and the two sides are handled differently
+///   (#1721): an unrecognised **landed** type is a violation, because it
+///   leaves the gate's question unanswered and an unanswered question must
+///   not promote staging; an unrecognised **declared** type is a warning
+///   naming both raw strings, because that string is the user's own file and
+///   says nothing about what landed.
 ///
 /// `protected_columns` and `allowed_type_changes` describe source-vs-target
 /// *evolution*, which a single-table load can't meaningfully evaluate (there
@@ -222,26 +226,49 @@ pub fn validate_contract_typed(
 
         // Type match — best-effort in Rocky's type vocabulary.
         //
-        // `Unknown` is decided here, before the matcher runs. Until #1614 a
-        // type string outside `warehouse_type_to_rocky`'s map — on either
-        // side — became `Unknown`, and `is_assignable` treats `Unknown` as
-        // assignable to and from anything, so the column satisfied whatever
-        // the contract declared and staging was promoted with nothing said.
-        // The same shape was closed on the compile-time gate in #1240 (I003).
-        // This gate has no info channel, so the report goes to `warnings`:
-        // it names the column and both raw type strings, and does not touch
-        // `passed`, because "could not compare" is not "does not conform".
+        // `Unknown` is decided here, before the matcher runs, and the two
+        // sides are NOT symmetric (#1721).
+        //
+        //   landed   the warehouse's own answer about what it stored
+        //   declared a string in the user's own contract file
+        //
+        // An unparseable LANDED type refuses. "Rocky could not read the
+        // warehouse's answer" is not evidence the data conforms, and
+        // treating it as a warning is what let a BigQuery `NUMERIC` column
+        // really holding (38,9) satisfy a `NUMERIC(10,2)` contract and get
+        // promoted out of staging. Until #1614 both sides became `Unknown`
+        // and `is_assignable` treats `Unknown` as assignable to and from
+        // anything; #1646 then removed the fabricated `Decimal(38,0)` that
+        // had been accidentally enforcing the right answer, leaving no
+        // comparison at all.
+        //
+        // An unparseable DECLARED type still reports. That string is the
+        // user's file, Rocky refusing to read it says nothing about the
+        // data, and the remedy is to edit the contract — so naming it is
+        // the useful response. The same shape is closed on the
+        // compile-time gate by I003 (#1240).
         let landed_ty = warehouse_type_to_rocky(&col.data_type);
         let expected_ty = warehouse_type_to_rocky(&req.data_type);
         let landed_unknown = landed_ty == RockyType::Unknown;
         let expected_unknown = expected_ty == RockyType::Unknown;
-        if landed_unknown || expected_unknown {
+        if landed_unknown {
+            violations.push(ContractViolation {
+                rule: "unverifiable_landed_type".to_string(),
+                column: req.name.clone(),
+                message: format!(
+                    "column '{}' landed as '{}', which Rocky cannot compare against the \
+                     contract's '{}'. The load is refused because an uncomparable landed \
+                     type is not evidence the column conforms. Declare the column with a \
+                     type Rocky parses, or fix the source so the warehouse reports a \
+                     precise type.",
+                    req.name, col.data_type, req.data_type
+                ),
+            });
+        } else if expected_unknown {
             warnings.push(unchecked_type_warning(
                 &req.name,
                 &col.data_type,
                 &req.data_type,
-                landed_unknown,
-                expected_unknown,
             ));
         } else if !landed_type_conforms(&landed_ty, &expected_ty) {
             violations.push(ContractViolation {
@@ -416,23 +443,17 @@ fn landed_type_conforms(landed: &RockyType, expected: &RockyType) -> bool {
 /// The warning for a required column whose type could not be compared.
 /// Names the column and both raw type strings, and says which side Rocky
 /// did not recognise, so the reader can fix the contract or extend the map.
-fn unchecked_type_warning(
-    column: &str,
-    landed_type: &str,
-    declared_type: &str,
-    landed_unknown: bool,
-    declared_unknown: bool,
-) -> String {
-    let which = match (landed_unknown, declared_unknown) {
-        (true, true) => "Rocky recognises neither type",
-        (true, false) => "Rocky does not recognise the landed type",
-        (false, true) => "Rocky does not recognise the declared type",
-        (false, false) => unreachable!("only called when at least one side is Unknown"),
-    };
+/// Report a declared type Rocky cannot parse.
+///
+/// Only the DECLARED side reaches here. An unparseable landed type is a
+/// violation, not a warning (#1721) — see the call site for why the two
+/// sides differ.
+fn unchecked_type_warning(column: &str, landed_type: &str, declared_type: &str) -> String {
     format!(
         "column '{column}' landed as '{landed_type}' and the contract declares '{declared_type}'; \
-         {which}, so the declared type was not checked. Presence and nullability were checked. \
-         The load was not refused for this."
+         Rocky does not recognise the declared type, so it was not checked. Presence and \
+         nullability were checked. The load was not refused for this, because the declared \
+         string is yours to correct and says nothing about what landed."
     )
 }
 
@@ -805,8 +826,15 @@ mod tests {
     /// A landed type outside Rocky's map cannot be compared, so it must not
     /// produce a type violation — and it must not pass silently either. Until
     /// #1614 this test pinned the fail-open: it asserted only `passed`.
+    /// A landed type Rocky cannot parse REFUSES the load (#1721).
+    ///
+    /// The gate's whole job is to decide whether what landed conforms. The
+    /// landed string is the warehouse's own answer, so failing to read it
+    /// leaves the question unanswered — and an unanswered question must not
+    /// promote staging. Asserted before the message text so a revert fails
+    /// on the consequence, not on wording.
     #[test]
-    fn test_typed_unknown_landed_type_is_reported_not_passed_silently() {
+    fn test_typed_unknown_landed_type_refuses_the_load() {
         let contract = ContractConfig {
             required_columns: vec![RequiredColumn {
                 name: "geo".into(),
@@ -817,22 +845,56 @@ mod tests {
         };
         let landed = vec![col_n("geo", "GEOMETRY", true)];
         let result = validate_contract_typed(&contract, &landed);
-        assert!(result.passed, "violations: {:?}", result.violations);
-        assert!(result.violations.is_empty());
+        assert!(
+            !result.passed,
+            "an uncomparable landed type must refuse, not pass: {result:?}"
+        );
         assert_eq!(
-            result.warnings.len(),
+            result.violations.len(),
             1,
-            "exactly one warning for the unchecked column: {:?}",
-            result.warnings
+            "violations: {:?}",
+            result.violations
         );
-        let w = &result.warnings[0];
+        let v = &result.violations[0];
+        assert_eq!(v.rule, "unverifiable_landed_type");
+        assert_eq!(v.column, "geo");
         assert!(
-            w.contains("'geo'") && w.contains("'GEOMETRY'") && w.contains("'BIGINT'"),
-            "the warning must name the column, the landed type and the declared type: {w}"
+            v.message.contains("'geo'")
+                && v.message.contains("'GEOMETRY'")
+                && v.message.contains("'BIGINT'"),
+            "the refusal must name the column and both raw type strings: {}",
+            v.message
+        );
+    }
+
+    /// The regression #1646 opened, stated as data rather than as types:
+    /// BigQuery reports a default-precision numeric as the bare string
+    /// `NUMERIC` while the column really holds (38,9). Before #1646 the
+    /// fabricated `Decimal(38,0)` refused this for the wrong reason; after
+    /// it, nothing refused it at all and staging was promoted.
+    #[test]
+    fn test_typed_bare_bigquery_numeric_does_not_satisfy_a_narrower_contract() {
+        let contract = ContractConfig {
+            required_columns: vec![RequiredColumn {
+                name: "amount".into(),
+                data_type: "NUMERIC(10,2)".into(),
+                nullable: true,
+            }],
+            ..Default::default()
+        };
+        let landed = vec![col_n("amount", "NUMERIC", true)];
+        let result = validate_contract_typed(&contract, &landed);
+        assert!(
+            !result.passed,
+            "a bare NUMERIC must not satisfy NUMERIC(10,2): {result:?}"
         );
         assert!(
-            w.contains("does not recognise the landed type"),
-            "the warning must say which side was not recognised: {w}"
+            result
+                .violations
+                .iter()
+                .any(|v| v.rule == "unverifiable_landed_type" && v.column == "amount"),
+            "violations: {:?}",
+            result.violations
         );
     }
 
@@ -863,9 +925,14 @@ mod tests {
         );
     }
 
-    /// Both sides unrecognised is one unchecked column, so one warning.
+    /// When BOTH sides are unrecognised, the landed side decides: refuse.
+    ///
+    /// A broken declared string does not soften an unreadable landed one.
+    /// The column is still unverified, so it still must not promote — and
+    /// reporting only the declared problem would name the half the user can
+    /// fix while staying silent about the half that blocks the answer.
     #[test]
-    fn test_typed_both_types_unknown_reported_once() {
+    fn test_typed_both_types_unknown_refuses_on_the_landed_side() {
         let contract = ContractConfig {
             required_columns: vec![RequiredColumn {
                 name: "geo".into(),
@@ -876,16 +943,26 @@ mod tests {
         };
         let landed = vec![col_n("geo", "GEOMETRY", true)];
         let result = validate_contract_typed(&contract, &landed);
-        assert!(result.passed, "violations: {:?}", result.violations);
-        assert_eq!(result.warnings.len(), 1, "warnings: {:?}", result.warnings);
-        let w = &result.warnings[0];
+        assert!(!result.passed, "violations: {:?}", result.violations);
+        assert_eq!(
+            result.violations.len(),
+            1,
+            "violations: {:?}",
+            result.violations
+        );
+        let v = &result.violations[0];
+        assert_eq!(v.rule, "unverifiable_landed_type");
         assert!(
-            w.contains("'geo'") && w.contains("'GEOMETRY'") && w.contains("'GEOM'"),
-            "the warning must name the column and both type strings: {w}"
+            v.message.contains("'geo'")
+                && v.message.contains("'GEOMETRY'")
+                && v.message.contains("'GEOM'"),
+            "the refusal must name the column and both type strings: {}",
+            v.message
         );
         assert!(
-            w.contains("recognises neither type"),
-            "the warning must say that neither side was recognised: {w}"
+            result.warnings.is_empty(),
+            "the landed refusal replaces the warning rather than adding to it: {:?}",
+            result.warnings
         );
     }
 
@@ -1053,11 +1130,14 @@ mod tests {
         );
     }
 
-    /// A malformed decimal on the landed side is reported too. Before #1614 it
-    /// was read as `DECIMAL(38,0)` and failed a narrower contract for a made-up
-    /// reason.
+    /// A malformed decimal on the landed side REFUSES (#1721). Before #1614
+    /// it was read as `DECIMAL(38,0)` and failed a narrower contract for a
+    /// made-up reason; #1614 stopped inventing the type and #1646 removed
+    /// the last fabricated one, which left the column promoted on no
+    /// comparison at all. Refusing is the third state: no fabricated type,
+    /// and no pass either.
     #[test]
-    fn test_typed_malformed_landed_decimal_is_reported() {
+    fn test_typed_malformed_landed_decimal_refuses() {
         let contract = ContractConfig {
             required_columns: vec![RequiredColumn {
                 name: "amount".into(),
@@ -1068,13 +1148,16 @@ mod tests {
         };
         let result =
             validate_contract_typed(&contract, &[col_n("amount", "DECIMAL(10,2,3)", true)]);
-        assert!(result.passed, "violations: {:?}", result.violations);
-        assert_eq!(result.warnings.len(), 1, "warnings: {:?}", result.warnings);
-        let w = &result.warnings[0];
-        assert!(
-            w.contains("'DECIMAL(10,2,3)'") && w.contains("does not recognise the landed type"),
-            "{w}"
+        assert!(!result.passed, "violations: {:?}", result.violations);
+        assert_eq!(
+            result.violations.len(),
+            1,
+            "violations: {:?}",
+            result.violations
         );
+        let v = &result.violations[0];
+        assert_eq!(v.rule, "unverifiable_landed_type");
+        assert!(v.message.contains("'DECIMAL(10,2,3)'"), "{}", v.message);
     }
 
     /// The matcher must answer "not a match" for `Unknown` on either side.

--- a/integrations/dagster/tests/fixtures_generated/ci.json
+++ b/integrations/dagster/tests/fixtures_generated/ci.json
@@ -14,7 +14,7 @@
       "message": "column 'customer_id' declares type Int64 in the contract, but Rocky could not work out the column's type, so it did not check the declared type",
       "span": null,
       "model": "revenue_summary",
-      "suggestion": "give `rocky compile` source schemas so `customer_id`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. A CAST to Int64 only helps when the value it casts already has a known type"
+      "suggestion": "give `rocky compile` source schemas so `customer_id`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. Do not add a CAST to silence this: a cast takes its type from the target, so it would report Int64 whatever the column actually holds"
     },
     {
       "severity": "Info",
@@ -22,7 +22,7 @@
       "message": "column 'total_revenue' declares type Decimal in the contract, but Rocky could not work out the column's type, so it did not check the declared type",
       "span": null,
       "model": "revenue_summary",
-      "suggestion": "give `rocky compile` source schemas so `total_revenue`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. A CAST to Decimal only helps when the value it casts already has a known type"
+      "suggestion": "give `rocky compile` source schemas so `total_revenue`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. Do not add a CAST to silence this: a cast takes its type from the target, so it would report Decimal whatever the column actually holds"
     },
     {
       "severity": "Info",
@@ -30,7 +30,7 @@
       "message": "column 'order_count' declares type Int64 in the contract, but Rocky could not work out the column's type, so it did not check the declared type",
       "span": null,
       "model": "revenue_summary",
-      "suggestion": "give `rocky compile` source schemas so `order_count`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. A CAST to Int64 only helps when the value it casts already has a known type"
+      "suggestion": "give `rocky compile` source schemas so `order_count`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. Do not add a CAST to silence this: a cast takes its type from the target, so it would report Int64 whatever the column actually holds"
     }
   ],
   "failures": []

--- a/integrations/dagster/tests/fixtures_generated/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/compile.json
@@ -10,7 +10,7 @@
       "message": "column 'customer_id' declares type Int64 in the contract, but Rocky could not work out the column's type, so it did not check the declared type",
       "span": null,
       "model": "revenue_summary",
-      "suggestion": "give `rocky compile` source schemas so `customer_id`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. A CAST to Int64 only helps when the value it casts already has a known type"
+      "suggestion": "give `rocky compile` source schemas so `customer_id`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. Do not add a CAST to silence this: a cast takes its type from the target, so it would report Int64 whatever the column actually holds"
     },
     {
       "severity": "Info",
@@ -18,7 +18,7 @@
       "message": "column 'total_revenue' declares type Decimal in the contract, but Rocky could not work out the column's type, so it did not check the declared type",
       "span": null,
       "model": "revenue_summary",
-      "suggestion": "give `rocky compile` source schemas so `total_revenue`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. A CAST to Decimal only helps when the value it casts already has a known type"
+      "suggestion": "give `rocky compile` source schemas so `total_revenue`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. Do not add a CAST to silence this: a cast takes its type from the target, so it would report Decimal whatever the column actually holds"
     },
     {
       "severity": "Info",
@@ -26,7 +26,7 @@
       "message": "column 'order_count' declares type Int64 in the contract, but Rocky could not work out the column's type, so it did not check the declared type",
       "span": null,
       "model": "revenue_summary",
-      "suggestion": "give `rocky compile` source schemas so `order_count`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. A CAST to Int64 only helps when the value it casts already has a known type"
+      "suggestion": "give `rocky compile` source schemas so `order_count`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. Do not add a CAST to silence this: a cast takes its type from the target, so it would report Int64 whatever the column actually holds"
     }
   ],
   "has_errors": false,

--- a/integrations/dagster/tests/fixtures_generated/contracts/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/contracts/compile.json
@@ -18,7 +18,7 @@
       "message": "column 'order_id' declares type Int64 in the contract, but Rocky could not work out the column's type, so it did not check the declared type",
       "span": null,
       "model": "broken_metrics",
-      "suggestion": "give `rocky compile` source schemas so `order_id`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. A CAST to Int64 only helps when the value it casts already has a known type"
+      "suggestion": "give `rocky compile` source schemas so `order_id`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. Do not add a CAST to silence this: a cast takes its type from the target, so it would report Int64 whatever the column actually holds"
     },
     {
       "severity": "Error",
@@ -34,7 +34,7 @@
       "message": "column 'amount' declares type Decimal in the contract, but Rocky could not work out the column's type, so it did not check the declared type",
       "span": null,
       "model": "broken_metrics",
-      "suggestion": "give `rocky compile` source schemas so `amount`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. A CAST to Decimal only helps when the value it casts already has a known type"
+      "suggestion": "give `rocky compile` source schemas so `amount`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. Do not add a CAST to silence this: a cast takes its type from the target, so it would report Decimal whatever the column actually holds"
     },
     {
       "severity": "Error",
@@ -50,7 +50,7 @@
       "message": "column 'order_id' declares type Int64 in the contract, but Rocky could not work out the column's type, so it did not check the declared type",
       "span": null,
       "model": "good_metrics",
-      "suggestion": "give `rocky compile` source schemas so `order_id`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. A CAST to Int64 only helps when the value it casts already has a known type"
+      "suggestion": "give `rocky compile` source schemas so `order_id`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. Do not add a CAST to silence this: a cast takes its type from the target, so it would report Int64 whatever the column actually holds"
     },
     {
       "severity": "Info",
@@ -58,7 +58,7 @@
       "message": "column 'customer_id' declares type Int64 in the contract, but Rocky could not work out the column's type, so it did not check the declared type",
       "span": null,
       "model": "good_metrics",
-      "suggestion": "give `rocky compile` source schemas so `customer_id`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. A CAST to Int64 only helps when the value it casts already has a known type"
+      "suggestion": "give `rocky compile` source schemas so `customer_id`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. Do not add a CAST to silence this: a cast takes its type from the target, so it would report Int64 whatever the column actually holds"
     },
     {
       "severity": "Info",
@@ -66,7 +66,7 @@
       "message": "column 'amount' declares type Decimal in the contract, but Rocky could not work out the column's type, so it did not check the declared type",
       "span": null,
       "model": "good_metrics",
-      "suggestion": "give `rocky compile` source schemas so `amount`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. A CAST to Decimal only helps when the value it casts already has a known type"
+      "suggestion": "give `rocky compile` source schemas so `amount`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. Do not add a CAST to silence this: a cast takes its type from the target, so it would report Decimal whatever the column actually holds"
     }
   ],
   "has_errors": true,

--- a/integrations/dagster/tests/fixtures_generated/test.json
+++ b/integrations/dagster/tests/fixtures_generated/test.json
@@ -26,7 +26,7 @@
       "message": "column 'customer_id' declares type Int64 in the contract, but Rocky could not work out the column's type, so it did not check the declared type",
       "span": null,
       "model": "revenue_summary",
-      "suggestion": "give `rocky compile` source schemas so `customer_id`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. A CAST to Int64 only helps when the value it casts already has a known type"
+      "suggestion": "give `rocky compile` source schemas so `customer_id`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. Do not add a CAST to silence this: a cast takes its type from the target, so it would report Int64 whatever the column actually holds"
     },
     {
       "severity": "Info",
@@ -34,7 +34,7 @@
       "message": "column 'total_revenue' declares type Decimal in the contract, but Rocky could not work out the column's type, so it did not check the declared type",
       "span": null,
       "model": "revenue_summary",
-      "suggestion": "give `rocky compile` source schemas so `total_revenue`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. A CAST to Decimal only helps when the value it casts already has a known type"
+      "suggestion": "give `rocky compile` source schemas so `total_revenue`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. Do not add a CAST to silence this: a cast takes its type from the target, so it would report Decimal whatever the column actually holds"
     },
     {
       "severity": "Info",
@@ -42,7 +42,7 @@
       "message": "column 'order_count' declares type Int64 in the contract, but Rocky could not work out the column's type, so it did not check the declared type",
       "span": null,
       "model": "revenue_summary",
-      "suggestion": "give `rocky compile` source schemas so `order_count`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. A CAST to Int64 only helps when the value it casts already has a known type"
+      "suggestion": "give `rocky compile` source schemas so `order_count`'s type resolves \u2014 `rocky discover --with-schemas` fills the cache, or use `rocky compile --with-seed`; `rocky test` and `rocky ci` always compile without them. Do not add a CAST to silence this: a cast takes its type from the target, so it would report Int64 whatever the column actually holds"
     }
   ]
 }

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -3292,7 +3292,7 @@
           "type": "boolean"
         },
         "type": {
-          "description": "Expected type, written in warehouse vocabulary (e.g. `BIGINT`, `VARCHAR`, `NUMBER(38,0)`). It is normalized to a portable Rocky type before comparison, so the same contract ports across warehouses (DuckDB `VARCHAR` and Snowflake `STRING` both match). A type the normalizer does not recognise is never compared: the load gate reports the column in `ContractResult::warnings` instead, and the type check neither passes nor fails it — presence and nullability still apply.",
+          "description": "Expected type, written in warehouse vocabulary (e.g. `BIGINT`, `VARCHAR`, `NUMBER(38,0)`). It is normalized to a portable Rocky type before comparison, so the same contract ports across warehouses (DuckDB `VARCHAR` and Snowflake `STRING` both match). A type string here that the normalizer does not recognise is reported in `ContractResult::warnings` and not compared — it is yours to correct, and presence and nullability still apply. An unrecognised *landed* type is different: it refuses the load (#1721).",
           "type": "string"
         }
       },

--- a/sdk/python/src/rocky_sdk/types_generated/rocky_project_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/rocky_project_schema.py
@@ -1323,7 +1323,7 @@ class RequiredColumn(BaseModel):
     nullable: bool | None = True
     type: str
     """
-    Expected type, written in warehouse vocabulary (e.g. `BIGINT`, `VARCHAR`, `NUMBER(38,0)`). It is normalized to a portable Rocky type before comparison, so the same contract ports across warehouses (DuckDB `VARCHAR` and Snowflake `STRING` both match). A type the normalizer does not recognise is never compared: the load gate reports the column in `ContractResult::warnings` instead, and the type check neither passes nor fails it — presence and nullability still apply.
+    Expected type, written in warehouse vocabulary (e.g. `BIGINT`, `VARCHAR`, `NUMBER(38,0)`). It is normalized to a portable Rocky type before comparison, so the same contract ports across warehouses (DuckDB `VARCHAR` and Snowflake `STRING` both match). A type string here that the normalizer does not recognise is reported in `ContractResult::warnings` and not compared — it is yours to correct, and presence and nullability still apply. An unrecognised *landed* type is different: it refuses the load (#1721).
     """
 
 


### PR DESCRIPTION
A contract violation the warehouse genuinely has was being reported instead of refused, so staging was promoted into the target. This closes that.

## What was wrong

`#1646` replaced a fabricated `Decimal(38,0)` with `RockyType::Unknown` for bare decimal type names. That removed a wrong comparison — and with it the enforcement.

```
landed "NUMERIC"  vs  contract NUMERIC(10,2)      (the column really holds (38,9))

  before #1646   Decimal(38,0)  ▸ 38 > 8 digits ▸ VIOLATION   right answer, wrong reason
  after  #1646   Unknown        ▸ warning       ▸ PROMOTED     wrong answer
  this PR        Unknown        ▸ VIOLATION                    right answer, right reason
```

BigQuery reports a default-precision numeric as the bare string `NUMERIC` — the repo's own live sweep asserts exactly that (`rocky-bigquery/tests/dialect_sweep_live.rs`). `rocky load` has no `--strict`, so the warning surfaced only as a `tracing::warn!` line and a JSON field while the data landed.

## The rule

The two sides of the comparison are not symmetric, and treating them alike is what created the hole.

| side | what it is | what an unreadable value means |
|---|---|---|
| **landed** | the warehouse's own answer about what it stored | the gate's question is **unanswered** → refuse |
| **declared** | a string in the user's own contract file | says nothing about the data → report, and name it |

An unanswered question must not promote staging. A contract file the user can fix should be named, not fatal.

## What changed

1. **`rocky-core/contracts.rs`** — an unparseable landed type is a `unverifiable_landed_type` violation naming both raw strings. The declared side keeps its warning.
2. **`rocky-compiler/contracts.rs`** — `I003` stops suggesting a `CAST`. `infer_expr_type`'s cast arm returns `(sql_type_to_rocky(data_type), nullable)`: the type comes purely from the CAST target and only `nullable` reads the input. So the old advice — *"a CAST only helps when the value it casts already has a known type"* — was false about its own mechanism, and following it on a `(38,9)` column would manufacture `Decimal(38,0)` and turn the diagnostic green.
3. **`rocky-compiler/typecheck.rs`** — the **third** normaliser now agrees with the other two: a bare `DECIMAL`/`NUMERIC` is `Unknown`, not `Decimal(38,0)`. `ExactNumberInfo::Precision(p)` stays concrete on purpose — SQL defines `DECIMAL(p)` as `DECIMAL(p, 0)`, so that scale is stated by the standard, not invented.
4. **`docs/concepts/capability-matrix.md`** — carried the same false CAST claim in published form.

## The accepted cost

This refuses some loads that pass today, **including ones whose data would have fitted**. A `NUMERIC(38,9)` contract against a bare landed `NUMERIC` is now refused even though the values are fine.

That is deliberate. The gate declines to certify a column it could not compare, rather than guessing in either direction — and unlike the old fabricated `Decimal(38,0)`, the refusal has a nameable remedy. The test that pays this cost says so in its own name.

## Tests

Five tests asserted the old behaviour, and two said so outright — `test_typed_bare_numeric_is_reported_not_refused`, and a comment conceding *"It is still not refused — `passed` is computed from violations only."* All inverted, with the consequence-shaped assertion ordered first so a revert fails on behaviour rather than on wording.

Two controls were added, because the blast radius genuinely widened — a refusal now covers "could not be read", not just "does not fit", so **every** unrecognised type string blocks a load that previously promoted:

- `test_healthy_adapter_describe_output_still_passes_the_gate` — real `DESCRIBE` output from the DuckDB, Databricks and Snowflake adapters still passes **at the gate**. The pre-existing control only proved those strings *parse*; this proves the gate accepts them, which is what an ordinary run depends on.
- `test_contract_gate_refuses_a_landed_type_it_cannot_compare` — end-to-end through COPY → staging → live `DESCRIBE` → promote, asserting the **target is absent** afterwards. The unit tests assert the verdict; only this one shows the rows never arrive.

`bare_decimal_is_unknown_while_stated_digits_stay_concrete` pins all three arms of the third normaliser. No test covered that arm before, which is how it drifted through two issues about this exact fabrication.

## Review notes

The load-gate consumer test lives in `rocky-cli` while the change is in `rocky-core`, so a per-crate test run misses it — it was caught by a workspace run.

Independent review: dispatched to Codex; its findings on the surrounding triage are recorded on the issue.

Refs #1721
