### PR TITLE
refactor(engine/rocky-cli): one derivation for the .rocky directory, and a test on the branch that made it worth sharing

### DIFF
--- a/engine/crates/rocky-cli/src/commands/doctor.rs
+++ b/engine/crates/rocky-cli/src/commands/doctor.rs
@@ -876,11 +876,7 @@ fn spool_check(config_path: &Path, suggestions: &mut Vec<String>) -> Option<Heal
     use rocky_core::schedule::spool;
 
     let start = Instant::now();
-    let rocky_dir = config_path
-        .parent()
-        .filter(|p| !p.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."))
-        .join(".rocky");
+    let rocky_dir = crate::commands::scheduler::rocky_dir_for_config(config_path);
     let dir = spool::spool_dir(&rocky_dir);
 
     // Does the spool exist at all? `read_dir` answers NotFound for both "never
@@ -978,11 +974,7 @@ fn scheduler_check(
     }
 
     let now = chrono::Utc::now();
-    let rocky_dir = config_path
-        .parent()
-        .filter(|p| !p.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."))
-        .join(".rocky");
+    let rocky_dir = crate::commands::scheduler::rocky_dir_for_config(config_path);
 
     let mut status = HealthStatus::Healthy;
     let mut messages: Vec<String> = Vec::new();

--- a/engine/crates/rocky-cli/src/commands/scheduler/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/scheduler/mod.rs
@@ -47,9 +47,17 @@ use crate::commands::tick::build_member_budgets;
 pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(15);
 
 /// The `.rocky` directory for a config file: its parent directory (the project
-/// root, not the process cwd) joined with `.rocky`. The single derivation shared
-/// by the reconciler loop, the schedule-status endpoint, and the webhook-ingress
-/// accept path, so all three agree on the tick lock and the demand spool.
+/// root, not the process cwd) joined with `.rocky`.
+///
+/// The single derivation, so every caller contends on the same tick lock and
+/// reads the same demand spool. Two processes launched from different working
+/// directories against the same `rocky.toml` must agree, and they only do
+/// because the rule is anchored to the config file rather than to the cwd.
+///
+/// The caller list is deliberately not enumerated here: it goes stale on its
+/// own, and it did — the previous version named three callers while nine
+/// derived the path, three of them by keeping a private copy of these five
+/// lines (#1901).
 pub fn rocky_dir_for_config(config_path: &Path) -> PathBuf {
     config_path
         .parent()
@@ -563,6 +571,49 @@ fn skip_reason_label(reason: &TickSkipReason) -> &'static str {
         TickSkipReason::ConfigError => "config_error",
         TickSkipReason::HistoryUnavailable => "history_unavailable",
         TickSkipReason::StateBusy => "state_busy",
+    }
+}
+
+#[cfg(test)]
+mod rocky_dir_tests {
+    use super::rocky_dir_for_config;
+    use std::path::{Path, PathBuf};
+
+    /// #1901. A bare `rocky.toml` has a parent — the EMPTY path — and that is
+    /// the branch the `filter` exists for.
+    ///
+    /// ```text
+    /// with the filter     ->  "." + ".rocky"  ->  ./.rocky
+    /// without it          ->  ""  + ".rocky"  ->  .rocky
+    /// ```
+    ///
+    /// Both resolve to the same directory, so a caller that only opens the
+    /// path cannot tell them apart. A caller that absolutizes, canonicalizes,
+    /// or compares two of these as strings can. Three call sites kept a
+    /// private copy of these five lines, which is how a change to the rule
+    /// would have reached one of them and not the others.
+    #[test]
+    fn a_config_with_no_directory_anchors_to_the_current_directory() {
+        assert_eq!(
+            rocky_dir_for_config(Path::new("rocky.toml")),
+            PathBuf::from(".").join(".rocky"),
+        );
+    }
+
+    /// The rule the doc comment is about: the CONFIG's directory, never the
+    /// process cwd. Two ticks launched from different working directories
+    /// against the same `rocky.toml` contend on the same lock only because of
+    /// this.
+    #[test]
+    fn the_directory_comes_from_the_config_path_not_the_cwd() {
+        assert_eq!(
+            rocky_dir_for_config(Path::new("/srv/projects/sales/rocky.toml")),
+            PathBuf::from("/srv/projects/sales/.rocky"),
+        );
+        assert_eq!(
+            rocky_dir_for_config(Path::new("../sibling/rocky.toml")),
+            PathBuf::from("../sibling/.rocky"),
+        );
     }
 }
 

--- a/engine/crates/rocky-cli/src/commands/tick.rs
+++ b/engine/crates/rocky-cli/src/commands/tick.rs
@@ -105,15 +105,10 @@ pub async fn run_tick(
     // the exact pre-wiring behavior.
     let member_budgets = build_member_budgets(&config, config_path, pipeline.as_deref());
 
-    // The `.rocky` directory holding the tick lock is anchored to the config
-    // file's directory (the project root), NOT the process cwd — two ticks
-    // launched from different cwds must contend on the same lock. It is also
-    // where the P3 webhook spool will live.
-    let rocky_dir = config_path
-        .parent()
-        .filter(|p| !p.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."))
-        .join(".rocky");
+    // Anchored to the config file's directory, NOT the process cwd — two ticks
+    // launched from different cwds must contend on the same lock and see the
+    // same webhook spool. `rocky_dir_for_config` is that rule.
+    let rocky_dir = crate::commands::scheduler::rocky_dir_for_config(config_path);
 
     let opts = TickOptions {
         dry_run,


### PR DESCRIPTION
Closes #1901. `rocky_dir_for_config` called itself the single derivation while three call sites kept a private copy of the same five lines.

```
before   scheduler/mod.rs:53  rocky_dir_for_config  ──▶ 6 callers
         tick.rs:112          (private copy)
         doctor.rs:877        (private copy)   <- spool_check
         doctor.rs:981        (private copy)   <- the scheduler health check

after    scheduler/mod.rs:53  rocky_dir_for_config  ──▶ 9 callers
```

This path decides which tick lock a process contends on and which webhook spool it reads. Nothing was broken — all four copies behaved identically — but a change to the rule would have reached one and not the others, and the two that would drift are the tick that consumes the spool and the doctor check that reports on it.

## The issue named two copies; there are three

#1901 lists `tick.rs:112` and `doctor.rs:877`. `doctor.rs:981` is a third, in `scheduler_check` — the health check that probes the tick lock for a wedged reconciler. Found by grepping the shape rather than the name:

```
grep -rn 'as_os_str().is_empty()' engine/crates/
```

`api.rs:1409`'s `project_root_for` applies the same parent rule to a different suffix (the project root, not `.rocky`). Left alone: it is a different derivation that happens to share a line, and folding it in would need a second shared helper this issue did not ask for.

## The doc comment

It enumerated three callers. Nine derive the path. An enumeration of call sites goes stale on its own — and it had — so it is gone; the rule it existed to state is not:

> Two processes launched from different working directories against the same `rocky.toml` must agree, and they only do because the rule is anchored to the config file rather than to the cwd.

## The branch that made it worth sharing

`rocky_dir_for_config` had no test. The interesting case is a bare `rocky.toml`, whose parent is the **empty** path:

```
with the filter     ->  "." + ".rocky"  ->  ./.rocky
without it          ->  ""  + ".rocky"  ->  .rocky
```

Both open the same directory, so a caller that only opens the path cannot tell them apart. A caller that absolutizes, canonicalizes, or compares two of these as strings can.

**Mutation-checked** by deleting the `filter`:

```
left:  ".rocky"
right: "./.rocky"
failures:
    commands::scheduler::rocky_dir_tests::a_config_with_no_directory_anchors_to_the_current_directory
mutation-check: OK — the test failed under mutation, so it is fix-sensitive.
```

`cargo test -p rocky-cli` 1985 + 63 across every target, 0 failed. Clippy `--all-targets --all-features` clean on `rocky-cli` and `rocky-mcp` (the out-of-crate caller), `cargo fmt --check` clean.

## What I am least confident about

That "behaviour-neutral" holds for `doctor.rs:981`, which I verified by reading rather than by a test that would fail if it did not. The three copies are textually identical to the function body and all three take `config_path`, so the substitution is exact — but `scheduler_check` is the one site whose output I did not exercise before and after. The existing doctor tests pass, and they cover the spool check at `:877` more thoroughly than the scheduler check at `:981`. If a reviewer wants that closed rather than argued, the cheap version is a doctor test that runs `scheduler_check` against a config with no directory component.

## What I think is being missed

The class survives the fix. `rocky_dir_for_config` is now the single `.rocky` derivation, but nothing enforces that — the next private copy compiles fine, exactly as these three did. The comment that claimed uniqueness is what failed here, and I have replaced it with a different comment.

A real guard exists and I did not build it: `.rocky` could be a newtype (`RockyDir(PathBuf)`) that only this function constructs, so a hand-rolled `join(".rocky")` would not type-check where a `RockyDir` is wanted. That is the `rust-style` newtype rule applied to a path instead of a string. It is a wider change than #1901 asked for — nine call sites plus the `spool::spool_dir`/`probe_tick_lock` signatures — so I have not filed it as a plan, only named it here.

**Independent red team: not run.** The Codex plugin cannot return a verdict into an autonomous loop, so this is self-reviewed at maximum effort and disclosed as such, per `AGENTS.md`.

Refs #1899
