### PR TITLE
refactor(engine): the policy freeze sources are typed, so the incomplete-list warning cannot be silently detached

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -13050,12 +13050,20 @@
         "description": "Which freeze sources the report read.",
         "properties": {
           "ledger": {
-            "description": "How the decision ledger was read.\n\n- `\"read\"` — a local backend, read in full. - `\"absent\"` — a local backend with no state store yet. Proven absent, not assumed: a path that exists but cannot be read is an error. - `\"local_mirror\"` — a remote `[state]` backend. What was read is the local mirror, which may be stale or empty; the remote authority was NOT downloaded, because this is a read-only route and the download replaces the local ledger. A freeze recorded by another pod can be missing here while an apply, which does download first, still denies. - `\"not_consulted\"` — no `[policy]` block, so nothing is in force and the enforcement gate reads no ledger either.",
-            "type": "string"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PolicyLedgerSource"
+              }
+            ],
+            "description": "How the decision ledger was read."
           },
           "markers": {
-            "description": "How the durable freeze markers were read.\n\n- `\"read\"` — the `[state]` backend has a durable object tier, read in full. Reads are NOT gated on `freeze_marker_writes`: that flag gates writes only, and an existing marker stays enforced after it is turned off, so a reader that honoured it would hide a live freeze. - `\"not_configured\"` — the backend keeps no durable object tier. - `\"not_consulted\"` — no `[policy]` block, as above.",
-            "type": "string"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PolicyMarkerSource"
+              }
+            ],
+            "description": "How the durable freeze markers were read."
           }
         },
         "required": [
@@ -13063,6 +13071,65 @@
           "markers"
         ],
         "type": "object"
+      },
+      "PolicyLedgerSource": {
+        "description": "How the decision ledger was read for a policy report.\n\nAn enum rather than a string because a consumer BRANCHES on it: the text renderer prints the incomplete-freeze-list warning on `LocalMirror` alone. As a bare string the producer and that branch were joined by nothing — renaming the written value compiled fine and silently retired the warning, with the tests on both ends still green (#1909).\n\nThe wire form is unchanged: the same four snake_case strings.",
+        "oneOf": [
+          {
+            "description": "A local backend, read in full.",
+            "enum": [
+              "read"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "A local backend with no state store yet. Proven absent, not assumed: a path that exists but cannot be read is an error.",
+            "enum": [
+              "absent"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "A remote `[state]` backend. What was read is the local mirror, which may be stale or empty; the remote authority was NOT downloaded, because this is a read-only route and the download replaces the local ledger. A freeze recorded by another pod can be missing here while an apply, which does download first, still denies.",
+            "enum": [
+              "local_mirror"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "No `[policy]` block, so nothing is in force and the enforcement gate reads no ledger either.",
+            "enum": [
+              "not_consulted"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "PolicyMarkerSource": {
+        "description": "How the durable freeze markers were read for a policy report.\n\nA separate enum from [`PolicyLedgerSource`], not a shared one: the two answer different questions and only two of their values coincide. A shared enum would let a match on the ledger claim to handle `NotConfigured`, which a ledger read cannot produce.\n\nThe wire form is unchanged: the same three snake_case strings.",
+        "oneOf": [
+          {
+            "description": "The `[state]` backend has a durable object tier, read in full. Reads are NOT gated on `freeze_marker_writes`: that flag gates writes only, and an existing marker stays enforced after it is turned off, so a reader that honoured it would hide a live freeze.",
+            "enum": [
+              "read"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "The backend keeps no durable object tier.",
+            "enum": [
+              "not_configured"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "No `[policy]` block, as above.",
+            "enum": [
+              "not_consulted"
+            ],
+            "type": "string"
+          }
+        ]
       },
       "PolicyModelAttributes": {
         "description": "The compiled attributes of the checked model, echoed back so the explain output is self-contained.",

--- a/editors/vscode/src/types/generated/policy_show.ts
+++ b/editors/vscode/src/types/generated/policy_show.ts
@@ -12,6 +12,22 @@
  */
 export type PolicyEffect = "allow" | "require_review" | "deny";
 /**
+ * How the decision ledger was read for a policy report.
+ *
+ * An enum rather than a string because a consumer BRANCHES on it: the text renderer prints the incomplete-freeze-list warning on `LocalMirror` alone. As a bare string the producer and that branch were joined by nothing — renaming the written value compiled fine and silently retired the warning, with the tests on both ends still green (#1909).
+ *
+ * The wire form is unchanged: the same four snake_case strings.
+ */
+export type PolicyLedgerSource = "read" | "absent" | "local_mirror" | "not_consulted";
+/**
+ * How the durable freeze markers were read for a policy report.
+ *
+ * A separate enum from [`PolicyLedgerSource`], not a shared one: the two answer different questions and only two of their values coincide. A shared enum would let a match on the ledger claim to handle `NotConfigured`, which a ledger read cannot produce.
+ *
+ * The wire form is unchanged: the same three snake_case strings.
+ */
+export type PolicyMarkerSource = "read" | "not_configured" | "not_consulted";
+/**
  * Who is attempting an action.
  *
  * `agent` is a non-human caller (an AI harness authoring, applying, or remediating). `human` is a person. In v0 the principal is supplied explicitly (`rocky policy check --principal …`); auto-detection is a later phase.
@@ -79,16 +95,12 @@ export interface PolicyRulesOutput {
 export interface PolicyFreezeSources {
   /**
    * How the decision ledger was read.
-   *
-   * - `"read"` — a local backend, read in full. - `"absent"` — a local backend with no state store yet. Proven absent, not assumed: a path that exists but cannot be read is an error. - `"local_mirror"` — a remote `[state]` backend. What was read is the local mirror, which may be stale or empty; the remote authority was NOT downloaded, because this is a read-only route and the download replaces the local ledger. A freeze recorded by another pod can be missing here while an apply, which does download first, still denies. - `"not_consulted"` — no `[policy]` block, so nothing is in force and the enforcement gate reads no ledger either.
    */
-  ledger: string;
+  ledger: PolicyLedgerSource;
   /**
    * How the durable freeze markers were read.
-   *
-   * - `"read"` — the `[state]` backend has a durable object tier, read in full. Reads are NOT gated on `freeze_marker_writes`: that flag gates writes only, and an existing marker stays enforced after it is turned off, so a reader that honoured it would hide a live freeze. - `"not_configured"` — the backend keeps no durable object tier. - `"not_consulted"` — no `[policy]` block, as above.
    */
-  markers: string;
+  markers: PolicyMarkerSource;
   [k: string]: unknown;
 }
 /**

--- a/engine/crates/rocky-cli/src/commands/policy.rs
+++ b/engine/crates/rocky-cli/src/commands/policy.rs
@@ -36,8 +36,9 @@ use rocky_core::state_sync::StateSyncError;
 
 use crate::output::{
     PolicyAutonomyBudgetOutput, PolicyCheckOutput, PolicyFreezeEntry, PolicyFreezeInForce,
-    PolicyFreezeOutput, PolicyFreezeSources, PolicyModelAttributes, PolicyRuleEntry,
-    PolicyRuleScopeOutput, PolicyRulesOutput, PolicyTestOutput, PolicyTestResult, print_json,
+    PolicyFreezeOutput, PolicyFreezeSources, PolicyLedgerSource, PolicyMarkerSource,
+    PolicyModelAttributes, PolicyRuleEntry, PolicyRuleScopeOutput, PolicyRulesOutput,
+    PolicyTestOutput, PolicyTestResult, print_json,
 };
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -285,13 +286,14 @@ pub fn run_policy_test(config_path: &Path, json: bool) -> Result<()> {
 
 /// The decision ledger's part of `rocky policy show`.
 ///
-/// `source` is one of `"read"`, `"absent"` or `"local_mirror"`. Absent is
-/// proven, not assumed: a store path that is missing is absence, a store path
-/// that is there but cannot be read (a dangling link, an unreadable ancestor)
-/// is an error.
+/// `source` is `Read`, `Absent` or `LocalMirror` — never `NotConsulted`, which
+/// only [`policy_show_unconsulted_ledger`] produces. Absent is proven, not
+/// assumed: a store path that is missing is absence, a store path that is
+/// there but cannot be read (a dangling link, an unreadable ancestor) is an
+/// error.
 #[derive(Debug)]
 pub struct PolicyShowLedger {
-    pub source: &'static str,
+    pub source: PolicyLedgerSource,
     pub freezes: Vec<ActiveFreeze>,
 }
 
@@ -309,14 +311,14 @@ pub fn read_policy_show_ledger(
     remote_backend: bool,
 ) -> Result<PolicyShowLedger> {
     let read_label = if remote_backend {
-        "local_mirror"
+        PolicyLedgerSource::LocalMirror
     } else {
-        "read"
+        PolicyLedgerSource::Read
     };
     let absent_label = if remote_backend {
-        "local_mirror"
+        PolicyLedgerSource::LocalMirror
     } else {
-        "absent"
+        PolicyLedgerSource::Absent
     };
     // `metadata` follows links: a dangling link is NotFound here, and the
     // classifier then reports it present-but-unreadable. An open on that path
@@ -474,9 +476,9 @@ pub fn assemble_policy_show(
         })
         .collect();
     let markers_source = match &markers {
-        PolicyShowMarkers::NotConsulted => "not_consulted",
-        PolicyShowMarkers::NotConfigured => "not_configured",
-        PolicyShowMarkers::Read(_) => "read",
+        PolicyShowMarkers::NotConsulted => PolicyMarkerSource::NotConsulted,
+        PolicyShowMarkers::NotConfigured => PolicyMarkerSource::NotConfigured,
+        PolicyShowMarkers::Read(_) => PolicyMarkerSource::Read,
     };
     if let PolicyShowMarkers::Read(markers) = markers {
         freezes.extend(markers.into_iter().map(|m| PolicyFreezeInForce {
@@ -498,8 +500,8 @@ pub fn assemble_policy_show(
         rules,
         freezes,
         freeze_sources: PolicyFreezeSources {
-            ledger: ledger_source.to_string(),
-            markers: markers_source.to_string(),
+            ledger: ledger_source,
+            markers: markers_source,
         },
     }
 }
@@ -547,7 +549,7 @@ pub fn policy_show_remote_backend(state_cfg: &StateConfig) -> bool {
 /// document whose own `configured` field says nothing enforces.
 pub fn policy_show_unconsulted_ledger() -> PolicyShowLedger {
     PolicyShowLedger {
-        source: "not_consulted",
+        source: PolicyLedgerSource::NotConsulted,
         freezes: Vec::new(),
     }
 }
@@ -694,14 +696,23 @@ fn render_show_text<W: Write>(w: &mut W, out: &PolicyRulesOutput) -> io::Result<
     writeln!(
         w,
         "freeze sources: ledger {}, markers {}",
-        out.freeze_sources.ledger, out.freeze_sources.markers
+        serde_plain(&out.freeze_sources.ledger),
+        serde_plain(&out.freeze_sources.markers)
     )?;
-    if out.freeze_sources.ledger == "local_mirror" {
-        writeln!(
-            w,
-            "  note: [state] is a remote backend. The ledger above is the local mirror; the \
+    // Matched exhaustively, not compared: this note is the only place the text
+    // says the freeze list may be incomplete, and a new ledger source must not
+    // be able to skip it by default (#1909).
+    match out.freeze_sources.ledger {
+        PolicyLedgerSource::LocalMirror => {
+            writeln!(
+                w,
+                "  note: [state] is a remote backend. The ledger above is the local mirror; the \
 remote authority was not downloaded, so a freeze recorded by another pod may be missing."
-        )?;
+            )?;
+        }
+        PolicyLedgerSource::Read
+        | PolicyLedgerSource::Absent
+        | PolicyLedgerSource::NotConsulted => {}
     }
     Ok(())
 }
@@ -2136,8 +2147,8 @@ expect = \"allow\"
         assert_eq!(out.default_agent_effect, PolicyEffect::RequireReview);
         assert!(out.rules.is_empty());
         assert!(out.freezes.is_empty());
-        assert_eq!(out.freeze_sources.ledger, "not_consulted");
-        assert_eq!(out.freeze_sources.markers, "not_consulted");
+        assert_eq!(out.freeze_sources.ledger, PolicyLedgerSource::NotConsulted);
+        assert_eq!(out.freeze_sources.markers, PolicyMarkerSource::NotConsulted);
     }
 
     /// The rules come out in file order with their position as `id`, and a
@@ -2184,8 +2195,11 @@ expect = \"allow\"
         assert!(f.since.is_some());
         assert!(f.plan_id.is_some());
         assert!(f.freeze_id.is_none());
-        assert_eq!(out.freeze_sources.ledger, "read");
-        assert_eq!(out.freeze_sources.markers, "not_configured");
+        assert_eq!(out.freeze_sources.ledger, PolicyLedgerSource::Read);
+        assert_eq!(
+            out.freeze_sources.markers,
+            PolicyMarkerSource::NotConfigured
+        );
 
         // Lifting it takes it out of force: the report reads the ledger's
         // projection, not its raw rows.
@@ -2270,7 +2284,7 @@ expect = \"allow\"
         let policy = PolicyConfig::default_posture();
         let frozen_at = chrono::Utc::now();
         let ledger = PolicyShowLedger {
-            source: "read",
+            source: PolicyLedgerSource::Read,
             freezes: vec![ActiveFreeze {
                 principal: PolicyPrincipal::Agent,
                 scope: "model=fct_*".to_string(),
@@ -2292,7 +2306,7 @@ expect = \"allow\"
         }];
 
         let out = assemble_policy_show(Some(&policy), ledger, PolicyShowMarkers::Read(markers));
-        assert_eq!(out.freeze_sources.markers, "read");
+        assert_eq!(out.freeze_sources.markers, PolicyMarkerSource::Read);
         assert_eq!(out.freezes.len(), 2);
         assert_eq!(out.freezes[0].source, "ledger");
         assert_eq!(out.freezes[0].plan_id.as_deref(), Some("freeze-1"));
@@ -2392,11 +2406,16 @@ expect = \"allow\"
         let missing = dir.path().join("state.redb");
 
         let local = read_policy_show_ledger(&missing, false).unwrap();
-        assert_eq!(local.source, "absent", "a local backend proves absence");
+        assert_eq!(
+            local.source,
+            PolicyLedgerSource::Absent,
+            "a local backend proves absence"
+        );
 
         let remote = read_policy_show_ledger(&missing, true).unwrap();
         assert_eq!(
-            remote.source, "local_mirror",
+            remote.source,
+            PolicyLedgerSource::LocalMirror,
             "a remote backend never proves absence from the local file alone"
         );
         assert!(remote.freezes.is_empty());
@@ -2458,13 +2477,13 @@ expect = \"allow\"
             "a freeze the gate never reads is not in force: {:?}",
             out.freezes
         );
-        assert_eq!(out.freeze_sources.ledger, "not_consulted");
-        assert_eq!(out.freeze_sources.markers, "not_consulted");
+        assert_eq!(out.freeze_sources.ledger, PolicyLedgerSource::NotConsulted);
+        assert_eq!(out.freeze_sources.markers, PolicyMarkerSource::NotConsulted);
 
         // And with the block restored, the same store reports it in force.
         let back = compute_policy_show(&config, &state_path).await.unwrap();
         assert_eq!(back.freezes.len(), 1, "the freeze itself never moved");
-        assert_eq!(back.freeze_sources.ledger, "read");
+        assert_eq!(back.freeze_sources.ledger, PolicyLedgerSource::Read);
     }
 
     /// `verify_after` is a first-class rule field that decides whether a
@@ -2574,12 +2593,13 @@ expect = \"allow\"
         .unwrap();
 
         let local = read_policy_show_ledger(&state_path, false).unwrap();
-        assert_eq!(local.source, "read");
+        assert_eq!(local.source, PolicyLedgerSource::Read);
         assert_eq!(local.freezes.len(), 1);
 
         let mirrored = read_policy_show_ledger(&state_path, true).unwrap();
         assert_eq!(
-            mirrored.source, "local_mirror",
+            mirrored.source,
+            PolicyLedgerSource::LocalMirror,
             "a populated local store on a remote backend is still only a mirror"
         );
         assert_eq!(
@@ -2675,8 +2695,8 @@ expect = \"allow\"
                 freeze_id: Some("fz-1".to_string()),
             }],
             freeze_sources: PolicyFreezeSources {
-                ledger: "read".to_string(),
-                markers: "read".to_string(),
+                ledger: PolicyLedgerSource::Read,
+                markers: PolicyMarkerSource::Read,
             },
         }
     }
@@ -2749,8 +2769,8 @@ expect = \"allow\"
         plane.rules.clear();
         plane.freezes.clear();
         plane.freeze_sources = PolicyFreezeSources {
-            ledger: "local_mirror".to_string(),
-            markers: "read".to_string(),
+            ledger: PolicyLedgerSource::LocalMirror,
+            markers: PolicyMarkerSource::Read,
         };
 
         let rendered = show_text(&plane);
@@ -2784,8 +2804,8 @@ expect = \"allow\"
         plane.rules.clear();
         plane.freezes.clear();
         plane.freeze_sources = PolicyFreezeSources {
-            ledger: "not_consulted".to_string(),
-            markers: "not_consulted".to_string(),
+            ledger: PolicyLedgerSource::NotConsulted,
+            markers: PolicyMarkerSource::NotConsulted,
         };
 
         let rendered = show_text(&plane);

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -8113,27 +8113,59 @@ pub struct PolicyFreezeInForce {
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct PolicyFreezeSources {
     /// How the decision ledger was read.
-    ///
-    /// - `"read"` — a local backend, read in full.
-    /// - `"absent"` — a local backend with no state store yet. Proven absent,
-    ///   not assumed: a path that exists but cannot be read is an error.
-    /// - `"local_mirror"` — a remote `[state]` backend. What was read is the
-    ///   local mirror, which may be stale or empty; the remote authority was
-    ///   NOT downloaded, because this is a read-only route and the download
-    ///   replaces the local ledger. A freeze recorded by another pod can be
-    ///   missing here while an apply, which does download first, still denies.
-    /// - `"not_consulted"` — no `[policy]` block, so nothing is in force and
-    ///   the enforcement gate reads no ledger either.
-    pub ledger: String,
+    pub ledger: PolicyLedgerSource,
     /// How the durable freeze markers were read.
-    ///
-    /// - `"read"` — the `[state]` backend has a durable object tier, read in
-    ///   full. Reads are NOT gated on `freeze_marker_writes`: that flag gates
-    ///   writes only, and an existing marker stays enforced after it is turned
-    ///   off, so a reader that honoured it would hide a live freeze.
-    /// - `"not_configured"` — the backend keeps no durable object tier.
-    /// - `"not_consulted"` — no `[policy]` block, as above.
-    pub markers: String,
+    pub markers: PolicyMarkerSource,
+}
+
+/// How the decision ledger was read for a policy report.
+///
+/// An enum rather than a string because a consumer BRANCHES on it: the text
+/// renderer prints the incomplete-freeze-list warning on `LocalMirror` alone.
+/// As a bare string the producer and that branch were joined by nothing —
+/// renaming the written value compiled fine and silently retired the warning,
+/// with the tests on both ends still green (#1909).
+///
+/// The wire form is unchanged: the same four snake_case strings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyLedgerSource {
+    /// A local backend, read in full.
+    Read,
+    /// A local backend with no state store yet. Proven absent, not assumed: a
+    /// path that exists but cannot be read is an error.
+    Absent,
+    /// A remote `[state]` backend. What was read is the local mirror, which
+    /// may be stale or empty; the remote authority was NOT downloaded, because
+    /// this is a read-only route and the download replaces the local ledger. A
+    /// freeze recorded by another pod can be missing here while an apply,
+    /// which does download first, still denies.
+    LocalMirror,
+    /// No `[policy]` block, so nothing is in force and the enforcement gate
+    /// reads no ledger either.
+    NotConsulted,
+}
+
+/// How the durable freeze markers were read for a policy report.
+///
+/// A separate enum from [`PolicyLedgerSource`], not a shared one: the two
+/// answer different questions and only two of their values coincide. A shared
+/// enum would let a match on the ledger claim to handle `NotConfigured`, which
+/// a ledger read cannot produce.
+///
+/// The wire form is unchanged: the same three snake_case strings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyMarkerSource {
+    /// The `[state]` backend has a durable object tier, read in full. Reads
+    /// are NOT gated on `freeze_marker_writes`: that flag gates writes only,
+    /// and an existing marker stays enforced after it is turned off, so a
+    /// reader that honoured it would hide a live freeze.
+    Read,
+    /// The backend keeps no durable object tier.
+    NotConfigured,
+    /// No `[policy]` block, as above.
+    NotConsulted,
 }
 
 /// JSON output for `rocky audit` — the agent-policy decision ledger.
@@ -11027,6 +11059,57 @@ pub struct JobStatus {
     /// shape is the `run` / `plan` / `apply` schema selected by
     /// [`kind`](Self::kind).
     pub result: Option<serde_json::Value>,
+}
+
+#[cfg(test)]
+mod policy_freeze_source_tests {
+    //! #1909. The two source fields became enums so a consumer that BRANCHES
+    //! on them cannot be silently detached from the producer. The claim that
+    //! bought is "the wire form does not move" — and nothing else pins it.
+    //!
+    //! These are the exact strings the fields carried as `String`, and they
+    //! are what the exported schema, the generated Pydantic models and the
+    //! generated TypeScript all enumerate. A renamed variant, an added one, or
+    //! a lost `#[serde(rename_all = "snake_case")]` changes the bytes on
+    //! `GET /api/v1/policy` for every existing client.
+    use super::*;
+
+    fn wire<T: Serialize>(value: &T) -> String {
+        serde_json::to_value(value)
+            .expect("serializes")
+            .as_str()
+            .expect("a unit variant is a JSON string")
+            .to_string()
+    }
+
+    #[test]
+    fn every_ledger_source_keeps_the_string_it_had() {
+        assert_eq!(wire(&PolicyLedgerSource::Read), "read");
+        assert_eq!(wire(&PolicyLedgerSource::Absent), "absent");
+        assert_eq!(wire(&PolicyLedgerSource::LocalMirror), "local_mirror");
+        assert_eq!(wire(&PolicyLedgerSource::NotConsulted), "not_consulted");
+    }
+
+    #[test]
+    fn every_marker_source_keeps_the_string_it_had() {
+        assert_eq!(wire(&PolicyMarkerSource::Read), "read");
+        assert_eq!(wire(&PolicyMarkerSource::NotConfigured), "not_configured");
+        assert_eq!(wire(&PolicyMarkerSource::NotConsulted), "not_consulted");
+    }
+
+    /// The whole struct, so a field rename is caught too — the enums pin the
+    /// values, this pins the keys they sit under.
+    #[test]
+    fn the_freeze_sources_object_is_byte_identical_to_the_string_version() {
+        let sources = PolicyFreezeSources {
+            ledger: PolicyLedgerSource::LocalMirror,
+            markers: PolicyMarkerSource::NotConfigured,
+        };
+        assert_eq!(
+            serde_json::to_string(&sources).expect("serializes"),
+            r#"{"ledger":"local_mirror","markers":"not_configured"}"#,
+        );
+    }
 }
 
 #[cfg(test)]

--- a/schemas/policy_show.schema.json
+++ b/schemas/policy_show.schema.json
@@ -193,12 +193,20 @@
       "description": "Which freeze sources the report read.",
       "properties": {
         "ledger": {
-          "description": "How the decision ledger was read.\n\n- `\"read\"` — a local backend, read in full. - `\"absent\"` — a local backend with no state store yet. Proven absent, not assumed: a path that exists but cannot be read is an error. - `\"local_mirror\"` — a remote `[state]` backend. What was read is the local mirror, which may be stale or empty; the remote authority was NOT downloaded, because this is a read-only route and the download replaces the local ledger. A freeze recorded by another pod can be missing here while an apply, which does download first, still denies. - `\"not_consulted\"` — no `[policy]` block, so nothing is in force and the enforcement gate reads no ledger either.",
-          "type": "string"
+          "allOf": [
+            {
+              "$ref": "#/definitions/PolicyLedgerSource"
+            }
+          ],
+          "description": "How the decision ledger was read."
         },
         "markers": {
-          "description": "How the durable freeze markers were read.\n\n- `\"read\"` — the `[state]` backend has a durable object tier, read in full. Reads are NOT gated on `freeze_marker_writes`: that flag gates writes only, and an existing marker stays enforced after it is turned off, so a reader that honoured it would hide a live freeze. - `\"not_configured\"` — the backend keeps no durable object tier. - `\"not_consulted\"` — no `[policy]` block, as above.",
-          "type": "string"
+          "allOf": [
+            {
+              "$ref": "#/definitions/PolicyMarkerSource"
+            }
+          ],
+          "description": "How the durable freeze markers were read."
         }
       },
       "required": [
@@ -206,6 +214,65 @@
         "markers"
       ],
       "type": "object"
+    },
+    "PolicyLedgerSource": {
+      "description": "How the decision ledger was read for a policy report.\n\nAn enum rather than a string because a consumer BRANCHES on it: the text renderer prints the incomplete-freeze-list warning on `LocalMirror` alone. As a bare string the producer and that branch were joined by nothing — renaming the written value compiled fine and silently retired the warning, with the tests on both ends still green (#1909).\n\nThe wire form is unchanged: the same four snake_case strings.",
+      "oneOf": [
+        {
+          "description": "A local backend, read in full.",
+          "enum": [
+            "read"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "A local backend with no state store yet. Proven absent, not assumed: a path that exists but cannot be read is an error.",
+          "enum": [
+            "absent"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "A remote `[state]` backend. What was read is the local mirror, which may be stale or empty; the remote authority was NOT downloaded, because this is a read-only route and the download replaces the local ledger. A freeze recorded by another pod can be missing here while an apply, which does download first, still denies.",
+          "enum": [
+            "local_mirror"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "No `[policy]` block, so nothing is in force and the enforcement gate reads no ledger either.",
+          "enum": [
+            "not_consulted"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "PolicyMarkerSource": {
+      "description": "How the durable freeze markers were read for a policy report.\n\nA separate enum from [`PolicyLedgerSource`], not a shared one: the two answer different questions and only two of their values coincide. A shared enum would let a match on the ledger claim to handle `NotConfigured`, which a ledger read cannot produce.\n\nThe wire form is unchanged: the same three snake_case strings.",
+      "oneOf": [
+        {
+          "description": "The `[state]` backend has a durable object tier, read in full. Reads are NOT gated on `freeze_marker_writes`: that flag gates writes only, and an existing marker stays enforced after it is turned off, so a reader that honoured it would hide a live freeze.",
+          "enum": [
+            "read"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "The backend keeps no durable object tier.",
+          "enum": [
+            "not_configured"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "No `[policy]` block, as above.",
+          "enum": [
+            "not_consulted"
+          ],
+          "type": "string"
+        }
+      ]
     },
     "PolicyPrincipal": {
       "description": "Who is attempting an action.\n\n`agent` is a non-human caller (an AI harness authoring, applying, or remediating). `human` is a person. In v0 the principal is supplied explicitly (`rocky policy check --principal …`); auto-detection is a later phase.",

--- a/sdk/python/src/rocky_sdk/types_generated/policy_show_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/policy_show_schema.py
@@ -137,23 +137,60 @@ class PolicyEffect19(StrEnum):
     deny = "deny"
 
 
-class PolicyFreezeSources(BaseModel):
+class PolicyLedgerSource1(StrEnum):
     """
-    Which freeze sources the report read.
+    A local backend, read in full.
     """
 
-    ledger: str
-    """
-    How the decision ledger was read.
+    read = "read"
 
-    - `"read"` — a local backend, read in full. - `"absent"` — a local backend with no state store yet. Proven absent, not assumed: a path that exists but cannot be read is an error. - `"local_mirror"` — a remote `[state]` backend. What was read is the local mirror, which may be stale or empty; the remote authority was NOT downloaded, because this is a read-only route and the download replaces the local ledger. A freeze recorded by another pod can be missing here while an apply, which does download first, still denies. - `"not_consulted"` — no `[policy]` block, so nothing is in force and the enforcement gate reads no ledger either.
-    """
-    markers: str
-    """
-    How the durable freeze markers were read.
 
-    - `"read"` — the `[state]` backend has a durable object tier, read in full. Reads are NOT gated on `freeze_marker_writes`: that flag gates writes only, and an existing marker stays enforced after it is turned off, so a reader that honoured it would hide a live freeze. - `"not_configured"` — the backend keeps no durable object tier. - `"not_consulted"` — no `[policy]` block, as above.
+class PolicyLedgerSource2(StrEnum):
     """
+    A local backend with no state store yet. Proven absent, not assumed: a path that exists but cannot be read is an error.
+    """
+
+    absent = "absent"
+
+
+class PolicyLedgerSource3(StrEnum):
+    """
+    A remote `[state]` backend. What was read is the local mirror, which may be stale or empty; the remote authority was NOT downloaded, because this is a read-only route and the download replaces the local ledger. A freeze recorded by another pod can be missing here while an apply, which does download first, still denies.
+    """
+
+    local_mirror = "local_mirror"
+
+
+class PolicyLedgerSource4(StrEnum):
+    """
+    No `[policy]` block, so nothing is in force and the enforcement gate reads no ledger either.
+    """
+
+    not_consulted = "not_consulted"
+
+
+class PolicyMarkerSource1(StrEnum):
+    """
+    The `[state]` backend has a durable object tier, read in full. Reads are NOT gated on `freeze_marker_writes`: that flag gates writes only, and an existing marker stays enforced after it is turned off, so a reader that honoured it would hide a live freeze.
+    """
+
+    read = "read"
+
+
+class PolicyMarkerSource2(StrEnum):
+    """
+    The backend keeps no durable object tier.
+    """
+
+    not_configured = "not_configured"
+
+
+class PolicyMarkerSource3(StrEnum):
+    """
+    No `[policy]` block, as above.
+    """
+
+    not_consulted = "not_consulted"
 
 
 class PolicyPrincipal11(StrEnum):
@@ -219,6 +256,26 @@ class PolicyFreezeInForce(BaseModel):
     source: str
     """
     `"ledger"` (a `rocky policy freeze` decision) or `"marker"` (a durable freeze marker in the remote object tier).
+    """
+
+
+class PolicyFreezeSources(BaseModel):
+    """
+    Which freeze sources the report read.
+    """
+
+    ledger: (
+        PolicyLedgerSource1
+        | PolicyLedgerSource2
+        | PolicyLedgerSource3
+        | PolicyLedgerSource4
+    )
+    """
+    How the decision ledger was read.
+    """
+    markers: PolicyMarkerSource1 | PolicyMarkerSource2 | PolicyMarkerSource3
+    """
+    How the durable freeze markers were read.
     """
 
 


### PR DESCRIPTION
Closes #1909. Two bare strings became two enums, so the producer and the branch that reads them are joined by the compiler.

```
before   read_policy_show_ledger  ──▶ "local_mirror"  (&'static str)
                                          ⋮  nothing connects these
         render_show_text         ──▶ == "local_mirror"

after    read_policy_show_ledger  ──▶ PolicyLedgerSource::LocalMirror
                                          │  the compiler
         render_show_text         ──▶ match { LocalMirror => note, ... }
```

## What was at risk

The `local_mirror` branch prints the only line that says the freeze list may be **incomplete**:

> note: [state] is a remote backend. The ledger above is the local mirror; the remote authority was not downloaded, so a freeze recorded by another pod may be missing.

Rename the written string and the match goes permanently false. `rocky policy show` then presents a partial read as an exhaustive one, and every test on both ends stays green — they set the field by hand.

## Proof the class is closed

Renaming the variant is now a build failure, at the branch itself:

```
error[E0599]: no variant ... named `LocalMirror` found for enum `PolicyLedgerSource`
    --> crates/rocky-cli/src/commands/policy.rs:314:29
    --> crates/rocky-cli/src/commands/policy.rs:319:29
    --> crates/rocky-cli/src/commands/policy.rs:706:29   <- the note

mutation-check: INCONCLUSIVE — the mutation broke the build
```

INCONCLUSIVE is the right verdict and the point of the change: there is no test to be fix-sensitive because the defect is no longer representable.

The renderer also **matches** rather than compares, so a new ledger source has to decide about the note instead of skipping it by default:

```rust
match out.freeze_sources.ledger {
    PolicyLedgerSource::LocalMirror => { writeln!(w, "  note: ...")?; }
    PolicyLedgerSource::Read | PolicyLedgerSource::Absent | PolicyLedgerSource::NotConsulted => {}
}
```

## Two enums, not one

`ledger` and `markers` overlap on `read` and `not_consulted` and diverge elsewhere:

| | values |
|---|---|
| `PolicyLedgerSource` | `read`, `absent`, `local_mirror`, `not_consulted` |
| `PolicyMarkerSource` | `read`, `not_configured`, `not_consulted` |

A shared enum would let a match on the ledger claim to handle `not_configured`, which a ledger read cannot produce. Splitting them keeps each match exhaustive over its real domain.

## The wire form does not move

That is the claim the whole change rests on, and nothing pinned it, so three tests do now:

```rust
assert_eq!(wire(&PolicyLedgerSource::LocalMirror), "local_mirror");
assert_eq!(
    serde_json::to_string(&sources).unwrap(),
    r#"{"ledger":"local_mirror","markers":"not_configured"}"#,
);
```

**Mutation-checked** by deleting `#[serde(rename_all = "snake_case")]`:

```
failures:
    output::policy_freeze_source_tests::every_ledger_source_keeps_the_string_it_had
    output::policy_freeze_source_tests::the_freeze_sources_object_is_byte_identical_to_the_string_version
mutation-check: OK — the test failed under mutation, so it is fix-sensitive.
```

The exported schema gets **stricter**: `"type": "string"` becomes the enumerated set, and the generated TypeScript is now `"read" | "absent" | "local_mirror" | "not_consulted"` instead of `string`. The generated Pydantic follows the same one-class-per-variant convention the existing `PolicyEffect` already uses in that file.

## The cascade

`just codegen` and `just regen-fixtures` both run. Four files regenerate; the dagster fixtures do not change, because no fixture covers `policy show`.

```
output.rs ──▶ schemas/policy_show.schema.json
          ──▶ sdk/python/.../policy_show_schema.py
          ──▶ editors/vscode/src/types/generated/policy_show.ts
          ──▶ docs/public/openapi.json
```

Green across all four subprojects: `cargo test -p rocky-cli` 1992 + 63, clippy `--all-targets --all-features` on `rocky-cli` and `rocky-mcp`, `cargo fmt --check`, `uv run pytest` 268 (sdk) and 773 (dagster), `npm run compile` (vscode).

## What I am least confident about

Whether `NotConsulted` belongs on `PolicyLedgerSource` at all. `PolicyShowLedger` — the type the real reader returns — can only produce `Read`, `Absent` or `LocalMirror`; `NotConsulted` comes solely from `policy_show_unconsulted_ledger`, a separate constructor for the no-`[policy]`-block case. So the enum is wider than either producer, and the renderer's match has an arm that one path can never reach.

Splitting further (a three-variant read result, widened at assembly) would make each producer's domain exact. I did not, because the field on the wire genuinely carries four values and a reader of the JSON needs one type for them. I think that is right, but it is the judgement in this PR I would most want a second opinion on.

## What I think is being missed

The same shape is still live one field away. `PolicyFreezeInForce.source` is a `String` holding `"ledger"` or `"marker"`, written in two places in `assemble_policy_show` and rendered straight into the text. It has no branch on it today, which is why #1909 did not name it — but "no consumer branches on it yet" is exactly what was true of `freeze_sources.ledger` before the note was added.

I did not fold it in: it is a second wire-visible field and the PR is already four subprojects wide. Worth its own pass, together with a sweep for other `&'static str` discriminants that reach `output.rs`, which I have not done.

**Independent red team: not run.** The Codex plugin cannot return a verdict into an autonomous loop, so this is self-reviewed at maximum effort and disclosed as such, per `AGENTS.md`. #1909 itself came out of building #1910.

Refs #1874, #1910
