### PR TITLE
fix(engine/rocky-cli): the inline drain returns an abort decision, so fail_fast and the error-rate abort act on it too

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -14233,7 +14233,10 @@ pub(crate) enum AbortCause {
     FailFast,
     /// `[execution] error_rate_abort_pct` — too many of the completions so far
     /// failed. Both numbers are carried so the log says what tripped it.
-    ErrorRate { observed_pct: u32, threshold_pct: u32 },
+    ErrorRate {
+        observed_pct: u32,
+        threshold_pct: u32,
+    },
 }
 
 /// What the caller must do after a drain collected one completion.

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -5004,8 +5004,17 @@ pub async fn run(
         });
     }
 
+    // Set when an inline drain hits `fail_fast` or the error-rate threshold.
+    // The drain cannot abort the loop it runs inside, so it returns the cause
+    // and the abort happens here (#1724).
+    let mut drain_abort: Option<AbortCause> = None;
+    let abort_policy = AbortPolicy {
+        fail_fast,
+        error_rate_abort_pct,
+    };
+
     for (idx, task) in tables_to_process.iter().enumerate() {
-        if interrupted || freeze_withheld.is_some() {
+        if interrupted || freeze_withheld.is_some() || drain_abort.is_some() {
             break;
         }
 
@@ -5015,7 +5024,7 @@ pub async fn run(
         // spawning and collection, enabling the AIMD feedback loop.
         if throttle.is_some() {
             while let Some(completed) = join_set.try_join_next() {
-                process_completed_result(
+                let decision = process_completed_result(
                     completed,
                     &tables_to_process,
                     &throttle,
@@ -5041,8 +5050,30 @@ pub async fn run(
                     &shared_state,
                     &shared_run_id,
                     &mut total_completed,
+                    &abort_policy,
                 )
                 .await;
+                if let DrainDecision::AbortRemaining(cause) = decision {
+                    match cause {
+                        AbortCause::FailFast => {
+                            warn!("fail_fast: a table failed, aborting remaining tables")
+                        }
+                        AbortCause::ErrorRate {
+                            observed_pct,
+                            threshold_pct,
+                        } => warn!(
+                            error_rate = observed_pct,
+                            threshold = threshold_pct,
+                            "error rate exceeded threshold, aborting remaining tables"
+                        ),
+                    }
+                    join_set.abort_all();
+                    drain_abort = Some(cause);
+                    break;
+                }
+            }
+            if drain_abort.is_some() {
+                break;
             }
         }
 
@@ -5101,6 +5132,13 @@ pub async fn run(
     // hard-exit watcher and flips `interrupted = true`; tasks already in
     // flight keep running and their results are still collected below.
     loop {
+        // An inline drain already aborted every remaining task. Joining them
+        // would collect one cancellation per table as a fresh "task failed"
+        // error — noise the final drain's own abort path avoids by breaking
+        // rather than draining (#1724).
+        if drain_abort.is_some() {
+            break;
+        }
         let result = tokio::select! {
             res = join_set.join_next() => match res {
                 Some(r) => r,
@@ -14177,6 +14215,42 @@ async fn collect_materialized_table(
 
 /// Processes a single completed task result during the spawn loop's inline
 /// drain pass (adaptive concurrency only). This avoids duplicating the
+/// The two `[execution]` settings that can stop a run before its last table.
+///
+/// Carried as its own struct rather than threading the whole pipeline config:
+/// these are the only two fields an inline drain's decision depends on, and a
+/// wider struct would let a later edit reach settings this path has no business
+/// reading.
+pub(crate) struct AbortPolicy {
+    pub fail_fast: bool,
+    pub error_rate_abort_pct: u32,
+}
+
+/// Why a drain asked its caller to stop the run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AbortCause {
+    /// `[execution] fail_fast` — the first failed table ends the run.
+    FailFast,
+    /// `[execution] error_rate_abort_pct` — too many of the completions so far
+    /// failed. Both numbers are carried so the log says what tripped it.
+    ErrorRate { observed_pct: u32, threshold_pct: u32 },
+}
+
+/// What the caller must do after a drain collected one completion.
+///
+/// The inline drain runs INSIDE the spawn loop and does not own the `JoinSet`
+/// the caller is still feeding, so it cannot abort that loop itself. Returning
+/// the decision is what lets `fail_fast` and `error_rate_abort_pct` act from
+/// this path at all (#1724) — acting here would abort a set the caller is
+/// still adding to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DrainDecision {
+    /// Nothing about this completion stops the run.
+    Continue,
+    /// Stop spawning and abort every table still in flight.
+    AbortRemaining(AbortCause),
+}
+
 /// result-handling logic from the main collection loop for results that
 /// arrive while we're still spawning tasks.
 ///
@@ -14184,14 +14258,19 @@ async fn collect_materialized_table(
 /// place a `TableResult` is consumed (#1718). The other three arms — pruned,
 /// failed and panicked — stay here: they are not a `TableResult`.
 ///
-/// The failed arm now matches the final drain on the two things an operator
-/// sees: the warehouse auth framing on `TableErrorOutput.error`, and the
-/// `materialize_error` hook (#1724). Two differences remain, and they are
-/// structural rather than oversights — an inline drain inside the spawn loop
-/// cannot break that loop, so neither `fail_fast`'s `abort_all` nor the
-/// `error_rate_abort_pct` check can act from here. Closing those means
-/// returning a decision to the caller instead of acting, which is a different
-/// change; it is tracked on #1724.
+/// The failed arm matches the final drain on the two things an operator sees:
+/// the warehouse auth framing on `TableErrorOutput.error`, and the
+/// `materialize_error` hook (#1724, first half).
+///
+/// The remaining two differences were structural — an inline drain inside the
+/// spawn loop cannot break that loop — so it returns a [`DrainDecision`]
+/// instead of acting, and the caller aborts. `fail_fast` and
+/// `error_rate_abort_pct` are therefore live on this path too, which under the
+/// default `ConcurrencyMode::Adaptive` is the path most tables take.
+///
+/// The order matches the final drain exactly: `fail_fast` is asked first and
+/// wins, then the error rate is checked on every completion — not only on a
+/// failed one, because a success moves the denominator.
 #[allow(clippy::too_many_arguments)]
 async fn process_completed_result(
     result: Result<(usize, Result<TableOutcome, anyhow::Error>), tokio::task::JoinError>,
@@ -14205,8 +14284,10 @@ async fn process_completed_result(
     shared_state: &Arc<StateStore>,
     shared_run_id: &str,
     total_completed: &mut usize,
-) {
+    policy: &AbortPolicy,
+) -> DrainDecision {
     *total_completed += 1;
+    let mut failed = false;
 
     match result {
         Ok((idx, Ok(TableOutcome::Pruned(pruned)))) => {
@@ -14259,7 +14340,10 @@ async fn process_completed_result(
                     rocky_core::state::TableStatus::Skipped,
                 )
                 .await;
-                return;
+                // A missing source table is a skip, not a failure: it enters no
+                // error and must not move the rate. The final drain's own
+                // `continue` past its rate check is the behaviour mirrored here.
+                return DrainDecision::Continue;
             }
 
             let table_key = tables_to_process
@@ -14333,6 +14417,7 @@ async fn process_completed_result(
                 failure_kind,
                 cooldown_seconds,
             });
+            failed = true;
         }
         Err(e) => {
             let msg = format!("task failed: {e}");
@@ -14361,8 +14446,25 @@ async fn process_completed_result(
                 failure_kind: FailureKind::Unknown,
                 cooldown_seconds: None,
             });
+            failed = true;
         }
     }
+
+    if failed && policy.fail_fast {
+        return DrainDecision::AbortRemaining(AbortCause::FailFast);
+    }
+    // Same guards as the final drain: the threshold is opt-in, and a rate over
+    // fewer than four completions is too noisy to act on.
+    if policy.error_rate_abort_pct > 0 && *total_completed >= 4 {
+        let observed_pct = (table_errors.len() as f64 / *total_completed as f64 * 100.0) as u32;
+        if observed_pct >= policy.error_rate_abort_pct {
+            return DrainDecision::AbortRemaining(AbortCause::ErrorRate {
+                observed_pct,
+                threshold_pct: policy.error_rate_abort_pct,
+            });
+        }
+    }
+    DrainDecision::Continue
 }
 
 /// Returns `true` if the error message indicates a warehouse rate limit.
@@ -17636,6 +17738,10 @@ http_path = "/sql/1.0/warehouses/abc) shadow(schema=x"
                 &store,
                 "run-1",
                 &mut total_completed,
+                &AbortPolicy {
+                    fail_fast: false,
+                    error_rate_abort_pct: 0,
+                },
             )
             .await;
         }
@@ -22793,6 +22899,10 @@ timestamp_column = "ts"
             &state,
             "run-1",
             &mut total_completed,
+            &AbortPolicy {
+                fail_fast: false,
+                error_rate_abort_pct: 0,
+            },
         )
         .await;
 
@@ -35816,6 +35926,142 @@ timestamp_column = "ts"
         }
     }
 
+    /// #1724: the inline drain returns the abort decision instead of acting,
+    /// so `fail_fast` finally reaches the path that collects most tables under
+    /// the default `ConcurrencyMode::Adaptive`.
+    ///
+    /// Four cases in one, because what matters is that each setting fires on
+    /// exactly its own trigger — a decision that always aborts would satisfy
+    /// any single case.
+    #[tokio::test]
+    async fn the_inline_drain_returns_the_abort_decision_for_both_settings() {
+        async fn decide(
+            outcome: Result<(usize, Result<TableOutcome, anyhow::Error>), tokio::task::JoinError>,
+            policy: &AbortPolicy,
+            prior_errors: usize,
+            prior_completed: usize,
+        ) -> DrainDecision {
+            let dir = tempfile::tempdir().unwrap();
+            let state = Arc::new(StateStore::open(&dir.path().join("state.redb")).unwrap());
+            let hook_registry = HookRegistry::from_config(&Default::default());
+            let tasks = vec![column_match_task(vec![], vec![])];
+            state
+                .init_run_progress(
+                    "run-1",
+                    &tasks.iter().map(table_key).collect::<Vec<_>>(),
+                    Some(&test_resume_scope("p1")),
+                )
+                .unwrap();
+
+            let semaphore = Semaphore::new(8);
+            let mut semaphore_capacity = 8;
+            let mut output = RunOutput::new(String::new(), 0, 1);
+            let mut pending_checks = HashMap::new();
+            let (mut source_refs, mut target_refs, mut freshness_refs) =
+                (Vec::new(), Vec::new(), Vec::new());
+            let mut batch_asset_keys = Vec::new();
+            let mut assertion_targets = Vec::new();
+            let (mut deferred_tags, mut deferred_watermarks) = (Vec::new(), Vec::new());
+            // Stand in for the failures already collected this run: the rate is
+            // errors over completions, so both sides have to be primed.
+            let mut table_errors: Vec<TableError> = (0..prior_errors)
+                .map(|_| TableError {
+                    asset_key: vec![],
+                    error: "earlier failure".to_string(),
+                    task_index: None,
+                    failure_kind: FailureKind::Unknown,
+                    cooldown_seconds: None,
+                })
+                .collect();
+            let mut total_completed = prior_completed;
+
+            process_completed_result(
+                outcome,
+                &tasks,
+                &None,
+                &semaphore,
+                &mut semaphore_capacity,
+                &mut MaterializedSinks {
+                    output: &mut output,
+                    pending_checks: &mut pending_checks,
+                    source_batch_refs: &mut source_refs,
+                    target_batch_refs: &mut target_refs,
+                    freshness_batch_refs: &mut freshness_refs,
+                    batch_asset_keys: &mut batch_asset_keys,
+                    assertion_targets: &mut assertion_targets,
+                    deferred_tags: &mut deferred_tags,
+                    deferred_watermarks: &mut deferred_watermarks,
+                },
+                &TableHookContext {
+                    registry: &hook_registry,
+                    run_id: "run-1",
+                    pipeline_name: "p1",
+                },
+                &mut table_errors,
+                &state,
+                "run-1",
+                &mut total_completed,
+                policy,
+            )
+            .await
+        }
+
+        let fail_fast = AbortPolicy {
+            fail_fast: true,
+            error_rate_abort_pct: 0,
+        };
+        let rate_50 = AbortPolicy {
+            fail_fast: false,
+            error_rate_abort_pct: 50,
+        };
+        let failure = || Ok((0usize, Err(anyhow::anyhow!("the warehouse said no"))));
+
+        assert_eq!(
+            decide(failure(), &fail_fast, 0, 0).await,
+            DrainDecision::AbortRemaining(AbortCause::FailFast),
+            "a failed table under fail_fast must stop the run from this path too",
+        );
+
+        // The success arm is the guard against a decision that always aborts.
+        assert_eq!(
+            decide(
+                Ok((
+                    0,
+                    Ok(TableOutcome::Pruned(PrunedTable {
+                        asset_key: vec!["t".into()],
+                        source_schema: "raw".into(),
+                        table_name: "orders".into(),
+                    })),
+                )),
+                &fail_fast,
+                0,
+                0,
+            )
+            .await,
+            DrainDecision::Continue,
+            "fail_fast reacts to a failure, not to every completion",
+        );
+
+        // Three prior errors + this one over four completions = 100%.
+        assert_eq!(
+            decide(failure(), &rate_50, 3, 3).await,
+            DrainDecision::AbortRemaining(AbortCause::ErrorRate {
+                observed_pct: 100,
+                threshold_pct: 50,
+            }),
+            "the error-rate abort must see the inline drain's completions",
+        );
+
+        // The same failure below the four-completion floor must NOT abort —
+        // that guard is what keeps one early failure from ending a large run,
+        // and it is the half a decision that always aborts would break.
+        assert_eq!(
+            decide(failure(), &rate_50, 1, 1).await,
+            DrainDecision::Continue,
+            "under four completions the rate is too noisy to act on",
+        );
+    }
+
     /// #1724. The inline drain's ERROR arm must match the final drain on the
     /// two things an operator sees: the warehouse-auth framing, and the
     /// `materialize_error` hook.
@@ -35916,6 +36162,10 @@ timestamp_column = "ts"
             &state,
             "run-1",
             &mut total_completed,
+            &AbortPolicy {
+                fail_fast: false,
+                error_rate_abort_pct: 0,
+            },
         )
         .await;
 
@@ -35989,6 +36239,10 @@ timestamp_column = "ts"
             &state,
             "run-1",
             &mut total_completed,
+            &AbortPolicy {
+                fail_fast: false,
+                error_rate_abort_pct: 0,
+            },
         )
         .await;
 


### PR DESCRIPTION
Closes #1724. The issue's first two rows shipped in #1754; this closes the remaining two, which were the structural ones.

`ConcurrencyMode::Adaptive` is `#[default]`, so the inline drain inside the spawn loop collects most tables once the semaphore saturates. It could not abort that loop, so `[execution] fail_fast` and `[execution] error_rate_abort_pct` were **silently inert** for every table it collected.

```
                         final drain    inline drain (default path)
frame_warehouse_error       yes            yes    <- #1754
materialize_error hook      fires          fires  <- #1754
fail_fast -> abort_all      yes            NO     <- here
error_rate_abort_pct        yes            NO     <- here
```

## Return the decision, don't act on it

The drain does not own the `JoinSet` the caller is still feeding, so aborting from inside it would abort a set still being added to. It answers instead:

```rust
pub(crate) enum DrainDecision {
    Continue,
    AbortRemaining(AbortCause),
}

pub(crate) enum AbortCause {
    FailFast,
    ErrorRate { observed_pct: u32, threshold_pct: u32 },
}
```

and the spawn loop acts: log the cause, `join_set.abort_all()`, stop spawning. `AbortCause` carries both numbers so the log says what tripped it rather than only that something did.

The two settings arrive as `AbortPolicy { fail_fast, error_rate_abort_pct }` — those two fields and no more. Threading the pipeline config would let a later edit reach settings this path has no business reading.

## The order and the guards mirror the final drain exactly

- `fail_fast` is asked first and wins.
- The error rate is then checked on **every** completion, not only a failed one — a success moves the denominator.
- The rate is opt-in (`> 0`) and floored at four completions, so one early failure cannot end a large run.
- A `TABLE_OR_VIEW_NOT_FOUND` skip returns `Continue` without touching the rate, matching the final drain's `continue` past its own check. A missing source table is a skip, not a failure, and must not move the numerator.

Getting any of these wrong would have made the inline path abort on inputs the final path tolerates — the same divergence in the other direction.

## The cancelled tasks

After an inline `abort_all()`, the final drain would `join_next()` each aborted task and record `task failed: … cancelled` as a fresh `TableError` — one per remaining table, which would also feed the very error rate that may have triggered the abort.

So the final drain breaks immediately when an inline abort happened. That is what the final drain's own abort path already does: `abort_all(); break;` leaves the cancelled tasks unjoined rather than collecting them.

## Evidence

**Mutation-checked.** `scripts/mutation-check.sh` removing the `fail_fast` return:

```
left:  Continue
right: AbortRemaining(FailFast)
mutation-check: OK — the test failed under mutation, so it is fix-sensitive.
```

**One test, four cases**, because each setting has to fire on its own trigger and a decision that always aborted would satisfy any single case:

```
  failed table, fail_fast on              -> AbortRemaining(FailFast)
  PRUNED table, fail_fast on              -> Continue
  failed table, 4 completions, 100% > 50% -> AbortRemaining(ErrorRate{100, 50})
  failed table, 2 completions, 100% > 50% -> Continue   (under the floor)
```

The second and fourth are the guards. Without them "always abort" passes.

`cargo test -p rocky-cli` 1966 passed, 0 failed, across every target. Clippy `--all-targets --all-features` clean, `cargo fmt --check` clean.

## What I am least confident about

Whether skipping the final drain after an inline abort loses a completion worth keeping. A table that finished successfully between the aborting completion and the `abort_all()` is sitting in the `JoinSet` and is now never collected, so its materialization is not reported and its watermark is not flushed — even though its data landed. The final drain's own abort path has exactly this property today, so this is consistent rather than new, and the alternative is worse: draining after an abort collects one cancellation per remaining table as a failure. But "consistent with the existing behaviour" is not the same as "right", and if that lost success matters, it matters on both paths and wants its own issue rather than a difference between them.

## What I think is being missed

The two drains are still two implementations of the same match. #1718 unified the materialized arm, #1754 aligned the framing and the hook, and this aligns the abort decision — three PRs, each closing one column of the same table, with the pruned and panicked arms still duplicated. The remaining divergence is small enough to be invisible and exactly the kind that grows back: the next arm someone edits will be edited in one place. Now that the decision is returned rather than acted on, the final drain could call `process_completed_result` too and act on the same `DrainDecision`, which would leave one implementation instead of two. That is a bigger change than this one and wants its own review, but it is the shape that stops this table reappearing.

**Independent red team: not run.** The Codex plugin cannot return a verdict into an autonomous loop, so this is self-reviewed at maximum effort and disclosed as such, per `AGENTS.md`.

Refs #1718, #1754
