### PR TITLE
fix(engine/rocky-core): a non-UTF-8 model filename is neither dropped by the walk nor mangled by the loader

### DIFF
--- a/engine/crates/rocky-ai/src/sidecar.rs
+++ b/engine/crates/rocky-ai/src/sidecar.rs
@@ -498,7 +498,7 @@ mod tests {
                 .unwrap();
 
         let inline = format!("---toml\n{sidecar}---\n\nSELECT 1\n");
-        let model = parse_model_inline(&inline, "fct_orders.sql", None).unwrap();
+        let model = parse_model_inline(&inline, Path::new("fct_orders.sql"), None).unwrap();
 
         assert_eq!(model.config.name, "fct_orders");
         assert_eq!(model.config.target.catalog, "generated");
@@ -524,7 +524,7 @@ mod tests {
         .unwrap();
 
         let inline = format!("---toml\n{sidecar}---\n\nSELECT 1\n");
-        let model = parse_model_inline(&inline, "events.sql", None).unwrap();
+        let model = parse_model_inline(&inline, Path::new("events.sql"), None).unwrap();
 
         match model.config.strategy {
             StrategyConfig::Incremental { timestamp_column } => {
@@ -543,7 +543,7 @@ mod tests {
                 .unwrap();
 
         let inline = format!("---toml\n{sidecar}---\n\nSELECT 1\n");
-        let model = parse_model_inline(&inline, "staging_users.sql", None).unwrap();
+        let model = parse_model_inline(&inline, Path::new("staging_users.sql"), None).unwrap();
         assert!(matches!(model.config.strategy, StrategyConfig::Ephemeral));
     }
 
@@ -562,7 +562,7 @@ mod tests {
         assert!(sidecar.contains("unique_key = [\"id\", \"created_at\"]"));
 
         let inline = format!("---toml\n{sidecar}---\n\nSELECT 1\n");
-        let model = parse_model_inline(&inline, "fct_orders.sql", None).unwrap();
+        let model = parse_model_inline(&inline, Path::new("fct_orders.sql"), None).unwrap();
         match model.config.strategy {
             StrategyConfig::Merge {
                 unique_key,

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -26574,8 +26574,9 @@ backend = "local"
     #[test]
     fn content_addressed_dispatch_ir_is_typed() {
         let content = "---toml\nname = \"ca_events\"\n\n[strategy]\ntype = \"content_addressed\"\nstorage_prefix = \"s3://bucket/ca_events\"\n\n[target]\ncatalog = \"analytics\"\nschema = \"marts\"\ntable = \"ca_events\"\n---\n\nSELECT 1 AS id, 'a' AS name\n";
-        let model = rocky_core::models::parse_model_inline(content, "ca_events.sql", None)
-            .expect("parse content-addressed model");
+        let model =
+            rocky_core::models::parse_model_inline(content, Path::new("ca_events.sql"), None)
+                .expect("parse content-addressed model");
         assert!(
             model.to_model_ir().skip_hash().is_none(),
             "bare to_model_ir() has no typed columns — the regression shape"

--- a/engine/crates/rocky-core/src/models.rs
+++ b/engine/crates/rocky-core/src/models.rs
@@ -1633,14 +1633,21 @@ pub fn load_models_from_dir_filtered(
     };
 
     // Collect all .sql file paths first (fs::read_dir is not Send)
+    //
+    // Compared as `OsStr`, not `&str`. `to_str()` returns `None` for a
+    // filename that is not valid UTF-8, and inside a `filter_map` that `?`
+    // DROPPED the file — before the extension was even looked at. So a model
+    // whose name carried one such byte was invisible to Rocky entirely: it did
+    // not compile, did not run, did not appear in `rocky dag`, and nothing
+    // said so (#1814). An `OsStr` comparison is byte-exact and total.
     let sql_files: Vec<std::path::PathBuf> = std::fs::read_dir(dir)?
         .filter_map(|entry| {
             let entry = entry.ok()?;
             let path = entry.path();
-            if path.file_name()?.to_str()? == "_defaults.toml" {
+            if path.file_name()? == std::ffi::OsStr::new("_defaults.toml") {
                 return None;
             }
-            if path.extension()?.to_str()? == "sql" && include(&path) {
+            if path.extension()? == std::ffi::OsStr::new("sql") && include(&path) {
                 Some(path)
             } else {
                 None

--- a/engine/crates/rocky-core/src/models.rs
+++ b/engine/crates/rocky-core/src/models.rs
@@ -1515,7 +1515,7 @@ pub fn load_model_pair_with_context(
 /// editor support (syntax highlighting, linting, autocomplete).
 pub fn parse_model_inline(
     content: &str,
-    file_path: &str,
+    file_path: &Path,
     defaults: Option<&DirDefaults>,
 ) -> Result<Model, ModelError> {
     parse_model_inline_with_context(content, file_path, defaults, &ModelLoadContext::default())
@@ -1524,32 +1524,43 @@ pub fn parse_model_inline(
 /// [`parse_model_inline`] with directory-level config resolution (groups +
 /// named tests). See [`load_model_pair_with_context`]. Bare `parse_model_inline`
 /// passes an empty context.
+///
+/// `file_path` is a `&Path`, not a `&str`. The directory loader hands it the
+/// real path off the filesystem walk, and a `&str` parameter forced that
+/// through `Path::display().to_string()` — which replaces every non-UTF-8 byte
+/// with U+FFFD. `Model::file_path` then no longer equalled the path any other
+/// caller held, and #1778 widened that field to `PathBuf` precisely so it
+/// would. The LSP's model lookup is `m.file_path == uri.to_file_path()`
+/// (`rocky-server/src/lsp.rs`), so on such a filename it silently matched
+/// nothing: no diagnostics, no hover, no go-to-definition (#1814).
 pub fn parse_model_inline_with_context(
     content: &str,
-    file_path: &str,
+    file_path: &Path,
     defaults: Option<&DirDefaults>,
     ctx: &ModelLoadContext,
 ) -> Result<Model, ModelError> {
-    let (frontmatter, sql) =
-        split_frontmatter(content).ok_or_else(|| ModelError::MissingFrontmatter {
-            path: file_path.to_string(),
-        })?;
+    // Only for the human-readable `path` on an error. Lossy is correct there —
+    // a diagnostic is text — and it never reaches `Model::file_path`.
+    let displayed = || file_path.display().to_string();
+
+    let (frontmatter, sql) = split_frontmatter(content)
+        .ok_or_else(|| ModelError::MissingFrontmatter { path: displayed() })?;
 
     let declared = extract_declared_fields(frontmatter);
 
     let frontmatter =
         substitute_env_vars(frontmatter).map_err(|source| ModelError::EnvSubstitution {
-            path: file_path.to_string(),
+            path: displayed(),
             source: Box::new(source),
         })?;
 
     let raw: RawModelConfig =
         toml::from_str(&frontmatter).map_err(|e| ModelError::ParseFrontmatter {
-            path: file_path.to_string(),
+            path: displayed(),
             source: e,
         })?;
 
-    let file_stem = Path::new(file_path)
+    let file_stem = file_path
         .file_stem()
         .map(|s| s.to_string_lossy().to_string())
         .unwrap_or_default();
@@ -1557,15 +1568,12 @@ pub fn parse_model_inline_with_context(
     let config = resolve_model_config(raw, &file_stem, defaults, ctx, declared)?;
 
     // Inline models can have a sibling contract too — same probe, same rule.
-    let contract_path = sibling_contract_path(Path::new(file_path));
+    let contract_path = sibling_contract_path(file_path);
 
     Ok(Model {
         config,
         sql: sql.to_string(),
-        // Lossless: this parser's `file_path` is a `&str` label supplied by
-        // the caller (a synthetic name like "fct_orders.sql"), never a path
-        // read off the filesystem, so widening it cannot lose bytes.
-        file_path: std::path::PathBuf::from(file_path),
+        file_path: file_path.to_path_buf(),
         contract_path,
     })
 }
@@ -1650,12 +1658,7 @@ pub fn load_models_from_dir_filtered(
                 load_model_pair_with_context(path, &toml_path, defaults.as_ref(), &ctx)
             } else {
                 let content = read_model_text(path)?;
-                parse_model_inline_with_context(
-                    &content,
-                    &path.display().to_string(),
-                    defaults.as_ref(),
-                    &ctx,
-                )
+                parse_model_inline_with_context(&content, path, defaults.as_ref(), &ctx)
             }
         })
         .collect::<Result<Vec<_>, _>>()?;
@@ -2209,7 +2212,7 @@ target = { catalog = "analytics", schema = "staging", table = "orders" }
 
 SELECT * FROM raw.orders
 "#;
-        let model = parse_model_inline(content, "stg_orders.sql", None).unwrap();
+        let model = parse_model_inline(content, Path::new("stg_orders.sql"), None).unwrap();
         assert_eq!(model.config.name, "stg_orders");
         assert!(model.config.depends_on.is_empty());
         assert!(model.sql.contains("SELECT * FROM raw.orders"));
@@ -2235,7 +2238,7 @@ table = "dim_customers"
 SELECT customer_id, name, email
 FROM analytics.staging.customers
 "#;
-        let model = parse_model_inline(content, "dim_customers.sql", None).unwrap();
+        let model = parse_model_inline(content, Path::new("dim_customers.sql"), None).unwrap();
         assert_eq!(model.config.name, "dim_customers");
         assert_eq!(model.config.depends_on, vec!["stg_customers"]);
         assert!(matches!(
@@ -2262,7 +2265,7 @@ table = "fct_events"
 
 SELECT id, payload, region FROM raw.events
 "#;
-        let model = parse_model_inline(content, "fct_events.sql", None).unwrap();
+        let model = parse_model_inline(content, Path::new("fct_events.sql"), None).unwrap();
         match &model.config.strategy {
             StrategyConfig::ContentAddressed {
                 storage_prefix,
@@ -2306,7 +2309,7 @@ table = "fct_events"
 
 SELECT id, payload FROM raw.events
 "#;
-        let model = parse_model_inline(content, "fct_events.sql", None).unwrap();
+        let model = parse_model_inline(content, Path::new("fct_events.sql"), None).unwrap();
         match &model.config.strategy {
             StrategyConfig::ContentAddressed {
                 storage_prefix,
@@ -2349,7 +2352,7 @@ SELECT o.order_id, c.name, o.amount
 FROM analytics.staging.orders o
 JOIN analytics.marts.dim_customers c ON o.customer_id = c.customer_id
 "#;
-        let model = parse_model_inline(content, "fct_orders.sql", None).unwrap();
+        let model = parse_model_inline(content, Path::new("fct_orders.sql"), None).unwrap();
         assert_eq!(model.config.name, "fct_orders");
         assert_eq!(model.config.depends_on.len(), 2);
         assert_eq!(model.config.sources.len(), 2);
@@ -2362,7 +2365,7 @@ JOIN analytics.marts.dim_customers c ON o.customer_id = c.customer_id
     #[test]
     fn test_parse_model_missing_frontmatter() {
         let content = "SELECT * FROM raw.orders";
-        let result = parse_model_inline(content, "bad.sql", None);
+        let result = parse_model_inline(content, Path::new("bad.sql"), None);
         assert!(matches!(result, Err(ModelError::MissingFrontmatter { .. })));
     }
 
@@ -2376,7 +2379,7 @@ target = { catalog = "c", schema = "s", table = "t" }
 ---
 SELECT 1
 "#,
-            "b.sql",
+            Path::new("b.sql"),
             None,
         )
         .unwrap();
@@ -2401,7 +2404,7 @@ table = "t"
 ---
 SELECT id, name, status FROM raw.src
 "#,
-            "dim.sql",
+            Path::new("dim.sql"),
             None,
         )
         .unwrap();
@@ -2436,7 +2439,7 @@ table = "v_active_customers"
 ---
 SELECT customer_id, name FROM analytics.marts.dim_customers WHERE status = 'active'
 "#;
-        let model = parse_model_inline(content, "v_active_customers.sql", None).unwrap();
+        let model = parse_model_inline(content, Path::new("v_active_customers.sql"), None).unwrap();
         assert!(matches!(model.config.strategy, StrategyConfig::View));
         let ir = model.to_model_ir();
         assert!(matches!(ir.materialization, MaterializationStrategy::View));
@@ -2457,7 +2460,7 @@ table = "mv_orders_daily"
 ---
 SELECT DATE(created_at) AS day, COUNT(*) FROM analytics.marts.fct_orders GROUP BY 1
 "#;
-        let model = parse_model_inline(content, "mv_orders_daily.sql", None).unwrap();
+        let model = parse_model_inline(content, Path::new("mv_orders_daily.sql"), None).unwrap();
         assert!(matches!(
             model.config.strategy,
             StrategyConfig::MaterializedView
@@ -2485,7 +2488,7 @@ table = "dt_orders_recent"
 ---
 SELECT id, customer_id, total FROM analytics.marts.fct_orders
 "#;
-        let model = parse_model_inline(content, "dt_orders_recent.sql", None).unwrap();
+        let model = parse_model_inline(content, Path::new("dt_orders_recent.sql"), None).unwrap();
         match &model.config.strategy {
             StrategyConfig::DynamicTable { target_lag } => {
                 assert_eq!(target_lag, "1 minute");
@@ -2525,7 +2528,7 @@ table = "fct_orders_v2"
 ---
 SELECT 1
 "#,
-            "fct_orders.sql",
+            Path::new("fct_orders.sql"),
             None,
         )
         .unwrap();
@@ -3136,6 +3139,77 @@ schema = "s"
         assert!(err_msg.contains("catalog"));
     }
 
+    /// #1814 finding 2: a legacy inline model's `file_path` must be the path it
+    /// was given, byte for byte.
+    ///
+    /// The parameter used to be a `&str`, so the directory loader passed
+    /// `path.display().to_string()` — which replaces every non-UTF-8 byte with
+    /// U+FFFD. `Model::file_path` then no longer equalled the path any other
+    /// caller held, and #1778 widened that field to `PathBuf` precisely so it
+    /// would. The LSP looks a model up with `m.file_path == uri.to_file_path()`
+    /// (`rocky-server/src/lsp.rs`), so on such a filename it matched nothing:
+    /// no diagnostics, no hover, no go-to-definition, silently.
+    ///
+    /// Unix-only: it needs a filename that is not valid UTF-8, and
+    /// `OsStrExt::from_bytes` is the only way to build one.
+    #[cfg(unix)]
+    #[test]
+    fn an_inline_model_keeps_a_non_utf8_path_byte_for_byte() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        // 0xFF is not valid UTF-8 anywhere, so `display()` renders it U+FFFD.
+        let path = std::path::PathBuf::from(OsStr::from_bytes(b"models/caf\xffe.sql"));
+        assert_ne!(
+            path,
+            std::path::PathBuf::from(path.display().to_string()),
+            "PRECONDITION: this path must actually be lossy under display(), \
+             else the assertion below holds for any implementation"
+        );
+
+        let model = parse_model_inline(
+            "---toml\n[target]\ncatalog = \"c\"\nschema = \"s\"\n---\nSELECT 1 AS id\n",
+            &path,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(model.file_path, path);
+        assert_eq!(
+            model.config.name, "caf\u{fffd}e",
+            "the NAME is derived through `to_string_lossy` and stays lossy — a \
+             model name is an identifier, not a path"
+        );
+    }
+
+    /// The same property one layer up, through the real directory walk — the
+    /// call site that actually did the lossy conversion.
+    ///
+    /// Linux-only, and that is a real coverage limit rather than a preference:
+    /// APFS refuses a non-UTF-8 filename outright (`EILSEQ`), so this cannot be
+    /// exercised on macOS at all. CI runs `ubuntu-latest`, so it runs there.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn the_directory_loader_keeps_a_non_utf8_filename_byte_for_byte() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join(OsStr::from_bytes(b"caf\xffe.sql"));
+        std::fs::write(
+            &path,
+            "---toml\n[target]\ncatalog = \"c\"\nschema = \"s\"\n---\nSELECT 1 AS id\n",
+        )
+        .unwrap();
+
+        let models = load_models_from_dir(dir.path(), None).unwrap();
+        assert_eq!(models.len(), 1, "the inline model must load");
+        assert_eq!(
+            models[0].file_path, path,
+            "a lossy round-trip here makes every path-keyed lookup miss this model"
+        );
+    }
+
     #[test]
     fn test_filename_with_dot_in_stem() {
         let dir = tempfile::TempDir::new().unwrap();
@@ -3233,7 +3307,7 @@ ssn = "confidential"
 
 SELECT email, phone, ssn FROM raw.users
 "#;
-        let model = parse_model_inline(content, "users.sql", None).unwrap();
+        let model = parse_model_inline(content, Path::new("users.sql"), None).unwrap();
         assert_eq!(
             model.config.classification.get("email"),
             Some(&"pii".to_string())
@@ -3264,7 +3338,7 @@ ip_address = "location_adjacent"
 
 SELECT * FROM raw.events
 "#;
-        let model = parse_model_inline(content, "telemetry.sql", None).unwrap();
+        let model = parse_model_inline(content, Path::new("telemetry.sql"), None).unwrap();
         assert_eq!(
             model.config.classification.get("user_id"),
             Some(&"gdpr_subject".to_string())
@@ -3293,7 +3367,7 @@ tier = "gold"
 
 SELECT 1
 "#;
-        let model = parse_model_inline(content, "fct_orders.sql", None).unwrap();
+        let model = parse_model_inline(content, Path::new("fct_orders.sql"), None).unwrap();
         assert_eq!(
             model.config.governance.tags.get("domain"),
             Some(&"finance".to_string())
@@ -3326,7 +3400,7 @@ target = { catalog = "c", schema = "s", table = "t" }
 
 SELECT 1
 "#;
-        let model = parse_model_inline(content, "no_gov.sql", None).unwrap();
+        let model = parse_model_inline(content, Path::new("no_gov.sql"), None).unwrap();
         assert!(model.config.governance.tags.is_empty());
     }
 
@@ -3339,7 +3413,7 @@ target = { catalog = "c", schema = "s", table = "t" }
 
 SELECT 1
 "#;
-        let model = parse_model_inline(content, "no_class.sql", None).unwrap();
+        let model = parse_model_inline(content, Path::new("no_class.sql"), None).unwrap();
         assert!(model.config.classification.is_empty());
     }
 
@@ -3355,7 +3429,7 @@ retention = "90d"
 
 SELECT * FROM raw.events
 "#;
-        let model = parse_model_inline(content, "events_daily.sql", None).unwrap();
+        let model = parse_model_inline(content, Path::new("events_daily.sql"), None).unwrap();
         assert_eq!(model.config.retention.map(|r| r.duration_days), Some(90));
     }
 
@@ -3369,7 +3443,7 @@ retention = "3y"
 
 SELECT * FROM raw.events
 "#;
-        let model = parse_model_inline(content, "long_history.sql", None).unwrap();
+        let model = parse_model_inline(content, Path::new("long_history.sql"), None).unwrap();
         assert_eq!(
             model.config.retention.map(|r| r.duration_days),
             Some(3 * 365)
@@ -3385,7 +3459,7 @@ target = { catalog = "c", schema = "s", table = "t" }
 
 SELECT 1
 "#;
-        let model = parse_model_inline(content, "no_retention.sql", None).unwrap();
+        let model = parse_model_inline(content, Path::new("no_retention.sql"), None).unwrap();
         assert!(model.config.retention.is_none());
     }
 
@@ -3405,7 +3479,7 @@ retention = "{bad}"
 SELECT 1
 "#
             );
-            let err = parse_model_inline(&content, "m.sql", None).unwrap_err();
+            let err = parse_model_inline(&content, Path::new("m.sql"), None).unwrap_err();
             match err {
                 ModelError::InvalidRetention { value, .. } => {
                     assert_eq!(value, *bad, "value field should be {bad}, got {value}");
@@ -4158,7 +4232,7 @@ table   = "inline_model"
 SELECT 1
 "#;
 
-        let model = parse_model_inline(content, "inline_model.sql", None).unwrap();
+        let model = parse_model_inline(content, Path::new("inline_model.sql"), None).unwrap();
         assert_eq!(model.config.target.catalog, "inline_warehouse");
         assert_eq!(model.config.target.schema, "staging");
 
@@ -4189,7 +4263,7 @@ table = "${ROCKY_TABLE_OVERRIDE:-customer_facts}"
 
 SELECT 1
 "#;
-        let model = parse_model_inline(content, "customer_facts.sql", None).unwrap();
+        let model = parse_model_inline(content, Path::new("customer_facts.sql"), None).unwrap();
 
         // Resolved values: env unset, so the default collapses to the literal.
         assert_eq!(model.config.name, "customer_facts");
@@ -4218,7 +4292,7 @@ schema = "marts"
 
 SELECT 1
 "#;
-        let model = parse_model_inline(content, "stg_orders.sql", None).unwrap();
+        let model = parse_model_inline(content, Path::new("stg_orders.sql"), None).unwrap();
         assert_eq!(model.config.name, "stg_orders");
         assert_eq!(model.config.target.table, "stg_orders");
         assert_eq!(model.config.name_declared, "stg_orders");
@@ -4240,7 +4314,7 @@ max_usd = 5.0
 
 SELECT 1
 "#;
-        let model = parse_model_inline(content, "fct_orders.sql", None).unwrap();
+        let model = parse_model_inline(content, Path::new("fct_orders.sql"), None).unwrap();
         let ir = model.to_model_ir();
         let ceiling = ir
             .cost_ceiling
@@ -4264,7 +4338,7 @@ on_breach = "warn"
 
 SELECT 1
 "#;
-        let model = parse_model_inline(content, "fct_orders.sql", None).unwrap();
+        let model = parse_model_inline(content, Path::new("fct_orders.sql"), None).unwrap();
         let ir = model.to_model_ir();
         assert!(
             ir.cost_ceiling.is_none(),
@@ -4282,7 +4356,7 @@ schema = "marts"
 
 SELECT 1
 "#;
-        let model = parse_model_inline(content, "fct_orders.sql", None).unwrap();
+        let model = parse_model_inline(content, Path::new("fct_orders.sql"), None).unwrap();
         let ir = model.to_model_ir();
         assert!(
             ir.cost_ceiling.is_none(),

--- a/engine/crates/rocky-duckdb/src/dialect.rs
+++ b/engine/crates/rocky-duckdb/src/dialect.rs
@@ -389,7 +389,7 @@ mod tests {
         let d = dialect();
         let mut ir = rocky_core::models::parse_model_inline(
             "---toml\n[target]\ncatalog = \"wh\"\nschema = \"marts\"\n---\n\nSELECT order_id FROM upstream",
-            "fct_orders.sql",
+            std::path::Path::new("fct_orders.sql"),
             None,
         )
         .unwrap()
@@ -417,7 +417,7 @@ mod tests {
         let d = dialect();
         let mut ir = rocky_core::models::parse_model_inline(
             "---toml\n[target]\ncatalog = \"wh\"\nschema = \"marts\"\n---\n\nSELECT order_id FROM upstream",
-            "fct_orders.sql",
+            std::path::Path::new("fct_orders.sql"),
             None,
         )
         .unwrap()


### PR DESCRIPTION
Closes #1814's **second** finding. The first (the crash window) and the third (the Dagster contract) are untouched and stay open on that issue.

#1814 said this was already known:

> #1778 made `Model::file_path` a `PathBuf` so the incremental typecheck stops missing a changed model. **Legacy inline models still convert the real filesystem path through `display().to_string()`.**

It also said the file:line needed re-deriving, and the issue was flagged as coming from a review that was cut off. It is real, and the code carried a comment asserting the opposite.

## The site

`models.rs`, the directory loader — the `.sql` file with no `.toml` sidecar, i.e. the legacy inline model:

```rust
parse_model_inline_with_context(
    &content,
    &path.display().to_string(),   // <- a real path from the filesystem walk
    ...
)
```

`display()` replaces every non-UTF-8 byte with U+FFFD, so `Model::file_path` came back different from the path the walk produced.

## The comment said this could not happen

```rust
// Lossless: this parser's `file_path` is a `&str` label supplied by
// the caller (a synthetic name like "fct_orders.sql"), never a path
// read off the filesystem, so widening it cannot lose bytes.
```

That was true of every **other** caller — all of them are inside `#[cfg(test)]` and pass string literals. The one production caller is the one it describes as impossible. The comment is deleted, not corrected: with a `&Path` parameter there is nothing left to justify.

## What it costs

`rocky-server/src/lsp.rs` looks a model up by path equality:

```rust
let file_path = uri.to_file_path().ok()?;
result.project.models.iter().find(|m| m.file_path == file_path)
```

`uri.to_file_path()` gives the real bytes; the model carried the lossy ones. So for a legacy inline model with a non-UTF-8 filename, the lookup found **nothing** — no diagnostics, no hover, no go-to-definition, no rename — and reported no error, because `None` there means "not a model file".

## The fix

`parse_model_inline` and `parse_model_inline_with_context` take `&Path`. The loader passes `path` straight through. The lossy conversion survives in exactly one place, and it is correct there:

```rust
// Only for the human-readable `path` on an error. Lossy is correct there —
// a diagnostic is text — and it never reaches `Model::file_path`.
let displayed = || file_path.display().to_string();
```

The model **name** stays lossy too, deliberately, and the test asserts it: a name is an identifier that has to be a `String`, not a path.

## A second defect, found by this PR's own test failing on CI

The Linux-only test I could not run locally **failed on CI with only the path fix**, finding zero models. The directory walk drops such a file before the parser ever sees it:

```rust
if path.file_name()?.to_str()? == "_defaults.toml" {   // <- None here DROPS the file
    return None;
}
if path.extension()?.to_str()? == "sql" && include(&path) {
```

`to_str()` is `None` for a non-UTF-8 name, and that `?` inside a `filter_map` returns `None` for the whole entry — before the extension is even looked at.

So the model was not merely mis-keyed, it was **invisible**: it did not compile, did not run, did not appear in `rocky dag`, and nothing said so. That is worse than the finding this PR set out to close, and it sat one layer above it.

Fixed by comparing `OsStr`, which is byte-exact and total. Swept for the same shape: `to_str()?` appears in one other place (`ci_diff.rs:276`), whose input is a `&str` all the way down, so it cannot produce `None` there.

## Evidence

**Mutation-checked**, restoring the round-trip:

```
failures:
    models::tests::an_inline_model_keeps_a_non_utf8_path_byte_for_byte
mutation-check: OK — the test failed under mutation, so it is fix-sensitive.
```

**Two tests, and the split between them is a real coverage limit rather than a preference.**

`an_inline_model_keeps_a_non_utf8_path_byte_for_byte` drives the parser directly with a path built from bytes. It carries a precondition assertion — the path must actually differ from its own `display()` round-trip — so it cannot pass vacuously on a platform where that is not true.

`the_directory_loader_keeps_a_non_utf8_filename_byte_for_byte` drives the real walk, and is `#[cfg(target_os = "linux")]`. **APFS refuses a non-UTF-8 filename outright** (`EILSEQ`, "Illegal byte sequence"), so it cannot run on macOS at all — I hit that writing it. CI is `ubuntu-latest`, so it runs there and not on my machine.

That split turned out to be the useful part. I could not mutation-check the walk fix locally for the same reason, but **CI ran the experiment for real**: the test failed on the commit that had only the path fix, and passes on the commit that adds the walk fix. That is the mutation and its control, on the platform where the input can exist.

`cargo test`: `-p rocky-core` 2196 passed, `-p rocky-cli` 1966, `-p rocky-compiler` 486, plus `rocky-ai`, `rocky-duckdb` and `rocky-server` — 0 failed anywhere. Clippy `--all-targets --all-features` clean on the edited crates, `cargo fmt --check` clean.

The signature change touches 33 call sites; all but one are `#[cfg(test)]` string literals that became `Path::new(…)`. One of my mechanical rewrites corrupted a TOML fixture inside a raw string (`update_columns = ["name", Path::new("status")]`) — `test_to_plan_merge` caught it, and a sweep for the shape found no others.

## What I am least confident about

That the LSP is the worst consumer of this. It is the one I traced, and it fails silently, which is why I led with it. But `Model::file_path` is read in nine places I found and I checked equality only at that one — `blast_radius.rs:157` builds a `name -> display().to_string()` map, and `api.rs:1115` serialises it for the HTTP surface. Both are already string-typed, so this change does not alter them, but it means a caller comparing an API-reported path against a `PathBuf` would still see the lossy form. That is a separate seam from the one this closes.

## What I think is being missed

The comment is the finding, and the walk is the same failure one layer up. Someone widened `file_path` to `PathBuf` in #1778, checked the parser's callers, found them all synthetic, and wrote that down as a guarantee — and the guarantee was false for the one caller that was not a test. The grep that would have caught it is "which caller is not in `#[cfg(test)]`", and the answer was a single line in the same file.

The same shape is worth a look on `path: String` in `ModelError` and on `blast_radius`'s map key: both are string-typed for reasons that may also be "every caller I checked was a literal".

**Independent red team: not run.** The Codex plugin cannot return a verdict into an autonomous loop, so this is self-reviewed at maximum effort and disclosed as such, per `AGENTS.md`. #1814 itself came from an independent pass that was cut off before reporting; re-deriving the file:line was the work it asked for.

Refs #1778, #1814
