### PR TITLE
fix(engine/rocky-sql): a CTE name is not a table read, so it derives no dependency edge

### DIFF
--- a/engine/crates/rocky-compiler/src/resolve.rs
+++ b/engine/crates/rocky-compiler/src/resolve.rs
@@ -759,7 +759,10 @@ mod tests {
     fn mutual_cte_names_do_not_close_a_cycle() {
         let models = vec![
             make_model("alpha", "WITH beta AS (SELECT 1 AS id) SELECT id FROM beta"),
-            make_model("beta", "WITH alpha AS (SELECT 2 AS id) SELECT id FROM alpha"),
+            make_model(
+                "beta",
+                "WITH alpha AS (SELECT 2 AS id) SELECT id FROM alpha",
+            ),
         ];
 
         let (dag_nodes, _lineage_cache, _diags) = resolve_dependencies(&models).unwrap();

--- a/engine/crates/rocky-compiler/src/resolve.rs
+++ b/engine/crates/rocky-compiler/src/resolve.rs
@@ -310,6 +310,14 @@ fn extract_deps_from_lineage(
     let mut renamed_target_reads = Vec::new();
 
     for table_ref in &lineage_result.source_tables {
+        // A CTE is local to the query and names no object outside it, so a CTE
+        // that happens to share a model's name must not derive an edge to it
+        // — and two models with mutual local CTE names must not close a cycle
+        // that does not exist (#1892).
+        match table_ref.binding {
+            lineage::TableBinding::Cte => continue,
+            lineage::TableBinding::Physical => {}
+        }
         if let TableRefKind::ModelRef(name) = classify_table_ref(&table_ref.name, model_names) {
             // Don't add self-references
             if name != model_name && seen.insert(name.clone()) {
@@ -719,5 +727,69 @@ mod tests {
         let (dag_nodes, _lineage_cache, _diags) = resolve_dependencies(&models).unwrap();
         let node = dag_nodes.iter().find(|n| n.name == "summary").unwrap();
         assert_eq!(node.depends_on, vec!["orders"]);
+    }
+
+    /// #1892: a CTE named after a model must derive no edge. The reader never
+    /// reads the model — the `WITH` clause shadows the name for the whole
+    /// query — so ordering it after the model is an invented dependency.
+    #[test]
+    fn a_cte_named_after_a_model_derives_no_edge() {
+        let models = vec![
+            make_model("orders", "SELECT 1 AS id"),
+            make_model(
+                "cte_reader",
+                "WITH orders AS (SELECT 2 AS id) SELECT id FROM orders",
+            ),
+        ];
+
+        let (dag_nodes, _lineage_cache, _diags) = resolve_dependencies(&models).unwrap();
+        let reader = dag_nodes.iter().find(|n| n.name == "cte_reader").unwrap();
+        assert!(
+            reader.depends_on.is_empty(),
+            "the CTE shadows the model name, so there is nothing to depend on: {:?}",
+            reader.depends_on
+        );
+    }
+
+    /// The worst form of the same defect, and the one that made it a refusal
+    /// rather than a mis-ordering: two models with mutual local CTE names have
+    /// no dependency in either direction, but the invented edges close a cycle
+    /// and `topological_sort` refuses the project outright (#1892).
+    #[test]
+    fn mutual_cte_names_do_not_close_a_cycle() {
+        let models = vec![
+            make_model("alpha", "WITH beta AS (SELECT 1 AS id) SELECT id FROM beta"),
+            make_model("beta", "WITH alpha AS (SELECT 2 AS id) SELECT id FROM alpha"),
+        ];
+
+        let (dag_nodes, _lineage_cache, _diags) = resolve_dependencies(&models).unwrap();
+        for node in &dag_nodes {
+            assert!(
+                node.depends_on.is_empty(),
+                "model '{}' has an invented dependency: {:?}",
+                node.name,
+                node.depends_on
+            );
+        }
+        rocky_ir::dag::topological_sort(&dag_nodes)
+            .expect("neither model reads the other, so the project must compile");
+    }
+
+    /// The guard against over-suppressing. A query that binds a CTE and ALSO
+    /// reads a real model must keep the real edge — the fix shadows the bound
+    /// name, not the whole `FROM` clause.
+    #[test]
+    fn a_query_with_a_cte_keeps_its_real_read_edge() {
+        let models = vec![
+            make_model("orders", "SELECT 1 AS id"),
+            make_model(
+                "mixed",
+                "WITH c AS (SELECT 1 AS id) SELECT c.id FROM c JOIN orders USING (id)",
+            ),
+        ];
+
+        let (dag_nodes, _lineage_cache, _diags) = resolve_dependencies(&models).unwrap();
+        let mixed = dag_nodes.iter().find(|n| n.name == "mixed").unwrap();
+        assert_eq!(mixed.depends_on, vec!["orders"]);
     }
 }

--- a/engine/crates/rocky-compiler/src/semantic.rs
+++ b/engine/crates/rocky-compiler/src/semantic.rs
@@ -746,6 +746,49 @@ mod tests {
         );
     }
 
+    /// #1892's consequence here, stated as a test rather than left implicit.
+    ///
+    /// Removing the invented CTE edge removes the thing `reader_depends_on_it`
+    /// above consults, so a `SELECT *` over a CTE named after a model stops
+    /// taking that model's columns. It falls through to `source_schemas`,
+    /// which is the same fall-through an external table of that name gets.
+    ///
+    /// This is a behaviour change, and it replaces a WRONG answer rather than
+    /// a right one: the CTE's own columns are what the query returns, and the
+    /// model's columns were never that. Resolving the star to the CTE body is
+    /// the further fix, and it needs `lineage.rs` to carry those columns —
+    /// #1867's half of the work.
+    #[test]
+    fn a_star_over_a_cte_no_longer_takes_the_shadowed_models_columns() {
+        let models = vec![
+            make_model("orders", "SELECT id, model_only_col FROM source.raw.o"),
+            make_model(
+                "zreader",
+                "WITH orders AS (SELECT 1 AS cte_only_col) SELECT * FROM orders",
+            ),
+        ];
+
+        let project = Project::from_models(models).unwrap();
+        let reader_deps = project
+            .dag_nodes
+            .iter()
+            .find(|n| n.name == "zreader")
+            .map(|n| n.depends_on.clone())
+            .unwrap_or_default();
+        assert!(
+            reader_deps.is_empty(),
+            "the CTE shadows the model, so no edge is derived: {reader_deps:?}"
+        );
+
+        let graph = build_semantic_graph(&project, &HashMap::new()).unwrap();
+        let reader = graph.model_schema("zreader").unwrap();
+        let names: Vec<&str> = reader.columns.iter().map(|c| c.name.as_str()).collect();
+        assert!(
+            !names.contains(&"model_only_col"),
+            "the shadowed model's columns are not what the query returns: {names:?}"
+        );
+    }
+
     /// The expansion must not depend on which model the topological walk
     /// reaches first.
     ///

--- a/engine/crates/rocky-sql/src/lineage.rs
+++ b/engine/crates/rocky-sql/src/lineage.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
@@ -104,12 +104,37 @@ pub struct LineageResult {
     pub unresolved_projections: usize,
 }
 
+/// What a name in a `FROM`/`JOIN` position actually refers to.
+///
+/// A `WITH` clause binds names that look exactly like table reads, so the name
+/// alone cannot tell the two apart. A consumer deriving dependencies must not
+/// treat a CTE as a read: a CTE named after a model would invent an edge to
+/// it, and two models with mutual local CTE names would close a cycle that
+/// does not exist (#1892).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum TableBinding {
+    /// A real read of a table, view or other physical relation.
+    #[default]
+    Physical,
+    /// A reference to a name bound by an enclosing `WITH` clause. Local to the
+    /// query — it names no object outside it.
+    Cte,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TableReference {
     /// Full table name (e.g., "catalog.schema.table").
     pub name: String,
     /// Alias if any.
     pub alias: Option<String>,
+    /// Whether this name is a real relation or a `WITH`-bound CTE (#1892).
+    ///
+    /// `#[serde(default)]` so a `LineageResult` cached by an older build
+    /// deserializes as [`TableBinding::Physical`] — the value every reference
+    /// carried before CTE scopes were tracked, so an old cache keeps its old
+    /// meaning rather than failing to load.
+    #[serde(default)]
+    pub binding: TableBinding,
     /// Output column names of a derived table (subquery in the `FROM` clause),
     /// when they can be determined statically — i.e. the subquery does not
     /// itself project a `SELECT *`. `None` for plain table references and for
@@ -141,11 +166,15 @@ pub struct TableReference {
 ///
 /// Subqueries return the alias `(subquery)` which callers should filter
 /// out (it can't match a model name).
+///
+/// Names bound by a `WITH` clause are dropped: a CTE is local to the query and
+/// names no object a consumer could depend on or schedule against (#1892).
 pub fn referenced_tables(sql: &str) -> Result<Vec<String>, String> {
     let result = extract_lineage(sql)?;
     let mut names: Vec<String> = result
         .source_tables
         .iter()
+        .filter(|t| t.binding == TableBinding::Physical)
         .map(|t| t.name.to_lowercase())
         .filter(|n| n != "(subquery)")
         .collect();
@@ -165,15 +194,41 @@ pub fn extract_lineage(sql: &str) -> Result<LineageResult, String> {
     let stmt = statements.first().ok_or_else(|| "empty SQL".to_string())?;
 
     match stmt {
-        Statement::Query(query) => extract_query_lineage(query),
+        Statement::Query(query) => extract_query_lineage(query, &CteScope::new()),
         _ => Err("lineage extraction only supports SELECT statements".to_string()),
     }
 }
 
-fn extract_query_lineage(query: &Query) -> Result<LineageResult, String> {
+/// The CTE names visible at a point in the walk, folded to lower case.
+///
+/// SQL scoping nests inward: a name bound by an outer query's `WITH` is
+/// visible inside that query's subqueries, so the set is passed down. It never
+/// travels back up — a CTE bound inside a subquery is invisible outside it.
+type CteScope = HashSet<String>;
+
+/// The names `query`'s own `WITH` clause binds, added to those already visible.
+///
+/// Every CTE in the clause is visible in the main body, so the whole clause is
+/// bound at once. That is enough while CTE **bodies** are not walked. When
+/// they are (#1867), the binding must become incremental: inside CTE *i* only
+/// CTEs 1..*i*-1 are visible, plus *i* itself when the clause is `RECURSIVE`.
+/// Binding the whole clause up front there would read a real table reference
+/// in an earlier body as a reference to a later CTE, and drop its edge.
+fn bind_cte_names(query: &Query, outer: &CteScope) -> CteScope {
+    let mut scope = outer.clone();
+    if let Some(with) = &query.with {
+        for cte in &with.cte_tables {
+            scope.insert(cte.alias.name.value.to_lowercase());
+        }
+    }
+    scope
+}
+
+fn extract_query_lineage(query: &Query, outer_ctes: &CteScope) -> Result<LineageResult, String> {
+    let ctes = bind_cte_names(query, outer_ctes);
     match query.body.as_ref() {
         SetExpr::Select(select) => {
-            let source_tables = extract_tables(&select.from);
+            let source_tables = extract_tables(&select.from, &ctes);
             let alias_map = build_alias_map(&source_tables);
             let (columns, has_star, unresolved_projections) =
                 extract_select_columns(&select.projection, &alias_map, &source_tables);
@@ -185,30 +240,40 @@ fn extract_query_lineage(query: &Query) -> Result<LineageResult, String> {
                 unresolved_projections,
             })
         }
-        SetExpr::Query(inner) => extract_query_lineage(inner),
+        SetExpr::Query(inner) => extract_query_lineage(inner, &ctes),
         _ => Err("unsupported query type for lineage".to_string()),
     }
 }
 
-fn extract_tables(from: &[TableWithJoins]) -> Vec<TableReference> {
+fn extract_tables(from: &[TableWithJoins], ctes: &CteScope) -> Vec<TableReference> {
     let mut tables = Vec::new();
 
     for table_with_joins in from {
-        extract_table_factor(&table_with_joins.relation, &mut tables);
+        extract_table_factor(&table_with_joins.relation, ctes, &mut tables);
         for join in &table_with_joins.joins {
-            extract_table_factor(&join.relation, &mut tables);
+            extract_table_factor(&join.relation, ctes, &mut tables);
         }
     }
 
     tables
 }
 
-fn extract_table_factor(factor: &TableFactor, tables: &mut Vec<TableReference>) {
+fn extract_table_factor(factor: &TableFactor, ctes: &CteScope, tables: &mut Vec<TableReference>) {
     match factor {
         TableFactor::Table { name, alias, .. } => {
+            let name = name.to_string();
+            // A CTE reference is always a single unqualified name, so a
+            // multi-part read can never be one — checking the whole spelling
+            // is what keeps `v2.orders` from being shadowed by a CTE `orders`.
+            let binding = if ctes.contains(&name.to_lowercase()) {
+                TableBinding::Cte
+            } else {
+                TableBinding::Physical
+            };
             tables.push(TableReference {
-                name: name.to_string(),
+                name,
                 alias: alias.as_ref().map(|a| a.name.value.clone()),
+                binding,
                 derived_columns: None,
                 derived_sources: Vec::new(),
             });
@@ -224,7 +289,7 @@ fn extract_table_factor(factor: &TableFactor, tables: &mut Vec<TableReference>) 
             // inner `SELECT *` (or a nested derived table that doesn't expand)
             // leaves `has_star = true` with no individual columns, in which
             // case we fall back to `None`.
-            let inner = extract_query_lineage(subquery).ok();
+            let inner = extract_query_lineage(subquery, ctes).ok();
             let derived_columns = inner.as_ref().and_then(|inner| {
                 if inner.has_star || inner.columns.is_empty() {
                     None
@@ -253,6 +318,7 @@ fn extract_table_factor(factor: &TableFactor, tables: &mut Vec<TableReference>) 
             tables.push(TableReference {
                 name: "(subquery)".to_string(),
                 alias: Some(a.name.value.clone()),
+                binding: TableBinding::Physical,
                 derived_columns,
                 derived_sources,
             });
@@ -855,5 +921,99 @@ mod tests {
         assert_eq!(avg.source_table, None);
         // The sourced column still resolves normally.
         assert!(by_name.contains_key("customer_id"));
+    }
+
+    /// #1892: a `WITH`-bound name looks exactly like a table read, and a
+    /// consumer that cannot tell them apart derives an edge to a model that
+    /// the query never reads.
+    #[test]
+    fn a_cte_reference_is_not_a_table_read() {
+        let result = extract_lineage("WITH orders AS (SELECT 2 AS id) SELECT id FROM orders")
+            .unwrap();
+
+        assert_eq!(result.source_tables.len(), 1);
+        assert_eq!(result.source_tables[0].name, "orders");
+        assert_eq!(result.source_tables[0].binding, TableBinding::Cte);
+
+        assert!(
+            referenced_tables("WITH orders AS (SELECT 2 AS id) SELECT id FROM orders")
+                .unwrap()
+                .is_empty(),
+            "a CTE names no object outside the query, so nothing can depend on it"
+        );
+    }
+
+    /// The other half of the same rule, and the one that keeps the fix from
+    /// suppressing real edges: the SAME spelling with no `WITH` clause is an
+    /// ordinary read and must stay one.
+    #[test]
+    fn the_same_name_without_a_with_clause_is_still_a_table_read() {
+        let result = extract_lineage("SELECT id FROM orders").unwrap();
+
+        assert_eq!(result.source_tables[0].binding, TableBinding::Physical);
+        assert_eq!(
+            referenced_tables("SELECT id FROM orders").unwrap(),
+            vec!["orders".to_string()]
+        );
+    }
+
+    /// A query may bind one CTE and read a real table in the same `FROM`.
+    /// Only the bound name is shadowed.
+    #[test]
+    fn only_the_bound_name_is_shadowed() {
+        let result =
+            extract_lineage("WITH c AS (SELECT 1 AS id) SELECT c.id FROM c JOIN orders USING (id)")
+                .unwrap();
+
+        let by_name: HashMap<&str, TableBinding> = result
+            .source_tables
+            .iter()
+            .map(|t| (t.name.as_str(), t.binding))
+            .collect();
+        assert_eq!(by_name["c"], TableBinding::Cte);
+        assert_eq!(by_name["orders"], TableBinding::Physical);
+    }
+
+    /// CTE names fold case, as SQL identifiers do. Without the fold, a project
+    /// writing `WITH Orders AS (…) … FROM orders` would keep the false edge.
+    #[test]
+    fn a_cte_name_shadows_across_case() {
+        let result =
+            extract_lineage("WITH Orders AS (SELECT 1 AS id) SELECT id FROM ORDERS").unwrap();
+
+        assert_eq!(result.source_tables[0].binding, TableBinding::Cte);
+    }
+
+    /// Scope nests inward: a name bound by the outer query is visible inside
+    /// that query's derived tables, so the inner read is shadowed too.
+    #[test]
+    fn an_outer_cte_shadows_inside_a_derived_table() {
+        let result = extract_lineage(
+            "WITH orders AS (SELECT 1 AS id) \
+             SELECT id FROM (SELECT id FROM orders) AS s",
+        )
+        .unwrap();
+
+        assert!(
+            referenced_tables(
+                "WITH orders AS (SELECT 1 AS id) SELECT id FROM (SELECT id FROM orders) AS s"
+            )
+            .unwrap()
+            .is_empty(),
+            "the inner read is the outer CTE, not a table: {:?}",
+            result.source_tables
+        );
+    }
+
+    /// A CTE reference is always a single unqualified name, so a qualified
+    /// read must not be shadowed by a CTE that shares its last part. Checking
+    /// the whole spelling rather than the stem is what buys this.
+    #[test]
+    fn a_qualified_read_is_not_shadowed_by_a_same_stem_cte() {
+        let result =
+            extract_lineage("WITH orders AS (SELECT 1 AS id) SELECT id FROM v2.orders").unwrap();
+
+        assert_eq!(result.source_tables[0].name, "v2.orders");
+        assert_eq!(result.source_tables[0].binding, TableBinding::Physical);
     }
 }

--- a/engine/crates/rocky-sql/src/lineage.rs
+++ b/engine/crates/rocky-sql/src/lineage.rs
@@ -928,8 +928,8 @@ mod tests {
     /// the query never reads.
     #[test]
     fn a_cte_reference_is_not_a_table_read() {
-        let result = extract_lineage("WITH orders AS (SELECT 2 AS id) SELECT id FROM orders")
-            .unwrap();
+        let result =
+            extract_lineage("WITH orders AS (SELECT 2 AS id) SELECT id FROM orders").unwrap();
 
         assert_eq!(result.source_tables.len(), 1);
         assert_eq!(result.source_tables[0].name, "orders");

--- a/engine/crates/rocky-sql/src/lineage.rs
+++ b/engine/crates/rocky-sql/src/lineage.rs
@@ -1016,4 +1016,37 @@ mod tests {
         assert_eq!(result.source_tables[0].name, "v2.orders");
         assert_eq!(result.source_tables[0].binding, TableBinding::Physical);
     }
+
+    /// The CTE name lives on the alias, and an explicit column list puts a
+    /// second thing there. The name must still bind, or the shadow silently
+    /// would not apply to this spelling.
+    ///
+    /// The other spelling worth naming is `WITH x AS MATERIALIZED (…)`, which
+    /// `DatabricksDialect` does not parse at all — so a model using it already
+    /// fails lineage extraction outright, long before binding is asked about.
+    /// That is pre-existing and unrelated to CTE scopes.
+    #[test]
+    fn an_explicit_column_list_still_binds_the_name() {
+        let result =
+            extract_lineage("WITH orders (id) AS (SELECT 1 AS id) SELECT id FROM orders").unwrap();
+
+        assert_eq!(
+            result.source_tables[0].binding,
+            TableBinding::Cte,
+            "the name is bound whatever else the clause carries"
+        );
+    }
+
+    /// A `WITH RECURSIVE` body names itself. The main body's read is still the
+    /// CTE, not a table.
+    #[test]
+    fn a_recursive_cte_binds_its_own_name() {
+        let result = extract_lineage(
+            "WITH RECURSIVE orders AS (SELECT 1 AS id UNION ALL SELECT id + 1 FROM orders \
+             WHERE id < 3) SELECT id FROM orders",
+        )
+        .unwrap();
+
+        assert_eq!(result.source_tables[0].binding, TableBinding::Cte);
+    }
 }


### PR DESCRIPTION
Closes #1892. A CTE named after a model invented a dependency on it — and two models with mutual local CTE names were refused at compile time as a cycle that does not exist.

```
$ rocky compile --models models
Error: circular dependency detected involving: ["alpha", "beta"]
```

Legal SQL. Neither model reads the other. `alpha` has a local CTE called `beta`, `beta` has one called `alpha`.

## The cause is one missing question

`extract_query_lineage` never looked at `query.with`, so the names a `WITH` clause binds were unknown. The main body was then walked by `extract_table_factor`, which sees `TableFactor::Table { name: "orders" }` and has no way to tell a CTE reference from a real table.

```
  WITH orders AS (…)        parsed, then discarded
  SELECT … FROM orders   -> TableFactor::Table { name: "orders" }
                         -> source_tables["orders"]
                         -> classify_table_ref -> ModelRef("orders")
                         -> edge  cte_reader -> orders          INVENTED
```

`resolve_dependencies` classified that name against `model_names`, matched, and added the edge. `topological_sort` then found the cycle.

## The fix names the two things apart

`TableReference` gains a `binding` field, and `TableBinding` is the enum that answers it:

```rust
pub enum TableBinding {
    #[default]
    Physical,
    Cte,
}
```

`extract_query_lineage` now builds a `CteScope` from `query.with` and passes it down. Dependency derivation and `referenced_tables` skip a `Cte` reference.

**This change only ever removes edges.** It cannot turn a compiling project into a refused one — the direction that would need a cycle guard.

## Three rules it has to get right, each with a test

**A CTE reference is always a single unqualified name.** So the check is on the whole spelling, not on the last part: `FROM v2.orders` is not shadowed by a CTE called `orders`. Without that, the fix would silently drop a real edge.

**Names fold case, as SQL identifiers do.** `WITH Orders AS (…) … FROM ORDERS` is one binding, not two names.

**Scope nests inward and never leaks up.** A CTE bound by the outer query is visible inside that query's derived tables, so the scope is threaded through the `Derived` arm. A CTE bound inside a subquery stays there.

The `bind_cte_names` doc records what a later change has to do differently. Binding the whole clause at once is right **only** while CTE bodies are not walked. When #1867 walks them, binding must become incremental — inside CTE *i* only CTEs 1..*i*-1 are visible, plus *i* itself when the clause is `RECURSIVE`. Otherwise this reads a real table reference in an earlier body as a reference to a later CTE and drops its edge:

```sql
WITH a AS (SELECT * FROM orders),   -- a real model read
     orders AS (SELECT 1)            -- the CTE, defined after
SELECT * FROM a
```

## Blast radius, measured rather than assumed

Every other consumer of `lineage.source_tables` is already fail-closed on CTEs, because `lineage_is_provably_complete` refuses any query carrying a `WITH`:

```
  rocky-cli/commands/skip_gate.rs:473    gated   already safe, unchanged
  rocky-cli/commands/backfill.rs:464     gated   already safe, unchanged
  rocky-cli/commands/run.rs:10137        gated   already safe, unchanged
  rocky-cli/commands/run.rs:11827        gated   already safe, unchanged
  rocky-compiler/src/resolve.rs:312      NOT gated   FIXED HERE
  rocky-compiler/src/semantic.rs:324     NOT gated   deliberately untouched
```

`lineage_is_provably_complete` is left exactly as strict. It is the skip gate's fail-safe, its whitelist is about *completeness*, and nothing here changes what the walk covers.

`semantic.rs`'s code is untouched, but its **behaviour changes**, and I had this wrong until I traced it. Correcting it here rather than shipping the claim:

`SELECT *` expansion is gated on `reader_depends_on_it` — #1631's fix, which binds the star to the DAG edge rather than to a name. Removing the invented edge removes exactly what that gate consults. So `SELECT * FROM orders` where `orders` is a CTE stops taking model `orders`'s columns and falls through to `source_schemas`, the same fall-through an external table of that name gets.

That replaces a **wrong** answer, not a right one: the CTE's own columns are what the query returns, and the model's columns were never that. Resolving the star to the CTE body is the further fix and needs `lineage.rs` to carry those columns — #1867's half.

Probed, because "falls through to nothing" is the kind of claim that turns into a new diagnostic:

```
  models/orders.sql     SELECT 1 AS model_col_a, 2 AS model_col_b
  models/cte_star.sql   WITH orders AS (SELECT 9 AS cte_col) SELECT * FROM orders
  models/downstream.sql SELECT model_col_a FROM cte_star

  rocky compile   has_errors: False    only I001 (SELECT * advisory)
```

No new error, no W006, no compile failure. `rocky lineage cte_star` now reports `columns: []` where it used to report the shadowed model's columns. `a_star_over_a_cte_no_longer_takes_the_shadowed_models_columns` pins it.

## Evidence

**Mutation-checked.** `scripts/mutation-check.sh` forcing every reference back to `Physical`:

```
thread 'resolve::tests::mutual_cte_names_do_not_close_a_cycle' panicked at
  model 'alpha' has an invented dependency: ["beta"]
mutation-check: OK — the test failed under mutation, so it is fix-sensitive.
```

**Twelve tests.** Eight in `lineage.rs` for the classification, the three rules above and two more `WITH` spellings, three in `resolve.rs` for the derived graph, one in `semantic.rs` for the star consequence. The third `resolve.rs` test is the one that keeps the fix honest: a query that binds a CTE **and** reads a real model must keep the real edge. Without it, suppressing the whole `FROM` clause would satisfy the other two.

I set out to write the spelling tests as a confidence gap and found one instead. `WITH orders (id) AS (…)` and `WITH RECURSIVE orders AS (…)` both bind correctly and are now pinned. `WITH orders AS MATERIALIZED (…)` does **not** parse under `DatabricksDialect` at all — so a model using it already fails lineage extraction outright, long before binding is asked about. That is pre-existing and unrelated to this change; it is recorded in the test's doc comment rather than left as an unknown.

**Probed with the built binary**, not only by unit test. `rocky compile --models …` on the same four fixtures, before and after:

```
                                                     before      after
  mutual CTE names                                   REFUSED   1 layer
  CTE named after a model            layers                2         1
  plain read of a model  (control)   layers                2         2
  subquery read          (#1867)     layers                1         1
```

The control is the one that matters most: an ordinary `SELECT id FROM orders` still derives its edge. The subquery row is unchanged on purpose — that is #1867's half, and this change does not touch it.

`cargo test -p rocky-sql` 296 passed, `-p rocky-compiler` 486 passed, `-p rocky-core` 2190 passed, `-p rocky-cli` 1965 passed, `-p rocky-engine` green — 0 failed anywhere. Clippy `--all-targets --all-features` clean on both edited crates, `cargo fmt --check` clean.

`LineageResult` is cached in memory only (`Project::lineage_cache`), derives no `JsonSchema`, and reaches no exported CLI output — so there is no schema bump and no codegen cascade. The new field carries `#[serde(default)]` regardless, matching the field beside it.

## What I am least confident about

Whether a model that today relies on the invented edge for its ordering will now run too early. The edge was false — the reader does not read the model — but a project can be accidentally correct: someone writes `WITH orders AS (…)` inside a model that genuinely needs `orders` built first, declares nothing, and the bug orders it anyway. Removing the edge makes that project race. There is no way to distinguish it from a correct project by looking at the SQL, since the read the dependency would come from is not there. I think it is still right to remove — an edge derived from a name the query never reads is not a dependency, and the fix that keeps such a project working is `depends_on` — but the honest statement is that this can surface a latent missing declaration rather than that it cannot.

## What I think is being missed

The deeper issue is that `source_tables` has always been a list of *names* with no record of what kind of thing each name is. `(subquery)` is a magic string in the same field; four separate consumers each re-derive "is this a real read" with their own guard, and one of them (`resolve.rs`) had no guard at all — which is this bug. `TableBinding` gives that field a place to say what it means, and `(subquery)` is the obvious next thing to move into it. Doing that would let `referenced_tables` stop string-matching a sentinel, and would make the next consumer's guard a `match` the compiler checks rather than a comparison someone has to remember.

**Independent red team: not run.** The Codex plugin cannot return a verdict into an autonomous loop, so this is self-reviewed at maximum effort and disclosed as such, per `AGENTS.md`. The defect was found by probing #1867's CTE half with the built binary rather than by reading the code.

Refs #1867, #1631, #1354
