### PR TITLE
test(engine): a governance adapter that records what it was asked to do

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -14272,7 +14272,11 @@ mod tests {
         first.retention = Some(rocky_core::retention::RetentionPolicy { duration_days: 90 });
         first.governance_tags = one_entry("owner", "analytics");
 
+        // The second model needs a leg BEFORE its set_tags too, or the
+        // expected sequence is identical whether the tags leg runs inside the
+        // per-model loop or in a second pass over every model.
         let mut second = ungoverned_model("customers");
+        second.classification = one_entry("region", "pii");
         second.governance_tags = one_entry("owner", "crm");
 
         let snapshot = super::GovernanceSnapshot {
@@ -14294,11 +14298,14 @@ mod tests {
                 "apply_masking_policy",
                 "apply_retention_policy",
                 "set_tags",
-                // "customers" — only `[governance.tags]`, so only that leg.
+                // "customers" — no retention, so that leg is skipped, and its
+                // calls follow orders' rather than grouping by method.
+                "apply_column_tags",
+                "apply_masking_policy",
                 "set_tags",
             ],
-            "the reconcile order, and the per-model skipping, must match the \
-             order the doc comment on reconcile_model_governance states"
+            "the reconcile must finish one model before starting the next, and \
+             skip the legs a model does not configure"
         );
     }
 

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -14226,6 +14226,134 @@ fn post_copy_column_match(
 #[cfg(test)]
 mod tests {
 
+    // ---------------------------------------------------------------------
+    // Governance seams, observed through a recording adapter (#1609)
+    //
+    // These four sites take `&dyn GovernanceAdapter`, so a recorder drops in
+    // without changing any signature. Every "the adapter was not called"
+    // assertion below is paired with one where the same wiring DOES record,
+    // because on its own an empty log cannot tell "no call was issued" from
+    // "the recorder was never reached".
+    // ---------------------------------------------------------------------
+
+    /// One snapshot entry with nothing governed. Callers switch on the fields
+    /// they are testing so each test states only what it depends on.
+    fn ungoverned_model(name: &str) -> super::GovernedModelGovernance {
+        super::GovernedModelGovernance {
+            name: name.to_string(),
+            target_catalog: "analytics".to_string(),
+            target_schema: "marts".to_string(),
+            target_table: name.to_string(),
+            strategy: rocky_core::models::StrategyConfig::FullRefresh,
+            classification: std::collections::BTreeMap::new(),
+            retention: None,
+            governance_tags: std::collections::BTreeMap::new(),
+        }
+    }
+
+    fn one_entry(key: &str, value: &str) -> std::collections::BTreeMap<String, String> {
+        let mut m = std::collections::BTreeMap::new();
+        m.insert(key.to_string(), value.to_string());
+        m
+    }
+
+    /// `reconcile_model_governance`'s doc comment claims a fixed order —
+    /// `apply_column_tags` → `apply_masking_policy` → `apply_retention_policy`
+    /// → `set_tags`, **per model, in compiled model order**.
+    ///
+    /// `replication_reconcile_uses_snapshot` pins that sequence for a single
+    /// model. The per-model half of the claim — that a second model's calls
+    /// follow the first's rather than grouping by method — had nothing
+    /// checking it.
+    #[tokio::test]
+    async fn a_reconcile_interleaves_its_calls_per_model_in_compiled_order() {
+        let mut first = ungoverned_model("orders");
+        first.classification = one_entry("email", "pii");
+        first.retention = Some(rocky_core::retention::RetentionPolicy { duration_days: 90 });
+        first.governance_tags = one_entry("owner", "analytics");
+
+        let mut second = ungoverned_model("customers");
+        second.governance_tags = one_entry("owner", "crm");
+
+        let snapshot = super::GovernanceSnapshot {
+            models: vec![first, second],
+        };
+        let mut tag_to_strategy = std::collections::BTreeMap::new();
+        tag_to_strategy.insert("pii".to_string(), rocky_ir::MaskStrategy::Hash);
+
+        let log = rocky_core::traits::GovernanceLog::default();
+        let governance = rocky_core::traits::RecordingGovernanceAdapter::new(log.clone());
+
+        super::reconcile_model_governance(&snapshot, &governance, &tag_to_strategy).await;
+
+        assert_eq!(
+            log.methods(),
+            vec![
+                // "orders" — every leg configured, in the documented order.
+                "apply_column_tags",
+                "apply_masking_policy",
+                "apply_retention_policy",
+                "set_tags",
+                // "customers" — only `[governance.tags]`, so only that leg.
+                "set_tags",
+            ],
+            "the reconcile order, and the per-model skipping, must match the \
+             order the doc comment on reconcile_model_governance states"
+        );
+    }
+
+    /// The negative control the positive test above licenses: a snapshot with
+    /// nothing governed reaches the adapter and issues no call at all.
+    #[tokio::test]
+    async fn a_reconcile_of_ungoverned_models_issues_no_adapter_call() {
+        let snapshot = super::GovernanceSnapshot {
+            models: vec![ungoverned_model("orders"), ungoverned_model("customers")],
+        };
+
+        let log = rocky_core::traits::GovernanceLog::default();
+        let governance = rocky_core::traits::RecordingGovernanceAdapter::new(log.clone());
+
+        super::reconcile_model_governance(
+            &snapshot,
+            &governance,
+            &std::collections::BTreeMap::new(),
+        )
+        .await;
+
+        assert!(
+            log.is_empty(),
+            "models with no classification, retention or tags must not reach \
+             the warehouse at all, but recorded {:?}",
+            log.methods()
+        );
+    }
+
+    /// A classification with no matching `[mask]` entry tags the column but
+    /// applies no policy — the masking leg is skipped, not called with an
+    /// empty policy.
+    #[tokio::test]
+    async fn an_unmapped_classification_tags_the_column_without_a_masking_call() {
+        let mut model = ungoverned_model("orders");
+        model.classification = one_entry("email", "pii");
+
+        let snapshot = super::GovernanceSnapshot {
+            models: vec![model],
+        };
+
+        let log = rocky_core::traits::GovernanceLog::default();
+        let governance = rocky_core::traits::RecordingGovernanceAdapter::new(log.clone());
+
+        super::reconcile_model_governance(
+            &snapshot,
+            &governance,
+            // "pii" is unmapped: no strategy resolves for the column.
+            &std::collections::BTreeMap::new(),
+        )
+        .await;
+
+        assert_eq!(log.methods(), vec!["apply_column_tags"]);
+    }
+
     /// Shared by the two remote-state quality tests below. Pod A of `harness`
     /// runs the REAL dispatcher on a quality pipeline whose only table does
     /// not exist in the (empty) DuckDB file: the row-count query fails, the

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -1795,6 +1795,331 @@ impl GovernanceAdapter for NoopGovernanceAdapter {
 }
 
 // ---------------------------------------------------------------------------
+// Recording governance adapter
+// ---------------------------------------------------------------------------
+
+/// One [`GovernanceAdapter`] call, captured by [`RecordingGovernanceAdapter`].
+///
+/// There is exactly one variant per trait method, including the ones with a
+/// default body. A method that went unrecorded would make every "this issued
+/// no governance calls" assertion pass for the wrong reason, so the mapping is
+/// pinned by `every_governance_method_is_recorded`.
+#[derive(Debug, Clone)]
+pub enum GovernanceCall {
+    SetTags {
+        target: TagTarget,
+        tags: BTreeMap<String, String>,
+    },
+    GetGrants {
+        target: GrantTarget,
+    },
+    ApplyGrants {
+        grants: Vec<Grant>,
+    },
+    RevokeGrants {
+        grants: Vec<Grant>,
+    },
+    BindWorkspace {
+        catalog: String,
+        workspace_id: u64,
+        binding_type: String,
+    },
+    SetIsolation {
+        catalog: String,
+        enabled: bool,
+    },
+    ListWorkspaceBindings {
+        catalog: String,
+    },
+    RemoveWorkspaceBinding {
+        catalog: String,
+        workspace_id: u64,
+    },
+    ApplyColumnTags {
+        table: TableRef,
+        column_tags: BTreeMap<String, BTreeMap<String, String>>,
+    },
+    ApplyMaskingPolicy {
+        table: TableRef,
+        policy: MaskingPolicy,
+        env: String,
+    },
+    ReconcileRoleGraph {
+        roles: BTreeMap<String, rocky_ir::ResolvedRole>,
+        catalogs: Vec<String>,
+    },
+    ApplyRetentionPolicy {
+        table: TableRef,
+        retention: RetentionPolicy,
+    },
+    ReadRetentionDays {
+        table: TableRef,
+    },
+    WriteRecipeManifest {
+        table: TableRef,
+        properties: BTreeMap<String, String>,
+    },
+}
+
+impl GovernanceCall {
+    /// The trait method this call came from, spelled exactly as in the trait.
+    ///
+    /// Assertions read better against these names than against the variants:
+    /// `assert_eq!(log.methods(), ["set_tags"])` says what the code did.
+    pub fn method(&self) -> &'static str {
+        match self {
+            Self::SetTags { .. } => "set_tags",
+            Self::GetGrants { .. } => "get_grants",
+            Self::ApplyGrants { .. } => "apply_grants",
+            Self::RevokeGrants { .. } => "revoke_grants",
+            Self::BindWorkspace { .. } => "bind_workspace",
+            Self::SetIsolation { .. } => "set_isolation",
+            Self::ListWorkspaceBindings { .. } => "list_workspace_bindings",
+            Self::RemoveWorkspaceBinding { .. } => "remove_workspace_binding",
+            Self::ApplyColumnTags { .. } => "apply_column_tags",
+            Self::ApplyMaskingPolicy { .. } => "apply_masking_policy",
+            Self::ReconcileRoleGraph { .. } => "reconcile_role_graph",
+            Self::ApplyRetentionPolicy { .. } => "apply_retention_policy",
+            Self::ReadRetentionDays { .. } => "read_retention_days",
+            Self::WriteRecipeManifest { .. } => "write_recipe_manifest",
+        }
+    }
+}
+
+/// The shared call log a [`RecordingGovernanceAdapter`] writes into.
+///
+/// Governance call sites take the adapter by value (`Box<dyn
+/// GovernanceAdapter>`) or borrow one they do not own, so a test cannot read
+/// the adapter back after handing it over. The log is a separate, cloneable
+/// handle: clone it before constructing the adapter and the assertions still
+/// have somewhere to look.
+#[derive(Debug, Clone, Default)]
+pub struct GovernanceLog {
+    calls: std::sync::Arc<std::sync::Mutex<Vec<GovernanceCall>>>,
+}
+
+impl GovernanceLog {
+    /// Every call recorded so far, oldest first.
+    pub fn calls(&self) -> Vec<GovernanceCall> {
+        self.lock().clone()
+    }
+
+    /// The method name of every call recorded so far, oldest first.
+    pub fn methods(&self) -> Vec<&'static str> {
+        self.lock().iter().map(GovernanceCall::method).collect()
+    }
+
+    /// `true` when nothing has been recorded.
+    ///
+    /// Read this only alongside a test proving the same wiring *does* record
+    /// when a call happens. On its own it cannot tell "no governance call was
+    /// issued" from "this adapter was never reached".
+    pub fn is_empty(&self) -> bool {
+        self.lock().is_empty()
+    }
+
+    fn push(&self, call: GovernanceCall) {
+        self.lock().push(call);
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, Vec<GovernanceCall>> {
+        // A panicking test must not turn every later assertion into a second
+        // panic about poisoning — recover the log so the first failure stays
+        // the one that gets reported.
+        self.calls
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+/// A [`GovernanceAdapter`] that records every call and then forwards it.
+///
+/// Wraps another adapter — [`NoopGovernanceAdapter`] by default — so inserting
+/// the recorder does not change what the code under test observes: every
+/// return value, including the errors the unsupported-operation defaults
+/// produce, is the inner adapter's.
+///
+/// ```rust
+/// use rocky_core::traits::{GovernanceLog, RecordingGovernanceAdapter};
+/// let log = GovernanceLog::default();
+/// let governance = RecordingGovernanceAdapter::new(log.clone());
+/// // hand `governance` to the code under test, then:
+/// assert!(log.is_empty());
+/// ```
+pub struct RecordingGovernanceAdapter {
+    log: GovernanceLog,
+    inner: Box<dyn GovernanceAdapter>,
+}
+
+impl RecordingGovernanceAdapter {
+    /// Record into `log`, forwarding to [`NoopGovernanceAdapter`].
+    pub fn new(log: GovernanceLog) -> Self {
+        Self {
+            log,
+            inner: Box::new(NoopGovernanceAdapter),
+        }
+    }
+
+    /// Record into `log`, forwarding to `inner`.
+    ///
+    /// Use this to keep a real adapter's behaviour — or a fake that returns
+    /// specific errors — while still seeing the call sequence.
+    pub fn wrapping(log: GovernanceLog, inner: Box<dyn GovernanceAdapter>) -> Self {
+        Self { log, inner }
+    }
+}
+
+#[async_trait]
+impl GovernanceAdapter for RecordingGovernanceAdapter {
+    async fn set_tags(
+        &self,
+        target: &TagTarget,
+        tags: &BTreeMap<String, String>,
+    ) -> AdapterResult<()> {
+        self.log.push(GovernanceCall::SetTags {
+            target: target.clone(),
+            tags: tags.clone(),
+        });
+        self.inner.set_tags(target, tags).await
+    }
+
+    async fn get_grants(&self, target: &GrantTarget) -> AdapterResult<Vec<Grant>> {
+        self.log.push(GovernanceCall::GetGrants {
+            target: target.clone(),
+        });
+        self.inner.get_grants(target).await
+    }
+
+    async fn apply_grants(&self, grants: &[Grant]) -> AdapterResult<()> {
+        self.log.push(GovernanceCall::ApplyGrants {
+            grants: grants.to_vec(),
+        });
+        self.inner.apply_grants(grants).await
+    }
+
+    async fn revoke_grants(&self, grants: &[Grant]) -> AdapterResult<()> {
+        self.log.push(GovernanceCall::RevokeGrants {
+            grants: grants.to_vec(),
+        });
+        self.inner.revoke_grants(grants).await
+    }
+
+    async fn bind_workspace(
+        &self,
+        catalog: &str,
+        workspace_id: u64,
+        binding_type: &str,
+    ) -> AdapterResult<()> {
+        self.log.push(GovernanceCall::BindWorkspace {
+            catalog: catalog.to_string(),
+            workspace_id,
+            binding_type: binding_type.to_string(),
+        });
+        self.inner
+            .bind_workspace(catalog, workspace_id, binding_type)
+            .await
+    }
+
+    async fn set_isolation(&self, catalog: &str, enabled: bool) -> AdapterResult<()> {
+        self.log.push(GovernanceCall::SetIsolation {
+            catalog: catalog.to_string(),
+            enabled,
+        });
+        self.inner.set_isolation(catalog, enabled).await
+    }
+
+    async fn list_workspace_bindings(&self, catalog: &str) -> AdapterResult<Vec<(u64, String)>> {
+        self.log.push(GovernanceCall::ListWorkspaceBindings {
+            catalog: catalog.to_string(),
+        });
+        self.inner.list_workspace_bindings(catalog).await
+    }
+
+    async fn remove_workspace_binding(
+        &self,
+        catalog: &str,
+        workspace_id: u64,
+    ) -> AdapterResult<()> {
+        self.log.push(GovernanceCall::RemoveWorkspaceBinding {
+            catalog: catalog.to_string(),
+            workspace_id,
+        });
+        self.inner
+            .remove_workspace_binding(catalog, workspace_id)
+            .await
+    }
+
+    async fn apply_column_tags(
+        &self,
+        table: &TableRef,
+        column_tags: &BTreeMap<String, BTreeMap<String, String>>,
+    ) -> AdapterResult<()> {
+        self.log.push(GovernanceCall::ApplyColumnTags {
+            table: table.clone(),
+            column_tags: column_tags.clone(),
+        });
+        self.inner.apply_column_tags(table, column_tags).await
+    }
+
+    async fn apply_masking_policy(
+        &self,
+        table: &TableRef,
+        policy: &MaskingPolicy,
+        env: &str,
+    ) -> AdapterResult<()> {
+        self.log.push(GovernanceCall::ApplyMaskingPolicy {
+            table: table.clone(),
+            policy: policy.clone(),
+            env: env.to_string(),
+        });
+        self.inner.apply_masking_policy(table, policy, env).await
+    }
+
+    async fn reconcile_role_graph(
+        &self,
+        roles: &BTreeMap<String, rocky_ir::ResolvedRole>,
+        catalogs: &[&str],
+    ) -> AdapterResult<()> {
+        self.log.push(GovernanceCall::ReconcileRoleGraph {
+            roles: roles.clone(),
+            catalogs: catalogs.iter().map(|c| (*c).to_string()).collect(),
+        });
+        self.inner.reconcile_role_graph(roles, catalogs).await
+    }
+
+    async fn apply_retention_policy(
+        &self,
+        table: &TableRef,
+        retention: &RetentionPolicy,
+    ) -> AdapterResult<()> {
+        self.log.push(GovernanceCall::ApplyRetentionPolicy {
+            table: table.clone(),
+            retention: *retention,
+        });
+        self.inner.apply_retention_policy(table, retention).await
+    }
+
+    async fn read_retention_days(&self, table: &TableRef) -> AdapterResult<Option<u32>> {
+        self.log.push(GovernanceCall::ReadRetentionDays {
+            table: table.clone(),
+        });
+        self.inner.read_retention_days(table).await
+    }
+
+    async fn write_recipe_manifest(
+        &self,
+        table: &TableRef,
+        properties: &BTreeMap<String, String>,
+    ) -> AdapterResult<()> {
+        self.log.push(GovernanceCall::WriteRecipeManifest {
+            table: table.clone(),
+            properties: properties.clone(),
+        });
+        self.inner.write_recipe_manifest(table, properties).await
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Type mapping
 // ---------------------------------------------------------------------------
 
@@ -1926,6 +2251,148 @@ mod tests {
     fn _assert_batch_check_object_safe(_: &dyn BatchCheckAdapter) {}
     // SqlDialect is not async, but still needs to be object-safe.
     fn _assert_dialect_object_safe(_: &dyn SqlDialect) {}
+
+    // -----------------------------------------------------------------
+    // RecordingGovernanceAdapter
+    // -----------------------------------------------------------------
+
+    /// Method names inside the `{ … }` block a `header` line opens, where
+    /// `header` is a line of this file with no leading whitespace.
+    ///
+    /// Reading the source is the only way to compare a trait's declared
+    /// surface against what one impl overrides: a method the recorder does
+    /// not override still *compiles*, because the trait default supplies a
+    /// body — it just silently never reaches the log.
+    fn method_names_in_block(header: &str) -> Vec<String> {
+        let source = include_str!("traits.rs");
+        let opens: Vec<usize> = source
+            .lines()
+            .enumerate()
+            .filter(|(_, line)| *line == header)
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(
+            opens.len(),
+            1,
+            "expected exactly one line reading {header:?}, found {}",
+            opens.len()
+        );
+
+        let mut names = Vec::new();
+        for line in source.lines().skip(opens[0] + 1) {
+            if line == "}" {
+                break;
+            }
+            let Some(rest) = line.strip_prefix("    ") else {
+                continue;
+            };
+            let rest = rest.strip_prefix("async ").unwrap_or(rest);
+            let Some(rest) = rest.strip_prefix("fn ") else {
+                continue;
+            };
+            let Some(name) = rest.split('(').next() else {
+                continue;
+            };
+            names.push(name.to_string());
+        }
+        names.sort();
+        names
+    }
+
+    /// A `GovernanceAdapter` method the recorder does not override inherits
+    /// the trait default, runs, and writes nothing to the log — so a "this
+    /// issued no governance calls" assertion would pass while the call was
+    /// made. Adding a method to the trait must therefore fail here until the
+    /// recorder covers it.
+    #[test]
+    fn every_governance_method_is_recorded() {
+        let declared = method_names_in_block("pub trait GovernanceAdapter: Send + Sync {");
+        let recorded =
+            method_names_in_block("impl GovernanceAdapter for RecordingGovernanceAdapter {");
+
+        assert!(
+            declared.len() >= 14,
+            "the trait scan found only {declared:?} — the scan is broken, not the trait"
+        );
+        assert_eq!(
+            declared, recorded,
+            "every GovernanceAdapter method must be recorded; \
+             add the missing variant to GovernanceCall and override the method"
+        );
+    }
+
+    /// The positive control for every "the log is empty" assertion: the same
+    /// wiring, with calls actually made, records them in order and names each
+    /// one after the method it came from.
+    #[tokio::test]
+    async fn a_recorded_call_names_the_method_it_came_from() {
+        let log = GovernanceLog::default();
+        let governance = RecordingGovernanceAdapter::new(log.clone());
+
+        assert!(log.is_empty(), "nothing has been called yet");
+
+        governance.apply_grants(&[]).await.unwrap();
+        governance.set_isolation("analytics", true).await.unwrap();
+        governance
+            .set_tags(
+                &TagTarget::Catalog("analytics".to_string()),
+                &BTreeMap::new(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            log.methods(),
+            vec!["apply_grants", "set_isolation", "set_tags"],
+            "calls are recorded in the order they were made"
+        );
+    }
+
+    /// The recorder is transparent: it forwards to the adapter it wraps and
+    /// returns that adapter's answer unchanged, errors included. A double
+    /// that swallowed the inner error would make the code under test take a
+    /// path it does not take in production.
+    #[tokio::test]
+    async fn the_recorder_returns_what_its_inner_adapter_returns() {
+        let noop_log = GovernanceLog::default();
+        let over_noop = RecordingGovernanceAdapter::new(noop_log.clone());
+        assert!(
+            over_noop.list_workspace_bindings("analytics").await.is_ok(),
+            "NoopGovernanceAdapter overrides list_workspace_bindings with Ok"
+        );
+
+        let minimal_log = GovernanceLog::default();
+        let over_minimal =
+            RecordingGovernanceAdapter::wrapping(minimal_log.clone(), Box::new(MinimalGovernance));
+        let err = over_minimal
+            .list_workspace_bindings("analytics")
+            .await
+            .expect_err("MinimalGovernance inherits the erroring trait default");
+        assert!(
+            err.to_string().contains("list_workspace_bindings"),
+            "unexpected error: {err}"
+        );
+
+        assert_eq!(noop_log.methods(), vec!["list_workspace_bindings"]);
+        assert_eq!(minimal_log.methods(), vec!["list_workspace_bindings"]);
+    }
+
+    /// A log handed out before the adapter was boxed still sees the calls.
+    /// Governance call sites take `Box<dyn GovernanceAdapter>` by value, so
+    /// this is the only way a test gets its assertions back.
+    #[tokio::test]
+    async fn the_log_outlives_the_adapter_it_was_given_to() {
+        let log = GovernanceLog::default();
+        let boxed: Box<dyn GovernanceAdapter> =
+            Box::new(RecordingGovernanceAdapter::new(log.clone()));
+
+        async fn consume(governance: Box<dyn GovernanceAdapter>) {
+            governance.apply_grants(&[]).await.unwrap();
+        }
+        consume(boxed).await;
+
+        assert_eq!(log.methods(), vec!["apply_grants"]);
+    }
 
     // Default workspace-binding primitives error out so adapters that don't
     // support the concept must override with explicit semantics.


### PR DESCRIPTION
Closes the buildable half of #1609 point 3: a governance adapter that records what it was asked to do, so a test can assert what a code path *did not* call instead of inferring it from control flow.

## What this does not do

It does **not** close the whole-run claim — "this run issued zero catalog / tag / binding / grant calls". That needs an injection point in `commands::run::run`, which is a separate decision. The constraint is posted on #1609.

## Why a shared recorder when two doubles already exist

`run.rs`'s test module hand-rolls two `GovernanceAdapter` fakes, each covering a disjoint slice:

| double | records | the other methods |
|---|---|---|
| `CountingGovernance` | 9 of 14 | inherit the trait default, run, and record nothing |
| `RecordingRecipeGovernance` | 1 of 14 (`write_recipe_manifest`) | same |

That is exactly the vacuity #1609 names. A "this issued no governance calls" assertion against `CountingGovernance` passes whether or not `write_recipe_manifest` was called, because it does not override it — and the test still compiles, because the trait supplies a body.

`RecordingGovernanceAdapter` records **all 14**, and `every_governance_method_is_recorded` scans the source to compare the trait's declared method names against the impl's, so adding a method to the trait fails until the recorder covers it.

It wraps another adapter — `NoopGovernanceAdapter` by default — and forwards after logging, so inserting it does not change what the code under test observes. The log is a separate cloneable handle (`GovernanceLog`), because every call site takes the adapter by value: a test that handed it over could not otherwise read it back.

Lives in `rocky-core::traits` next to `NoopGovernanceAdapter`, so `rocky-server` and the adapter crates get it too, and it is not feature-gated.

## Three tests at the reconcile seam

Each states something neither existing double can:

- **`a_reconcile_of_ungoverned_models_issues_no_adapter_call`** — a snapshot with no classification, retention or tags issues no call at all. `apply_model_governance_tags_respects_only_model_filter` asserts an empty *tagged* list; nothing asserted an empty transcript.
- **`an_unmapped_classification_tags_the_column_without_a_masking_call`** — a classification whose tag has no `[mask]` entry tags the column and skips the masking leg, rather than calling `apply_masking_policy` with an empty policy. `replication_reconcile_uses_snapshot` maps every tag it uses, so that branch had no coverage.
- **`a_reconcile_interleaves_its_calls_per_model_in_compiled_order`** — two models interleave per model rather than grouping by method. That is the half of `reconcile_model_governance`'s documented order the single-model test could not reach.

Every "the adapter was not called" assertion here is paired with one where the same wiring **does** record, because on its own an empty log cannot tell "no call was issued" from "the recorder was never reached".

## Evidence

`scripts/mutation-check.sh`, four mutations, each RED then restored:

| mutation | test that caught it |
|---|---|
| drop the recorder's `remove_workspace_binding` override (no other test calls it) | `every_governance_method_is_recorded` |
| `if !column_strategies.is_empty()` → `if true` | `an_unmapped_classification_...` |
| `if !tags.is_empty()` → `if true` | `a_reconcile_of_ungoverned_models_...` |
| move the tags leg into a second pass over every model | `a_reconcile_interleaves_...` |

The last one found a real defect in my own test: with only the first model carrying non-tag legs, the expected sequence was identical either way, so the test was blind to the thing it claimed to pin. Fixed in its own commit.

`cargo test -p rocky-core -p rocky-cli --all-features` green (4090 tests). Clippy `--all-targets --all-features` clean, `cargo fmt --check` clean.

## Follow-up, deliberately not here

Folding `CountingGovernance` and `RecordingRecipeGovernance` into the recorder. About 20 tests assert on their formatted transcript strings; that is a wide mechanical diff and does not belong in the same change as the thing that would replace them.

## What I am least confident about

Whether `a_reconcile_interleaves_its_calls_per_model_in_compiled_order` earns its place next to `replication_reconcile_uses_snapshot`, which already pins a one-model sequence exactly. It survived a mutation the single-model test does not catch, so it is not a restatement — but it is the thinnest of the three.

## What I think I am missing

Whether the source-scan guard is the right shape. It catches a method added to the trait and not to the recorder. It does **not** catch a recorder override that logs the *wrong* variant — `set_tags` pushing `GovernanceCall::GetGrants` would pass every test here. A `method()`-vs-variant mapping test would close that, and I did not write one because the mapping is a flat `match` with no logic; that is a judgement call, not a proof.

**Independent red team: not run.** The Codex plugin cannot return a verdict into an autonomous loop, so this is self-reviewed at maximum effort and disclosed as such, per `AGENTS.md`.

Refs #1609, #1594, #1461
