### PR TITLE
test(dagster): pin the reason beside the severity on a passing unmeasured check

### DIFF
--- a/integrations/dagster/tests/test_checks.py
+++ b/integrations/dagster/tests/test_checks.py
@@ -122,6 +122,46 @@ def test_check_metadata_surfaces_advisory_severity():
     assert check_metadata(failing)["severity"].value == "warning"
 
 
+def test_passing_unmeasured_check_shows_the_reason_beside_the_severity():
+    """The #1785 shape: ``passed=True`` *and* ``not_evaluated`` set.
+
+    ``cross_source_overlap_not_applicable`` is the one constructor that reports
+    a passing check carrying a not-evaluated reason, and it takes the
+    operator's configured severity. So a viewer sees ``severity: warning`` for
+    a group Rocky never measured.
+
+    That reads wrong only if the severity stands alone. Both fields must be
+    present, because each answers a different question:
+
+        severity      is this check advisory?      configured intent
+        not_evaluated did this check measure?      what actually happened
+
+    Together they are accurate; either alone is not. This pins the pair, which
+    is what nothing asserted before — the existing not-evaluated coverage is
+    the ``passed=False`` / ``severity="error"`` shape.
+    """
+    check = CheckResult(
+        name="cross_source_overlap",
+        passed=True,
+        severity="warning",
+        overlap_count=0,
+        not_evaluated="only one sibling declares a key, so no overlap was computed",
+    )
+    metadata = check_metadata(check)
+
+    assert "not_evaluated" in metadata, (
+        "a passing check that measured nothing must still say so; without this "
+        "the severity is the only thing a reader sees"
+    )
+    assert "only one sibling declares a key" in metadata["not_evaluated"].value
+    assert metadata["severity"].value == "warning"
+
+    # And the severity mapping is unchanged by it: an unmeasured advisory check
+    # stays WARN, so it does not degrade asset health on the strength of a
+    # reading nobody took.
+    assert dagster_check_severity(check) == dg.AssetCheckSeverity.WARN
+
+
 def test_check_metadata_omits_default_error_severity():
     """The implicit ``error`` default is not surfaced — it would clutter every
     check's panel with no added signal."""


### PR DESCRIPTION
Test-only. Closes the coverage gap behind #1785 after establishing that the production fix it asks for already shipped.

## What #1785 asked for, and why nothing was built

The issue's preferred option was *"surface `not_evaluated` as its own metadata field"*, on the premise that *"the information is already on the wire and simply is not rendered."*

It is rendered — `check_metadata` has emitted it since #1709. So there was no production change to make, and the issue read as open because nothing pinned the one case it is about.

## The gap

`cross_source_overlap_not_applicable` is the only constructor that reports `passed=True` **while** carrying a `not_evaluated` reason, and it takes the operator's configured severity. A viewer of that case sees:

```
not_evaluated : only one sibling declares a key, so no overlap was computed
severity      : warning
```

Both are needed, and each answers a different question:

| field | question | source |
|---|---|---|
| `severity` | is this check advisory? | configured intent |
| `not_evaluated` | did this check measure anything? | what happened |

Together they are accurate. The severity reads as a claim about a measurement only if it stands alone — so the pair is the property worth pinning, and nothing pinned it. The existing not-evaluated coverage (`test_undeclared_checks.py:440`) is the `passed=False` / `severity="error"` shape.

## Why not map `not_evaluated` to ERROR

That was the issue's option 2, and it is deliberately not taken. It would make an unmeasured advisory check degrade asset health on the strength of a reading nobody took — the inverse of the #1741 rule, which was about refusing to *confirm* an unmeasured check. Declining to confirm is right; asserting a failure is not. The test pins `WARN` for that case so a later change has to disagree on purpose.

Refs #1785
