### PR TITLE
fix(playground): the POC suite exercises the binary it is pointed at, and leaves the checkout clean

### DIFF
--- a/examples/playground/pocs/02-performance/02-merge-upsert/run.sh
+++ b/examples/playground/pocs/02-performance/02-merge-upsert/run.sh
@@ -6,7 +6,11 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$HERE"
 
 # Clean state from previous runs
-rm -rf .rocky-state.redb .rocky-state.redb.lock models/.rocky-state.redb models/.rocky-state.redb.lock poc.duckdb expected
+# NOT `rm -rf expected`: that directory holds a TRACKED .gitkeep, and
+# removing it leaves the checkout dirty after a suite run (#1676). Clear the
+# generated files instead.
+rm -rf .rocky-state.redb .rocky-state.redb.lock models/.rocky-state.redb models/.rocky-state.redb.lock poc.duckdb
+rm -f expected/*.json expected/*.txt
 mkdir -p expected
 
 echo "=== validate ==="

--- a/examples/playground/pocs/03-ai/07-policy/run.sh
+++ b/examples/playground/pocs/03-ai/07-policy/run.sh
@@ -18,6 +18,13 @@ mkdir -p expected
 # smoke runner puts a fresh one there).
 find_rocky() {
     local d="$HERE"
+    # An explicit ROCKY_BIN wins over every guess below: it is how the POC
+    # harness names the binary under test, and a walk that prefers a release
+    # build would otherwise exercise a stale one (#1676).
+    if [ -n "${ROCKY_BIN:-}" ]; then
+        echo "$ROCKY_BIN"
+        return 0
+    fi
     while [ "$d" != "/" ]; do
         if [ -f "$d/engine/Cargo.toml" ]; then
             for cand in "$d/engine/target/release/rocky" "$d/engine/target/debug/rocky"; do

--- a/examples/playground/pocs/04-governance/08-cross-team-contracts/run.sh
+++ b/examples/playground/pocs/04-governance/08-cross-team-contracts/run.sh
@@ -11,15 +11,27 @@
 set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROCKY="$HERE/../../../../../engine/target/release/rocky"
+# ROCKY_BIN first — it is how the POC harness names the binary under test
+# (#1676). Then a local release build, then a debug one, then PATH. Before
+# this the release path was the ONLY candidate, so a debug-built run failed
+# here with a message about building the engine, on a machine where the engine
+# was already built.
+ROCKY="${ROCKY_BIN:-}"
+if [[ -z "$ROCKY" ]]; then
+    REPO_ROOT="$(cd "$HERE/../../../../.." && pwd)"
+    for cand in "$REPO_ROOT/engine/target/release/rocky" "$REPO_ROOT/engine/target/debug/rocky"; do
+        [[ -x "$cand" ]] && { ROCKY="$cand"; break; }
+    done
+fi
+[[ -z "$ROCKY" ]] && ROCKY="$(command -v rocky || true)"
 
 PRODUCER="$HERE/orders-producer"
 CONSUMER="$HERE/shipments-consumer"
 VENDOR="$CONSUMER/vendor/orders"
 
 if [[ ! -x "$ROCKY" ]]; then
-    echo "ERROR: built rocky binary not found at $ROCKY"
-    echo "Build it first:  (cd engine && cargo build --release -p rocky)"
+    echo "ERROR: no rocky binary. Set ROCKY_BIN, or build one:"
+    echo "  (cd engine && cargo build -p rocky)"
     exit 1
 fi
 

--- a/examples/playground/pocs/04-governance/11-agent-policy/run.sh
+++ b/examples/playground/pocs/04-governance/11-agent-policy/run.sh
@@ -33,6 +33,13 @@ mkdir -p "$HERE/expected"
 # Resolve to an ABSOLUTE path now, before we cd into the throwaway repo.
 find_rocky() {
     local d="$HERE"
+    # An explicit ROCKY_BIN wins over every guess below: it is how the POC
+    # harness names the binary under test, and a walk that prefers a release
+    # build would otherwise exercise a stale one (#1676).
+    if [ -n "${ROCKY_BIN:-}" ]; then
+        echo "$ROCKY_BIN"
+        return 0
+    fi
     while [ "$d" != "/" ]; do
         if [ -f "$d/engine/Cargo.toml" ]; then
             for cand in "$d/engine/target/release/rocky" "$d/engine/target/debug/rocky"; do

--- a/examples/playground/pocs/05-orchestration/12-webhook-ingress/run.sh
+++ b/examples/playground/pocs/05-orchestration/12-webhook-ingress/run.sh
@@ -55,12 +55,16 @@ BODY='{"event":"orders.synced"}'
 SIG=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $NF}')
 
 echo "==> signed POST /api/v1/hooks/trigger/hello"
-CODE=$(curl -sS -o resp.json -w '%{http_code}' -X POST \
+# Under expected/, not the POC root: the .gitignore covers generated files
+# there, and a bare resp.json left a suite run with an untracked file in the
+# checkout (#1676).
+mkdir -p expected
+CODE=$(curl -sS -o expected/resp.json -w '%{http_code}' -X POST \
   "${BASE}/api/v1/hooks/trigger/hello" \
   -H "X-Rocky-Signature: ${SIG}" \
   -H "X-Rocky-Delivery: poc-evt-1" \
   --data-binary "$BODY")
-echo "    → HTTP ${CODE}: $(cat resp.json)"
+echo "    → HTTP ${CODE}: $(cat expected/resp.json)"
 if [[ "$CODE" != "202" ]]; then echo "FAIL: expected 202"; exit 1; fi
 
 echo "==> unsigned POST must be rejected"

--- a/examples/playground/scripts/run-all-duckdb.sh
+++ b/examples/playground/scripts/run-all-duckdb.sh
@@ -6,6 +6,30 @@ set -uo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
+# Name the binary under test ONCE, and export it.
+#
+# Ten POCs do not call bare `rocky`: they resolve a path themselves, and every
+# one of them prefers `engine/target/release/rocky` over PATH. A caller that
+# puts a DEBUG build on PATH — which is what a PR-time job would do (#1676) —
+# would silently exercise a stale release binary in those ten, or hard-fail
+# where a POC has no fallback. The suite would report on a binary nobody asked
+# it to test.
+#
+# `ROCKY_BIN` is the override those POCs consult first, so exporting it here
+# makes PATH and the path-resolving POCs agree by construction.
+#
+# Fail fast rather than let 101 POCs each discover the same missing binary:
+# one message that says what is wrong beats 101 that say a command was not
+# found.
+ROCKY_BIN="${ROCKY_BIN:-$(command -v rocky || true)}"
+if [ -z "$ROCKY_BIN" ]; then
+    echo "error: no rocky binary. Put one on PATH or set ROCKY_BIN." >&2
+    echo "  (cd engine && cargo build -p rocky) then add engine/target/debug to PATH" >&2
+    exit 1
+fi
+export ROCKY_BIN
+echo "Binary under test: $ROCKY_BIN"
+
 passed=0
 failed=0
 skipped=0


### PR DESCRIPTION
Refs #1676. **Does not close it** — nothing here runs a POC at PR time. It removes the reason a PR-time job would be untrustworthy if one were added.

Found by doing what #1676 proposes: running all 101 POCs against a source-built **debug** binary, which is what a PR-time job would build.

```
before (debug binary on PATH)   84 passed, 1 failed
                                tree dirty: deleted .gitkeep, untracked resp.json
after                           85 passed, 0 failed
                                tree clean
```

## 1. Ten POCs do not test the binary the harness is pointed at

They do not call bare `rocky`. They resolve a path themselves, and **every one prefers `engine/target/release/rocky` over PATH**:

```
02-performance/14-skip-unchanged                 05-orchestration/11-state-namespacing
03-ai/06-mcp-grounding                           06-developer-experience/10-pr-preview-and-data-diff
03-ai/07-policy                                  06-developer-experience/11-lineage-diff
04-governance/08-cross-team-contracts            06-developer-experience/20-defer-against-prod
04-governance/10-recipe-provenance               04-governance/11-agent-policy
```

In the weekly job this is invisible: it runs `cargo build --release`, so the preferred path *is* the binary under test and the two agree by coincidence. Point the harness at a debug build and they diverge — a stale release build gets exercised where one exists, and `04-governance/08-cross-team-contracts` hard-fails with "Build it first", on a machine where the engine was already built.

`run-all-duckdb.sh` now resolves the binary once and exports `ROCKY_BIN`, the override those POCs consult first. Seven already honoured it. Three did not and now do — `03-ai/07-policy` and `04-governance/11-agent-policy` share a `find_rocky` walk that never looked at it, and `08-cross-team-contracts` had no fallback chain at all.

The suite also fails fast with one message when there is no binary, rather than letting 101 POCs each discover it separately.

## 2 and 3. A suite run left the checkout dirty

- `02-performance/02-merge-upsert` did `rm -rf … expected`, taking the **tracked** `expected/.gitkeep` with it. It clears the generated files instead.
- `05-orchestration/12-webhook-ingress` wrote `resp.json` into the POC root, where the `.gitignore` does not reach. Moved under `expected/`.

Both matter more than they look: a PR-time POC job that dirties the working tree turns any `git status` drift gate red for a reason that has nothing to do with the change under review.

## The override is load-bearing, not decorative

Asserting "ROCKY_BIN now wins" is a claim about a fallback order I had not exercised, so I exercised it. With a deliberately stale `engine/target/release/rocky` planted — a stub that exits 97 and prints a marker:

```
ROCKY_BIN set,   08-cross-team-contracts   exit 0, marker never printed
ROCKY_BIN set,   11-lineage-diff           exit 0, marker never printed
ROCKY_BIN unset, 08-cross-team-contracts   exit 1, marker printed   <- the control
```

The control is what makes the other two mean something: it proves the release-preferring path really is reachable, so the override really is beating it rather than the stub never being consulted.

## What I am least confident about

Whether exporting `ROCKY_BIN` from the harness is the right layer. It fixes every POC that honours the variable, but nothing *enforces* that a new POC honours it — a new `run.sh` that hardcodes a path is still free to ignore the harness, and this change makes that failure quieter than before, because the suite now looks like it names the binary under test. The enforcing shape is a check that every `run.sh` either calls bare `rocky` or reads `ROCKY_BIN`, which is a grep-level gate I did not add here.

I also have not verified the weekly job still passes: it builds release, so `ROCKY_BIN` will resolve to the release binary on PATH and nothing changes for it — but that is reasoning, not a run.

## What I think is being missed

The three defects share a cause worth naming, because #1676's proposed gate inherits it. Each POC decides for itself what "the rocky binary" means and where its scratch files go, and 101 POCs made 101 such decisions with no shared contract. The suite script cannot enforce a convention it never states.

`examples/playground/CLAUDE.md` already mandates one convention for credential guards — the `: "${VAR:?…}"` form — and `run-all-duckdb.sh` keys its skip logic off that form rather than a hand-maintained list. That is the pattern that scales. The same treatment for the binary and for scratch-file placement would make this class structural rather than a sweep, and would give the PR-time gate something to stand on.

**Independent red team: not run.** The Codex plugin cannot return a verdict into an autonomous loop, so this is self-reviewed at maximum effort and disclosed as such, per `AGENTS.md`.

Refs #1666, #1638
