### PR TITLE
fix(engine/rocky-core): the spool refuses a timestamp its own reader cannot parse back

### DIFF
--- a/engine/crates/rocky-core/src/schedule/spool.rs
+++ b/engine/crates/rocky-core/src/schedule/spool.rs
@@ -263,6 +263,39 @@ fn tombstone_path(key_path: &Path) -> PathBuf {
 /// (`EIO`/`ENOSPC`) a duplicate returns an error (surfaced as `500`) rather than
 /// the pre-durability `202` — the sender retries, and no ack is ever more
 /// durable than the entry it deduplicates against.
+/// The RFC 3339 rendering of `now`, refused if the reader cannot parse it back.
+///
+/// `DateTime::to_rfc3339` renders a year outside `0..=9999` with an expanded
+/// signed year — `+10000-01-01T00:00:00+00:00` — and chrono's own RFC 3339
+/// parser requires exactly four year digits. So [`accept`] could durably
+/// store a `received_at` that no reader would ever accept back.
+///
+/// The check is the round trip itself, through the same `parse_from_rfc3339`
+/// the reader calls, rather than a year-range test that restates chrono's rule
+/// and would go stale if chrono changed it.
+///
+/// Refusing at the write is what keeps the invariant one-sided. `rocky
+/// schedule spool` already reports an unparseable `received_at` as `skipped`
+/// with reason `bad_timestamp`, and that report should mean "this file was
+/// corrupted or hand-written", never "the accept path is allowed to produce
+/// this".
+///
+/// Not reachable through the webhook ingress, which stamps `Utc::now()`.
+/// [`accept`] is public, so it is reachable.
+fn round_trippable_rfc3339(now: DateTime<Utc>) -> io::Result<String> {
+    let rendered = now.to_rfc3339();
+    if let Err(e) = DateTime::parse_from_rfc3339(&rendered) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "refusing to spool a demand stamped {rendered:?}: it does not parse back as \
+                 RFC 3339 ({e}), so the reader would report it as bad_timestamp forever"
+            ),
+        ));
+    }
+    Ok(rendered)
+}
+
 pub fn accept(
     rocky_dir: &Path,
     pipeline: &str,
@@ -294,6 +327,9 @@ pub fn accept_journaled(
     now: DateTime<Utc>,
     journal: &dyn SpoolJournal,
 ) -> io::Result<AcceptOutcome> {
+    // Before `create_dir_all`, so a refused stamp leaves no trace on disk.
+    let received_at = round_trippable_rfc3339(now)?;
+
     let dir = spool_dir(rocky_dir);
     std::fs::create_dir_all(&dir)?;
 
@@ -321,7 +357,7 @@ pub fn accept_journaled(
         pipeline: pipeline.to_string(),
         kind,
         token: token.to_string(),
-        received_at: now.to_rfc3339(),
+        received_at,
         body_hash: body_hash.to_string(),
     };
     let bytes =
@@ -687,6 +723,77 @@ mod tests {
 
     fn now() -> DateTime<Utc> {
         Utc.with_ymd_and_hms(2026, 5, 1, 0, 0, 0).unwrap()
+    }
+
+    /// #1903. The write refuses a stamp the reader cannot parse back.
+    ///
+    /// Year 10000 renders as `+10000-01-01T00:00:00+00:00` — an expanded
+    /// signed year, which `parse_from_rfc3339` rejects. Before this, `accept`
+    /// stored it durably and every reader thereafter reported the file as
+    /// `bad_timestamp`, forever, for a demand the spool itself had written.
+    #[test]
+    fn a_stamp_the_reader_cannot_parse_is_refused_at_the_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let rocky_dir = dir.path().join(".rocky");
+        let far_future = Utc.with_ymd_and_hms(10000, 1, 1, 0, 0, 0).unwrap();
+
+        // PRECONDITION: this stamp really is one the reader refuses. Without
+        // it the test passes for any `accept` that errors for any reason.
+        let rendered = far_future.to_rfc3339();
+        assert!(
+            DateTime::parse_from_rfc3339(&rendered).is_err(),
+            "PRECONDITION: {rendered} must be unparseable, or this test proves nothing"
+        );
+
+        let err = accept(
+            &rocky_dir,
+            "sales",
+            WebhookKind::Id,
+            "delivery-1",
+            "hash",
+            far_future,
+        )
+        .expect_err("a stamp the reader refuses must not be spooled");
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert!(
+            err.to_string().contains(&rendered),
+            "the refusal must name the stamp it refused, got: {err}"
+        );
+        assert!(
+            !spool_dir(&rocky_dir).as_path().try_exists().unwrap(),
+            "a refused stamp must leave nothing on disk"
+        );
+    }
+
+    /// The control. The boundary chrono can still render in four digits is
+    /// accepted, and comes back out.
+    #[test]
+    fn the_last_four_digit_year_is_accepted_and_reads_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let rocky_dir = dir.path().join(".rocky");
+        let last = Utc.with_ymd_and_hms(9999, 12, 31, 23, 59, 59).unwrap();
+
+        accept(
+            &rocky_dir,
+            "sales",
+            WebhookKind::Id,
+            "delivery-1",
+            "hash",
+            last,
+        )
+        .expect("year 9999 round-trips");
+
+        let files = list_pending_files(&rocky_dir).expect("list");
+        assert_eq!(files.len(), 1);
+        let demand: PendingDemand =
+            serde_json::from_slice(&std::fs::read(&files[0]).unwrap()).unwrap();
+        assert_eq!(
+            DateTime::parse_from_rfc3339(&demand.received_at)
+                .expect("the spooled stamp parses back")
+                .with_timezone(&Utc),
+            last,
+        );
     }
 
     /// A journal that records the step order for the crash-safety assertion.


### PR DESCRIPTION
Refs #1903, part 2 only. The spool wrote a timestamp its own reader refuses.

```
accept   now.to_rfc3339()          ->  "+10000-01-01T00:00:00+00:00"   written, fsynced, durable
reader   parse_from_rfc3339(...)   ->  Err: four year digits required
         every listing, forever    ->  skipped, reason bad_timestamp
```

Chrono renders a year outside `0..=9999` with an expanded signed year. Its own RFC 3339 parser requires exactly four year digits. So the two disagree, and `accept` was on the writing side of the disagreement.

Not reachable through the webhook ingress, which stamps `Utc::now()`. `spool::accept` is public, so it is reachable.

## The fix is the round trip, not a year range

```rust
fn round_trippable_rfc3339(now: DateTime<Utc>) -> io::Result<String> {
    let rendered = now.to_rfc3339();
    if let Err(e) = DateTime::parse_from_rfc3339(&rendered) { ... }
    Ok(rendered)
}
```

Through the **same** `parse_from_rfc3339` the reader calls, rather than a `0..=9999` test that restates chrono's rule in a second place and goes stale if chrono changes it.

It runs before `create_dir_all`, so a refused stamp leaves nothing on disk.

It also runs before the `WebhookKind::Id` tombstone check, which changes one case: a redelivery of an already-consumed demand carrying a bad stamp now errors where it previously returned `Duplicate`. Unreachable from the ingress, which stamps `Utc::now()`. Validate-first is the order I want anyway — a value the module cannot store is not a fact about whether the delivery was already seen, and answering `Duplicate` would report success for a demand that could never have been spooled in the first place.

## Why refuse rather than tolerate

`rocky schedule spool` already reports an unparseable `received_at` as `skipped` with reason `bad_timestamp`, so nothing was being dropped or crashing. That reader is still there and still needed — a spool file can be corrupted or hand-written.

What changes is what the report *means*. Before, `bad_timestamp` could describe a file the spool wrote itself, and an operator had no way to tell that from corruption. Now the accept path cannot produce it.

## Tests

| Test | What it pins |
|---|---|
| `a_stamp_the_reader_cannot_parse_is_refused_at_the_write` | year 10000 is refused, the error names the stamp, and nothing is created on disk |
| `the_last_four_digit_year_is_accepted_and_reads_back` | the boundary still works — 9999-12-31 spools and parses back equal |

The first opens with a precondition assertion that the chosen stamp really is one `parse_from_rfc3339` refuses. Without it the test would pass for an `accept` that errored for any unrelated reason.

**Mutation-checked** by reverting to the unconditional `now.to_rfc3339()`:

```
failures:
    schedule::spool::tests::a_stamp_the_reader_cannot_parse_is_refused_at_the_write
mutation-check: OK — the test failed under mutation, so it is fix-sensitive.
```

`cargo test -p rocky-core` 2205 + 90 across every target, 0 failed. `-p rocky-cli --lib schedule_spool` 14 passed, including the two API parity tests. Clippy `--all-targets --all-features` clean, `cargo fmt --check` clean.

## Part 1 is not in this PR

#1903's first half — `classify_not_found` cannot see a masked `NotFound` on Windows, so an unreadable spool reads as an empty one — is left open deliberately. It needs two things this PR cannot supply:

- **A decision.** The issue offers a portable sentinel file versus a `#[cfg(windows)]` enumeration probe. They differ in migration cost for existing spools, and the choice is not mine.
- **Evidence.** The issue's own "least confident about" is whether ordinary local NTFS ACLs produce the masked shape at all, or whether it needs access-based enumeration on an SMB share. Only a Windows/SMB integration test settles that, and it decides whether the exposure is real or theoretical.

The issue stays open for it.

## What I am least confident about

Whether `InvalidInput` is the right `io::ErrorKind`, and whether returning `io::Result` at all is right for a caller-argument defect. Every other refusal in this module is a genuine I/O failure; this one is the caller handing over a value the module cannot store. `InvalidInput` is the closest match in the existing signature, and changing `accept` to a typed error is a wider change than this half of the issue asked for. A caller matching on `ErrorKind` to decide whether to retry would now see a permanent failure in a kind that usually means "the argument was wrong", which is accurate, but I did not audit the ingress handler for such a match.

## What I think is being missed

`received_at` is a `String` on `PendingDemand`, and that is the actual defect class. A `DateTime<Utc>` field with serde's RFC 3339 support would make this unrepresentable rather than refused — the type would carry the round-trip guarantee, and no caller could stamp a value the reader rejects.

I did not do it because it is a stored-format change: existing spool files hold the string, and a typed field changes what `serde_json::from_slice` accepts for them. That needs a migration story for demands already on disk, which is more than this half of #1903 asked for. Worth noting that the same `String`-for-a-timestamp shape appears on other spool-adjacent records I have not surveyed.

**Independent red team: not run.** The Codex plugin cannot return a verdict into an autonomous loop, so this is self-reviewed at maximum effort and disclosed as such, per `AGENTS.md`. Part 2 of #1903 itself came from an independent Codex review of #1899.

Refs #1899
