### PR TITLE
fix(dagster): a compliance scan that crashed reports not-evaluated, not passed

### DIFF
--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -3042,7 +3042,23 @@ def _emit_governance_events(
         try:
             compliance_output = rocky.compliance()
         except Exception as exc:  # noqa: BLE001
-            context.log.warning(f"rocky compliance failed, skipping compliance events: {exc}")
+            # A crashed scan is not a clean scan. `compliance_exception` is in
+            # PASS_BY_ABSENCE_CHECK_NAMES, so yielding nothing here would let
+            # the placeholder report `passed=True` — a green badge for a scan
+            # that never produced a verdict (#1790). Say so on every asset that
+            # declared the spec, which is every selected one.
+            context.log.warning(f"rocky compliance failed, reporting it on every asset: {exc}")
+            for key in sorted(selected_keys, key=lambda k: k.path):
+                yield dg.AssetCheckResult(
+                    asset_key=key,
+                    check_name=COMPLIANCE_CHECK_NAME,
+                    passed=False,
+                    severity=dg.AssetCheckSeverity.WARN,
+                    metadata={
+                        "status": "not_evaluated",
+                        "reason": f"rocky compliance failed: {exc}",
+                    },
+                )
         else:
             yield from compliance_check_results(compliance_output, key_resolver=resolver)
 

--- a/integrations/dagster/tests/test_execution.py
+++ b/integrations/dagster/tests/test_execution.py
@@ -696,8 +696,24 @@ def test_governance_compliance_drops_exceptions_for_unknown_models(
 def test_governance_compliance_failure_does_not_fail_materialization(
     discover_json: str, run_json: str, tmp_path: Path
 ):
-    """If ``rocky compliance`` raises, the multi-asset logs a warning and
-    continues — the drift/anomaly path has the same tolerance."""
+    """If ``rocky compliance`` raises, the multi-asset logs a warning and the
+    materialization still succeeds — but the check reports NOT EVALUATED, not
+    passed (#1790).
+
+    This assertion was reversed deliberately. It used to require
+    ``passed is True``, on the reading that a transient governance read failure
+    is "not a user-facing compliance violation". That is true and is not the
+    question: ``passed=True`` claims the scan ran and found nothing, and a scan
+    that crashed did neither. The third answer — evaluated, clean, or not
+    evaluated — is what WARN plus ``status: not_evaluated`` says, and it is the
+    rule this codebase already settled one layer down in #1741 and again for
+    measurement checks in #1645: a check that did not run is not a check that
+    passed.
+
+    What has NOT changed is the tolerance the old name describes: the
+    materialization still succeeds. A governance read failure degrades a check,
+    it does not fail the run.
+    """
     defs = _build_defs_with_flags(discover_json, tmp_path, surface_compliance=True)
     run_result = RunResult.model_validate_json(run_json)
     orders_key = dg.AssetKey(["fivetran", "acme", "us_west", "shopify", "orders"])
@@ -716,24 +732,24 @@ def test_governance_compliance_failure_does_not_fail_materialization(
             raise_on_error=False,
         )
 
-    # Materialization still succeeds — compliance error is swallowed.
+    # The failure degrades the check; it does not fail the run.
     assert exec_result.success
-    # The pre-declared ``compliance_exception`` spec still produces a
-    # placeholder (Dagster requires every declared spec to yield a
-    # result) — but the placeholder passes rather than propagating the
-    # binary crash as a WARN. That's the design: a transient governance
-    # read failure is a logged-and-skipped event, not a user-facing
-    # compliance violation.
     check_evaluations = [
         e for e in exec_result.all_events if e.event_type_value == "ASSET_CHECK_EVALUATION"
     ]
     compliance_checks = [
         e for e in check_evaluations if e.event_specific_data.check_name == "compliance_exception"
     ]
-    # Exactly one placeholder result, and it must be passing (not WARN).
+    # Exactly one result — the explicit not-evaluated one, which also means the
+    # PASS_BY_ABSENCE placeholder did not fire. If it had, this would be two.
     assert len(compliance_checks) == 1
     eval_data = compliance_checks[0].event_specific_data
-    assert eval_data.passed is True
+    assert eval_data.passed is False, (
+        "a compliance scan that crashed must not report a green badge (#1790)"
+    )
+    assert eval_data.severity == dg.AssetCheckSeverity.WARN
+    assert eval_data.metadata["status"].value == "not_evaluated"
+    assert "simulated binary crash" in eval_data.metadata["reason"].value
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes the `compliance_exception` half of #1790. The `row_count_anomaly` half stays open: it needs the engine field #1645's second half is about, and this change does not touch it.

A `rocky compliance` subprocess failure was logged and swallowed, yielding nothing. `compliance_exception` is in `PASS_BY_ABSENCE_CHECK_NAMES`, so the placeholder then reported `passed=True`.

```
  rocky compliance raises
        |
        v
  except: log.warning, yield NOTHING
        |
        v
  placeholder loop: name is PASS_BY_ABSENCE  ->  passed = True
        |
        v
  green badge for a scan that produced no verdict
```

A crashed scan is indistinguishable from a clean one, which is the whole defect #1645 was filed about, surviving inside the exception list added to fix it.

## The fix

The `except` branch yields an explicit result on every selected asset instead of nothing:

```python
passed=False
severity=dg.AssetCheckSeverity.WARN
metadata={"status": "not_evaluated", "reason": f"rocky compliance failed: {exc}"}
```

`selected_keys` is the right set because `_build_check_specs` declares the spec on **every** asset when `surface_compliance` is on (`component.py:2446`) — not on a subset. Yielding a real result also suppresses the placeholder for those keys, which is what closes the hole rather than merely reporting alongside it.

## I reversed a deliberate assertion, and I am saying so

`test_governance_compliance_failure_does_not_fail_materialization` required `eval_data.passed is True`, with this justification in the test itself:

> the placeholder passes rather than propagating the binary crash as a WARN. That's the design: a transient governance read failure is a logged-and-skipped event, not a user-facing compliance violation.

The first half of that is right and is not the question. A crash is not a compliance violation — but `passed=True` does not say "no violation", it says **the scan ran and found nothing**, and a scan that crashed did neither. The answer is a third value, and Dagster spells it WARN with `status: not_evaluated`.

That is the rule this codebase already settled twice:

```
  #1741   engine     a check that did not run is not a check that passed
  #1645   dagster    measurement checks: silence -> passed=False + WARN
  here    dagster    an EVENT check whose producer crashed is the same case
```

`PASS_BY_ABSENCE` is sound when the producer ran and had nothing to say. It was applied to a producer that may not have run at all — the assumption #1790 names.

What has not changed is the tolerance the test's name describes: **the materialization still succeeds.** A governance read failure degrades a check; it does not fail the run. That assertion is kept, and the test's docstring now states both halves.

## Evidence

The rewritten test would fail on either mistake:

```
  passed is False                        the crash is not reported as clean
  len(compliance_checks) == 1            the placeholder did NOT also fire
  severity == WARN                       degraded, not a violation
  metadata["status"] == "not_evaluated"  says which of the three it is
  "simulated binary crash" in reason     the cause reaches the operator
```

The length assertion is the one that pins the actual mechanism: if the explicit result did not suppress the placeholder, there would be two.

`uv run pytest` 773 passed, 0 failed. `ruff check` clean, `ruff format --check` clean — 54 files already formatted. No schema change, so no `just codegen` and no fixture regeneration.

## What I am least confident about

Whether yielding on every selected key is right when only some of them materialized. The placeholder loop checks `cs.asset_key in materialized_keys` first and reports `passed=False, "table not materialized"` for the rest, so before this change an unmaterialized asset already got a failing compliance result for a different reason. Now it gets mine instead, and "rocky compliance failed" is a less accurate explanation for that asset than "table not materialized" was. Both are failing and both are WARN, so no badge changes colour — but the reason string is worse for that case, and I did not find a clean way to reach `materialized_keys` from `_emit_governance_events` without widening its signature.

## What I think is being missed

The remaining half of #1790 is the more serious one and this change cannot reach it. `row_count_anomaly` is declared unconditionally by Dagster but produced conditionally by the engine (`run.rs:6499`, gated on `row_count_enabled && state_store`), and Dagster has no way to learn which — `ChecksConfigOutput` carries only `freshness` and `configured_checks`, and `configured_checks` excludes the four defaults by design. So with `row_count = false` in `rocky.toml`, the green badge for a detector that never ran is still there after this PR. That makes #1645's second half load-bearing for correctness rather than for noise, which is a re-characterisation #1790 already makes and which is worth not losing.

The narrower lesson: `PASS_BY_ABSENCE_CHECK_NAMES` is a claim about a **producer**, held in a list of consumer-side **names**. Nothing ties an entry to the condition under which its producer runs, so the next event check added to that list inherits the same unchecked assumption.

**Independent red team: not run.** The Codex plugin cannot return a verdict into an autonomous loop, so this is self-reviewed at maximum effort and disclosed as such, per `AGENTS.md`. #1790 itself came from an independent Codex review of #1786 and #1782.

Refs #1645, #1782, #1741, #1619
