### PR TITLE
test(engine): a CLI output with no exported schema now fails CI

### DIFF
--- a/engine/crates/rocky-cli/src/commands/export_schemas.rs
+++ b/engine/crates/rocky-cli/src/commands/export_schemas.rs
@@ -250,6 +250,149 @@ mod tests {
     use super::*;
     use std::collections::HashSet;
 
+    /// Every `*Output` type in `output.rs` that derives `JsonSchema`, paired
+    /// with the line it is declared on (for the failure message).
+    ///
+    /// The scan is deliberately over `output.rs` only. A new CLI output goes
+    /// there, so a type this misses is a type nobody added — and a type it
+    /// wrongly picks up is answered by the containment rule below rather than
+    /// by an allowlist.
+    fn json_schema_output_types() -> Vec<String> {
+        let source = include_str!("../output.rs");
+        let lines: Vec<&str> = source.lines().collect();
+        let mut found = Vec::new();
+
+        for (i, line) in lines.iter().enumerate() {
+            let Some(rest) = line
+                .strip_prefix("pub struct ")
+                .or_else(|| line.strip_prefix("pub enum "))
+            else {
+                continue;
+            };
+            let name: String = rest
+                .chars()
+                .take_while(|c| c.is_alphanumeric() || *c == '_')
+                .collect();
+            if !name.ends_with("Output") {
+                continue;
+            }
+
+            // Walk back over the declaration's attributes and doc comments to
+            // find its `#[derive(...)]`, which may be wrapped across lines.
+            let mut attrs = String::new();
+            let mut j = i;
+            while j > 0 {
+                j -= 1;
+                let prev = lines[j];
+                let is_attached = prev.starts_with("#[")
+                    || prev.starts_with("///")
+                    || prev.starts_with("    ")
+                    || prev.starts_with(")]")
+                    || prev.trim().is_empty();
+                if !is_attached {
+                    break;
+                }
+                attrs.push_str(prev);
+                attrs.push('\n');
+            }
+            if attrs.contains("JsonSchema") {
+                found.push(name);
+            }
+        }
+
+        found.sort();
+        found.dedup();
+        found
+    }
+
+    /// Every name the registered schemas account for: each schema's own
+    /// `title`, plus every type it inlines under `definitions` / `$defs`.
+    fn names_the_registered_schemas_account_for() -> HashSet<String> {
+        let mut names = HashSet::new();
+        for (_, schema) in schemas() {
+            let Some(obj) = schema.as_object() else {
+                continue;
+            };
+            if let Some(title) = obj.get("title").and_then(|t| t.as_str()) {
+                names.insert(title.to_string());
+            }
+            for key in ["definitions", "$defs"] {
+                if let Some(defs) = obj.get(key).and_then(|d| d.as_object()) {
+                    names.extend(defs.keys().cloned());
+                }
+            }
+        }
+        names
+    }
+
+    /// The roster gate (#1760). A `JsonSchema`-deriving `*Output` type must
+    /// either be registered in [`schemas()`] or be inlined into some
+    /// registered schema. A type that is neither is a **serialization root
+    /// with no exported schema** — an `--output json` surface with no Pydantic
+    /// model and no TypeScript interface.
+    ///
+    /// # Why `codegen-drift` cannot see this
+    ///
+    /// That workflow runs `just codegen` and compares the committed bindings
+    /// against what it produces. Both sides are derived from [`schemas()`], so
+    /// a type missing from the roster is missing from both and the check is
+    /// green. Absence reads as agreement. This test is the independent half:
+    /// it asks the SOURCE what types exist, and the generated schemas what
+    /// they account for.
+    ///
+    /// # Why containment rather than counting derives
+    ///
+    /// Most `*Output` types are nested — schemars inlines them into their
+    /// parent's `definitions` and they need no standalone entry. Counting
+    /// derives and comparing against the roster length needs an allowlist of
+    /// every nested type, and an allowlist drifts. Asking the generated
+    /// schemas what they already inline needs none: on the tree that added
+    /// this test, 145 candidates resolved with **zero** exceptions.
+    ///
+    /// The rule is also fully discriminating. Un-registering any one of the
+    /// 93 registered roots makes this test fail — including the six that
+    /// reached `main` unregistered and were found by reading the roster by
+    /// eye: `SnapshotOutput` and `DocsOutput` (#1699), and the four
+    /// `List*Output` types (#1760).
+    #[test]
+    fn every_output_type_is_registered_or_inlined() {
+        let accounted = names_the_registered_schemas_account_for();
+        let missing: Vec<String> = json_schema_output_types()
+            .into_iter()
+            .filter(|name| !accounted.contains(name))
+            .collect();
+
+        assert!(
+            missing.is_empty(),
+            "these `output.rs` types derive JsonSchema, are registered in no \
+             schema, and are inlined into none — so they are CLI outputs with \
+             no exported schema and no generated bindings: {missing:?}\n\
+             Register each in `schemas()` and run `just codegen`. If one is \
+             genuinely not a CLI output, it should not derive JsonSchema."
+        );
+    }
+
+    /// The scan must actually find types. A parser change that silently
+    /// matched nothing would make the gate above pass on an empty set — the
+    /// exact "absence reads as agreement" failure it exists to close.
+    #[test]
+    fn the_output_type_scan_finds_the_types_it_claims_to() {
+        let found = json_schema_output_types();
+        assert!(
+            found.len() > 100,
+            "the output.rs scan found only {} types, which means the parser \
+             broke rather than the file shrinking: {found:?}",
+            found.len()
+        );
+        for expected in ["RunOutput", "PlanOutput", "SnapshotOutput", "DocsOutput"] {
+            assert!(
+                found.iter().any(|n| n == expected),
+                "the scan missed {expected}, so it is not reading declarations \
+                 the way the gate assumes"
+            );
+        }
+    }
+
     /// Every entry in `schemas()` must produce a valid Draft-07 JSON Schema
     /// with at least a top-level `type`, `$ref`, or `oneOf`. Catches the
     /// failure mode where a struct's `JsonSchema` derive misbehaves.


### PR DESCRIPTION
Closes #1760 — the gate half. #1810 already registered the four `rocky list` verbs; this is the part that stops the next one reaching main.

## The hole

`codegen-drift` runs `just codegen` and fails when the committed bindings differ from what it produces. Both sides come from `schemas()`, so a type missing from the roster is missing from both and the check is green.

```
   output.rs                  schemas()              committed bindings
   ─────────                  ─────────              ──────────────────
   SnapshotOutput   ──✗──▶    (not there)   ──▶      (not there)
                                  └──────── agree ───────┘   ✅ green
```

That is how `rocky snapshot` and `rocky docs` (#1699), then the four `rocky list` verbs (#1810), shipped with no Pydantic model and no TypeScript interface. Each was found by a human reading the roster by eye.

## The rule

Ask the two sides independently. `output.rs` says which `JsonSchema`-deriving `*Output` types exist; the generated schemas say which names they account for — each schema's own `title`, plus everything it inlines under `definitions` / `$defs`. A type in neither is a **serialization root with no exported schema**.

## Why not the shapes the issue measured

I recorded three candidate rules on the issue and the numbers for each. This is a fourth, and it is the only one that needs no exceptions list:

| rule | roots | flagged | exceptions needed |
|---|---|---|---|
| name occurs once in `output.rs` | 41 | 0 | misses real roots |
| literal `print_json(&X)` | 9 | 0 | most call sites pass a variable |
| referenced-as-field, `output.rs` scan | 92 | 6 (4 real) | **2** — references from other files |
| **registered-or-inlined (this PR)** | — | **0** | **0** |

The decided option — one inventory both `schemas()` and the test read — could not enforce on its own, for the reason recorded on the issue: an inventory *is* the roster, so a type absent from it is absent from both sides again. Counting `#[derive(..JsonSchema..)]` and comparing against the roster length fails differently: 145 candidates against 107 registered schemas, and most of the gap is legitimate nesting, so it needs an allowlist of ~50 names that drifts.

Asking the generated schemas what they already inline replaces that allowlist with a fact.

## Measured before building

```
candidates in output.rs .................. 145
accounted for by a registered schema ..... 145
missing .................................... 0        ← sound, no exceptions

registered roots ........................... 93
caught if un-registered .................... 93
blind ....................................... 0        ← complete
```

Complete matters as much as sound: a gate that flags nothing looks identical to a clean tree. Un-registering **any** of the 93 registered roots fails this test, including all six that historically got through.

Verified with `scripts/mutation-check.sh`: dropping `entry::<SnapshotOutput>("snapshot")` from the roster — literally #1699's defect — makes it RED, then restores.

## The parser's own guard

`the_output_type_scan_finds_the_types_it_claims_to` asserts the scan finds >100 types and names four specific ones. A parser change that silently matched nothing would make the gate pass on an empty set, which is the same "absence reads as agreement" failure it exists to close.

## Scope

Test-only. No production code, no schema change, no new dependency, no CI config change — `engine-ci.yml` already runs `cargo nextest run --all-features`.

`cargo test -p rocky-cli --lib` green (1911 tests). Clippy `--all-targets --all-features` clean, `cargo fmt --check` clean.

## Split out, not dropped

Two manual steps behind the roster stay manual, and this gate does not see them:

- both binding barrels are hand-maintained (`sdk/python/src/rocky_sdk/types_generated/__init__.py`, `editors/vscode/src/types/generated/index.ts`);
- `justfile:165` restores that `__init__.py` from HEAD after every codegen pass, so hand-edits made *before* a codegen run are silently reverted by it.

A registered type with no barrel entry is generated but inert. `sdk/python/tests/test_barrel_completeness.py` catches a name in `__all__` with no `_LAZY` entry, not a type in neither, and the TypeScript barrel has no check at all. Filed as #1853 — it gates a different surface, in two other languages.

## What I am least confident about

The scan reads `output.rs` only. A CLI output declared elsewhere — `commands/doctor.rs` already holds one, per `AGENTS.md` — is invisible to it, so the gate's recall is "every output that lives where outputs are supposed to live". Widening it to the whole crate is a bigger scan whose false-positive behaviour I have not measured, and the four defects this class has produced were all in `output.rs`.

## What I think I am missing

Whether "inlined into a registered schema" can go stale in the wrong direction. If a parent stops referencing a nested type but the type stays in `output.rs`, it becomes an unregistered root and this gate starts failing — correctly, but it will read as an unrelated break to whoever removed the field. The failure message names the type and says to register it or drop the derive, which is the right instruction for that case too, but it is a diagnosis someone has to make.

**Independent red team: not run.** The Codex plugin cannot return a verdict into an autonomous loop, so this is self-reviewed at maximum effort and disclosed as such, per `AGENTS.md`.

Refs #1760, #1699, #1810
