### PR TITLE
fix(engine/rocky-core): an unreadable schedule cursor skips the tick instead of running a paused pipeline

### DIFF
--- a/engine/crates/rocky-cli/src/commands/tick.rs
+++ b/engine/crates/rocky-cli/src/commands/tick.rs
@@ -466,7 +466,7 @@ fn map_source_skip(skip: &SourceSkip) -> SourceEvaluation {
         SkipReason::FailureBackoff { resume_at } => ("failure_backoff", Some(*resume_at), None),
         SkipReason::PartialBackoff { resume_at } => ("partial_backoff", Some(*resume_at), None),
         SkipReason::Superseded => ("superseded", None, None),
-        SkipReason::HistoryError => ("history_unavailable", None, None),
+        SkipReason::HistoryError | SkipReason::CursorError => ("history_unavailable", None, None),
     };
     SourceEvaluation {
         source: demand_kind_str(skip.source).to_string(),

--- a/engine/crates/rocky-core/src/schedule/demand.rs
+++ b/engine/crates/rocky-core/src/schedule/demand.rs
@@ -218,6 +218,14 @@ pub enum SkipReason {
     /// standing demand was skipped rather than misclassified. Fail-closed: never
     /// a false-skip (`after`) or false-fire (`freshness`).
     HistoryError,
+    /// The schedule CURSOR could not be read, so every source was skipped
+    /// rather than evaluated against a default that says "not paused, never
+    /// ran, no failures" (#1877). Distinct from [`Self::HistoryError`] because
+    /// it is a different read with a different blast radius — it suppresses
+    /// the cron path too, not only the standing demands — though both render
+    /// as `history_unavailable` in the tick report, which is the frozen
+    /// contract's name for this class.
+    CursorError,
 }
 
 /// A per-source skip record.
@@ -256,10 +264,33 @@ pub struct RunSuccess {
     pub finished_at: DateTime<Utc>,
 }
 
+/// A cursor read that could not be completed (a store fault or a corrupt
+/// row). Like [`HistoryError`] it is **never** conflated with "never
+/// evaluated": the default cursor says `paused = false`, no anchor and no
+/// consecutive failures, and a fault read as that default runs a paused
+/// pipeline, re-derives catchup from scratch, and resets the failure-backoff
+/// ladder (#1877).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CursorError(pub String);
+
+impl std::fmt::Display for CursorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "schedule-cursor read failed: {}", self.0)
+    }
+}
+
+impl std::error::Error for CursorError {}
+
 /// Read-only view of the schedule cursors.
 pub trait ScheduleStateView {
     /// The cursor for a pipeline, or its default when never evaluated.
-    fn get(&self, pipeline: &str) -> ScheduleStateRecord;
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CursorError`] when the cursor cannot be read. Callers MUST
+    /// fail closed on this — never treat it as "never evaluated", which is a
+    /// legitimate `Ok(default)` and means something else entirely.
+    fn get(&self, pipeline: &str) -> Result<ScheduleStateRecord, CursorError>;
 }
 
 /// A run-history read that could not be completed (a store fault or a corrupt
@@ -507,7 +538,26 @@ pub fn evaluate_one(
         return out;
     }
 
-    let cursor = state.get(&schedule.pipeline);
+    // A cursor that cannot be READ is not a cursor that says "not paused".
+    // Before #1877 the live view collapsed a store fault into the default
+    // record, and `evaluate_one` gated on `cursor.paused` — so a fault ran a
+    // paused pipeline on the primary scheduling path. Two more fields go with
+    // it, which is why this returns rather than continuing with a default:
+    //
+    //   paused               -> false      a paused pipeline fires
+    //   last-run anchor      -> unset      catchup re-derives from scratch
+    //   consecutive_failures -> 0          the failure backoff ladder resets
+    //
+    // The backoff reset is the quiet one: a pipeline failing repeatedly is
+    // backing off precisely when the store is under stress, so a fault that
+    // clears the ladder makes it fire again immediately.
+    let Ok(cursor) = state.get(&schedule.pipeline) else {
+        out.skips.push(SourceSkip {
+            source: DemandKind::Cron,
+            reason: SkipReason::CursorError,
+        });
+        return out;
+    };
 
     // Runtime hold — the state-level sibling of `enabled = false`, checked
     // after the cursor fetch because that is where it lives. Suppresses every
@@ -746,8 +796,18 @@ mod tests {
     #[derive(Default)]
     struct States(HashMap<String, ScheduleStateRecord>);
     impl ScheduleStateView for States {
-        fn get(&self, pipeline: &str) -> ScheduleStateRecord {
-            self.0.get(pipeline).cloned().unwrap_or_default()
+        fn get(&self, pipeline: &str) -> Result<ScheduleStateRecord, CursorError> {
+            Ok(self.0.get(pipeline).cloned().unwrap_or_default())
+        }
+    }
+
+    /// A cursor view whose read always faults — the state the live store
+    /// reaches on a failed read transaction or a corrupt row, which no test
+    /// double could express before the trait could return an error.
+    struct UnreadableCursor;
+    impl ScheduleStateView for UnreadableCursor {
+        fn get(&self, _pipeline: &str) -> Result<ScheduleStateRecord, CursorError> {
+            Err(CursorError("injected cursor read fault".to_string()))
         }
     }
 
@@ -1187,6 +1247,96 @@ mod tests {
         let e = evaluate_one(&s, &states, &History::default(), ts(2026, 6, 1, 4, 0));
         assert!(e.due.is_none(), "a paused pipeline must produce no demand");
         assert!(e.skips.iter().any(|k| k.reason == SkipReason::Paused));
+    }
+
+    /// #1877. A cursor that cannot be READ is not a cursor that says
+    /// "not paused". `StoreState::get` used to do
+    /// `get_schedule_state(...).ok().flatten().unwrap_or_default()`, and
+    /// `ScheduleStateRecord::default()` has `paused: false` — so a read
+    /// transaction that failed to open, a table that failed to open, or a
+    /// corrupt cursor row RAN A PAUSED PIPELINE, on the primary scheduling
+    /// path.
+    ///
+    /// The trait could not express the fault at all, which is why no test
+    /// could reach this state before: the fix is the signature.
+    #[test]
+    fn an_unreadable_cursor_skips_every_source_instead_of_running_the_pipeline() {
+        let s = cron_schedule("raw", Catchup::Latest);
+        let e = evaluate_one(
+            &s,
+            &UnreadableCursor,
+            &History::default(),
+            ts(2026, 6, 1, 4, 0),
+        );
+        assert!(
+            e.due.is_none(),
+            "a cursor fault must not fire a demand: {:?}",
+            e.due
+        );
+        assert!(
+            e.skips.iter().any(|k| k.reason == SkipReason::CursorError),
+            "and it must be recorded loudly, not silently dropped: {:?}",
+            e.skips
+        );
+    }
+
+    /// The two things that go with `paused` when a default stands in for a
+    /// real cursor, which is why the fault returns rather than continuing:
+    ///
+    /// ```text
+    ///   paused               -> false      a paused pipeline fires
+    ///   last-run anchor      -> unset      catchup re-derives from scratch
+    ///   consecutive_failures -> 0          the failure backoff ladder resets
+    /// ```
+    ///
+    /// The backoff reset is the quiet one. A pipeline failing repeatedly is
+    /// backing off precisely when the store is under stress, so a fault that
+    /// clears the ladder makes it fire again immediately — the opposite of
+    /// what the ladder is for. This pins that a faulting cursor produces NO
+    /// anchor write either: a tick that could not read the cursor must not
+    /// advance it.
+    #[test]
+    fn a_cursor_fault_writes_no_anchor_and_does_not_clear_a_backoff() {
+        let s = cron_schedule("raw", Catchup::Latest);
+        let e = evaluate_one(
+            &s,
+            &UnreadableCursor,
+            &History::default(),
+            ts(2026, 6, 1, 4, 0),
+        );
+        assert!(
+            e.anchor_init.is_none(),
+            "a tick that could not read the cursor must not initialise its anchor"
+        );
+        assert!(
+            e.catchup_advance.is_none(),
+            "nor advance it past occurrences it never evaluated"
+        );
+    }
+
+    /// The negative control, and the reason "always skip" is not a fix. An
+    /// ABSENT cursor — `Ok(None)` from the store, a pipeline never evaluated —
+    /// is a legitimate default and must still fire. Without this, returning
+    /// `Err` for every read would satisfy the fault tests above while
+    /// silencing every schedule in the project.
+    #[test]
+    fn a_never_evaluated_cursor_still_fires() {
+        let s = cron_schedule("raw", Catchup::Latest);
+        let e = evaluate_one(
+            &s,
+            &States::default(),
+            &History::default(),
+            ts(2026, 6, 1, 4, 0),
+        );
+        assert!(
+            e.skips.iter().all(|k| k.reason != SkipReason::CursorError),
+            "an absent cursor is not a fault: {:?}",
+            e.skips
+        );
+        assert!(
+            e.due.is_some() || e.anchor_init.is_some(),
+            "a first evaluation either fires or initialises its anchor: {e:?}"
+        );
     }
 
     /// The hold releases: the identical evaluation with `paused` cleared is

--- a/engine/crates/rocky-core/src/schedule/reconcile.rs
+++ b/engine/crates/rocky-core/src/schedule/reconcile.rs
@@ -55,8 +55,9 @@ use super::claim::{
     sweep_terminal_claim,
 };
 use super::demand::{
-    Demand, EvaluatedPipeline, HistoryError, ResolvedSchedule, RunHistoryView, RunSuccess,
-    ScheduleConfigError, ScheduleStateView, SkipReason, SourceSkip, evaluate_one, resolve_schedule,
+    CursorError, Demand, EvaluatedPipeline, HistoryError, ResolvedSchedule, RunHistoryView,
+    RunSuccess, ScheduleConfigError, ScheduleStateView, SkipReason, SourceSkip, evaluate_one,
+    resolve_schedule,
 };
 use super::lock::{TickAcquire, TickLock};
 use super::record::{ScheduleStateMutation, ScheduleStateRecord};
@@ -820,12 +821,15 @@ async fn consume_webhook_demands(
 struct StoreState<'a>(&'a StateStore);
 
 impl ScheduleStateView for StoreState<'_> {
-    fn get(&self, pipeline: &str) -> ScheduleStateRecord {
-        self.0
-            .get_schedule_state(pipeline)
-            .ok()
-            .flatten()
-            .unwrap_or_default()
+    fn get(&self, pipeline: &str) -> Result<ScheduleStateRecord, CursorError> {
+        // `Ok(None)` is "never evaluated" and IS the default cursor. A store
+        // fault is not, and the `.ok().flatten().unwrap_or_default()` this
+        // replaces made the two the same value (#1877).
+        match self.0.get_schedule_state(pipeline) {
+            Ok(Some(record)) => Ok(record),
+            Ok(None) => Ok(ScheduleStateRecord::default()),
+            Err(e) => Err(CursorError(e.to_string())),
+        }
     }
 }
 
@@ -1043,7 +1047,12 @@ fn map_skip(pipeline: &str, skip: &SourceSkip) -> Option<SkippedDemand> {
             resume_at: *resume_at,
         },
         // Recorded, never elided — a read fault must be visible in the report.
-        SkipReason::HistoryError => TickSkipReason::HistoryUnavailable,
+        // Same frozen-contract name as the history fault: both are "a store
+        // read fault made the classification unreliable, surfaced loudly". The
+        // reason set mirrors the tick contract and is asserted against
+        // `span_attrs::SCHEDULER_SKIP_REASONS`, so a new variant here would be
+        // a user-visible change for no gain in what an operator can do.
+        SkipReason::HistoryError | SkipReason::CursorError => TickSkipReason::HistoryUnavailable,
     };
     Some(SkippedDemand {
         pipeline: pipeline.to_string(),


### PR DESCRIPTION
Closes #1877. The cron/standing sibling of #1876, and worse: a store read fault did not just lose `paused`, it discarded the whole cursor.

`ScheduleStateView::get` returned `ScheduleStateRecord` and could not express failure, so the live view collapsed a fault into the default record:

```rust
self.0.get_schedule_state(pipeline).ok().flatten().unwrap_or_default()
```

`ScheduleStateRecord` derives `Default`, so `paused` is `false`, and `evaluate_one` gates on exactly that. A read transaction that failed to open, a table that failed to open, or a corrupt cursor row **ran a paused pipeline** — on the primary scheduling path, not the webhook one #1876 fixed.

## Three things were lost, not one

```
paused               -> false      a paused pipeline fires
last-run anchor      -> unset      catchup re-derives from scratch
consecutive_failures -> 0          the failure backoff ladder resets
```

The backoff reset is the quiet one. A pipeline failing repeatedly is backing off **precisely when the store is under stress**, so a fault that clears the ladder makes it fire again immediately — the opposite of what the ladder is for.

## The fix is the signature

`fn get(&self, pipeline: &str) -> Result<ScheduleStateRecord, CursorError>`, and `evaluate_one` skips every source on `Err` instead of evaluating a default.

`Ok(None)` from the store — "never evaluated" — is still the default cursor, because that is a real answer and a legitimate one. **Conflating it with "could not read" was the defect**, and the trait's own doc described only the first case.

The codebase already stated the rule this broke. Eight lines below the trait, the history read's doc says a read error

> must fail closed — skip the demand loudly — rather than misread as "never ran"

`SkipReason::HistoryError` exists for that. The cursor read had no equivalent because the trait could not return one.

## Reusing the frozen contract's name

`SkipReason::CursorError` is a new variant and both of its exhaustive matches now name it. It maps to the existing `TickSkipReason::HistoryUnavailable` rather than adding a variant there: that reason set mirrors the frozen tick contract and is asserted against `span_attrs::SCHEDULER_SKIP_REASONS`, and this is the class that reason already names — a store read fault that makes the classification unreliable.

The internal distinction is kept because the two reads have different blast radii — this one suppresses cron too, not only the standing demands — while the rendered string set is unchanged.

## Evidence

The fault could not be reached by any test double before, because the trait could not express it. That is the missing wire this change adds, and it is why every review of this class up to now was static tracing.

**Mutation-checked.** `scripts/mutation-check.sh` restoring `unwrap_or_default()`:

```
test an_unreadable_cursor_skips_every_source_instead_of_running_the_pipeline ... FAILED
  and it must be recorded loudly, not silently dropped:
    [SourceSkip { source: Cron, reason: NotDue }]
mutation-check: OK — the test failed under mutation, so it is fix-sensitive.
```

The mutant's skip reason is `NotDue` — the fault reading as an ordinary quiet tick, which is exactly the silence the fix replaces.

Three tests. The third is what keeps the fix honest: **an absent cursor must still fire.** Without it, returning `Err` for every read would satisfy both fault tests while silencing every schedule in the project. The second pins that a faulting tick writes no anchor and advances no catchup — a tick that could not read the cursor must not move it.

`cargo test -p rocky-core --lib` 2190 passed, 0 failed. `cargo test -p rocky-cli --lib` 1965 passed, 0 failed. Clippy `--all-targets --all-features -D warnings` clean, `cargo fmt --check` clean.

One run of the `rocky-cli` suite failed a single test before that clean run, and I cannot say which — I truncated the output and lost the name, then the rerun was green. I am recording it rather than omitting it. The machine was running clippy concurrently, and #1890 is an open report of exactly that shape (`fires_due_cron_each_tick_without_drift` is wall-clock sensitive and flaked under parallel load earlier today), but attributing this one to it would be a guess.

## What I am least confident about

Whether a *persistently* unreadable cursor now strands a pipeline silently enough to matter. Every tick records a `CursorError` skip, so it is visible rather than silent — but nothing escalates it, and a permanently corrupt cursor row would skip that pipeline forever while the tick report stays green in aggregate. `StateBusy` and the pre-existing `HistoryError` have the same property, so this is consistent rather than new; it is still a shape worth a bound.

## What I think is being missed

`evaluate_one` returns on the fault before the `enabled` check's sibling paths, so a cursor fault now suppresses `after` and `freshness` demands too, not just cron. That is correct — the cursor feeds all three — but it means a store fault on ONE pipeline's cursor row stops that pipeline's downstream `after` consumers from ever seeing a satisfaction, and they will record their own skips for a reason that is two hops away. The tick report will show a `CursorError` on `raw` and a `NotDue` on everything downstream of it, with nothing tying the two together. That is not a regression — the old code produced the same downstream silence, just after wrongly running the upstream — but a reader diagnosing it has no thread to pull.

**Independent red team: not run.** The Codex plugin cannot return a verdict into an autonomous loop, so this is self-reviewed at maximum effort and disclosed as such, per `AGENTS.md`. The defect was found by the follow-up grep PR #1876 said it owed.

Refs #1831, #1876, #1830, #1334
