### PR TITLE
fix(engine/rocky-cli): a maintenance plan names a table, not whatever string was typed

### DIFF
--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -3220,6 +3220,73 @@ fn compile_target_to_name(
 /// The returned [`TouchedTargets`] says which keys were resolved to a model,
 /// so the gate records a graph key for those alone; a verbatim key is a
 /// policy subject, not a model.
+/// Is `s` a three-part `catalog.schema.table` name?
+///
+/// SQL identifiers are `^[a-zA-Z0-9_]+$` (`rocky-sql/validation.rs`), so a dot
+/// only ever separates parts and splitting is exact rather than a heuristic.
+pub(crate) fn is_three_part_fqn(s: &str) -> bool {
+    let parts: Vec<&str> = s.split('.').collect();
+    parts.len() == 3 && parts.iter().all(|p| !p.is_empty())
+}
+
+/// Every non-ephemeral model this project declares, as `name -> target FQN`.
+///
+/// The maintenance WRITERS (`rocky compact`, `rocky archive`) use this to
+/// record a fully-qualified table on the plan instead of whatever string the
+/// operator typed (#1829). It reuses [`resolve_touched_apply_targets`]'s own
+/// loader, confinement and ephemeral skip on purpose: a writer that derived
+/// the mapping differently from the gate that later reads it would put the
+/// two back out of step, which is the defect being closed.
+///
+/// Fails CLOSED for the same reason the gate does: a models glob that cannot
+/// be confined to the project root means we cannot say what a name refers to,
+/// and guessing is what produced the conflation.
+pub(crate) fn model_target_fqns(
+    config: &rocky_core::config::RockyConfig,
+    config_path: &Path,
+) -> Result<BTreeMap<String, String>> {
+    let models_dir = resolve_confined_config_models_dir(config_path, Some(config)).context(
+        "refusing to plan this maintenance operation: the project's models glob could not be          confined to the project root, so a bare name cannot be resolved to a table",
+    )?;
+    let models_glob = resolve_config_models_glob(config_path, Some(config));
+    let (models, load_errors) = match models_glob.as_deref() {
+        Some(glob) => crate::models_loader::load_project_models_matching_partial(
+            &models_dir,
+            glob,
+            Some(&config.freshness),
+        ),
+        None => {
+            crate::models_loader::load_project_models_partial(&models_dir, Some(&config.freshness))
+        }
+    };
+    for e in &load_errors {
+        tracing::warn!(
+            error = %format!("{e:#}"),
+            "some models could not be loaded; a bare maintenance target naming one of them will not resolve"
+        );
+    }
+    let mut by_name = BTreeMap::new();
+    for m in &models {
+        // An ephemeral model is inlined as a CTE and materializes nothing, so
+        // it has no table to compact or archive. Same exclusion the gate
+        // makes (#1815, review round seven).
+        if matches!(
+            m.config.strategy,
+            rocky_core::models::StrategyConfig::Ephemeral
+        ) {
+            continue;
+        }
+        by_name.insert(
+            m.config.name.clone(),
+            format!(
+                "{}.{}.{}",
+                m.config.target.catalog, m.config.target.schema, m.config.target.table
+            ),
+        );
+    }
+    Ok(by_name)
+}
+
 pub(crate) fn resolve_touched_apply_targets(
     config: &rocky_core::config::RockyConfig,
     config_path: &Path,

--- a/engine/crates/rocky-cli/src/commands/archive.rs
+++ b/engine/crates/rocky-cli/src/commands/archive.rs
@@ -65,6 +65,39 @@ fn persist_archive_plan(
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// Resolve `--model <name>` to the model's fully-qualified target table.
+///
+/// `None` in, `None` out — that is the project-wide archive, which names no
+/// table and is unaffected. A name already written `catalog.schema.table` is
+/// kept as-is, so an operator who names a table directly still can.
+///
+/// Anything else must be a model this project declares. An unknown name is
+/// REFUSED rather than passed through: `DELETE FROM <name>` against whatever
+/// the warehouse's search path resolves is not a plan anyone reviewed.
+fn resolve_archive_model_target(config_path: &Path, model: Option<&str>) -> Result<Option<String>> {
+    let Some(name) = model else {
+        return Ok(None);
+    };
+    if crate::commands::apply::is_three_part_fqn(name) {
+        return Ok(Some(name.to_string()));
+    }
+    let config = rocky_core::config::load_rocky_config(config_path).with_context(|| {
+        format!(
+            "refusing to plan an archive of '{name}': the config could not be loaded, so the \
+             model's target table cannot be resolved"
+        )
+    })?;
+    let by_name = crate::commands::apply::model_target_fqns(&config, config_path)?;
+    match by_name.get(name) {
+        Some(fqn) => Ok(Some(fqn.clone())),
+        None => anyhow::bail!(
+            "refusing to plan an archive of '{name}': no model by that name is declared in \
+             this project. `--model` takes a model name, or a fully qualified table \
+             (catalog.schema.table) to name one directly"
+        ),
+    }
+}
+
 /// Execute `rocky archive`.
 ///
 /// After generating the plan, persists it to `.rocky/plans/<plan_id>.json`
@@ -81,6 +114,18 @@ pub fn run_archive(
 ) -> Result<()> {
     // Parse the older_than duration (e.g., "90d", "6m", "1y")
     let days = parse_duration_days(older_than)?;
+    // `--model` names a MODEL (that is what the flag is documented as), so
+    // resolve it to that model's target table and record THAT on the plan
+    // (#1829). Before this the operator's string was recorded verbatim, and
+    // the apply gate had to re-derive what it meant from the string alone —
+    // the same string `rocky compact` uses to mean a physical table. One
+    // resolver, two commands, opposite intents, no way to tell them apart.
+    //
+    // It also fixes the SQL: `DELETE FROM orders` depended on the warehouse's
+    // search path resolving to the same table the model declares. Now the
+    // statement names the table the model itself points at.
+    let model = resolve_archive_model_target(config_path, model)?;
+    let model = model.as_deref();
     // Resolve the configured target dialect (config-only, no credentials) so
     // the gated generator fails fast off Databricks at plan time instead of
     // printing DELETE/VACUUM SQL the warehouse rejects at apply time.
@@ -747,6 +792,104 @@ pub(crate) async fn run_archive_apply_alias_in_with(
 
 #[cfg(test)]
 mod tests {
+    /// #1829(1), the archive half. `--model` is documented as a MODEL name,
+    /// while `rocky compact`'s positional argument is documented as a TABLE —
+    /// and both used to record the operator's string verbatim onto the plan,
+    /// where ONE resolver had to re-derive which of the two it was looking at.
+    ///
+    /// A model name now resolves to that model's own target table before the
+    /// plan is written, so the gate reads a fact instead of guessing. It also
+    /// fixes the SQL: `DELETE FROM orders` depended on the warehouse's search
+    /// path landing on the same table the model declares.
+    mod model_target_resolution {
+        use std::path::Path;
+
+        /// A model whose NAME and TARGET TABLE differ — the only fixture where
+        /// resolving and not resolving give different answers.
+        fn write_project(dir: &Path) -> std::path::PathBuf {
+            let models = dir.join("models");
+            std::fs::create_dir_all(&models).unwrap();
+            std::fs::write(models.join("orders.sql"), "SELECT 1 AS id\n").unwrap();
+            std::fs::write(
+                models.join("orders.toml"),
+                "name = \"orders\"\n\n[strategy]\ntype = \"full_refresh\"\n\n\
+                 [target]\ncatalog = \"wh\"\nschema = \"marts\"\ntable = \"orders_v2\"\n",
+            )
+            .unwrap();
+            let toml = r#"
+[adapter]
+type = "databricks"
+host = "https://example.cloud.databricks.com"
+http_path = "/sql/1.0/warehouses/abc"
+token = "pat-xxx"
+
+[pipeline.p]
+type = "transformation"
+models = "models/**"
+
+[pipeline.p.target]
+adapter = "default"
+"#;
+            let path = dir.join("rocky.toml");
+            std::fs::write(&path, toml).unwrap();
+            path
+        }
+
+        #[test]
+        fn a_model_name_becomes_the_models_own_table() {
+            let dir = tempfile::tempdir().unwrap();
+            let config = write_project(dir.path());
+
+            let resolved = super::super::resolve_archive_model_target(&config, Some("orders"))
+                .expect("a declared model resolves");
+            assert_eq!(
+                resolved.as_deref(),
+                Some("wh.marts.orders_v2"),
+                "the plan must name the table the MODEL declares, not the string typed"
+            );
+        }
+
+        /// The negative control, and the reason this is not just a rename: an
+        /// unknown name is REFUSED rather than passed through. Passing it
+        /// through would emit `DELETE FROM <name>` against whatever the
+        /// warehouse's search path resolves — a destructive statement nobody
+        /// reviewed.
+        #[test]
+        fn an_unknown_model_name_is_refused_not_passed_through() {
+            let dir = tempfile::tempdir().unwrap();
+            let config = write_project(dir.path());
+
+            let err = super::super::resolve_archive_model_target(&config, Some("ghost"))
+                .expect_err("an undeclared model must refuse");
+            let msg = format!("{err:#}");
+            assert!(
+                msg.contains("no model by that name"),
+                "the refusal says what is wrong: {msg}"
+            );
+        }
+
+        /// Two shapes that must NOT change. A fully qualified name is kept
+        /// verbatim so an operator can still name a table directly, and the
+        /// project-wide archive (no `--model`) names no table at all.
+        #[test]
+        fn a_fully_qualified_name_and_the_project_wide_archive_are_unchanged() {
+            let dir = tempfile::tempdir().unwrap();
+            let config = write_project(dir.path());
+
+            assert_eq!(
+                super::super::resolve_archive_model_target(&config, Some("wh.raw.events"))
+                    .unwrap()
+                    .as_deref(),
+                Some("wh.raw.events"),
+            );
+            assert_eq!(
+                super::super::resolve_archive_model_target(&config, None).unwrap(),
+                None,
+                "the project-wide archive names no table and must not start"
+            );
+        }
+    }
+
     use super::*;
 
     /// Policy-gate parity coverage for `archive apply` (PR-1). Archive is the

--- a/engine/crates/rocky-cli/src/commands/compact.rs
+++ b/engine/crates/rocky-cli/src/commands/compact.rs
@@ -86,6 +86,20 @@ pub fn run_compact(
         .map_err(|e| anyhow::anyhow!("invalid --target-size: {e}"))?
         .unwrap_or(256);
 
+    // The plan must name a TABLE, fully qualified (#1829). This argument is
+    // documented `catalog.schema.table`, but a bare name used to be recorded
+    // verbatim, and the apply gate's resolver reads a bare name that matches a
+    // model as THAT MODEL — so policy was evaluated for a logical model while
+    // the regenerated `OPTIMIZE`/`VACUUM` ran against a physical table of the
+    // same name. Two readings of one string, on a destructive operation.
+    //
+    // Refused rather than guessed. Resolving a bare name to a same-named
+    // model's target would be the opposite guess and just as wrong: an
+    // operator who meant the physical table would silently compact something
+    // else. The message names the model's target when one matches, so the
+    // operator can say which they meant.
+    require_fully_qualified_compact_target(config_path, model)?;
+
     // Resolve the configured target dialect (config-only, no credentials) and
     // generate through the gated `compact_from_ir`, so `rocky compact` fails
     // fast off Databricks at plan time instead of printing OPTIMIZE/VACUUM SQL
@@ -1275,6 +1289,36 @@ fn pick_sample_tables(stats: &DedupStats, max: usize) -> Vec<String> {
 /// CLI args and config files (via `--catalog` scope resolution), both of
 /// which are untrusted from the engine's perspective. See the validation
 /// rules in `engine/CLAUDE.md`.
+/// Refuse a compact target that is not a three-part `catalog.schema.table`.
+///
+/// See the call site for why this is a refusal and not a resolution. The model
+/// lookup exists ONLY to make the message actionable — it never rewrites the
+/// target — and a project whose models cannot be loaded still gets the plain
+/// refusal rather than an error about model loading.
+fn require_fully_qualified_compact_target(config_path: &Path, target: &str) -> Result<()> {
+    if crate::commands::apply::is_three_part_fqn(target) {
+        return Ok(());
+    }
+    let hint = rocky_core::config::load_rocky_config(config_path)
+        .ok()
+        .and_then(|cfg| crate::commands::apply::model_target_fqns(&cfg, config_path).ok())
+        .and_then(|by_name| by_name.get(target).cloned());
+    let Some(fqn) = hint else {
+        anyhow::bail!(
+            "refusing to plan a compaction of '{target}': `rocky compact` takes a fully \
+             qualified table (catalog.schema.table). A bare name cannot say whether it means \
+             a physical table or a model, and this plan regenerates OPTIMIZE/VACUUM against \
+             whatever it names"
+        );
+    };
+    anyhow::bail!(
+        "refusing to plan a compaction of '{target}': `rocky compact` takes a fully qualified \
+         table (catalog.schema.table), and '{target}' is also the name of a model. If you mean \
+         that model's table, run `rocky compact {fqn}`; if you mean a physical table called \
+         '{target}', name it in full"
+    )
+}
+
 fn generate_compact_sql(
     model: &str,
     target_size_mb: u64,
@@ -1766,6 +1810,90 @@ mod tests {
         /// with the given `[policy]` rules spliced in. No credentials are used:
         /// the injectable sink never builds the real adapter, and the gate/
         /// dialect only read the parsed config.
+        /// A project with one model whose NAME and whose TARGET TABLE differ,
+        /// which is the fixture #1829 asks for: it is the only shape where
+        /// reading a bare string as a model and reading it as a table give
+        /// different answers.
+        fn write_project_with_a_differently_targeted_model(dir: &Path) -> std::path::PathBuf {
+            let models = dir.join("models");
+            std::fs::create_dir_all(&models).unwrap();
+            std::fs::write(models.join("orders.sql"), "SELECT 1 AS id\n").unwrap();
+            std::fs::write(
+                models.join("orders.toml"),
+                "name = \"orders\"\n\n[strategy]\ntype = \"full_refresh\"\n\n\
+                 [target]\ncatalog = \"wh\"\nschema = \"marts\"\ntable = \"orders_v2\"\n",
+            )
+            .unwrap();
+            write_config(dir, "")
+        }
+
+        /// #1829(1). `rocky compact orders` used to record `target_table =
+        /// "orders"` verbatim. Apply then regenerated `OPTIMIZE orders` — a
+        /// PHYSICAL table — while `resolve_touched_apply_targets` read the
+        /// same bare string as the LOGICAL model `orders` and keyed policy on
+        /// its attributes. Two readings of one string, on a destructive
+        /// operation.
+        ///
+        /// Refused, not resolved. Rewriting `orders` to the model's
+        /// `wh.marts.orders_v2` would be the opposite guess and just as wrong
+        /// for an operator who meant a physical table called `orders`. The
+        /// message names the model's table so they can say which they meant.
+        #[test]
+        fn compact_refuses_a_bare_target_and_names_the_models_own_table() {
+            let dir = tempfile::tempdir().unwrap();
+            let config = write_project_with_a_differently_targeted_model(dir.path());
+
+            let err = super::require_fully_qualified_compact_target(&config, "orders")
+                .expect_err("a bare target that is also a model name must refuse");
+            let msg = format!("{err:#}");
+            assert!(
+                msg.contains("wh.marts.orders_v2"),
+                "the refusal must name the model's actual table: {msg}"
+            );
+            assert!(
+                msg.contains("also the name of a model"),
+                "and say why it cannot choose: {msg}"
+            );
+        }
+
+        /// The same refusal with no model in sight: still refused, because a
+        /// bare name cannot say what it means whether or not a model happens
+        /// to share it. Without this, "refuse only on collision" would look
+        /// like a fix while leaving `OPTIMIZE orders` resolving through the
+        /// warehouse's search path.
+        #[test]
+        fn compact_refuses_a_bare_target_with_no_model_of_that_name() {
+            let dir = tempfile::tempdir().unwrap();
+            let config = write_project_with_a_differently_targeted_model(dir.path());
+
+            let err = super::require_fully_qualified_compact_target(&config, "events")
+                .expect_err("a bare target must refuse even with no same-named model");
+            let msg = format!("{err:#}");
+            assert!(
+                msg.contains("fully") && msg.contains("catalog.schema.table"),
+                "the refusal says what to pass instead: {msg}"
+            );
+            assert!(
+                !msg.contains("also the name of a model"),
+                "and does not claim a collision that is not there: {msg}"
+            );
+        }
+
+        /// The control. A fully qualified target is what this command is
+        /// documented to take, and it must still pass — including one whose
+        /// leaf is a model name, which is the case a name-based refusal would
+        /// have broken.
+        #[test]
+        fn compact_accepts_a_fully_qualified_target() {
+            let dir = tempfile::tempdir().unwrap();
+            let config = write_project_with_a_differently_targeted_model(dir.path());
+
+            super::require_fully_qualified_compact_target(&config, "wh.marts.orders_v2")
+                .expect("the model's own table, named in full");
+            super::require_fully_qualified_compact_target(&config, "wh.raw.orders")
+                .expect("a physical table whose leaf matches a model name");
+        }
+
         fn write_config(dir: &Path, policy_rules: &str) -> std::path::PathBuf {
             let toml = format!(
                 r#"


### PR DESCRIPTION
Closes #1829 item 1. Items 2, 3 and 4 stay open on that issue.

`rocky compact orders` recorded `target_table = "orders"` verbatim. Apply regenerated `OPTIMIZE orders` / `VACUUM orders` — a **physical** table — while `resolve_touched_apply_targets` read the same bare string as the **logical model** `orders` and keyed policy on its attributes.

```
  rocky compact orders
      |
  plan: target_table = "orders"          <- the string, not a table
      |
      +--> apply regenerates   OPTIMIZE orders          the PHYSICAL table
      +--> policy gate keys on model `orders`           a DIFFERENT object
```

The policy plane evaluated one object while the SQL mutated another, on a destructive operation.

## The root is one resolver serving two opposite intents

```
rocky compact <arg>            arg is documented `catalog.schema.table`
rocky archive --model <arg>    arg is documented "a specific model"
```

Both recorded the operator's string as-is, so the shared resolver had to re-derive which of the two it was looking at from the string alone. Its bare-name branch is **right for archive and wrong for compact** — and nothing on the plan said which command wrote it.

## Each writer records a table, in the way its own argument allows

- **`rocky compact` refuses a bare name.** Resolving it to a same-named model's target would be the opposite guess and just as wrong: an operator who meant a physical table would silently compact something else. The refusal names the model's own table when one matches, so they can say which they meant.
- **`rocky archive --model X` resolves X** to that model's target table before the plan is written, and refuses a name no model declares. This also fixes the SQL — `DELETE FROM orders` depended on the warehouse's search path landing on the table the model declares.

Both derive the mapping through one `model_target_fqns`, which reuses `resolve_touched_apply_targets`'s own loader, confinement and ephemeral skip. A writer that derived it differently from the gate that reads it would put the two back out of step, which is the defect being closed.

`--catalog` on both commands was already correct — `scope.rs` assembles three-part names. I checked rather than assumed, because the variable was named `fqn`, and a name is a claim.

## What this does not do

- **The resolver's bare-name branch stays live.** Two producers still reach it: plans persisted before this change, and any future writer. Removing it would refuse those plans rather than gate them.
- **`rocky compact` refusing a bare argument is a behaviour change.** It was never documented as accepting one, and the refusal is loud with the fully-qualified form in the message.

## Evidence

The fixture is the one the issue asks for: a model whose **name** and **target table** differ (`orders` → `wh.marts.orders_v2`), which is the only shape where the two readings give different answers.

**Mutation-checked.** `scripts/mutation-check.sh` accepting a bare target again:

```
test compact_refuses_a_bare_target_and_names_the_models_own_table ... FAILED
  a bare target that is also a model name must refuse: ()
mutation-check: OK — the test failed under mutation, so it is fix-sensitive.
```

Each refusal has a control: a fully qualified target still passes — including one whose **leaf** matches a model name, which a name-based refusal would have broken — and the project-wide archive still names no table. Without those, "refuse everything" would satisfy the refusal tests.

`cargo test -p rocky-cli --lib` 1965 passed, 0 failed. Clippy `--all-targets --all-features -D warnings` clean, `cargo fmt --check` clean.

## What I am least confident about

Whether refusing is right for `rocky compact`, or only defensible. Refusing is safe and says why, but it breaks an invocation that worked, and the issue's own wording leaves room for the other reading ("a bare argument must be **either** a model … **or** a table"). I chose refusal because compact's argument is documented as a table, so resolving a bare name to a model would contradict the flag's own documentation — but an operator who has been typing `rocky compact orders` against a model will experience this as a regression, and the message is the only thing that makes it navigable. If the preference is to resolve instead, that is a small change to the same function, and the tests would invert cleanly.

I also have not exercised the end-to-end apply path with a plan written by the new writers — the tests are on the resolution functions. The gate's own behaviour on a fully-qualified target is already covered by #1828's tests, but "the writer's output flows through the gate correctly" is reasoned rather than run.

## What I think is being missed

The two commands now agree because each was fixed to match its own documentation, not because anything enforces agreement. `CompactPlanIr::target_table` and `ArchivePlanIr::target_table` are still `String`, still free to hold a bare name, and a third maintenance command would be free to invent a third convention. The enforcing shape is the discriminator item 1 actually asks for — the plan saying whether its subject is a table or a model — which also lets the resolver stop guessing for old plans instead of only for new ones. I did not add it because it is a plan-shape change that item 3 already queues one of, and doing both in one PR would put two schema questions in front of the same reviewer.

**Independent red team: not run.** The Codex plugin cannot return a verdict into an autonomous loop, so this is self-reviewed at maximum effort and disclosed as such, per `AGENTS.md`. The defect itself was found by an independent review of #1828, rounds two and three.

Refs #1828, #1815
