### PR TITLE
ci: don't let a third-party runner repo fail every engine job

### DIFF
--- a/.github/workflows/codegen-drift.yml
+++ b/.github/workflows/codegen-drift.yml
@@ -162,7 +162,14 @@ jobs:
         # Present on the current ubuntu-24.04 image, but the `ubuntu-latest`
         # alias is mutable — guard on the binary, not on the image, so this is
         # a no-op today and still self-heals if a future image drops cmake.
-        run: command -v cmake >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y cmake; }
+        run: |
+          # Already guarded on cmake being absent; the strip covers the case
+          # where it is. See the note in engine-ci.yml.
+          command -v cmake >/dev/null 2>&1 && exit 0
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update
+          sudo apt-get install -y cmake
 
       - name: Free disk space and add swap
         run: |

--- a/.github/workflows/engine-ci.yml
+++ b/.github/workflows/engine-ci.yml
@@ -167,7 +167,20 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
           sudo fallocate -l 4G /mnt/swapfile && sudo chmod 600 /mnt/swapfile && sudo mkswap /mnt/swapfile && sudo swapon /mnt/swapfile || true
-      - run: sudo apt-get update && sudo apt-get install -y cmake
+      # `apt-get update` exits non-zero when ANY configured source serves a
+      # bad index, including the third-party ones the GitHub runner image
+      # ships (Google Chrome, Microsoft). On 2026-09-09 Chrome's repo served
+      # a stale `Packages.gz` and every engine job died here before
+      # compiling a line. Neither cmake nor the cross toolchain comes from
+      # those repos, so they are removed first — and cmake is usually
+      # preinstalled, so the whole block is skipped.
+      - name: Install cmake
+        run: |
+          command -v cmake >/dev/null 2>&1 && exit 0
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update
+          sudo apt-get install -y cmake
       - name: Install cargo-nextest
         uses: taiki-e/install-action@5bf6ce016fd2e72eefc647cbca1e4213f65955b8 # v2.87.5
         with:
@@ -214,7 +227,20 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
           sudo fallocate -l 4G /mnt/swapfile && sudo chmod 600 /mnt/swapfile && sudo mkswap /mnt/swapfile && sudo swapon /mnt/swapfile || true
-      - run: sudo apt-get update && sudo apt-get install -y cmake
+      # `apt-get update` exits non-zero when ANY configured source serves a
+      # bad index, including the third-party ones the GitHub runner image
+      # ships (Google Chrome, Microsoft). On 2026-09-09 Chrome's repo served
+      # a stale `Packages.gz` and every engine job died here before
+      # compiling a line. Neither cmake nor the cross toolchain comes from
+      # those repos, so they are removed first — and cmake is usually
+      # preinstalled, so the whole block is skipped.
+      - name: Install cmake
+        run: |
+          command -v cmake >/dev/null 2>&1 && exit 0
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update
+          sudo apt-get install -y cmake
       - run: cargo clippy --all-targets --all-features -- -D warnings
 
   fmt:
@@ -285,7 +311,20 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
           sudo fallocate -l 4G /mnt/swapfile && sudo chmod 600 /mnt/swapfile && sudo mkswap /mnt/swapfile && sudo swapon /mnt/swapfile || true
-      - run: sudo apt-get update && sudo apt-get install -y cmake
+      # `apt-get update` exits non-zero when ANY configured source serves a
+      # bad index, including the third-party ones the GitHub runner image
+      # ships (Google Chrome, Microsoft). On 2026-09-09 Chrome's repo served
+      # a stale `Packages.gz` and every engine job died here before
+      # compiling a line. Neither cmake nor the cross toolchain comes from
+      # those repos, so they are removed first — and cmake is usually
+      # preinstalled, so the whole block is skipped.
+      - name: Install cmake
+        run: |
+          command -v cmake >/dev/null 2>&1 && exit 0
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update
+          sudo apt-get install -y cmake
       # Mirror engine-release.yml exactly: the browser UI built by the `ui` job
       # is embedded with `--features ui`; every other feature stays default.
       - name: Fetch the browser UI build

--- a/.github/workflows/engine-release.yml
+++ b/.github/workflows/engine-release.yml
@@ -137,6 +137,11 @@ jobs:
       - name: Install cross-compilation toolchain
         if: matrix.cross
         run: |
+          # See the note in engine-ci.yml: a third-party source with a bad
+          # index fails `apt-get update` for everyone, and the cross
+          # toolchain does not come from one.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
 

--- a/.github/workflows/engine-weekly.yml
+++ b/.github/workflows/engine-weekly.yml
@@ -116,7 +116,20 @@ jobs:
                       /usr/local/lib/node_modules /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force || true
           sudo fallocate -l 4G /mnt/swapfile && sudo chmod 600 /mnt/swapfile && sudo mkswap /mnt/swapfile && sudo swapon /mnt/swapfile || true
-      - run: sudo apt-get update && sudo apt-get install -y cmake
+      # `apt-get update` exits non-zero when ANY configured source serves a
+      # bad index, including the third-party ones the GitHub runner image
+      # ships (Google Chrome, Microsoft). On 2026-09-09 Chrome's repo served
+      # a stale `Packages.gz` and every engine job died here before
+      # compiling a line. Neither cmake nor the cross toolchain comes from
+      # those repos, so they are removed first — and cmake is usually
+      # preinstalled, so the whole block is skipped.
+      - name: Install cmake
+        run: |
+          command -v cmake >/dev/null 2>&1 && exit 0
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update
+          sudo apt-get install -y cmake
       - name: Install cargo-tarpaulin
         # Pinned + --locked for the same reason as cargo-audit above.
         run: cargo install cargo-tarpaulin --version 0.31.2 --locked
@@ -176,7 +189,20 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
           sudo fallocate -l 4G /mnt/swapfile && sudo chmod 600 /mnt/swapfile && sudo mkswap /mnt/swapfile && sudo swapon /mnt/swapfile || true
-      - run: sudo apt-get update && sudo apt-get install -y cmake
+      # `apt-get update` exits non-zero when ANY configured source serves a
+      # bad index, including the third-party ones the GitHub runner image
+      # ships (Google Chrome, Microsoft). On 2026-09-09 Chrome's repo served
+      # a stale `Packages.gz` and every engine job died here before
+      # compiling a line. Neither cmake nor the cross toolchain comes from
+      # those repos, so they are removed first — and cmake is usually
+      # preinstalled, so the whole block is skipped.
+      - name: Install cmake
+        run: |
+          command -v cmake >/dev/null 2>&1 && exit 0
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update
+          sudo apt-get install -y cmake
       - name: Build rocky binary
         working-directory: engine
         run: cargo build --release

--- a/.github/workflows/manifest-conformance.yml
+++ b/.github/workflows/manifest-conformance.yml
@@ -72,7 +72,20 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
           sudo fallocate -l 4G /mnt/swapfile && sudo chmod 600 /mnt/swapfile && sudo mkswap /mnt/swapfile && sudo swapon /mnt/swapfile || true
-      - run: sudo apt-get update && sudo apt-get install -y cmake
+      # `apt-get update` exits non-zero when ANY configured source serves a
+      # bad index, including the third-party ones the GitHub runner image
+      # ships (Google Chrome, Microsoft). On 2026-09-09 Chrome's repo served
+      # a stale `Packages.gz` and every engine job died here before
+      # compiling a line. Neither cmake nor the cross toolchain comes from
+      # those repos, so they are removed first — and cmake is usually
+      # preinstalled, so the whole block is skipped.
+      - name: Install cmake
+        run: |
+          command -v cmake >/dev/null 2>&1 && exit 0
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update
+          sudo apt-get install -y cmake
       - name: Build rocky + rocky-verify
         working-directory: engine
         run: cargo build --release --bin rocky --bin rocky-verify


### PR DESCRIPTION
Every engine CI job is failing before it compiles a line. Not on anything in the diff — on `apt-get update`.

```
Run sudo apt-get update && sudo apt-get install -y cmake
  E: Failed to fetch https://dl.google.com/linux/chrome-stable/.../Packages.gz  Hash Sum mismatch
  ##[error]Process completed with exit code 100.
```

Google's Chrome apt repo is serving an index that does not match its own Release file (`Release file created at 17:16:59`, `Last modification reported 09:41:12`). `apt-get update` exits non-zero when **any** configured source fails, and the GitHub runner image ships Google Chrome and Microsoft sources by default — so a stale mirror at Google takes down Test, Clippy and Release-build smoke on every engine PR.

**It is not a flake.** Reproduced on two runs of the same commit 22 minutes apart (`gh run rerun --failed`), and on two open PRs whose diffs share no files.

## The fix

Two measures, because either alone leaves a hole:

```
  guard on the binary      cmake is preinstalled on the runner image, so
                           the common path never touches apt at all

  strip third-party        neither cmake nor gcc-aarch64-linux-gnu comes
  source lists first       from Google or Microsoft, so when cmake IS
                           missing, a broken mirror there cannot sink it
```

`codegen-drift.yml` already had the first half — which is exactly why it kept passing while everything else went red. All eight sites now have both.

| workflow | sites |
|---|---|
| `engine-ci.yml` | 3 |
| `engine-weekly.yml` | 2 |
| `manifest-conformance.yml` | 1 |
| `engine-release.yml` | 1 (cross toolchain) |
| `codegen-drift.yml` | 1 (guard already present, strip added) |

## Checked, not assumed

- **The guard does not abort under `bash -e`.** GitHub runs `run:` blocks with `-e`, and `command -v cmake && exit 0` is an AND-OR list whose failure `set -e` ignores. Verified by running it: with a missing binary it falls through to the install path and exits 0, rather than aborting the step.
- **All 25 workflow files still parse** after the edit.

## What this deliberately does not do

It does not pin or vendor cmake, and it does not add `|| true` to `apt-get update`. A masked update failure would hide a real one — the point is to stop consulting repos this build has no business consulting, not to stop noticing when the ones it needs are broken.

Closes #1844. Unblocks #1841 and #1842.
