### PR TITLE
test(engine/rocky-cli): the review queue tests open their DuckDB file by an absolute path

### DIFF
--- a/engine/crates/rocky-cli/src/commands/review.rs
+++ b/engine/crates/rocky-cli/src/commands/review.rs
@@ -2658,11 +2658,14 @@ mod tests {
         let config_path = root.join("rocky.toml");
         std::fs::write(
             &config_path,
-            "[adapter]\ntype = \"duckdb\"\npath = \"x.duckdb\"\n\n\
+            format!(
+                "[adapter]\ntype = \"duckdb\"\npath = '{}'\n\n\
              [pipeline.p]\ntype = \"transformation\"\nmodels = \"models/**\"\n\n\
              [pipeline.p.target.governance]\nauto_create_schemas = true\n\n\
              [pipeline.q]\ntype = \"transformation\"\nmodels = \"models/**\"\n\n\
              [pipeline.q.target.governance]\nauto_create_schemas = true\n",
+                root.join("x.duckdb").display()
+            ),
         )
         .unwrap();
         let out = compute_review_queue(root, &config_path, &state_path, &models_dir)
@@ -2687,9 +2690,12 @@ mod tests {
         let config_path = root.join("rocky.toml");
         std::fs::write(
             &config_path,
-            "[adapter]\ntype = \"duckdb\"\npath = \"x.duckdb\"\n\n\
+            format!(
+                "[adapter]\ntype = \"duckdb\"\npath = '{}'\n\n\
              [pipeline.p]\ntype = \"transformation\"\nmodels = \"models/**\"\n\n\
              [pipeline.p.target.governance]\nauto_create_schemas = true\n",
+                root.join("x.duckdb").display()
+            ),
         )
         .unwrap();
         config_path
@@ -2721,10 +2727,13 @@ mod tests {
         let config_path = root.join("rocky.toml");
         std::fs::write(
             &config_path,
-            "[adapter]\ntype = \"duckdb\"\npath = \"x.duckdb\"\n\n\
+            format!(
+                "[adapter]\ntype = \"duckdb\"\npath = '{}'\n\n\
              [pipeline.p]\ntype = \"transformation\"\nmodels = \"models/**\"\n\n\
              [pipeline.p.target.governance]\nauto_create_schemas = true\n\n\
              [policy]\nversion = 1\ndefault_agent_effect = \"require_review\"\n",
+                root.join("x.duckdb").display()
+            ),
         )
         .unwrap();
 
@@ -2813,10 +2822,13 @@ mod tests {
         let config_path = root.join("rocky.toml");
         std::fs::write(
             &config_path,
-            "[adapter]\ntype = \"duckdb\"\npath = \"x.duckdb\"\n\n\
+            format!(
+                "[adapter]\ntype = \"duckdb\"\npath = '{}'\n\n\
              [pipeline.p]\ntype = \"transformation\"\nmodels = \"models/**\"\n\n\
              [pipeline.p.target.governance]\nauto_create_schemas = true\n\n\
              [policy]\nversion = 1\ndefault_agent_effect = \"require_review\"\n",
+                root.join("x.duckdb").display()
+            ),
         )
         .unwrap();
         touch_plan_file(root, "repl");


### PR DESCRIPTION
One flaky test, fixed at its cause. Test module only; no behaviour changes.

**The flake.** `commands::review::tests::the_entry_offers_no_read_where_the_routes_front_door_is_shut` failed the `Test` job on #1855 and #1861 (`preview_model` was `None`, expected `Some("a")`), and passed on rerun both times.

**Mechanism, verified.** The test writes a `rocky.toml` with `path = "x.duckdb"`. `compute_review_queue` decides whether the samples route's front door is open by calling `AdapterRegistry::from_config`, which opens the DuckDB file eagerly (`registry.rs`: `DuckDbWarehouseAdapter::open`). A relative path resolves against the process cwd. Twenty-two tests in the `rocky-cli` lib test binary call `set_current_dir`, so under nextest's scheduling the cwd at that moment can be unwritable or already deleted; the open fails, the door reads as shut, the assertion fails.

**Reproduced without the race.** Running the lib test binary from `/` (unwritable) fails with exactly the CI assertion; from a writable directory it passes. After this change the run from `/` passes.

**Change.** The four configs in this test module name the file by an absolute path under the test's own temp root, as a TOML literal string so a Windows path survives.

Bookkeeping: no changelog (test only). Red team: none; a one-cause test fixture fix with a deterministic reproduction, which AGENTS.md exempts as mechanical.
