### PR TITLE
fix(engine/ui): a plan page carries nothing of the previous plan, and the queue names its models

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -17214,7 +17214,7 @@
             "type": "string"
           },
           "models": {
-            "description": "The graph keys this entry stands for — names of compiled models, and only those: the set the ledger row recorded, or its bare `model` when the compiled graph has a model of that name. It is the set `blast_radius` was computed over. **Empty means unknown**, never \"no models\": a subject that is not a compiled model (a replication target is gated by table name; a plan-level row's `model` is a label), a model since removed, a failed compile, or a row from before its producer recorded the set. A consumer that needs a model name takes it from here; `model` is display text and is not to be parsed.",
+            "description": "The graph keys this entry stands for — names of compiled models, and only those: the set the ledger row recorded, or its bare `model` when the compiled graph has a model of that name. It is the set `blast_radius` was computed over and what `rocky audit --for` will match. **Empty means unknown**, never \"no models\": a subject that is not a compiled model (a replication target is gated by table name; a plan-level row's `model` is a label), a model since removed, a failed compile, or a row from before its producer recorded the set. `model` is display text and is not to be parsed.\n\nA key here is for ranking and audit. It is **not** a licence to read rows — `preview_model` is.",
             "items": {
               "type": "string"
             },
@@ -17223,6 +17223,13 @@
           "plan_id": {
             "description": "The plan whose approval clears this escalation.",
             "type": "string"
+          },
+          "preview_model": {
+            "description": "The one model of this entry that `GET /api/v1/models/{name}/rows` would read, decided by that route's own admission rules (a valid name, in the compiled project, not time-interval, no compile errors, a single SELECT), or `null`: the entry names no model or several, or the route would refuse the one it names — a dotted name, a model a restore plan recorded that is gone from the current project, a model that no longer compiles. A consumer offers a sample from this and from nothing else.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "principal": {
             "allOf": [

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -17214,7 +17214,7 @@
             "type": "string"
           },
           "models": {
-            "description": "The graph keys this entry stands for: the model set the ledger row recorded, or the single `model` on an ordinary evaluation row. It is the set `blast_radius` was computed over. **Empty means unknown** — a plan-level row written before the engine kept its set — and never \"no models\". A consumer that needs a model name takes it from here; `model` is display text and is not to be parsed.",
+            "description": "The graph keys this entry stands for — names of compiled models, and only those: the set the ledger row recorded, or its bare `model` when the compiled graph has a model of that name. It is the set `blast_radius` was computed over. **Empty means unknown**, never \"no models\": a subject that is not a compiled model (a replication target is gated by table name; a plan-level row's `model` is a label), a model since removed, a failed compile, or a row from before its producer recorded the set. A consumer that needs a model name takes it from here; `model` is display text and is not to be parsed.",
             "items": {
               "type": "string"
             },

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -17225,7 +17225,7 @@
             "type": "string"
           },
           "preview_model": {
-            "description": "The one model of this entry that `GET /api/v1/models/{name}/rows` would read, decided by that route's own admission rules (a valid name, in the compiled project, not time-interval, no compile errors, a single SELECT), or `null`: the entry names no model or several, or the route would refuse the one it names — a dotted name, a model a restore plan recorded that is gone from the current project, a model that no longer compiles. A consumer offers a sample from this and from nothing else.",
+            "description": "The one model of this entry that `GET /api/v1/models/{name}/rows` would admit, decided by that route's own rules — its front door (the strict config, the adapter registry, one resolvable pipeline with no name given) and its admission of the model (a valid name, in the compiled project, not time-interval, no compile errors, a single SELECT) — or `null`: the entry names no model or several, the route's front door is shut for this project, or the route would refuse the one model it names (a dotted name, a model a restore plan recorded that is gone from the current project, a model that no longer compiles). A consumer offers a sample from this and from nothing else.\n\nWhat this cannot promise is the request itself: the adapter's reachability and credentials at query time, the masking of classified columns, the route's concurrency and time limits. Those refusals arrive as the route's own envelope and render as themselves.",
             "type": [
               "string",
               "null"

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -17210,8 +17210,15 @@
             "type": "string"
           },
           "model": {
-            "description": "The model the escalation is about.",
+            "description": "The model the escalation is about. On a plan-level escalation (`backfill` / `gc` / `restore`) this is a human label — `\"backfill: 3 model(s)\"` — and not a model name; the names are in `models`.",
             "type": "string"
+          },
+          "models": {
+            "description": "The graph keys this entry stands for: the model set the ledger row recorded, or the single `model` on an ordinary evaluation row. It is the set `blast_radius` was computed over. **Empty means unknown** — a plan-level row written before the engine kept its set — and never \"no models\". A consumer that needs a model name takes it from here; `model` is display text and is not to be parsed.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           "plan_id": {
             "description": "The plan whose approval clears this escalation.",
@@ -17259,6 +17266,7 @@
           "classification_weight",
           "decision_ref",
           "model",
+          "models",
           "plan_id",
           "principal",
           "reason",

--- a/editors/vscode/src/types/generated/review_queue.ts
+++ b/editors/vscode/src/types/generated/review_queue.ts
@@ -85,7 +85,7 @@ export interface ReviewQueueEntry {
    */
   model: string;
   /**
-   * The graph keys this entry stands for: the model set the ledger row recorded, or the single `model` on an ordinary evaluation row. It is the set `blast_radius` was computed over. **Empty means unknown** — a plan-level row written before the engine kept its set — and never "no models". A consumer that needs a model name takes it from here; `model` is display text and is not to be parsed.
+   * The graph keys this entry stands for — names of compiled models, and only those: the set the ledger row recorded, or its bare `model` when the compiled graph has a model of that name. It is the set `blast_radius` was computed over. **Empty means unknown**, never "no models": a subject that is not a compiled model (a replication target is gated by table name; a plan-level row's `model` is a label), a model since removed, a failed compile, or a row from before its producer recorded the set. A consumer that needs a model name takes it from here; `model` is display text and is not to be parsed.
    */
   models: string[];
   /**

--- a/editors/vscode/src/types/generated/review_queue.ts
+++ b/editors/vscode/src/types/generated/review_queue.ts
@@ -81,9 +81,13 @@ export interface ReviewQueueEntry {
    */
   decision_ref: string;
   /**
-   * The model the escalation is about.
+   * The model the escalation is about. On a plan-level escalation (`backfill` / `gc` / `restore`) this is a human label — `"backfill: 3 model(s)"` — and not a model name; the names are in `models`.
    */
   model: string;
+  /**
+   * The graph keys this entry stands for: the model set the ledger row recorded, or the single `model` on an ordinary evaluation row. It is the set `blast_radius` was computed over. **Empty means unknown** — a plan-level row written before the engine kept its set — and never "no models". A consumer that needs a model name takes it from here; `model` is display text and is not to be parsed.
+   */
+  models: string[];
   /**
    * The plan whose approval clears this escalation.
    */

--- a/editors/vscode/src/types/generated/review_queue.ts
+++ b/editors/vscode/src/types/generated/review_queue.ts
@@ -85,13 +85,19 @@ export interface ReviewQueueEntry {
    */
   model: string;
   /**
-   * The graph keys this entry stands for — names of compiled models, and only those: the set the ledger row recorded, or its bare `model` when the compiled graph has a model of that name. It is the set `blast_radius` was computed over. **Empty means unknown**, never "no models": a subject that is not a compiled model (a replication target is gated by table name; a plan-level row's `model` is a label), a model since removed, a failed compile, or a row from before its producer recorded the set. A consumer that needs a model name takes it from here; `model` is display text and is not to be parsed.
+   * The graph keys this entry stands for — names of compiled models, and only those: the set the ledger row recorded, or its bare `model` when the compiled graph has a model of that name. It is the set `blast_radius` was computed over and what `rocky audit --for` will match. **Empty means unknown**, never "no models": a subject that is not a compiled model (a replication target is gated by table name; a plan-level row's `model` is a label), a model since removed, a failed compile, or a row from before its producer recorded the set. `model` is display text and is not to be parsed.
+   *
+   * A key here is for ranking and audit. It is **not** a licence to read rows — `preview_model` is.
    */
   models: string[];
   /**
    * The plan whose approval clears this escalation.
    */
   plan_id: string;
+  /**
+   * The one model of this entry that `GET /api/v1/models/{name}/rows` would read, decided by that route's own admission rules (a valid name, in the compiled project, not time-interval, no compile errors, a single SELECT), or `null`: the entry names no model or several, or the route would refuse the one it names — a dotted name, a model a restore plan recorded that is gone from the current project, a model that no longer compiles. A consumer offers a sample from this and from nothing else.
+   */
+  preview_model?: string | null;
   /**
    * Who authored the change (`human` / `agent`).
    */

--- a/editors/vscode/src/types/generated/review_queue.ts
+++ b/editors/vscode/src/types/generated/review_queue.ts
@@ -95,7 +95,9 @@ export interface ReviewQueueEntry {
    */
   plan_id: string;
   /**
-   * The one model of this entry that `GET /api/v1/models/{name}/rows` would read, decided by that route's own admission rules (a valid name, in the compiled project, not time-interval, no compile errors, a single SELECT), or `null`: the entry names no model or several, or the route would refuse the one it names — a dotted name, a model a restore plan recorded that is gone from the current project, a model that no longer compiles. A consumer offers a sample from this and from nothing else.
+   * The one model of this entry that `GET /api/v1/models/{name}/rows` would admit, decided by that route's own rules — its front door (the strict config, the adapter registry, one resolvable pipeline with no name given) and its admission of the model (a valid name, in the compiled project, not time-interval, no compile errors, a single SELECT) — or `null`: the entry names no model or several, the route's front door is shut for this project, or the route would refuse the one model it names (a dotted name, a model a restore plan recorded that is gone from the current project, a model that no longer compiles). A consumer offers a sample from this and from nothing else.
+   *
+   * What this cannot promise is the request itself: the adapter's reachability and credentials at query time, the masking of classified columns, the route's concurrency and time limits. Those refusals arrive as the route's own envelope and render as themselves.
    */
   preview_model?: string | null;
   /**

--- a/engine/crates/rocky-cli/src/api.rs
+++ b/engine/crates/rocky-cli/src/api.rs
@@ -3622,6 +3622,7 @@ mod tests {
             .expect("run recorded");
         store
             .record_policy_decision(&PolicyDecisionRecord {
+                keys_recorded: false,
                 models: Vec::new(),
                 timestamp: now - chrono::Duration::minutes(30),
                 plan_id: "freeze:global".to_string(),
@@ -3937,6 +3938,7 @@ mod tests {
         StateStore::open(&state_path)
             .unwrap()
             .record_policy_decision(&PolicyDecisionRecord {
+                keys_recorded: false,
                 models: Vec::new(),
                 timestamp: chrono::Utc::now() - chrono::Duration::minutes(5),
                 plan_id: "plan-revenue-daily".to_string(),

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -1772,6 +1772,7 @@ fn evaluate_apply_policy_with_policy_matching_dual(
                     principal,
                     touched,
                     attrs,
+                    GateSubjects::CompiledModels,
                     &prior_decisions,
                     marker_freezes,
                     snapshot_unreadable,
@@ -1798,6 +1799,7 @@ fn evaluate_apply_policy_with_policy_matching_dual(
         principal,
         touched,
         eval_attrs,
+        GateSubjects::CompiledModels,
         &prior_decisions,
         marker_freezes,
         snapshot_unreadable,
@@ -1951,6 +1953,7 @@ pub(crate) fn evaluate_apply_policy_with_store(
     models_glob: Option<&str>,
     ledger: &StateStore,
     marker_freezes: &[rocky_core::freeze_marker::ActiveMarkerFreeze],
+    subjects: GateSubjects,
 ) -> PolicyGate {
     // Finding 1: takes the SAME `[policy]` snapshot `run` already holds (its L1212
     // `rocky_cfg`), not a reload — the in-run replication gate must evaluate the
@@ -1973,6 +1976,7 @@ pub(crate) fn evaluate_apply_policy_with_store(
         principal,
         touched,
         &attrs_map,
+        subjects,
         &prior_decisions,
         marker_freezes,
         snapshot_unreadable,
@@ -2027,6 +2031,22 @@ pub(crate) fn resolve_policy_and_attrs(
     Ok((policy.clone(), attrs))
 }
 
+/// What the keys of a gate's `touched` map name. The map holds strings; only
+/// the caller knows whether they are the compiled project's models or a
+/// replication's target tables, and the row the gate records must not call a
+/// target a model. A target that happens to share a compiled model's name
+/// still matches that model's policy attributes (the plane's standing rule),
+/// but it is not that model, and a consumer that read the row's `models` as
+/// a licence to sample would read the wrong thing (#1815).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum GateSubjects {
+    /// Keys are models of the compiled project (apply, promote, gc, restore,
+    /// the MCP propose gate).
+    CompiledModels,
+    /// Keys are replication target table names, gated under bare `apply`.
+    ReplicationTargets,
+}
+
 /// The per-model evaluation loop shared by [`evaluate_apply_policy`] and
 /// [`evaluate_apply_policy_with_store`]. The snapshot and the record sink are
 /// supplied by the caller so the two variants differ only in how they reach the
@@ -2038,6 +2058,7 @@ pub(crate) fn evaluate_apply_policy_core(
     principal: PolicyPrincipal,
     touched: &BTreeMap<String, PolicyCapability>,
     attrs_map: &BTreeMap<String, ModelAttributes>,
+    subjects: GateSubjects,
     prior_decisions: &[PolicyDecisionRecord],
     // The projected durable freeze-marker set, hoisted at the async command
     // entry. OR-ed with the ledger freeze projection inside
@@ -2060,8 +2081,13 @@ pub(crate) fn evaluate_apply_policy_core(
         // Whether the subject is a model of the compiled project. The same
         // field carries a replication target's table name and, on plan-level
         // rows, a label; only a compiled model is a graph key, and only the
-        // producer knows that for certain, so it records it (#1815).
-        let compiled_model = attrs_map.contains_key(model);
+        // producer knows that for certain, so it records it (#1815). Being
+        // in the attribute map is not enough: a target named like a model
+        // is in it too, which is why the caller says what its keys are.
+        let compiled_model = match subjects {
+            GateSubjects::CompiledModels => attrs_map.contains_key(model),
+            GateSubjects::ReplicationTargets => false,
+        };
         let attrs = match attrs_map.get(model) {
             Some(a) => a,
             None => {
@@ -2911,6 +2937,7 @@ impl GovernedRunContext<'_> {
             models_glob.as_deref(),
             ledger,
             marker_freezes,
+            GateSubjects::ReplicationTargets,
         );
         apply_policy_gate(self.root, self.plan_id, gate)?;
 
@@ -7937,6 +7964,59 @@ auto_create_schemas = true
             .expect("a v1 replication-only (no-model) plan must NOT be refused (#1)");
         super::preflight_snapshot(Some(&v2), "p", false)
             .expect("a v2 replication-only (no-model) plan must NOT be refused (#1)");
+        Ok(())
+    }
+
+    /// A replication target that shares a compiled model's NAME is still a
+    /// target. The gate matches it against that model's policy attributes
+    /// (the plane's standing rule, unchanged here), but the row it records
+    /// must not name the model as a graph key: the review queue would offer
+    /// to sample it, and the unrelated compiled model is what would be read
+    /// (#1815, review round two). Restoring `attrs_map.contains_key` as the
+    /// whole test, without the caller's word, makes this fail.
+    #[test]
+    fn a_replication_target_named_like_a_model_records_no_model_key() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        // No rules: the default agent posture is `require_review`.
+        let config = write_config(dir.path(), "")?;
+        let models = dir.path().join("models");
+        std::fs::create_dir_all(&models)?;
+        std::fs::write(models.join("orders.sql"), "SELECT id FROM source.raw.t")?;
+        std::fs::write(
+            models.join("orders.toml"),
+            "name = \"orders\"\n\n[strategy]\ntype = \"full_refresh\"\n\n\
+             [target]\ncatalog = \"c\"\nschema = \"s\"\ntable = \"orders\"\n",
+        )?;
+        let state = dir.path().join("state.redb");
+        let ledger = StateStore::open(&state)?;
+        let ctx = super::GovernedRunContext {
+            principal: PolicyPrincipal::Agent,
+            plan_id: "plan_x",
+            root: dir.path(),
+            config_path: &config,
+            expected_ir_fingerprint: None,
+            expected_config_identity: None,
+            require_fingerprint: false,
+            reviewed_source_schemas: None,
+            expects_models: true,
+            replication_verify_after: Mutex::new(BTreeSet::new()),
+        };
+        let loaded_cfg = rocky_core::config::load_rocky_config(&config)?;
+        let targets: BTreeSet<String> = ["orders".to_string()].into_iter().collect();
+        // The verdict is the plane's business; this test is about the row.
+        let _ = ctx.gate_replication_targets(&targets, &ledger, &loaded_cfg, &[]);
+
+        let rows = ledger.list_policy_decisions()?;
+        let row = rows
+            .iter()
+            .find(|r| r.plan_id == "plan_x" && r.model == "orders")
+            .expect("the target's decision row");
+        assert_eq!(row.effect, rocky_core::config::PolicyEffect::RequireReview);
+        assert!(
+            row.models.is_empty(),
+            "a target is not a model, even one named like a model: {:?}",
+            row.models
+        );
         Ok(())
     }
 

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -505,6 +505,7 @@ async fn run_apply_run_plan(
         models_glob.as_deref(),
         state_path,
         &marker_freezes,
+        GateSubjects::CompiledModels,
     );
     apply_policy_gate(root, plan_id, gate)?;
 
@@ -1578,6 +1579,7 @@ pub fn evaluate_apply_policy_with_policy(
         None,
         state_path,
         marker_freezes,
+        GateSubjects::CompiledModels,
     )
 }
 
@@ -1591,6 +1593,7 @@ pub(crate) fn evaluate_apply_policy_with_policy_matching(
     models_glob: Option<&str>,
     state_path: &Path,
     marker_freezes: &[rocky_core::freeze_marker::ActiveMarkerFreeze],
+    subjects: GateSubjects<'_>,
 ) -> PolicyGate {
     evaluate_apply_policy_with_policy_matching_dual(
         policy,
@@ -1602,6 +1605,7 @@ pub(crate) fn evaluate_apply_policy_with_policy_matching(
         state_path,
         marker_freezes,
         None,
+        subjects,
     )
 }
 
@@ -1674,6 +1678,7 @@ pub fn evaluate_apply_policy_with_extra_classifications(
         state_path,
         marker_freezes,
         Some(prior_classifications),
+        GateSubjects::CompiledModels,
     )
 }
 
@@ -1703,6 +1708,7 @@ fn evaluate_apply_policy_with_policy_matching_dual(
     state_path: &Path,
     marker_freezes: &[rocky_core::freeze_marker::ActiveMarkerFreeze],
     prior_classifications: Option<&BTreeMap<String, Vec<String>>>,
+    subjects: GateSubjects<'_>,
 ) -> PolicyGate {
     let (policy, attrs_map) =
         match resolve_policy_and_attrs(policy, touched, models_dir, models_glob) {
@@ -1772,7 +1778,7 @@ fn evaluate_apply_policy_with_policy_matching_dual(
                     principal,
                     touched,
                     attrs,
-                    GateSubjects::CompiledModels,
+                    subjects,
                     &prior_decisions,
                     marker_freezes,
                     snapshot_unreadable,
@@ -1799,7 +1805,7 @@ fn evaluate_apply_policy_with_policy_matching_dual(
         principal,
         touched,
         eval_attrs,
-        GateSubjects::CompiledModels,
+        subjects,
         &prior_decisions,
         marker_freezes,
         snapshot_unreadable,
@@ -1953,7 +1959,7 @@ pub(crate) fn evaluate_apply_policy_with_store(
     models_glob: Option<&str>,
     ledger: &StateStore,
     marker_freezes: &[rocky_core::freeze_marker::ActiveMarkerFreeze],
-    subjects: GateSubjects,
+    subjects: GateSubjects<'_>,
 ) -> PolicyGate {
     // Finding 1: takes the SAME `[policy]` snapshot `run` already holds (its L1212
     // `rocky_cfg`), not a reload — the in-run replication gate must evaluate the
@@ -2039,12 +2045,21 @@ pub(crate) fn resolve_policy_and_attrs(
 /// but it is not that model, and a consumer that read the row's `models` as
 /// a licence to sample would read the wrong thing (#1815).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum GateSubjects {
-    /// Keys are models of the compiled project (apply, promote, gc, restore,
-    /// the MCP propose gate).
+pub(crate) enum GateSubjects<'a> {
+    /// Every key is a model of the compiled project (run/apply, backfill, gc,
+    /// restore, the MCP propose gate) — or, for maintenance, was resolved to
+    /// one by a resolver that resolves every key matching a model's name, so
+    /// a verbatim key is never also a model name.
     CompiledModels,
     /// Keys are replication target table names, gated under bare `apply`.
     ReplicationTargets,
+    /// Only the keys in this set were resolved to compiled models; any other
+    /// key is a target string the caller kept verbatim because it could not
+    /// be mapped (promote: an FQN the current project no longer targets).
+    /// A verbatim FQN can equal a dotted model's name — `corp.prod.orders`
+    /// is a legal model name — and the attribute map would then hold it, so
+    /// membership there is not enough (#1815, review round four).
+    Resolved(&'a BTreeSet<String>),
 }
 
 /// The per-model evaluation loop shared by [`evaluate_apply_policy`] and
@@ -2058,7 +2073,7 @@ pub(crate) fn evaluate_apply_policy_core(
     principal: PolicyPrincipal,
     touched: &BTreeMap<String, PolicyCapability>,
     attrs_map: &BTreeMap<String, ModelAttributes>,
-    subjects: GateSubjects,
+    subjects: GateSubjects<'_>,
     prior_decisions: &[PolicyDecisionRecord],
     // The projected durable freeze-marker set, hoisted at the async command
     // entry. OR-ed with the ledger freeze projection inside
@@ -2087,6 +2102,9 @@ pub(crate) fn evaluate_apply_policy_core(
         let compiled_model = match subjects {
             GateSubjects::CompiledModels => attrs_map.contains_key(model),
             GateSubjects::ReplicationTargets => false,
+            GateSubjects::Resolved(resolved) => {
+                resolved.contains(model) && attrs_map.contains_key(model)
+            }
         };
         let attrs = match attrs_map.get(model) {
             Some(a) => a,
@@ -2312,7 +2330,7 @@ fn touched_models_for_promote(
     promote: &PromotePlan,
     models_dir: &Path,
     models_glob: Option<&str>,
-) -> BTreeMap<String, PolicyCapability> {
+) -> (BTreeMap<String, PolicyCapability>, BTreeSet<String>) {
     // The full executable target set: every SQL target plus every target a
     // finding named (a finding target may, in principle, not appear in
     // `targets` — union both so nothing escapes).
@@ -2324,18 +2342,29 @@ fn touched_models_for_promote(
         }
     }
     if target_fqns.is_empty() {
-        return BTreeMap::new();
+        return (BTreeMap::new(), BTreeSet::new());
     }
     let target_to_name = compile_target_to_name(models_dir, models_glob);
-    target_fqns
+    // The keys this function RESOLVED to a model, as distinct from the FQNs
+    // it kept verbatim. A verbatim FQN can spell a dotted model's name, and
+    // the gate must not record it as that model's key (#1815, round four).
+    let mut resolved = BTreeSet::new();
+    let touched = target_fqns
         .into_iter()
         .map(|fqn| {
             // Map FQN → logical name so a name-scoped rule matches; fail-closed
             // to the FQN when unmappable rather than dropping the target.
-            let name = target_to_name.get(&fqn).cloned().unwrap_or(fqn);
+            let name = match target_to_name.get(&fqn) {
+                Some(name) => {
+                    resolved.insert(name.clone());
+                    name.clone()
+                }
+                None => fqn,
+            };
             (name, PolicyCapability::Promote)
         })
-        .collect()
+        .collect();
+    (touched, resolved)
 }
 
 /// Canonical, process-stable fingerprint of the **compiled-IR projection** that
@@ -3015,7 +3044,7 @@ pub(crate) fn gate_promote_plan(
     );
     let promote_models_dir = resolve_confined_config_models_dir(config_path, Some(&loaded.config))?;
     let promote_models_glob = resolve_config_models_glob(config_path, Some(&loaded.config));
-    let touched = touched_models_for_promote(
+    let (touched, resolved) = touched_models_for_promote(
         promote_plan,
         &promote_models_dir,
         promote_models_glob.as_deref(),
@@ -3038,6 +3067,7 @@ pub(crate) fn gate_promote_plan(
         promote_models_glob.as_deref(),
         state_path,
         &marker_freezes,
+        GateSubjects::Resolved(&resolved),
     );
     apply_policy_gate(root, plan_id, gate)?;
     Ok(loaded)
@@ -3292,6 +3322,9 @@ pub(crate) async fn gate_maintenance_apply(
         models_glob.as_deref(),
         state_path,
         &marker_freezes,
+        // Every key the maintenance resolver leaves is either a model it
+        // resolved or a string no model is named — see `GateSubjects`.
+        GateSubjects::CompiledModels,
     );
     apply_policy_gate(root, plan_id, gate)
 }
@@ -3622,6 +3655,7 @@ async fn run_apply_ai_authored_plan(
         models_glob.as_deref(),
         state_path,
         &marker_freezes,
+        GateSubjects::CompiledModels,
     );
     // #1459: human review is a FLOOR for an AI-authored plan, not a
     // policy-dependent extra. This used to run only under
@@ -7299,7 +7333,8 @@ effect = "allow"
         };
         // Empty models_dir → nothing compiles; the fail-closed path must still
         // gate the plan's SQL target.
-        let touched = super::touched_models_for_promote(&promote, Path::new("/nonexistent"), None);
+        let (touched, _) =
+            super::touched_models_for_promote(&promote, Path::new("/nonexistent"), None);
         assert_eq!(
             touched.get("cat.prod.orders"),
             Some(&PolicyCapability::Promote),
@@ -7335,7 +7370,8 @@ effect = "allow"
         };
         // No compilable project → target_to_name is empty → the fail-closed
         // path keeps the changed target under its own name.
-        let touched = super::touched_models_for_promote(&promote, Path::new("/nonexistent"), None);
+        let (touched, _) =
+            super::touched_models_for_promote(&promote, Path::new("/nonexistent"), None);
         assert_eq!(
             touched.get("cat.prod.orders"),
             Some(&PolicyCapability::Promote),
@@ -7361,7 +7397,9 @@ effect = "allow"
             created_at: chrono::Utc::now(),
         };
         assert!(
-            super::touched_models_for_promote(&promote, Path::new("/nonexistent"), None).is_empty()
+            super::touched_models_for_promote(&promote, Path::new("/nonexistent"), None)
+                .0
+                .is_empty()
         );
     }
 
@@ -7409,7 +7447,7 @@ effect = "allow"
             plan_audit: vec![],
             created_at: chrono::Utc::now(),
         };
-        let touched = super::touched_models_for_promote(&promote, &models_dir, None);
+        let (touched, _) = super::touched_models_for_promote(&promote, &models_dir, None);
         // Both targets — mapped to their logical names — are gated, even though
         // only `orders` produced a finding.
         assert_eq!(touched.get("orders"), Some(&PolicyCapability::Promote));
@@ -7447,7 +7485,7 @@ effect = "allow"
             plan_audit: vec![],
             created_at: chrono::Utc::now(),
         };
-        let touched = super::touched_models_for_promote(&promote, &models_dir, None);
+        let (touched, resolved) = super::touched_models_for_promote(&promote, &models_dir, None);
         assert!(
             touched.contains_key("orders"),
             "the FQN must map to the logical name 'orders': {touched:?}"
@@ -7456,6 +7494,90 @@ effect = "allow"
             !touched.contains_key("c.s.orders"),
             "the FQN must not remain when it is mappable: {touched:?}"
         );
+        assert!(
+            resolved.contains("orders"),
+            "and the resolver says so: {resolved:?}"
+        );
+    }
+
+    /// A promote target the current project no longer maps is kept verbatim
+    /// (fail-closed, D5) — and a verbatim FQN can spell a dotted model's
+    /// NAME. `corp.prod.orders` is a legal model name, so the attribute map
+    /// holds it and the gate's string test would call the target that model,
+    /// record its key, and let the review screen sample an unrelated model
+    /// beside a promote that overwrites a different table (#1815, review
+    /// round four). The resolver says which keys it resolved; the gate
+    /// records a key for those alone. Passing `CompiledModels` here instead
+    /// of `Resolved` makes this fail.
+    #[test]
+    fn promote_records_no_model_key_for_a_verbatim_target_that_spells_a_model_name()
+    -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let config = write_config(dir.path(), "")?;
+        let models_dir = dir.path().join("models");
+        write_min_model(&models_dir, "orders"); // FQN c.s.orders
+        write_min_model(&models_dir, "corp.prod.orders"); // a dotted NAME
+        let state = dir.path().join("state.redb");
+
+        let promote = crate::output::PromotePlan {
+            branch_name: "fix".to_string(),
+            base_ref: "main".to_string(),
+            head_ref: "abc".to_string(),
+            branch_state_hash: "h".to_string(),
+            approvals_used: vec![],
+            approvals_rejected: vec![],
+            breaking_changes: None,
+            allow_breaking: false,
+            targets: vec![
+                // Mappable: the model `orders` targets it.
+                crate::output::PromoteTargetPlan {
+                    target: "c.s.orders".to_string(),
+                    source: "c.b.orders".to_string(),
+                    statement: "CREATE OR REPLACE ...".to_string(),
+                },
+                // Unmappable: no model targets this FQN any more, but a model
+                // is NAMED this.
+                crate::output::PromoteTargetPlan {
+                    target: "corp.prod.orders".to_string(),
+                    source: "corp.branch.orders".to_string(),
+                    statement: "CREATE OR REPLACE ...".to_string(),
+                },
+            ],
+            plan_audit: vec![],
+            created_at: chrono::Utc::now(),
+        };
+        let (touched, resolved) = super::touched_models_for_promote(&promote, &models_dir, None);
+        assert!(touched.contains_key("orders") && touched.contains_key("corp.prod.orders"));
+        assert!(resolved.contains("orders") && !resolved.contains("corp.prod.orders"));
+
+        let loaded = rocky_core::config::load_rocky_config(&config)?;
+        let _gate = super::evaluate_apply_policy_with_policy_matching(
+            loaded.policy.as_ref(),
+            "plan_p",
+            PolicyPrincipal::Agent,
+            &touched,
+            &models_dir,
+            None,
+            &state,
+            &[],
+            super::GateSubjects::Resolved(&resolved),
+        );
+        let rows = StateStore::open(&state)?.list_policy_decisions()?;
+        let row = |model: &str| {
+            rows.iter()
+                .find(|r| r.plan_id == "plan_p" && r.model == model)
+                .unwrap_or_else(|| panic!("a row for {model}"))
+        };
+        assert_eq!(
+            row("orders").models,
+            vec!["orders".to_string()],
+            "resolved: its key"
+        );
+        assert!(
+            row("corp.prod.orders").models.is_empty(),
+            "verbatim: no key, whatever a model happens to be named"
+        );
+        Ok(())
     }
 
     /// `resolve_config_models_dir` reads the transformation pipeline's `models`

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -3275,7 +3275,22 @@ pub(crate) fn resolve_touched_apply_targets(
             m.config.target.catalog, m.config.target.schema, m.config.target.table
         )
         .to_lowercase();
-        fqn_to_name.insert(fqn, m.config.name.clone());
+        // Two models declaring one physical table is the compiler's E036,
+        // which the maintenance loader (partial, not the compiler) never
+        // sees. Keeping one owner silently let the policy plane evaluate
+        // whichever name sorted last and the ledger record only that one —
+        // a denied co-owner vanished (#1815, review round six). A destructive
+        // apply against a table with two owners refuses.
+        if let Some(other) = fqn_to_name.insert(fqn.clone(), m.config.name.clone())
+            && other != m.config.name
+        {
+            return Err(anyhow::anyhow!(
+                "refusing to gate this apply: models '{other}' and '{}' both declare the target \
+                 table '{fqn}' (compiler E036). A maintenance apply against a table with two \
+                 owners cannot say whose policy governs it; fix the duplicate target first",
+                m.config.name
+            ));
+        }
     }
 
     let mut touched = BTreeMap::new();
@@ -5259,6 +5274,108 @@ mod tests {
                 && msg.contains("name of model 'corp.prod.orders'"),
             "the refusal names both readings: {msg}"
         );
+    }
+
+    /// Two models declaring the same physical table (the compiler's E036,
+    /// invisible to the maintenance loader) used to collapse to whichever
+    /// name sorted last: the policy plane evaluated that one, the ledger
+    /// recorded that one, and a co-owner a rule denied simply vanished
+    /// (#1815, review round six). A destructive apply refuses instead.
+    #[test]
+    fn a_table_with_two_owners_refuses_the_maintenance_gate() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let config_path = root.join("rocky.toml");
+        std::fs::write(
+            &config_path,
+            "[adapter]\ntype = \"duckdb\"\npath = \"p.duckdb\"\n\n\
+             [pipeline.silver]\ntype = \"transformation\"\n\n\
+             [pipeline.silver.target]\nadapter = \"default\"\n",
+        )
+        .unwrap();
+        let models = root.join("models");
+        std::fs::create_dir_all(&models).unwrap();
+        for name in ["pii_orders", "zzz_public"] {
+            std::fs::write(models.join(format!("{name}.sql")), "SELECT 1 AS id\n").unwrap();
+            std::fs::write(
+                models.join(format!("{name}.toml")),
+                format!(
+                    "name = \"{name}\"\n[target]\ncatalog = \"corp\"\nschema = \"prod\"\ntable = \"orders\"\n"
+                ),
+            )
+            .unwrap();
+        }
+        let cfg = rocky_core::config::load_rocky_config(&config_path).unwrap();
+        let err =
+            resolve_touched_apply_targets(&cfg, &config_path, ["corp.prod.orders".to_string()])
+                .expect_err("two owners of one table must refuse, not pick one");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("'pii_orders'") && msg.contains("'zzz_public'") && msg.contains("E036"),
+            "the refusal names both owners: {msg}"
+        );
+    }
+
+    /// The PRODUCTION maintenance gate, end to end: a table its model targets
+    /// records that model's key; a table no model targets is gated under its
+    /// own string and records none. This reaches `gate_maintenance_apply`
+    /// itself — the sibling test below hands `Resolved` to the evaluator by
+    /// hand and so could not tell whether production does (#1815, review
+    /// round six). Passing `CompiledModels` in `gate_maintenance_apply`
+    /// makes the last assertion fail.
+    #[tokio::test]
+    async fn the_maintenance_gate_records_a_key_for_a_model_and_none_for_a_stranger()
+    -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let config_path = write_config(dir.path(), "")?;
+        let models = dir.path().join("models");
+        std::fs::create_dir_all(&models)?;
+        std::fs::write(models.join("orders.sql"), "SELECT 1 AS id\n")?;
+        std::fs::write(
+            models.join("orders.toml"),
+            "name = \"orders\"\n\n[strategy]\ntype = \"full_refresh\"\n\n\
+             [target]\ncatalog = \"corp\"\nschema = \"prod\"\ntable = \"orders\"\n",
+        )?;
+        let cfg = rocky_core::config::load_rocky_config(&config_path)?;
+        let targets = resolve_touched_apply_targets(
+            &cfg,
+            &config_path,
+            ["corp.prod.orders".to_string(), "x.y.z".to_string()],
+        )?;
+        let plan = PersistedPlan {
+            plan_id: "plan_gate".to_string(),
+            kind: PlanKind::Compact,
+            created_at: chrono::Utc::now(),
+            format_version: 2,
+            principal: None,
+            payload: serde_json::json!({}),
+        };
+        let state = dir.path().join("state.redb");
+        // The default agent posture escalates; the verdict is not the point.
+        let _ = gate_maintenance_apply(
+            dir.path(),
+            &plan,
+            "plan_gate",
+            &cfg,
+            &config_path,
+            &state,
+            PolicyPrincipal::Agent,
+            &targets,
+        )
+        .await;
+
+        let rows = StateStore::open(&state)?.list_policy_decisions()?;
+        let row = |model: &str| {
+            rows.iter()
+                .find(|r| r.plan_id == "plan_gate" && r.model == model)
+                .unwrap_or_else(|| panic!("a row for {model}"))
+        };
+        assert_eq!(row("orders").models, vec!["orders".to_string()]);
+        assert!(
+            row("x.y.z").models.is_empty(),
+            "a stranger is no model's key"
+        );
+        Ok(())
     }
 
     /// Without the ambiguity, a table resolves to the model that targets it

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -2057,6 +2057,11 @@ pub(crate) fn evaluate_apply_policy_core(
     let mut worst: Option<PolicyGate> = None;
     for (model, capability) in touched {
         let owned;
+        // Whether the subject is a model of the compiled project. The same
+        // field carries a replication target's table name and, on plan-level
+        // rows, a label; only a compiled model is a graph key, and only the
+        // producer knows that for certain, so it records it (#1815).
+        let compiled_model = attrs_map.contains_key(model);
         let attrs = match attrs_map.get(model) {
             Some(a) => a,
             None => {
@@ -2102,7 +2107,11 @@ pub(crate) fn evaluate_apply_policy_core(
         }
 
         record(&PolicyDecisionRecord {
-            models: Vec::new(),
+            models: if compiled_model {
+                vec![model.clone()]
+            } else {
+                Vec::new()
+            },
             timestamp: now,
             plan_id: plan_id.to_string(),
             principal,

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -2150,6 +2150,9 @@ pub(crate) fn evaluate_apply_policy_core(
         }
 
         record(&PolicyDecisionRecord {
+            // The gate decided this set on purpose: an empty one says "no
+            // compiled model here", and the queue must not re-resolve it.
+            keys_recorded: true,
             models: if compiled_model {
                 vec![model.clone()]
             } else {
@@ -3238,10 +3241,11 @@ pub(crate) fn resolve_touched_apply_targets(
     )?;
     let models_dir = Some(models_dir);
     let models_glob = resolve_config_models_glob(config_path, Some(config));
-    // Physical FQN (lowercased) → logical model name, plus the set of known
-    // logical names, from the project's model sidecars. Best-effort: a load
-    // failure just leaves the maps empty and every target falls through as-is.
-    let mut fqn_to_name: BTreeMap<String, String> = BTreeMap::new();
+    // Physical FQN (lowercased) → the logical models that declare it, plus
+    // the set of known logical names, from the project's model sidecars.
+    // Best-effort: a load failure just leaves the maps empty and every target
+    // falls through as-is.
+    let mut fqn_owners: BTreeMap<String, Vec<String>> = BTreeMap::new();
     let mut names: BTreeSet<String> = BTreeSet::new();
     // Partial, NOT `load_project_models`: this map is a policy input, so losing
     // it wholesale because one unrelated subdirectory is malformed is a
@@ -3270,33 +3274,54 @@ pub(crate) fn resolve_touched_apply_targets(
     }
     for m in &models {
         names.insert(m.config.name.clone());
+        // An ephemeral model is inlined as a CTE and materializes nothing:
+        // its `[target]` is a phantom the compiler excludes from ownership
+        // too (`project.rs`). Indexing it here let a scratch model's policy
+        // govern a real table it never owned (#1815, review round seven).
+        if matches!(
+            m.config.strategy,
+            rocky_core::models::StrategyConfig::Ephemeral
+        ) {
+            continue;
+        }
         let fqn = format!(
             "{}.{}.{}",
             m.config.target.catalog, m.config.target.schema, m.config.target.table
         )
         .to_lowercase();
-        // Two models declaring one physical table is the compiler's E036,
-        // which the maintenance loader (partial, not the compiler) never
-        // sees. Keeping one owner silently let the policy plane evaluate
-        // whichever name sorted last and the ledger record only that one —
-        // a denied co-owner vanished (#1815, review round six). A destructive
-        // apply against a table with two owners refuses.
-        if let Some(other) = fqn_to_name.insert(fqn.clone(), m.config.name.clone())
-            && other != m.config.name
-        {
-            return Err(anyhow::anyhow!(
-                "refusing to gate this apply: models '{other}' and '{}' both declare the target \
-                 table '{fqn}' (compiler E036). A maintenance apply against a table with two \
-                 owners cannot say whose policy governs it; fix the duplicate target first",
-                m.config.name
-            ));
+        let owners = fqn_owners.entry(fqn).or_default();
+        if !owners.contains(&m.config.name) {
+            owners.push(m.config.name.clone());
         }
     }
 
     let mut touched = BTreeMap::new();
     let mut resolved = BTreeSet::new();
     for target in targets {
-        let by_fqn = fqn_to_name.get(&target.to_lowercase()).cloned();
+        let by_fqn = match fqn_owners.get(&target.to_lowercase()).map(Vec::as_slice) {
+            None | Some([]) => None,
+            Some([owner]) => Some(owner.clone()),
+            // Two models declaring one physical table is the compiler's E036,
+            // which the maintenance loader (partial, not the compiler) never
+            // sees. Keeping one owner silently let the policy plane evaluate
+            // whichever name sorted last and the ledger record only that one —
+            // a denied co-owner vanished (#1815, review round six). Refused
+            // only when the plan actually names that table (round seven): a
+            // duplicate elsewhere in the project is the compiler's to report.
+            Some(owners) => {
+                return Err(anyhow::anyhow!(
+                    "refusing to gate this apply: maintenance target '{target}' is declared \
+                     by models {} (compiler E036). A destructive apply against a table with \
+                     two owners cannot say whose policy governs it; fix the duplicate target \
+                     first",
+                    owners
+                        .iter()
+                        .map(|o| format!("'{o}'"))
+                        .collect::<Vec<_>>()
+                        .join(" and ")
+                ));
+            }
+        };
         let by_name = names.contains(&target).then(|| target.clone());
         let name = match (by_fqn, by_name) {
             // A model that targets a table spelled like its own name: one
@@ -3574,6 +3599,7 @@ fn run_verify_after(
     // Best-effort custody entry — the gate below is the safety boundary; the
     // ledger is the trail.
     let record = PolicyDecisionRecord {
+        keys_recorded: false,
         models: Vec::new(),
         timestamp: chrono::Utc::now(),
         plan_id: plan_id.to_string(),
@@ -5314,6 +5340,63 @@ mod tests {
             msg.contains("'pii_orders'") && msg.contains("'zzz_public'") && msg.contains("E036"),
             "the refusal names both owners: {msg}"
         );
+
+        // A plan that never names the duplicated table is not refused for it:
+        // the duplicate elsewhere is the compiler's to report.
+        let targets = resolve_touched_apply_targets(&cfg, &config_path, ["x.y.z".to_string()])
+            .expect("an untouched duplicate is not this plan's problem");
+        assert!(targets.touched.contains_key("x.y.z"));
+    }
+
+    /// An ephemeral model is inlined and materializes nothing; its `[target]`
+    /// is a phantom the compiler excludes from ownership. Indexed as an owner
+    /// here, a scratch model's `allow` rule governed a real table it never
+    /// owned, and beside the real owner it raised a false two-owner refusal
+    /// (#1815, review round seven). Indexing it again makes this fail.
+    #[test]
+    fn an_ephemeral_model_owns_no_table() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let config_path = root.join("rocky.toml");
+        std::fs::write(
+            &config_path,
+            "[adapter]\ntype = \"duckdb\"\npath = \"p.duckdb\"\n\n\
+             [pipeline.silver]\ntype = \"transformation\"\n\n\
+             [pipeline.silver.target]\nadapter = \"default\"\n",
+        )
+        .unwrap();
+        let models = root.join("models");
+        std::fs::create_dir_all(&models).unwrap();
+        std::fs::write(models.join("scratch.sql"), "SELECT 1 AS id\n").unwrap();
+        std::fs::write(
+            models.join("scratch.toml"),
+            "name = \"scratch\"\n[strategy]\ntype = \"ephemeral\"\n[target]\ncatalog = \"corp\"\nschema = \"prod\"\ntable = \"orders\"\n",
+        )
+        .unwrap();
+        let cfg = rocky_core::config::load_rocky_config(&config_path).unwrap();
+
+        // Alone: the table is nobody's, so the target stays verbatim and is
+        // no model's key.
+        let alone =
+            resolve_touched_apply_targets(&cfg, &config_path, ["corp.prod.orders".to_string()])
+                .expect("a phantom target resolves to no owner");
+        assert!(alone.touched.contains_key("corp.prod.orders"), "{alone:?}");
+        assert!(alone.resolved.is_empty(), "{alone:?}");
+
+        // Beside a real owner: that owner, and no two-owner refusal.
+        std::fs::write(models.join("orders.sql"), "SELECT 1 AS id\n").unwrap();
+        std::fs::write(
+            models.join("orders.toml"),
+            "name = \"orders\"\n[target]\ncatalog = \"corp\"\nschema = \"prod\"\ntable = \"orders\"\n",
+        )
+        .unwrap();
+        let owned =
+            resolve_touched_apply_targets(&cfg, &config_path, ["corp.prod.orders".to_string()])
+                .expect("one real owner beside a phantom is one owner");
+        assert!(
+            owned.touched.contains_key("orders") && owned.resolved.contains("orders"),
+            "{owned:?}"
+        );
     }
 
     /// The PRODUCTION maintenance gate, end to end: a table its model targets
@@ -5321,8 +5404,15 @@ mod tests {
     /// own string and records none. This reaches `gate_maintenance_apply`
     /// itself — the sibling test below hands `Resolved` to the evaluator by
     /// hand and so could not tell whether production does (#1815, review
-    /// round six). Passing `CompiledModels` in `gate_maintenance_apply`
-    /// makes the last assertion fail.
+    /// round six).
+    ///
+    /// The stranger is made to spell a model's NAME between resolution and
+    /// the gate: the resolver and the gate's attribute compile read the model
+    /// tree separately, so a model named `x.y.z` added in between is in the
+    /// attribute map but not in the resolved set (round seven). That is the
+    /// case where `Resolved` and `CompiledModels` differ, and passing
+    /// `CompiledModels` in `gate_maintenance_apply` makes the last assertion
+    /// fail.
     #[tokio::test]
     async fn the_maintenance_gate_records_a_key_for_a_model_and_none_for_a_stranger()
     -> anyhow::Result<()> {
@@ -5341,6 +5431,14 @@ mod tests {
             &cfg,
             &config_path,
             ["corp.prod.orders".to_string(), "x.y.z".to_string()],
+        )?;
+        // Between resolution and the gate, a model NAMED like the stranger
+        // appears (targeting elsewhere): the attribute map will hold it.
+        std::fs::write(models.join("x.y.z.sql"), "SELECT 1 AS id\n")?;
+        std::fs::write(
+            models.join("x.y.z.toml"),
+            "name = \"x.y.z\"\n\n[strategy]\ntype = \"full_refresh\"\n\n\
+             [target]\ncatalog = \"c\"\nschema = \"s\"\ntable = \"xyz\"\n",
         )?;
         let plan = PersistedPlan {
             plan_id: "plan_gate".to_string(),
@@ -6266,6 +6364,7 @@ auto_create_schemas = true
         let store = StateStore::open(state_path)?;
         let now = chrono::Utc::now();
         store.record_policy_decision(&PolicyDecisionRecord {
+            keys_recorded: false,
             models: Vec::new(),
             timestamp: now,
             plan_id: format!(

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -2047,18 +2047,17 @@ pub(crate) fn resolve_policy_and_attrs(
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum GateSubjects<'a> {
     /// Every key is a model of the compiled project (run/apply, backfill, gc,
-    /// restore, the MCP propose gate) — or, for maintenance, was resolved to
-    /// one by a resolver that resolves every key matching a model's name, so
-    /// a verbatim key is never also a model name.
+    /// restore, the MCP propose gate).
     CompiledModels,
     /// Keys are replication target table names, gated under bare `apply`.
     ReplicationTargets,
     /// Only the keys in this set were resolved to compiled models; any other
     /// key is a target string the caller kept verbatim because it could not
-    /// be mapped (promote: an FQN the current project no longer targets).
-    /// A verbatim FQN can equal a dotted model's name — `corp.prod.orders`
-    /// is a legal model name — and the attribute map would then hold it, so
-    /// membership there is not enough (#1815, review round four).
+    /// be mapped (promote: an FQN the current project no longer targets;
+    /// maintenance: a table no model targets). A verbatim FQN can equal a
+    /// dotted model's name — `corp.prod.orders` is a legal model name — and
+    /// the attribute map would then hold it, so membership there is not
+    /// enough (#1815, review rounds four and five).
     Resolved(&'a BTreeSet<String>),
 }
 
@@ -3200,11 +3199,25 @@ fn compile_target_to_name(
 /// Compact plans always carry a concrete `target_table`; the archive
 /// targetless (`None`, `DELETE FROM *`) case is refused by the caller before
 /// this is reached, so every identifier here is a concrete string.
+///
+/// **Which reading wins, and when neither may.** A target string is looked
+/// up as a physical FQN first — the plan's SQL mutates exactly that table, so
+/// the model whose target it is, is the model touched — and as a logical
+/// name second (`--model X`). A string that is BOTH the target table of one
+/// model and the name of another is refused: the plan cannot say which it
+/// meant, a dotted model name can spell an FQN, and this apply is
+/// destructive. The names-first order that stood before resolved a catalog
+/// FQN to the wrong model whenever a model happened to be named like it
+/// (#1815, review round five).
+///
+/// The returned [`TouchedTargets`] says which keys were resolved to a model,
+/// so the gate records a graph key for those alone; a verbatim key is a
+/// policy subject, not a model.
 pub(crate) fn resolve_touched_apply_targets(
     config: &rocky_core::config::RockyConfig,
     config_path: &Path,
     targets: impl IntoIterator<Item = String>,
-) -> Result<BTreeMap<String, PolicyCapability>> {
+) -> Result<TouchedTargets> {
     // Fail CLOSED. This map is a POLICY input for `rocky compact` / `rocky
     // archive` — both destructive. Degrading an unconfinable models glob to
     // "no models" would leave every target unresolved, and this function's own
@@ -3266,17 +3279,45 @@ pub(crate) fn resolve_touched_apply_targets(
     }
 
     let mut touched = BTreeMap::new();
+    let mut resolved = BTreeSet::new();
     for target in targets {
-        let name = if names.contains(&target) {
-            target
-        } else if let Some(name) = fqn_to_name.get(&target.to_lowercase()) {
-            name.clone()
-        } else {
-            target
+        let by_fqn = fqn_to_name.get(&target.to_lowercase()).cloned();
+        let by_name = names.contains(&target).then(|| target.clone());
+        let name = match (by_fqn, by_name) {
+            // A model that targets a table spelled like its own name: one
+            // model either way.
+            (Some(fqn_owner), Some(named)) if fqn_owner == named => fqn_owner,
+            (Some(fqn_owner), Some(named)) => {
+                return Err(anyhow::anyhow!(
+                    "refusing to gate this apply: maintenance target '{target}' is both the \
+                     target table of model '{fqn_owner}' and the name of model '{named}'. \
+                     The plan cannot say which it means and this apply is destructive; \
+                     rename one of them, or re-plan with the form that names only one"
+                ));
+            }
+            (Some(fqn_owner), None) => fqn_owner,
+            (None, Some(named)) => named,
+            (None, None) => {
+                // Neither a known table nor a known name: kept verbatim so a
+                // blanket rule still gates it, but it is no model's key.
+                touched.insert(target, PolicyCapability::Apply);
+                continue;
+            }
         };
+        resolved.insert(name.clone());
         touched.insert(name, PolicyCapability::Apply);
     }
-    Ok(touched)
+    Ok(TouchedTargets { touched, resolved })
+}
+
+/// A maintenance plan's policy subjects, and which of them the resolver
+/// could vouch for as compiled models. See [`resolve_touched_apply_targets`].
+#[derive(Debug, Default)]
+pub(crate) struct TouchedTargets {
+    /// Every subject, keyed for the policy plane (`Apply`).
+    pub(crate) touched: BTreeMap<String, PolicyCapability>,
+    /// The subjects that are models of the compiled project.
+    pub(crate) resolved: BTreeSet<String>,
 }
 
 /// Gate a maintenance apply (`compact` / `archive`) under
@@ -3302,8 +3343,9 @@ pub(crate) async fn gate_maintenance_apply(
     config_path: &Path,
     state_path: &Path,
     runtime_principal: PolicyPrincipal,
-    touched: &BTreeMap<String, PolicyCapability>,
+    targets: &TouchedTargets,
 ) -> Result<()> {
+    let touched = &targets.touched;
     let models_dir = resolve_confined_config_models_dir(config_path, Some(config))?;
     let models_glob = resolve_config_models_glob(config_path, Some(config));
     // Pull the authoritative remote freeze/budget ledger before the gate reads
@@ -3322,9 +3364,9 @@ pub(crate) async fn gate_maintenance_apply(
         models_glob.as_deref(),
         state_path,
         &marker_freezes,
-        // Every key the maintenance resolver leaves is either a model it
-        // resolved or a string no model is named — see `GateSubjects`.
-        GateSubjects::CompiledModels,
+        // The resolver says which subjects are models; a verbatim table is
+        // gated but records no model's key.
+        GateSubjects::Resolved(&targets.resolved),
     );
     apply_policy_gate(root, plan_id, gate)
 }
@@ -5095,7 +5137,10 @@ mod tests {
             principal: None,
             payload: serde_json::json!({}),
         };
-        let touched = BTreeMap::from([("orders".to_string(), PolicyCapability::Apply)]);
+        let touched = TouchedTargets {
+            touched: BTreeMap::from([("orders".to_string(), PolicyCapability::Apply)]),
+            resolved: BTreeSet::from(["orders".to_string()]),
+        };
 
         let error = gate_maintenance_apply(
             &project,
@@ -5158,10 +5203,116 @@ mod tests {
                 .expect("a confinable models glob must resolve targets, not refuse");
 
         assert!(
-            touched.contains_key("payments"),
+            touched.touched.contains_key("payments"),
             "the physical FQN must map to the logical model name so an \
              attribute-scoped policy rule still fires; got {touched:?}"
         );
+        assert!(
+            touched.resolved.contains("payments"),
+            "and it is a model: {touched:?}"
+        );
+    }
+
+    /// The names-first order resolved a catalog FQN to the WRONG model when
+    /// another model happened to be named like it: `rocky compact --catalog
+    /// corp` discovers `corp.prod.orders` — model B's table — and a model A
+    /// named `corp.prod.orders` (a legal dotted name) won the lookup, so the
+    /// gate evaluated A, recorded A's key, and the review screen offered A's
+    /// rows beside a plan that compacts B's table (#1815, review round five).
+    /// The plan cannot say which it meant; a destructive apply refuses.
+    #[test]
+    fn an_ambiguous_maintenance_target_refuses_rather_than_picking_a_model() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let config_path = root.join("rocky.toml");
+        std::fs::write(
+            &config_path,
+            "[adapter]\ntype = \"duckdb\"\npath = \"p.duckdb\"\n\n\
+             [pipeline.silver]\ntype = \"transformation\"\n\n\
+             [pipeline.silver.target]\nadapter = \"default\"\n",
+        )
+        .unwrap();
+        let models = root.join("models");
+        std::fs::create_dir_all(&models).unwrap();
+        // Model A: NAMED corp.prod.orders, targeting somewhere else.
+        std::fs::write(models.join("corp.prod.orders.sql"), "SELECT 1 AS id\n").unwrap();
+        std::fs::write(
+            models.join("corp.prod.orders.toml"),
+            "name = \"corp.prod.orders\"\n[target]\ncatalog = \"warehouse\"\nschema = \"gold\"\ntable = \"shadow_orders\"\n",
+        )
+        .unwrap();
+        // Model B: named orders, TARGETING corp.prod.orders.
+        std::fs::write(models.join("orders.sql"), "SELECT 1 AS id\n").unwrap();
+        std::fs::write(
+            models.join("orders.toml"),
+            "name = \"orders\"\n[target]\ncatalog = \"corp\"\nschema = \"prod\"\ntable = \"orders\"\n",
+        )
+        .unwrap();
+
+        let cfg = rocky_core::config::load_rocky_config(&config_path).unwrap();
+        let err =
+            resolve_touched_apply_targets(&cfg, &config_path, ["corp.prod.orders".to_string()])
+                .expect_err("a string that is one model's table and another's name must refuse");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("target table of model 'orders'")
+                && msg.contains("name of model 'corp.prod.orders'"),
+            "the refusal names both readings: {msg}"
+        );
+    }
+
+    /// Without the ambiguity, a table resolves to the model that targets it
+    /// (the FQN reading first), and a table no model targets is gated under
+    /// its own string but records no model's key — the gate is told which
+    /// keys the resolver vouched for. Passing `CompiledModels` for
+    /// maintenance makes the last assertion fail.
+    #[test]
+    fn a_maintenance_table_resolves_to_its_model_and_a_stranger_records_no_key()
+    -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let config_path = write_config(dir.path(), "")?;
+        let models = dir.path().join("models");
+        std::fs::create_dir_all(&models)?;
+        std::fs::write(models.join("orders.sql"), "SELECT 1 AS id\n")?;
+        std::fs::write(
+            models.join("orders.toml"),
+            "name = \"orders\"\n\n[strategy]\ntype = \"full_refresh\"\n\n\
+             [target]\ncatalog = \"corp\"\nschema = \"prod\"\ntable = \"orders\"\n",
+        )?;
+        let cfg = rocky_core::config::load_rocky_config(&config_path)?;
+        let targets = resolve_touched_apply_targets(
+            &cfg,
+            &config_path,
+            ["corp.prod.orders".to_string(), "x.y.z".to_string()],
+        )?;
+        assert!(targets.touched.contains_key("orders"), "{targets:?}");
+        assert!(targets.touched.contains_key("x.y.z"), "{targets:?}");
+        assert!(targets.resolved.contains("orders") && !targets.resolved.contains("x.y.z"));
+
+        let state = dir.path().join("state.redb");
+        let _gate = super::evaluate_apply_policy_with_policy_matching(
+            cfg.policy.as_ref(),
+            "plan_m",
+            PolicyPrincipal::Agent,
+            &targets.touched,
+            &models,
+            None,
+            &state,
+            &[],
+            super::GateSubjects::Resolved(&targets.resolved),
+        );
+        let rows = StateStore::open(&state)?.list_policy_decisions()?;
+        let row = |model: &str| {
+            rows.iter()
+                .find(|r| r.plan_id == "plan_m" && r.model == model)
+                .unwrap_or_else(|| panic!("a row for {model}"))
+        };
+        assert_eq!(row("orders").models, vec!["orders".to_string()]);
+        assert!(
+            row("x.y.z").models.is_empty(),
+            "a stranger is no model's key"
+        );
+        Ok(())
     }
 
     /// A models glob that cannot be confined to the project root REFUSES the

--- a/engine/crates/rocky-cli/src/commands/audit.rs
+++ b/engine/crates/rocky-cli/src/commands/audit.rs
@@ -1344,6 +1344,7 @@ mod tests {
         effect: PolicyEffect,
     ) -> PolicyDecisionRecord {
         PolicyDecisionRecord {
+            keys_recorded: false,
             models: Vec::new(),
             timestamp: Utc.with_ymd_and_hms(2026, 7, 7, 0, 0, secs).unwrap(),
             plan_id: plan_id.to_string(),
@@ -1388,6 +1389,7 @@ mod tests {
 
         let label = "backfill: 2 model(s)";
         let plan_level = PolicyDecisionRecord {
+            keys_recorded: false,
             models: vec!["dim_customer".to_string(), "fct_orders".to_string()],
             timestamp: Utc::now(),
             plan_id: "planBF".to_string(),
@@ -1441,6 +1443,7 @@ mod tests {
         use rocky_core::config::{PolicyCapability, PolicyEffect, PolicyPrincipal};
 
         let decisions = vec![PolicyDecisionRecord {
+            keys_recorded: false,
             models: Vec::new(),
             timestamp: Utc::now(),
             plan_id: "planA".to_string(),
@@ -1481,6 +1484,7 @@ mod tests {
         let state_path = root.join("state.redb");
 
         let plan_level = |plan_id: &str, models: Vec<&str>, label: &str| PolicyDecisionRecord {
+            keys_recorded: false,
             models: models.into_iter().map(str::to_string).collect(),
             timestamp: Utc.with_ymd_and_hms(2026, 9, 8, 0, 0, 1).unwrap(),
             plan_id: plan_id.to_string(),
@@ -1769,6 +1773,7 @@ mod tests {
         reason: &str,
     ) -> PolicyDecisionRecord {
         PolicyDecisionRecord {
+            keys_recorded: false,
             models: Vec::new(),
             timestamp: Utc.with_ymd_and_hms(2026, 7, 7, 0, 0, secs).unwrap(),
             plan_id: plan_id.to_string(),
@@ -1929,6 +1934,7 @@ mod tests {
         effect: PolicyEffect,
     ) -> PolicyDecisionRecord {
         PolicyDecisionRecord {
+            keys_recorded: false,
             models: Vec::new(),
             timestamp: Utc.with_ymd_and_hms(2026, 7, 7, 0, 0, secs).unwrap(),
             plan_id: plan_id.to_string(),

--- a/engine/crates/rocky-cli/src/commands/audit.rs
+++ b/engine/crates/rocky-cli/src/commands/audit.rs
@@ -793,10 +793,17 @@ pub(crate) fn blast_radius_of(
 /// re-open the ranking collapse this exists to fix. Here the question is how
 /// much the plan's change reaches, and a model rebuilt because another member
 /// changed is part of that reach.
+///
+/// **No subjects, no answer.** An empty set of names unions to an empty set,
+/// which would report as a measured zero for a row that named nothing — the
+/// same partial-count-as-measurement the all-or-nothing rule refuses. A row
+/// that resolves to no keys (a pre-v28 plan-level escalation) is unknown.
 pub(crate) fn blast_radius_union<'a>(
     result: &compile::CompileResult,
     models: impl IntoIterator<Item = &'a str>,
 ) -> Option<BTreeSet<String>> {
+    let mut models = models.into_iter().peekable();
+    models.peek()?;
     let mut union: BTreeSet<String> = BTreeSet::new();
     for model in models {
         let (_, transitive) = blast_radius_of(result, model)?;

--- a/engine/crates/rocky-cli/src/commands/brief.rs
+++ b/engine/crates/rocky-cli/src/commands/brief.rs
@@ -1721,6 +1721,7 @@ mod tests {
         rule_id: Option<usize>,
     ) -> PolicyDecisionRecord {
         PolicyDecisionRecord {
+            keys_recorded: false,
             models: Vec::new(),
             timestamp: ts(h),
             plan_id: format!("plan-{model}-{h}"),

--- a/engine/crates/rocky-cli/src/commands/drift_governance.rs
+++ b/engine/crates/rocky-cli/src/commands/drift_governance.rs
@@ -321,6 +321,7 @@ impl DriftGovernor {
         }
 
         let record = PolicyDecisionRecord {
+            keys_recorded: false,
             models: Vec::new(),
             timestamp: chrono::Utc::now(),
             plan_id: decision_plan_id(&self.run_id),
@@ -544,6 +545,7 @@ pub(crate) fn finalize_drift_verify_after(
         // carrying `rule_id` is exactly the pair
         // `budget_failures_in_window` counts against the granting rule.
         let record = PolicyDecisionRecord {
+            keys_recorded: false,
             models: Vec::new(),
             timestamp: chrono::Utc::now(),
             plan_id: decision_plan.clone(),
@@ -795,6 +797,7 @@ mod tests {
     /// attached. Written by `govern` under `autoapply:<run_id>`.
     fn applied_decision(run_id: &str, model: &str) -> PolicyDecisionRecord {
         PolicyDecisionRecord {
+            keys_recorded: false,
             models: Vec::new(),
             timestamp: chrono::Utc::now(),
             plan_id: decision_plan_id(run_id),
@@ -1043,6 +1046,7 @@ mod tests {
             PolicyPrincipal::Human => "human",
         };
         PolicyDecisionRecord {
+            keys_recorded: false,
             models: Vec::new(),
             timestamp: now,
             plan_id: format!("{}{label}:{}", policy::FREEZE_PLAN_PREFIX, now.to_rfc3339()),
@@ -1145,6 +1149,7 @@ mod tests {
             .unwrap();
         store
             .record_policy_decision(&PolicyDecisionRecord {
+                keys_recorded: false,
                 models: Vec::new(),
                 timestamp: chrono::Utc::now(),
                 plan_id: decision_plan_id("run-b1"),

--- a/engine/crates/rocky-cli/src/commands/gc.rs
+++ b/engine/crates/rocky-cli/src/commands/gc.rs
@@ -4443,6 +4443,7 @@ auto_create_schemas = true
         // A ledger-only freeze row for THIS principal → deny. This is the
         // marker-blind bypass the review caught: no marker exists at all.
         let freeze = rocky_core::state::PolicyDecisionRecord {
+            keys_recorded: false,
             models: Vec::new(),
             timestamp: Utc::now(),
             plan_id: "freeze:unit".to_string(),
@@ -4569,6 +4570,7 @@ auto_create_schemas = true
                         let store = StateStore::open(&self.path).unwrap();
                         store
                             .record_policy_decision(&rocky_core::state::PolicyDecisionRecord {
+                                keys_recorded: false,
                                 models: Vec::new(),
                                 timestamp: Utc::now(),
                                 plan_id: "freeze:mid-seam".to_string(),

--- a/engine/crates/rocky-cli/src/commands/gc.rs
+++ b/engine/crates/rocky-cli/src/commands/gc.rs
@@ -1772,6 +1772,7 @@ pub(crate) async fn run_gc_apply_in_with(
         models_glob.as_deref(),
         state_path,
         &marker_freezes,
+        crate::commands::apply::GateSubjects::CompiledModels,
     );
     if let PolicyGate::Deny {
         model,

--- a/engine/crates/rocky-cli/src/commands/gc.rs
+++ b/engine/crates/rocky-cli/src/commands/gc.rs
@@ -1580,6 +1580,7 @@ async fn gc_seam_regate(
         principal,
         touched,
         &attrs_map,
+        crate::commands::apply::GateSubjects::CompiledModels,
         prior_decisions,
         &fresh_markers,
         false,

--- a/engine/crates/rocky-cli/src/commands/policy.rs
+++ b/engine/crates/rocky-cli/src/commands/policy.rs
@@ -594,6 +594,7 @@ pub fn run_policy_freeze(
             });
         }
         let record = PolicyDecisionRecord {
+            keys_recorded: false,
             models: Vec::new(),
             timestamp: now,
             plan_id: plan_id.clone(),
@@ -1418,6 +1419,7 @@ max_retries = 0
         let _serial = rocky_core::state_sync::remote_testing::serial_guard();
         let harness = CrossPodHarness::new_s3_like();
         let winner = PolicyDecisionRecord {
+            keys_recorded: false,
             models: Vec::new(),
             timestamp: chrono::Utc::now(),
             plan_id: "existing-run-winner".to_string(),

--- a/engine/crates/rocky-cli/src/commands/preview_rows.rs
+++ b/engine/crates/rocky-cli/src/commands/preview_rows.rs
@@ -175,65 +175,11 @@ pub async fn compute_preview_rows(
     let result = compile::compile(&compiler_cfg)
         .map_err(|e| fail("compile_error", &format!("compile failed: {e}"), None))?;
 
-    let Some(m) = result
-        .project
-        .models
-        .iter()
-        .find(|m| m.config.name == model)
-    else {
-        return Err(fail(
-            "model_not_found",
-            &format!("model '{model}' not found in pipeline"),
-            None,
-        ));
-    };
-
-    // Guards.
-    if matches!(m.config.strategy, StrategyConfig::TimeInterval { .. }) {
-        return Err(fail(
-            "unsupported_model_kind",
-            &format!(
-                "model '{model}' is a time-interval model; preview rows can't resolve partition placeholders"
-            ),
-            None,
-        ));
-    }
-    let model_has_errors = m.sql.trim().is_empty()
-        || result
-            .diagnostics
-            .iter()
-            .any(|d| d.model == model && d.severity == Severity::Error);
-    if model_has_errors {
-        return Err(fail(
-            "compile_error",
-            &format!("model '{model}' has compile errors; fix them before previewing"),
-            None,
-        ));
-    }
-
-    // Expand Rocky macros (model.sql may contain unexpanded macro calls).
-    let macros_dir = models_dir.join("../macros");
-    let macro_defs = if macros_dir.is_dir() {
-        rocky_core::macros::load_macros_from_dir(&macros_dir)
-            .map_err(|e| fail("compile_error", &format!("macro load failed: {e}"), None))?
-    } else {
-        Vec::new()
-    };
-    let expanded = rocky_core::macros::expand_macros(&m.sql, &macro_defs).map_err(|e| {
-        fail(
-            "compile_error",
-            &format!("macro expansion failed: {e}"),
-            None,
-        )
-    })?;
-
-    if !rocky_sql::parser::is_single_select(&expanded) {
-        return Err(fail(
-            "unsupported_model_kind",
-            &format!("model '{model}' did not compile to a single SELECT statement"),
-            None,
-        ));
-    }
+    let Admitted {
+        model: m,
+        expanded,
+        macro_defs,
+    } = admit_model(&result, models_dir, model)?;
 
     // Resolve which output columns must be masked (workspace-default env).
     let masks = rocky_cfg.resolve_mask_for_env(None);
@@ -554,6 +500,103 @@ impl PreviewFailure {
 
 /// Build a [`PreviewFailure`]. Prints nothing: the caller decides how to
 /// render it.
+/// A model the preview route has admitted, with what the route needs next.
+pub(crate) struct Admitted<'a> {
+    pub(crate) model: &'a rocky_core::models::Model,
+    /// The model's SQL with Rocky macros expanded.
+    pub(crate) expanded: String,
+    /// The macro set, kept for an ad-hoc selection that references macros.
+    pub(crate) macro_defs: Vec<rocky_core::macros::MacroDef>,
+}
+
+/// The route's admission rules for a model, in one place: a valid name, a
+/// model of the compiled project, not time-interval, free of compile errors,
+/// and a single SELECT once macros are expanded. Every refusal is the same
+/// envelope the route returns.
+///
+/// One derivation, on purpose. The review queue asks this before it offers a
+/// sample (`ReviewQueueEntry::preview_model`), so what the queue says the
+/// route would read is exactly what the route reads. A consumer that decided
+/// from a name alone got it wrong both ways — a dotted model name the route
+/// refuses, a target that is no model (#1815).
+pub(crate) fn admit_model<'a>(
+    result: &'a compile::CompileResult,
+    models_dir: &Path,
+    model: &str,
+) -> std::result::Result<Admitted<'a>, PreviewFailure> {
+    rocky_sql::validation::validate_identifier(model).map_err(|_| {
+        fail(
+            "invalid_model_name",
+            &format!("invalid model name '{model}'"),
+            None,
+        )
+    })?;
+    let Some(m) = result
+        .project
+        .models
+        .iter()
+        .find(|m| m.config.name == model)
+    else {
+        return Err(fail(
+            "model_not_found",
+            &format!("model '{model}' not found in pipeline"),
+            None,
+        ));
+    };
+
+    // Guards.
+    if matches!(m.config.strategy, StrategyConfig::TimeInterval { .. }) {
+        return Err(fail(
+            "unsupported_model_kind",
+            &format!(
+                "model '{model}' is a time-interval model; preview rows can't resolve partition placeholders"
+            ),
+            None,
+        ));
+    }
+    let model_has_errors = m.sql.trim().is_empty()
+        || result
+            .diagnostics
+            .iter()
+            .any(|d| d.model == model && d.severity == Severity::Error);
+    if model_has_errors {
+        return Err(fail(
+            "compile_error",
+            &format!("model '{model}' has compile errors; fix them before previewing"),
+            None,
+        ));
+    }
+
+    // Expand Rocky macros (model.sql may contain unexpanded macro calls).
+    let macros_dir = models_dir.join("../macros");
+    let macro_defs = if macros_dir.is_dir() {
+        rocky_core::macros::load_macros_from_dir(&macros_dir)
+            .map_err(|e| fail("compile_error", &format!("macro load failed: {e}"), None))?
+    } else {
+        Vec::new()
+    };
+    let expanded = rocky_core::macros::expand_macros(&m.sql, &macro_defs).map_err(|e| {
+        fail(
+            "compile_error",
+            &format!("macro expansion failed: {e}"),
+            None,
+        )
+    })?;
+
+    if !rocky_sql::parser::is_single_select(&expanded) {
+        return Err(fail(
+            "unsupported_model_kind",
+            &format!("model '{model}' did not compile to a single SELECT statement"),
+            None,
+        ));
+    }
+    Ok(Admitted {
+        model: m,
+        expanded,
+        macro_defs,
+    })
+}
+
 fn fail(kind: &str, message: &str, extra: Option<serde_json::Value>) -> PreviewFailure {
     PreviewFailure {
         kind: kind.to_string(),

--- a/engine/crates/rocky-cli/src/commands/restore.rs
+++ b/engine/crates/rocky-cli/src/commands/restore.rs
@@ -998,6 +998,7 @@ pub(crate) async fn run_restore_apply_in_with(
         models_glob.as_deref(),
         state_path,
         &marker_freezes,
+        crate::commands::apply::GateSubjects::CompiledModels,
     );
     if let PolicyGate::Deny {
         model,

--- a/engine/crates/rocky-cli/src/commands/review.rs
+++ b/engine/crates/rocky-cli/src/commands/review.rs
@@ -859,6 +859,18 @@ fn build_queue(
             // so what a consumer is told the row stands for is exactly what
             // the blast radius was computed over.
             let models = queue_graph_keys(d, compiled.as_ref());
+            // What the samples route would read for this row, decided by the
+            // route's own admission (`preview_rows::admit_model`) and not by
+            // any consumer's reading of a name. `models` ranks and audits;
+            // only this licenses an offer to read (#1815).
+            let preview_model = match (models.as_slice(), compiled.as_ref()) {
+                ([only], Some(result)) => {
+                    crate::commands::preview_rows::admit_model(result, models_dir, only)
+                        .ok()
+                        .map(|_| only.clone())
+                }
+                _ => None,
+            };
             // Deduplicated union, all-or-nothing: an absent member makes the
             // whole answer unknown rather than a partial count dressed as a
             // measurement, and no members at all is unknown too. See
@@ -879,6 +891,7 @@ fn build_queue(
                 capability: d.capability,
                 model: d.model.clone(),
                 models,
+                preview_model,
                 rule_id: d.rule_id,
                 reason: d.reason.clone(),
                 blast_radius,
@@ -927,10 +940,7 @@ pub(crate) fn select_outstanding<'a>(
     plan_exists: impl Fn(&str) -> bool,
 ) -> (Vec<&'a PolicyDecisionRecord>, u64) {
     let mut latest: BTreeMap<(&str, &str), &PolicyDecisionRecord> = BTreeMap::new();
-    for d in decisions
-        .into_iter()
-        .filter(|d| d.effect == PolicyEffect::RequireReview)
-    {
+    for d in decisions {
         latest
             .entry((d.plan_id.as_str(), d.model.as_str()))
             .and_modify(|cur| {
@@ -943,6 +953,13 @@ pub(crate) fn select_outstanding<'a>(
     let mut excluded_non_plan: u64 = 0;
     let outstanding = latest
         .into_values()
+        // The LATEST decision per key decides, whatever its effect. A
+        // `require_review` that a later `allow` or `deny` for the same
+        // (plan, model) superseded is history: approving it is moot under
+        // the `allow` and cannot make apply succeed under the `deny`.
+        // Filtering to `require_review` BEFORE picking the latest kept such
+        // rows approvable (#1815, review round two).
+        .filter(|d| d.effect == PolicyEffect::RequireReview)
         .filter(|d| !is_reviewed(&d.plan_id))
         .filter(|d| {
             if plan_exists(&d.plan_id) {
@@ -1472,6 +1489,71 @@ mod tests {
         assert_eq!(d.model, "x");
         // The newest of the two planA/x rows wins (the breaking one at secs=9).
         assert_eq!(d.capability, PolicyCapability::SchemaChangeBreaking);
+    }
+
+    /// The latest decision per (plan, model) decides. A `require_review`
+    /// followed by an `allow` (policy loosened, plan re-run) is moot; one
+    /// followed by a `deny` cannot be made to succeed by approval. Both used
+    /// to stay in the queue, because the effect filter ran before the
+    /// latest-row pick. The reverse orders still queue: the newest row is the
+    /// escalation.
+    #[test]
+    fn a_later_allow_or_deny_supersedes_an_older_require_review() {
+        let decisions = vec![
+            qd(
+                1,
+                "planA",
+                "x",
+                PolicyEffect::RequireReview,
+                PolicyCapability::Apply,
+            ),
+            qd(
+                5,
+                "planA",
+                "x",
+                PolicyEffect::Allow,
+                PolicyCapability::Apply,
+            ),
+            qd(
+                1,
+                "planB",
+                "y",
+                PolicyEffect::RequireReview,
+                PolicyCapability::Apply,
+            ),
+            qd(5, "planB", "y", PolicyEffect::Deny, PolicyCapability::Apply),
+            qd(
+                1,
+                "planC",
+                "z",
+                PolicyEffect::Allow,
+                PolicyCapability::Apply,
+            ),
+            qd(
+                5,
+                "planC",
+                "z",
+                PolicyEffect::RequireReview,
+                PolicyCapability::Apply,
+            ),
+            qd(1, "planD", "w", PolicyEffect::Deny, PolicyCapability::Apply),
+            qd(
+                5,
+                "planD",
+                "w",
+                PolicyEffect::RequireReview,
+                PolicyCapability::Apply,
+            ),
+        ];
+        let (out, excluded) = select_outstanding(&decisions, |_| false, |_| true);
+        assert_eq!(excluded, 0);
+        let mut plans: Vec<&str> = out.iter().map(|d| d.plan_id.as_str()).collect();
+        plans.sort_unstable();
+        assert_eq!(
+            plans,
+            vec!["planC", "planD"],
+            "superseded escalations are history; new ones queue"
+        );
     }
 
     /// FIX: decision-only custody rows (`draft:*`, `autoapply:*`, …) whose
@@ -2421,6 +2503,77 @@ mod tests {
             bf.blast_radius,
             Some(1),
             "ranked on the set, not on the label"
+        );
+
+        // A graph key is not a licence to read: the samples route refuses a
+        // dotted name, so the queue offers none — while `a` is readable, a
+        // target is not a model, and two models are not one to read.
+        assert_eq!(ordinary.preview_model.as_deref(), Some("a"));
+        assert_eq!(dotted.preview_model, None);
+        assert_eq!(replication.preview_model, None);
+        assert_eq!(bf.preview_model, None);
+    }
+
+    /// `preview_model` follows the samples route's own admission, not the
+    /// graph's: a model a restore plan recorded that is gone from the current
+    /// project, and a model that no longer compiles, are graph keys the route
+    /// would refuse, so no offer is made. Deciding from `models` alone makes
+    /// this fail.
+    #[test]
+    fn the_entry_offers_a_read_only_where_the_samples_route_would_answer() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let models_dir = root.join("models");
+        write_blast_graph(&models_dir);
+        // A model whose SQL does not parse: in the project, with an error.
+        std::fs::write(models_dir.join("shaky.sql"), "SELECT FROM WHERE").unwrap();
+        std::fs::write(
+            models_dir.join("shaky.toml"),
+            "name = \"shaky\"\n\n[strategy]\ntype = \"full_refresh\"\n\n\
+             [target]\ncatalog = \"c\"\nschema = \"s\"\ntable = \"shaky\"\n",
+        )
+        .unwrap();
+        let state_path = root.join("state.redb");
+
+        // A restore plan's recorded set names a tombstoned model the current
+        // project no longer has.
+        touch_plan_file(root, "restore_gone");
+        record_plan_review_escalation(
+            &state_path,
+            "restore_gone",
+            PolicyPrincipal::Human,
+            PolicyCapability::Restore,
+            "restore: gone (abc123…)",
+            vec!["gone".to_string()],
+            "restore plan awaits review",
+        );
+        touch_plan_file(root, "shaky_plan");
+        {
+            let store = StateStore::open(&state_path).unwrap();
+            store
+                .record_policy_decision(&qd(
+                    1,
+                    "shaky_plan",
+                    "shaky",
+                    PolicyEffect::RequireReview,
+                    PolicyCapability::Apply,
+                ))
+                .unwrap();
+        }
+
+        let out = compute_review_queue(root, &root.join("rocky.toml"), &state_path, &models_dir)
+            .expect("a model that fails to parse degrades the ranking, it does not refuse");
+        let by_plan = |plan: &str| out.pending.iter().find(|e| e.plan_id == plan).unwrap();
+        assert_eq!(by_plan("restore_gone").models, vec!["gone".to_string()]);
+        assert_eq!(
+            by_plan("restore_gone").preview_model,
+            None,
+            "not in the current project"
+        );
+        assert_eq!(
+            by_plan("shaky_plan").preview_model,
+            None,
+            "the route refuses compile errors"
         );
     }
 

--- a/engine/crates/rocky-cli/src/commands/review.rs
+++ b/engine/crates/rocky-cli/src/commands/review.rs
@@ -1014,11 +1014,18 @@ pub(crate) fn select_outstanding<'a>(
 /// a compile that failed, or a row from before its producer recorded the set.
 /// `graph_keys` is deliberately not used here: it also yields the label, on
 /// purpose, so `audit --for` can match it.
+///
+/// **The producer's word stands.** A row whose producer recorded its set
+/// (`keys_recorded`) is taken as written, an empty set included: the gate
+/// wrote "no compiled model" for a replication target, and resolving its
+/// bare name against the graph anyway turned a target called `orders` into
+/// the compiled model `orders` and offered its rows (#1815, review round
+/// seven). Only a row that never said — pre-v29 — is resolved by the graph.
 fn queue_graph_keys(
     d: &PolicyDecisionRecord,
     compiled: Option<&rocky_compiler::compile::CompileResult>,
 ) -> Vec<String> {
-    if !d.models.is_empty() {
+    if !d.models.is_empty() || d.keys_recorded {
         return d.models.clone();
     }
     let in_graph = compiled.is_some_and(|r| r.semantic_graph.model_schema(&d.model).is_some());
@@ -1061,6 +1068,8 @@ pub(crate) fn record_plan_review_escalation(
     reason: &str,
 ) {
     let record = PolicyDecisionRecord {
+        // The plan-level writer names its set on purpose.
+        keys_recorded: true,
         models,
         timestamp: Utc::now(),
         plan_id: plan_id.to_string(),
@@ -1415,6 +1424,7 @@ mod tests {
         cap: PolicyCapability,
     ) -> PolicyDecisionRecord {
         PolicyDecisionRecord {
+            keys_recorded: false,
             models: Vec::new(),
             timestamp: Utc.with_ymd_and_hms(2026, 7, 7, 0, 0, secs).unwrap(),
             plan_id: plan_id.to_string(),
@@ -2776,6 +2786,87 @@ mod tests {
         assert_eq!(entry("a").blast_radius, Some(3));
         assert!(entry("raw_orders").models.is_empty());
         assert_eq!(entry("raw_orders").blast_radius, None);
+    }
+
+    /// **The queue must not undo the gate's word.** A replication target
+    /// called `orders`, gated beside a compiled model also called `orders`:
+    /// the gate records `keys_recorded` with an empty set — "this is no
+    /// model" — and the queue used to resolve the bare name against the graph
+    /// anyway, hand over the compiled model as the key, and offer its rows
+    /// (#1815, review round seven). Dropping the `keys_recorded` check makes
+    /// this fail.
+    #[test]
+    fn the_queue_keeps_a_gates_no_model_word_even_when_a_model_shares_the_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let models_dir = root.join("models");
+        write_blast_graph(&models_dir);
+        // A compiled model that happens to share the target's name.
+        std::fs::write(models_dir.join("orders.sql"), "SELECT id FROM a").unwrap();
+        std::fs::write(
+            models_dir.join("orders.toml"),
+            "name = \"orders\"\n\n[strategy]\ntype = \"full_refresh\"\n\n\
+             [target]\ncatalog = \"c\"\nschema = \"s\"\ntable = \"orders\"\n",
+        )
+        .unwrap();
+        let state_path = root.join("state.redb");
+        let config_path = root.join("rocky.toml");
+        std::fs::write(
+            &config_path,
+            "[adapter]\ntype = \"duckdb\"\npath = \"x.duckdb\"\n\n\
+             [pipeline.p]\ntype = \"transformation\"\nmodels = \"models/**\"\n\n\
+             [pipeline.p.target.governance]\nauto_create_schemas = true\n\n\
+             [policy]\nversion = 1\ndefault_agent_effect = \"require_review\"\n",
+        )
+        .unwrap();
+        touch_plan_file(root, "repl");
+        let cfg = rocky_core::config::load_rocky_config(&config_path).unwrap();
+        {
+            // The real replication gate path, through the held-store evaluator.
+            let ledger = StateStore::open(&state_path).unwrap();
+            let touched: BTreeMap<String, PolicyCapability> =
+                [("orders".to_string(), PolicyCapability::Apply)]
+                    .into_iter()
+                    .collect();
+            let _ = crate::commands::apply::evaluate_apply_policy_with_store(
+                cfg.policy.as_ref(),
+                "repl",
+                PolicyPrincipal::Agent,
+                &touched,
+                &models_dir,
+                None,
+                &ledger,
+                &[],
+                crate::commands::apply::GateSubjects::ReplicationTargets,
+            );
+            let rows = ledger.list_policy_decisions().unwrap();
+            let row = rows
+                .iter()
+                .find(|r| r.plan_id == "repl")
+                .expect("the target's row");
+            assert!(
+                row.keys_recorded && row.models.is_empty(),
+                "the gate's word: no model"
+            );
+        }
+
+        let out = compute_review_queue(root, &config_path, &state_path, &models_dir)
+            .expect("the queue must rank");
+        let entry = out
+            .pending
+            .iter()
+            .find(|e| e.plan_id == "repl")
+            .expect("listed");
+        assert!(
+            entry.models.is_empty(),
+            "the queue keeps the gate's word: {:?}",
+            entry.models
+        );
+        assert_eq!(
+            entry.preview_model, None,
+            "and offers no read of the same-named model"
+        );
+        assert_eq!(entry.blast_radius, None);
     }
 
     /// When the compile fails, a bare `model` cannot be checked against any

--- a/engine/crates/rocky-cli/src/commands/review.rs
+++ b/engine/crates/rocky-cli/src/commands/review.rs
@@ -858,7 +858,7 @@ fn build_queue(
             // One derivation serves both the ranking and the entry's `models`,
             // so what a consumer is told the row stands for is exactly what
             // the blast radius was computed over.
-            let models = queue_graph_keys(d);
+            let models = queue_graph_keys(d, compiled.as_ref());
             // Deduplicated union, all-or-nothing: an absent member makes the
             // whole answer unknown rather than a partial count dressed as a
             // measurement, and no members at all is unknown too. See
@@ -959,26 +959,31 @@ pub(crate) fn select_outstanding<'a>(
 /// The graph keys a queue row stands for — what the ranking resolves and what
 /// the entry reports as `models`, from one derivation so the two cannot drift.
 ///
-/// The recorded set when there is one. Otherwise `model`, when it could be a
-/// graph key at all: a model name is admitted by
-/// `rocky_sql::validation::validate_identifier`, and a value that rule
-/// refuses can be in no graph. That is the case of a plan-level row written
-/// before the engine kept its set (pre-v28): its `model` is a label —
-/// `"backfill: 3 model(s)"` — and handing a label over as if it were a name
-/// is how the UI came to parse it (#1815). So the answer there is *no keys* —
-/// unknown — not the label dressed as a key.
+/// The recorded set when there is one: producers write it when they know
+/// their subject is a compiled model (the apply-time gate, since #1815) or
+/// which models a plan-level escalation covers (#1766). Otherwise the row's
+/// bare `model` is a key only if the compiled graph has it. Nothing about the
+/// string itself can say: the same field holds a compiled model's name, a
+/// replication target's table name (gated under bare `apply`, never a model)
+/// and, on a pre-v28 plan-level row, a label — and a model name may carry a
+/// dot (`v2.fct_orders`), so an identifier check fails both ways. Two rules
+/// were tried and rejected on the record: the capability (the gate records
+/// ordinary rows with the plan's capability) and identifier syntax (admits a
+/// replication target, rejects a dotted name).
 ///
-/// The capability is NOT the discriminator, and was tried: the apply-time
-/// gate records one ordinary row per touched model with the plan's own
-/// capability (`gc` over `orders`), and those rows carry a real name in
-/// `model` and no set. Only the name's shape tells the two apart, and every
-/// label the engine has ever written (`backfill: …`, `gc: …`, `restore: …`)
-/// fails it. `graph_keys` is deliberately not used here: it also yields the
-/// label, on purpose, so `audit --for` can match it.
-fn queue_graph_keys(d: &PolicyDecisionRecord) -> Vec<String> {
+/// No keys means unknown: a subject no graph can name, a model since removed,
+/// a compile that failed, or a row from before its producer recorded the set.
+/// `graph_keys` is deliberately not used here: it also yields the label, on
+/// purpose, so `audit --for` can match it.
+fn queue_graph_keys(
+    d: &PolicyDecisionRecord,
+    compiled: Option<&rocky_compiler::compile::CompileResult>,
+) -> Vec<String> {
     if !d.models.is_empty() {
-        d.models.clone()
-    } else if rocky_sql::validation::validate_identifier(&d.model).is_ok() {
+        return d.models.clone();
+    }
+    let in_graph = compiled.is_some_and(|r| r.semantic_graph.model_schema(&d.model).is_some());
+    if in_graph {
         vec![d.model.clone()]
     } else {
         Vec::new()
@@ -1109,7 +1114,7 @@ fn render_queue_text(out: &ReviewQueueOutput) {
         // in `models`, and the JSON carries them, so the text does too.
         if e.models.as_slice() != std::slice::from_ref(&e.model) {
             let listed = if e.models.is_empty() {
-                "unknown (the row was recorded before the engine kept the set)".to_string()
+                "none the compiled graph can name".to_string()
             } else {
                 e.models.join(", ")
             };
@@ -2275,8 +2280,10 @@ mod tests {
     /// could sample it, which accepted `"backfill_3_models"` as a name and
     /// would have sampled a real model of that name (#1815). Restoring the
     /// label as the ordinary row's key, dropping the set from a plan-level
-    /// row, or deciding by capability instead of by the name's shape, makes
-    /// this fail.
+    /// row, or deciding by capability or by identifier syntax instead of by
+    /// the compiled graph, makes this fail: the dotted model below is a real
+    /// graph key an identifier check rejects, and the replication target is
+    /// an identifier no graph has.
     #[test]
     fn the_entry_reports_the_graph_keys_the_ranking_resolved() {
         let tmp = tempfile::tempdir().unwrap();
@@ -2296,6 +2303,46 @@ mod tests {
                     "a",
                     PolicyEffect::RequireReview,
                     PolicyCapability::SchemaChangeBreaking,
+                ))
+                .unwrap();
+        }
+        // A model whose name carries a dot. Rocky loads it as a model, the
+        // graph indexes it by that exact string, and an identifier check
+        // rejects it — so the graph, not the syntax, must decide.
+        std::fs::write(models_dir.join("v2.fct_orders.sql"), "SELECT id FROM a").unwrap();
+        std::fs::write(
+            models_dir.join("v2.fct_orders.toml"),
+            "name = \"v2.fct_orders\"\n\n[strategy]\ntype = \"full_refresh\"\n\n\
+             [target]\ncatalog = \"c\"\nschema = \"s\"\ntable = \"fct_orders\"\n",
+        )
+        .unwrap();
+        touch_plan_file(root, "dotted");
+        {
+            let store = StateStore::open(&state_path).unwrap();
+            store
+                .record_policy_decision(&qd(
+                    4,
+                    "dotted",
+                    "v2.fct_orders",
+                    PolicyEffect::RequireReview,
+                    PolicyCapability::Apply,
+                ))
+                .unwrap();
+        }
+        // A replication target: gated under bare `apply` by TABLE name, which
+        // is an identifier and is not a model. It must not be handed over as
+        // one — the UI would offer to sample it, and a compiled model that
+        // happened to share the name would be what got sampled.
+        touch_plan_file(root, "replication");
+        {
+            let store = StateStore::open(&state_path).unwrap();
+            store
+                .record_policy_decision(&qd(
+                    3,
+                    "replication",
+                    "raw_orders",
+                    PolicyEffect::RequireReview,
+                    PolicyCapability::Apply,
                 ))
                 .unwrap();
         }
@@ -2339,7 +2386,8 @@ mod tests {
         let ordinary = by_plan("ordinary");
         assert_eq!(ordinary.model, "a");
         assert_eq!(ordinary.models, vec!["a".to_string()]);
-        assert_eq!(ordinary.blast_radius, Some(3), "ranked on `a`, the one key");
+        // b, c, d and the dotted model below all sit downstream of `a`.
+        assert_eq!(ordinary.blast_radius, Some(4), "ranked on `a`, the one key");
 
         let gc_applied = by_plan("gc_applied");
         assert_eq!(gc_applied.models, vec!["b".to_string()]);
@@ -2348,6 +2396,21 @@ mod tests {
             Some(1),
             "a gc row over a real name ranks on it"
         );
+
+        let dotted = by_plan("dotted");
+        assert_eq!(dotted.models, vec!["v2.fct_orders".to_string()]);
+        assert_eq!(
+            dotted.blast_radius,
+            Some(0),
+            "a leaf the graph has: a measured zero"
+        );
+
+        let replication = by_plan("replication");
+        assert!(
+            replication.models.is_empty(),
+            "a replication target is not a model, whatever its name looks like"
+        );
+        assert_eq!(replication.blast_radius, None);
 
         let bf = by_plan("bf");
         assert_eq!(bf.model, "backfill_2_models", "the label is untouched");
@@ -2366,6 +2429,160 @@ mod tests {
     /// The queue reaches this through a pre-v28 plan-level row, and the test
     /// above pins the queue's answer; this one pins the function's, so the
     /// guard cannot quietly move to one caller.
+    /// **The producer binds the contract.** This drives the real apply-time
+    /// gate, not a hand-built row: with a policy that escalates every agent
+    /// apply, a touched set holding a compiled model and a replication-target
+    /// name records two rows under ONE plan. The compiled model's row carries
+    /// its own key; the target's carries none, because the gate could not
+    /// name a model for it. The queue then reports exactly that, and lists
+    /// both rows — one per (plan, model), never one per plan.
+    ///
+    /// Restoring `models: Vec::new()` in the gate's record makes the first
+    /// assertion fail; making the queue accept any identifier makes the
+    /// target's assertion fail.
+    #[test]
+    fn the_apply_gate_records_a_compiled_models_key_and_no_key_for_a_target() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let models_dir = root.join("models");
+        write_blast_graph(&models_dir);
+        let state_path = root.join("state.redb");
+        let config_path = root.join("rocky.toml");
+        std::fs::write(
+            &config_path,
+            "[adapter]\ntype = \"duckdb\"\npath = \"x.duckdb\"\n\n\
+             [pipeline.p]\ntype = \"transformation\"\nmodels = \"models/**\"\n\n\
+             [pipeline.p.target.governance]\nauto_create_schemas = true\n\n\
+             [policy]\nversion = 1\ndefault_agent_effect = \"require_review\"\n",
+        )
+        .unwrap();
+
+        touch_plan_file(root, "plan_e2e");
+        let touched: BTreeMap<String, PolicyCapability> = [
+            ("a".to_string(), PolicyCapability::Apply),
+            ("raw_orders".to_string(), PolicyCapability::Apply),
+        ]
+        .into_iter()
+        .collect();
+        let gate = crate::commands::apply::evaluate_apply_policy(
+            &config_path,
+            "plan_e2e",
+            PolicyPrincipal::Agent,
+            &touched,
+            &models_dir,
+            &state_path,
+            &[],
+        );
+        assert!(
+            matches!(
+                gate,
+                crate::commands::apply::PolicyGate::RequireReview { .. }
+            ),
+            "the default posture escalates: {gate:?}"
+        );
+
+        // What the gate wrote.
+        let rows = StateStore::open(&state_path)
+            .unwrap()
+            .list_policy_decisions()
+            .unwrap();
+        let row = |model: &str| {
+            rows.iter()
+                .find(|r| r.plan_id == "plan_e2e" && r.model == model)
+                .unwrap_or_else(|| panic!("a row for {model}"))
+        };
+        assert_eq!(
+            row("a").models,
+            vec!["a".to_string()],
+            "a compiled model records its key"
+        );
+        assert!(
+            row("raw_orders").models.is_empty(),
+            "a target is not a model"
+        );
+
+        // What the queue says about it.
+        let out = compute_review_queue(root, &config_path, &state_path, &models_dir)
+            .expect("the queue must rank");
+        let entries: Vec<_> = out
+            .pending
+            .iter()
+            .filter(|e| e.plan_id == "plan_e2e")
+            .collect();
+        assert_eq!(entries.len(), 2, "one row per (plan, model), both listed");
+        let entry = |model: &str| entries.iter().find(|e| e.model == model).unwrap();
+        assert_eq!(entry("a").models, vec!["a".to_string()]);
+        assert_eq!(entry("a").blast_radius, Some(3));
+        assert!(entry("raw_orders").models.is_empty());
+        assert_eq!(entry("raw_orders").blast_radius, None);
+    }
+
+    /// When the compile fails, a bare `model` cannot be checked against any
+    /// graph, so it is unknown — but a set the producer recorded stands,
+    /// because the producer knew. The ranking is unchanged either way (every
+    /// radius is already unknown under a failed compile); what this pins is
+    /// that the entry does not invent a key it cannot vouch for, and does not
+    /// drop one it was given.
+    #[test]
+    fn a_failed_compile_keeps_recorded_keys_and_vouches_for_no_bare_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let models_dir = root.join("models");
+        write_blast_graph(&models_dir);
+        // A model that does not parse breaks the compile.
+        std::fs::write(models_dir.join("broken.sql"), "SELECT FROM WHERE").unwrap();
+        std::fs::write(
+            models_dir.join("broken.toml"),
+            "name = \"broken\"\n\n[strategy]\ntype = \"full_refresh\"\n\n\
+             [target]\ncatalog = \"c\"\nschema = \"s\"\ntable = \"broken\"\n",
+        )
+        .unwrap();
+        let state_path = root.join("state.redb");
+
+        touch_plan_file(root, "bare");
+        {
+            let store = StateStore::open(&state_path).unwrap();
+            store
+                .record_policy_decision(&qd(
+                    1,
+                    "bare",
+                    "a",
+                    PolicyEffect::RequireReview,
+                    PolicyCapability::Apply,
+                ))
+                .unwrap();
+        }
+        touch_plan_file(root, "recorded");
+        record_plan_review_escalation(
+            &state_path,
+            "recorded",
+            PolicyPrincipal::Agent,
+            PolicyCapability::Backfill,
+            "backfill: 2 model(s)",
+            vec!["a".to_string(), "b".to_string()],
+            "backfill plan awaits review",
+        );
+
+        let out = compute_review_queue(root, &root.join("rocky.toml"), &state_path, &models_dir)
+            .expect("a failed compile degrades the ranking, it does not refuse the queue");
+        let by_plan = |plan: &str| out.pending.iter().find(|e| e.plan_id == plan).unwrap();
+        assert!(
+            by_plan("bare").models.is_empty(),
+            "no graph to check the bare name against"
+        );
+        assert_eq!(
+            by_plan("recorded").models,
+            vec!["a".to_string(), "b".to_string()]
+        );
+        for e in &out.pending {
+            assert_eq!(
+                e.blast_radius, None,
+                "{}: nothing resolves without a compile",
+                e.plan_id
+            );
+        }
+    }
+
     #[test]
     fn a_union_over_no_subjects_is_unknown_not_zero() {
         let tmp = tempfile::tempdir().unwrap();

--- a/engine/crates/rocky-cli/src/commands/review.rs
+++ b/engine/crates/rocky-cli/src/commands/review.rs
@@ -855,24 +855,18 @@ fn build_queue(
     let mut entries: Vec<ReviewQueueEntry> = outstanding
         .into_iter()
         .map(|d| {
-            // The keys that must RESOLVE are the recorded model set — or, on
-            // an ordinary row that has none, the single `model`, which is the
-            // graph key there. `graph_keys` is deliberately not used for this:
-            // it also yields the human label so `audit --for` can match it, and
-            // a label resolves in no graph, so requiring it to resolve would
-            // make every plan-level row unknown forever.
-            let radius_keys: Vec<&str> = if d.models.is_empty() {
-                vec![d.model.as_str()]
-            } else {
-                d.models.iter().map(String::as_str).collect()
-            };
+            // One derivation serves both the ranking and the entry's `models`,
+            // so what a consumer is told the row stands for is exactly what
+            // the blast radius was computed over.
+            let models = queue_graph_keys(d);
             // Deduplicated union, all-or-nothing: an absent member makes the
             // whole answer unknown rather than a partial count dressed as a
-            // measurement. See `blast_radius_union` for why union and not
-            // `max`, and why the plan's own models stay in.
+            // measurement, and no members at all is unknown too. See
+            // `blast_radius_union` for why union and not `max`, and why the
+            // plan's own models stay in.
             let blast_radius = compiled
                 .as_ref()
-                .and_then(|r| blast_radius_union(r, radius_keys.iter().copied()))
+                .and_then(|r| blast_radius_union(r, models.iter().map(String::as_str)))
                 .map(|reached| reached.len() as u64);
             let classification_weight = classification_weight(d.capability);
             let staleness_seconds = (now - d.timestamp).num_seconds().max(0);
@@ -884,6 +878,7 @@ fn build_queue(
                 principal: d.principal,
                 capability: d.capability,
                 model: d.model.clone(),
+                models,
                 rule_id: d.rule_id,
                 reason: d.reason.clone(),
                 blast_radius,
@@ -959,6 +954,35 @@ pub(crate) fn select_outstanding<'a>(
         })
         .collect();
     (outstanding, excluded_non_plan)
+}
+
+/// The graph keys a queue row stands for — what the ranking resolves and what
+/// the entry reports as `models`, from one derivation so the two cannot drift.
+///
+/// The recorded set when there is one. Otherwise `model`, when it could be a
+/// graph key at all: a model name is admitted by
+/// `rocky_sql::validation::validate_identifier`, and a value that rule
+/// refuses can be in no graph. That is the case of a plan-level row written
+/// before the engine kept its set (pre-v28): its `model` is a label —
+/// `"backfill: 3 model(s)"` — and handing a label over as if it were a name
+/// is how the UI came to parse it (#1815). So the answer there is *no keys* —
+/// unknown — not the label dressed as a key.
+///
+/// The capability is NOT the discriminator, and was tried: the apply-time
+/// gate records one ordinary row per touched model with the plan's own
+/// capability (`gc` over `orders`), and those rows carry a real name in
+/// `model` and no set. Only the name's shape tells the two apart, and every
+/// label the engine has ever written (`backfill: …`, `gc: …`, `restore: …`)
+/// fails it. `graph_keys` is deliberately not used here: it also yields the
+/// label, on purpose, so `audit --for` can match it.
+fn queue_graph_keys(d: &PolicyDecisionRecord) -> Vec<String> {
+    if !d.models.is_empty() {
+        d.models.clone()
+    } else if rocky_sql::validation::validate_identifier(&d.model).is_ok() {
+        vec![d.model.clone()]
+    } else {
+        Vec::new()
+    }
 }
 
 /// Record the "this plan awaits review" escalation for an unconditionally
@@ -1081,6 +1105,16 @@ fn render_queue_text(out: &ReviewQueueOutput) {
             e.score,
         );
         println!("     {}", e.reason);
+        // The label above is display text; on a plan-level row the names are
+        // in `models`, and the JSON carries them, so the text does too.
+        if e.models.as_slice() != std::slice::from_ref(&e.model) {
+            let listed = if e.models.is_empty() {
+                "unknown (the row was recorded before the engine kept the set)".to_string()
+            } else {
+                e.models.join(", ")
+            };
+            println!("     models: {listed}");
+        }
         println!("     approve: {}", e.approve_command);
     }
 }
@@ -2210,6 +2244,141 @@ mod tests {
                 e.plan_id
             );
         }
+        // And the entry says which it is. The pre-v28 row's `model` is a label
+        // that resolves nowhere, and the entry does not hand it over as if it
+        // were a name: `models` is empty, which is the documented "unknown".
+        let by_plan = |plan: &str| {
+            out.pending
+                .iter()
+                .find(|e| e.plan_id == plan)
+                .unwrap_or_else(|| panic!("{plan} must be listed"))
+        };
+        assert!(
+            by_plan("p_empty").models.is_empty(),
+            "a pre-v28 plan-level row reports no keys, never its label as one"
+        );
+        assert_eq!(by_plan("p_empty").model, "backfill: 2 model(s)");
+        assert_eq!(by_plan("p_gone").models, vec!["deleted_since".to_string()]);
+    }
+
+    /// The entry's `models` is the set the ranking resolved, from the same
+    /// derivation, so a consumer that wants a model NAME reads it from there
+    /// and never parses the label. Three shapes, one rule each:
+    ///
+    /// - an ordinary evaluation row: `models` is the one graph key, which is
+    ///   `model` itself;
+    /// - a plan-level row with its set: `models` is that set, and `model`
+    ///   stays the label;
+    /// - a plan-level row without one (covered above): `models` is empty.
+    ///
+    /// The UI used a `^[a-zA-Z0-9_]+$` regex on `model` to decide whether it
+    /// could sample it, which accepted `"backfill_3_models"` as a name and
+    /// would have sampled a real model of that name (#1815). Restoring the
+    /// label as the ordinary row's key, dropping the set from a plan-level
+    /// row, or deciding by capability instead of by the name's shape, makes
+    /// this fail.
+    #[test]
+    fn the_entry_reports_the_graph_keys_the_ranking_resolved() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let models_dir = root.join("models");
+        write_blast_graph(&models_dir);
+        let state_path = root.join("state.redb");
+
+        // An ordinary evaluation row: `model` is the graph key, the set empty.
+        touch_plan_file(root, "ordinary");
+        {
+            let store = StateStore::open(&state_path).unwrap();
+            store
+                .record_policy_decision(&qd(
+                    1,
+                    "ordinary",
+                    "a",
+                    PolicyEffect::RequireReview,
+                    PolicyCapability::SchemaChangeBreaking,
+                ))
+                .unwrap();
+        }
+        // The apply-time gate's row for a gc plan: the plan's capability, a
+        // real model name, no set. A capability-based rule called this
+        // plan-level and threw the name away; the name is the key.
+        touch_plan_file(root, "gc_applied");
+        {
+            let store = StateStore::open(&state_path).unwrap();
+            store
+                .record_policy_decision(&qd(
+                    2,
+                    "gc_applied",
+                    "b",
+                    PolicyEffect::RequireReview,
+                    PolicyCapability::Gc,
+                ))
+                .unwrap();
+        }
+        // A plan-level row with its set; its `model` is a label that would
+        // pass the identifier regex the UI used to trust.
+        touch_plan_file(root, "bf");
+        record_plan_review_escalation(
+            &state_path,
+            "bf",
+            PolicyPrincipal::Agent,
+            PolicyCapability::Backfill,
+            "backfill_2_models",
+            vec!["b".to_string(), "d".to_string()],
+            "backfill plan awaits review",
+        );
+
+        let out = compute_review_queue(root, &root.join("rocky.toml"), &state_path, &models_dir)
+            .expect("the queue must rank");
+        let by_plan = |plan: &str| {
+            out.pending
+                .iter()
+                .find(|e| e.plan_id == plan)
+                .unwrap_or_else(|| panic!("{plan} must be listed"))
+        };
+        let ordinary = by_plan("ordinary");
+        assert_eq!(ordinary.model, "a");
+        assert_eq!(ordinary.models, vec!["a".to_string()]);
+        assert_eq!(ordinary.blast_radius, Some(3), "ranked on `a`, the one key");
+
+        let gc_applied = by_plan("gc_applied");
+        assert_eq!(gc_applied.models, vec!["b".to_string()]);
+        assert_eq!(
+            gc_applied.blast_radius,
+            Some(1),
+            "a gc row over a real name ranks on it"
+        );
+
+        let bf = by_plan("bf");
+        assert_eq!(bf.model, "backfill_2_models", "the label is untouched");
+        assert_eq!(bf.models, vec!["b".to_string(), "d".to_string()]);
+        // `b` reaches `c`; `d` is a leaf. Ranked on the label it would be
+        // unknown (`None`), since no graph has a model called that.
+        assert_eq!(
+            bf.blast_radius,
+            Some(1),
+            "ranked on the set, not on the label"
+        );
+    }
+
+    /// `blast_radius_union` over no names is `None`, not `Some(∅)`: an empty
+    /// union would report as a measured zero for a row that named nothing.
+    /// The queue reaches this through a pre-v28 plan-level row, and the test
+    /// above pins the queue's answer; this one pins the function's, so the
+    /// guard cannot quietly move to one caller.
+    #[test]
+    fn a_union_over_no_subjects_is_unknown_not_zero() {
+        let tmp = tempfile::tempdir().unwrap();
+        let models_dir = tmp.path().join("models");
+        write_blast_graph(&models_dir);
+        let compiled = compile_project_with_schemas(Default::default(), &models_dir)
+            .expect("the blast graph compiles");
+        assert_eq!(blast_radius_union(&compiled, std::iter::empty()), None);
+        assert_eq!(
+            blast_radius_union(&compiled, ["c"]).map(|s| s.len()),
+            Some(0),
+            "a live leaf alone really is a measured zero — the discriminator"
+        );
     }
 
     /// A present-but-unloadable `rocky.toml` refuses the queue, and the error

--- a/engine/crates/rocky-cli/src/commands/review.rs
+++ b/engine/crates/rocky-cli/src/commands/review.rs
@@ -852,6 +852,18 @@ fn build_queue(
     // unchanged. Only the config leg above refuses, and it already ran.
     let compiled = compile_project_with_schemas(source_schemas, models_dir).ok();
 
+    // Whether the samples route would get past its own front door for this
+    // project: the strict config loader, the adapter registry, and pipeline
+    // resolution with no `pipeline` parameter (the UI sends none). The queue
+    // itself tolerates an unset credential and an absent config on purpose;
+    // the route does not, and a queue that offered a read there would be
+    // advertising an answer the route cannot give (#1815, review round
+    // three). Decided once; it is the project's, not a row's.
+    let route_front_door_open = rocky_core::config::load_rocky_config(config_path)
+        .ok()
+        .filter(|cfg| crate::registry::AdapterRegistry::from_config(cfg).is_ok())
+        .is_some_and(|cfg| crate::registry::resolve_pipeline(&cfg, None).is_ok());
+
     let mut entries: Vec<ReviewQueueEntry> = outstanding
         .into_iter()
         .map(|d| {
@@ -864,7 +876,7 @@ fn build_queue(
             // any consumer's reading of a name. `models` ranks and audits;
             // only this licenses an offer to read (#1815).
             let preview_model = match (models.as_slice(), compiled.as_ref()) {
-                ([only], Some(result)) => {
+                ([only], Some(result)) if route_front_door_open => {
                     crate::commands::preview_rows::admit_model(result, models_dir, only)
                         .ok()
                         .map(|_| only.clone())
@@ -940,7 +952,18 @@ pub(crate) fn select_outstanding<'a>(
     plan_exists: impl Fn(&str) -> bool,
 ) -> (Vec<&'a PolicyDecisionRecord>, u64) {
     let mut latest: BTreeMap<(&str, &str), &PolicyDecisionRecord> = BTreeMap::new();
-    for d in decisions {
+    // A `deny` row is left out of the latest-row pick, so it neither queues
+    // nor supersedes. It cannot supersede: the fail-closed path records a
+    // `deny` when the ledger snapshot could not be read — an operational
+    // refusal, not a policy decision about the plan — and the row cannot say
+    // which kind it is. Letting it supersede hid an escalation the policy
+    // still required until someone retried the mutation (#1815, review round
+    // three). A superseded-by-deny escalation stays approvable, which is what
+    // it was before; approval then meets the deny at apply, loudly.
+    for d in decisions
+        .into_iter()
+        .filter(|d| d.effect != PolicyEffect::Deny)
+    {
         latest
             .entry((d.plan_id.as_str(), d.model.as_str()))
             .and_modify(|cur| {
@@ -953,12 +976,11 @@ pub(crate) fn select_outstanding<'a>(
     let mut excluded_non_plan: u64 = 0;
     let outstanding = latest
         .into_values()
-        // The LATEST decision per key decides, whatever its effect. A
-        // `require_review` that a later `allow` or `deny` for the same
-        // (plan, model) superseded is history: approving it is moot under
-        // the `allow` and cannot make apply succeed under the `deny`.
-        // Filtering to `require_review` BEFORE picking the latest kept such
-        // rows approvable (#1815, review round two).
+        // The LATEST of `require_review` and `allow` per key decides. A
+        // `require_review` that a later `allow` for the same (plan, model)
+        // superseded is history: policy loosened, the plan re-ran, approving
+        // it is moot. Filtering to `require_review` BEFORE picking the
+        // latest kept such rows approvable (#1815, review round two).
         .filter(|d| d.effect == PolicyEffect::RequireReview)
         .filter(|d| !is_reviewed(&d.plan_id))
         .filter(|d| {
@@ -1491,14 +1513,16 @@ mod tests {
         assert_eq!(d.capability, PolicyCapability::SchemaChangeBreaking);
     }
 
-    /// The latest decision per (plan, model) decides. A `require_review`
-    /// followed by an `allow` (policy loosened, plan re-run) is moot; one
-    /// followed by a `deny` cannot be made to succeed by approval. Both used
-    /// to stay in the queue, because the effect filter ran before the
-    /// latest-row pick. The reverse orders still queue: the newest row is the
-    /// escalation.
+    /// The latest of `require_review` and `allow` per (plan, model) decides.
+    /// A `require_review` followed by an `allow` (policy loosened, plan
+    /// re-run) is moot and used to stay in the queue, because the effect
+    /// filter ran before the latest-row pick. A later `deny` does NOT
+    /// supersede: a deny may be the fail-closed refusal of an unreadable
+    /// ledger, which says nothing about the plan, and the row cannot tell
+    /// the two apart — so the escalation stays, as it always did. The
+    /// reverse orders queue: the newest row is the escalation.
     #[test]
-    fn a_later_allow_or_deny_supersedes_an_older_require_review() {
+    fn a_later_allow_supersedes_an_older_require_review_but_a_deny_does_not() {
         let decisions = vec![
             qd(
                 1,
@@ -1551,8 +1575,8 @@ mod tests {
         plans.sort_unstable();
         assert_eq!(
             plans,
-            vec!["planC", "planD"],
-            "superseded escalations are history; new ones queue"
+            vec!["planB", "planC", "planD"],
+            "an allow supersedes; a deny does not; new escalations queue"
         );
     }
 
@@ -2372,6 +2396,7 @@ mod tests {
         let root = tmp.path();
         let models_dir = root.join("models");
         write_blast_graph(&models_dir);
+        let config_path = write_single_pipeline_config(root);
         let state_path = root.join("state.redb");
 
         // An ordinary evaluation row: `model` is the graph key, the set empty.
@@ -2457,7 +2482,7 @@ mod tests {
             "backfill plan awaits review",
         );
 
-        let out = compute_review_queue(root, &root.join("rocky.toml"), &state_path, &models_dir)
+        let out = compute_review_queue(root, &config_path, &state_path, &models_dir)
             .expect("the queue must rank");
         let by_plan = |plan: &str| {
             out.pending
@@ -2525,6 +2550,7 @@ mod tests {
         let root = tmp.path();
         let models_dir = root.join("models");
         write_blast_graph(&models_dir);
+        let config_path = write_single_pipeline_config(root);
         // A model whose SQL does not parse: in the project, with an error.
         std::fs::write(models_dir.join("shaky.sql"), "SELECT FROM WHERE").unwrap();
         std::fs::write(
@@ -2561,7 +2587,7 @@ mod tests {
                 .unwrap();
         }
 
-        let out = compute_review_queue(root, &root.join("rocky.toml"), &state_path, &models_dir)
+        let out = compute_review_queue(root, &config_path, &state_path, &models_dir)
             .expect("a model that fails to parse degrades the ranking, it does not refuse");
         let by_plan = |plan: &str| out.pending.iter().find(|e| e.plan_id == plan).unwrap();
         assert_eq!(by_plan("restore_gone").models, vec!["gone".to_string()]);
@@ -2575,6 +2601,88 @@ mod tests {
             None,
             "the route refuses compile errors"
         );
+    }
+
+    /// The samples route has a front door the queue must not promise past:
+    /// the strict config loader, the adapter registry, and pipeline
+    /// resolution with no name. With two pipelines the UI (which sends no
+    /// `pipeline`) would get `pipeline_error` on every click; with no config
+    /// at all, `config_error`. The queue still ranks — its own tolerance is
+    /// deliberate and pinned elsewhere — but offers no read. Dropping the
+    /// front-door check makes this fail.
+    #[test]
+    fn the_entry_offers_no_read_where_the_routes_front_door_is_shut() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let models_dir = root.join("models");
+        write_blast_graph(&models_dir);
+        let state_path = root.join("state.redb");
+        touch_plan_file(root, "ordinary");
+        {
+            let store = StateStore::open(&state_path).unwrap();
+            store
+                .record_policy_decision(&qd(
+                    1,
+                    "ordinary",
+                    "a",
+                    PolicyEffect::RequireReview,
+                    PolicyCapability::Apply,
+                ))
+                .unwrap();
+        }
+
+        // No config at all: the queue ranks, the route would refuse.
+        let out = compute_review_queue(root, &root.join("rocky.toml"), &state_path, &models_dir)
+            .expect("the queue ranks without a config");
+        assert_eq!(
+            out.pending[0].models,
+            vec!["a".to_string()],
+            "still a graph key"
+        );
+        assert_eq!(
+            out.pending[0].preview_model, None,
+            "no config, no front door"
+        );
+
+        // Two pipelines: the route cannot pick one without a name.
+        let config_path = root.join("rocky.toml");
+        std::fs::write(
+            &config_path,
+            "[adapter]\ntype = \"duckdb\"\npath = \"x.duckdb\"\n\n\
+             [pipeline.p]\ntype = \"transformation\"\nmodels = \"models/**\"\n\n\
+             [pipeline.p.target.governance]\nauto_create_schemas = true\n\n\
+             [pipeline.q]\ntype = \"transformation\"\nmodels = \"models/**\"\n\n\
+             [pipeline.q.target.governance]\nauto_create_schemas = true\n",
+        )
+        .unwrap();
+        let out = compute_review_queue(root, &config_path, &state_path, &models_dir)
+            .expect("the queue ranks with two pipelines");
+        assert_eq!(
+            out.pending[0].preview_model, None,
+            "two pipelines, no name: shut"
+        );
+
+        // One pipeline: open, and `a` is readable.
+        write_single_pipeline_config(root);
+        let out = compute_review_queue(root, &config_path, &state_path, &models_dir)
+            .expect("the queue ranks with one pipeline");
+        assert_eq!(out.pending[0].preview_model.as_deref(), Some("a"));
+    }
+
+    /// A config the samples route's front door accepts: the strict loader,
+    /// the adapter registry, and pipeline resolution with no name. The queue
+    /// tolerates more than the route does, so a queue that offers a read
+    /// without this would be advertising an answer the route cannot give.
+    fn write_single_pipeline_config(root: &Path) -> std::path::PathBuf {
+        let config_path = root.join("rocky.toml");
+        std::fs::write(
+            &config_path,
+            "[adapter]\ntype = \"duckdb\"\npath = \"x.duckdb\"\n\n\
+             [pipeline.p]\ntype = \"transformation\"\nmodels = \"models/**\"\n\n\
+             [pipeline.p.target.governance]\nauto_create_schemas = true\n",
+        )
+        .unwrap();
+        config_path
     }
 
     /// `blast_radius_union` over no names is `None`, not `Some(∅)`: an empty

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -7650,8 +7650,17 @@ pub struct ReviewQueueEntry {
     /// The capability that was evaluated (its `schema_change.*` refinement is
     /// the change class the ranking weighs).
     pub capability: rocky_core::config::PolicyCapability,
-    /// The model the escalation is about.
+    /// The model the escalation is about. On a plan-level escalation
+    /// (`backfill` / `gc` / `restore`) this is a human label — `"backfill: 3
+    /// model(s)"` — and not a model name; the names are in `models`.
     pub model: String,
+    /// The graph keys this entry stands for: the model set the ledger row
+    /// recorded, or the single `model` on an ordinary evaluation row. It is
+    /// the set `blast_radius` was computed over. **Empty means unknown** — a
+    /// plan-level row written before the engine kept its set — and never "no
+    /// models". A consumer that needs a model name takes it from here; `model`
+    /// is display text and is not to be parsed.
+    pub models: Vec<String>,
     /// Index of the winning `[[policy.rules]]` entry, or `null` when the
     /// escalation came from the default posture.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -7654,12 +7654,15 @@ pub struct ReviewQueueEntry {
     /// (`backfill` / `gc` / `restore`) this is a human label — `"backfill: 3
     /// model(s)"` — and not a model name; the names are in `models`.
     pub model: String,
-    /// The graph keys this entry stands for: the model set the ledger row
-    /// recorded, or the single `model` on an ordinary evaluation row. It is
-    /// the set `blast_radius` was computed over. **Empty means unknown** — a
-    /// plan-level row written before the engine kept its set — and never "no
-    /// models". A consumer that needs a model name takes it from here; `model`
-    /// is display text and is not to be parsed.
+    /// The graph keys this entry stands for — names of compiled models, and
+    /// only those: the set the ledger row recorded, or its bare `model` when
+    /// the compiled graph has a model of that name. It is the set
+    /// `blast_radius` was computed over. **Empty means unknown**, never "no
+    /// models": a subject that is not a compiled model (a replication target
+    /// is gated by table name; a plan-level row's `model` is a label), a
+    /// model since removed, a failed compile, or a row from before its
+    /// producer recorded the set. A consumer that needs a model name takes it
+    /// from here; `model` is display text and is not to be parsed.
     pub models: Vec<String>,
     /// Index of the winning `[[policy.rules]]` entry, or `null` when the
     /// escalation came from the default posture.

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -7657,13 +7657,25 @@ pub struct ReviewQueueEntry {
     /// The graph keys this entry stands for — names of compiled models, and
     /// only those: the set the ledger row recorded, or its bare `model` when
     /// the compiled graph has a model of that name. It is the set
-    /// `blast_radius` was computed over. **Empty means unknown**, never "no
-    /// models": a subject that is not a compiled model (a replication target
-    /// is gated by table name; a plan-level row's `model` is a label), a
-    /// model since removed, a failed compile, or a row from before its
-    /// producer recorded the set. A consumer that needs a model name takes it
-    /// from here; `model` is display text and is not to be parsed.
+    /// `blast_radius` was computed over and what `rocky audit --for` will
+    /// match. **Empty means unknown**, never "no models": a subject that is
+    /// not a compiled model (a replication target is gated by table name; a
+    /// plan-level row's `model` is a label), a model since removed, a failed
+    /// compile, or a row from before its producer recorded the set. `model`
+    /// is display text and is not to be parsed.
+    ///
+    /// A key here is for ranking and audit. It is **not** a licence to read
+    /// rows — `preview_model` is.
     pub models: Vec<String>,
+    /// The one model of this entry that `GET /api/v1/models/{name}/rows`
+    /// would read, decided by that route's own admission rules (a valid
+    /// name, in the compiled project, not time-interval, no compile errors,
+    /// a single SELECT), or `null`: the entry names no model or several, or
+    /// the route would refuse the one it names — a dotted name, a model a
+    /// restore plan recorded that is gone from the current project, a model
+    /// that no longer compiles. A consumer offers a sample from this and from
+    /// nothing else.
+    pub preview_model: Option<String>,
     /// Index of the winning `[[policy.rules]]` entry, or `null` when the
     /// escalation came from the default posture.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -7668,13 +7668,20 @@ pub struct ReviewQueueEntry {
     /// rows — `preview_model` is.
     pub models: Vec<String>,
     /// The one model of this entry that `GET /api/v1/models/{name}/rows`
-    /// would read, decided by that route's own admission rules (a valid
-    /// name, in the compiled project, not time-interval, no compile errors,
-    /// a single SELECT), or `null`: the entry names no model or several, or
-    /// the route would refuse the one it names — a dotted name, a model a
-    /// restore plan recorded that is gone from the current project, a model
-    /// that no longer compiles. A consumer offers a sample from this and from
-    /// nothing else.
+    /// would admit, decided by that route's own rules — its front door (the
+    /// strict config, the adapter registry, one resolvable pipeline with no
+    /// name given) and its admission of the model (a valid name, in the
+    /// compiled project, not time-interval, no compile errors, a single
+    /// SELECT) — or `null`: the entry names no model or several, the route's
+    /// front door is shut for this project, or the route would refuse the
+    /// one model it names (a dotted name, a model a restore plan recorded
+    /// that is gone from the current project, a model that no longer
+    /// compiles). A consumer offers a sample from this and from nothing else.
+    ///
+    /// What this cannot promise is the request itself: the adapter's
+    /// reachability and credentials at query time, the masking of classified
+    /// columns, the route's concurrency and time limits. Those refusals
+    /// arrive as the route's own envelope and render as themselves.
     pub preview_model: Option<String>,
     /// Index of the winning `[[policy.rules]]` entry, or `null` when the
     /// escalation came from the default posture.

--- a/engine/crates/rocky-core/src/policy.rs
+++ b/engine/crates/rocky-core/src/policy.rs
@@ -1689,6 +1689,7 @@ mod tests {
     /// A plain evaluation row: winning `rule_id`, empty `verify_after`.
     fn plain_row(plan_id: &str, rule_id: Option<usize>, ts: DateTime<Utc>) -> PolicyDecisionRecord {
         PolicyDecisionRecord {
+            keys_recorded: false,
             models: Vec::new(),
             timestamp: ts,
             plan_id: plan_id.to_string(),
@@ -1707,6 +1708,7 @@ mod tests {
     /// means the post-apply verification FAILED (burns budget).
     fn verify_fail_row(plan_id: &str, ts: DateTime<Utc>) -> PolicyDecisionRecord {
         PolicyDecisionRecord {
+            keys_recorded: false,
             models: Vec::new(),
             timestamp: ts,
             plan_id: plan_id.to_string(),
@@ -1724,6 +1726,7 @@ mod tests {
     /// A passing verify-after custody row — must NOT burn budget.
     fn verify_pass_row(plan_id: &str, ts: DateTime<Utc>) -> PolicyDecisionRecord {
         PolicyDecisionRecord {
+            keys_recorded: false,
             models: Vec::new(),
             timestamp: ts,
             plan_id: plan_id.to_string(),
@@ -1745,6 +1748,7 @@ mod tests {
         ts: DateTime<Utc>,
     ) -> PolicyDecisionRecord {
         PolicyDecisionRecord {
+            keys_recorded: false,
             models: Vec::new(),
             timestamp: ts,
             plan_id: format!("{prefix}{}", ts.to_rfc3339()),

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -6097,18 +6097,22 @@ pub struct PolicyDecisionRecord {
     pub capability: crate::config::PolicyCapability,
     /// The model the decision was about — the concrete scope that matched.
     pub model: String,
-    /// The graph keys this decision covers, when [`Self::model`] cannot be one.
+    /// The graph keys this decision covers, as the producer knew them.
     ///
-    /// Empty on an ordinary evaluation row, where `model` **is** the graph key
-    /// and this field would only repeat it. Non-empty on a **plan-level**
-    /// escalation (`backfill` / `gc` / `restore`), where `model` is a
-    /// human-readable summary — `"backfill: 3 model(s)"` — that no graph lookup
-    /// can resolve. Those rows record the real model names here so a consumer
-    /// can compute a blast radius or match `rocky audit --for <model>` without
-    /// parsing the label.
+    /// Non-empty on a **plan-level** escalation (`backfill` / `gc` /
+    /// `restore`), where `model` is a human-readable summary — `"backfill: 3
+    /// model(s)"` — that no graph lookup can resolve, so the real names go
+    /// here. Also the single name on an apply-time evaluation row whose
+    /// subject is a model of the compiled project (#1815) — the gate is the
+    /// one place that knows, because the same `model` field carries a
+    /// replication target's table name, which is gated by name and is not a
+    /// model. Empty when the producer could not name a graph key, or on a row
+    /// written before it recorded one.
     ///
     /// Read through [`Self::graph_keys`], never directly: an empty vec means
-    /// "fall back to `model`", not "this decision covers no model".
+    /// "fall back to `model`", not "this decision covers no model". The
+    /// review queue, which must not hand a non-model over as a name, resolves
+    /// an empty set against the compiled graph instead.
     #[serde(default)]
     pub models: Vec<String>,
     /// The resolved verdict.

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -818,7 +818,25 @@ const SNAPSHOT_MEMORY_WARN_BYTES: u64 = 128 * 1024 * 1024;
 ///   unchanged, so it behaves exactly as it does today. It does not reach the
 ///   blob anyway — the version check runs at OPEN and `[state]
 ///   on_schema_mismatch` engages there.
-const CURRENT_SCHEMA_VERSION: u32 = 28;
+///
+/// - **v29** — records whether a policy decision's model set was the
+///   producer's word: a new serde-additive
+///   [`PolicyDecisionRecord::keys_recorded`] flag. Not a table change; no blob
+///   walk. A v28 blob forward-deserializes with it `false`, guarded by
+///   `test_v28_policy_decision_forward_deserializes_keys_recorded_false`.
+///
+///   **What it fixes (#1815).** v28's `models` could not tell "the gate said
+///   this subject is no model" (an empty set it wrote on purpose) from "the
+///   row predates the set" (an empty set by default). A consumer that
+///   resolved the bare `model` against the compiled graph for the second
+///   case did it for the first too, and a replication target named like a
+///   compiled model was offered for sampling as that model.
+///
+///   **On upgrade.** A v28 store is stamped v29 in place and every record is
+///   kept, reading back with the flag `false` — "unknown", the only honest
+///   reading of a row that never said. **On rollback.** One extra key,
+///   ignored; the version check at OPEN engages `[state] on_schema_mismatch`.
+const CURRENT_SCHEMA_VERSION: u32 = 29;
 
 /// Errors from the embedded redb state store.
 #[derive(Debug, Error)]
@@ -6115,6 +6133,22 @@ pub struct PolicyDecisionRecord {
     /// an empty set against the compiled graph instead.
     #[serde(default)]
     pub models: Vec<String>,
+    /// Whether the producer decided [`Self::models`] on purpose.
+    ///
+    /// `true` means the set is the producer's word — including an EMPTY set,
+    /// which then says "this subject is no compiled model": a replication
+    /// target gated by table name, a maintenance table no model owns, a
+    /// promote target the current project no longer maps. `false` means the
+    /// row was written before producers recorded the set (pre-v29), where an
+    /// empty set says only "unknown" and a consumer may still resolve the
+    /// bare `model` against the compiled graph.
+    ///
+    /// Without this bit the two were the same bytes, and the review queue
+    /// undid a gate's "not a model" by re-resolving the name — a replication
+    /// target called `orders` became the compiled model `orders`, and its
+    /// rows were offered for sampling (#1815, review round seven).
+    #[serde(default)]
+    pub keys_recorded: bool,
     /// The resolved verdict.
     pub effect: crate::config::PolicyEffect,
     /// Index of the winning `[[policy.rules]]` entry, or `None` for the
@@ -11717,6 +11751,7 @@ mod tests {
         let (store, _dir) = temp_store();
         // Two decisions with distinct timestamps → forward scan is oldest-first.
         let earlier = PolicyDecisionRecord {
+            keys_recorded: false,
             models: Vec::new(),
             timestamp: chrono::DateTime::parse_from_rfc3339("2026-07-07T10:00:00Z")
                 .unwrap()
@@ -11732,6 +11767,7 @@ mod tests {
             auto_apply: None,
         };
         let later = PolicyDecisionRecord {
+            keys_recorded: false,
             models: Vec::new(),
             timestamp: chrono::DateTime::parse_from_rfc3339("2026-07-07T11:00:00Z")
                 .unwrap()
@@ -11771,6 +11807,7 @@ mod tests {
 
         // A full record serialized with `models` stripped — a v27 blob.
         let record = PolicyDecisionRecord {
+            keys_recorded: false,
             models: vec!["dim_customer".to_string()],
             timestamp: chrono::DateTime::parse_from_rfc3339("2026-09-07T10:00:00Z")
                 .unwrap()
@@ -11807,6 +11844,46 @@ mod tests {
         );
     }
 
+    /// A v28 policy decision — one whose blob has no `keys_recorded` key —
+    /// must forward-deserialize with the flag `false`: a row that never said
+    /// whether its set was deliberate is "unknown", and a consumer may still
+    /// resolve its bare `model`. Guards the v29 bump.
+    #[test]
+    fn test_v28_policy_decision_forward_deserializes_keys_recorded_false() {
+        use crate::config::{PolicyCapability, PolicyEffect, PolicyPrincipal};
+
+        let record = PolicyDecisionRecord {
+            keys_recorded: true,
+            models: Vec::new(),
+            timestamp: chrono::DateTime::parse_from_rfc3339("2026-09-09T10:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            plan_id: "plan_v28".to_string(),
+            principal: PolicyPrincipal::Agent,
+            capability: PolicyCapability::Apply,
+            model: "orders".to_string(),
+            effect: PolicyEffect::RequireReview,
+            rule_id: None,
+            reason: "replication target awaits review".to_string(),
+            verify_after: Vec::new(),
+            auto_apply: None,
+        };
+        let mut value = serde_json::to_value(&record).expect("serialize record");
+        value
+            .as_object_mut()
+            .expect("record is an object")
+            .remove("keys_recorded");
+        let blob = serde_json::to_vec(&value).expect("reserialize without field");
+
+        let read: PolicyDecisionRecord = serde_json::from_slice(&blob)
+            .expect("v28 PolicyDecisionRecord must forward-deserialize");
+        assert_eq!(read.plan_id, "plan_v28");
+        assert!(
+            !read.keys_recorded,
+            "a v28 blob never said whether its set was deliberate: unknown, not vouched"
+        );
+    }
+
     /// `graph_keys` yields the model set when there is one and the single
     /// `model` when there is not — and NEVER yields nothing.
     ///
@@ -11820,6 +11897,7 @@ mod tests {
         use crate::config::{PolicyCapability, PolicyEffect, PolicyPrincipal};
 
         let base = PolicyDecisionRecord {
+            keys_recorded: false,
             models: Vec::new(),
             timestamp: Utc::now(),
             plan_id: "p".to_string(),
@@ -11846,6 +11924,7 @@ mod tests {
         // keeps the audit screen's `subject={entry.model}` custody link
         // working, which an exclusive matcher would have broken.
         let with_models = PolicyDecisionRecord {
+            keys_recorded: false,
             models: vec!["dim_customer".to_string(), "fct_orders".to_string()],
             ..base.clone()
         };
@@ -11856,6 +11935,7 @@ mod tests {
 
         // An ordinary row: `model` is the graph key and there is no set.
         let ordinary = PolicyDecisionRecord {
+            keys_recorded: false,
             models: Vec::new(),
             model: "fct_orders".to_string(),
             ..base
@@ -11872,6 +11952,7 @@ mod tests {
 
         // A full v17 record serialized with `auto_apply` stripped.
         let record = PolicyDecisionRecord {
+            keys_recorded: false,
             models: Vec::new(),
             timestamp: chrono::DateTime::parse_from_rfc3339("2026-07-07T10:00:00Z")
                 .unwrap()
@@ -12657,6 +12738,7 @@ mod tests {
             let store = StateStore::open(&path).unwrap();
             store
                 .record_policy_decision(&PolicyDecisionRecord {
+                    keys_recorded: false,
                     models: Vec::new(),
                     timestamp: Utc::now(),
                     plan_id: "planPre28".to_string(),
@@ -12806,7 +12888,7 @@ mod tests {
         // serde-additive shape. NO table change either — so this stanza moves
         // the version only; guarded by
         // `test_v25_run_record_forward_deserializes_verify_after_failed_false`.
-        const EXPECTED_VERSION: u32 = 28;
+        const EXPECTED_VERSION: u32 = 29;
         // v28 adds `PolicyDecisionRecord::models` (#1766), the graph keys
         // behind a plan-level review escalation's human label. The same
         // serde-additive shape as v25-v27: NO table change — `EXPECTED_TABLES`

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -12719,8 +12719,9 @@ mod tests {
     }
 
     /// The v28 upgrade claim, exercised rather than asserted in a comment:
-    /// a v27 store is stamped v28 **in place**, every policy-decision row is
-    /// KEPT, and each one reads back with `models` empty.
+    /// a v27 store is stamped forward **in place** (to v28 then, to the
+    /// current version now), every policy-decision row is KEPT, and each one
+    /// reads back with `models` empty.
     ///
     /// The generic `open_with_policy_recreate_upgrades_older_store_without_
     /// recreating` above stamps version 6 and checks a watermark. It proves
@@ -12895,6 +12896,10 @@ mod tests {
         // is deliberately unchanged below — so this stanza moves the version
         // only; guarded by
         // `test_v27_policy_decision_forward_deserializes_models_empty`.
+        // v29 adds `PolicyDecisionRecord::keys_recorded` (#1815), whether
+        // that set was the producer's word. Same serde-additive shape: NO
+        // table change, the version moves only; guarded by
+        // `test_v28_policy_decision_forward_deserializes_keys_recorded_false`.
         const EXPECTED_TABLES: &[&str] = &[
             "branches",
             "check_history",

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -5144,6 +5144,7 @@ mod tests {
             let store = StateStore::open(&pod_a).unwrap();
             store
                 .record_policy_decision(&PolicyDecisionRecord {
+                    keys_recorded: false,
                     models: Vec::new(),
                     timestamp: now,
                     plan_id: "plan-1".into(),
@@ -5159,6 +5160,7 @@ mod tests {
                 .unwrap();
             store
                 .record_policy_decision(&PolicyDecisionRecord {
+                    keys_recorded: false,
                     models: Vec::new(),
                     timestamp: now,
                     plan_id: "plan-1".into(),
@@ -5596,6 +5598,7 @@ mod tests {
 
     fn seam_policy_record(plan_id: &str) -> crate::state::PolicyDecisionRecord {
         crate::state::PolicyDecisionRecord {
+            keys_recorded: false,
             models: Vec::new(),
             timestamp: chrono::Utc::now(),
             plan_id: plan_id.to_string(),

--- a/engine/ui/src/components.test.tsx
+++ b/engine/ui/src/components.test.tsx
@@ -1,0 +1,30 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Clip } from "./components";
+
+describe("Clip", () => {
+  /// The marker is the screen's, not the value's. A cut renders it as its
+  /// own element; a value that merely contains "…" renders that as text, so
+  /// the two can be told apart — before this, `shortId("abcdefghij…")` and a
+  /// cut id looked the same (#1815).
+  it("renders the cut marker as an element, and a literal ellipsis as text", () => {
+    const cut = render(<Clip value={"a".repeat(64)} />);
+    const marker = cut.container.querySelector("[data-clipped]");
+    expect(marker).not.toBeNull();
+    expect(cut.container.textContent).toBe(`${"a".repeat(12)}…`);
+    expect(cut.container.querySelector(`[title="${"a".repeat(64)}"]`)).not.toBeNull();
+    cut.unmount();
+
+    const literal = render(<Clip value="abcdefghij…" />);
+    expect(literal.container.querySelector("[data-clipped]")).toBeNull();
+    expect(literal.container.textContent).toBe("abcdefghij…");
+  });
+
+  it("keeps both ends when asked, with the marker between them", () => {
+    const { container } = render(
+      <Clip value="product:revenue_daily@sha256:5b1bf5c@21" keepEnds />,
+    );
+    expect(container.textContent).toBe("product:re…1bf5c@21");
+    expect(container.querySelector("[data-clipped]")?.textContent).toBe("…");
+  });
+});

--- a/engine/ui/src/components.tsx
+++ b/engine/ui/src/components.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { clipHead, clipMiddle } from "./format";
 
 /** Trust-signal tone, the idiom the VS Code Inspector uses. */
 export type Tone = "ok" | "warn" | "risk" | "muted" | "pending";
@@ -41,6 +42,31 @@ export function StatusCard({
         <div className="mt-0.5 text-xs text-zinc-500 dark:text-zinc-400">{sub}</div>
       )}
     </div>
+  );
+}
+
+/**
+ * A long identifier cut for a cell, with the full value in `title`.
+ *
+ * The marker is its own element, rendered only when something was cut, and
+ * dimmed so it reads as the screen's mark and not the value's text. A value
+ * that happens to end in "…" renders that character as plain text, so a
+ * reader — and a test — can tell the two apart (#1815). `keepEnds` keeps both
+ * ends for a compound id whose tail distinguishes it (#1756).
+ */
+export function Clip({ value, keepEnds = false }: { value: string; keepEnds?: boolean }) {
+  const clipped = keepEnds ? clipMiddle(value) : clipHead(value);
+  if (!clipped.clipped) {
+    return <span title={value}>{clipped.text}</span>;
+  }
+  return (
+    <span title={value}>
+      {clipped.head}
+      <span data-clipped="" aria-hidden="true" className="text-zinc-400 dark:text-zinc-500">
+        …
+      </span>
+      {clipped.tail}
+    </span>
   );
 }
 

--- a/engine/ui/src/estate/RunsPanel.tsx
+++ b/engine/ui/src/estate/RunsPanel.tsx
@@ -1,6 +1,7 @@
 import type { HistoryOutput } from "@rocky-types/history";
 import { EmptyState, type Tone } from "../components";
-import { formatDuration, formatInstant, orNotRecorded, shortId } from "../format";
+import { Clip } from "../components";
+import { formatDuration, formatInstant, orNotRecorded } from "../format";
 
 function statusTone(status: string): Tone {
   switch (status.toLowerCase()) {
@@ -52,7 +53,7 @@ export function RunsPanel({ history, now }: { history: HistoryOutput; now?: numb
           {history.runs.map((run) => (
             <tr key={run.run_id} className="border-t border-zinc-100 dark:border-zinc-800">
               <td className="pr-3 font-mono" title={run.run_id}>
-                <span title={run.run_id}>{shortId(run.run_id)}</span>
+                <Clip value={run.run_id} />
               </td>
               <td className="pr-3">{formatInstant(run.started_at, now)}</td>
               <td className={`pr-3 font-medium ${TONE_TEXT[statusTone(run.status)]}`}>

--- a/engine/ui/src/estate/useResource.test.ts
+++ b/engine/ui/src/estate/useResource.test.ts
@@ -1,0 +1,63 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useResource } from "./useResource";
+
+/** A promise whose settlement the test holds. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe("useResource", () => {
+  /// The value on hand belongs to the identity it was loaded for. When the
+  /// identity moves, the hook must not show the old value under the new one
+  /// for even a frame: on the review screen that frame was plan A's approve
+  /// command under plan B's heading (#1815). So the check is synchronous,
+  /// right after the rerender, before any load has settled.
+  it("shows loading, not the previous value, the moment its identity changes", async () => {
+    const reads: Record<string, ReturnType<typeof deferred<string>>> = {
+      a: deferred<string>(),
+      b: deferred<string>(),
+    };
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useResource(() => reads[id].promise, [id]),
+      { initialProps: { id: "a" } },
+    );
+    expect(result.current.kind).toBe("loading");
+
+    await act(async () => reads.a.resolve("A's value"));
+    expect(result.current).toMatchObject({ kind: "ready", value: "A's value" });
+
+    rerender({ id: "b" });
+    expect(result.current.kind).toBe("loading");
+
+    await act(async () => reads.b.resolve("B's value"));
+    expect(result.current).toMatchObject({ kind: "ready", value: "B's value" });
+
+    // And back: A's old value is not a cache. It was for an identity the hook
+    // has since left, and a fresh read is in flight.
+    reads.a = deferred<string>();
+    rerender({ id: "a" });
+    expect(result.current.kind).toBe("loading");
+  });
+
+  /// A reload of the SAME identity — the interval, a refresh button — keeps
+  /// the value up until the new one lands. A panel that blinked to "loading"
+  /// on every tick would be worse than one that never refreshed.
+  it("keeps the current value across a reload of the same identity", async () => {
+    let pending = deferred<number>();
+    const { result } = renderHook(() => useResource(() => pending.promise, ["same"]));
+    await act(async () => pending.resolve(1));
+    expect(result.current).toMatchObject({ kind: "ready", value: 1 });
+
+    pending = deferred<number>();
+    act(() => result.current.reload());
+    expect(result.current).toMatchObject({ kind: "ready", value: 1 });
+
+    await act(async () => pending.resolve(2));
+    expect(result.current).toMatchObject({ kind: "ready", value: 2 });
+  });
+});

--- a/engine/ui/src/estate/useResource.ts
+++ b/engine/ui/src/estate/useResource.ts
@@ -8,30 +8,58 @@ export type Resource<T> =
   | { kind: "refused"; error: ApiError }
   | { kind: "unreachable"; message: string };
 
+/** A settled read, tagged with the identity it was loaded for. */
+interface Settled<T> {
+  deps: DependencyList;
+  state: Resource<T>;
+}
+
+function sameDeps(a: DependencyList, b: DependencyList): boolean {
+  return a.length === b.length && a.every((value, index) => Object.is(value, b[index]));
+}
+
 /**
  * Load a typed payload, expose its state, and reload on demand or on an
  * interval. A refused route is a state, not an exception: the panel shows
  * the envelope and the other panels keep rendering.
+ *
+ * `deps` is the identity of what `load` reads — a plan id, a product name.
+ * A value on hand belongs to the identity it was loaded for, and when the
+ * identity moves the value is not shown under the new one, not even for a
+ * frame: it is plan A's approve command under plan B's heading (#1815). A
+ * reload of the SAME identity (the interval, a refresh button) keeps the old
+ * value up until the new one lands, so a refresh never blinks.
  */
 export function useResource<T>(
   load: () => Promise<T>,
   deps: DependencyList,
   intervalMs?: number,
 ): Resource<T> & { reload: () => void } {
-  const [state, setState] = useState<Resource<T>>({ kind: "loading" });
+  const [settled, setSettled] = useState<Settled<T> | null>(null);
   const [tick, setTick] = useState(0);
   const reload = useCallback(() => setTick((t) => t + 1), []);
 
+  // Derived in render, not reset in an effect: an effect runs after the
+  // frame with the stale value has already painted.
+  const state: Resource<T> =
+    settled !== null && sameDeps(settled.deps, deps) ? settled.state : { kind: "loading" };
+
   useEffect(() => {
     let cancelled = false;
+    // The identity this read is for. A late answer carries it, so even one
+    // that slipped past `cancelled` cannot render under a different identity.
+    const identity = deps;
     load()
       .then((value) => {
-        if (!cancelled) setState({ kind: "ready", value });
+        if (!cancelled) setSettled({ deps: identity, state: { kind: "ready", value } });
       })
       .catch((error: unknown) => {
         if (cancelled) return;
-        if (error instanceof ApiError) setState({ kind: "refused", error });
-        else setState({ kind: "unreachable", message: String(error) });
+        const state: Resource<T> =
+          error instanceof ApiError
+            ? { kind: "refused", error }
+            : { kind: "unreachable", message: String(error) };
+        setSettled({ deps: identity, state });
       });
     return () => {
       cancelled = true;

--- a/engine/ui/src/format.test.ts
+++ b/engine/ui/src/format.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   NOT_RECORDED,
-  elideMiddle,
+  clipHead,
+  clipMiddle,
   formatDuration,
   formatInstant,
   orNotRecorded,
-  shortId,
 } from "./format";
 
 describe("orNotRecorded", () => {
@@ -47,41 +47,65 @@ describe("formatInstant", () => {
   });
 });
 
-describe("shortId", () => {
-  it("keeps short ids whole and marks a cut with an ellipsis", () => {
-    expect(shortId("run-1")).toBe("run-1");
-    expect(shortId("a".repeat(64))).toBe(`${"a".repeat(12)}…`);
+describe("clipHead", () => {
+  it("keeps short ids whole and says when it cut", () => {
+    expect(clipHead("run-1")).toEqual({ clipped: false, text: "run-1" });
+    expect(clipHead("a".repeat(64))).toEqual({ clipped: true, head: "a".repeat(12), tail: "" });
   });
 
-  it("does not mark an id that was not cut", () => {
+  it("does not claim a cut it did not make", () => {
     // Exactly at the limit: twelve characters are shown, nothing was dropped,
-    // so an ellipsis would claim a truncation that did not happen.
-    expect(shortId("a".repeat(12))).toBe("a".repeat(12));
-    expect(shortId("a".repeat(13))).toBe(`${"a".repeat(12)}…`);
+    // so a marker would claim a truncation that did not happen.
+    expect(clipHead("a".repeat(12))).toEqual({ clipped: false, text: "a".repeat(12) });
+    expect(clipHead("a".repeat(13)).clipped).toBe(true);
+  });
+
+  /// `String.prototype.slice` counts UTF-16 code units, and a cut at the
+  /// twelfth unit of `aaaaaaaaaaa😀z` lands between the emoji's two
+  /// surrogates, leaving a lone `\ud83d` on screen (#1815). The cut is made
+  /// between characters a reader sees.
+  it("never splits a surrogate pair", () => {
+    const cut = clipHead("aaaaaaaaaaa😀z");
+    expect(cut).toEqual({ clipped: true, head: "aaaaaaaaaaa😀", tail: "" });
+    expect(/[\ud800-\udbff]$/.test(cut.clipped ? cut.head : "")).toBe(false);
+  });
+
+  /// The marker is a flag, not a character, so a value that contains "…"
+  /// is not mistaken for one that was cut.
+  it("reports a literal ellipsis as text that was not cut", () => {
+    expect(clipHead("abcdefghij…")).toEqual({ clipped: false, text: "abcdefghij…" });
   });
 });
 
-describe("elideMiddle", () => {
+describe("clipMiddle", () => {
   it("keeps both ends of a compound identifier", () => {
-    // #1756: `shortId` renders every key for one product identically, because
-    // they all begin `product:<name>@`. The tail is what distinguishes them.
+    // #1756: a leading slice renders every key for one product identically,
+    // because they all begin `product:<name>@`. The tail is what
+    // distinguishes them.
     const key = "product:revenue_daily@sha256:5b1bf5c@21";
-    expect(elideMiddle(key)).toBe("product:re…1bf5c@21");
-    expect(elideMiddle(key)).toContain("@21");
+    expect(clipMiddle(key)).toEqual({ clipped: true, head: "product:re", tail: "1bf5c@21" });
   });
 
-  it("distinguishes two keys that shortId renders identically", () => {
-    const a = "product:revenue_daily@sha256:5b1bf5c@21";
-    const b = "product:revenue_daily@sha256:5b1bf5c@22";
-    expect(shortId(a)).toBe(shortId(b));
-    expect(elideMiddle(a)).not.toBe(elideMiddle(b));
+  it("distinguishes two keys whose heads are the same", () => {
+    const a = clipMiddle("product:revenue_daily@sha256:5b1bf5c@21");
+    const b = clipMiddle("product:revenue_daily@sha256:5b1bf5c@22");
+    expect(clipHead("product:revenue_daily@sha256:5b1bf5c@21")).toEqual(
+      clipHead("product:revenue_daily@sha256:5b1bf5c@22"),
+    );
+    expect(a).not.toEqual(b);
   });
 
-  it("returns a value unchanged rather than rendering it longer", () => {
-    // head + tail + the ellipsis is 19 characters, so anything at or under
-    // that gains nothing from eliding.
-    expect(elideMiddle("a".repeat(19))).toBe("a".repeat(19));
-    expect(elideMiddle("a".repeat(20)).length).toBeLessThan(20);
-    expect(elideMiddle("short")).toBe("short");
+  it("returns a value uncut rather than rendering it longer", () => {
+    // head + tail + the marker is 19 characters, so anything at or under
+    // that gains nothing from cutting.
+    expect(clipMiddle("a".repeat(19))).toEqual({ clipped: false, text: "a".repeat(19) });
+    const cut = clipMiddle("a".repeat(20));
+    expect(cut.clipped).toBe(true);
+    expect(clipMiddle("short")).toEqual({ clipped: false, text: "short" });
+  });
+
+  it("never splits a surrogate pair at either end", () => {
+    const cut = clipMiddle("aaaaaaaaa😀bbbbbbbbbb");
+    expect(cut).toEqual({ clipped: true, head: "aaaaaaaaa😀", tail: "bbbbbbbb" });
   });
 });

--- a/engine/ui/src/format.test.ts
+++ b/engine/ui/src/format.test.ts
@@ -70,6 +70,35 @@ describe("clipHead", () => {
     expect(/[\ud800-\udbff]$/.test(cut.clipped ? cut.head : "")).toBe(false);
   });
 
+  /// Where the runtime segments graphemes, a combining mark stays with its
+  /// base: `é` written as `e` + U+0301 is one character to the reader.
+  it("keeps a combining mark with its base where the runtime can see it", () => {
+    expect(typeof Intl.Segmenter).toBe("function");
+    const cut = clipHead(`${"a".repeat(11)}e\u0301z`);
+    expect(cut).toEqual({ clipped: true, head: `${"a".repeat(11)}e\u0301`, tail: "" });
+  });
+
+  /// Without `Intl.Segmenter` the units are code points. That still keeps
+  /// every surrogate pair whole — the one guarantee the fallback makes.
+  it("still keeps surrogate pairs whole without Intl.Segmenter", () => {
+    const segmenter = Intl.Segmenter;
+    Object.defineProperty(Intl, "Segmenter", { value: undefined, configurable: true });
+    try {
+      expect(clipHead("aaaaaaaaaaa😀z")).toEqual({
+        clipped: true,
+        head: "aaaaaaaaaaa😀",
+        tail: "",
+      });
+      expect(clipMiddle("aaaaaaaaa😀bbbbbbbbbb")).toEqual({
+        clipped: true,
+        head: "aaaaaaaaa😀",
+        tail: "bbbbbbbb",
+      });
+    } finally {
+      Object.defineProperty(Intl, "Segmenter", { value: segmenter, configurable: true });
+    }
+  });
+
   /// The marker is a flag, not a character, so a value that contains "…"
   /// is not mistaken for one that was cut.
   it("reports a literal ellipsis as text that was not cut", () => {

--- a/engine/ui/src/format.ts
+++ b/engine/ui/src/format.ts
@@ -57,11 +57,13 @@ export type Clipped =
   | { clipped: true; head: string; tail: string };
 
 /**
- * The characters a reader sees, so a cut never lands inside one. `String`
- * indexes UTF-16 code units, and slicing at one splits a surrogate pair: a
- * slice can end in a lone high surrogate. Grapheme segmentation is used where
- * the runtime has it; code points are the fallback, which still keeps every
- * pair whole.
+ * The units a cut may fall between. `String` indexes UTF-16 code units, and
+ * slicing at one splits a surrogate pair: a slice can end in a lone high
+ * surrogate. Where the runtime has `Intl.Segmenter` the units are grapheme
+ * clusters — what a reader sees, an `é` written as `e` plus a combining
+ * accent included. Without it they are code points, which keeps every
+ * surrogate pair whole but can still part a combining mark from its base;
+ * that is the guarantee the fallback makes, and the only one.
  */
 function characters(value: string): string[] {
   if (typeof Intl !== "undefined" && typeof Intl.Segmenter === "function") {

--- a/engine/ui/src/format.ts
+++ b/engine/ui/src/format.ts
@@ -46,21 +46,49 @@ function formatAgo(deltaMs: number): string {
 }
 
 /**
- * The first 12 characters of a long id, for a table cell, with an ellipsis so
- * a truncation reads as one. Put the full id in `title` at the call site.
+ * Text cut for display. `clipped` is the fact a marker stands for, kept apart
+ * from the text so the marker is rendered from it and never inferred from the
+ * characters — a value that happens to contain "…" is not a value that was
+ * cut, and before this the two rendered identically (#1815). `<Clip>` in
+ * `components.tsx` is the one renderer.
+ */
+export type Clipped =
+  | { clipped: false; text: string }
+  | { clipped: true; head: string; tail: string };
+
+/**
+ * The characters a reader sees, so a cut never lands inside one. `String`
+ * indexes UTF-16 code units, and slicing at one splits a surrogate pair: a
+ * slice can end in a lone high surrogate. Grapheme segmentation is used where
+ * the runtime has it; code points are the fallback, which still keeps every
+ * pair whole.
+ */
+function characters(value: string): string[] {
+  if (typeof Intl !== "undefined" && typeof Intl.Segmenter === "function") {
+    const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+    return Array.from(segmenter.segment(value), (part) => part.segment);
+  }
+  return Array.from(value);
+}
+
+/**
+ * The first 12 characters of a long id, and whether that cut anything. Put
+ * the full id in `title` at the call site — `<Clip>` does.
  *
  * Right for an id whose HEAD identifies it — a hex digest, a run id. A
- * compound id whose tail is the distinguishing part wants `elideMiddle`
+ * compound id whose tail is the distinguishing part wants `clipMiddle`
  * instead: every fulfillment idempotency key for one product begins
  * `product:<name>@`, so twelve leading characters of it distinguish nothing
  * (#1756).
  */
-export function shortId(id: string): string {
-  return id.length > 12 ? `${id.slice(0, 12)}…` : id;
+export function clipHead(id: string, keep = 12): Clipped {
+  const chars = characters(id);
+  if (chars.length <= keep) return { clipped: false, text: id };
+  return { clipped: true, head: chars.slice(0, keep).join(""), tail: "" };
 }
 
 /**
- * Keeps both ends of a compound identifier and elides the middle:
+ * Keeps both ends of a compound identifier and cuts the middle:
  * `product:revenue_daily@sha256:5b1bf5c@21` renders as `product:re…1bf5c@21`,
  * keeping the digest tail and the sequence number that tell two keys apart.
  *
@@ -68,11 +96,16 @@ export function shortId(id: string): string {
  * text and knows nothing about any identifier's grammar, so a key whose shape
  * changes still renders, just with a different slice shown.
  *
- * Returns the input unchanged when eliding would not make it shorter, so a
- * value near the limit never renders LONGER than it is.
+ * Returns the input uncut when cutting would not make it shorter, so a value
+ * near the limit never renders LONGER than it is.
  */
-export function elideMiddle(value: string, head = 10, tail = 8): string {
-  if (head < 0 || tail < 0) return value;
-  if (value.length <= head + tail + 1) return value;
-  return `${value.slice(0, head)}…${value.slice(value.length - tail)}`;
+export function clipMiddle(value: string, head = 10, tail = 8): Clipped {
+  if (head < 0 || tail < 0) return { clipped: false, text: value };
+  const chars = characters(value);
+  if (chars.length <= head + tail + 1) return { clipped: false, text: value };
+  return {
+    clipped: true,
+    head: chars.slice(0, head).join(""),
+    tail: chars.slice(chars.length - tail).join(""),
+  };
 }

--- a/engine/ui/src/governor/ProductsScreen.test.tsx
+++ b/engine/ui/src/governor/ProductsScreen.test.tsx
@@ -280,8 +280,11 @@ describe("ProductsScreen", () => {
   it("renders a hostile event and product name as text, never as markup", async () => {
     const hostile = '<img src=x onerror="alert(1)">';
     const { container } = render(
+      // The name reaches the heading and the custody link. An earlier
+      // version of this test passed a benign name and only put the hostile
+      // value in the event, so the heading was never exercised (#1815).
       <ProductsScreen
-        name="revenue_daily"
+        name={hostile}
         loaders={loaders({
           journal: vi.fn(async () => ({
             ...JOURNAL,
@@ -293,7 +296,34 @@ describe("ProductsScreen", () => {
     );
 
     expect(await screen.findByText(hostile)).toBeTruthy();
+    expect(screen.getByRole("heading", { name: hostile })).toBeTruthy();
+    expect(screen.getByRole("link", { name: `product:${hostile}` })).toBeTruthy();
     expect(container.querySelector("img")).toBeNull();
+  });
+
+  /// Product A's standing and journal must not sit under product B's heading
+  /// while B's reads are still in flight (#1815).
+  it("carries nothing of product A under product B's heading", async () => {
+    let releaseB!: (value: ProductStatusOutput) => void;
+    const statusB = new Promise<ProductStatusOutput>((resolve) => {
+      releaseB = resolve;
+    });
+    const shared = loaders({
+      status: vi.fn(async (name: string) => (name === "revenue_daily" ? STATUS : statusB)),
+    });
+    const view = render(<ProductsScreen name="revenue_daily" loaders={shared} />);
+    await screen.findByText("observed_passing");
+    await screen.findAllByText("change proposed");
+
+    view.rerender(<ProductsScreen name="costs_daily" loaders={shared} />);
+
+    expect(screen.getByRole("heading", { name: "costs_daily" })).toBeTruthy();
+    expect(screen.queryByText("observed_passing")).toBeNull();
+    expect(screen.getByText("reading the product…")).toBeTruthy();
+
+    releaseB({ ...STATUS, fulfill_state: "proposed" } as ProductStatusOutput);
+    await screen.findByText("proposed");
+    expect(screen.queryByText("observed_passing")).toBeNull();
   });
 
   it("builds a product path that survives an awkward name", () => {

--- a/engine/ui/src/governor/ProductsScreen.tsx
+++ b/engine/ui/src/governor/ProductsScreen.tsx
@@ -3,9 +3,9 @@ import type { ProductJournalEntry, ProductJournalOutput } from "@rocky-types/pro
 import type { ProductListEntry, ProductListOutput } from "@rocky-types/product_list";
 import type { ProductStatusOutput } from "@rocky-types/product_status";
 import { apiGet } from "../api";
-import { StatusCard } from "../components";
+import { Clip, StatusCard } from "../components";
 import { useResource } from "../estate/useResource";
-import { elideMiddle, formatInstant, shortId } from "../format";
+import { formatInstant } from "../format";
 import { navigateTo, pathForLane } from "../router";
 import { ResourceState } from "../review/ResourceState";
 import { reviewPath } from "../review/paths";
@@ -141,13 +141,17 @@ function JournalRow({ entry }: { entry: ProductJournalEntry }) {
       <td className={`${cell} text-[11px] break-words text-zinc-500 dark:text-zinc-400`}>
         <div className="flex flex-wrap gap-x-3 gap-y-1">
           {entry.spec_digest != null && (
-            <span title={entry.spec_digest}>spec {shortId(entry.spec_digest)}</span>
+            <span>
+              spec <Clip value={entry.spec_digest} />
+            </span>
           )}
           {entry.idempotency_key != null && (
-            // Not `shortId`: every key for this product begins
-            // `product:<name>@`, so a leading slice distinguishes nothing, and
-            // the product name is already the page title (#1756).
-            <span title={entry.idempotency_key}>key {elideMiddle(entry.idempotency_key)}</span>
+            // Both ends: every key for this product begins `product:<name>@`,
+            // so a leading slice distinguishes nothing, and the product name is
+            // already the page title (#1756).
+            <span>
+              key <Clip value={entry.idempotency_key} keepEnds />
+            </span>
           )}
           {entry.plan_id != null && (
             <a
@@ -157,9 +161,8 @@ function JournalRow({ entry }: { entry: ProductJournalEntry }) {
                 navigateTo(reviewPath(entry.plan_id as string));
               }}
               className="font-mono text-sky-700 underline-offset-2 hover:underline dark:text-sky-400"
-              title={entry.plan_id}
             >
-              plan {shortId(entry.plan_id)}
+              plan <Clip value={entry.plan_id} />
             </a>
           )}
         </div>
@@ -259,7 +262,7 @@ function Standing({ status }: { status: ProductStatusOutput }) {
           label="working spec"
           value={
             status.spec_digest ? (
-              <span title={status.spec_digest}>{shortId(status.spec_digest)}</span>
+              <Clip value={status.spec_digest} />
             ) : (
               "not present"
             )

--- a/engine/ui/src/review/PlanDetail.test.tsx
+++ b/engine/ui/src/review/PlanDetail.test.tsx
@@ -127,9 +127,13 @@ describe("PlanDetail", () => {
     // Two cards say "signed off" once a marker exists — the review status and
     // the approval. Either is enough to know the queue has released the plan.
     await screen.findAllByText("signed off");
-    const panel = await screen.findByRole("region", { name: "Sample rows" });
+    // The offer is the button, and it exists only once the model is known.
+    // Waiting for it also waits out the fallback's "not known yet" section,
+    // which shares the region's name and is what a slower product read
+    // shows first.
+    await screen.findByRole("button", { name: /Show \d+ rows/ });
+    const panel = screen.getByRole("region", { name: "Sample rows" });
     expect(panel.textContent).toContain("revenue_daily");
-    expect(screen.getByRole("button", { name: /Show \d+ rows/ })).toBeTruthy();
   });
 
   /// Absent is not empty. A missing panel would read as "this plan touches no

--- a/engine/ui/src/review/PlanDetail.test.tsx
+++ b/engine/ui/src/review/PlanDetail.test.tsx
@@ -53,6 +53,7 @@ const QUEUE: ReviewQueueOutput = {
       capability: "schema_change.breaking",
       model: "orders",
       models: ["orders"],
+      preview_model: "orders",
       rule_id: 2,
       reason: "a breaking schema change needs a human",
       blast_radius: 7,
@@ -166,6 +167,7 @@ describe("PlanDetail", () => {
           capability: "backfill",
           model: "backfill: 3 model(s)",
           models: ["orders", "customers", "payments"],
+          preview_model: null,
           blast_radius: undefined,
         },
       ],
@@ -199,6 +201,7 @@ describe("PlanDetail", () => {
           capability: "backfill",
           model: "backfill_3_models",
           models: ["orders", "customers", "payments"],
+          preview_model: null,
           blast_radius: undefined,
         },
       ],
@@ -231,6 +234,7 @@ describe("PlanDetail", () => {
           capability: "gc",
           model: "gc",
           models: [],
+          preview_model: null,
           blast_radius: undefined,
         },
       ],
@@ -249,6 +253,41 @@ describe("PlanDetail", () => {
     await screen.findByText("no single model to sample");
     expect(screen.queryByRole("button", { name: /Show \d+ rows/ })).toBeNull();
     expect(screen.getByText(/names no compiled model for this plan \(gc "gc"\)/)).toBeTruthy();
+  });
+
+  /// A graph key is not a licence to read. The engine says per row what the
+  /// samples route would read (`preview_model`); a dotted model name, a
+  /// model a restore recorded that is gone, a model with compile errors are
+  /// keys the route refuses, and the screen must not offer them (#1815,
+  /// review round two). Offering from `models` makes this fail.
+  it("offers no sample for a model the samples route would refuse", async () => {
+    const refused: ReviewQueueOutput = {
+      ...QUEUE,
+      pending: [
+        {
+          ...QUEUE.pending[0],
+          model: "v2.fct_orders",
+          models: ["v2.fct_orders"],
+          preview_model: null,
+        },
+      ],
+    };
+
+    render(
+      <PlanDetail
+        planId={PLAN}
+        loaders={loaders({
+          status: vi.fn(async () => ({ ...STATUS, product_id: undefined })),
+          queue: vi.fn(async () => refused),
+        })}
+      />,
+    );
+
+    await screen.findByText("no single model to sample");
+    expect(screen.queryByRole("button", { name: /Show \d+ rows/ })).toBeNull();
+    expect(
+      screen.getByText(/The samples route would read none of the models this plan names \(v2\.fct_orders\)/),
+    ).toBeTruthy();
   });
 
   /// The apply-time gate records one decision per touched model, and the
@@ -273,6 +312,7 @@ describe("PlanDetail", () => {
           decision_ref: "2026-09-06T09:00:00Z|aaa|customers",
           model: "customers",
           models: ["customers"],
+          preview_model: "customers",
           rule_id: 5,
           reason: "customers is a governed product input",
         },
@@ -315,6 +355,7 @@ describe("PlanDetail", () => {
           capability: "restore",
           model: "restore: 1 tombstoned model",
           models: ["orders", "customers"],
+          preview_model: null,
           blast_radius: undefined,
         },
       ],
@@ -389,6 +430,7 @@ describe("PlanDetail", () => {
           plan_id: PLAN_B,
           model: "customers",
           models: ["customers"],
+          preview_model: "customers",
           approve_command: `rocky review ${PLAN_B} --approve`,
         },
       ],

--- a/engine/ui/src/review/PlanDetail.test.tsx
+++ b/engine/ui/src/review/PlanDetail.test.tsx
@@ -183,8 +183,7 @@ describe("PlanDetail", () => {
 
     await screen.findByText("no single model to sample");
     expect(screen.queryByRole("button", { name: /Show \d+ rows/ })).toBeNull();
-    expect(screen.getByText(/This backfill plan touches 3 models: orders, customers, payments/))
-      .toBeTruthy();
+    expect(screen.getByText(/This plan touches 3 models: orders, customers, payments/)).toBeTruthy();
   });
 
   /// The screen used a `^[a-zA-Z0-9_]+$` regex on the label to decide whether
@@ -220,9 +219,10 @@ describe("PlanDetail", () => {
     expect(screen.queryByRole("region", { name: "Sample rows" })).toBeNull();
   });
 
-  /// A plan-level row from before the engine kept its set has an empty
-  /// `models`. That is "unknown", never "the label is the model".
-  it("says a plan-level row recorded no model set rather than parsing its label", async () => {
+  /// A row whose `models` is empty names no compiled model: a plan-level row
+  /// from before the engine kept its set, a replication target, a removed
+  /// model. That is "unknown", never "the label is the model".
+  it("says the queue names no compiled model rather than parsing the label", async () => {
     const unrecorded: ReviewQueueOutput = {
       ...QUEUE,
       pending: [
@@ -248,7 +248,59 @@ describe("PlanDetail", () => {
 
     await screen.findByText("no single model to sample");
     expect(screen.queryByRole("button", { name: /Show \d+ rows/ })).toBeNull();
-    expect(screen.getByText(/recorded no model set for this gc plan \("gc"\)/)).toBeTruthy();
+    expect(screen.getByText(/names no compiled model for this plan \(gc "gc"\)/)).toBeTruthy();
+  });
+
+  /// The apply-time gate records one decision per touched model, and the
+  /// queue keeps one row per (plan, model): a plan over two models under two
+  /// rules pends twice. Keeping only the first row showed one reason and one
+  /// model beside a command that clears both (#1815).
+  it("shows every escalation of one plan, and one command that clears them all", async () => {
+    const twice: ReviewQueueOutput = {
+      ...QUEUE,
+      total: 2,
+      pending: [
+        {
+          ...QUEUE.pending[0],
+          decision_ref: "2026-09-06T09:00:00Z|aaa|orders",
+          model: "orders",
+          models: ["orders"],
+          rule_id: 2,
+          reason: "orders carries a classified column",
+        },
+        {
+          ...QUEUE.pending[0],
+          decision_ref: "2026-09-06T09:00:00Z|aaa|customers",
+          model: "customers",
+          models: ["customers"],
+          rule_id: 5,
+          reason: "customers is a governed product input",
+        },
+      ],
+    };
+
+    render(
+      <PlanDetail
+        planId={PLAN}
+        loaders={loaders({
+          status: vi.fn(async () => ({ ...STATUS, product_id: undefined })),
+          queue: vi.fn(async () => twice),
+        })}
+      />,
+    );
+
+    await screen.findByText("orders carries a classified column");
+    expect(screen.getByText("customers is a governed product input")).toBeTruthy();
+    expect(screen.getByText("#2")).toBeTruthy();
+    expect(screen.getByText("#5")).toBeTruthy();
+    expect(screen.getByText(/2 escalations name this plan/)).toBeTruthy();
+    // Two models is not one to sample; both are named.
+    expect(screen.getByText("no single model to sample")).toBeTruthy();
+    expect(screen.getByText(/touches 2 models: orders, customers/)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Show \d+ rows/ })).toBeNull();
+    // One command, and it says what it clears.
+    expect(screen.getAllByText(`rocky review ${PLAN} --approve`)).toHaveLength(1);
+    expect(screen.getByText(/clears every one of the 2 escalations/)).toBeTruthy();
   });
 
   /// Backfill is not the only capability whose queue `model` holds a sentence:
@@ -279,7 +331,10 @@ describe("PlanDetail", () => {
     );
 
     await screen.findByText("no single model to sample");
-    expect(screen.getByText(/This restore plan/)).toBeTruthy();
+    expect(screen.getByText(/This plan touches 2 models: orders, customers/)).toBeTruthy();
+    // The capability is shown where the engine put it — on the escalation —
+    // and the sample card does not guess one.
+    expect(screen.getByText("restore")).toBeTruthy();
     expect(screen.queryByText(/backfill/)).toBeNull();
   });
 

--- a/engine/ui/src/review/PlanDetail.test.tsx
+++ b/engine/ui/src/review/PlanDetail.test.tsx
@@ -290,6 +290,40 @@ describe("PlanDetail", () => {
     ).toBeTruthy();
   });
 
+  /// A product-bound plan still in the queue whose row the engine marked
+  /// unreadable (`preview_model: null` — a time-interval model, say) must not
+  /// fall back to the product's output model: that offers the very read the
+  /// route refuses. The product stands in only once the plan has left the
+  /// queue (#1815, review round three).
+  it("does not fall back to the product's model while the queue says none is readable", async () => {
+    const unreadable: ReviewQueueOutput = {
+      ...QUEUE,
+      pending: [{ ...QUEUE.pending[0], models: ["revenue_daily"], preview_model: null }],
+    };
+
+    render(
+      <PlanDetail
+        planId={PLAN}
+        loaders={loaders({
+          status: vi.fn(async () => ({
+            ...STATUS,
+            product_id: "product:revenue_daily",
+            spec_digest: "sha256:1111",
+          })),
+          queue: vi.fn(async () => unreadable),
+        })}
+      />,
+    );
+
+    await screen.findByText("no single model to sample");
+    // The product read did happen (the spec-drift card needs it)…
+    await screen.findByText("unchanged");
+    // …and still no offer.
+    expect(screen.queryByRole("button", { name: /Show \d+ rows/ })).toBeNull();
+    expect(screen.getByText(/The samples route would read none of the models this plan names/))
+      .toBeTruthy();
+  });
+
   /// The apply-time gate records one decision per touched model, and the
   /// queue keeps one row per (plan, model): a plan over two models under two
   /// rules pends twice. Keeping only the first row showed one reason and one

--- a/engine/ui/src/review/PlanDetail.test.tsx
+++ b/engine/ui/src/review/PlanDetail.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { ProductStatusOutput } from "@rocky-types/product_status";
 import type { ReviewOutput } from "@rocky-types/review";
 import type { ReviewQueueOutput } from "@rocky-types/review_queue";
 import type { ReviewStatusOutput } from "@rocky-types/review_status";
+import type { PreviewRowsOutput } from "@rocky-types/preview_rows";
 import statusFixture from "@rocky-fixtures/review_status.json";
 import { ApiError } from "../api";
 import { PlanDetail, type PlanLoaders, describeFinding, productNameFromId } from "./PlanDetail";
@@ -51,6 +52,7 @@ const QUEUE: ReviewQueueOutput = {
       principal: "agent",
       capability: "schema_change.breaking",
       model: "orders",
+      models: ["orders"],
       rule_id: 2,
       reason: "a breaking schema change needs a human",
       blast_radius: 7,
@@ -70,6 +72,22 @@ const PRODUCT: ProductStatusOutput = {
   spec_digest: "sha256:1111",
   output_model: "revenue_daily",
 } as unknown as ProductStatusOutput;
+
+/** What the sample route answers, for the one test that lets a sample run. */
+const SAMPLE: PreviewRowsOutput = {
+  version: "1.74.0",
+  command: "preview-rows",
+  model: "orders",
+  cte: null,
+  columns: ["id"],
+  rows: [[1]],
+  row_count: 1,
+  limit_applied: 20,
+  truncated: false,
+  executed_sql: "SELECT id FROM orders LIMIT 20",
+  adapter_kind: "duckdb",
+  duration_ms: 1,
+};
 
 /** The queue after a sign-off: the escalation is resolved, so nothing pends. */
 const EMPTY_QUEUE: ReviewQueueOutput = { ...QUEUE, total: 0, pending: [] };
@@ -132,9 +150,10 @@ describe("PlanDetail", () => {
   });
 
   /// A backfill escalation puts a display sentence in the queue's `model`
-  /// field — "backfill: 3 model(s)". Feeding that to the samples route earns a
-  /// 400 `invalid_model_name` on every click, so the offer must not be made.
-  it("does not offer to sample a backfill, whose queue entry names no single model", async () => {
+  /// field — "backfill: 3 model(s)" — and the real names in `models`. Three
+  /// models is not one to sample, so the offer is not made; the card names
+  /// them instead.
+  it("does not offer to sample a backfill over several models, and names them", async () => {
     const backfill: ReviewQueueOutput = {
       ...QUEUE,
       pending: [
@@ -142,6 +161,7 @@ describe("PlanDetail", () => {
           ...QUEUE.pending[0],
           capability: "backfill",
           model: "backfill: 3 model(s)",
+          models: ["orders", "customers", "payments"],
           blast_radius: undefined,
         },
       ],
@@ -159,8 +179,72 @@ describe("PlanDetail", () => {
 
     await screen.findByText("no single model to sample");
     expect(screen.queryByRole("button", { name: /Show \d+ rows/ })).toBeNull();
-    // and it quotes what it was given, naming the capability the engine sent
-    expect(screen.getByText(/backfill: 3 model\(s\)/)).toBeTruthy();
+    expect(screen.getByText(/This backfill plan touches 3 models: orders, customers, payments/))
+      .toBeTruthy();
+  });
+
+  /// The screen used a `^[a-zA-Z0-9_]+$` regex on the label to decide whether
+  /// it was a model name. `backfill_3_models` passed, and a click would have
+  /// sampled a real model of that name. The label is display text; only the
+  /// recorded set can name a model (#1815).
+  it("never treats an identifier-shaped label as the model to sample", async () => {
+    const shaped: ReviewQueueOutput = {
+      ...QUEUE,
+      pending: [
+        {
+          ...QUEUE.pending[0],
+          capability: "backfill",
+          model: "backfill_3_models",
+          models: ["orders", "customers", "payments"],
+          blast_radius: undefined,
+        },
+      ],
+    };
+
+    render(
+      <PlanDetail
+        planId={PLAN}
+        loaders={loaders({
+          status: vi.fn(async () => ({ ...STATUS, product_id: undefined })),
+          queue: vi.fn(async () => shaped),
+        })}
+      />,
+    );
+
+    await screen.findByText("no single model to sample");
+    expect(screen.queryByRole("button", { name: /Show \d+ rows/ })).toBeNull();
+    expect(screen.queryByRole("region", { name: "Sample rows" })).toBeNull();
+  });
+
+  /// A plan-level row from before the engine kept its set has an empty
+  /// `models`. That is "unknown", never "the label is the model".
+  it("says a plan-level row recorded no model set rather than parsing its label", async () => {
+    const unrecorded: ReviewQueueOutput = {
+      ...QUEUE,
+      pending: [
+        {
+          ...QUEUE.pending[0],
+          capability: "gc",
+          model: "gc",
+          models: [],
+          blast_radius: undefined,
+        },
+      ],
+    };
+
+    render(
+      <PlanDetail
+        planId={PLAN}
+        loaders={loaders({
+          status: vi.fn(async () => ({ ...STATUS, product_id: undefined })),
+          queue: vi.fn(async () => unrecorded),
+        })}
+      />,
+    );
+
+    await screen.findByText("no single model to sample");
+    expect(screen.queryByRole("button", { name: /Show \d+ rows/ })).toBeNull();
+    expect(screen.getByText(/recorded no model set for this gc plan \("gc"\)/)).toBeTruthy();
   });
 
   /// Backfill is not the only capability whose queue `model` holds a sentence:
@@ -174,6 +258,7 @@ describe("PlanDetail", () => {
           ...QUEUE.pending[0],
           capability: "restore",
           model: "restore: 1 tombstoned model",
+          models: ["orders", "customers"],
           blast_radius: undefined,
         },
       ],
@@ -190,8 +275,8 @@ describe("PlanDetail", () => {
     );
 
     await screen.findByText("no single model to sample");
-    expect(screen.getByText(/this restore plan/)).toBeTruthy();
-    expect(screen.queryByText(/a backfill covers/)).toBeNull();
+    expect(screen.getByText(/This restore plan/)).toBeTruthy();
+    expect(screen.queryByText(/backfill/)).toBeNull();
   });
 
   /// "The queue does not name this plan" and "the queue could not be read" are
@@ -215,6 +300,82 @@ describe("PlanDetail", () => {
     // The queue feeds several panels, so its refusal shows in more than one.
     await screen.findAllByText(/state_unreadable/);
     expect(screen.queryByText("not in the queue")).toBeNull();
+    // The sample fallback is one of them. It used to read the same `null`
+    // as "no longer in the queue" and print that beside the refusal: an
+    // unreadable queue is unknown, not empty (#1815).
+    expect(screen.queryByText(/no longer in the queue/)).toBeNull();
+    expect(screen.getByText("Which model to sample is not known yet.")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Show \d+ rows/ })).toBeNull();
+  });
+
+  /// Navigating from plan A straight to plan B, with B's reads slower. The
+  /// heading updates at once; before this, every panel under it kept A's
+  /// answer — A's status, A's sample, and A's approve command under B's
+  /// heading — and the sample panel kept its consent, so B's warehouse query
+  /// ran with no click (#1815). The check is synchronous after the rerender:
+  /// no frame may show A under B.
+  it("carries nothing of plan A under plan B's heading, and asks again before sampling", async () => {
+    const PLAN_B = "b".repeat(64);
+    let releaseB!: (value: ReviewStatusOutput) => void;
+    const statusB = new Promise<ReviewStatusOutput>((resolve) => {
+      releaseB = resolve;
+    });
+    const queue: ReviewQueueOutput = {
+      ...QUEUE,
+      total: 2,
+      pending: [
+        QUEUE.pending[0],
+        {
+          ...QUEUE.pending[0],
+          plan_id: PLAN_B,
+          model: "customers",
+          models: ["customers"],
+          approve_command: `rocky review ${PLAN_B} --approve`,
+        },
+      ],
+    };
+    const sampled: string[] = [];
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      sampled.push(String(input));
+      return new Response(JSON.stringify(SAMPLE), { status: 200 });
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    try {
+      const shared = loaders({
+        status: vi.fn(async (planId: string) => (planId === PLAN ? STATUS : statusB)),
+        diff: vi.fn(async (planId: string) => ({ ...DIFF, plan_id: planId })),
+        queue: vi.fn(async () => queue),
+      });
+      const view = render(<PlanDetail planId={PLAN} loaders={shared} />);
+      await screen.findByText("awaiting a human");
+      expect(screen.getByText(`rocky review ${PLAN} --approve`)).toBeTruthy();
+      // Consent for A's model, given by a click.
+      fireEvent.click(screen.getByRole("button", { name: /Show \d+ rows/ }));
+      await waitFor(() => expect(sampled).toHaveLength(1));
+      expect(sampled[0]).toContain("/models/orders/rows");
+
+      view.rerender(<PlanDetail planId={PLAN_B} loaders={shared} />);
+
+      // Synchronously: B's heading, and nothing of A under it.
+      expect(document.querySelector(`[title="${PLAN_B}"]`)).toBeTruthy();
+      expect(document.querySelector(`[title="${PLAN}"]`)).toBeNull();
+      expect(screen.queryByText(`rocky review ${PLAN} --approve`)).toBeNull();
+      expect(screen.queryByText("awaiting a human")).toBeNull();
+      expect(screen.getByText("reading the plan…")).toBeTruthy();
+
+      releaseB({ ...STATUS, plan_id: PLAN_B });
+      await screen.findByText(`rocky review ${PLAN_B} --approve`);
+      // B's model is offered, not read: the button is back and the only
+      // query that ever ran is A's.
+      expect(screen.getByRole("button", { name: /Show \d+ rows/ })).toBeTruthy();
+      expect(screen.getByRole("region", { name: "Sample rows" }).textContent).toContain(
+        "customers",
+      );
+      expect(sampled).toHaveLength(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   it("shows the plan, its findings, the escalation and the approve command", async () => {

--- a/engine/ui/src/review/PlanDetail.tsx
+++ b/engine/ui/src/review/PlanDetail.tsx
@@ -64,6 +64,26 @@ export function modelsNamedBy(entries: ReviewQueueEntry[]): string[] {
   return Array.from(new Set(entries.flatMap((entry) => entry.models)));
 }
 
+/**
+ * The distinct models the samples route would read for a plan's rows. The
+ * engine decides this per row under the route's own admission rules
+ * (`preview_model`); a graph key in `models` is for ranking and audit and is
+ * not a licence to read — a dotted name, a model a restore plan recorded
+ * that is gone from the project, a model that no longer compiles are all
+ * keys the route refuses (#1815).
+ */
+export function previewTargetsOf(entries: ReviewQueueEntry[]): string[] {
+  return Array.from(
+    new Set(
+      entries.flatMap((entry) =>
+        entry.preview_model === null || entry.preview_model === undefined
+          ? []
+          : [entry.preview_model],
+      ),
+    ),
+  );
+}
+
 /** One breaking finding as a sentence, from the tagged union the engine emits. */
 export function describeFinding(finding: BreakingFinding): string {
   const change = finding.change as Record<string, unknown>;
@@ -340,21 +360,22 @@ function SampleFallback({
     const { entries } = lookup;
     const named = modelsNamedBy(entries);
     const subjects = entries.map((entry) => `${entry.capability} "${entry.model}"`).join(", ");
-    return (
-      <StatusCard
-        label="sample rows"
-        value="no single model to sample"
-        sub={
-          named.length === 0
-            ? // The engine could not vouch for a compiled model behind the
-              // row: its subject is not one (a replication target, a label),
-              // the model is gone, or the compile could not name it. The
-              // screen does not guess which.
-              `The queue names no compiled model for this plan (${subjects}), so there is nothing to read rows from. Sample from the estate screen instead.`
-            : `This plan touches ${named.length} models: ${named.join(", ")}. Sample each from the estate screen instead.`
-        }
-      />
-    );
+    let sub: string;
+    if (named.length === 0) {
+      // The engine could not vouch for a compiled model behind the row: its
+      // subject is not one (a replication target, a label), the model is
+      // gone, or the compile could not name it. The screen does not guess
+      // which.
+      sub = `The queue names no compiled model for this plan (${subjects}), so there is nothing to read rows from. Sample from the estate screen instead.`;
+    } else if (named.length > 1) {
+      sub = `This plan touches ${named.length} models: ${named.join(", ")}. Sample each from the estate screen instead.`;
+    } else {
+      // One model named, and no preview target offered for it: the samples
+      // route would refuse it. The engine applied the route's own rules;
+      // the screen repeats them rather than guessing which one bit.
+      sub = `The samples route would read none of the models this plan names (${named.join(", ")}): it reads one model at a time, in the current project, with no compile errors and not time-interval. Sample from the estate screen instead.`;
+    }
+    return <StatusCard label="sample rows" value="no single model to sample" sub={sub} />;
   }
   return (
     <StatusCard
@@ -420,15 +441,16 @@ export function PlanDetail({
   // name) and is never parsed here. A regex on it once decided a label was a
   // name, and `backfill_3_models` would have sampled a real model of that
   // name (#1815). The panel takes the plan's rows together, and only when
-  // they name exactly one model.
+  // the engine says the samples route would read exactly one model for them
+  // (`preview_model`, decided under that route's own admission rules).
   //
   // The queue is not a durable source: an approval marker resolves the
   // escalation, so the entry disappears the moment the plan is signed off —
   // and that is exactly when the table it built starts existing. The
   // product's own status carries `output_model`, and this screen already
   // reads it for the spec-drift card, so the fallback costs no request.
-  const named = modelsNamedBy(entries);
-  const fromQueue = named.length === 1 ? named[0] : null;
+  const targets = previewTargetsOf(entries);
+  const fromQueue = targets.length === 1 ? targets[0] : null;
   const fromProduct =
     product.kind === "ready" ? (product.value.output_model ?? null) : null;
   const model = fromQueue ?? fromProduct;

--- a/engine/ui/src/review/PlanDetail.tsx
+++ b/engine/ui/src/review/PlanDetail.tsx
@@ -4,9 +4,9 @@ import type { BreakingFinding, ReviewOutput } from "@rocky-types/review";
 import type { ReviewQueueEntry, ReviewQueueOutput } from "@rocky-types/review_queue";
 import type { ReviewStatusOutput } from "@rocky-types/review_status";
 import { apiGet } from "../api";
-import { StatusCard } from "../components";
+import { Clip, StatusCard } from "../components";
 import { type Resource, useResource } from "../estate/useResource";
-import { formatInstant, shortId } from "../format";
+import { formatInstant } from "../format";
 import { CustodyLink } from "../governor/links";
 import { ResourceState } from "./ResourceState";
 import { SamplePanel } from "./SamplePanel";
@@ -25,15 +25,32 @@ export const defaultPlanLoaders: PlanLoaders = {
   product: (name) => apiGet<ProductStatusOutput>(`products/${encodeURIComponent(name)}`),
 };
 
-/**
- * What the samples route will accept as a model name — the same shape as
- * `rocky_sql::validation::validate_identifier` (`^[a-zA-Z0-9_]+$`).
- */
-const MODEL_NAME = /^[a-zA-Z0-9_]+$/;
-
 /** A `product:<name>` identity reduced to the name the products route takes. */
 export function productNameFromId(productId: string): string {
   return productId.startsWith("product:") ? productId.slice("product:".length) : productId;
+}
+
+/**
+ * What the queue says about one plan. Three answers, because the queue is a
+ * resource and a resource has three ways to stand: it named the plan, it was
+ * read and did not name it, or it could not be read. Only the middle one is
+ * "not in the queue". The last is unknown, and unknown is never shown as
+ * absent: a queue refused with `engine_busy` says nothing about whether the
+ * plan is in it, and a screen that said "no longer in the queue" beside that
+ * refusal was asserting what it could not know (#1815).
+ */
+export type QueueLookup =
+  | { kind: "unknown"; queue: Resource<ReviewQueueOutput> }
+  | { kind: "absent" }
+  | { kind: "present"; entry: ReviewQueueEntry };
+
+export function lookupQueueEntry(
+  queue: Resource<ReviewQueueOutput>,
+  planId: string,
+): QueueLookup {
+  if (queue.kind !== "ready") return { kind: "unknown", queue };
+  const entry = queue.value.pending.find((row) => row.plan_id === planId);
+  return entry === undefined ? { kind: "absent" } : { kind: "present", entry };
 }
 
 /** One breaking finding as a sentence, from the tagged union the engine emits. */
@@ -142,7 +159,11 @@ function SpecDrift({
       <StatusCard
         label="the spec it was planned against"
         value="unchanged"
-        sub={`Still ${shortId(planned)}.`}
+        sub={
+          <>
+            Still <Clip value={planned} />.
+          </>
+        }
       />
     );
   }
@@ -151,37 +172,32 @@ function SpecDrift({
       label="the spec it was planned against"
       value="the spec moved"
       tone="risk"
-      sub={`Planned against ${shortId(planned)}; the product is now ${shortId(
-        current,
-      )}. Applying this plan would be refused, because apply checks the digest.`}
+      sub={
+        <>
+          Planned against <Clip value={planned} />; the product is now <Clip value={current} />.
+          Applying this plan would be refused, because apply checks the digest.
+        </>
+      }
     />
   );
 }
 
-function Escalation({
-  entry,
-  queue,
-  planId,
-}: {
-  entry: ReviewQueueEntry | null;
-  queue: Resource<ReviewQueueOutput>;
-  planId: string;
-}) {
+function Escalation({ lookup, planId }: { lookup: QueueLookup; planId: string }) {
   // "The queue does not name this plan" and "the queue could not be read" are
   // different facts, and only the first is safe to state. Collapsing them told
   // a reader that an escalation had been resolved when the server had in fact
   // refused the request.
-  if (queue.kind !== "ready") {
+  if (lookup.kind === "unknown") {
     return (
       <section aria-label="Why it needs a human" className="space-y-2">
         <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
           Why it needs a human
         </h3>
-        <ResourceState resource={queue} loadingLine="reading the review queue…" />
+        <ResourceState resource={lookup.queue} loadingLine="reading the review queue…" />
       </section>
     );
   }
-  if (entry === null) {
+  if (lookup.kind === "absent") {
     return (
       <StatusCard
         label="why it needs a human"
@@ -190,6 +206,7 @@ function Escalation({
       />
     );
   }
+  const { entry } = lookup;
   return (
     <section aria-label="Why it needs a human" className="space-y-2">
       <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
@@ -249,6 +266,67 @@ function HowToApprove({ status, entry }: { status: ReviewStatusOutput; entry: Re
 }
 
 /**
+ * Why there is no sample panel, said only as far as the payloads support.
+ *
+ * Absent is not empty. A missing panel reads as "this plan touches no data";
+ * this says instead which fact is missing, and it is a different fact each
+ * time: the queue named several models, or none; the product could not be
+ * read; the queue could not be read. Only when the queue was READ and does
+ * not name the plan, and no product names a model, does the screen say the
+ * plan has left the queue — that is the one case it knows (#1815).
+ */
+function SampleFallback({
+  lookup,
+  productId,
+  product,
+}: {
+  lookup: QueueLookup;
+  productId: string | null;
+  product: Resource<ProductStatusOutput>;
+}) {
+  const pending = (resource: Resource<unknown>, loadingLine: string) => (
+    <section aria-label="Sample rows" className="space-y-2">
+      <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Sample rows</h3>
+      <p className="text-xs text-zinc-600 dark:text-zinc-300">
+        Which model to sample is not known yet.
+      </p>
+      <ResourceState resource={resource} loadingLine={loadingLine} />
+    </section>
+  );
+  if (lookup.kind === "unknown") {
+    return pending(lookup.queue, "reading the review queue…");
+  }
+  if (productId !== null && product.kind !== "ready") {
+    return pending(product, "reading the product…");
+  }
+  if (lookup.kind === "present") {
+    const { entry } = lookup;
+    return (
+      <StatusCard
+        label="sample rows"
+        value="no single model to sample"
+        sub={
+          entry.models.length === 0
+            ? `The queue recorded no model set for this ${entry.capability} plan ("${entry.model}"): it was escalated before the engine kept one. Sample the models it touches from the estate screen instead.`
+            : `This ${entry.capability} plan touches ${entry.models.length} models: ${entry.models.join(", ")}. Sample each from the estate screen instead.`
+        }
+      />
+    );
+  }
+  return (
+    <StatusCard
+      label="sample rows"
+      value="no single model to sample"
+      sub={
+        productId !== null
+          ? "The plan is no longer in the review queue and its product names no output model, so there is nothing to read rows from."
+          : "Neither the review queue nor a product names a model for this plan, so there is nothing to read rows from. A plan that is not product-bound and no longer in the queue has no model on this screen."
+      }
+    />
+  );
+}
+
+/**
  * One plan, read-only: what it is, what it would break, why policy stopped it,
  * whether the spec moved under it, a sample of the data, and the command that
  * would approve it.
@@ -284,43 +362,37 @@ export function PlanDetail({
     return (
       <section aria-label="The plan" className="space-y-3">
         <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-          Plan <span title={planId}>{shortId(planId)}</span>
+          Plan <Clip value={planId} />
         </h2>
         <ResourceState resource={status} loadingLine="reading the plan…" />
       </section>
     );
   }
 
-  const entry =
-    queue.kind === "ready"
-      ? (queue.value.pending.find((row) => row.plan_id === planId) ?? null)
-      : null;
-  // Which model to sample. The queue entry names it, but the queue is not a
-  // durable source: an approval marker resolves the escalation, so the entry
-  // disappears the moment the plan is signed off — and that is exactly when
-  // the table it built starts existing. Reading the queue alone meant the
-  // panel could never show real rows for a product's first plan: before the
-  // approval there is no table, and after it there is no entry.
+  const lookup = lookupQueueEntry(queue, planId);
+  const entry = lookup.kind === "present" ? lookup.entry : null;
+  // Which model to sample. The queue entry's `models` is the set the engine
+  // recorded for the escalation — the real names, kept apart from `model`,
+  // which is display text ("backfill: 3 model(s)") and is never parsed here.
+  // A regex on it once decided a label was a name, and `backfill_3_models`
+  // would have sampled a real model of that name (#1815). The panel takes the
+  // set only when it names exactly one model.
   //
-  // The product's own status carries `output_model`, and this screen already
+  // The queue is not a durable source: an approval marker resolves the
+  // escalation, so the entry disappears the moment the plan is signed off —
+  // and that is exactly when the table it built starts existing. The
+  // product's own status carries `output_model`, and this screen already
   // reads it for the spec-drift card, so the fallback costs no request.
-  //
-  // The queue entry's `model` is not always a model name. A backfill escalation
-  // puts a display sentence there — "backfill: 3 model(s)" — and feeding that to
-  // the samples route earns a 400 `invalid_model_name` on every click. So take
-  // the field only when it could be a name. The server stays the authority
-  // (`rocky_sql::validation::validate_identifier`, `^[a-zA-Z0-9_]+$`); this only
-  // withholds an offer the server would refuse, so a drift here declines to ask
-  // rather than asking wrongly.
-  const named = entry?.model !== undefined && MODEL_NAME.test(entry.model) ? entry.model : null;
-  const model =
-    named ?? (product.kind === "ready" ? (product.value.output_model ?? null) : null);
+  const fromQueue = entry !== null && entry.models.length === 1 ? entry.models[0] : null;
+  const fromProduct =
+    product.kind === "ready" ? (product.value.output_model ?? null) : null;
+  const model = fromQueue ?? fromProduct;
 
   return (
     <div className="space-y-4">
       <section aria-label="The plan" className="space-y-2">
         <h2 className="font-mono text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-          <span title={planId}>{shortId(planId)}</span>
+          <Clip value={planId} />
         </h2>
         <div className="grid gap-2 sm:grid-cols-3">
           <StatusCard label="kind" value={status.value.kind} />
@@ -347,7 +419,7 @@ export function PlanDetail({
         </section>
       )}
 
-      <Escalation entry={entry} queue={queue} planId={planId} />
+      <Escalation lookup={lookup} planId={planId} />
 
       {productId !== null &&
         (product.kind === "ready" ? (
@@ -364,23 +436,7 @@ export function PlanDetail({
       {model !== null ? (
         <SamplePanel model={model} />
       ) : (
-        // Absent is not empty. A missing panel reads as "this plan touches no
-        // data"; say instead that the screen could not work out which model to
-        // sample, which is a different thing and has a different fix.
-        //
-        // Say only what the payload supports. Backfill is not the only
-        // capability whose `model` field holds a sentence — gc and restore
-        // write one too — so quote the sentence and name the capability the
-        // engine gave, rather than describing a backfill the plan may not be.
-        <StatusCard
-          label="sample rows"
-          value="no single model to sample"
-          sub={
-            entry !== null
-              ? `The queue describes this ${entry.capability} plan as "${entry.model}", which is not a model name this panel can read rows from. Sample the models it touches from the estate screen instead.`
-              : "Neither the review queue nor the product names a model for this plan, so there is nothing to read rows from. A plan that is not product-bound and no longer in the queue has no model on this screen."
-          }
-        />
+        <SampleFallback lookup={lookup} productId={productId} product={product} />
       )}
 
       <HowToApprove status={status.value} entry={entry} />

--- a/engine/ui/src/review/PlanDetail.tsx
+++ b/engine/ui/src/review/PlanDetail.tsx
@@ -451,8 +451,15 @@ export function PlanDetail({
   // reads it for the spec-drift card, so the fallback costs no request.
   const targets = previewTargetsOf(entries);
   const fromQueue = targets.length === 1 ? targets[0] : null;
+  // The product's output model stands in only once the plan has LEFT the
+  // queue (approved, its table now real). While the plan is in the queue the
+  // engine has already said which model, if any, the samples route would
+  // read, and a null there is an answer — a product fallback beside it
+  // offered a read the route refuses (#1815, review round three).
   const fromProduct =
-    product.kind === "ready" ? (product.value.output_model ?? null) : null;
+    lookup.kind === "absent" && product.kind === "ready"
+      ? (product.value.output_model ?? null)
+      : null;
   const model = fromQueue ?? fromProduct;
 
   return (

--- a/engine/ui/src/review/PlanDetail.tsx
+++ b/engine/ui/src/review/PlanDetail.tsx
@@ -38,19 +38,30 @@ export function productNameFromId(productId: string): string {
  * absent: a queue refused with `engine_busy` says nothing about whether the
  * plan is in it, and a screen that said "no longer in the queue" beside that
  * refusal was asserting what it could not know (#1815).
+ *
+ * A present plan carries EVERY row that names it. The apply-time gate records
+ * one decision per touched model and the queue keeps one row per (plan,
+ * model), so a plan over two models under two rules pends twice, with two
+ * reasons. Keeping the first row showed one reason beside a command that
+ * clears both (#1815).
  */
 export type QueueLookup =
   | { kind: "unknown"; queue: Resource<ReviewQueueOutput> }
   | { kind: "absent" }
-  | { kind: "present"; entry: ReviewQueueEntry };
+  | { kind: "present"; entries: ReviewQueueEntry[] };
 
 export function lookupQueueEntry(
   queue: Resource<ReviewQueueOutput>,
   planId: string,
 ): QueueLookup {
   if (queue.kind !== "ready") return { kind: "unknown", queue };
-  const entry = queue.value.pending.find((row) => row.plan_id === planId);
-  return entry === undefined ? { kind: "absent" } : { kind: "present", entry };
+  const entries = queue.value.pending.filter((row) => row.plan_id === planId);
+  return entries.length === 0 ? { kind: "absent" } : { kind: "present", entries };
+}
+
+/** The distinct compiled models a plan's rows name, in the queue's order. */
+export function modelsNamedBy(entries: ReviewQueueEntry[]): string[] {
+  return Array.from(new Set(entries.flatMap((entry) => entry.models)));
 }
 
 /** One breaking finding as a sentence, from the tagged union the engine emits. */
@@ -206,31 +217,49 @@ function Escalation({ lookup, planId }: { lookup: QueueLookup; planId: string })
       />
     );
   }
-  const { entry } = lookup;
+  const { entries } = lookup;
   return (
-    <section aria-label="Why it needs a human" className="space-y-2">
+    <section aria-label="Why it needs a human" className="space-y-3">
       <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
         Why it needs a human
       </h3>
-      <p className="text-sm text-zinc-800 dark:text-zinc-200">{entry.reason}</p>
-      <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-zinc-600 sm:grid-cols-4 dark:text-zinc-300">
-        <div>
-          <dt className="text-zinc-500 dark:text-zinc-400">capability</dt>
-          <dd>{entry.capability}</dd>
+      {entries.length > 1 && (
+        <p className="text-xs text-zinc-600 dark:text-zinc-300">
+          {entries.length} escalations name this plan, one per model policy stopped. Approving
+          the plan clears all of them.
+        </p>
+      )}
+      {entries.map((entry) => (
+        <div key={entry.decision_ref} className="space-y-2">
+          <p className="text-sm text-zinc-800 dark:text-zinc-200">{entry.reason}</p>
+          <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-zinc-600 sm:grid-cols-5 dark:text-zinc-300">
+            <div>
+              <dt className="text-zinc-500 dark:text-zinc-400">model</dt>
+              <dd className="font-mono break-all">{entry.model}</dd>
+            </div>
+            <div>
+              <dt className="text-zinc-500 dark:text-zinc-400">capability</dt>
+              <dd>{entry.capability}</dd>
+            </div>
+            <div>
+              <dt className="text-zinc-500 dark:text-zinc-400">principal</dt>
+              <dd>{entry.principal}</dd>
+            </div>
+            <div>
+              <dt className="text-zinc-500 dark:text-zinc-400">rule</dt>
+              <dd>
+                {entry.rule_id === undefined || entry.rule_id === null
+                  ? "the default effect"
+                  : `#${entry.rule_id}`}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-zinc-500 dark:text-zinc-400">blast radius</dt>
+              <dd>{entry.blast_radius ?? "not computed"}</dd>
+            </div>
+          </dl>
         </div>
-        <div>
-          <dt className="text-zinc-500 dark:text-zinc-400">principal</dt>
-          <dd>{entry.principal}</dd>
-        </div>
-        <div>
-          <dt className="text-zinc-500 dark:text-zinc-400">rule</dt>
-          <dd>{entry.rule_id === undefined || entry.rule_id === null ? "the default effect" : `#${entry.rule_id}`}</dd>
-        </div>
-        <div>
-          <dt className="text-zinc-500 dark:text-zinc-400">blast radius</dt>
-          <dd>{entry.blast_radius ?? "not computed"}</dd>
-        </div>
-      </dl>
+      ))}
       <p className="text-xs text-zinc-600 dark:text-zinc-300">
         Every decision recorded about this plan: <CustodyLink subject={planId} />
       </p>
@@ -238,7 +267,13 @@ function Escalation({ lookup, planId }: { lookup: QueueLookup; planId: string })
   );
 }
 
-function HowToApprove({ status, entry }: { status: ReviewStatusOutput; entry: ReviewQueueEntry | null }) {
+function HowToApprove({
+  status,
+  entries,
+}: {
+  status: ReviewStatusOutput;
+  entries: ReviewQueueEntry[];
+}) {
   if (status.reviewed) {
     return (
       <StatusCard
@@ -250,13 +285,15 @@ function HowToApprove({ status, entry }: { status: ReviewStatusOutput; entry: Re
       />
     );
   }
-  const command = entry?.approve_command ?? `rocky review ${status.plan_id} --approve`;
+  // Every row of one plan carries the same command: approval is per plan.
+  const command = entries[0]?.approve_command ?? `rocky review ${status.plan_id} --approve`;
   return (
     <section aria-label="How to approve" className="space-y-2">
       <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">How to approve</h3>
       <p className="text-xs text-zinc-600 dark:text-zinc-300">
         Approving happens in a terminal, on purpose: the marker records a git identity, and this
         page holds a read-only token. Copy the command.
+        {entries.length > 1 ? ` It clears every one of the ${entries.length} escalations above.` : ""}
       </p>
       <pre className="overflow-x-auto rounded bg-zinc-50 p-2 font-mono text-xs dark:bg-zinc-800">
         {command}
@@ -300,15 +337,21 @@ function SampleFallback({
     return pending(product, "reading the product…");
   }
   if (lookup.kind === "present") {
-    const { entry } = lookup;
+    const { entries } = lookup;
+    const named = modelsNamedBy(entries);
+    const subjects = entries.map((entry) => `${entry.capability} "${entry.model}"`).join(", ");
     return (
       <StatusCard
         label="sample rows"
         value="no single model to sample"
         sub={
-          entry.models.length === 0
-            ? `The queue recorded no model set for this ${entry.capability} plan ("${entry.model}"): it was escalated before the engine kept one. Sample the models it touches from the estate screen instead.`
-            : `This ${entry.capability} plan touches ${entry.models.length} models: ${entry.models.join(", ")}. Sample each from the estate screen instead.`
+          named.length === 0
+            ? // The engine could not vouch for a compiled model behind the
+              // row: its subject is not one (a replication target, a label),
+              // the model is gone, or the compile could not name it. The
+              // screen does not guess which.
+              `The queue names no compiled model for this plan (${subjects}), so there is nothing to read rows from. Sample from the estate screen instead.`
+            : `This plan touches ${named.length} models: ${named.join(", ")}. Sample each from the estate screen instead.`
         }
       />
     );
@@ -370,20 +413,22 @@ export function PlanDetail({
   }
 
   const lookup = lookupQueueEntry(queue, planId);
-  const entry = lookup.kind === "present" ? lookup.entry : null;
-  // Which model to sample. The queue entry's `models` is the set the engine
-  // recorded for the escalation — the real names, kept apart from `model`,
-  // which is display text ("backfill: 3 model(s)") and is never parsed here.
-  // A regex on it once decided a label was a name, and `backfill_3_models`
-  // would have sampled a real model of that name (#1815). The panel takes the
-  // set only when it names exactly one model.
+  const entries = lookup.kind === "present" ? lookup.entries : [];
+  // Which model to sample. Each row's `models` is the set of compiled models
+  // the engine vouches for — the real names, kept apart from `model`, which
+  // is display text ("backfill: 3 model(s)", a replication target's table
+  // name) and is never parsed here. A regex on it once decided a label was a
+  // name, and `backfill_3_models` would have sampled a real model of that
+  // name (#1815). The panel takes the plan's rows together, and only when
+  // they name exactly one model.
   //
   // The queue is not a durable source: an approval marker resolves the
   // escalation, so the entry disappears the moment the plan is signed off —
   // and that is exactly when the table it built starts existing. The
   // product's own status carries `output_model`, and this screen already
   // reads it for the spec-drift card, so the fallback costs no request.
-  const fromQueue = entry !== null && entry.models.length === 1 ? entry.models[0] : null;
+  const named = modelsNamedBy(entries);
+  const fromQueue = named.length === 1 ? named[0] : null;
   const fromProduct =
     product.kind === "ready" ? (product.value.output_model ?? null) : null;
   const model = fromQueue ?? fromProduct;
@@ -439,7 +484,7 @@ export function PlanDetail({
         <SampleFallback lookup={lookup} productId={productId} product={product} />
       )}
 
-      <HowToApprove status={status.value} entry={entry} />
+      <HowToApprove status={status.value} entries={entries} />
     </div>
   );
 }

--- a/engine/ui/src/review/QueuePanel.test.tsx
+++ b/engine/ui/src/review/QueuePanel.test.tsx
@@ -21,6 +21,7 @@ const QUEUE: ReviewQueueOutput = {
       capability: "schema_change.breaking",
       model: "orders",
       models: ["orders"],
+      preview_model: "orders",
       rule_id: 2,
       reason: "a breaking schema change needs a human",
       blast_radius: 7,
@@ -37,6 +38,7 @@ const QUEUE: ReviewQueueOutput = {
       capability: "schema_change.additive",
       model: "customers",
       models: ["customers"],
+      preview_model: "customers",
       rule_id: null,
       reason: "the default effect asks for review",
       blast_radius: null,
@@ -84,6 +86,7 @@ describe("QueuePanel", () => {
           capability: "backfill" as const,
           model: "backfill: 3 model(s)",
           models: ["orders", "customers", "payments"],
+          preview_model: null,
         },
       ],
     }));

--- a/engine/ui/src/review/QueuePanel.test.tsx
+++ b/engine/ui/src/review/QueuePanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { ReviewQueueOutput } from "@rocky-types/review_queue";
 import { ApiError } from "../api";
@@ -20,6 +20,7 @@ const QUEUE: ReviewQueueOutput = {
       principal: "agent",
       capability: "schema_change.breaking",
       model: "orders",
+      models: ["orders"],
       rule_id: 2,
       reason: "a breaking schema change needs a human",
       blast_radius: 7,
@@ -35,6 +36,7 @@ const QUEUE: ReviewQueueOutput = {
       principal: "agent",
       capability: "schema_change.additive",
       model: "customers",
+      models: ["customers"],
       rule_id: null,
       reason: "the default effect asks for review",
       blast_radius: null,
@@ -67,6 +69,31 @@ describe("QueuePanel", () => {
     // The excluded rows are explained, not hidden: "2 waiting" beside a ledger
     // holding five rows is otherwise a question the screen leaves open.
     expect(screen.getByText(/3 further rows in the ledger/)).toBeTruthy();
+  });
+
+  /// On a plan-level row `model` is a label — "backfill: 3 model(s)" — and
+  /// the engine reports the names in `models`. The row shows them; an
+  /// ordinary row, whose set is its label, does not repeat itself.
+  it("lists the recorded model set on a plan-level row, and only there", async () => {
+    const load = vi.fn(async () => ({
+      ...QUEUE,
+      pending: [
+        QUEUE.pending[0],
+        {
+          ...QUEUE.pending[1],
+          capability: "backfill" as const,
+          model: "backfill: 3 model(s)",
+          models: ["orders", "customers", "payments"],
+        },
+      ],
+    }));
+    render(<QueuePanel load={load} now={NOW} />);
+
+    await screen.findByText("2 waiting for review");
+    const [ordinary, planLevel] = screen.getAllByRole("listitem");
+    expect(within(planLevel).getByText("models")).toBeTruthy();
+    expect(within(planLevel).getByText("orders, customers, payments")).toBeTruthy();
+    expect(within(ordinary).queryByText("models")).toBeNull();
   });
 
   it("says plainly when nothing is waiting", async () => {

--- a/engine/ui/src/review/QueuePanel.tsx
+++ b/engine/ui/src/review/QueuePanel.tsx
@@ -2,7 +2,8 @@ import type { ReviewQueueEntry, ReviewQueueOutput } from "@rocky-types/review_qu
 import { apiGet } from "../api";
 import { useResource } from "../estate/useResource";
 import { ResourceState } from "./ResourceState";
-import { formatInstant, shortId } from "../format";
+import { Clip } from "../components";
+import { formatInstant } from "../format";
 import { navigateTo } from "../router";
 import { reviewPath } from "./paths";
 
@@ -33,7 +34,7 @@ function QueueRow({ entry, now }: { entry: ReviewQueueEntry; now?: number }) {
           }}
           className="font-mono text-sm text-sky-700 underline-offset-2 hover:underline dark:text-sky-400"
         >
-          <span title={entry.plan_id}>{shortId(entry.plan_id)}</span>
+          <Clip value={entry.plan_id} />
         </a>
         <span className="text-[11px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
           {entry.capability} · {entry.principal}
@@ -45,6 +46,17 @@ function QueueRow({ entry, now }: { entry: ReviewQueueEntry; now?: number }) {
           <dt className="text-zinc-500 dark:text-zinc-400">model</dt>
           <dd className="font-mono break-all">{entry.model}</dd>
         </div>
+        {!(entry.models.length === 1 && entry.models[0] === entry.model) && (
+          // On a plan-level row `model` is a label — "backfill: 3 model(s)" —
+          // and the names are in `models`. Shown only when they differ; on an
+          // ordinary row the set is the label and the cell would repeat it.
+          <div>
+            <dt className="text-zinc-500 dark:text-zinc-400">models</dt>
+            <dd className="font-mono break-all">
+              {entry.models.length === 0 ? "not recorded" : entry.models.join(", ")}
+            </dd>
+          </div>
+        )}
         <div>
           <dt className="text-zinc-500 dark:text-zinc-400">blast radius</dt>
           <dd>{entry.blast_radius ?? "not computed"}</dd>

--- a/engine/ui/src/review/QueuePanel.tsx
+++ b/engine/ui/src/review/QueuePanel.tsx
@@ -53,7 +53,7 @@ function QueueRow({ entry, now }: { entry: ReviewQueueEntry; now?: number }) {
           <div>
             <dt className="text-zinc-500 dark:text-zinc-400">models</dt>
             <dd className="font-mono break-all">
-              {entry.models.length === 0 ? "not recorded" : entry.models.join(", ")}
+              {entry.models.length === 0 ? "none the graph can name" : entry.models.join(", ")}
             </dd>
           </div>
         )}

--- a/engine/ui/src/review/SamplePanel.test.tsx
+++ b/engine/ui/src/review/SamplePanel.test.tsx
@@ -36,6 +36,26 @@ describe("SamplePanel", () => {
     expect(load).toHaveBeenCalledWith("orders");
   });
 
+  /// Consent is given for one model. D8 made sampling a per-request consent;
+  /// a panel that kept `asked` across a model change turned one press into
+  /// consent for whatever model came next, and ran that query with no click
+  /// (#1815).
+  it("withdraws consent when the model under it changes", async () => {
+    const load = vi.fn(async () => SAMPLE);
+    const view = render(<SamplePanel model="orders" load={load} />);
+    fireEvent.click(screen.getByRole("button", { name: `Show ${SAMPLE_LIMIT} rows` }));
+    await waitFor(() => expect(load).toHaveBeenCalledTimes(1));
+
+    view.rerender(<SamplePanel model="customers" load={load} />);
+
+    // The button is back, nothing ran for the new model, and the panel says
+    // which model a press would now read.
+    expect(screen.getByRole("button", { name: `Show ${SAMPLE_LIMIT} rows` })).toBeTruthy();
+    expect(screen.getByText("customers")).toBeTruthy();
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(load).not.toHaveBeenCalledWith("customers");
+  });
+
   it("renders the rows, a null as null, and the SQL that ran", async () => {
     const load = vi.fn(async () => SAMPLE);
     render(<SamplePanel model="orders" load={load} />);

--- a/engine/ui/src/review/SamplePanel.tsx
+++ b/engine/ui/src/review/SamplePanel.tsx
@@ -78,6 +78,12 @@ function SampleTable({ sample }: { sample: PreviewRowsOutput }) {
  * renders as itself through [`ResourceState`], because "the adapter cannot
  * express this column's mask" and "nobody consented" are different problems
  * with different fixes.
+ *
+ * Consent is given for one model. The panel is keyed on the model, so when
+ * the screen swaps the model under it — the queue answers after the product,
+ * the route names another plan — the panel remounts with consent withdrawn
+ * and the button back. Without the key a viewer who had pressed the button
+ * for model A had, in effect, pressed it for whatever came next (#1815).
  */
 export function SamplePanel({
   model,
@@ -86,6 +92,10 @@ export function SamplePanel({
   model: string;
   load?: SampleLoader;
 }) {
+  return <ConsentedSample key={model} model={model} load={load} />;
+}
+
+function ConsentedSample({ model, load }: { model: string; load: SampleLoader }) {
   const [asked, setAsked] = useState(false);
   const loader = useCallback(() => load(model), [load, model]);
   // The hook fetches on mount, so it is mounted only once the viewer asks.

--- a/integrations/dagster/tests/fixtures_generated/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor.json
@@ -17,7 +17,7 @@
     {
       "name": "state_schema",
       "status": "healthy",
-      "message": "state schema v28 matches this binary",
+      "message": "state schema v29 matches this binary",
       "duration_ms": 0
     },
     {

--- a/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
@@ -17,7 +17,7 @@
     {
       "name": "state_schema",
       "status": "healthy",
-      "message": "no on-disk state schema (binary supports v28)",
+      "message": "no on-disk state schema (binary supports v29)",
       "duration_ms": 0
     },
     {

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 28,
-  "schema_version_on_disk": 28
+  "schema_version_supported": 29,
+  "schema_version_on_disk": 29
 }

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 28,
-  "schema_version_on_disk": 28
+  "schema_version_supported": 29,
+  "schema_version_on_disk": 29
 }

--- a/integrations/dagster/tests/fixtures_generated/state.json
+++ b/integrations/dagster/tests/fixtures_generated/state.json
@@ -8,6 +8,6 @@
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ],
-  "schema_version_supported": 28,
-  "schema_version_on_disk": 28
+  "schema_version_supported": 29,
+  "schema_version_on_disk": 29
 }

--- a/schemas/review_queue.schema.json
+++ b/schemas/review_queue.schema.json
@@ -148,7 +148,7 @@
           "type": "string"
         },
         "models": {
-          "description": "The graph keys this entry stands for — names of compiled models, and only those: the set the ledger row recorded, or its bare `model` when the compiled graph has a model of that name. It is the set `blast_radius` was computed over. **Empty means unknown**, never \"no models\": a subject that is not a compiled model (a replication target is gated by table name; a plan-level row's `model` is a label), a model since removed, a failed compile, or a row from before its producer recorded the set. A consumer that needs a model name takes it from here; `model` is display text and is not to be parsed.",
+          "description": "The graph keys this entry stands for — names of compiled models, and only those: the set the ledger row recorded, or its bare `model` when the compiled graph has a model of that name. It is the set `blast_radius` was computed over and what `rocky audit --for` will match. **Empty means unknown**, never \"no models\": a subject that is not a compiled model (a replication target is gated by table name; a plan-level row's `model` is a label), a model since removed, a failed compile, or a row from before its producer recorded the set. `model` is display text and is not to be parsed.\n\nA key here is for ranking and audit. It is **not** a licence to read rows — `preview_model` is.",
           "items": {
             "type": "string"
           },
@@ -157,6 +157,13 @@
         "plan_id": {
           "description": "The plan whose approval clears this escalation.",
           "type": "string"
+        },
+        "preview_model": {
+          "description": "The one model of this entry that `GET /api/v1/models/{name}/rows` would read, decided by that route's own admission rules (a valid name, in the compiled project, not time-interval, no compile errors, a single SELECT), or `null`: the entry names no model or several, or the route would refuse the one it names — a dotted name, a model a restore plan recorded that is gone from the current project, a model that no longer compiles. A consumer offers a sample from this and from nothing else.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "principal": {
           "allOf": [

--- a/schemas/review_queue.schema.json
+++ b/schemas/review_queue.schema.json
@@ -159,7 +159,7 @@
           "type": "string"
         },
         "preview_model": {
-          "description": "The one model of this entry that `GET /api/v1/models/{name}/rows` would read, decided by that route's own admission rules (a valid name, in the compiled project, not time-interval, no compile errors, a single SELECT), or `null`: the entry names no model or several, or the route would refuse the one it names — a dotted name, a model a restore plan recorded that is gone from the current project, a model that no longer compiles. A consumer offers a sample from this and from nothing else.",
+          "description": "The one model of this entry that `GET /api/v1/models/{name}/rows` would admit, decided by that route's own rules — its front door (the strict config, the adapter registry, one resolvable pipeline with no name given) and its admission of the model (a valid name, in the compiled project, not time-interval, no compile errors, a single SELECT) — or `null`: the entry names no model or several, the route's front door is shut for this project, or the route would refuse the one model it names (a dotted name, a model a restore plan recorded that is gone from the current project, a model that no longer compiles). A consumer offers a sample from this and from nothing else.\n\nWhat this cannot promise is the request itself: the adapter's reachability and credentials at query time, the masking of classified columns, the route's concurrency and time limits. Those refusals arrive as the route's own envelope and render as themselves.",
           "type": [
             "string",
             "null"

--- a/schemas/review_queue.schema.json
+++ b/schemas/review_queue.schema.json
@@ -148,7 +148,7 @@
           "type": "string"
         },
         "models": {
-          "description": "The graph keys this entry stands for: the model set the ledger row recorded, or the single `model` on an ordinary evaluation row. It is the set `blast_radius` was computed over. **Empty means unknown** — a plan-level row written before the engine kept its set — and never \"no models\". A consumer that needs a model name takes it from here; `model` is display text and is not to be parsed.",
+          "description": "The graph keys this entry stands for — names of compiled models, and only those: the set the ledger row recorded, or its bare `model` when the compiled graph has a model of that name. It is the set `blast_radius` was computed over. **Empty means unknown**, never \"no models\": a subject that is not a compiled model (a replication target is gated by table name; a plan-level row's `model` is a label), a model since removed, a failed compile, or a row from before its producer recorded the set. A consumer that needs a model name takes it from here; `model` is display text and is not to be parsed.",
           "items": {
             "type": "string"
           },

--- a/schemas/review_queue.schema.json
+++ b/schemas/review_queue.schema.json
@@ -144,8 +144,15 @@
           "type": "string"
         },
         "model": {
-          "description": "The model the escalation is about.",
+          "description": "The model the escalation is about. On a plan-level escalation (`backfill` / `gc` / `restore`) this is a human label — `\"backfill: 3 model(s)\"` — and not a model name; the names are in `models`.",
           "type": "string"
+        },
+        "models": {
+          "description": "The graph keys this entry stands for: the model set the ledger row recorded, or the single `model` on an ordinary evaluation row. It is the set `blast_radius` was computed over. **Empty means unknown** — a plan-level row written before the engine kept its set — and never \"no models\". A consumer that needs a model name takes it from here; `model` is display text and is not to be parsed.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "plan_id": {
           "description": "The plan whose approval clears this escalation.",
@@ -193,6 +200,7 @@
         "classification_weight",
         "decision_ref",
         "model",
+        "models",
         "plan_id",
         "principal",
         "reason",

--- a/sdk/python/src/rocky_sdk/types_generated/review_queue_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/review_queue_schema.py
@@ -164,7 +164,7 @@ class ReviewQueueEntry(BaseModel):
     """
     models: list[str]
     """
-    The graph keys this entry stands for: the model set the ledger row recorded, or the single `model` on an ordinary evaluation row. It is the set `blast_radius` was computed over. **Empty means unknown** — a plan-level row written before the engine kept its set — and never "no models". A consumer that needs a model name takes it from here; `model` is display text and is not to be parsed.
+    The graph keys this entry stands for — names of compiled models, and only those: the set the ledger row recorded, or its bare `model` when the compiled graph has a model of that name. It is the set `blast_radius` was computed over. **Empty means unknown**, never "no models": a subject that is not a compiled model (a replication target is gated by table name; a plan-level row's `model` is a label), a model since removed, a failed compile, or a row from before its producer recorded the set. A consumer that needs a model name takes it from here; `model` is display text and is not to be parsed.
     """
     plan_id: str
     """

--- a/sdk/python/src/rocky_sdk/types_generated/review_queue_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/review_queue_schema.py
@@ -160,7 +160,11 @@ class ReviewQueueEntry(BaseModel):
     """
     model: str
     """
-    The model the escalation is about.
+    The model the escalation is about. On a plan-level escalation (`backfill` / `gc` / `restore`) this is a human label — `"backfill: 3 model(s)"` — and not a model name; the names are in `models`.
+    """
+    models: list[str]
+    """
+    The graph keys this entry stands for: the model set the ledger row recorded, or the single `model` on an ordinary evaluation row. It is the set `blast_radius` was computed over. **Empty means unknown** — a plan-level row written before the engine kept its set — and never "no models". A consumer that needs a model name takes it from here; `model` is display text and is not to be parsed.
     """
     plan_id: str
     """

--- a/sdk/python/src/rocky_sdk/types_generated/review_queue_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/review_queue_schema.py
@@ -164,11 +164,17 @@ class ReviewQueueEntry(BaseModel):
     """
     models: list[str]
     """
-    The graph keys this entry stands for — names of compiled models, and only those: the set the ledger row recorded, or its bare `model` when the compiled graph has a model of that name. It is the set `blast_radius` was computed over. **Empty means unknown**, never "no models": a subject that is not a compiled model (a replication target is gated by table name; a plan-level row's `model` is a label), a model since removed, a failed compile, or a row from before its producer recorded the set. A consumer that needs a model name takes it from here; `model` is display text and is not to be parsed.
+    The graph keys this entry stands for — names of compiled models, and only those: the set the ledger row recorded, or its bare `model` when the compiled graph has a model of that name. It is the set `blast_radius` was computed over and what `rocky audit --for` will match. **Empty means unknown**, never "no models": a subject that is not a compiled model (a replication target is gated by table name; a plan-level row's `model` is a label), a model since removed, a failed compile, or a row from before its producer recorded the set. `model` is display text and is not to be parsed.
+
+    A key here is for ranking and audit. It is **not** a licence to read rows — `preview_model` is.
     """
     plan_id: str
     """
     The plan whose approval clears this escalation.
+    """
+    preview_model: str | None = None
+    """
+    The one model of this entry that `GET /api/v1/models/{name}/rows` would read, decided by that route's own admission rules (a valid name, in the compiled project, not time-interval, no compile errors, a single SELECT), or `null`: the entry names no model or several, or the route would refuse the one it names — a dotted name, a model a restore plan recorded that is gone from the current project, a model that no longer compiles. A consumer offers a sample from this and from nothing else.
     """
     principal: PolicyPrincipal | PolicyPrincipal16
     """

--- a/sdk/python/src/rocky_sdk/types_generated/review_queue_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/review_queue_schema.py
@@ -174,7 +174,9 @@ class ReviewQueueEntry(BaseModel):
     """
     preview_model: str | None = None
     """
-    The one model of this entry that `GET /api/v1/models/{name}/rows` would read, decided by that route's own admission rules (a valid name, in the compiled project, not time-interval, no compile errors, a single SELECT), or `null`: the entry names no model or several, or the route would refuse the one it names — a dotted name, a model a restore plan recorded that is gone from the current project, a model that no longer compiles. A consumer offers a sample from this and from nothing else.
+    The one model of this entry that `GET /api/v1/models/{name}/rows` would admit, decided by that route's own rules — its front door (the strict config, the adapter registry, one resolvable pipeline with no name given) and its admission of the model (a valid name, in the compiled project, not time-interval, no compile errors, a single SELECT) — or `null`: the entry names no model or several, the route's front door is shut for this project, or the route would refuse the one model it names (a dotted name, a model a restore plan recorded that is gone from the current project, a model that no longer compiles). A consumer offers a sample from this and from nothing else.
+
+    What this cannot promise is the request itself: the adapter's reachability and credentials at query time, the masking of classified columns, the route's concurrency and time limits. Those refusals arrive as the route's own envelope and render as themselves.
     """
     principal: PolicyPrincipal | PolicyPrincipal16
     """


### PR DESCRIPTION
Closes #1815.

Navigating from plan A straight to plan B left every panel under B's heading showing A: A's status, A's sample rows, and **A's approve command**. Because the sample panel also kept its consent, changing the model started B's warehouse query with no click. The same shape put product A's standing under product B's heading. Four smaller findings from the same review are fixed alongside.

## What changed

**The identity fix is in the hook, not in a `key`.** `useResource` now derives its state from the deps it was loaded for, in render: when the identity moves, the value on hand is not shown under the new one, not even for a frame. A reload of the *same* identity (interval, refresh button) keeps the old value until the new one lands, as before. Every detail panel shares this hook — plan, product, model — so fixing it there closes the class; a `key` on `PlanDetail` would have fixed one screen and hidden the defect from the other two.

**Consent is per model.** `SamplePanel` keys its consent state on the model, so a model swap under it withdraws consent and brings the button back. D8 made sampling per-request consent; this keeps it that way.

**A refused queue is unknown, not empty.** `lookupQueueEntry` gives three answers — unknown / absent / present — and only *absent* may say "no longer in the queue". The sample fallback used to read the same `null` as absence and print that beside the queue's refusal.

**The engine names the models; the UI stops guessing.** `ReviewQueueEntry` gains `models`: the set the ledger row recorded, or the single `model` on an ordinary row — the same keys the blast radius was computed over, from one derivation, so the two cannot drift. Empty means unknown (a pre-v28 plan-level row). The UI's `^[a-zA-Z0-9_]+$` check on the label is gone; `backfill_3_models` would have passed it and sampled a real model of that name. Schema, Pydantic and TypeScript bindings regenerated.

The derivation was wrong once during this PR and is worth stating: the first version treated an empty set on a `backfill`/`gc`/`restore` row as "plan-level, unknown". But the apply-time gate records one ordinary row per touched model *with the plan's capability* (`gc` over `orders`, no set), and that rule threw the name away. The rule that holds is the name's shape by the engine's own admission rule (`validate_identifier`): a value it refuses is in no graph, and every label the engine has ever written fails it. `blast_radius_union` over no subjects now returns unknown rather than a measured zero, with its own test.

**Truncation is grapheme-safe and the marker is honest.** `clipHead` / `clipMiddle` cut between user-perceived characters and return whether they cut; `<Clip>` renders the marker as its own dimmed element only when something was cut. A value that merely contains "…" renders it as text.

**The hostile-name test reaches its sink.** It passes the hostile value as the product name, so the heading and custody link are exercised, not only the journal event.

## Tests

- UI: 8 new (`useResource` identity + same-identity reload, `SamplePanel` consent withdrawal, `PlanDetail` A→B transition with a fetch spy proving one query ever ran, refused-queue fallback wording, identifier-shaped label, unrecorded set, `ProductsScreen` A→B, `Clip` marker vs literal, surrogate pairs at both ends). Existing tests updated to the new copy and fixtures.
- Engine: `the_entry_reports_the_graph_keys_the_ranking_resolved` (ordinary row, apply-time gc row, plan-level row with its set), `a_union_over_no_subjects_is_unknown_not_zero`, and the pre-v28 assertions added to `a_plan_level_row_with_no_resolvable_model_ranks_unknown_not_zero`.

## Not in this PR

- A `key` on the route-level components. Deliberate, see above.
- The `models` cell on the queue panel shows the set only where it differs from the label.



---

## What changed after the description above — eight review rounds

The description above is the first commit. Seven more landed under independent review (Codex, with a second model concurring on each round), each dispositioned in the comments. The thread running through all of them: **a string cannot say what kind of thing it is; the writer that knew must record it.**

- **`models` on the queue entry, and who decides it.** Three reader-side rules were tried and each broke — the capability, identifier syntax, graph membership — before the rule that holds: the gate says what its subjects are (`GateSubjects`: compiled models, replication targets, or the set a resolver could vouch for), the ledger row says whether its set was deliberate (`keys_recorded`, state schema v29), and the queue takes a recorded set as written, resolving only rows that never said.
- **`preview_model`, the only licence to read.** Computed by the samples route's own admission code, lifted into one function the route and the queue both call, and gated on the route's front door (strict config, adapter registry, one resolvable pipeline). The UI offers a sample from it and from nothing else; the product's output model stands in only once the plan has left the queue.
- **Every row of a plan.** The queue keeps one row per touched model; the screen now shows each, with one command that clears them all.
- **Supersession.** A later `allow` retires an older `require_review`. A `deny` does not, because the fail-closed refusal of an unreadable ledger is recorded as one and the row cannot say which kind it is.
- **The maintenance resolver.** A table resolves to the model that targets it (the physical reading first); a string that is one model's table and another's name refuses; a table with two owners refuses only when the plan names it; ephemeral models own no table; a table no model owns is gated but records no model's key. Promote's resolver likewise vouches only for the keys it mapped.

Thirty mutation checks; the final round PASSED with a second model concurring. Residuals that need plan-time or ledger-time provenance the CLI does not yet record — compact's bare name, archive's two-part identifier, the MCP draft tools' stem/name mismatch, the fail-closed `deny` bit, clock rollback — are in #1829 with the reviewers' fixtures.
