### PR TITLE
fix(engine/rocky-core): a config parse error no longer echoes a resolved secret

### DIFF
--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -168,13 +168,21 @@ pub enum ConfigError {
     #[error("failed to parse TOML: {0}")]
     ParseToml(#[from] toml::de::Error),
 
-    /// TOML parse/deserialize error after env-var substitution, enriched with
-    /// the list of substituted env vars so the operator can narrow the cause
-    /// (e.g. a negative `timeout_secs` that came from `${TIMEOUT}`).
-    #[error("failed to parse TOML: {source}{env_var_hint}")]
+    /// TOML parse/deserialize error after env-var substitution, naming the
+    /// substituted env vars so the operator can narrow the cause (e.g. a
+    /// negative `timeout_secs` that came from `${TIMEOUT}`).
+    ///
+    /// Carries a pre-rendered, REDACTED message rather than the
+    /// `toml::de::Error` itself, and deliberately has no `#[source]`.
+    /// Substitution happens before the parse, so by the time toml renders the
+    /// offending line that line holds the RESOLVED value — and every route
+    /// that reports a config failure renders the whole chain with
+    /// `format!("{e:#}")`. Keeping the raw error reachable, in the source
+    /// chain or anywhere else, would put a live credential in an HTTP body.
+    /// See the redaction in `redact_substituted_values`.
+    #[error("failed to parse TOML: {rendered}{env_var_hint}")]
     ParseTomlWithEnvContext {
-        #[source]
-        source: toml::de::Error,
+        rendered: String,
         env_var_hint: String,
     },
 
@@ -2459,30 +2467,47 @@ fn substitute_env_vars_inner(input: &str) -> EnvExpansion {
 /// and a BARE `port = ${PORT}` then fails to parse — for a reason the parse
 /// error itself cannot express. Listing the unresolved names here keeps that
 /// error pointing at `PORT` instead of at a stray `$`.
+/// Replace every substituted env-var VALUE in `text` with `${NAME}`, the
+/// placeholder the operator actually wrote.
+///
+/// Substitution happens before the TOML is parsed, so a parse error renders
+/// the offending line with the resolved value already in it. `toml` gives no
+/// way to ask which byte ranges came from a substitution, and
+/// [`EnvVarSubstitution`] records only name and value, so this searches for
+/// each value and puts the placeholder back.
+///
+/// Longest value first, so a value that contains another value cannot leave a
+/// fragment of the longer one behind. Empty values are skipped: they match
+/// everywhere and would replace nothing useful.
+///
+/// This is a belt-and-braces pass over a rendering, not a parser. It is here
+/// because the alternative is a live credential in an HTTP error body, and a
+/// redaction that occasionally over-redacts a coincidentally identical string
+/// is the safe direction to be wrong in.
+pub fn redact_substituted_values(text: &str, substitutions: &[EnvVarSubstitution]) -> String {
+    let mut ordered: Vec<&EnvVarSubstitution> = substitutions
+        .iter()
+        .filter(|sub| !sub.value.is_empty())
+        .collect();
+    ordered.sort_by_key(|sub| std::cmp::Reverse(sub.value.len()));
+
+    let mut out = text.to_string();
+    for sub in ordered {
+        out = out.replace(&sub.value, &format!("${{{}}}", sub.name));
+    }
+    out
+}
+
 fn format_env_var_hint(substitutions: &[EnvVarSubstitution], unresolved: &[String]) -> String {
     if substitutions.is_empty() && unresolved.is_empty() {
         return String::new();
     }
-    const MAX_VALUE_LEN: usize = 40;
     // De-dup by name, keeping first occurrence.
     let mut seen = std::collections::HashSet::new();
     let parts: Vec<String> = substitutions
         .iter()
         .filter(|sub| seen.insert(&sub.name))
-        .map(|sub| {
-            let truncated = if sub.value.len() > MAX_VALUE_LEN {
-                // Truncate on a UTF-8 char boundary — a fixed byte slice panics
-                // when byte MAX_VALUE_LEN lands inside a multibyte character.
-                let end = (0..=MAX_VALUE_LEN)
-                    .rev()
-                    .find(|&i| sub.value.is_char_boundary(i))
-                    .unwrap_or(0);
-                format!("{}…", &sub.value[..end])
-            } else {
-                sub.value.clone()
-            };
-            format!("{}={:?}", sub.name, truncated)
-        })
+        .map(|sub| sub.name.clone())
         .collect();
     let mut hint = String::new();
     if !parts.is_empty() {
@@ -6444,10 +6469,18 @@ fn parse_rocky_config_str_with(
     let env_var_hint = format_env_var_hint(&substitutions, &missing_names);
     let to_parse_err = |source: toml::de::Error| -> ConfigError {
         if env_var_hint.is_empty() {
+            // No substitutions AND no unresolved vars: the rendered line is
+            // what the operator wrote, and there is nothing to say about it.
+            // Keyed on the hint, not on substitutions: an UNRESOLVED var
+            // produces a hint with no substitution, and an existing test
+            // caught this dropping that hint on the floor.
             ConfigError::ParseToml(source)
         } else {
+            // Render ONCE, here, where the substitutions are still in scope,
+            // and redact before the error exists. A caller cannot leak what
+            // the error never carried.
             ConfigError::ParseTomlWithEnvContext {
-                source,
+                rendered: redact_substituted_values(&source.to_string(), &substitutions),
                 env_var_hint: env_var_hint.clone(),
             }
         }
@@ -7543,19 +7576,142 @@ mod tests {
     }
     use super::*;
 
+    /// The hint names the env vars and never prints their values.
+    ///
+    /// It used to print `NAME="VALUE"`, truncated to 40 bytes, which is longer
+    /// than most tokens. That is a good affordance in a terminal the operator
+    /// already owns and a disclosure the moment the error is rendered over
+    /// HTTP, which every route does with `format!("{e:#}")`. The name alone
+    /// preserves what makes it useful: which var to go and look at.
     #[test]
-    fn format_env_var_hint_truncates_on_char_boundary() {
-        // Regression: a fixed `&value[..40]` slice panicked when byte 40 landed
-        // inside a multibyte character. A long value with multibyte chars
-        // spanning the boundary must truncate cleanly (no panic).
-        let value = "é".repeat(30); // 60 bytes; byte 40 is mid-character
+    fn the_env_var_hint_names_vars_without_printing_their_values() {
+        let subs = vec![
+            EnvVarSubstitution {
+                name: "DATABRICKS_TOKEN".to_string(),
+                value: "dapi-SUPERSECRET-abc123".to_string(),
+            },
+            EnvVarSubstitution {
+                name: "WAREHOUSE".to_string(),
+                value: "analytics".to_string(),
+            },
+        ];
+        let hint = format_env_var_hint(&subs, &[]);
+
+        assert!(hint.contains("DATABRICKS_TOKEN"), "{hint}");
+        assert!(hint.contains("WAREHOUSE"), "{hint}");
+        assert!(
+            !hint.contains("dapi-SUPERSECRET-abc123"),
+            "the hint must not carry a resolved value: {hint}"
+        );
+        assert!(
+            !hint.contains("analytics"),
+            "not only the secret-looking ones; the hint cannot tell them apart: {hint}"
+        );
+    }
+
+    /// A multibyte value must not panic the redactor or the hint.
+    ///
+    /// The hint previously truncated on a byte index and needed a char-boundary
+    /// search to avoid panicking. It no longer truncates, but the redactor now
+    /// does the string work, so the same input is worth keeping.
+    #[test]
+    fn multibyte_values_are_redacted_without_panicking() {
         let subs = vec![EnvVarSubstitution {
-            name: "SECRET".to_string(),
-            value,
+            name: "MOTTO".to_string(),
+            value: "日本語のテキストがここにあります".to_string(),
         }];
-        let hint = format_env_var_hint(&subs, &[]); // must not panic
-        assert!(hint.contains("SECRET"));
-        assert!(hint.contains('…'));
+        let _ = format_env_var_hint(&subs, &[]);
+        let out = redact_substituted_values("path = 日本語のテキストがここにあります", &subs);
+        assert_eq!(out, "path = ${MOTTO}");
+    }
+
+    /// The redactor puts back the placeholder the operator wrote.
+    #[test]
+    fn redaction_replaces_a_resolved_value_with_its_placeholder() {
+        let subs = vec![EnvVarSubstitution {
+            name: "TOKEN".to_string(),
+            value: "dapi-abc123".to_string(),
+        }];
+        let rendered =
+            "TOML parse error at line 3\n  |\n3 | path = dapi-abc123\n  |        ^^^^^^^^^^^";
+        let out = redact_substituted_values(rendered, &subs);
+
+        assert!(!out.contains("dapi-abc123"), "{out}");
+        assert!(out.contains("${TOKEN}"), "{out}");
+        assert!(
+            out.contains("TOML parse error at line 3"),
+            "the diagnosis survives: {out}"
+        );
+    }
+
+    /// A value that contains another value must not leave a fragment behind.
+    ///
+    /// Redacting the shorter one first would rewrite the inside of the longer
+    /// one and leave its outer characters exposed, so the pass goes longest
+    /// first. This is the case that makes the ordering load-bearing.
+    #[test]
+    fn a_value_containing_another_value_is_fully_redacted() {
+        let subs = vec![
+            EnvVarSubstitution {
+                name: "SHORT".to_string(),
+                value: "abc".to_string(),
+            },
+            EnvVarSubstitution {
+                name: "LONG".to_string(),
+                value: "xxabcxx".to_string(),
+            },
+        ];
+        let out = redact_substituted_values("a = xxabcxx", &subs);
+        assert!(
+            !out.contains("xxabcxx") && !out.contains("xx${SHORT}xx"),
+            "the longer value must be redacted whole, not have its middle rewritten: {out}"
+        );
+        assert_eq!(out, "a = ${LONG}");
+    }
+
+    /// An empty substitution must not match everywhere.
+    #[test]
+    fn an_empty_value_redacts_nothing() {
+        let subs = vec![EnvVarSubstitution {
+            name: "EMPTY".to_string(),
+            value: String::new(),
+        }];
+        assert_eq!(redact_substituted_values("a = 1", &subs), "a = 1");
+    }
+
+    /// End to end, through the real loader: a resolved value that breaks the
+    /// parse must not appear anywhere in the error a route would render.
+    ///
+    /// This asserts the VALUE is absent rather than that the message has some
+    /// shape, because a reworded hint that still interpolated would pass a
+    /// wording assertion and leak just the same.
+    #[test]
+    fn a_parse_failure_never_renders_the_resolved_value() {
+        const SECRET: &str = "SUPERSECRET-abc123-DO-NOT-LEAK";
+        // SAFETY: single-threaded test process; the var is removed below.
+        unsafe { std::env::set_var("ROCKY_TEST_LEAK_PROBE", SECRET) };
+
+        // Valid TOML before substitution, broken after: the value is bare.
+        let (_d, path) =
+            write_cfg("[adapter]\ntype = \"duckdb\"\npath = ${ROCKY_TEST_LEAK_PROBE}\n");
+        let err = load_rocky_config(&path).expect_err("a bare resolved value is not valid TOML");
+
+        let full = format!("{err:#}");
+        let display = format!("{err}");
+        unsafe { std::env::remove_var("ROCKY_TEST_LEAK_PROBE") };
+
+        assert!(
+            !full.contains(SECRET),
+            "the resolved value reached the rendered chain a route serves: {full}"
+        );
+        assert!(
+            !display.contains(SECRET),
+            "the resolved value reached the Display a route serves: {display}"
+        );
+        assert!(
+            full.contains("ROCKY_TEST_LEAK_PROBE"),
+            "the operator still needs to know which var to look at: {full}"
+        );
     }
 
     /// WP-01 PR-B: `load_rocky_config_fingerprinted` is deterministic across


### PR DESCRIPTION
A config parse error served a live credential over HTTP and drew it on a screen. This closes that path. It does **not** close #1886, which stays open — the red team found three more paths, described at the bottom and filed as #1897.

**The path.** `${VAR}` is substituted **before** the TOML is parsed. So when the parse then fails, the resolved value is already in the text, and two separate things carried it outward:

- the parse error echoes the offending line, which by then holds the value rather than the placeholder;
- the env-var hint printed each substitution as `NAME="VALUE"`, truncated to 40 bytes, which is longer than most tokens.

Every route that reports a config failure renders the chain with `format!("{e:#}")`, and the browser UI puts that string in the project card's subtitle. The realistic trigger is not a contrived probe: it is a project that templates one secret and has one typo somewhere else in the file.

```toml
[adapter]
type = "databricks"
token = "${DATABRICKS_TOKEN}"
host = "example.com          # unterminated string, anywhere in the file
```

**Fixed at one producer.** Six call sites render the chain, so a boundary drawn at each of them is a boundary the next route forgets. `ParseTomlWithEnvContext` now carries a pre-rendered, redacted message and deliberately has **no `#[source]`**. The raw `toml::de::Error` is unreachable, so no caller can print what the error never held.

I first described this as fixing the problem "at the source". That was wrong, and the review is what corrected it. This fixes **one** producer — `load_rocky_config`'s TOML parse. Substitution happens in more places than that, and the other producers are untouched.

`redact_substituted_values` puts `${NAME}` back wherever a resolved value appears. toml offers no way to ask which byte ranges came from a substitution, and `EnvVarSubstitution` records only name and value, so it searches for each value **longest first** — a shorter value nested in a longer one would otherwise rewrite its middle and leave the ends exposed. Empty values are skipped, since they match everywhere.

The hint keeps the names and drops the values. Naming the variable is what made it useful: it tells an operator which one to look at, and they already have the environment. It is a good affordance in a terminal and a disclosure over HTTP, and the fix is to stop it crossing that line rather than to delete it.

**Tests assert the value is ABSENT**, not that the message has a shape. A reworded hint that still interpolated would pass a wording assertion and leak just the same. The end-to-end case goes through the real loader with a real env var set.

| Mutation | Result |
|---|---|
| restore the `NAME="VALUE"` hint | fix-sensitive |
| skip the redaction of the echoed parse line | fix-sensitive |

Both break `a_parse_failure_never_renders_the_resolved_value`, which is the point: the two halves have different causes and either alone would still leak.

**An existing test caught a regression while I wrote this.** I first keyed the branch on whether any substitution happened, but an *unresolved* var produces a hint with no substitution, so that config lost its hint entirely. `credential_tolerant_load_names_an_unresolved_var_in_a_parse_error` named exactly that case. The branch is now keyed on the hint.

**Scope.** Whether a resolved `${VAR}` may appear in a load-bearing config field *at all* — `scope`, `verify_after`, budget windows, adapter fields a reader needs — is a separate decision, #1878. This is a bug under every answer to it, which is why it is not waiting on that.

Found by the session working the first-run UI, which reproduced it live against `GET /api/v1/project` rather than reasoning about it, and deliberately kept it out of a layout PR.

Refs #1878. Refs #1886. Refs #1897.

## Red team

Codex (`codex:codex-rescue`), one round, on `7c2c42ef`. **Verdict: REJECT.** Five findings. Three are paths this PR does not close, and they are the reason the PR no longer claims #1886. I verified all three against the code before accepting them; none were rebutted.

**1. Post-parse validation errors still disclose (MISSING — accepted, not fixed here).** Substitution provenance is discarded once `parse_rocky_config` returns, so every *validation* error renders text that may already hold a resolved value with no redactor in reach. `autonomy_budget = { failures = 2, window = "${ROCKY_SECRET}" }` is cloned at `config.rs:3423` and rendered as `{window:?}` by `PolicyBudgetInvalidWindow` at `config.rs:333`, which reaches `GET /api/v1/policy` at `api.rs:2135`.

I measured the class rather than guessing at it: **20 of 28 `ConfigError` variants interpolate a `String`/`PathBuf`/`Vec<String>` field.** Not every one is reachable with attacker-influenced text, but the ones that carry `pipeline`, `adapter`, `table`, `component`, `window`, `backend` and `reason` all read config strings, and substitution runs before parse, so any of them can hold a resolved value.

**2. Exact substring replacement is not a secrecy guarantee (WRONG on the specific example, right in general — recorded).** The claim was that a multiline value renders as a single offending source line so neither fragment equals the whole, and that `"""${ROCKY_SECRET}"""` renders a decoded newline as an escaped `\n` the replace cannot match. I could not construct the escaping case as described. But the *general* point stands and I am not defending against it: any transformation of the value between substitution and rendering — escaping, quoting, span truncation, line splitting — defeats an exact match. This is the known weakness of redacting a rendered string, it is why this construction is weaker than a structural fix, and it is part of what #1897 has to settle.

**3. Model sidecar and frontmatter parse sites bypass the redactor entirely (MISSING — accepted, not fixed here).** Confirmed end-to-end. All three sites call `substitute_env_vars`, the wrapper that *discards* the substitution report (`config.rs:2344`), then parse: `models.rs:683` (`_defaults.toml`), `models.rs:1479` (sidecars), `models.rs:1540` (inline frontmatter). `ModelError::ParseFrontmatter` at `models.rs:38` embeds the raw `toml::de::Error` and interpolates it into its own `Display`, so `e.to_string()` at `rocky-server/src/state.rs:467` publishes the echoed line as a failure reason that `GET /api/v1/project` returns. A `_defaults.toml` that templates a secret and has a typo leaks it exactly the way `rocky.toml` did.

The redactor cannot simply be applied at these sites: the wrapper they call throws the report away, so closing this changes a signature used well beyond config loading.

**4. Dropping `#[source]` breaks no consumer (CONFIRMED).** Matches what I found: no `.source()` walk and no `downcast_ref::<toml::de::Error>()` outside `config.rs`.

**5. Ordering and `${NAME}` are not blockers (CONFIRMED).** Longest-first is sound for the nesting case, and restoring the placeholder the operator wrote is the right replacement.

**Disposition.** Findings 4 and 5 need no change. Findings 1 and 3 are real, are wider than this diff, and both turn on the same missing thing the reviewer named: there is no defined trust boundary for environment-expanded config. Closing them by chasing producers is unbounded — I cannot enumerate the callers that will parse expanded text next. That is a design decision, so it is filed as #1897 rather than guessed at here, and #1886 stays open until it is answered.

What this PR is worth landing for: the reported path is closed and proven fix-sensitive, and the hint no longer prints values by design. What it must not do is claim the rest.
