### PR TITLE
fix(engine): an unreadable rocky.toml is reported, not read as absent

### DIFF
--- a/docs/src/content/docs/concepts/compiler.md
+++ b/docs/src/content/docs/concepts/compiler.md
@@ -260,6 +260,7 @@ span, and sometimes a suggested fix.
 | `W010` | Contract defines a column not in model output (not required) |
 | `W011` | Contract exists for a model not found in the project |
 | `W012` | An `[imports.<name>]` snapshot could not be loaded; `E030`/`E033` checks skipped |
+| `W013` | `rocky.toml` is present but could not be read, so every project-level check is silent (`rocky lsp` and `rocky serve` only; one-shot commands refuse instead) |
 | `W030` | Imported producer added a column, surfaced only to consumers reading it via `SELECT *` |
 | `W031` | Imported producer widened the type of a column this project reads (cross-team contract) |
 | `I001` | Model dependency inferred from SQL |

--- a/engine/crates/rocky-cli/src/api.rs
+++ b/engine/crates/rocky-cli/src/api.rs
@@ -1158,12 +1158,32 @@ async fn compile_status(
     Ok(PrettyJson(output))
 }
 
+/// `POST /api/v1/compile` — recompile in place.
+///
+/// Reports `status: "recompiled"` when the project config loaded or is
+/// absent, and `status: "recompiled_degraded"` with `config_error` when a
+/// `rocky.toml` is present and could not be read.
+///
+/// It used to answer `"recompiled"` unconditionally, so an SDK caller could
+/// not distinguish a project that declares no masks and no freshness from
+/// one whose config failed to parse — the compile silently ran with empty
+/// project inputs and the route still said success (#1625). `serve` still
+/// compiles rather than refusing (a resident server must not go dark
+/// mid-edit), but it no longer calls that outcome the same thing.
 async fn trigger_compile(State(state): State<Arc<ServerState>>) -> impl IntoResponse {
-    state.recompile().await;
-    (
-        StatusCode::OK,
-        Json(serde_json::json!({ "status": "recompiled" })),
-    )
+    match state.recompile().await {
+        None => (
+            StatusCode::OK,
+            Json(serde_json::json!({ "status": "recompiled" })),
+        ),
+        Some(config_error) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "status": "recompiled_degraded",
+                "config_error": config_error,
+            })),
+        ),
+    }
 }
 
 /// `GET /api/v1/dag` — canonical [`DagOutput`].

--- a/engine/crates/rocky-compiler/src/diagnostic.rs
+++ b/engine/crates/rocky-compiler/src/diagnostic.rs
@@ -199,6 +199,24 @@ pub const W011: &str = "W011";
 /// error — the consumer compiles, it just isn't verified against that
 /// producer this run.
 pub const W012: &str = "W012";
+/// The project's `rocky.toml` is present and could not be read, so the
+/// project-level checks that depend on it did not run (#1625).
+///
+/// Same shape as [`W012`] one level up: the compile itself still succeeds —
+/// models parse and typecheck without a project config — but `[mask]` /
+/// `[classifications.allow_unmasked]` (W004), the `[freshness]` default
+/// (W005) and the warehouse schema cache all came through empty because the
+/// file could not be parsed, not because the project declares nothing.
+///
+/// Emitted by the long-running surfaces — `rocky lsp` and `rocky serve` —
+/// which stay usable on a broken config by design rather than refusing.
+/// Every one-shot entry point (`rocky lineage`, the MCP tools, `rocky plan`)
+/// refuses instead: those return an answer a caller acts on, and an answer
+/// computed from a config that never loaded is wrong rather than degraded.
+///
+/// A project with NO `rocky.toml` does not emit this. Absence is an ordinary
+/// project fact; unreadability is a failure to read.
+pub const W013: &str = "W013";
 
 /// Imported producer added a column. Surfaced (at info severity) only to
 /// consumers that read the producer via `SELECT *`, where an added column

--- a/engine/crates/rocky-server/src/lsp.rs
+++ b/engine/crates/rocky-server/src/lsp.rs
@@ -364,6 +364,10 @@ pub struct RockyLsp {
     /// session per `models_dir` rather than per keystroke. See
     /// `schema_cache_throttle.rs`.
     schema_cache_throttle: SchemaCacheThrottle,
+    /// Whether a W013 squiggle is currently published on `rocky.toml`
+    /// (#1625). See [`RockyLsp::publish_project_config_diagnostic`] for why
+    /// the state is tracked rather than republished on every compile.
+    config_diagnostic_published: Arc<AtomicBool>,
     /// Salsa database for incremental DSL parsing — backs `didOpen` /
     /// `didChange` so a parsed `RockyFile` is memoized across keystrokes
     /// and only re-runs when the buffer text actually changes.
@@ -400,6 +404,17 @@ impl RockyLsp {
         notified.await;
     }
 
+    /// Where this project's `rocky.toml` lives, given its models directory.
+    ///
+    /// One derivation, because two of them would be a bug that is invisible
+    /// until it matters: [`Self::project_compiler_inputs`] decides whether
+    /// the config is unreadable, and [`Self::publish_project_config_diagnostic`]
+    /// decides which file to squiggle. If those ever disagreed the warning
+    /// would land on a file that is fine, or on nothing at all.
+    fn project_config_path(models_dir: &std::path::Path) -> Option<std::path::PathBuf> {
+        models_dir.parent().map(|root| root.join("rocky.toml"))
+    }
+
     /// The project-level compiler inputs, read from `rocky.toml`.
     ///
     /// One derivation for both compile paths — the initial
@@ -410,23 +425,41 @@ impl RockyLsp {
     /// keystroke.
     ///
     /// Project root = `models_dir.parent()`, the same assumption the
-    /// schema-cache loader makes. A missing or unreadable `rocky.toml`
-    /// falls back to empty defaults, which is the "no project config"
-    /// behaviour rather than an error: an editor must keep type-checking a
-    /// models directory that has no project around it.
+    /// schema-cache loader makes. A *missing* `rocky.toml` falls back to
+    /// empty defaults, which is the "no project config" behaviour rather
+    /// than an error: an editor must keep type-checking a models directory
+    /// that has no project around it.
+    ///
+    /// The fourth element separates the other case: a `rocky.toml` that is
+    /// present and unparseable (#1625). It used to be swallowed by `.ok()`, so
+    /// W004 / W005 simply went quiet and the editor looked like a project
+    /// that declares no masks and no freshness — indistinguishable from one
+    /// that genuinely declares none. The LSP still compiles (staying usable
+    /// on a broken config is the point of an editor surface), but the
+    /// silence is now reported as W013 rather than being invisible.
     fn project_compiler_inputs(
         models_dir: &std::path::Path,
     ) -> (
         std::collections::BTreeMap<String, rocky_core::config::MaskEntry>,
         Vec<String>,
         rocky_core::config::ProjectFreshnessConfig,
+        Option<String>,
     ) {
-        models_dir
-            .parent()
-            .map(|root| root.join("rocky.toml"))
-            .and_then(|toml_path| rocky_core::config::load_rocky_config(&toml_path).ok())
-            .map(|c| (c.mask, c.classifications.allow_unmasked, c.freshness))
-            .unwrap_or_default()
+        let Some(toml_path) = Self::project_config_path(models_dir) else {
+            return (Default::default(), Vec::new(), Default::default(), None);
+        };
+        match rocky_core::config::load_optional_project_config(Some(&toml_path)) {
+            // A project with no `rocky.toml` declares nothing, and that is
+            // an ordinary fact rather than a failure to read.
+            Ok(None) => (Default::default(), Vec::new(), Default::default(), None),
+            Ok(Some(c)) => (c.mask, c.classifications.allow_unmasked, c.freshness, None),
+            Err(e) => (
+                Default::default(),
+                Vec::new(),
+                Default::default(),
+                Some(format!("{} could not be read: {e}", toml_path.display())),
+            ),
+        }
     }
 
     async fn recompile(&self) {
@@ -449,7 +482,15 @@ impl RockyLsp {
         // Load `rocky.toml` so the W004 classification-tag check + W005
         // freshness coverage check fire in the LSP, and so a model with no
         // `[freshness]` block of its own carries the project's.
-        let (mask, allow_unmasked, project_freshness) = Self::project_compiler_inputs(&dir_path);
+        let (mask, allow_unmasked, project_freshness, config_unreadable) =
+            Self::project_compiler_inputs(&dir_path);
+        Self::publish_project_config_diagnostic(
+            &self.client,
+            &self.config_diagnostic_published,
+            &dir_path,
+            config_unreadable.as_deref(),
+        )
+        .await;
 
         let config = CompilerConfig {
             models_dir: dir_path.clone(),
@@ -596,6 +637,69 @@ impl RockyLsp {
             };
             self.client.publish_diagnostics(uri, vec![diag], None).await;
         }
+    }
+
+    /// Publish (or clear) the W013 squiggle on `rocky.toml` itself (#1625).
+    ///
+    /// The project config is not a model, so a compiler `Diagnostic` cannot
+    /// carry it: [`Self::publish_diagnostics`] resolves every diagnostic to
+    /// a model file and `continue`s past anything it cannot place, so a
+    /// project-scoped one would be silently dropped — which is the exact
+    /// failure this fixes. It goes straight to the file it is about.
+    ///
+    /// Called on every compile, but it only WRITES when the answer changed:
+    /// it publishes once when the config goes bad and clears once when it is
+    /// fixed. A squiggle that outlived the fix would be its own lie, so the
+    /// clear is not optional — but it happens once, not on every keystroke.
+    ///
+    /// `published` carries that state, and tracking it is not an
+    /// optimisation. `Client::publish_diagnostics` sends into tower-lsp's
+    /// outgoing channel, and the `initialized` handler awaits the startup
+    /// compile — so against a client that has not begun draining the socket
+    /// yet, a message written on every compile deadlocks the handshake. The
+    /// protocol-level test below is exactly that client. Writing only on a
+    /// transition means the ordinary path puts nothing on the wire at all.
+    ///
+    /// An associated fn rather than a method because the debounced
+    /// `did_change` recompile runs in a spawned task that holds clones, not
+    /// `&self`.
+    async fn publish_project_config_diagnostic(
+        client: &Client,
+        published: &AtomicBool,
+        models_dir: &std::path::Path,
+        reason: Option<&str>,
+    ) {
+        // Nothing to say and nothing outstanding: stay off the wire.
+        if reason.is_none() && !published.load(Ordering::SeqCst) {
+            return;
+        }
+        let Some(toml_path) = Self::project_config_path(models_dir) else {
+            return;
+        };
+        let Ok(uri) = Url::from_file_path(&toml_path) else {
+            return;
+        };
+        let diags = match reason {
+            None => Vec::new(),
+            Some(reason) => vec![Diagnostic {
+                range: Range::default(),
+                severity: Some(DiagnosticSeverity::WARNING),
+                code: Some(NumberOrString::String(
+                    rocky_compiler::diagnostic::W013.to_string(),
+                )),
+                source: Some("rocky".to_string()),
+                message: format!(
+                    "{reason}\n\nThe models still type-check, but every project-level check \
+                     is silent because this file could not be parsed: masking (W004), the \
+                     project [freshness] default (W005), and the cached warehouse schemas all \
+                     came through empty \u{2014} indistinguishable from a project that declares \
+                     none of them."
+                ),
+                ..Default::default()
+            }],
+        };
+        published.store(reason.is_some(), Ordering::SeqCst);
+        client.publish_diagnostics(uri, diags, None).await;
     }
 
     /// Read `rocky.toml` from the project root and return its URI + raw
@@ -1271,6 +1375,7 @@ impl LanguageServer for RockyLsp {
             // doesn't re-emit the info log that `recompile()` already
             // emitted for the same project.
             let schema_cache_throttle = self.schema_cache_throttle.clone();
+            let config_diagnostic_published = self.config_diagnostic_published.clone();
 
             tokio::spawn(async move {
                 tokio::time::sleep(std::time::Duration::from_millis(300)).await;
@@ -1292,8 +1397,15 @@ impl LanguageServer for RockyLsp {
                 // `[freshness]` block after the first edit, so a model's
                 // inherited freshness vanished from the IDE's view of the
                 // project the moment the user typed.
-                let (mask, allow_unmasked, project_freshness) =
+                let (mask, allow_unmasked, project_freshness, config_unreadable) =
                     Self::project_compiler_inputs(&dir_path);
+                Self::publish_project_config_diagnostic(
+                    &client,
+                    &config_diagnostic_published,
+                    &dir_path,
+                    config_unreadable.as_deref(),
+                )
+                .await;
                 let config = CompilerConfig {
                     models_dir: dir_path,
                     contracts_dir: None,
@@ -4452,6 +4564,7 @@ pub async fn run_lsp() {
         init_notify: Arc::new(Notify::new()),
         semantic_tokens_cache: Arc::new(RwLock::new(HashMap::new())),
         schema_cache_throttle: SchemaCacheThrottle::new(),
+        config_diagnostic_published: Arc::new(AtomicBool::new(false)),
         salsa_db: Arc::new(Mutex::new(RockyDatabase::default())),
         salsa_sources: Arc::new(RwLock::new(HashMap::new())),
     });
@@ -4491,6 +4604,7 @@ mod tests {
             init_notify: Arc::new(Notify::new()),
             semantic_tokens_cache: Arc::new(RwLock::new(HashMap::new())),
             schema_cache_throttle: SchemaCacheThrottle::new(),
+            config_diagnostic_published: Arc::new(AtomicBool::new(false)),
             salsa_db: Arc::new(Mutex::new(RockyDatabase::default())),
             salsa_sources: Arc::new(RwLock::new(HashMap::new())),
         });
@@ -4574,16 +4688,118 @@ mod tests {
         let models = root.join("models");
         std::fs::create_dir_all(&models).unwrap();
 
-        let (_mask, allow_unmasked, freshness) = RockyLsp::project_compiler_inputs(&models);
+        let (_mask, allow_unmasked, freshness, unreadable) =
+            RockyLsp::project_compiler_inputs(&models);
         assert_eq!(freshness.expected_lag_seconds, Some(900));
         assert_eq!(freshness.time_column.as_deref(), Some("updated_at"));
         assert_eq!(allow_unmasked, vec!["public".to_string()]);
+        assert!(
+            unreadable.is_none(),
+            "a config that parsed is not unreadable"
+        );
 
         // No project around the models directory is not an error.
         let bare = tempfile::tempdir().unwrap();
-        let (_m, a, f) = RockyLsp::project_compiler_inputs(bare.path());
+        let (_m, a, f, u) = RockyLsp::project_compiler_inputs(bare.path());
         assert!(a.is_empty());
         assert_eq!(f.expected_lag_seconds, None);
+        assert!(
+            u.is_none(),
+            "an ABSENT rocky.toml is a fact about the project, not a read failure; \
+             emitting W013 here would squiggle every bare models directory"
+        );
+    }
+
+    /// The wire, not the value.
+    ///
+    /// `project_compiler_inputs` returning a reason is useless unless somebody
+    /// publishes it, and the two call sites are inside `recompile` and inside
+    /// the debounced `did_change` task — one behind a live LSP client, the
+    /// other behind a 300 ms sleep in a spawned task. Neither is reachable
+    /// from a unit test, so deleting both publish calls would leave every
+    /// other test in this file green while the editor went back to silence:
+    /// exactly the "coded but not wired" shape this fix is about.
+    ///
+    /// So the source is the assertion. Every call to `project_compiler_inputs`
+    /// must be followed by a `publish_project_config_diagnostic` call — the
+    /// counts must match, and neither may be zero.
+    ///
+    /// What this does NOT prove, stated so nobody leans on it further than it
+    /// reaches: it counts text. It cannot tell that the reason passed to the
+    /// publisher is the one that call site computed, only that a publish
+    /// happens for every derivation. The value half is covered by
+    /// [`an_unparseable_project_config_reports_a_reason_instead_of_going_quiet`];
+    /// the end-to-end pairing is covered by neither and would need a live LSP
+    /// client.
+    #[test]
+    fn every_project_config_read_publishes_its_verdict() {
+        let source = include_str!("lsp.rs");
+        // Strip comments and the test module, so prose naming either symbol
+        // (this doc comment included) cannot inflate a count.
+        let code_end = source
+            .find("\nmod tests {")
+            .or_else(|| source.find("\n    mod tests {"))
+            .unwrap_or(source.len());
+        let code: String = source[..code_end]
+            .lines()
+            .filter(|l| !l.trim_start().starts_with("//!") && !l.trim_start().starts_with("///"))
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let reads = code.matches("Self::project_compiler_inputs(").count();
+        let publishes = code
+            .matches("Self::publish_project_config_diagnostic(")
+            .count();
+
+        assert!(
+            reads > 0,
+            "the project config must still be read somewhere; if this hits zero the \
+             search string is stale, not the code"
+        );
+        assert_eq!(
+            reads, publishes,
+            "every read of the project config must publish its verdict. {reads} call(s) \
+             to project_compiler_inputs but {publishes} call(s) to \
+             publish_project_config_diagnostic — a read without a publish is a config \
+             error that vanishes, which is the defect #1625 fixes"
+        );
+    }
+
+    /// The case #1625 is about: `rocky.toml` is present and unparseable.
+    ///
+    /// Before, `.ok()` collapsed this into the same empty defaults as "no
+    /// project", so the editor silently stopped running W004 and W005 and
+    /// looked like a project that declares neither. The reason now comes
+    /// back so the LSP can squiggle the file, and the compiler inputs stay
+    /// empty so the editor keeps type-checking.
+    #[test]
+    fn an_unparseable_project_config_reports_a_reason_instead_of_going_quiet() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(
+            root.path().join("rocky.toml"),
+            "[adapter.wh]\ntype = \"duckdb\"\nthis is not toml at all",
+        )
+        .unwrap();
+        let models = root.path().join("models");
+        std::fs::create_dir_all(&models).unwrap();
+
+        let (mask, allow_unmasked, freshness, unreadable) =
+            RockyLsp::project_compiler_inputs(&models);
+
+        let reason = unreadable.expect(
+            "a present-but-unparseable rocky.toml must report WHY it is silent; \
+             returning None would be indistinguishable from a project with no config",
+        );
+        assert!(
+            reason.contains("rocky.toml"),
+            "the reason must name the file the user has to fix, got: {reason}"
+        );
+
+        // Still compiles. The editor does not go blank on a broken config.
+        assert!(mask.is_empty());
+        assert!(allow_unmasked.is_empty());
+        assert_eq!(freshness.expected_lag_seconds, None);
     }
 
     fn make_graph() -> SemanticGraph {

--- a/engine/crates/rocky-server/src/state.rs
+++ b/engine/crates/rocky-server/src/state.rs
@@ -205,33 +205,68 @@ impl ServerState {
     }
 
     /// Recompile the project and update the stored result.
-    pub async fn recompile(&self) {
+    ///
+    /// Returns the reason the project config could not be READ, when that is
+    /// what happened. `None` covers both "it loaded" and "there is none" —
+    /// a project with no `rocky.toml` is an ordinary project, not a failure.
+    ///
+    /// `serve` keeps compiling on an unreadable config, which is a contract
+    /// rather than an accident (#1625): a resident server watching a
+    /// directory should not go dark because someone is mid-edit in
+    /// `rocky.toml`. What it must not do is what it did — carry on silently,
+    /// so a caller cannot tell "this project declares no masks" from "the
+    /// file that declares them could not be parsed". The reason now rides
+    /// out on a W013 diagnostic and on this return value.
+    pub async fn recompile(&self) -> Option<String> {
         info!(models_dir = %self.models_dir.display(), "compiling project");
+
+        // ONE read of `rocky.toml` for the whole recompile. It used to be
+        // loaded twice — here and again inside the schema-cache loader —
+        // and each copy decided independently what a broken config meant.
+        // That per-caller decision is the defect #1625 is about, so there
+        // is now one snapshot and one decision.
+        let project_config =
+            rocky_core::config::load_optional_project_config(self.config_path.as_deref());
+
+        let config_unreadable = match &project_config {
+            // `Ok(None)` is "no rocky.toml", which is an ordinary fact
+            // about the project rather than a failure to read one.
+            Ok(_) => None,
+            Err(e) => {
+                let path = self
+                    .config_path
+                    .as_ref()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_else(|| "rocky.toml".to_string());
+                warn!(error = %e, config = %path, "rocky.toml could not be read");
+                Some(format!("{path} could not be read: {e}"))
+            }
+        };
+        let project_config = project_config.ok().flatten();
 
         // Load cached source schemas so the server's hover/inlay-hint
         // surfaces typecheck against real warehouse types when the cache
         // is warm. Degrades to empty on cold cache, missing state.redb,
         // or `[cache.schemas] enabled = false`. See
         // `rocky-cli::source_schemas` for the CLI equivalent.
-        let source_schemas = self.load_cached_source_schemas().await;
+        let schema_cache_config = project_config
+            .as_ref()
+            .map(|c| c.cache.schemas.clone())
+            .unwrap_or_default();
+        let source_schemas = self.load_cached_source_schemas(schema_cache_config).await;
 
-        // Load `[mask]` + `[classifications.allow_unmasked]` (W004) and the
-        // `[freshness]` default bit (W005) from rocky.toml, mirroring the
-        // CLI compile path. Without a config_path (or on a parse error) both
-        // come through empty and the checks stay silent — matching standalone
-        // `rocky compile --models models/`.
-        let (mask, allow_unmasked, project_freshness) = match &self.config_path {
-            Some(path) => match rocky_core::config::load_rocky_config(path) {
-                Ok(cfg) => (
-                    cfg.mask.clone(),
-                    cfg.classifications.allow_unmasked.clone(),
-                    cfg.freshness.clone(),
-                ),
-                Err(e) => {
-                    debug!(error = %e, "rocky.toml load failed; W004/W005 will be silent");
-                    (Default::default(), Vec::new(), Default::default())
-                }
-            },
+        // `[mask]` + `[classifications.allow_unmasked]` (W004) and the
+        // `[freshness]` default bit (W005), mirroring the CLI compile path.
+        // With no rocky.toml these come through empty and the checks stay
+        // silent — matching standalone `rocky compile --models models/`.
+        // With an UNREADABLE one they also come through empty, but that is
+        // now reported rather than assumed equivalent.
+        let (mask, allow_unmasked, project_freshness) = match &project_config {
+            Some(cfg) => (
+                cfg.mask.clone(),
+                cfg.classifications.allow_unmasked.clone(),
+                cfg.freshness.clone(),
+            ),
             None => (Default::default(), Vec::new(), Default::default()),
         };
 
@@ -259,12 +294,32 @@ impl ServerState {
                 Ok(r) => r,
                 Err(join_err) => {
                     warn!(error = %join_err, "compile task join failed");
-                    return;
+                    return config_unreadable;
                 }
             };
 
         match compile_result {
-            Ok(result) => {
+            Ok(mut result) => {
+                // The compiler never saw the config, so it cannot raise
+                // this itself. Attach W013 to the stored result so every
+                // reader of `compile_result` — the diagnostics counts on
+                // `GET /api/v1/meta`, the browser UI — sees that the
+                // project-level checks were silent because the file could
+                // not be parsed, not because the project declares nothing.
+                if let Some(ref reason) = config_unreadable {
+                    result
+                        .diagnostics
+                        .push(rocky_compiler::diagnostic::Diagnostic::warning(
+                            rocky_compiler::diagnostic::W013,
+                            "rocky.toml",
+                            format!(
+                                "{reason}. The models still compile, but the project-level \
+                                 checks are silent: masking (W004), the project [freshness] \
+                                 default (W005), and the cached warehouse schemas all came \
+                                 through empty."
+                            ),
+                        ));
+                }
                 let model_count = result.project.model_count();
                 let diag_count = result.diagnostics.len();
                 let has_errors = result.has_errors;
@@ -280,6 +335,8 @@ impl ServerState {
                 warn!(error = %e, "compilation failed");
             }
         }
+
+        config_unreadable
     }
 
     /// Load the schema-cache-backed `source_schemas` map for this
@@ -288,19 +345,17 @@ impl ServerState {
     /// server observes exactly the same file that `rocky run` writes to
     /// (unified default — `<models>/.rocky-state.redb` — with the legacy
     /// CWD fallback for existing projects).
+    ///
+    /// `schema_cache_config` comes from the caller's single `rocky.toml`
+    /// snapshot rather than a second read of the file. This used to load the
+    /// config again and `unwrap_or_default()` the error, making it the second
+    /// place in one function that independently decided a broken config meant
+    /// "defaults" (#1625). Absent a config it still falls back to the
+    /// defaults (enabled + 24h TTL), so zero-config projects mirror the CLI.
     async fn load_cached_source_schemas(
         &self,
+        schema_cache_config: rocky_core::config::SchemaCacheConfig,
     ) -> HashMap<String, Vec<rocky_compiler::types::TypedColumn>> {
-        // Config lookup: fall back to defaults (enabled + 24h TTL) when
-        // no rocky.toml is wired in, so LSP/server behaviour mirrors the
-        // CLI for zero-config projects.
-        let schema_cache_config = match &self.config_path {
-            Some(path) => rocky_core::config::load_rocky_config(path)
-                .map(|c| c.cache.schemas)
-                .unwrap_or_default(),
-            None => rocky_core::config::SchemaCacheConfig::default(),
-        };
-
         if !schema_cache_config.enabled {
             return HashMap::new();
         }
@@ -426,6 +481,86 @@ mod tests {
             w004_count(result),
             0,
             "allow_unmasked must suppress W004 in the server compile path"
+        );
+    }
+
+    /// The case #1625 is about, on the `serve` side.
+    ///
+    /// A `rocky.toml` that is present and unparseable used to be swallowed
+    /// by `debug!` + defaults. The compile then ran with an empty `[mask]`,
+    /// an empty `allow_unmasked` and no project `[freshness]`, and every
+    /// reader — `POST /api/v1/compile`, the diagnostics counts, the UI —
+    /// was told the same thing as a project that genuinely declares none of
+    /// those. `serve` still compiles (a resident server must not go dark
+    /// mid-edit), but it now says WHY the project-level checks are silent.
+    #[tokio::test]
+    async fn an_unreadable_config_is_reported_rather_than_treated_as_absent() {
+        // Valid enough to exist, invalid as TOML.
+        let (_dir, models_dir, config_path) = pii_project("[classifications\nnot = toml\n");
+        let state = ServerState::new(models_dir, None, Some(config_path.clone()));
+
+        let reason = state.recompile().await.expect(
+            "a present-but-unparseable rocky.toml must be reported; returning None would \
+             make POST /api/v1/compile answer plain success after degrading",
+        );
+        assert!(
+            reason.contains(&config_path.display().to_string()),
+            "the reason must name the file to fix, got: {reason}"
+        );
+
+        let guard = state.compile_result.read().await;
+        let result = guard.as_ref().expect("compile result");
+
+        // The contract: still usable. Serve does not refuse.
+        assert!(
+            result.project.model_count() > 0,
+            "serve must keep compiling the models on a broken config"
+        );
+
+        // And the silence is visible to every reader of `compile_result`.
+        let w013: Vec<&str> = result
+            .diagnostics
+            .iter()
+            .filter(|d| &*d.code == "W013")
+            .map(|d| &*d.message)
+            .collect();
+        assert_eq!(
+            w013.len(),
+            1,
+            "exactly one W013 must reach the stored result; without it the compile \
+             is indistinguishable from a project that declares nothing"
+        );
+    }
+
+    /// The other half, and the reason W013 cannot simply fire whenever the
+    /// project inputs are empty: a project with NO `rocky.toml` is an
+    /// ordinary project. Squiggling it would make the warning noise.
+    #[tokio::test]
+    async fn a_project_with_no_config_is_not_reported_as_unreadable() {
+        let dir = tempfile::tempdir().unwrap();
+        let models_dir = dir.path().join("models");
+        std::fs::create_dir(&models_dir).unwrap();
+        let mut sql = std::fs::File::create(models_dir.join("users.sql")).unwrap();
+        write!(sql, "SELECT 1 AS id").unwrap();
+        let mut sidecar = std::fs::File::create(models_dir.join("users.toml")).unwrap();
+        write!(
+            sidecar,
+            "name = \"users\"\n\n[target]\ncatalog = \"demo\"\nschema = \"main\"\ntable = \"users\"\n"
+        )
+        .unwrap();
+
+        // No `rocky.toml` written at this path.
+        let state = ServerState::new(models_dir, None, Some(dir.path().join("rocky.toml")));
+        assert!(
+            state.recompile().await.is_none(),
+            "an ABSENT rocky.toml is a fact about the project, not a failure to read one"
+        );
+
+        let guard = state.compile_result.read().await;
+        let result = guard.as_ref().expect("compile result");
+        assert!(
+            !result.diagnostics.iter().any(|d| &*d.code == "W013"),
+            "W013 must not fire on a project that simply has no config"
         );
     }
 


### PR DESCRIPTION
Eleven entry points each decided for themselves what an unreadable `rocky.toml` meant. Seven already route through `load_optional_project_config`. This is the last four, all in `rocky-server`, and they are the two surfaces #1625 said might legitimately answer differently.

## What was left

I measured before building. Of the entry points #1625 named, `rocky lineage` and the MCP tools already refuse — they cite this issue in their own comments. What remained:

| site | before |
|---|---|
| LSP initial compile | `.ok()` → defaults, no diagnostic |
| LSP debounced `didChange` | same, independently |
| `serve` recompile | `debug!` → defaults |
| `serve` schema-cache load | a **second** read of the same file, `unwrap_or_default()` |

The last two are in one function. It read `rocky.toml` twice and each copy decided separately what a broken one meant — the per-caller shape the issue is about, inside a single call.

## The contract these two surfaces get

Not a refusal. The issue asked the deciding question and answered it conditionally:

> For the LSP and `serve` the answer may legitimately differ — staying usable with a broken config is a defensible product choice for an editor. But it should be a stated contract, not an accident of `.ok()`, and the refusal should surface as a diagnostic rather than vanish.

Both surfaces are resident. A refusal means a blank editor, or a dark server, while someone is mid-edit in `rocky.toml`. So they keep compiling — and say why the project-level checks went quiet:

```
  rocky.toml is ABSENT      ─▶  compile with empty project inputs, no warning
                                (an ordinary project, not a failure)

  rocky.toml is UNREADABLE  ─▶  compile with empty project inputs, W013
                                LSP    a squiggle on rocky.toml itself
                                serve  in `result.diagnostics` + on the POST route
```

Separating those two is the whole point. Before, both produced the same silence, so a reader could not tell "this project declares no masks" from "the file that declares them could not be parsed".

`W013` is new: *`rocky.toml` is present but could not be read, so every project-level check is silent*. It is in the diagnostics table in `docs/concepts/compiler.md`.

## Where the LSP squiggle goes, and why not through the compiler

The project config is not a model, so a compiler `Diagnostic` cannot carry it. `publish_diagnostics` resolves every diagnostic to a model file and `continue`s past anything it cannot place — a project-scoped one would be **silently dropped**, which is the exact failure being fixed. It publishes to the `rocky.toml` URI directly instead, and always publishes, including empty to clear: a squiggle that outlived the fix would be its own lie.

## Two deviations, stated

**1. `POST /api/v1/compile` answers 200, not 500.** The issue calls the GET/POST split out by name, and this does not close it: `GET` still refuses (it calls `compile_output`), `POST` now answers `200` with `status: "recompiled_degraded"` and a `config_error` field. The reasoning: `POST` means "recompile now", and the recompile did happen — the models were compiled and the result stored. A `500` would say nothing happened, which is false. What it must not do is answer plain `"recompiled"`, which is what it did. Overrule this one on its own if you want them symmetric; it does not touch the editor behaviour.

The in-repo SDK only calls `GET /api/v1/compile`, so nothing downstream reads the new field yet. The route returns an ad-hoc `json!` with no `JsonSchema`, so there is no binding to regenerate and no `just codegen` cascade.

**2. Literal option A has no meaning inside `recompile()`.** "Every other `ConfigError` propagates" needs a caller to propagate to. `recompile()` has none — it is a `tokio::spawn` at startup and a file watcher. Propagating there means going dark, not refusing. So the reason travels as a return value and a diagnostic, and the one place with a real caller (`POST`) is deviation 1.

## A deadlock this introduced, and how it showed up

The first wiring published on **every** compile, including an empty vector to clear. That hung `a_failed_startup_compile_reaches_the_editor_as_an_error_message` — a pre-existing protocol-level test that drives a real `LspService`. `Client::publish_diagnostics` writes to tower-lsp'''s outgoing channel, the `initialized` handler awaits the startup compile, and a client that has not begun draining the socket yet never lets that write complete. The test went from 0.01s to over 300s.

The fix is a transition flag: publish once when the config goes bad, clear once when it is fixed, write nothing otherwise. The clear is still not optional — a squiggle outliving the fix would be its own lie — it just happens on the edge rather than on every keystroke. That test is the guard, and its failure mode is a **hang**, not an assertion. Said plainly so a future CI timeout there is read correctly.

## Tests, and what each one actually catches

| test | reverting what fails it |
|---|---|
| `an_unparseable_project_config_reports_a_reason_instead_of_going_quiet` (lsp) | `.ok()` on the config load |
| `an_unreadable_config_is_reported_rather_than_treated_as_absent` (serve) | the `debug!` + defaults arm, or dropping the W013 push |
| `a_project_with_no_config_is_not_reported_as_unreadable` (serve) | making W013 fire on empty project inputs instead of on a read failure |
| `every_project_config_read_publishes_its_verdict` (lsp) | deleting either publish call site |

All four are **mutation-checked** with `scripts/mutation-check.sh`. The wire guard matters most: deleting the debounced publish call leaves **106 of 107 tests green** and fails only that one.

That last one is a source scan, and it exists because the LSP wire is otherwise untestable here: both call sites sit behind a live client or a 300 ms sleep in a spawned task, so **deleting both publish calls leaves every other test green** while the editor goes back to silence — the coded-but-not-wired shape. It counts text: it proves a publish happens for every read, not that the reason passed is the one that read computed. The value half is the first test; the end-to-end pairing is covered by neither and would need a live LSP client. Stated so nobody leans on it further than it reaches.

The two toml-path derivations are now one function, `project_config_path`, for the same reason: if "which file is unreadable" and "which file to squiggle" ever disagreed, the warning would land on a file that is fine.

## A silence that also goes away

The shared loader is credential-tolerant. Neither old path was — both called `load_rocky_config`. So a project whose adapter reads `token = "${DATABRICKS_TOKEN}"` with that variable unset used to fail the config load on **both** surfaces and silently lose W004 and W005 — the same defect, triggered by an ordinary unset env var rather than a malformed file. Both now load it and the checks run.

Neither path connects: each reads `[mask]`, `[classifications]`, `[freshness]` and `[cache.schemas]`, then drops the config. An unresolved credential placeholder never reaches an adapter.

## Not changed

`load_optional_project_config` still maps `FileNotFound` to `Ok(None)`, so a project with no `rocky.toml` behaves exactly as before on every surface. A cold schema cache, a disabled cache and an unreadable state store still degrade — only the config-error path moved.

Refs #1625
