### PR TITLE
fix(engine): a gate that cannot read its config refuses instead of passing

### DIFF
--- a/engine/crates/rocky-cli/src/commands/branch.rs
+++ b/engine/crates/rocky-cli/src/commands/branch.rs
@@ -742,8 +742,16 @@ pub(crate) fn run_approval_gate(
 
 /// Run the breaking-change gate for a plan step, updating `audit`.
 ///
-/// Returns the same `Option<Vec<BreakingFinding>>` as the internal
-/// `evaluate_breaking_change_gate` — `None` when the gate was skipped.
+/// Mirrors the internal `evaluate_breaking_change_gate`:
+///
+/// - `Ok(Some(findings))` — the gate ran; the caller filters on
+///   [`BreakingFinding::is_breaking`];
+/// - `Ok(None)` — the gate was SKIPPED (no models directory, or either side
+///   failed to compile), with a `BreakingChangesGateSkipped` audit event
+///   carrying the reason. The caller lets the promote proceed;
+/// - `Err(_)` — the gate could not read the project at all (#1702). That is
+///   NOT a skip: skipping would let the promote through past a gate that
+///   examined nothing.
 pub(crate) fn run_breaking_change_gate_for_plan(
     config_path: &Path,
     models_dir: &Path,
@@ -752,7 +760,7 @@ pub(crate) fn run_breaking_change_gate_for_plan(
     actor: &ApproverIdentity,
     record: &BranchRecord,
     branch_state_hash: &str,
-) -> Option<Vec<rocky_core::breaking_change::BreakingFinding>> {
+) -> anyhow::Result<Option<Vec<rocky_core::breaking_change::BreakingFinding>>> {
     evaluate_breaking_change_gate(
         config_path,
         models_dir,
@@ -1419,7 +1427,7 @@ fn evaluate_breaking_change_gate(
     actor: &ApproverIdentity,
     record: &BranchRecord,
     branch_state_hash: &str,
-) -> Option<Vec<BreakingFinding>> {
+) -> anyhow::Result<Option<Vec<BreakingFinding>>> {
     use rocky_compiler::compile::{self, CompilerConfig};
 
     let push_skip = |audit: &mut Vec<AuditEvent>, reason: String| {
@@ -1442,22 +1450,41 @@ fn evaluate_breaking_change_gate(
                 models_dir.display()
             ),
         );
-        return None;
+        return Ok(None);
     }
 
     // Seed both compiles with the cached source schemas so the resulting
-    // IR uses real types rather than `Unknown`. Mirrors `compute_ci_diff`'s
-    // policy: degrade to an empty map on config / cache failure rather than
-    // blocking the promote on a configuration issue.
-    let source_schemas = match rocky_core::config::load_rocky_config(config_path) {
-        Ok(cfg) => {
+    // IR uses real types rather than `Unknown`.
+    //
+    // An unloadable config REFUSES the promote (#1702). It cannot skip: the
+    // caller reads a skipped gate as `if let Some(findings)`, so `None`
+    // lets the promote through — and the old degrade produced the same
+    // outcome more quietly, by typing every leaf `Unknown` so that no
+    // breaking change could be found. Either way a promote proceeded past a
+    // gate that never read the project. A gate that cannot read its input
+    // has not passed.
+    //
+    // An absent config file is not that case, and still degrades: there is
+    // nothing to fail to read.
+    let source_schemas = match rocky_core::config::load_optional_project_config(Some(config_path)) {
+        Ok(Some(cfg)) => {
             let schema_cfg = cfg.cache.schemas.with_ttl_override(None);
             // The state path is independent of the source-schemas cache for
             // the gate's purposes; use the workspace default.
             let state_path = std::path::PathBuf::from(".rocky/state.redb");
             crate::source_schemas::load_cached_source_schemas(&schema_cfg, &state_path)
         }
-        Err(_) => std::collections::HashMap::new(),
+        Ok(None) => std::collections::HashMap::new(),
+        Err(e) => {
+            return Err(anyhow::anyhow!(
+                "cannot evaluate the breaking-change gate: failed to load config from {}: \
+                 {e}. Promoting past a gate that could not read the project would allow a \
+                 breaking change through unexamined — every source column would type as \
+                 `Unknown`, so nothing could be found breaking. Fix the config, then \
+                 re-run the promote",
+                config_path.display()
+            ));
+        }
     };
 
     let head_compile = {
@@ -1471,7 +1498,7 @@ fn evaluate_breaking_change_gate(
             Ok(r) => r,
             Err(e) => {
                 push_skip(audit, format!("HEAD compile failed — gate skipped: {e}"));
-                return None;
+                return Ok(None);
             }
         }
     };
@@ -1481,13 +1508,13 @@ fn evaluate_breaking_change_gate(
             Ok(r) => r,
             Err(reason) => {
                 push_skip(audit, format!("{reason} — gate skipped"));
-                return None;
+                return Ok(None);
             }
         };
 
     let base_ir = compile_result_to_project_ir(&base_compile);
     let head_ir = compile_result_to_project_ir(&head_compile);
-    Some(breaking_change::diff_project_ir(&base_ir, &head_ir))
+    Ok(Some(breaking_change::diff_project_ir(&base_ir, &head_ir)))
 }
 
 /// Project a [`rocky_compiler::compile::CompileResult`] into a
@@ -2467,7 +2494,9 @@ mod tests {
 
         std::env::set_current_dir(saved_cwd).unwrap();
 
-        let findings = findings.expect("gate must run when both refs compile");
+        let findings = findings
+            .expect("the gate must not refuse: the config loads")
+            .expect("gate must run when both refs compile");
         let breaking: Vec<&BreakingFinding> = findings.iter().filter(|f| f.is_breaking()).collect();
         assert!(
             !breaking.is_empty(),
@@ -2546,11 +2575,69 @@ mod tests {
 
         std::env::set_current_dir(saved_cwd).unwrap();
 
-        let findings = findings.expect("gate must run when both refs compile");
+        let findings = findings
+            .expect("the gate must not refuse: the config loads")
+            .expect("gate must run when both refs compile");
         let breaking_count = findings.iter().filter(|f| f.is_breaking()).count();
         assert_eq!(
             breaking_count, 0,
             "a SQL-body-only change must produce zero breaking findings, got {findings:?}"
+        );
+    }
+
+    /// An UNLOADABLE config refuses the gate rather than skipping it
+    /// (#1702).
+    ///
+    /// The distinction this pins is the whole point: a missing models
+    /// directory SKIPS (the test below), and a skip lets the promote
+    /// proceed — the caller reads the gate as `if let Some(findings)`. So
+    /// if an unreadable config also skipped, a promote would pass a gate
+    /// that examined nothing. Worse, the behaviour before this change was
+    /// quieter than a skip: the config error degraded to an empty schema
+    /// map, every source column typed as `Unknown`, no finding could be
+    /// breaking, and the gate reported a clean pass it had not earned.
+    ///
+    /// Asserted on the ERROR, not on a message: the promote must not
+    /// proceed. The audit must stay empty, because this is not a skip and
+    /// recording it as one would be the same lie in the ledger.
+    #[test]
+    fn gate_refuses_rather_than_skips_when_the_config_cannot_be_read() {
+        let _cwd_guard = cwd_lock();
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        // Present and unparseable — NOT absent. Absence is an ordinary
+        // project fact and still degrades; this is a config that exists and
+        // cannot be read.
+        let broken = "[adapters.duckdb\ntype = \"duckdb\"\n";
+        let models_dir = init_git_repo_with_models(dir, broken, &[("widgets", "SELECT 1 AS id")]);
+
+        let config_path = dir.join("rocky.toml");
+        let mut audit: Vec<AuditEvent> = Vec::new();
+        let record = sample_record("fix-price");
+
+        let saved_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir).unwrap();
+        let result = evaluate_breaking_change_gate(
+            &config_path,
+            &models_dir,
+            "main",
+            &mut audit,
+            &dummy_actor(),
+            &record,
+            "branch-state-hash",
+        );
+        std::env::set_current_dir(saved_cwd).unwrap();
+
+        let err = result.expect_err("an unreadable config must refuse the promote, not skip it");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("failed to load config"),
+            "the refusal names the cause: {msg}"
+        );
+        assert!(
+            audit.is_empty(),
+            "a refusal is not a skip — recording BreakingChangesGateSkipped would claim the \
+             gate ran and was bypassed for a known reason: {audit:?}"
         );
     }
 
@@ -2602,7 +2689,9 @@ mod tests {
         std::env::set_current_dir(saved_cwd).unwrap();
 
         assert!(
-            findings.is_none(),
+            findings
+                .expect("the gate must not refuse: the config loads")
+                .is_none(),
             "gate must return None when the base ref has no models"
         );
         assert_eq!(audit.len(), 1, "exactly one skip event must be recorded");
@@ -2641,7 +2730,11 @@ mod tests {
             "branch-state-hash",
         );
 
-        assert!(findings.is_none());
+        assert!(
+            findings
+                .expect("a missing models dir SKIPS the gate; it does not refuse")
+                .is_none()
+        );
         assert_eq!(audit.len(), 1);
         assert_eq!(audit[0].kind, AuditEventKind::BreakingChangesGateSkipped);
     }

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -1294,7 +1294,34 @@ pub fn compute_embedded_capabilities(
     // config identity. Every path below stamps `fingerprint_version` so a NEW
     // plan whose fingerprint could not be produced is distinguishable from a
     // genuinely-legacy plan at apply time (finding #7).
-    let loaded_cfg = rocky_core::config::load_rocky_config(config_path).ok();
+    // A gate that cannot read its input has not passed (#1702).
+    //
+    // This used to be `.ok()`. #1680 established that the degrade is
+    // fail-OPEN, not fail-closed as an earlier comment claimed: an empty
+    // schema map types both sides' leaves as `Unknown`, so a real
+    // `BIGINT -> VARCHAR` source change produces no finding, the model is
+    // ABSENT from `changed`, and `EmbeddedCapabilities::touched` gates an
+    // absent model under the bare `Apply` capability instead of
+    // `SchemaChangeBreaking`. A `schema_change.breaking` deny rule therefore
+    // did not fire on a model whose type really did change.
+    //
+    // `load_optional_project_config` keeps the one degrade that is a fact
+    // about the project rather than a failure to read it: NO config file is
+    // `Ok(None)`, and the capability computation proceeds without one
+    // exactly as before. Every other `ConfigError` — unparseable, unreadable,
+    // a dangling symlink — propagates, so the plan refuses instead of
+    // embedding a capability set computed from types it could not resolve.
+    let loaded_cfg =
+        rocky_core::config::load_optional_project_config(Some(config_path)).map_err(|e| {
+            anyhow::anyhow!(
+                "cannot compute this plan's embedded capabilities: failed to load config \
+                 from {}: {e}. The capability set decides what a governed apply is allowed \
+                 to do, and computing it without the project's source-schema cache silently \
+                 weakens it — a breaking type change would be gated as a plain apply. Fix \
+                 the config, then re-plan",
+                config_path.display()
+            )
+        })?;
     let config_identity = loaded_cfg
         .as_ref()
         .map(crate::commands::apply::config_policy_identity);
@@ -1346,21 +1373,18 @@ pub fn compute_embedded_capabilities(
     // `rocky.toml` (the `.ok()` above), a cold cache, a disabled cache, an
     // unreadable state store.
     //
-    // This used to claim the degrade "only ever fails *closed* (more models look
-    // breaking), never open." That is FALSE and #1680 corrected it. An empty map
-    // types both sides' leaves as `Unknown`, so a real `BIGINT -> VARCHAR` change
-    // on a source column produces `Unknown` vs `Unknown` — no finding at all. The
-    // model is then ABSENT from `changed`, and `EmbeddedCapabilities::touched`
-    // maps an absent model to the bare `PolicyCapability::Apply`, not
-    // `SchemaChangeBreaking` (see `plan_store.rs`). A `schema_change.breaking`
-    // deny rule therefore does not fire on a model whose type really did change.
-    // That is fail-OPEN, in the one direction the comment promised was safe.
+    // The remaining degrades here are NOT the unloadable-config one — that
+    // refuses above now (#1702). What is left is a cold cache, a disabled
+    // cache, an unreadable state store, or a project with no config file at
+    // all. Those are facts about the project rather than a gate that could
+    // not read its input, and they degrade to empty types as before.
     //
-    // Left as-is on purpose in #1680, which fixed only the comment. Refusing here
-    // changes what a governed `rocky plan` does on a config that never loaded,
-    // and the same question is open for the `rocky branch promote` gate
-    // (`branch.rs`) and `plan.rs`'s `--semantic` leg. #1667 deferred those three
-    // together and they should move together.
+    // The distinction matters because the degrade IS fail-open, as #1680
+    // established: an empty map types both sides' leaves as `Unknown`, so a
+    // real `BIGINT -> VARCHAR` source change produces no finding, the model
+    // is absent from `changed`, and `touched` gates it under the bare
+    // `Apply` capability. That is why the config case now refuses rather
+    // than joining them.
     let source_schemas = match (state_path, loaded_cfg.as_ref()) {
         (Some(sp), Some(cfg)) => {
             let schema_cfg = cfg.cache.schemas.clone().with_ttl_override(None);
@@ -2088,14 +2112,36 @@ fn compute_semantic_verdict(
     }
 
     // Seed both compiles from the current warehouse schema cache so the IR
-    // carries real leaf types. Degrade to an empty map on config / cache
-    // failure rather than blocking the preview.
-    let source_schemas = match rocky_core::config::load_rocky_config(config_path) {
-        Ok(cfg) => {
+    // carries real leaf types.
+    //
+    // `--semantic` is a PREVIEW, not an apply-authorization gate, so its way
+    // of not passing is to omit the verdict rather than to refuse the
+    // command (#1702). That distinction is the whole reason this arm differs
+    // from `compute_embedded_capabilities` above, which refuses.
+    //
+    // What it must not do is what it did before: degrade to empty types and
+    // emit a verdict anyway. Every leaf then types as `Unknown`, so a real
+    // breaking change produces no finding and the preview reads GREEN — a
+    // verdict computed from types it could not resolve, presented exactly
+    // like one that was. Omitting says "no verdict", which is true.
+    //
+    // An absent config file is not that case: there is nothing to fail to
+    // read, and the preview proceeds on empty types as before.
+    let source_schemas = match rocky_core::config::load_optional_project_config(Some(config_path)) {
+        Ok(Some(cfg)) => {
             let schema_cfg = cfg.cache.schemas.with_ttl_override(None);
             crate::source_schemas::load_cached_source_schemas(&schema_cfg, state_path)
         }
-        Err(_) => std::collections::HashMap::new(),
+        Ok(None) => std::collections::HashMap::new(),
+        Err(e) => {
+            tracing::debug!(
+                config = %config_path.display(),
+                error = %e,
+                "plan --semantic: config failed to load — verdict omitted rather than \
+                 computed from unresolved types"
+            );
+            return None;
+        }
     };
 
     let head_compile = {
@@ -2396,6 +2442,9 @@ pub(crate) async fn build_promote_plan_inner(
     )?;
 
     // Breaking-change gate — runs before the plan is written.
+    // `?` on purpose (#1702): a gate that could not read the project refuses
+    // the promote. A SKIP still returns `Ok(None)` and still lets the
+    // promote proceed — that shape is unchanged.
     let breaking_findings = run_breaking_change_gate_for_plan(
         config_path,
         models_dir,
@@ -2404,7 +2453,7 @@ pub(crate) async fn build_promote_plan_inner(
         &actor,
         &record,
         &branch_state_hash,
-    );
+    )?;
 
     if let Some(findings) = &breaking_findings {
         let breaking: Vec<_> = findings.iter().filter(|f| f.is_breaking()).collect();


### PR DESCRIPTION
Three gates degraded an unloadable `rocky.toml` to an empty source-schema map and carried on. A gate that cannot read its input has not passed.

## What the degrade actually cost

`#1680` established this and fixed only the comment, which had claimed the degrade "only ever fails *closed*". It does not:

```
config fails to load
  └─▶ source schemas = {}
        └─▶ both sides' leaves type as `Unknown`
              └─▶ a real BIGINT → VARCHAR source change yields NO finding
                    └─▶ the model is ABSENT from `changed`
                          └─▶ `touched` gates it under the bare `Apply` capability,
                              not `SchemaChangeBreaking`
```

So a `schema_change.breaking` deny rule did not fire on a model whose type really did change — fail-open, in the one direction the old comment promised was safe.

## Each site refuses in the shape its own surface already has

| site | previous shape | now |
|---|---|---|
| `compute_embedded_capabilities` | `Result`, `.ok()` on the config | propagates. This capability set decides what a governed apply may do; computing it from types it could not resolve silently weakens it. |
| branch promote gate | `Option`; `None` = skipped, and the caller reads `if let Some(findings)` — so **a skip lets the promote through** | returns `Result`. A skip is still `Ok(None)`; a config it cannot read is `Err`. |
| `plan --semantic` | `Option<Verdict>` | **omits** the verdict. |

The third is deliberately not a refusal. `--semantic` is a *preview*, not an apply-authorization gate, so refusing the whole command would cost more than it buys. What it must not do is what it did: emit a verdict computed from `Unknown`-vs-`Unknown`, which reads **green**, presented exactly like one that resolved real types. Omitting says "no verdict", which is true.

## What still degrades, on purpose

`load_optional_project_config` maps `FileNotFound` to `Ok(None)`, so a project with **no** `rocky.toml` behaves exactly as before — that is a fact about the project, not a failure to read it. A cold cache, a disabled cache and an unreadable state store also still degrade. Only the config-error path changed.

## Reversing a deliberate decision

The site carried `// Left as-is on purpose in #1680`, so the pinning-test check ran first: **no test asserted the old degrade** for an unloadable config, and the existing gate tests all pass a valid config. Four of them now unwrap the new `Result`, each `.expect()` naming which outcome it expects and why — a missing models directory still **skips**, and says so.

## Tests

`gate_refuses_rather_than_skips_when_the_config_cannot_be_read` pins the distinction that matters: a present-and-unparseable config must `Err`, and the audit must stay **empty** — recording `BreakingChangesGateSkipped` would put the same lie in the ledger. Asserted on the error and the audit, not on message wording.

**Mutation-checked** via `scripts/mutation-check.sh`: restoring `Err(_) => HashMap::new()` fails the test.

Full engine gate green — 1895 `rocky-cli` lib tests, clippy `--all-targets --all-features`, fmt. `init_adapter_scaffold_compiles` fails here and on `main` alike; pre-existing and filed as #1833.

Refs #1702
