### PR TITLE
test(engine): reach make_ai_client's config refusal with an injectable key

### DIFF
--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -3369,12 +3369,31 @@ impl RockyMcpServer {
     /// the warehouse, so an unset `${VAR}` in an adapter's connection field
     /// must not block them (#1536).
     fn make_ai_client(&self) -> anyhow::Result<Option<rocky_ai::client::LlmClient>> {
+        self.make_ai_client_with_key(
+            std::env::var(rocky_ai::client::AI_API_KEY_ENV)
+                .ok()
+                .filter(|v| !v.is_empty()),
+        )
+    }
+
+    /// [`Self::make_ai_client`] with the key supplied rather than read from the
+    /// environment.
+    ///
+    /// The seam exists so the refusal can be TESTED (#1702). The ordering below
+    /// is the whole behaviour — key first, config second — and a test that
+    /// cannot supply a key only ever exercises the early `Ok(None)`, never the
+    /// config read. `std::env::set_var` is `unsafe` on edition 2024 and racy
+    /// across the test binary's threads, so injecting the key is the honest way
+    /// to reach the second line.
+    fn make_ai_client_with_key(
+        &self,
+        api_key: Option<String>,
+    ) -> anyhow::Result<Option<rocky_ai::client::LlmClient>> {
         // The key check stays FIRST. A server with no key never builds a client
         // at all, so the token ceiling is moot there and refusing on the config
         // would be a new failure on a healthy keyless server.
-        let api_key = match std::env::var(rocky_ai::client::AI_API_KEY_ENV) {
-            Ok(v) if !v.is_empty() => v,
-            _ => return Ok(None),
+        let Some(api_key) = api_key else {
+            return Ok(None);
         };
         let max_tokens = self.ai_max_tokens()?;
         let ai_config = rocky_ai::client::AiConfig {
@@ -10517,6 +10536,41 @@ database = ":memory:"
     // `make_ai_client` BEFORE its compile, so this is the first config read
     // those tools make.
     // ------------------------------------------------------------------
+
+    /// The refusal reaches the path callers actually take (#1702).
+    ///
+    /// `ai_max_tokens_refuses_a_present_but_unloadable_config` below proves the
+    /// helper refuses. It does NOT prove `make_ai_client` propagates that — it
+    /// calls a different function, and the tools call this one. With no key in
+    /// the environment the production entry point returns `Ok(None)` before it
+    /// ever reads the config, so the whole class was covered one function away
+    /// from where it fires.
+    #[test]
+    fn make_ai_client_refuses_an_unloadable_config_once_a_key_is_present() {
+        let (_tmp, server) = write_mcp_project(Some(INVALID_MCP_TOML));
+        // `LlmClient` is not `Debug`, so `expect_err` is unavailable here.
+        let Err(err) = server.make_ai_client_with_key(Some("sk-test-not-a-real-key".to_string()))
+        else {
+            panic!("a present-but-unloadable rocky.toml must refuse, not default")
+        };
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("failed to load config from"),
+            "the refusal must name the file to fix, got: {msg}"
+        );
+    }
+
+    /// And the ordering it depends on: no key means no client, whatever the
+    /// config says. A keyless server is healthy, so a broken `rocky.toml` must
+    /// not turn it into a failing one.
+    #[test]
+    fn make_ai_client_without_a_key_is_none_even_on_an_unloadable_config() {
+        let (_tmp, server) = write_mcp_project(Some(INVALID_MCP_TOML));
+        let Ok(client) = server.make_ai_client_with_key(None) else {
+            panic!("a keyless server must not fail on the config it never reads")
+        };
+        assert!(client.is_none());
+    }
 
     /// A present-but-unloadable `rocky.toml` refuses, naming the file, instead
     /// of silently falling back to `DEFAULT_MAX_TOKENS`.


### PR DESCRIPTION
The last open item on #1702. The MCP `[ai]` refusal was real; the test for it called a different function.

## The gap

```
  make_ai_client()      1. read ANTHROPIC_API_KEY  ─▶ unset? return Ok(None)
                        2. ai_max_tokens()?        ─▶ refuses on a bad config

  the test called       ai_max_tokens()  directly
  the tools call        make_ai_client()
```

With no key in the environment — which is every CI run and most dev machines — `make_ai_client` returns at line 1. Line 2 was never reached, so nothing proved the refusal survives the call the three generator tools (`ai_contract`, `ai_test`, `explain_model`) actually make. The issue named this and said what it needed: *"A test seam that injects the key would close that."*

`std::env::set_var` is `unsafe` on edition 2024 and racy across the test binary's threads, so the key comes in as an argument instead.

## The shape

`make_ai_client` is now a one-line wrapper that reads the environment. `make_ai_client_with_key` holds the logic — and the ordering, which is the part that matters and is now pinned from both sides:

| key | config | before | now |
|---|---|---|---|
| unset | broken | `Ok(None)` | `Ok(None)`, tested |
| set | broken | refuses, naming the file | same, tested |

The key check staying **first** is deliberate and load-bearing: a server with no key never builds a client, so the token ceiling is moot and refusing on the config would turn a healthy keyless server into a failing one. `make_ai_client_without_a_key_is_none_even_on_an_unloadable_config` pins that half, so a later "simplification" that reads the config first fails rather than silently breaking keyless servers.

## What this does not change

No production behaviour. `make_ai_client`'s observable result is identical for every input — it reads the same env var and applies the same rule. This is coverage reaching a path that already worked.

## Where #1702 stands

Measured against the issue's own seven-row table, after #1835:

| site | state |
|---|---|
| `review.rs` queue path | already converted; its remaining `.ok()` at `review.rs:862` is a deliberate *capability probe* (whether the samples route's front door would open), where a broken config genuinely means "no" |
| `plan.rs` `compute_embedded_capabilities` | #1835 |
| `plan.rs` `--semantic` | #1835 |
| `branch.rs` promote gate | #1835 |
| `brief.rs` (two sites) | already on `load_optional_project_config` |
| `cost.rs` | already on `load_optional_project_config` |
| `restore.rs` (five sites) | **not a defect** — all five sit after `#[cfg(test)]` at `restore.rs:1086`. The production read at `restore.rs:873` propagates with context. |
| smaller item: refusals naming the file | `compile.rs`, `emit_sql.rs` and `preview_dialect` all carry `failed to load config from <path>` |
| smaller item: the MCP `[ai]` seam | **this PR** |

Refs #1702
