### PR TITLE
fix(engine/rocky-sql): a read inside a subquery or a WITH body derives its DAG edge

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -28264,22 +28264,34 @@ auto_create_schemas = true
         );
     }
 
-    /// GUARANTEE-BOUNDARY parity (intentional, not a latent bug): for a read
-    /// Rocky cannot statically resolve — a CTE / anything `lineage_is_provably_
-    /// complete` rejects, i.e. an "uncertain" model — containment behaves
-    /// *identically* to a normal fail-fast run. Under `--parallel 2` a same-layer
-    /// uncertain reader of a failed producer materializes on stale data in BOTH
-    /// modes; that is a pre-existing property of parallel fail-fast, not a
-    /// containment regression.
+    /// Containment ⊆ fail-fast, on a CTE read — and **the boundary moved**
+    /// under it (#1867).
     ///
-    /// This test locks the achievable invariant — **containment never
-    /// materializes anything fail-fast wouldn't** (containment ⊆ fail-fast) — by
-    /// running the same project twice under `--parallel 2`, once with
-    /// `contain_failures = false` and once `= true`, and asserting identical
-    /// materialization sets. It will catch a future change that either
-    /// over-contains (would false-fail healthy CTE projects) or regresses below
-    /// fail-fast. Declaring the dependency via `ref()` lifts the read into the
-    /// resolved, guaranteed set (covered by the resolved-read tests above).
+    /// The invariant this test locks is unchanged: run the same project twice
+    /// under `--parallel 2`, once with `contain_failures = false` and once
+    /// `= true`, and the materialization sets must be identical. It catches a
+    /// change that either over-contains (false-failing healthy CTE projects) or
+    /// regresses below fail-fast.
+    ///
+    /// What changed is the fixture's outcome, and it changed for the better.
+    /// This used to assert that `rollup` **builds** in both modes, on the
+    /// reasoning that its CTE read of the failed producer's target was
+    /// unenumerable, so nothing could order the two and a same-layer reader
+    /// materialized on stale data. That was the documented best-effort
+    /// boundary. Since #1867 the read inside a `WITH` body reaches
+    /// `referenced_tables`, so `derive_physical_edges` matches it against
+    /// `stage_orders`'s target `(main, orders_current)` and
+    /// `augment_physical_read_edges` puts the two in different layers. The
+    /// producer fails, so `rollup` is now withheld — in both modes.
+    ///
+    /// So the assertion is inverted deliberately: `rollup` must NOT build. That
+    /// is exactly the failure #1867 describes (a reader running before its
+    /// producer and reading stale data), and the old assertion pinned it as
+    /// acceptable because nothing could see the read.
+    ///
+    /// Declaring the dependency via `ref()` still lifts the read into the
+    /// resolved, guaranteed set (covered by the resolved-read tests above);
+    /// that path is unchanged and remains the hard guarantee.
     #[cfg(feature = "duckdb")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn containment_matches_fail_fast_for_same_layer_uncertain_read() {
@@ -28309,18 +28321,24 @@ auto_create_schemas = true
         assert_eq!(
             mat_set(&out_ff),
             mat_set(&out_ct),
-            "containment must not materialize anything fail-fast wouldn't for a same-layer \
-             uncertain (CTE) read — the achievable containment ⊆ fail-fast invariant"
+            "containment must not materialize anything fail-fast wouldn't for a CTE read — \
+             the achievable containment ⊆ fail-fast invariant"
         );
         assert!(
-            mat_set(&out_ct).contains("rollup"),
-            "the unenumerable (CTE) reader builds in BOTH modes — the documented best-effort \
-             boundary (declare the dep via ref() for a hard guarantee)"
+            !mat_set(&out_ct).contains("rollup"),
+            "the CTE reader must NOT build on the failed producer's stale target: the read \
+             inside the WITH body is visible since #1867, so the physical-edge derivation \
+             orders the two and the producer's failure withholds the reader; got {:?}",
+            mat_set(&out_ct)
         );
+        // The reader is now withheld for a reason containment can NAME, where
+        // before it was built and the staleness was invisible. Whether that
+        // shows up on `contained` is containment's own bookkeeping; what this
+        // pins is that it is not silently materialized.
         assert!(
-            out_ct.contained.is_empty(),
-            "a same-layer uncertain read is fail-fast parity, NOT over-contained: {:?}",
-            out_ct.contained
+            !mat_set(&out_ff).contains("rollup"),
+            "fail-fast withholds it too, so the two modes agree for the same reason: {:?}",
+            mat_set(&out_ff)
         );
     }
 

--- a/engine/crates/rocky-compiler/src/resolve.rs
+++ b/engine/crates/rocky-compiler/src/resolve.rs
@@ -329,6 +329,24 @@ fn extract_deps_from_lineage(
         }
     }
 
+    // Reads that live inside a derived table or a `WITH` body (#1867). They
+    // are dependencies, not relations the outer query selects from, so they
+    // arrive on their own field rather than in `source_tables` — but they
+    // derive edges exactly like a top-level read.
+    //
+    // Already lower-cased and already stripped of `WITH`-bound names by
+    // `extract_lineage`, so the CTE-shadowing rule (#1892) holds here too.
+    for name in &lineage_result.nested_sources {
+        if let TableRefKind::ModelRef(name) = classify_table_ref(name, model_names) {
+            if name != model_name && seen.insert(name.clone()) {
+                if renamed_targets.contains_key(name.as_str()) {
+                    renamed_target_reads.push(name.clone());
+                }
+                deps.push(name);
+            }
+        }
+    }
+
     (deps, renamed_target_reads)
 }
 
@@ -794,5 +812,86 @@ mod tests {
         let (dag_nodes, _lineage_cache, _diags) = resolve_dependencies(&models).unwrap();
         let mixed = dag_nodes.iter().find(|n| n.name == "mixed").unwrap();
         assert_eq!(mixed.depends_on, vec!["orders"]);
+    }
+
+    /// #1867: a read inside a derived table derives the edge. Before this the
+    /// pair shared an execution layer, so `--parallel` raced them and a serial
+    /// run got its order from the alphabetical root walk.
+    ///
+    /// The reader is named to sort FIRST, because that is what makes the
+    /// assertion mean something: without the edge the walk would put it first.
+    #[test]
+    fn a_subquery_read_derives_the_edge() {
+        let models = vec![
+            make_model("orders", "SELECT 1 AS id"),
+            make_model("a_reader", "SELECT id FROM (SELECT id FROM orders) AS s"),
+        ];
+
+        let (dag_nodes, _lineage_cache, _diags) = resolve_dependencies(&models).unwrap();
+        let reader = dag_nodes.iter().find(|n| n.name == "a_reader").unwrap();
+        assert_eq!(reader.depends_on, vec!["orders"]);
+
+        let order = rocky_ir::dag::topological_sort(&dag_nodes).unwrap();
+        let pos = |name: &str| order.iter().position(|n| n == name).unwrap();
+        assert!(
+            pos("orders") < pos("a_reader"),
+            "the producer must run first: {order:?}"
+        );
+    }
+
+    /// The same for a read inside a `WITH` body.
+    #[test]
+    fn a_cte_body_read_derives_the_edge() {
+        let models = vec![
+            make_model("orders", "SELECT 1 AS id"),
+            make_model(
+                "a_reader",
+                "WITH c AS (SELECT id FROM orders) SELECT id FROM c",
+            ),
+        ];
+
+        let (dag_nodes, _lineage_cache, _diags) = resolve_dependencies(&models).unwrap();
+        let reader = dag_nodes.iter().find(|n| n.name == "a_reader").unwrap();
+        assert_eq!(reader.depends_on, vec!["orders"]);
+    }
+
+    /// #1892's rule survives one level down: a name a `WITH` clause bound is
+    /// not a table read wherever it appears, including inside another body.
+    #[test]
+    fn a_shadowed_name_inside_a_body_still_derives_no_edge() {
+        let models = vec![
+            make_model("orders", "SELECT 1 AS id"),
+            make_model(
+                "a_reader",
+                "WITH orders AS (SELECT 2 AS id), \
+                 c AS (SELECT id FROM orders) \
+                 SELECT id FROM c",
+            ),
+        ];
+
+        let (dag_nodes, _lineage_cache, _diags) = resolve_dependencies(&models).unwrap();
+        let reader = dag_nodes.iter().find(|n| n.name == "a_reader").unwrap();
+        assert!(
+            reader.depends_on.is_empty(),
+            "the body reads the CTE above it, not the model: {:?}",
+            reader.depends_on
+        );
+    }
+
+    /// A model reading its own name from inside a subquery is still a
+    /// self-reference and still gets no edge — the nested path applies the
+    /// same exclusion the top-level one does, or the model would depend on
+    /// itself and `topological_sort` would refuse the project.
+    #[test]
+    fn a_nested_self_read_derives_no_edge() {
+        let models = vec![make_model(
+            "orders",
+            "SELECT id FROM (SELECT id FROM orders) AS s",
+        )];
+
+        let (dag_nodes, _lineage_cache, _diags) = resolve_dependencies(&models).unwrap();
+        assert!(dag_nodes[0].depends_on.is_empty());
+        rocky_ir::dag::topological_sort(&dag_nodes)
+            .expect("a self-read must not close a cycle");
     }
 }

--- a/engine/crates/rocky-compiler/src/resolve.rs
+++ b/engine/crates/rocky-compiler/src/resolve.rs
@@ -337,13 +337,14 @@ fn extract_deps_from_lineage(
     // Already lower-cased and already stripped of `WITH`-bound names by
     // `extract_lineage`, so the CTE-shadowing rule (#1892) holds here too.
     for name in &lineage_result.nested_sources {
-        if let TableRefKind::ModelRef(name) = classify_table_ref(name, model_names) {
-            if name != model_name && seen.insert(name.clone()) {
-                if renamed_targets.contains_key(name.as_str()) {
-                    renamed_target_reads.push(name.clone());
-                }
-                deps.push(name);
+        if let TableRefKind::ModelRef(name) = classify_table_ref(name, model_names)
+            && name != model_name
+            && seen.insert(name.clone())
+        {
+            if renamed_targets.contains_key(name.as_str()) {
+                renamed_target_reads.push(name.clone());
             }
+            deps.push(name);
         }
     }
 
@@ -878,6 +879,45 @@ mod tests {
         );
     }
 
+    /// The one user-visible REFUSAL this change introduces, decided
+    /// deliberately rather than discovered later.
+    ///
+    /// Two models that genuinely read each other through subqueries compiled
+    /// before #1867 — one execution layer, silently mis-ordered — because
+    /// neither read derived an edge. Now both edges exist and they close a
+    /// cycle, so `topological_sort` refuses the project.
+    ///
+    /// That is correct: it IS a cycle, and Rocky was running it in whatever
+    /// order the alphabetical root walk produced. But it is a divergence worth
+    /// naming — `augment_physical_read_edges` guarantees the opposite for its
+    /// own derivation ("this recompute cannot turn a compiling project into a
+    /// refused one"), because it skips cycle-closing candidates and warns.
+    /// Compile-time has no such guard and does not want one: a compile-time
+    /// cycle is a project error, not a scheduling hint.
+    #[test]
+    fn mutual_subquery_reads_are_refused_as_the_cycle_they_are() {
+        let models = vec![
+            make_model("alpha", "SELECT id FROM (SELECT id FROM beta) AS s"),
+            make_model("beta", "SELECT id FROM (SELECT id FROM alpha) AS s"),
+        ];
+
+        let (dag_nodes, _lineage_cache, _diags) = resolve_dependencies(&models).unwrap();
+        assert_eq!(
+            dag_nodes
+                .iter()
+                .find(|n| n.name == "alpha")
+                .unwrap()
+                .depends_on,
+            vec!["beta"]
+        );
+        let err = rocky_ir::dag::topological_sort(&dag_nodes)
+            .expect_err("the two models really do read each other");
+        assert!(
+            format!("{err}").contains("circular"),
+            "and it is reported as a cycle: {err}"
+        );
+    }
+
     /// A model reading its own name from inside a subquery is still a
     /// self-reference and still gets no edge — the nested path applies the
     /// same exclusion the top-level one does, or the model would depend on
@@ -891,7 +931,6 @@ mod tests {
 
         let (dag_nodes, _lineage_cache, _diags) = resolve_dependencies(&models).unwrap();
         assert!(dag_nodes[0].depends_on.is_empty());
-        rocky_ir::dag::topological_sort(&dag_nodes)
-            .expect("a self-read must not close a cycle");
+        rocky_ir::dag::topological_sort(&dag_nodes).expect("a self-read must not close a cycle");
     }
 }

--- a/engine/crates/rocky-sql/src/lineage.rs
+++ b/engine/crates/rocky-sql/src/lineage.rs
@@ -102,6 +102,26 @@ pub struct LineageResult {
     /// the pre-existing behaviour for such caches, not a new risk.
     #[serde(default)]
     pub unresolved_projections: usize,
+    /// Table names read INSIDE a derived table or a `WITH` body, lower-cased,
+    /// with `WITH`-bound names already removed (#1867).
+    ///
+    /// [`Self::source_tables`] holds only the top-level `FROM`/`JOIN`
+    /// relations, so a read of a model from inside `(SELECT … FROM m)` or
+    /// `WITH x AS (SELECT … FROM m)` was invisible to every consumer and no
+    /// scheduler ordered the reader after `m`. This carries those reads.
+    ///
+    /// Deliberately a separate field rather than more `source_tables` entries:
+    /// those feed alias resolution and `SELECT *` expansion, which are about
+    /// what the query's own `FROM` clause names. A nested read is a dependency,
+    /// not a relation the outer query can select from.
+    ///
+    /// **Best-effort, not complete.** It covers derived tables and `WITH`
+    /// bodies. It does not cover a sub-query in `WHERE`, `HAVING`, `GROUP BY`,
+    /// a qualifier or a function argument. `crate::lineage_complete` is the
+    /// only correct answer to "is this set exhaustive", and it stays exactly as
+    /// strict — do not read a non-empty value here as completeness.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub nested_sources: Vec<String>,
 }
 
 /// What a name in a `FROM`/`JOIN` position actually refers to.
@@ -164,8 +184,9 @@ pub struct TableReference {
 /// intersected with known model names to produce implicit dependencies
 /// without requiring explicit `depends_on` declarations in sidecar TOMLs.
 ///
-/// Subqueries return the alias `(subquery)` which callers should filter
-/// out (it can't match a model name).
+/// The `(subquery)` marker never appears: a derived table contributes the
+/// names read INSIDE it (`LineageResult::nested_sources`, #1867) rather than a
+/// placeholder the caller has to filter.
 ///
 /// Names bound by a `WITH` clause are dropped: a CTE is local to the query and
 /// names no object a consumer could depend on or schedule against (#1892).
@@ -177,6 +198,7 @@ pub fn referenced_tables(sql: &str) -> Result<Vec<String>, String> {
         .filter(|t| t.binding == TableBinding::Physical)
         .map(|t| t.name.to_lowercase())
         .filter(|n| n != "(subquery)")
+        .chain(result.nested_sources.iter().cloned())
         .collect();
     names.sort();
     names.dedup();
@@ -206,14 +228,10 @@ pub fn extract_lineage(sql: &str) -> Result<LineageResult, String> {
 /// travels back up — a CTE bound inside a subquery is invisible outside it.
 type CteScope = HashSet<String>;
 
-/// The names `query`'s own `WITH` clause binds, added to those already visible.
+/// Every name `query`'s own `WITH` clause binds, added to those already
+/// visible. This is the set the query's MAIN BODY sees: all of them.
 ///
-/// Every CTE in the clause is visible in the main body, so the whole clause is
-/// bound at once. That is enough while CTE **bodies** are not walked. When
-/// they are (#1867), the binding must become incremental: inside CTE *i* only
-/// CTEs 1..*i*-1 are visible, plus *i* itself when the clause is `RECURSIVE`.
-/// Binding the whole clause up front there would read a real table reference
-/// in an earlier body as a reference to a later CTE, and drop its edge.
+/// The bodies need a narrower set — see [`walk_cte_bodies`].
 fn bind_cte_names(query: &Query, outer: &CteScope) -> CteScope {
     let mut scope = outer.clone();
     if let Some(with) = &query.with {
@@ -224,11 +242,67 @@ fn bind_cte_names(query: &Query, outer: &CteScope) -> CteScope {
     scope
 }
 
+/// The real table names read inside `query`'s own `WITH` bodies, in clause
+/// order, with `WITH`-bound names removed.
+///
+/// **Binding is incremental, and that is the whole point.** Inside CTE *i*,
+/// only CTEs 1..*i*-1 are visible — plus *i* itself when the clause is
+/// `RECURSIVE`, because a recursive CTE names itself. Binding the whole clause
+/// up front would read a real table in an earlier body as a reference to a
+/// later CTE and silently drop its edge:
+///
+/// ```sql
+/// WITH a AS (SELECT * FROM orders),   -- a real read of model `orders`
+///      orders AS (SELECT 1)            -- the CTE, defined AFTER
+/// SELECT * FROM a
+/// ```
+fn walk_cte_bodies(query: &Query, outer: &CteScope) -> Vec<String> {
+    let Some(with) = &query.with else {
+        return Vec::new();
+    };
+    let mut visible = outer.clone();
+    let mut found = Vec::new();
+    for cte in &with.cte_tables {
+        let own_name = cte.alias.name.value.to_lowercase();
+        let mut body_scope = visible.clone();
+        if with.recursive {
+            body_scope.insert(own_name.clone());
+        }
+        if let Ok(inner) = extract_query_lineage(&cte.query, &body_scope) {
+            collect_nested(&inner, &mut found);
+        }
+        visible.insert(own_name);
+    }
+    found
+}
+
+/// Fold one inner query's reads into a nested-source list.
+///
+/// Takes NAMES only. An inner query's `has_star` and `unresolved_projections`
+/// describe the inner projection, and merging them into the outer result would
+/// claim the outer model's own column set is unresolved when it is not.
+fn collect_nested(inner: &LineageResult, out: &mut Vec<String>) {
+    for t in &inner.source_tables {
+        if t.binding == TableBinding::Physical && t.name != "(subquery)" {
+            out.push(t.name.to_lowercase());
+        }
+    }
+    out.extend(inner.nested_sources.iter().cloned());
+}
+
 fn extract_query_lineage(query: &Query, outer_ctes: &CteScope) -> Result<LineageResult, String> {
     let ctes = bind_cte_names(query, outer_ctes);
+    let mut nested_sources = walk_cte_bodies(query, outer_ctes);
     match query.body.as_ref() {
         SetExpr::Select(select) => {
-            let source_tables = extract_tables(&select.from, &ctes);
+            // A derived table's own reads come back alongside the relations.
+            // The `(subquery)` entry stays in `source_tables` — alias
+            // resolution and star expansion still need it — but it names no
+            // object, so the names inside it are what a consumer depends on.
+            let (source_tables, derived_reads) = extract_tables(&select.from, &ctes);
+            nested_sources.extend(derived_reads);
+            nested_sources.sort();
+            nested_sources.dedup();
             let alias_map = build_alias_map(&source_tables);
             let (columns, has_star, unresolved_projections) =
                 extract_select_columns(&select.projection, &alias_map, &source_tables);
@@ -238,27 +312,48 @@ fn extract_query_lineage(query: &Query, outer_ctes: &CteScope) -> Result<Lineage
                 columns,
                 has_star,
                 unresolved_projections,
+                nested_sources,
             })
         }
-        SetExpr::Query(inner) => extract_query_lineage(inner, &ctes),
+        SetExpr::Query(inner) => {
+            let mut result = extract_query_lineage(inner, &ctes)?;
+            nested_sources.append(&mut result.nested_sources);
+            nested_sources.sort();
+            nested_sources.dedup();
+            result.nested_sources = nested_sources;
+            Ok(result)
+        }
         _ => Err("unsupported query type for lineage".to_string()),
     }
 }
 
-fn extract_tables(from: &[TableWithJoins], ctes: &CteScope) -> Vec<TableReference> {
+/// The relations named in `from`, plus the table names read INSIDE any derived
+/// table there (#1867). The two are returned separately because they answer
+/// different questions: the first is what the query can select from, the second
+/// is what it depends on.
+fn extract_tables(
+    from: &[TableWithJoins],
+    ctes: &CteScope,
+) -> (Vec<TableReference>, Vec<String>) {
     let mut tables = Vec::new();
+    let mut nested = Vec::new();
 
     for table_with_joins in from {
-        extract_table_factor(&table_with_joins.relation, ctes, &mut tables);
+        extract_table_factor(&table_with_joins.relation, ctes, &mut tables, &mut nested);
         for join in &table_with_joins.joins {
-            extract_table_factor(&join.relation, ctes, &mut tables);
+            extract_table_factor(&join.relation, ctes, &mut tables, &mut nested);
         }
     }
 
-    tables
+    (tables, nested)
 }
 
-fn extract_table_factor(factor: &TableFactor, ctes: &CteScope, tables: &mut Vec<TableReference>) {
+fn extract_table_factor(
+    factor: &TableFactor,
+    ctes: &CteScope,
+    tables: &mut Vec<TableReference>,
+    nested: &mut Vec<String>,
+) {
     match factor {
         TableFactor::Table { name, alias, .. } => {
             let name = name.to_string();
@@ -290,6 +385,12 @@ fn extract_table_factor(factor: &TableFactor, ctes: &CteScope, tables: &mut Vec<
             // leaves `has_star = true` with no individual columns, in which
             // case we fall back to `None`.
             let inner = extract_query_lineage(subquery, ctes).ok();
+            // The inner query's own reads are this model's dependencies. Taken
+            // as NAMES only — the inner `has_star` describes the inner
+            // projection, not the outer model's column set (#1867).
+            if let Some(inner) = inner.as_ref() {
+                collect_nested(inner, nested);
+            }
             let derived_columns = inner.as_ref().and_then(|inner| {
                 if inner.has_star || inner.columns.is_empty() {
                     None
@@ -1048,5 +1149,124 @@ mod tests {
         .unwrap();
 
         assert_eq!(result.source_tables[0].binding, TableBinding::Cte);
+    }
+
+    /// #1867: a read inside a derived table is a dependency. It used to reach
+    /// no consumer at all — `source_tables` held the literal `(subquery)` and
+    /// nothing looked inside it — so no scheduler ordered the reader after its
+    /// producer.
+    #[test]
+    fn a_subquery_read_surfaces_as_a_dependency() {
+        let sql = "SELECT id FROM (SELECT id FROM orders) AS s";
+        let result = extract_lineage(sql).unwrap();
+
+        assert_eq!(result.source_tables[0].name, "(subquery)");
+        assert_eq!(result.nested_sources, vec!["orders".to_string()]);
+        assert_eq!(
+            referenced_tables(sql).unwrap(),
+            vec!["orders".to_string()],
+            "the marker is gone and the real read is there"
+        );
+    }
+
+    /// The same for a `WITH` body. The CTE's own name stays out — it names no
+    /// object outside the query (#1892).
+    #[test]
+    fn a_cte_body_read_surfaces_but_the_cte_name_does_not() {
+        let sql = "WITH c AS (SELECT id FROM orders) SELECT id FROM c";
+
+        assert_eq!(referenced_tables(sql).unwrap(), vec!["orders".to_string()]);
+    }
+
+    /// The rule the incremental binding exists for. `orders` inside `a`'s body
+    /// is a REAL table: a non-recursive CTE only sees the CTEs declared before
+    /// it, so the `orders` CTE declared afterwards does not shadow it.
+    ///
+    /// Binding the whole clause up front would classify that read as a CTE
+    /// reference and drop the edge — silently, and only for this ordering.
+    #[test]
+    fn a_cte_declared_after_a_body_does_not_shadow_that_bodys_read() {
+        let sql = "WITH a AS (SELECT id FROM orders), \
+                   orders AS (SELECT 1 AS id) \
+                   SELECT id FROM a";
+
+        assert_eq!(
+            referenced_tables(sql).unwrap(),
+            vec!["orders".to_string()],
+            "the read in `a` predates the `orders` CTE, so it is the table"
+        );
+    }
+
+    /// And the other ordering, which must give the opposite answer: declared
+    /// FIRST, the CTE does shadow the read.
+    #[test]
+    fn a_cte_declared_before_a_body_does_shadow_that_bodys_read() {
+        let sql = "WITH orders AS (SELECT 1 AS id), \
+                   a AS (SELECT id FROM orders) \
+                   SELECT id FROM a";
+
+        assert!(
+            referenced_tables(sql).unwrap().is_empty(),
+            "the read in `a` is the CTE above it, not a table"
+        );
+    }
+
+    /// A `WITH RECURSIVE` body names itself, so its self-read is not a table.
+    #[test]
+    fn a_recursive_body_does_not_read_itself_as_a_table() {
+        let sql = "WITH RECURSIVE walk AS (SELECT id FROM walk) SELECT id FROM walk";
+
+        assert!(
+            referenced_tables(sql).unwrap().is_empty(),
+            "the recursive CTE is not a table"
+        );
+    }
+
+    /// A limitation, pinned so it is a known gap rather than a surprise: a CTE
+    /// body that is a SET OPERATION contributes nothing.
+    ///
+    /// `extract_query_lineage` handles `SetExpr::Select` and `SetExpr::Query`
+    /// and returns `Err` for `SetExpr::SetOperation`, so `walk_cte_bodies`
+    /// skips such a body entirely. `UNION ALL` inside a recursive CTE is the
+    /// ordinary spelling of one, so #1867's fix does not reach it.
+    ///
+    /// This test exists because the recursive test above was originally
+    /// written with a `UNION ALL` body and PASSED VACUOUSLY — the CTE name was
+    /// absent because nothing was walked, not because self-binding worked.
+    #[test]
+    fn a_set_operation_cte_body_contributes_no_reads() {
+        let sql = "WITH walk AS ( \
+                     SELECT id FROM seed \
+                     UNION ALL \
+                     SELECT id FROM other \
+                   ) SELECT id FROM walk";
+
+        assert!(
+            referenced_tables(sql).unwrap().is_empty(),
+            "known gap: a set-operation body is not walked, so `seed` and \
+             `other` derive no edge"
+        );
+    }
+
+    /// Reads two levels down still surface — the walk recurses rather than
+    /// looking one level.
+    #[test]
+    fn a_read_two_levels_down_still_surfaces() {
+        let sql = "SELECT id FROM (SELECT id FROM (SELECT id FROM orders) AS inner_q) AS outer_q";
+
+        assert_eq!(referenced_tables(sql).unwrap(), vec!["orders".to_string()]);
+    }
+
+    /// The inner query's OWN projection facts must not become the outer
+    /// model's. An inner `SELECT *` says nothing about whether the outer
+    /// model's column set is known, and merging it would make every model with
+    /// a `SELECT *` subquery look unresolved.
+    #[test]
+    fn an_inner_star_does_not_make_the_outer_projection_unresolved() {
+        let result = extract_lineage("SELECT id FROM (SELECT * FROM orders) AS s").unwrap();
+
+        assert!(!result.has_star, "the OUTER projection names its column");
+        assert_eq!(result.unresolved_projections, 0);
+        assert_eq!(result.nested_sources, vec!["orders".to_string()]);
     }
 }

--- a/engine/crates/rocky-sql/src/lineage.rs
+++ b/engine/crates/rocky-sql/src/lineage.rs
@@ -331,10 +331,7 @@ fn extract_query_lineage(query: &Query, outer_ctes: &CteScope) -> Result<Lineage
 /// table there (#1867). The two are returned separately because they answer
 /// different questions: the first is what the query can select from, the second
 /// is what it depends on.
-fn extract_tables(
-    from: &[TableWithJoins],
-    ctes: &CteScope,
-) -> (Vec<TableReference>, Vec<String>) {
+fn extract_tables(from: &[TableWithJoins], ctes: &CteScope) -> (Vec<TableReference>, Vec<String>) {
     let mut tables = Vec::new();
     let mut nested = Vec::new();
 

--- a/engine/crates/rocky-sql/src/lineage_complete.rs
+++ b/engine/crates/rocky-sql/src/lineage_complete.rs
@@ -9,15 +9,24 @@
 //!
 //! # Why this exists
 //!
-//! `extract_lineage` walks only the top-level `FROM`/`JOIN` relations and
-//! records non-`Table` table-factors as either the opaque `(subquery)` marker
-//! (for a derived table) or nothing at all (Pivot, Unpivot, Unnest, table
-//! functions, JSON tables, nested joins — its `_ => {}` arm). It also never
-//! descends into `WHERE`/`HAVING`/projection sub-queries or CTE bodies. So for
-//! anything but a plain single `SELECT` over bare tables, its source set can be
-//! **incomplete** — and an incomplete-but-non-empty (or empty) source set would
-//! let the gate skip a model whose true upstream actually moved. That is silent
-//! production staleness, the worst failure the gate exists to prevent.
+//! `extract_lineage`'s `source_tables` holds only the top-level `FROM`/`JOIN`
+//! relations, recording non-`Table` table-factors as either the opaque
+//! `(subquery)` marker (for a derived table) or nothing at all (Pivot, Unpivot,
+//! Unnest, table functions, JSON tables, nested joins — its `_ => {}` arm).
+//!
+//! Since #1867 it does descend into derived tables and `WITH` bodies, carrying
+//! what it finds on `LineageResult::nested_sources`. That is a **widening, not
+//! completeness**, and this gate must not be relaxed for it. Still not reached:
+//! a sub-query in `WHERE`, `HAVING`, `GROUP BY`, a qualifier or a function
+//! argument, and any body that is a set operation (`extract_query_lineage`
+//! returns `Err` for `SetExpr::SetOperation`, so a `UNION` CTE body is skipped
+//! entirely). Partial coverage that reads as complete is exactly the silent
+//! staleness this gate exists to prevent.
+//!
+//! So for anything but a plain single `SELECT` over bare tables, the source set
+//! can be **incomplete** — and an incomplete-but-non-empty (or empty) source set
+//! would let the gate skip a model whose true upstream actually moved. That is
+//! silent production staleness, the worst failure the gate exists to prevent.
 //!
 //! Rather than make `extract_lineage` recurse (it feeds dependency derivation
 //! and the lineage/Inspector surfaces, which have different needs), this check


### PR DESCRIPTION
Closes #1867 — the two halves that survived the triage. The dotted-name half was reverted after probing: `augment_physical_read_edges` already derives that edge from target components, and a dotted model name cannot execute anywhere (`validate_identifier` is `^[a-zA-Z0-9_]+$`). That is recorded on the issue and the title was narrowed to match.

`source_tables` holds only the top-level `FROM`/`JOIN` relations. So a read of a model from inside a derived table or a `WITH` body reached **no consumer at all** — not dependency derivation, not `derive_physical_edges`, not label inference — and no scheduler ordered the reader after its producer.

```
  SELECT id FROM (SELECT id FROM orders) AS s     ->  source_tables = ["(subquery)"]
  WITH c AS (SELECT id FROM orders) SELECT … c    ->  the WITH clause was never walked
```

Both now derive the edge.

## The shape

`extract_lineage` walks derived tables and `WITH` bodies and carries what it finds on a new field:

```rust
pub nested_sources: Vec<String>,   // lower-cased, WITH-bound names removed
```

Separate from `source_tables` on purpose. Those entries feed alias resolution and `SELECT *` expansion, which are about what the query's own `FROM` clause names. A nested read is a **dependency**, not a relation the outer query can select from — and adding it to `source_tables` would change star expansion, which this PR deliberately does not touch.

`referenced_tables` and `extract_deps_from_lineage` consume it. `(subquery)` no longer reaches `referenced_tables` at all: a derived table now contributes the names read inside it rather than a placeholder every caller had to filter.

## Binding inside the bodies is incremental, and that is the fix's real content

A non-recursive CTE sees only the CTEs declared **before** it. So walking body *i* binds names 1..*i*-1 — plus *i* itself when the clause is `RECURSIVE`, because a recursive CTE names itself.

```sql
WITH a AS (SELECT id FROM orders),   -- `orders` is the TABLE: the CTE below does not exist yet
     orders AS (SELECT 1 AS id)
SELECT id FROM a
```

Binding the whole clause up front reads that as a CTE reference and silently drops the edge — for that ordering only. Two tests pin both directions, and they must disagree:

```
  orders declared AFTER  a's body  ->  referenced_tables == ["orders"]
  orders declared BEFORE a's body  ->  referenced_tables == []
```

**Mutation-checked** with `visible = bind_cte_names(query, outer)` before the loop:

```
failures:
    lineage::tests::a_cte_declared_after_a_body_does_not_shadow_that_bodys_read
mutation-check: OK — the test failed under mutation, so it is fix-sensitive.
```

#1892's rule holds one level down too: a `WITH`-bound name is not a table read wherever it appears.

## One user-visible refusal, decided rather than discovered

Two models that genuinely read each other through subqueries **compiled before this change** — one execution layer, silently mis-ordered — because neither read derived an edge. Now both edges exist and close a cycle:

```
$ rocky compile --models models
Error: circular dependency detected involving: ["alpha", "beta"]
```

That is correct. It is a real cycle, and Rocky was running it in whatever order the alphabetical root walk produced.

It is also a **divergence worth naming**: `augment_physical_read_edges` guarantees the opposite for its own derivation — *"Cycle-closing candidates never leave the derivation … so this recompute cannot turn a compiling project into a refused one."* Compile-time has no such guard and should not get one: a compile-time cycle is a project error, not a scheduling hint. `mutual_subquery_reads_are_refused_as_the_cycle_they_are` pins it with that reasoning in its doc.

## A containment boundary moved, and I inverted its test deliberately

`containment_matches_fail_fast_for_same_layer_uncertain_read` asserted that a CTE reader of a **failed** producer's target still **builds**, in both modes, because the read was unenumerable and nothing could order the two. Its doc called that "the documented best-effort boundary".

It is not the boundary any more. The `WITH`-body read now reaches `referenced_tables`, `derive_physical_edges` matches it against the producer's target `(main, orders_current)`, and `augment_physical_read_edges` puts them in different layers — so the producer's failure withholds the reader.

The assertion is now `!contains("rollup")`. That is exactly the stale-data failure #1867 describes, and the old assertion pinned it as acceptable **because nothing could see the read**. The containment ⊆ fail-fast invariant the test exists for is unchanged and still asserted. The `ref()` path is untouched and remains the hard guarantee.

## Known gaps, pinned rather than left to be discovered

`a_set_operation_cte_body_contributes_no_reads` records one: `extract_query_lineage` returns `Err` for `SetExpr::SetOperation`, so a `UNION` body is skipped entirely. `UNION ALL` is the ordinary spelling of a recursive CTE, so this fix does not reach those.

That test exists because my first recursive test **passed vacuously** — the CTE name was absent because nothing was walked, not because self-binding worked. A precondition assertion caught it. The rewritten recursive test uses a body that parses.

`lineage_is_provably_complete` is left **exactly as strict**, and its module doc now says why: this is a widening, not completeness. Still unreached — a sub-query in `WHERE`, `HAVING`, `GROUP BY`, a qualifier or a function argument, and any set-operation body. Partial coverage that reads as complete is the silent-staleness class that gate exists for.

`TableReference::derived_sources` still exists and is unchanged. It populates only when the inner query is an unresolved `SELECT *`, and `semantic.rs` reads it for star expansion. `nested_sources` carries inner reads unconditionally and feeds dependency derivation. Both are live, with different consumers; neither supersedes the other.

## Evidence

`rocky compile --models …` on four fixtures, before and after:

```
                                                before          after
  subquery read of a model         layers            1               2
  CTE BODY read of a model         layers            1               2
  CTE SHADOWING a model            layers            1               1   (#1892, unchanged)
  plain read of a model (control)  layers            2               2
  mutual subquery reads                       1 layer         REFUSED
```

The reader is named to sort **first** in each fixture, so the layer count is not satisfiable by the alphabetical root walk.

12 new tests (8 in `lineage.rs`, 4 in `resolve.rs`). `cargo test`: `-p rocky-sql` 304 passed, `-p rocky-compiler` 490, `-p rocky-core` 2190, `-p rocky-cli` 1965 across every target — 0 failed anywhere. Clippy `--all-targets --all-features` clean on all three edited crates, `cargo fmt --check` clean.

`LineageResult` is cached in memory only (`Project::lineage_cache`), derives no `JsonSchema`, and reaches no exported CLI output — no schema bump, no codegen cascade. The new field carries `#[serde(default)]` regardless.

## What I am least confident about

Whether the newly-derived edges can refuse a project that is not actually cyclic. The refusal above is sound because both reads are real. But `classify_table_ref` binds a bare nested name to a model by **name**, and #1354's whole point is that a bare name need not reach that model's object — so a project where two models each read a bare name that coincides with the other's model name, without either read reaching the other's output, would now be refused where before it merely mis-ordered. I could not construct that shape without also constructing the #1354 collision itself, and D012 already warns on it, but "the cycle is real" rests on the same name-vs-object assumption D012 exists to flag.

## What I think is being missed

`nested_sources` widens the feed but leaves `SELECT *` expansion where it was. A model reading `SELECT * FROM (SELECT * FROM orders) AS s` now derives the edge to `orders` and still expands its star from `derived_sources`, which populates only in that one unresolved-inner case. So the dependency graph and the column graph now disagree about which reads they can see — the graph knows about a read the type-checker still cannot resolve columns through. That is not a regression (the column side is unchanged) but it is a new asymmetry, and #1631's star-binding gate consults `depends_on`, so the two are already coupled. Worth a look before anything else is built on either.

**Independent red team: not run.** The Codex plugin cannot return a verdict into an autonomous loop, so this is self-reviewed at maximum effort and disclosed as such, per `AGENTS.md`.

Refs #1892, #1354, #1631, #1275
