### PR TITLE
fix(engine): expression checks are parsed and allowlisted, not interpolated raw

### DIFF
--- a/docs/src/content/docs/concepts/data-quality-checks.md
+++ b/docs/src/content/docs/concepts/data-quality-checks.md
@@ -157,7 +157,7 @@ filter = "region = 'US'"
 | `unique_expr` | set | `key_expr: String` | A derived **key expression** is unique across rows (`GROUP BY <expr> HAVING COUNT(*) > 1`). For when the meaningful identity is a *computed* value (e.g. a surrogate built to be stable across a multi-tenant union) that neither `unique` (single column) nor `composite` (column tuple) can express. `key_expr` is passed through as written (like `expression`), subject to the one narrow refusal described under **Filters**. NULL keys are not excluded — use `filter` to scope them out. |
 | `accepted_values` | row | `values: [String]` | Every non-NULL value is in the fixed set. |
 | `relationships` | row | `to_table`, `to_column` | Every non-NULL value exists in `to_table.to_column` (referential integrity). |
-| `expression` | row | `expression: String` | Custom SQL boolean predicate must hold per row. |
+| `expression` | row | `expression: String` | Custom SQL boolean predicate must hold per row. Bounded: one expression over the row's own columns, calling only allowlisted pure scalar functions — no subquery, no qualified function. See **Filters** below. |
 | `row_count_range` | table | `min`, `max` (both optional) | Table row count falls within the inclusive range. |
 | `in_range` | row | `min`, `max` (both optional, numeric) | Column's values fall within the numeric range. NULLs pass. |
 | `regex_match` | row | `pattern: String` | Column matches the dialect-specific regex. NULLs pass. Patterns are validated against a strict allowlist (no single quotes, backticks, or semicolons). |
@@ -264,7 +264,16 @@ One check does apply, to `filter`, `expression` and `key_expr` alike. Rocky refu
 
 The check runs when Rocky builds the query, and it names the field and the table so you know which line to fix.
 
-Be clear about what this does not do. It stops the fragment ending Rocky's statement and starting another. It does **not** make the fragment a single expression: Rocky does not track parentheses, so a fragment can still close the parenthesis Rocky wraps it in and add its own clauses. And it does not limit what the expression may read — a subquery runs with the same warehouse credentials as the rest of the pipeline. Treat a check expression as code you are running, because it is.
+Be clear about what this check does not do. It stops the fragment ending Rocky's statement and starting another. It does **not** make the fragment a single expression: Rocky does not track parentheses here, so a `filter` or `key_expr` can still close the parenthesis Rocky wraps it in and add its own clauses. And it does not limit what a `filter` or `key_expr` may read — a subquery runs with the same warehouse credentials as the rest of the pipeline. Treat those two as code you are running, because they are.
+
+`expression` gets a second, stronger gate. Rocky parses it under the target dialect and refuses it unless it is exactly one boolean expression over the row's own columns:
+
+- anything left over after one expression — so it cannot close Rocky's parenthesis and add clauses;
+- any subquery, in any position;
+- any qualified function name, such as `schema.fn(...)` — that is how user-defined, remote and plugin functions are reached;
+- any function that is not on Rocky's allowlist of pure scalar functions.
+
+Comparisons, `CASE`, `CAST`, `BETWEEN`, `IN (...)` with literals, and functions such as `coalesce`, `nullif`, `abs`, `round`, `length`, `lower`, `upper`, `trim`, `regexp_like`, `now` and `date_trunc` pass. Functions that read a file, a secret, a session variable or a remote endpoint do not, whatever their name looks like — DuckDB's `read_text`, Snowflake's `GETVARIABLE` and Databricks' `secret` all sit in ordinary scalar position and are refused by name. The refusal names the function. The gate runs when Rocky builds the test SQL, before anything executes, so a refused check is reported as refused rather than silently skipped. The same gate runs when an agent authors a check through the `draft_check` MCP tool, so a bad expression is refused when written.
 
 ### Row quarantine
 

--- a/docs/src/content/docs/reference/model-format.md
+++ b/docs/src/content/docs/reference/model-format.md
@@ -381,7 +381,9 @@ type = "row_count_range"
 min = 1
 ```
 
-`filter` and `expression` are user-supplied SQL passed through verbatim, so treat them with the same trust as any SQL you run against the warehouse.
+`expression` is bounded. Rocky parses it under the target dialect and refuses anything that is not one boolean expression over the model's own columns: a subquery, a qualified function name (`schema.fn(...)`), or a function outside its allowlist of pure scalar functions is refused when the test SQL is generated, before anything runs. Comparisons, `CASE`, `CAST`, and functions such as `coalesce`, `length`, `lower` and `date_trunc` pass; anything that can read a file, a secret, session state or a remote endpoint does not. The refusal names the function.
+
+`filter` is not bounded. It is passed through verbatim, so treat it with the same trust as any SQL you run against the warehouse.
 
 ### `[[use_test]]`
 

--- a/engine/crates/rocky-core/src/tests.rs
+++ b/engine/crates/rocky-core/src/tests.rs
@@ -1163,6 +1163,53 @@ target = { catalog = "c", schema = "s", table = "t" }
         assert!(err.to_string().contains("expression"));
     }
 
+    /// The content boundary (#1524) is WIRED into the generator, not only
+    /// defined in `rocky_sql::check_expression`. Each case is one refusal
+    /// class; the generator must surface it as a `TestGenError`, which is
+    /// what makes a refused check visible in the executed/deferred counts
+    /// instead of running. The last case proves an ordinary predicate
+    /// still generates — a boundary that refuses the ordinary case is a
+    /// bug, not a control.
+    #[test]
+    fn test_expression_content_boundary_is_wired() {
+        let decl = |expression: &str| TestDecl {
+            test_type: TestType::Expression {
+                expression: expression.into(),
+            },
+            column: None,
+            severity: TestSeverity::Error,
+            filter: None,
+        };
+        for (expression, must_mention) in [
+            ("read_text('/etc/passwd') IS NULL", "read_text"),
+            ("amount > (SELECT max(amount) FROM other)", "subquery"),
+            ("project.dataset.remote_fn(amount) IS NULL", "qualified"),
+            ("amount > 0) OR 1=1 --", "past the end"),
+        ] {
+            let err = generate_test_sql(&decl(expression), "orders")
+                .expect_err(&format!("{expression} must be refused at generation"));
+            assert!(
+                err.to_string().contains(must_mention),
+                "{expression}: the refusal must say why — got: {err}"
+            );
+        }
+        // Dialect is threaded: the same DuckDB read primitive is refused
+        // under the DuckDB parser, not only the generic one.
+        let duck = rocky_sql::check_expression::dialect_for("duckdb");
+        assert!(
+            rocky_sql::check_expression::validate_check_expression(
+                "ctx",
+                "read_text('/etc/passwd') IS NULL",
+                duck.as_ref()
+            )
+            .is_err()
+        );
+        assert_eq!(
+            generate_test_sql(&decl("coalesce(amount, 0) >= 0"), "orders").unwrap(),
+            "SELECT COUNT(*) FROM orders WHERE NOT (coalesce(amount, 0) >= 0)"
+        );
+    }
+
     #[test]
     fn test_row_count_range_no_bounds() {
         let decl = TestDecl {

--- a/engine/crates/rocky-core/src/tests.rs
+++ b/engine/crates/rocky-core/src/tests.rs
@@ -508,15 +508,31 @@ fn generate_test_sql_inner(
                 return Err(TestGenError::MissingExpression);
             }
             // Expression is user-supplied SQL — we cannot validate it as an
-            // identifier. The gate below refuses anything that could END this
-            // statement and start another. It does NOT make the fragment one
-            // expression: parentheses are not tracked, so the fragment can
-            // still close the `NOT (` below and add clauses. Nor does it bound
-            // reads — a subquery or a DuckDB `read_csv` still runs with the
-            // project's credentials. See `reject_statement_terminator`.
-            validation::reject_statement_terminator(
-                &format!("expression test `expression` on {table}"),
+            // identifier. Two gates, in order:
+            //
+            // 1. `reject_statement_terminator` refuses anything that could END
+            //    this statement and start another, without parsing.
+            // 2. `validate_check_expression` parses the fragment under the
+            //    target dialect and refuses anything that is not ONE boolean
+            //    expression calling only allowlisted pure scalar functions:
+            //    trailing tokens (so it cannot close the `NOT (` below and
+            //    add clauses), any subquery, any qualified function, any
+            //    function off the list. This is the content boundary #1524
+            //    asked for — a DuckDB `read_text`, a Snowflake `GETVARIABLE`,
+            //    a BigQuery remote function all sit in scalar position and
+            //    are refused by name.
+            //
+            // Both run at generation time, which is before execution on every
+            // path, so a refused check shows in the deferred/executed counts
+            // rather than vanishing.
+            let context = format!("expression test `expression` on {table}");
+            validation::reject_statement_terminator(&context, expression)?;
+            let sql_dialect =
+                rocky_sql::check_expression::dialect_for(dialect.map_or("generic", |d| d.name()));
+            rocky_sql::check_expression::validate_check_expression(
+                &context,
                 expression,
+                sql_dialect.as_ref(),
             )?;
             Ok(format!(
                 "SELECT COUNT(*) FROM {table} WHERE {}NOT ({expression})",

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -4584,6 +4584,9 @@ impl RockyMcpServer {
         // bare top-level key) smuggled alongside a valid `[[tests]]` block is
         // rejected instead of being appended verbatim into the model's sidecar.
         validate_check_spec(&spec)?;
+        // Content gate for `expression` checks (#1524): refuse a bad
+        // expression when it is WRITTEN, not when it is later run.
+        validate_check_spec_expressions(&spec)?;
         let paths = self.resolve_draft_paths(&args.model)?;
         if !self.model_source_exists(&paths.stem) {
             return Err(ToolError::model_not_found(&paths.stem));
@@ -7312,6 +7315,61 @@ fn validate_check_spec(spec: &str) -> Result<(), Json<ToolError>> {
                  column = \"id\"",
             ));
         }
+    }
+    Ok(())
+}
+
+/// Content gate for the `expression` checks in a `draft_check` spec (#1524).
+///
+/// Applies the same boundary `rocky test` enforces at generation time —
+/// one boolean expression, no subquery, no qualified function, only
+/// allowlisted pure scalar functions — but BEFORE the sidecar write, so an
+/// expression that can never run is refused at authoring time with the
+/// reason, rather than committed and refused later. Direct file writers
+/// bypass this tool entirely; the generation-time check is the backstop
+/// for them.
+///
+/// Parses under the generic dialect: the MCP server does not resolve the
+/// target warehouse here. A broader dialect can only accept MORE syntax,
+/// and acceptance still has to clear the function and subquery walk.
+fn validate_check_spec_expressions(spec: &str) -> Result<(), Json<ToolError>> {
+    // `validate_check_spec` already proved this parses and holds a `tests`
+    // array; a second parse is cheaper than threading the table through.
+    let Ok(parsed) = toml::from_str::<toml::Table>(spec) else {
+        return Ok(());
+    };
+    let Some(tests) = parsed.get("tests").and_then(toml::Value::as_array) else {
+        return Ok(());
+    };
+    let dialect = rocky_sql::check_expression::dialect_for("generic");
+    for (index, test) in tests.iter().enumerate() {
+        let Some(table) = test.as_table() else {
+            continue;
+        };
+        if table.get("type").and_then(toml::Value::as_str) != Some("expression") {
+            continue;
+        }
+        // A missing `expression` is the generator's `MissingExpression`;
+        // this gate judges content, not presence.
+        let Some(expression) = table.get("expression").and_then(toml::Value::as_str) else {
+            continue;
+        };
+        let context = format!("draft_check `tests[{index}]` expression");
+        rocky_sql::check_expression::validate_check_expression(
+            &context,
+            expression,
+            dialect.as_ref(),
+        )
+        .map_err(|err| {
+            ToolError::invalid_argument(
+                err.to_string(),
+                "An expression check is one boolean expression over the model's own columns \
+                 — comparisons, CASE, CAST, and pure scalar functions such as coalesce, \
+                 length, lower or date_trunc. It may not contain a subquery, a qualified \
+                 function, or a warehouse function that reads files, secrets, session state \
+                 or remote endpoints.",
+            )
+        })?;
     }
     Ok(())
 }

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -2253,6 +2253,49 @@ async fn draft_check_rejects_smuggled_sidecar_config() {
     client.cancel().await.unwrap();
 }
 
+/// #1524: an `expression` check that reaches outside the row is refused at
+/// AUTHORING time, before the sidecar write — not committed and refused
+/// later at `rocky test`. A DuckDB `read_text` sits in scalar position and
+/// passes every structural gate; only the content boundary catches it.
+/// The sidecar must be byte-identical afterwards, and the refusal must
+/// name the function so the agent can act on it.
+#[tokio::test]
+async fn draft_check_rejects_an_unbounded_expression_before_the_write() {
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+
+    let before = std::fs::read_to_string(dir.path().join("models").join("orders.toml")).unwrap();
+    let spec = "[[tests]]\ntype = \"expression\"\n\
+                expression = \"read_text('/etc/passwd') IS NULL\"\n";
+    let args = serde_json::json!({ "model": "orders", "spec": spec })
+        .as_object()
+        .unwrap()
+        .clone();
+    let result = client
+        .call_tool(CallToolRequestParams::new("draft_check").with_arguments(args))
+        .await
+        .expect("draft_check call");
+
+    assert_eq!(
+        result.is_error,
+        Some(true),
+        "an expression calling a read primitive is an error"
+    );
+    let err = result.structured_content.expect("structured envelope");
+    assert_eq!(err["code"], serde_json::json!("invalid_argument"));
+    assert!(
+        err["message"].as_str().unwrap().contains("read_text"),
+        "the refused function is named: {err:?}"
+    );
+
+    let after = std::fs::read_to_string(dir.path().join("models").join("orders.toml")).unwrap();
+    assert_eq!(after, before, "a refused expression writes nothing");
+
+    client.cancel().await.unwrap();
+}
+
 // ---------------------------------------------------------------------------
 // draft_metadata (FF-WP1)
 // ---------------------------------------------------------------------------

--- a/engine/crates/rocky-sql/src/check_expression.rs
+++ b/engine/crates/rocky-sql/src/check_expression.rs
@@ -1,0 +1,502 @@
+//! Content boundary for declarative `expression` checks (#1524).
+//!
+//! An expression check is interpolated verbatim into
+//! `SELECT COUNT(*) FROM <table> WHERE NOT (<expression>)` and executed with
+//! the project's warehouse credentials. Two callers run that statement: a
+//! human at `rocky test --declarative`, and the fulfillment loop, unattended,
+//! after every apply. So the expression's *content* is an execution surface,
+//! and this module is the boundary on what it may be.
+//!
+//! The boundary is an **allowlist**, not a denylist, and the reason is worth
+//! stating because the denylist is the obvious cheaper design. Rejecting
+//! subqueries and table-valued functions misses read primitives that sit in
+//! ordinary scalar position and look like any other call in the AST:
+//!
+//! | dialect    | scalar-position trigger              | reaches           |
+//! |------------|--------------------------------------|-------------------|
+//! | DuckDB     | `read_text('/etc/passwd') IS NULL`   | the filesystem    |
+//! | Snowflake  | `GETVARIABLE('SECRET') IS NULL`      | session variables |
+//! | BigQuery   | `project.ds.remote_fn(col) IS NULL`  | an HTTP endpoint  |
+//! | Databricks | `secret('scope','key') IS NULL`      | the secret store  |
+//! | Trino      | `catalog.schema.udf(col) IS NULL`    | any plugin        |
+//!
+//! The read primitive is not a shape; it is specific names, one per dialect.
+//! Only a named set of pure scalar functions is a boundary.
+//!
+//! What is refused, in order:
+//! 1. anything that does not parse as exactly one expression under the
+//!    target dialect (trailing tokens included — `x) OR 1=1 --` must not
+//!    be able to close the generated `NOT (` and add clauses);
+//! 2. any nested query, wherever it appears;
+//! 3. any qualified function name — that is how UDFs, remote functions and
+//!    plugin functions are reached;
+//! 4. any unqualified function not in [`CHECK_EXPRESSION_FUNCTIONS`].
+//!
+//! Refusal happens when the test SQL is generated, which is before execution
+//! on every path, so a refused check is visible in the deferred/executed
+//! counts the fulfillment loop reports rather than silently dropped. The
+//! same validator runs before the sidecar write in the MCP `draft_check`
+//! tool, so a bad expression is refused when written, not when run.
+
+use std::ops::ControlFlow;
+
+use sqlparser::ast::{Expr, ObjectNamePart, Query, TableFactor, Visit, Visitor};
+use sqlparser::dialect::{
+    BigQueryDialect, DatabricksDialect, Dialect, DuckDbDialect, GenericDialect, SnowflakeDialect,
+};
+use sqlparser::parser::Parser;
+use sqlparser::tokenizer::Token;
+
+use crate::validation::ValidationError;
+
+/// Pure scalar functions an `expression` check may call, lowercase.
+///
+/// Every entry must be a function of its arguments alone: no filesystem,
+/// network, secret store, session variable, or identity read. Non-determinism
+/// on its own is tolerated (`now()`), a read of anything outside the row is
+/// not. Constructs the parser turns into dedicated AST nodes rather than
+/// `Function` — `CAST`, `EXTRACT`, `TRIM`, `SUBSTRING`, `POSITION`, `CEIL`,
+/// `FLOOR`, `CASE` — need no entry here.
+///
+/// Every `expression` check in the tree at the time of writing uses
+/// comparisons only, so this list is a starting point sized to plausible
+/// use, not a survey. A refusal names the function; extending the list is a
+/// one-line change here.
+pub const CHECK_EXPRESSION_FUNCTIONS: &[&str] = &[
+    // null handling / conditionals
+    "coalesce",
+    "nullif",
+    "ifnull",
+    "nvl",
+    "iff",
+    "if",
+    "greatest",
+    "least",
+    // numeric
+    "abs",
+    "sign",
+    "mod",
+    "power",
+    "pow",
+    "sqrt",
+    "round",
+    "trunc",
+    "truncate",
+    "ceiling",
+    "isnan",
+    "isinf",
+    "isfinite",
+    "is_nan",
+    "is_inf",
+    // string
+    "length",
+    "len",
+    "char_length",
+    "character_length",
+    "lower",
+    "upper",
+    "ltrim",
+    "rtrim",
+    "btrim",
+    "concat",
+    "replace",
+    "left",
+    "right",
+    "reverse",
+    "repeat",
+    "lpad",
+    "rpad",
+    "split_part",
+    "strpos",
+    "instr",
+    "starts_with",
+    "startswith",
+    "ends_with",
+    "endswith",
+    "contains",
+    "regexp_matches",
+    "regexp_like",
+    "regexp_contains",
+    "rlike",
+    "regexp_replace",
+    "regexp_extract",
+    // date / time
+    "now",
+    "current_date",
+    "current_timestamp",
+    "current_time",
+    "localtime",
+    "localtimestamp",
+    "date",
+    "datetime",
+    "timestamp",
+    "to_date",
+    "to_timestamp",
+    "year",
+    "month",
+    "day",
+    "hour",
+    "minute",
+    "second",
+    "date_trunc",
+    "date_part",
+    "datediff",
+    "date_diff",
+    "dateadd",
+    "date_add",
+    "date_sub",
+    "epoch",
+    // type
+    "try_cast",
+    "safe_cast",
+    "typeof",
+    // hashing (pure functions of their input)
+    "hash",
+    "md5",
+    "sha256",
+];
+
+/// Niladic session-identity functions that SQL lets you write WITHOUT
+/// parentheses, lowercase.
+///
+/// Under `GenericDialect` sqlparser turns a bare `CURRENT_USER` into an
+/// `Expr::Function` and the allowlist refuses it. Under the warehouse
+/// dialects the same bare keyword falls through to a plain identifier —
+/// indistinguishable from a column named `current_user` — and would pass
+/// as a column reference. These are session-state reads, the class the
+/// allowlist exists to exclude, so an UNQUOTED identifier with one of these
+/// names is refused. A quoted `"current_user"` is unambiguously a column
+/// and passes.
+const SESSION_IDENTITY_KEYWORDS: &[&str] = &[
+    "current_user",
+    "session_user",
+    "user",
+    "current_role",
+    "current_catalog",
+    "current_schema",
+    "current_database",
+    "current_account",
+    "current_warehouse",
+    "current_session",
+];
+
+/// The sqlparser dialect to parse an expression under, from a Rocky
+/// `SqlDialect::name()`.
+///
+/// Trino has no sqlparser dialect; it parses under `GenericDialect`, which
+/// accepts a superset of the syntax the others share. Unknown names take
+/// the same route — parsing under a broader dialect can only *accept* more
+/// syntax, and acceptance still has to clear the walker below.
+pub fn dialect_for(name: &str) -> Box<dyn Dialect> {
+    match name.to_ascii_lowercase().as_str() {
+        "duckdb" => Box::new(DuckDbDialect),
+        "snowflake" => Box::new(SnowflakeDialect),
+        "bigquery" => Box::new(BigQueryDialect),
+        "databricks" => Box::new(DatabricksDialect),
+        _ => Box::new(GenericDialect),
+    }
+}
+
+/// Refuse an `expression` check whose content is not one boolean expression
+/// over the model's own columns calling only allowlisted scalar functions.
+///
+/// `context` names the check for the message (e.g. ``expression test
+/// `expression` on wh.main.orders``).
+///
+/// # Errors
+///
+/// One of the `Expression*` variants of [`ValidationError`], in the order
+/// listed in the module docs.
+pub fn validate_check_expression(
+    context: &str,
+    expression: &str,
+    dialect: &dyn Dialect,
+) -> Result<(), ValidationError> {
+    let unparseable = |detail: String| ValidationError::ExpressionUnparseable {
+        context: context.to_string(),
+        detail,
+    };
+    let mut parser = Parser::new(dialect)
+        .try_with_sql(expression)
+        .map_err(|err| unparseable(err.to_string()))?;
+    let expr = parser
+        .parse_expr()
+        .map_err(|err| unparseable(err.to_string()))?;
+    // `parse_expr` stops at the first token that cannot continue an
+    // expression — a `)` that would close the generated `NOT (`, a comma,
+    // a keyword. Anything left over is the fragment escaping its slot.
+    if parser.peek_token().token != Token::EOF {
+        return Err(ValidationError::ExpressionTrailingTokens {
+            context: context.to_string(),
+        });
+    }
+    let mut walker = Walker { context };
+    match expr.visit(&mut walker) {
+        ControlFlow::Break(err) => Err(err),
+        ControlFlow::Continue(()) => Ok(()),
+    }
+}
+
+/// Walks every node of the parsed expression. `sqlparser`'s visitor
+/// descends into nested expressions, function arguments and subqueries on
+/// its own, so a refusal here does not depend on enumerating `Expr`
+/// variants by hand — a variant this module has never heard of is still
+/// walked, and any `Query` or `Function` inside it is still judged.
+struct Walker<'a> {
+    context: &'a str,
+}
+
+impl Visitor for Walker<'_> {
+    type Break = ValidationError;
+
+    // Any query anywhere: a scalar subquery, `IN (SELECT ..)`, `EXISTS`,
+    // `ANY`/`ALL` — they all carry a `Query` and all reach other tables.
+    fn pre_visit_query(&mut self, _query: &Query) -> ControlFlow<Self::Break> {
+        ControlFlow::Break(ValidationError::ExpressionSubquery {
+            context: self.context.to_string(),
+        })
+    }
+
+    // Defensive: a bare expression has no FROM, so a table factor can only
+    // appear inside a query the arm above already refused. Kept so the
+    // refusal does not depend on visitor ordering.
+    fn pre_visit_table_factor(&mut self, _tf: &TableFactor) -> ControlFlow<Self::Break> {
+        ControlFlow::Break(ValidationError::ExpressionSubquery {
+            context: self.context.to_string(),
+        })
+    }
+
+    fn pre_visit_expr(&mut self, expr: &Expr) -> ControlFlow<Self::Break> {
+        match expr {
+            Expr::Function(function) => {
+                let parts = &function.name.0;
+                let [ObjectNamePart::Identifier(ident)] = parts.as_slice() else {
+                    // Either qualified (`a.b.f`) or a dialect-specific
+                    // identifier-producing part. Both are how UDFs, remote
+                    // functions and plugin functions are reached.
+                    return ControlFlow::Break(ValidationError::ExpressionQualifiedFunction {
+                        context: self.context.to_string(),
+                        function: function.name.to_string(),
+                    });
+                };
+                let name = ident.value.to_ascii_lowercase();
+                if CHECK_EXPRESSION_FUNCTIONS.contains(&name.as_str()) {
+                    ControlFlow::Continue(())
+                } else {
+                    ControlFlow::Break(ValidationError::ExpressionFunctionNotAllowed {
+                        context: self.context.to_string(),
+                        function: ident.value.clone(),
+                    })
+                }
+            }
+            // A lambda is a function body the warehouse executes; the
+            // functions it can call are the same question one level down,
+            // and nothing an expression check needs is expressed as one.
+            Expr::Lambda(_) => ControlFlow::Break(ValidationError::ExpressionFunctionNotAllowed {
+                context: self.context.to_string(),
+                function: "<lambda>".to_string(),
+            }),
+            // A bare, unquoted `current_user` is a session read spelled as
+            // an identifier — see `SESSION_IDENTITY_KEYWORDS`.
+            Expr::Identifier(ident)
+                if ident.quote_style.is_none()
+                    && SESSION_IDENTITY_KEYWORDS
+                        .contains(&ident.value.to_ascii_lowercase().as_str()) =>
+            {
+                ControlFlow::Break(ValidationError::ExpressionFunctionNotAllowed {
+                    context: self.context.to_string(),
+                    function: ident.value.clone(),
+                })
+            }
+            _ => ControlFlow::Continue(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CTX: &str = "expression test `expression` on wh.main.orders";
+
+    fn check(expression: &str) -> Result<(), ValidationError> {
+        validate_check_expression(CTX, expression, &GenericDialect)
+    }
+
+    fn check_on(dialect: &str, expression: &str) -> Result<(), ValidationError> {
+        validate_check_expression(CTX, expression, dialect_for(dialect).as_ref())
+    }
+
+    /// Every `expression` check in the tree at the time of writing, plus the
+    /// ordinary shapes a contract author reaches for. All must pass — a
+    /// boundary that refuses the ordinary case is a bug, not a control.
+    #[test]
+    fn ordinary_predicates_pass() {
+        for expr in [
+            "amount > 0",
+            "amount >= 0",
+            "revenue_eur >= 0",
+            "client_id > 0",
+            "status IN ('open', 'closed')",
+            "email IS NOT NULL",
+            "amount BETWEEN 0 AND 1000",
+            "coalesce(discount, 0) <= amount",
+            "length(trim(name)) > 0",
+            "lower(status) = 'open'",
+            "CASE WHEN qty > 0 THEN price > 0 ELSE TRUE END",
+            "CAST(amount AS DECIMAL(10,2)) >= 0",
+            "created_at <= now()",
+            "date_trunc('day', created_at) IS NOT NULL",
+            "amount > 0 AND NOT (status = 'void' OR status = 'refunded')",
+            "regexp_like(email, '^[^@]+@[^@]+$')",
+        ] {
+            check(expr).unwrap_or_else(|err| panic!("{expr} must pass: {err}"));
+        }
+    }
+
+    /// The read primitives the allowlist exists for, one per dialect. Each
+    /// sits in scalar position and would parse cleanly under a denylist
+    /// that only knew about subqueries and table functions.
+    #[test]
+    fn scalar_position_read_primitives_are_refused_by_name() {
+        let cases = [
+            ("duckdb", "read_text('/etc/passwd') IS NULL", "read_text"),
+            ("snowflake", "GETVARIABLE('SECRET') IS NULL", "GETVARIABLE"),
+            ("databricks", "secret('scope', 'key') IS NULL", "secret"),
+            ("generic", "read_csv('/tmp/x.csv') IS NULL", "read_csv"),
+        ];
+        for (dialect, expr, function) in cases {
+            match check_on(dialect, expr) {
+                Err(ValidationError::ExpressionFunctionNotAllowed { function: f, .. }) => {
+                    assert_eq!(f, function, "{expr} must name the function it refused");
+                }
+                other => panic!("{expr} on {dialect} must be refused by name: {other:?}"),
+            }
+        }
+    }
+
+    /// Session identity is a read of session state and has three spellings
+    /// the parsers disagree on: a bare keyword that `GenericDialect` turns
+    /// into a `Function`, the same bare keyword that the warehouse dialects
+    /// turn into a plain identifier, and the parenthesised call. All three
+    /// are refused; a QUOTED identifier of the same name is a column.
+    #[test]
+    fn session_identity_is_refused_in_every_spelling() {
+        for (dialect, expr) in [
+            ("generic", "current_user = 'admin'"),
+            ("duckdb", "current_user = 'admin'"),
+            ("snowflake", "CURRENT_USER = 'admin'"),
+            ("databricks", "session_user = 'admin'"),
+            ("snowflake", "CURRENT_USER() = 'admin'"),
+            ("generic", "current_user() = 'admin'"),
+        ] {
+            assert!(
+                check_on(dialect, expr).is_err(),
+                "{expr} on {dialect} must be refused: {:?}",
+                check_on(dialect, expr)
+            );
+        }
+        check_on("duckdb", "\"current_user\" = 'admin'")
+            .expect("a quoted identifier is unambiguously a column");
+    }
+
+    /// Qualified names are how BigQuery remote functions and Trino plugin
+    /// functions are reached. Refused regardless of the last segment — a
+    /// qualified `coalesce` is still someone else's `coalesce`.
+    #[test]
+    fn qualified_functions_are_refused() {
+        for expr in [
+            "project.dataset.remote_fn(col) IS NULL",
+            "catalog.schema.udf(col) = 1",
+            "myschema.coalesce(a, b) IS NOT NULL",
+        ] {
+            assert!(
+                matches!(
+                    check(expr),
+                    Err(ValidationError::ExpressionQualifiedFunction { .. })
+                ),
+                "{expr} must be refused as qualified: {:?}",
+                check(expr)
+            );
+        }
+    }
+
+    /// A subquery in any position reads another table.
+    #[test]
+    fn subqueries_are_refused_wherever_they_appear() {
+        for expr in [
+            "amount > (SELECT max(amount) FROM other)",
+            "id IN (SELECT id FROM allowlist)",
+            "EXISTS (SELECT 1 FROM t WHERE t.id = id)",
+            "amount > ANY (SELECT amount FROM t)",
+            "coalesce((SELECT 1), 0) = 1",
+        ] {
+            assert!(
+                matches!(check(expr), Err(ValidationError::ExpressionSubquery { .. })),
+                "{expr} must be refused as a subquery: {:?}",
+                check(expr)
+            );
+        }
+    }
+
+    /// The fragment is spliced as `NOT (<expression>)`. A trailing `)` closes
+    /// that group and the rest becomes new clauses on the generated
+    /// statement. `parse_expr` stops at the `)`; the leftover is the escape.
+    #[test]
+    fn a_fragment_that_escapes_its_slot_is_refused() {
+        for expr in [
+            "amount > 0) OR 1=1 --",
+            "amount > 0, 1",
+            "amount > 0 amount",
+        ] {
+            assert!(
+                matches!(
+                    check(expr),
+                    Err(ValidationError::ExpressionTrailingTokens { .. })
+                        | Err(ValidationError::ExpressionUnparseable { .. })
+                ),
+                "{expr} must not be accepted as one expression: {:?}",
+                check(expr)
+            );
+        }
+    }
+
+    #[test]
+    fn unparseable_text_is_refused_with_the_parser_detail() {
+        match check("amount >") {
+            Err(ValidationError::ExpressionUnparseable { detail, .. }) => {
+                assert!(!detail.is_empty(), "the parser's reason must be carried");
+            }
+            other => panic!("must be unparseable: {other:?}"),
+        }
+    }
+
+    /// Allowlist matching is case-insensitive; SQL function names are.
+    #[test]
+    fn allowlist_is_case_insensitive() {
+        check("COALESCE(a, 0) > 0").expect("upper-case allowlisted function");
+        check("Coalesce(a, 0) > 0").expect("mixed-case allowlisted function");
+    }
+
+    /// Every allowlist entry is lowercase and unique, so a lookup by
+    /// lowercased name cannot miss one that is present.
+    #[test]
+    fn allowlist_is_lowercase_and_deduplicated() {
+        let mut seen = std::collections::BTreeSet::new();
+        for name in CHECK_EXPRESSION_FUNCTIONS {
+            assert_eq!(*name, name.to_ascii_lowercase(), "{name} must be lowercase");
+            assert!(seen.insert(*name), "{name} is listed twice");
+        }
+    }
+
+    /// The dialect mapper never fails: an unknown name parses under
+    /// `GenericDialect`, and the walker still judges the result.
+    #[test]
+    fn unknown_dialect_falls_back_to_generic_and_still_judges() {
+        assert!(check_on("trino", "amount > 0").is_ok());
+        assert!(matches!(
+            check_on("not-a-dialect", "read_text('x') IS NULL"),
+            Err(ValidationError::ExpressionFunctionNotAllowed { .. })
+        ));
+    }
+}

--- a/engine/crates/rocky-sql/src/lib.rs
+++ b/engine/crates/rocky-sql/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod check_expression;
 pub mod consumed_columns;
 pub mod defer;
 pub mod determinism;

--- a/engine/crates/rocky-sql/src/validation.rs
+++ b/engine/crates/rocky-sql/src/validation.rs
@@ -74,6 +74,45 @@ pub enum ValidationError {
         context: String,
         token: &'static str,
     },
+
+    // ---- `expression` check content (#1524) -------------------------------
+    // An expression check is interpolated into `WHERE NOT (<expression>)` and
+    // executed with the project's warehouse credentials. These four refuse
+    // anything that is not one boolean expression over the model's own
+    // columns. See `crate::check_expression`.
+    #[error(
+        "{context}: expression does not parse as a single SQL expression ({detail}). An \
+         expression check is one boolean expression over the model's columns, e.g. \
+         `amount >= 0`"
+    )]
+    ExpressionUnparseable { context: String, detail: String },
+
+    #[error(
+        "{context}: expression continues past the end of one expression. Only a single \
+         boolean expression is accepted — no trailing clauses, commas or operators"
+    )]
+    ExpressionTrailingTokens { context: String },
+
+    #[error(
+        "{context}: expression contains a subquery. An expression check may only read the \
+         row's own columns; it cannot read other tables"
+    )]
+    ExpressionSubquery { context: String },
+
+    #[error(
+        "{context}: expression calls `{function}`, which is not on the allowlist of pure \
+         scalar functions an expression check may use. Warehouse functions can read files, \
+         secrets, session state or remote endpoints, so only a named set is permitted. To \
+         extend it, add the function to `CHECK_EXPRESSION_FUNCTIONS` in rocky-sql"
+    )]
+    ExpressionFunctionNotAllowed { context: String, function: String },
+
+    #[error(
+        "{context}: expression calls the qualified function `{function}`. Qualified names \
+         reach user-defined, remote or plugin functions, which are never allowed in an \
+         expression check"
+    )]
+    ExpressionQualifiedFunction { context: String, function: String },
 }
 
 /// Validates a SQL identifier (catalog, schema, table, column names).


### PR DESCRIPTION
A declarative `expression` check was interpolated verbatim into `WHERE NOT (<expression>)` and run with the project's warehouse credentials — by a human at `rocky test`, and by the fulfillment loop unattended after every apply. This adds the content boundary #1524 asked for.

## What was open

#1595 refused statement terminators at the SQL-fragment seams. Its own comment conceded the rest:

> It does NOT make the fragment one expression: parentheses are not tracked, so the fragment can still close the `NOT (` below and add clauses. Nor does it bound reads — a subquery or a DuckDB `read_csv` still runs with the project's credentials.

## The boundary

Parse under the target dialect; refuse anything that is not **one boolean expression over the row's own columns calling only allowlisted pure scalar functions**:

| refused | why |
|---|---|
| tokens left after one expression | `amount > 0) OR 1=1 --` closes the generated `NOT (` and adds clauses |
| any nested query, anywhere | reads another table |
| any qualified function name | how UDFs, remote and plugin functions are reached |
| any unqualified function off the allowlist | see below |
| an unquoted bare identifier naming a niladic session function | `current_user` — the warehouse dialects parse it as a column |

## Why an allowlist and not the cheaper denylist

Rejecting subqueries and table-valued functions looks sufficient and is not. These sit in **scalar position** and look like any other call in the AST — one per dialect Rocky supports:

| dialect | trigger | reaches |
|---|---|---|
| DuckDB | `read_text('/etc/passwd') IS NULL` | the filesystem |
| Snowflake | `GETVARIABLE('SECRET') IS NULL` | session variables |
| BigQuery | `project.ds.remote_fn(col) IS NULL` | an HTTP endpoint |
| Databricks | `secret('scope','key') IS NULL` | the secret store |
| Trino | `catalog.schema.udf(col) IS NULL` | any plugin |

The read primitive is not a shape; it is specific names. Only a named set is a boundary. Same posture `validation.rs` already takes for identifiers.

Every `expression` check in the tree uses comparisons only, so the list starts small (~80 pure scalar functions). A refusal names the function; extending the list is one line. Constructs the parser turns into dedicated nodes — `CAST`, `EXTRACT`, `TRIM`, `SUBSTRING`, `CASE` — need no entry.

## Two call sites

- **The test SQL generator** (`rocky-core/tests.rs`), under the real dialect. This runs before execution on every path, so a refused check appears in the fulfillment loop's deferred/executed counts rather than vanishing — the property #1495 insisted on.
- **`draft_check`** (`rocky-mcp/tools.rs`), before the sidecar write, so an agent-authored expression is refused when written. Parses under the generic dialect (the MCP server does not resolve the warehouse there); the generation-time check is the backstop, and direct file writers bypass this tool entirely.

## Walker, not a variant list

The walk uses sqlparser's `Visitor` (`pre_visit_query`, `pre_visit_expr`), so a nested `Query` or `Function` is judged wherever it appears — inside `CASE`, inside a function argument, inside an `Expr` variant this module has never heard of. No hand-enumeration of `Expr` to drift.

## What this does NOT bound, and the docs now say so

`filter` and `key_expr` are still passed through verbatim. The docs previously lumped all three together under one warning; they now state that `expression` is bounded and the other two are not.

## Tests

- `rocky-sql`: 10 unit tests — the ordinary predicates all pass (a boundary that refuses the ordinary case is a bug), each refusal class, the per-dialect read primitives refused **by name**, session identity in all three spellings the parsers disagree on, allowlist hygiene.
- `rocky-core`: the boundary is **wired** into the generator — each class surfaces as a `TestGenError`, dialect is threaded, and `coalesce(amount, 0) >= 0` still generates.
- `rocky-mcp` roundtrip: a `read_text` expression is refused by `draft_check` **before the write**, the sidecar is byte-identical after, and the refusal names the function.

Refs #1524
