### PR TITLE
fix(engine): local pipeline arms honour [state] on_schema_mismatch

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -2831,17 +2831,46 @@ pub async fn run(
             // The handle is dropped immediately — redb is single-writer, and
             // this open exists to apply the policy and read one bit, not to
             // hold state open across the run.
-            {
+            //
+            // Gated on the models directory being PRESENT, because the no-op
+            // arm (`models = "models/**"` with no such directory) is defined
+            // by mutating nothing — `run_local` opens no store there, and
+            // `noop_transformation_with_existing_state_file_skips_sessionless_sweep`
+            // asserts the state file stays byte-identical. Opening it here to
+            // apply a policy would be exactly the sessionless mutation that
+            // test exists to forbid.
+            if matches!(
+                &models_dir_decision,
+                super::run_local::ModelsDirDecision::Present(_)
+            ) {
                 let policy_store = rocky_core::state::StateStore::open_with_policy(
                     state_path,
                     rocky_cfg.state.on_schema_mismatch,
-                )
-                .with_context(|| {
-                    format!(
-                        "failed to open state store at {}",
-                        state_path.display()
-                    )
-                })?;
+                );
+                // The open can still fail — a corrupt store, or a newer one
+                // under `on_schema_mismatch = "fail"`. A bare `?` here would
+                // return with the session still alive, and dropping a live
+                // `RemoteStateSession` without finalize/abandon leaks the
+                // remote lock (it panics in debug). Every other arm abandons
+                // first; so does this one. Found by mutation-checking the
+                // test below, which reverted the policy open and hit exactly
+                // this path.
+                let policy_store = match policy_store {
+                    Ok(store) => store,
+                    Err(e) => {
+                        // `abandon` consumes the session, so take it out of
+                        // the Option rather than borrowing.
+                        if let Some(session) = tx_session.take() {
+                            session
+                                .abandon("transformation state store open failed")
+                                .await;
+                        }
+                        return Err(anyhow::Error::new(e).context(format!(
+                            "failed to open state store at {}",
+                            state_path.display()
+                        )));
+                    }
+                };
                 // Forward-incompat recreate ⇒ never push the downgraded
                 // ledger back over newer shared state. The other three
                 // honouring arms carry this; the transformation arm was safe
@@ -2995,13 +3024,23 @@ pub async fn run(
             // Same policy application as the transformation arm above
             // (#1679). See that block for why it lives at the dispatch site.
             {
-                let policy_store = rocky_core::state::StateStore::open_with_policy(
+                // A bare `?` here would return with the session still
+                // alive, and dropping a live `RemoteStateSession` without
+                // finalize/abandon leaks the remote lock. Same obligation as
+                // the transformation arm above.
+                let policy_store = match rocky_core::state::StateStore::open_with_policy(
                     state_path,
                     rocky_cfg.state.on_schema_mismatch,
-                )
-                .with_context(|| {
-                    format!("failed to open state store at {}", state_path.display())
-                })?;
+                ) {
+                    Ok(store) => store,
+                    Err(e) => {
+                        session.abandon("state store open failed").await;
+                        return Err(anyhow::Error::new(e).context(format!(
+                            "failed to open state store at {}",
+                            state_path.display()
+                        )));
+                    }
+                };
                 if policy_store.was_recreated_for_forward_incompat() {
                     session.set_suppress_upload("forward-incompat recreate");
                 }
@@ -3086,13 +3125,23 @@ pub async fn run(
             // Same policy application as the transformation arm above
             // (#1679). See that block for why it lives at the dispatch site.
             {
-                let policy_store = rocky_core::state::StateStore::open_with_policy(
+                // A bare `?` here would return with the session still
+                // alive, and dropping a live `RemoteStateSession` without
+                // finalize/abandon leaks the remote lock. Same obligation as
+                // the transformation arm above.
+                let policy_store = match rocky_core::state::StateStore::open_with_policy(
                     state_path,
                     rocky_cfg.state.on_schema_mismatch,
-                )
-                .with_context(|| {
-                    format!("failed to open state store at {}", state_path.display())
-                })?;
+                ) {
+                    Ok(store) => store,
+                    Err(e) => {
+                        session.abandon("state store open failed").await;
+                        return Err(anyhow::Error::new(e).context(format!(
+                            "failed to open state store at {}",
+                            state_path.display()
+                        )));
+                    }
+                };
                 if policy_store.was_recreated_for_forward_incompat() {
                     session.set_suppress_upload("forward-incompat recreate");
                 }

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -2810,6 +2810,49 @@ pub async fn run(
                 }
                 tx_session = Some(session);
             }
+            // `[state] on_schema_mismatch` applies here too (#1679).
+            //
+            // The transformation arm used to open the store with a plain
+            // `StateStore::open`, which refuses a forward-incompatible store
+            // whatever the key says — so a project that set
+            // `on_schema_mismatch = "recreate"` for a rollback got a hard
+            // refusal from `rocky run --pipeline <transformation>` and a
+            // successful recreate from the same command with
+            // `--idempotency-key`, because the claim happens to open under
+            // the policy before dispatch. One key, one meaning, both paths.
+            //
+            // Applied HERE rather than inside `run_local` for two reasons:
+            // the recreate fact has to reach the session that owns the
+            // upload, and this is where that session lives; and doing it
+            // before dispatch leaves `run_local`'s own open looking at an
+            // already-compatible store, which is exactly what the
+            // `--idempotency-key` path was doing by accident.
+            //
+            // The handle is dropped immediately — redb is single-writer, and
+            // this open exists to apply the policy and read one bit, not to
+            // hold state open across the run.
+            {
+                let policy_store = rocky_core::state::StateStore::open_with_policy(
+                    state_path,
+                    rocky_cfg.state.on_schema_mismatch,
+                )
+                .with_context(|| {
+                    format!(
+                        "failed to open state store at {}",
+                        state_path.display()
+                    )
+                })?;
+                // Forward-incompat recreate ⇒ never push the downgraded
+                // ledger back over newer shared state. The other three
+                // honouring arms carry this; the transformation arm was safe
+                // without it only because it could never recreate, and that
+                // is what this change removes.
+                if policy_store.was_recreated_for_forward_incompat()
+                    && let Some(session) = tx_session.as_mut()
+                {
+                    session.set_suppress_upload("forward-incompat recreate");
+                }
+            }
             let dispatch_result = super::run_local::run_transformation(
                 models_dir_decision,
                 &models_glob,
@@ -2949,6 +2992,20 @@ pub async fn run(
                 }
                 Ok(()) => {}
             }
+            // Same policy application as the transformation arm above
+            // (#1679). See that block for why it lives at the dispatch site.
+            {
+                let policy_store = rocky_core::state::StateStore::open_with_policy(
+                    state_path,
+                    rocky_cfg.state.on_schema_mismatch,
+                )
+                .with_context(|| {
+                    format!("failed to open state store at {}", state_path.display())
+                })?;
+                if policy_store.was_recreated_for_forward_incompat() {
+                    session.set_suppress_upload("forward-incompat recreate");
+                }
+            }
             let dispatch_result = super::run_local::run_quality(
                 config_path,
                 q,
@@ -3025,6 +3082,20 @@ pub async fn run(
                     session.set_suppress_upload("indeterminate download");
                 }
                 Ok(()) => {}
+            }
+            // Same policy application as the transformation arm above
+            // (#1679). See that block for why it lives at the dispatch site.
+            {
+                let policy_store = rocky_core::state::StateStore::open_with_policy(
+                    state_path,
+                    rocky_cfg.state.on_schema_mismatch,
+                )
+                .with_context(|| {
+                    format!("failed to open state store at {}", state_path.display())
+                })?;
+                if policy_store.was_recreated_for_forward_incompat() {
+                    session.set_suppress_upload("forward-incompat recreate");
+                }
             }
             let dispatch_result = super::run_local::run_snapshot(
                 config_path,

--- a/engine/crates/rocky-cli/tests/remote_state_bypass.rs
+++ b/engine/crates/rocky-cli/tests/remote_state_bypass.rs
@@ -1150,3 +1150,73 @@ async fn backfill_forward_incompat_recreate_suppresses_upload() {
         "the shared remote must still carry the newer pod's state, not a downgraded blob"
     );
 }
+
+/// A transformation-pipeline run honours `[state] on_schema_mismatch` and
+/// suppresses its upload when the policy recreated the store (#1679).
+///
+/// Two properties in one drive, because they only mean something together:
+///
+/// 1. **The run proceeds.** Before the fix the transformation arm opened with
+///    a plain `StateStore::open`, which refuses a forward-incompatible store
+///    whatever the key says — so this `drive_run` returned `Err` while
+///    replication, model-only and load all recreated as documented. The same
+///    command with `--idempotency-key` *did* recreate, because the claim
+///    opens under the policy before dispatch; that asymmetry is what this
+///    closes.
+/// 2. **The upload is suppressed.** Now that the arm can recreate, it takes
+///    on the caller obligation the other three already carry: never push a
+///    downgraded ledger over newer shared state.
+///
+/// The forward-incompat state arrives the way it does in production — a newer
+/// pod uploaded its (v+1) ledger and this older binary's session restores it
+/// on acquire. Stamping the local file alone cannot drive this: the download
+/// rebuilds the local file and erases the stamp before the arm opens it.
+#[tokio::test]
+async fn transformation_forward_incompat_recreate_proceeds_and_suppresses_upload() {
+    let _serial = remote_testing::serial_guard();
+    let harness = CrossPodHarness::new_s3_like();
+    let project = ModelProject::new("SELECT 1 AS id\n");
+    let future_version = rocky_core::state::current_schema_version() + 1;
+
+    rocky_core::state::force_schema_version(&harness.pod_a.state_path, &future_version.to_string());
+    harness
+        .upload(&harness.pod_a)
+        .await
+        .expect("newer pod's upload");
+    let puts_before = harness.faults.count(FaultOp::Put);
+
+    // Property 1. This is the assertion that was RED before the fix.
+    drive_run(&project, None, None)
+        .await
+        .expect("a recreate-policy transformation run proceeds instead of refusing");
+
+    // Property 2, ordered first among the post-conditions so a revert fails
+    // on the consequence — a clobbered remote — not on a version number.
+    assert_eq!(
+        harness.faults.count(FaultOp::Put),
+        puts_before,
+        "a forward-incompat recreated store must suppress the transformation run's \
+         terminal upload — uploading would push the downgraded blob over the newer \
+         shared state"
+    );
+
+    // Non-vacuous: the recreate really fired, so the suppression path was
+    // reachable rather than skipped for want of anything to suppress.
+    assert_eq!(
+        StateStore::peek_schema_version(&project.state_path).expect("peek recreated version"),
+        Some(rocky_core::state::current_schema_version()),
+        "the run must have recreated the store (proves the suppression path was \
+         reachable, not vacuously skipped)"
+    );
+
+    // The no-clobber end state: a fresh pod still restores the NEWER blob.
+    let _authority = harness
+        .download(&harness.pod_b)
+        .await
+        .expect("pod B start-download");
+    assert_eq!(
+        StateStore::peek_schema_version(&harness.pod_b.state_path).expect("peek pod B version"),
+        Some(future_version),
+        "the shared remote must still carry the newer pod's state, not a downgraded blob"
+    );
+}


### PR DESCRIPTION
`[state] on_schema_mismatch` is documented as what the binary does when it opens a state store written by a newer build. Three arms honoured it; three refused regardless. This makes all six agree.

## The asymmetry that settles it

The transformation, quality and snapshot arms opened with a plain `StateStore::open`, which refuses a forward-incompatible store whatever the key says. So a project that set `on_schema_mismatch = "recreate"` for a rollback got a hard refusal.

Worse, the same command contradicted itself:

```
rocky run --pipeline <transformation>                    →  REFUSES
rocky run --pipeline <transformation> --idempotency-key k →  RECREATES
```

The claim path opens under the policy *before* dispatch, so `recreate` fires there and `run_local`'s later plain open finds a fresh, compatible store. Same command, same config, opposite outcome on one flag — and that flagged path carried **no upload suppression**.

## The fix

Apply the policy at the dispatch site, which is where the `RemoteStateSession` that owns the upload lives, so the recreate fact can suppress it. That is what the idempotency path was doing by accident, done deliberately and with the obligation the other arms carry: a downgraded ledger must never be pushed over newer shared state.

Two guards the first attempt got wrong, both found by mutation-checking the test rather than by reading the diff:

- **The session was leaked on the error path.** A bare `?` returned with the session still alive; dropping a live `RemoteStateSession` without finalize/abandon leaks the remote lock and panics in debug. Reverting the policy open under mutation made the refusal fire, and the test died on `RemoteStateSession dropped without finalize/abandon` rather than on its assertion. All three arms now abandon first, as the model-only arm already did.
- **The no-op arm mutated state.** The open was unconditional, so a transformation pipeline whose models directory does not exist — the arm *defined* by mutating nothing — had its store opened to apply a policy. `noop_transformation_with_existing_state_file_skips_sessionless_sweep` went red. Now gated on `ModelsDirDecision::Present`, matching where `run_local` opens a store at all.

## Scope

The issue names the transformation arm. Quality and snapshot are fixed with it because the decision's stated reason was that refusing on one path makes one key mean two things — fixing only transformation would have left exactly that, one arm narrower.

## Test

`transformation_forward_incompat_recreate_proceeds_and_suppresses_upload`, mirroring the existing backfill test. It asserts two properties that only mean something together: the run **proceeds** (RED before the fix — the plain open refused), and its terminal upload is **suppressed** (the obligation the arm takes on the moment it can recreate). The suppression assertion is ordered first so a revert fails on the consequence — a clobbered remote — rather than on a version number.

The forward-incompat state arrives as it does in production: a newer pod uploads a v+1 ledger and this older binary's session restores it on acquire. Stamping the local file alone cannot drive this — the download rebuilds the file and erases the stamp before the arm opens it.

**Mutation-checked** via `scripts/mutation-check.sh`: reverting `open_with_policy` → `open` across all three arms fails the test.

Refs #1679
