### PR TITLE
fix(engine): a shadow object is disposable and belongs to the run that made it

### DIFF
--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -853,7 +853,11 @@ async fn execute_run_plan(
         Some(rocky_core::shadow::ShadowConfig {
             suffix: shadow_suffix,
             schema_override: run_plan.shadow_schema.clone(),
-            cleanup_after: false,
+            // Disposable, matching `rocky run --shadow` (#1273): a plain
+            // shadow object exists to be compared and then go away, and
+            // that is what makes the ownership refusal sound. The branch
+            // arm above stays persistent on purpose.
+            cleanup_after: true,
         })
     } else {
         None

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -74,6 +74,7 @@ pub mod schedule_status;
 pub mod scheduler;
 mod seed;
 mod serve;
+mod shadow_lifecycle;
 mod shell;
 mod skip_gate;
 mod snapshot;

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -8181,11 +8181,51 @@ fn apply_shadow_rewrite(
                     model.config.name
                 );
             }
-            rocky_core::models::StrategyConfig::FullRefresh
-            | rocky_core::models::StrategyConfig::Incremental { .. }
+            // The incremental family cannot produce a comparable shadow
+            // (#1273). These strategies build on what the target ALREADY
+            // holds, and a shadow target holds nothing:
+            //
+            //   first run   the CTAS *is* the load, so the shadow gets one
+            //               delta while production holds full history — the
+            //               comparison reports a near-total row-count loss
+            //               that says nothing about the change under review;
+            //   self-read   `WHERE ts > (SELECT MAX(ts) FROM main.events)`
+            //               is deliberately NOT redirected (pointing it at
+            //               the empty shadow would change what the model
+            //               computes), so the shadow gets rows strictly
+            //               newer than production's maximum — normally zero;
+            //   repeat run  with nothing dropped between runs, the second
+            //               run appends to the first run's leftover and the
+            //               row count drifts further every time.
+            //
+            // Producing an incomparable number is worse than refusing, so
+            // these join the two strategies above rather than running.
+            // Seeding the shadow from production first would make the
+            // comparison meaningful, but that is a full copy per model and
+            // a cost decision nobody has taken.
+            rocky_core::models::StrategyConfig::Incremental { .. }
             | rocky_core::models::StrategyConfig::Merge { .. }
             | rocky_core::models::StrategyConfig::DeleteInsert { .. }
-            | rocky_core::models::StrategyConfig::Microbatch { .. }
+            | rocky_core::models::StrategyConfig::Microbatch { .. } => {
+                anyhow::bail!(
+                    "shadow/branch execution is not supported for model '{}': its \
+                     '{}' strategy builds on rows the target already holds, and a shadow \
+                     target starts empty — so the shadow would be compared against a \
+                     production table it was never built the same way as. Give the model \
+                     `full_refresh` to shadow it, or exclude it from this run with --model",
+                    model.config.name,
+                    match &model.config.strategy {
+                        rocky_core::models::StrategyConfig::Incremental { .. } => "incremental",
+                        rocky_core::models::StrategyConfig::Merge { .. } => "merge",
+                        rocky_core::models::StrategyConfig::DeleteInsert { .. } => "delete_insert",
+                        _ => "microbatch",
+                    }
+                );
+            }
+            // What survives is exactly the set that REPLACES its target
+            // rather than adding to it, so a shadow build is a complete,
+            // comparable output and the object is disposable.
+            rocky_core::models::StrategyConfig::FullRefresh
             | rocky_core::models::StrategyConfig::View
             | rocky_core::models::StrategyConfig::MaterializedView
             | rocky_core::models::StrategyConfig::DynamicTable { .. } => {}
@@ -9540,6 +9580,10 @@ pub(crate) async fn execute_models(
         )?;
     }
 
+    // Shadow objects this run derived, in selection order. Empty on every
+    // non-shadow run, so the ownership preflight and the cleanup below are
+    // both no-ops there (#1273).
+    let mut shadow_objects: Vec<crate::commands::shadow_lifecycle::ShadowObject> = Vec::new();
     if let Some(config) = shadow_config {
         apply_shadow_rewrite(
             &mut compile_result,
@@ -9549,6 +9593,36 @@ pub(crate) async fn execute_models(
             warehouse.dialect(),
             resilience.contain_failures,
         )?;
+        // `apply_shadow_rewrite` rewrote each selected model's target in
+        // place, so the models now carry their shadow names. Collect them
+        // BEFORE anything executes: the ownership check and the cleanup are
+        // the same list, and deriving it twice is how the two would drift.
+        for model in &compile_result.project.models {
+            let selected = model_name_filter.is_none_or(|f| f == model.config.name)
+                && model_set.is_none_or(|set| set.contains(&model.config.name));
+            if !selected {
+                continue;
+            }
+            shadow_objects.push(crate::commands::shadow_lifecycle::ShadowObject {
+                model: model.config.name.clone(),
+                target: rocky_ir::TargetRef {
+                    catalog: model.config.target.catalog.clone(),
+                    schema: model.config.target.schema.clone(),
+                    table: model.config.target.table.clone(),
+                },
+            });
+        }
+        // Refuse before any write: a shadow object is disposable and
+        // belongs to the run that made it, so anything already sitting at
+        // one of these names is either not Rocky's or debris from a run
+        // that did not finish. Replacing it silently is the defect #1273
+        // reported and reproduced.
+        crate::commands::shadow_lifecycle::refuse_occupied_shadow_targets(
+            warehouse,
+            warehouse.dialect(),
+            &shadow_objects,
+        )
+        .await?;
         output.shadow = true;
     } else {
         augment_physical_read_edges(
@@ -10809,6 +10883,36 @@ pub(crate) async fn execute_models(
                 entries = reuse_index_entries.len(),
                 "recorded auditable-reuse input-match spine"
             );
+        }
+    }
+
+    // `cleanup_after` finally has a consumer (#1273). It has always been
+    // documented as "whether to drop shadow tables after comparison
+    // completes" and defaulted to `true`, while nothing read it and every
+    // construction hard-coded `false` — so shadow objects accumulated, and
+    // the next run wrote over its own leftover.
+    //
+    // Dropped only on the success path, on purpose: a run that failed is
+    // evidence, and destroying it to save the operator one statement is the
+    // wrong trade. The next run refuses on those leftovers rather than
+    // replacing them, and prints the drop — so the failure mode is a
+    // refusal with a remedy, never a silent overwrite.
+    //
+    // A named `--branch` sets `cleanup_after = false`: its objects are the
+    // point of the branch, not debris.
+    if let Some(config) = shadow_config
+        && config.cleanup_after
+        && !shadow_objects.is_empty()
+    {
+        let warnings = crate::commands::shadow_lifecycle::drop_owned_shadow_objects(
+            warehouse,
+            warehouse.dialect(),
+            &shadow_objects,
+        )
+        .await;
+        for warning in warnings {
+            warn!("{warning}");
+            output.scheduling_warnings.push(warning);
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -9612,17 +9612,29 @@ pub(crate) async fn execute_models(
                 },
             });
         }
-        // Refuse before any write: a shadow object is disposable and
-        // belongs to the run that made it, so anything already sitting at
-        // one of these names is either not Rocky's or debris from a run
-        // that did not finish. Replacing it silently is the defect #1273
-        // reported and reproduced.
-        crate::commands::shadow_lifecycle::refuse_occupied_shadow_targets(
-            warehouse,
-            warehouse.dialect(),
-            &shadow_objects,
-        )
-        .await?;
+        // Refuse before any write — but ONLY in the disposable mode.
+        //
+        // `cleanup_after` is exactly the axis this turns on, because it is
+        // what makes "the name should be free" a true invariant: a run that
+        // drops what it made leaves nothing, so an object sitting there is
+        // either not Rocky's or debris from a run that did not finish, and
+        // replacing it silently is the defect #1273 reported.
+        //
+        // With `cleanup_after` off — a named `--branch`, or any caller that
+        // asks for objects outliving the run — the previous run's objects
+        // are SUPPOSED to still be there, and the next run is supposed to
+        // replace them. Refusing would break the feature outright. Rocky
+        // cannot tell its own leftover from a stranger's without a
+        // persisted owner record, so it does not guess: the persistent mode
+        // keeps no per-object ownership check, and #1273 stays open for it.
+        if config.cleanup_after {
+            crate::commands::shadow_lifecycle::refuse_occupied_shadow_targets(
+                warehouse,
+                warehouse.dialect(),
+                &shadow_objects,
+            )
+            .await?;
+        }
         output.shadow = true;
     } else {
         augment_physical_read_edges(

--- a/engine/crates/rocky-cli/src/commands/shadow_lifecycle.rs
+++ b/engine/crates/rocky-cli/src/commands/shadow_lifecycle.rs
@@ -1,0 +1,261 @@
+//! Ownership and lifecycle for the objects a `--shadow` run writes (#1273).
+//!
+//! Before this module, a shadow target was a *name* Rocky derived and then
+//! wrote to. Nothing asked whether an object already sat at that name, and
+//! nothing removed the object afterwards. Three symptoms fell out of that
+//! one gap, and the contract below answers all three together because
+//! fixing any one of them in isolation contradicts the others.
+//!
+//! **The contract: a shadow target is disposable and Rocky-owned.**
+//!
+//! ```text
+//!   before a shadow run writes   is anything already at this name?
+//!                                  yes ─▶ REFUSE, naming the object
+//!                                  no  ─▶ this run owns it
+//!   after the run succeeds       drop what this run created (cleanup_after)
+//! ```
+//!
+//! Why "already there" is a sound refusal, which it would NOT have been
+//! before: `apply_shadow_rewrite` now refuses the incremental family, so
+//! every strategy that reaches a shadow write REPLACES its target rather
+//! than adding to it — and `cleanup_after` now actually drops. Together
+//! those mean a clean run leaves the name empty, so an object sitting
+//! there is either somebody else's or the debris of a run that failed. In
+//! both cases writing over it is the thing #1273 reported.
+//!
+//! **What "Rocky-owned" means here, exactly.** It means *this run created
+//! it*. That is the strictest reading, and it is the only one available
+//! without persisting ownership: a state record would have to survive a
+//! deleted state file and a different machine to be trusted, and a
+//! warehouse tag is not portable across the adapters Rocky targets. The
+//! cost of the strict reading is that a shadow run which failed part-way
+//! leaves objects that the next run refuses — so the refusal names the
+//! object and prints the statement that clears it.
+
+use anyhow::Result;
+use rocky_core::traits::{SqlDialect, WarehouseAdapter};
+use rocky_ir::TargetRef;
+
+/// A shadow object this run intends to write, or wrote.
+#[derive(Debug, Clone)]
+pub(crate) struct ShadowObject {
+    /// The model that owns it, for the message.
+    pub(crate) model: String,
+    /// The derived shadow target.
+    pub(crate) target: TargetRef,
+}
+
+/// Refuse the run if anything already sits at a shadow target.
+///
+/// Runs once, before any model executes, so a refusal leaves the warehouse
+/// exactly as it was — the same posture as the target-collision preflight
+/// (#1461) and the `metadata_columns` guard (#1594).
+///
+/// A `describe_table` that fails is treated as "absent". That is deliberate
+/// and is the same reading `execute_one_plain_model` takes: the adapters do
+/// not agree on a typed not-found error, so an existence probe can only
+/// distinguish "returned columns" from "did not". The consequence is a
+/// missed refusal on a transient error, never a spurious one — and the
+/// alternative, refusing every shadow run whose probe hiccuped, would make
+/// the feature unusable on a flaky connection.
+///
+/// # Errors
+///
+/// Names the first occupied target, the model that would have written it,
+/// and the statement that clears it.
+pub(crate) async fn refuse_occupied_shadow_targets(
+    warehouse: &dyn WarehouseAdapter,
+    dialect: &dyn SqlDialect,
+    objects: &[ShadowObject],
+) -> Result<()> {
+    for object in objects {
+        let table_ref = rocky_ir::TableRef {
+            catalog: object.target.catalog.clone(),
+            schema: object.target.schema.clone(),
+            table: object.target.table.clone(),
+        };
+        let occupied = warehouse
+            .describe_table(&table_ref)
+            .await
+            .map(|columns| !columns.is_empty())
+            .unwrap_or(false);
+        if occupied {
+            let formatted = dialect
+                .format_table_ref(
+                    &object.target.catalog,
+                    &object.target.schema,
+                    &object.target.table,
+                )
+                .map_err(|e| anyhow::anyhow!("formatting the shadow target ref: {e}"))?;
+            anyhow::bail!(
+                "shadow target {formatted} already exists, and this run did not create it — \
+                 refusing to replace an object Rocky does not own. A shadow object is \
+                 disposable and belongs to the run that made it; anything already at that \
+                 name is either not Rocky's or debris from a run that did not finish. \
+                 Model '{}' would have written it. Drop it if it is debris:\n    {}",
+                object.model,
+                dialect.drop_table_sql(&formatted)
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Drop the shadow objects this run created.
+///
+/// Called only on a successful run, and only when `cleanup_after` is set —
+/// which is the default for a one-off `--shadow`, and deliberately off for
+/// a named `--branch`, whose objects are the point of the branch.
+///
+/// Best-effort by design: a failed drop is reported to the caller as a
+/// warning rather than failing a run whose real work already succeeded.
+/// The next run's ownership refusal is what stops the leftover being
+/// silently written over, so a missed drop degrades to a refusal with a
+/// remedy, never to a silent replace.
+pub(crate) async fn drop_owned_shadow_objects(
+    warehouse: &dyn WarehouseAdapter,
+    dialect: &dyn SqlDialect,
+    objects: &[ShadowObject],
+) -> Vec<String> {
+    let mut warnings = Vec::new();
+    for object in objects {
+        let formatted = match dialect.format_table_ref(
+            &object.target.catalog,
+            &object.target.schema,
+            &object.target.table,
+        ) {
+            Ok(formatted) => formatted,
+            Err(e) => {
+                warnings.push(format!(
+                    "could not format the shadow target for model '{}' to drop it: {e}",
+                    object.model
+                ));
+                continue;
+            }
+        };
+        if let Err(e) = warehouse
+            .execute_statement(&dialect.drop_table_sql(&formatted))
+            .await
+        {
+            warnings.push(format!(
+                "could not drop shadow object {formatted} for model '{}': {e}. It stays on the \
+                 warehouse; the next shadow run will refuse until it is removed",
+                object.model
+            ));
+        }
+    }
+    warnings
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rocky_duckdb::DuckDbConnector;
+    use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+    use std::sync::{Arc, Mutex};
+
+    fn object(table: &str) -> ShadowObject {
+        ShadowObject {
+            model: "orders".to_string(),
+            target: TargetRef {
+                catalog: String::new(),
+                schema: "main".into(),
+                table: table.into(),
+            },
+        }
+    }
+
+    fn duckdb() -> DuckDbWarehouseAdapter {
+        let shared = Arc::new(Mutex::new(DuckDbConnector::in_memory().expect("duckdb")));
+        DuckDbWarehouseAdapter::from_shared(shared)
+    }
+
+    /// An empty name is this run's to take.
+    #[tokio::test]
+    async fn an_unoccupied_target_passes() {
+        let wh = duckdb();
+        let dialect = wh.dialect();
+        refuse_occupied_shadow_targets(&wh, dialect, &[object("orders_rocky_shadow")])
+            .await
+            .expect("nothing is there, so the run owns the name");
+    }
+
+    /// The #1273 case: somebody else's table at the derived name. The
+    /// refusal names the object, the model, and the statement that clears
+    /// it — and the table is still there afterwards.
+    #[tokio::test]
+    async fn an_occupied_target_is_refused_and_left_untouched() {
+        let wh = duckdb();
+        let dialect = wh.dialect();
+        wh.execute_statement(
+            "CREATE TABLE main.orders_rocky_shadow AS SELECT 'do-not-touch' AS sentinel",
+        )
+        .await
+        .expect("seed somebody else's table");
+
+        let err = refuse_occupied_shadow_targets(&wh, dialect, &[object("orders_rocky_shadow")])
+            .await
+            .expect_err("an occupied shadow target must refuse");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("orders_rocky_shadow"), "{msg}");
+        assert!(msg.contains("does not own"), "{msg}");
+        assert!(msg.contains("DROP TABLE"), "the remedy is printed: {msg}");
+        assert!(msg.contains("'orders'"), "the model is named: {msg}");
+
+        let columns = wh
+            .describe_table(&rocky_ir::TableRef {
+                catalog: String::new(),
+                schema: "main".into(),
+                table: "orders_rocky_shadow".into(),
+            })
+            .await
+            .expect("the seeded table is still there");
+        assert_eq!(
+            columns.into_iter().map(|c| c.name).collect::<Vec<_>>(),
+            vec!["sentinel".to_string()],
+            "a refusal must not have touched the object it refused over"
+        );
+    }
+
+    /// Cleanup removes what the run created, and is idempotent — a second
+    /// drop of an absent object is not an error, so a crash between the
+    /// drop and the record cannot wedge the next run.
+    #[tokio::test]
+    async fn cleanup_drops_owned_objects_and_is_idempotent() {
+        let wh = duckdb();
+        let dialect = wh.dialect();
+        wh.execute_statement("CREATE TABLE main.orders_rocky_shadow AS SELECT 1 AS id")
+            .await
+            .expect("create the shadow object");
+
+        let objects = [object("orders_rocky_shadow")];
+        assert!(
+            drop_owned_shadow_objects(&wh, dialect, &objects)
+                .await
+                .is_empty(),
+            "dropping an object this run created reports nothing"
+        );
+        let gone = wh
+            .describe_table(&rocky_ir::TableRef {
+                catalog: String::new(),
+                schema: "main".into(),
+                table: "orders_rocky_shadow".into(),
+            })
+            .await
+            .map(|c| c.is_empty())
+            .unwrap_or(true);
+        assert!(gone, "the shadow object is dropped");
+
+        assert!(
+            drop_owned_shadow_objects(&wh, dialect, &objects)
+                .await
+                .is_empty(),
+            "a second drop is a no-op, not an error"
+        );
+
+        // And the name is free again: the next run's ownership check passes.
+        refuse_occupied_shadow_targets(&wh, dialect, &objects)
+            .await
+            .expect("cleanup leaves the name available for the next run");
+    }
+}

--- a/engine/crates/rocky-cli/src/commands/shadow_lifecycle.rs
+++ b/engine/crates/rocky-cli/src/commands/shadow_lifecycle.rs
@@ -217,6 +217,35 @@ mod tests {
         );
     }
 
+    /// The refusal is scoped to the DISPOSABLE mode, and the caller is what
+    /// scopes it (`run.rs` calls this only when `cleanup_after` is set).
+    ///
+    /// This test pins the reason, because the scoping is a decision and not
+    /// an oversight: with `cleanup_after` off, the previous run's objects
+    /// are supposed to still be there and the next run is supposed to
+    /// replace them, so an unconditional refusal would make a named
+    /// `--branch` refuse its own workspace on every re-run. Rocky cannot
+    /// tell its own leftover from a stranger's without a persisted owner
+    /// record, so the persistent mode keeps no per-object check and #1273
+    /// stays open for it.
+    ///
+    /// What this function must NOT do is decide that for itself — a future
+    /// caller that forgets the gate should get a refusal, not a silent pass.
+    #[tokio::test]
+    async fn the_check_itself_is_unconditional_and_the_caller_scopes_it() {
+        let wh = duckdb();
+        let dialect = wh.dialect();
+        wh.execute_statement("CREATE TABLE main.orders_rocky_shadow AS SELECT 1 AS id")
+            .await
+            .expect("seed");
+        assert!(
+            refuse_occupied_shadow_targets(&wh, dialect, &[object("orders_rocky_shadow")])
+                .await
+                .is_err(),
+            "the primitive always refuses an occupied target; only the call site is conditional"
+        );
+    }
+
     /// Cleanup removes what the run created, and is idempotent — a second
     /// drop of an absent object is not an error, so a crash between the
     /// drop and the record cannot wedge the next run.

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -3820,7 +3820,15 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                 Some(rocky_core::shadow::ShadowConfig {
                     suffix: shadow_suffix,
                     schema_override: shadow_schema,
-                    cleanup_after: false,
+                    // A one-off `--shadow` object is disposable: it exists to
+                    // be compared against production and then go away
+                    // (#1273). This honours the documented default that
+                    // nothing read before — the `false` here is what made
+                    // shadow objects accumulate and let the next run write
+                    // over its own leftover. The `--branch` arm above keeps
+                    // `false` deliberately: a named branch's objects are the
+                    // point of the branch.
+                    cleanup_after: true,
                 })
             } else {
                 None

--- a/engine/rocky/tests/shadow_target_ownership.rs
+++ b/engine/rocky/tests/shadow_target_ownership.rs
@@ -1,31 +1,24 @@
-//! PROBE for #1273 symptom 1: does an unnamed `--shadow` run write over a
-//! pre-existing warehouse object Rocky did not create?
+//! #1273: a shadow object is disposable and belongs to the run that made it.
 //!
-//! This file documents a defect; it does not fix one. See the `#[ignore]` on
-//! the test below and the reason in its doc comment.
+//! This file began as a PROBE that documented the open defect — an unnamed
+//! `--shadow` run replaced a pre-existing warehouse object at the derived
+//! shadow name, having asked the warehouse nothing. Its own doc comment said
+//! to invert it when a refusal landed. That is what these tests are now.
 //!
 //! ```text
-//!   warehouse before:  main.orders_rocky_shadow  (unrelated, one column
-//!                                                 `unrelated_sentinel`)
+//!   warehouse before   main.orders_rocky_shadow   (somebody else's, one
+//!                                                  column `unrelated_sentinel`)
 //!            │
-//!   rocky run --shadow  ──►  apply_shadow_rewrite rewrites the model target
-//!            │                to `orders_rocky_shadow`
+//!   rocky run --shadow ──▶ ownership preflight ──▶ REFUSE, naming the object
+//!            │                                     and printing the DROP
 //!            ▼
-//!   full_refresh CTAS  ──►  CREATE OR REPLACE TABLE …
-//!            │
-//!   warehouse after:   main.orders_rocky_shadow  (the MODEL's columns)
+//!   warehouse after    main.orders_rocky_shadow   (untouched)
 //! ```
 //!
-//! Nothing between the rewrite and the write asks whether the object already
-//! exists or who owns it. `apply_shadow_rewrite` (`rocky-cli`,
-//! `commands/run.rs`) refuses a derived shadow target that collides with a
-//! configured production target or with another selected model's shadow
-//! target — both are checks against the PROJECT, not against the warehouse.
-//! The transformation executor's only existence probe (`describe_table` in
-//! `execute_one_plain_model`) is gated on the strategies that mutate an
-//! existing target (Merge / Incremental / DeleteInsert / Microbatch), so a
-//! `full_refresh` model reaches its `CREATE OR REPLACE TABLE` having asked
-//! the warehouse nothing at all.
+//! The two tests are the two halves of the contract, and neither means much
+//! alone: a run refuses to write a name it does not own, and a run that DID
+//! own its name leaves nothing behind — which is what makes "already there"
+//! a sound signal in the first place.
 
 use std::fs;
 use std::process::Command;
@@ -52,24 +45,10 @@ catalog = "probe"
 schema = "main"
 "#;
 
-/// An unnamed `--shadow` run replaces a pre-existing table at the derived
-/// shadow name, with no ownership check.
-///
-/// **`#[ignore]` on purpose.** It documents the open defect in #1273 rather
-/// than guarding a fix: with no ownership or lifecycle contract for shadow
-/// objects there is no correct behaviour to assert, so a green CI lane must
-/// not depend on the current one. Delete the `#[ignore]` and invert the
-/// assertions when #1273 lands a refusal; until then run it with
-/// `cargo test -p rocky --test shadow_target_ownership -- --ignored`.
-///
-/// The pre-existing table carries a column no model produces, so the
-/// observation is a schema identity — not a row count, which a same-shape
-/// coincidence could satisfy.
-#[test]
-#[ignore = "documents open defect #1273: shadow objects have no ownership contract"]
-fn an_unnamed_shadow_run_replaces_a_pre_existing_table_it_does_not_own() {
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let root = tmp.path();
+/// Lay out a project with one `full_refresh` model targeting
+/// `probe.main.orders`, whose derived shadow name is
+/// `orders_rocky_shadow`.
+fn project(root: &std::path::Path) {
     let models = root.join("models");
     fs::create_dir_all(&models).expect("create models dir");
     fs::write(root.join("rocky.toml"), CONFIG).expect("write rocky.toml");
@@ -79,6 +58,28 @@ fn an_unnamed_shadow_run_replaces_a_pre_existing_table_it_does_not_own() {
     )
     .expect("write model sql");
     fs::write(models.join("orders.toml"), SIDECAR).expect("write sidecar");
+}
+
+fn run_shadow(root: &std::path::Path) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_rocky"))
+        .args(["-c", "rocky.toml", "run", "--shadow", "--output", "json"])
+        .current_dir(root)
+        .env("RUST_LOG", "error")
+        .output()
+        .expect("rocky must launch")
+}
+
+/// An unnamed `--shadow` run REFUSES a pre-existing object at the derived
+/// shadow name, and leaves it exactly as it found it.
+///
+/// The pre-existing table carries a column no model produces, so the
+/// observation is a schema identity — not a row count, which a same-shape
+/// coincidence could satisfy.
+#[test]
+fn an_unnamed_shadow_run_refuses_a_pre_existing_table_it_does_not_own() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+    project(root);
 
     // Somebody else's table, sitting at the name `--shadow` derives.
     {
@@ -89,35 +90,84 @@ fn an_unnamed_shadow_run_replaces_a_pre_existing_table_it_does_not_own() {
         )
         .expect("seed the pre-existing shadow-name table");
     }
+
+    let out = run_shadow(root);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    // The CONSEQUENCE first, so a revert fails on the thing that matters —
+    // the object surviving — rather than on the wording of a message. This
+    // is the assertion the original probe watched fail.
     assert_eq!(
         columns_of(root, "orders_rocky_shadow"),
         vec!["unrelated_sentinel".to_string()],
-        "precondition: the pre-existing table is the one we seeded"
+        "the pre-existing table must be untouched\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
-
-    let out = Command::new(env!("CARGO_BIN_EXE_rocky"))
-        .args(["-c", "rocky.toml", "run", "--shadow", "--output", "json"])
-        .current_dir(root)
-        .env("RUST_LOG", "error")
-        .output()
-        .expect("rocky must launch");
-
-    let after = columns_of(root, "orders_rocky_shadow");
     assert!(
-        !after.contains(&"unrelated_sentinel".to_string()),
-        "the pre-existing table survived — a guard has landed, so #1273 \
-         symptom 1 is fixed and this probe should be inverted. columns: \
-         {after:?}\nstdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr),
+        !out.status.success(),
+        "the run must refuse, not proceed\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
+
+    // The refusal reaches the operator through the JSON `errors` array,
+    // which is where `--output json` puts a run failure; stderr carries the
+    // one-line summary. Assert over both so the test does not pin which.
+    let reported = format!("{stdout}{stderr}");
+    assert!(
+        reported.contains("orders_rocky_shadow"),
+        "the refusal names the occupied object\n{reported}"
+    );
+    assert!(
+        reported.contains("does not own"),
+        "the refusal says why\n{reported}"
+    );
+    assert!(
+        reported.contains("DROP TABLE"),
+        "the refusal prints the remedy\n{reported}"
+    );
+}
+
+/// A shadow run that DOES own its name succeeds and leaves nothing behind:
+/// `cleanup_after` defaults on for a one-off `--shadow`, so the object it
+/// created is dropped.
+///
+/// This is what makes the refusal above sound rather than merely strict —
+/// without it, every second shadow run would trip over its own leftover.
+/// Running twice proves it: the second run cannot succeed unless the first
+/// one cleaned up after itself.
+#[test]
+fn a_shadow_run_cleans_up_after_itself_so_the_next_one_can_run() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+    project(root);
+
+    // Production exists, so the shadow run has something to be a shadow OF
+    // — and gives the run a real schema to write into.
+    {
+        let conn = duckdb::Connection::open(root.join("probe.duckdb")).expect("open duckdb");
+        conn.execute_batch("CREATE TABLE main.orders AS SELECT 0 AS id, 'prod' AS origin;")
+            .expect("seed production");
+    }
+
+    for attempt in 1..=2 {
+        let out = run_shadow(root);
+        assert!(
+            out.status.success(),
+            "shadow run {attempt} must succeed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+        assert!(
+            columns_of(root, "orders_rocky_shadow").is_empty(),
+            "run {attempt} must leave no shadow object behind — cleanup_after \
+             defaults on for a one-off --shadow"
+        );
+    }
+
+    // Production is untouched by either run: the shadow never wrote there.
     assert_eq!(
-        after,
+        columns_of(root, "orders"),
         vec!["id".to_string(), "origin".to_string()],
-        "the shadow run replaced the unrelated table with the model's own \
-         columns\nstdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr),
+        "production must be untouched"
     );
 }
 


### PR DESCRIPTION
Shadow targets had no ownership or lifecycle contract. Three symptoms fell out of that one gap, and this lands the contract — because fixing any one of them alone contradicts the others.

## The contract

**A shadow object is disposable and belongs to the run that made it.**

```
before a disposable shadow run writes   is anything already at this name?
                                          yes ─▶ REFUSE, naming the object + the DROP
                                          no  ─▶ this run owns it
after that run succeeds                 drop what it created (cleanup_after)
```

## The three symptoms

**Ownership.** An unnamed `--shadow` run replaced whatever sat at the derived shadow name, having asked the warehouse nothing — the transformation executor's only existence probe is gated on the strategies that *mutate* an existing target, so a `full_refresh` model reached its `CREATE OR REPLACE` having asked nothing at all. Reproduced by execution on 2026-09-05. A preflight now refuses an occupied shadow target before any model runs.

**Lifecycle.** `cleanup_after` was documented, defaulted `true`, and had **no consumer** while every construction hard-coded `false`. Objects accumulated. A one-off `--shadow` now honours it; `--branch` keeps `false` deliberately.

**Strategy.** The incremental family is refused under shadow, joining `content_addressed`, `time_interval` and `ephemeral`. Those strategies build on what the target already holds and a shadow target starts empty, so the comparison was never meaningful:

| shape | what the shadow got |
|---|---|
| first run | one delta, against production's full history |
| self-referential (`WHERE ts > (SELECT MAX(ts) FROM main.events)`) | zero rows — the watermark read is deliberately *not* redirected |
| repeat run | appended to the last run's leftover; drift compounds |

Producing an incomparable number is worse than refusing.

## Why "already there" is a sound signal, which it would not have been before

Only replace-the-target strategies survive the refusal above, and cleanup now runs — so a clean disposable run leaves the name empty. Without both, the check would fire on Rocky's own debris every time.

## Scope, and what stays open

The refusal fires **only when `cleanup_after` is set**. That is not an oversight, and an existing test is what forced it: a named `--branch` is a persistent workspace whose objects are *meant* to survive and be replaced next run, so an unconditional refusal made every branch re-run fail on its own tables.

So: **a persistent shadow or branch namespace gets no per-object ownership check.** Rocky cannot tell its own leftover from a stranger's without a persisted owner record, and inventing one that survives a deleted state file and a different machine is a larger change than this. #1273 stays open for that mode rather than being papered over. The primitive itself stays unconditional, with a test pinning that, so a future caller that forgets the gate gets a refusal rather than a silent pass.

"Rocky-owned" here means **this run created it** — the strictest reading available without persistence. The cost is that a part-way failure leaves objects the next run refuses; the refusal prints the exact `DROP`.

Cleanup runs on success only: a failed run is evidence, and destroying it to save one statement is the wrong trade.

## This refuses runs that used to work

- a `--shadow` run over an incremental / merge / delete_insert / microbatch model now fails, with the reason and the remedy;
- a disposable `--shadow` run that finds debris refuses until it is dropped.

Both are the contract, not collateral. Branch runs are unaffected.

## Tests

`engine/rocky/tests/shadow_target_ownership.rs` was written as a probe documenting the open defect, `#[ignore]`d, with instructions to invert it when a refusal landed. **It is inverted.** The pre-existing table now survives, and the assertion on the object comes *before* any message assertion so a revert fails on the consequence rather than on wording.

A second end-to-end test proves a run that owns its name leaves nothing behind — by running shadow twice, which cannot pass unless the first run cleaned up. Without that half the refusal would break every second run, so the two are asserted together.

Unit tests in `shadow_lifecycle.rs` cover the unoccupied pass, the occupied refusal (object untouched afterwards, model named, `DROP` printed), idempotent cleanup, and the caller-scoping decision.

Full engine suite green: 1899 `rocky-cli` lib tests, every `rocky` integration suite, clippy `--all-targets --all-features`, fmt.

`init_adapter_scaffold_compiles` fails on this branch **and on `main` with no changes** — pre-existing, unrelated, filed as #1833 with the diagnosis.

Refs #1273
