### PR TITLE
test(engine/rocky-cli): the cron drift test drives ticks directly and asserts their outcomes

### DIFF
--- a/engine/crates/rocky-cli/src/commands/scheduler/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/scheduler/mod.rs
@@ -1451,58 +1451,79 @@ cron = "* * * * *"
         );
     }
 
-    /// The loop fires a due cron demand once per tick after the first-sight
-    /// anchor, with no drift: N iterations ⇒ exactly N−1 fires (the first tick
-    /// only anchors), each an occurrence of the every-minute schedule.
+    /// A due cron demand fires once per tick after the first-sight anchor,
+    /// with no drift: N ticks ⇒ exactly N−1 fires (the first only anchors),
+    /// each an occurrence of the every-minute schedule.
+    ///
+    /// Driven through `run_one_tick` directly rather than through
+    /// `run_scheduler`, and this is the point of the test rather than an
+    /// implementation detail (#1890). The loop version synchronised on
+    /// `FakeClock::wait_for_park` and asserted the run count between ticks, so
+    /// a tick that ran and SKIPPED — a held tick lock, a busy state store, an
+    /// unreadable spool: every one of them non-fatal by design — read as a
+    /// missed fire and flaked the test. The clock was never the problem; it is
+    /// injected, and `scheduler/mod.rs` reads no wall clock at all.
+    ///
+    /// So the tick outcomes are collected and asserted too. A skip now names
+    /// itself instead of arriving as an off-by-one count, and the drift
+    /// property is proved where it actually lives — in the tick and its cursor,
+    /// not in the loop that calls it. `run_scheduler`'s own shape stays covered
+    /// by the tests below that still spawn it.
     #[tokio::test]
     async fn fires_due_cron_each_tick_without_drift() {
         let (dir, config_path) = temp_project(CRON_EVERY_MINUTE);
         let state = test_state(dir.path());
-        let clock = FakeClock::new(at(2026, 5, 2, 3, 0));
         let capture = Arc::new(CapturingSpawner::new(0));
-        let shutdown = Drain::new();
-        // These tests drive the loop directly, not through the server, so there is
-        // no startup barrier — hand it a pre-signalled readiness latch.
-        let ready = Drain::new();
-        ready.signal();
-
-        let clock_dyn: Arc<dyn Clock> = clock.clone();
         let spawner: Arc<dyn Spawner> = capture.clone();
-        let task = tokio::spawn(run_scheduler(
-            Arc::clone(&state),
-            config_path,
-            SchedulerConfig {
-                poll_interval: Duration::from_secs(60),
-                drain_timeout: Duration::from_secs(60),
-            },
-            clock_dyn,
-            shutdown.clone(),
-            ready.clone(),
-            spawner,
-            SchedulerMetrics::disabled(),
-        ));
+        let harness = MetricsHarness::new();
+        let metrics = harness.metrics();
+        let shutdown = Drain::new();
+        let clock = FakeClock::new(at(2026, 5, 2, 3, 0));
+        let state_path = dir.path().join(".rocky-state.redb");
+        let rocky_dir = dir.path().join(".rocky");
 
-        // Iteration 1 (now = 03:00): first sight ⇒ anchor, no fire.
-        clock.wait_for_park(1).await;
-        assert_eq!(capture.run_count(), 0, "first sight must not fire");
-
-        // Nine more ticks, one minute apart ⇒ nine fires, one per occurrence.
-        for i in 1..=9u64 {
-            clock.advance(60);
-            clock.wait_for_park(i + 1).await;
-            assert_eq!(
-                capture.run_count(),
-                i as usize,
-                "tick {i} fires exactly one occurrence (no drift, no double)",
-            );
+        // Tick 1 at 03:00 is first sight ⇒ anchor only. Nine more, one minute
+        // apart, are nine occurrences of `* * * * *`.
+        let mut counts = Vec::new();
+        for i in 0..10 {
+            if i > 0 {
+                clock.advance(60);
+            }
+            run_one_tick(
+                &state,
+                &config_path,
+                &state_path,
+                &rocky_dir,
+                clock.as_ref(),
+                &shutdown,
+                spawner.as_ref(),
+                &metrics,
+            )
+            .await;
+            counts.push(capture.run_count());
         }
 
-        shutdown.signal();
-        tokio::time::timeout(Duration::from_secs(5), task)
-            .await
-            .expect("loop exits promptly on shutdown")
-            .unwrap();
+        let points = harness.collect();
+        let outcomes: Vec<(Option<&str>, f64)> = points
+            .iter()
+            .filter(|p| p.name == "rocky.scheduler.ticks")
+            .map(|p| (p.attr("outcome"), p.value))
+            .collect();
 
+        // The cumulative count after each tick. Anything but this is either a
+        // skipped tick or a double fire, and `outcomes` says which.
+        assert_eq!(
+            counts,
+            vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            "one fire per tick after the anchor; tick outcomes were {outcomes:?}",
+        );
+        assert_eq!(
+            outcomes,
+            vec![(Some("completed"), 10.0)],
+            "every tick completed — a non-fatal skip carries its own outcome \
+             label, so ruling it out here is what keeps a skipped tick from \
+             reading as a missed fire",
+        );
         assert_eq!(capture.runs_for("raw").len(), 9);
     }
 


### PR DESCRIPTION
Closes #1890. The flake was not the clock, and my own issue said it was. Correcting that first, because it decides the fix.

## What the report got wrong

`fires_due_cron_each_tick_without_drift` was called "wall-clock sensitive". It is not. The scheduler reads time only through an injected `Arc<dyn Clock>`, and the test hands it a `FakeClock` the test itself advances:

```
grep 'Utc::now()|Instant::now()|SystemTime::now'  scheduler/mod.rs   ->  0 matches
```

So the fix the issue proposed — "drive the clock rather than read it" — was already done, and would have changed nothing.

I also expected a capture racing the park, and that is not there either. `run_one_tick(…).await` completes before the loop sleeps, `FakeClock::sleep` increments `park_count` as its first action, and `CapturingSpawner::run_count` is a mutex-guarded `Vec::len`. A park means the tick finished and its capture is visible.

## What it actually was

A tick that **ran and skipped**. `run_one_tick`'s own doc says so:

> Every failure mode here is non-fatal to the loop: a config parse error, a permit held by an API job, or a tick fault each skip this iteration and the loop lives on.

and its span already records which one:

```
rocky.scheduler.outcome     rocky.scheduler.state_busy
rocky.scheduler.skipped     rocky.scheduler.lock_overridden
rocky.scheduler.drained     rocky.scheduler.spool_unreadable
```

The test passed `SchedulerMetrics::disabled()`, threw all of that away, and asserted a bare count between ticks. So a skip arrived as:

```
assertion `left == right` failed: tick 2 fires exactly one occurrence (no drift, no double)
  left: 1
 right: 2
```

which is indistinguishable from the regression the test exists to catch. That is what taught everyone to re-run it.

## The fix

Drive `run_one_tick` in a loop — the shape `drive_ticks_with_metrics_prepared` in the same module already uses — collect the tick outcomes, and assert both:

```rust
assert_eq!(
    counts, vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
    "one fire per tick after the anchor; tick outcomes were {outcomes:?}",
);
assert_eq!(outcomes, vec![(Some("completed"), 10.0)], …);
```

A skip now names itself. `[(Some("state_busy"), …)]` in the message is a diagnosis; `[(Some("completed"), 10.0)]` with a short count is a real regression and worth stopping for.

**The drift property is proved where it lives.** It is a property of the tick and its cursor, not of the loop that calls the tick. Removing `run_scheduler` from this test removes the concurrency, not the coverage — and `run_scheduler`'s own shape stays covered by the five tests below this one that still spawn it.

I did **not** take the "assert a range instead" stopgap the issue offered. It would hide exactly the case worth catching.

## Evidence

The assertion caught its own expectation being wrong on the first run, which is the cheapest possible demonstration that it reports the outcome:

```
left:  [(Some("completed"), 10.0)]
right: [(Some("reconciled"), 10.0)]
```

`completed` is the real label; I had guessed `reconciled`. Fixed, and the message now carries the outcome either way.

`cargo test -p rocky-cli --lib` 1965 passed, 0 failed. Clippy `--all-targets --all-features` clean, `cargo fmt --check` clean. No production code changed — this is a test-only diff.

## What I am least confident about

Whether `state_busy` was genuinely the skip that fired. I named it as the class that fits "under parallel load", but each test builds its own redb in its own temp dir, so there is no cross-test contention by construction, and I have not proved a single test's tick can collide with itself. The other candidates — the tick lock and the spool read — fit the shape equally well. The change does not depend on which one it was: it makes the next occurrence say so instead of leaving it to be inferred, which is the part I could not do from the original panic message.

## What I think is being missed

This is the third report in a row with one shape: a non-fatal skip that is recorded and then discarded by the caller that needed it. #1876 and #1877 were both "a fault became a default and nothing said so"; this is "a skip became a missing fire and nothing said so". The scheduler computes the right answer on every tick. The test harness was the only consumer throwing it away, and `SchedulerMetrics::disabled()` is the switch that did it — quietly, in the nine call sites that remain in this module. A double that captured outcomes by default would make that class visible at the point of failure rather than after it.

**Independent red team: not run.** The Codex plugin cannot return a verdict into an autonomous loop, so this is self-reviewed at maximum effort and disclosed as such, per `AGENTS.md`. The correction came from grepping for wall-clock reads before trusting my own report of one.

Refs #1827, #1877, #1876
