### PR TITLE
ci: catch the containment allow-list up to the action pins on main

### DIFF
--- a/.github/scripts/check_credential_containment.py
+++ b/.github/scripts/check_credential_containment.py
@@ -63,7 +63,7 @@ DOCKER_SETUP_BUILDX_SOURCE = (
     "docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e"
 )
 DEPLOY_PAGES_SOURCE = (
-    "actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128"
+    "actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346"
 )
 UPLOAD_PAGES_ARTIFACT_SOURCE = (
     "actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9"
@@ -80,7 +80,7 @@ GH_RELEASE_SOURCE = (
     "softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228"
 )
 TAIKI_INSTALL_SOURCE = (
-    "taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1"
+    "taiki-e/install-action@5bf6ce016fd2e72eefc647cbca1e4213f65955b8"
 )
 # Actions a job may run when it is not reachable from a pull request. Release,
 # publish and deployment workflows never execute candidate code, so the


### PR DESCRIPTION
## `main` is red on a required check right now

```
.github/workflows/engine-docs.yml: release step action source is not allow-listed
.github/workflows/engine-release.yml: release step action source is not allow-listed
credential-containment policy: 2 violation(s)
```

Reproduce on a clean checkout of `main`:

```
python3 .github/scripts/check_credential_containment.py .
```

`Credential containment policy` is one of the seven required contexts on `Protect main`, so **every open PR inherits both violations** and none can merge without admin until this lands.

## Cause

#1774 bumped two release-step pins. The allow-list constants they are checked against did not move with them.

| Workflow | Action | Pin on main | Allow-list said |
|---|---|---|---|
| `engine-docs.yml` | `actions/deploy-pages` | `368f8252` (v5.0.1) | `cd2ce8fc` (v5.0.0) |
| `engine-release.yml` | `taiki-e/install-action` | `5bf6ce01` (v2.87.5) | `82cd3e76` (v2.85.13) |

`engine-ci.yml` also moved to `5bf6ce01` but is not flagged — the rule guards *release step* sources, the ones in jobs a pull request cannot reach.

## The fix

Two constants, now naming the SHA each workflow actually uses. Each was verified against the upstream tag it claims **before** being written here — a pinned-SHA bump is exactly where a substituted commit would hide:

```
gh api repos/actions/deploy-pages/git/ref/tags/v5.0.1     -> 368f82528645a54fb793d4d04e342629a3f51346
gh api repos/taiki-e/install-action/git/ref/tags/v2.87.5  -> 5bf6ce016fd2e72eefc647cbca1e4213f65955b8
```

After the change, on this branch:

```
credential-containment policy: passed
```

## This needs an admin merge, and cannot land any other way

The check runs the **trusted** copy of the script against the candidate tree, so a PR that edits the allow-list is judged by the allow-list it is replacing. It is refused twice — reproduced by running `main`'s script against this branch:

```
::error::.github/scripts/check_credential_containment.py: frozen trust root differs from trusted base
::error::.github/workflows/engine-docs.yml: release step action source is not allow-listed
::error::.github/workflows/engine-release.yml: release step action source is not allow-listed
credential-containment policy: 3 violation(s)
```

That deadlock is #1769. This PR does not fix it — it clears the breakage the deadlock caused.

## The ordering lesson

An allow-list extension has to land **before** the pin bump it covers, never after. #1588 was the extension for the earlier bumps and it is still open; #1774 went in first, which is how `main` ended up red.

#1588 is now stale rather than merely conflicting: it pins `taiki-e/install-action` at **v2.87.1**, and `main` is on **v2.87.5**. Merging it as-is would downgrade the workflows and point the allow-list at a SHA nothing uses. It needs re-cutting against current `main`, not a rebase.

Refs #1769
