### PR TITLE
docs(engine): a stop grace must cover the drain AND the kill grace after it

### DIFF
--- a/deploy/rocky/README.md
+++ b/deploy/rocky/README.md
@@ -42,7 +42,7 @@ Open that address. The token travels in the URL fragment, which never reaches th
 | `ROCKY_WEBHOOK_SECRET` | `--ui --scheduler` refuses to start without it. The scheduler's webhook route authenticates with this secret, not with the bearer token. |
 | `ports: 127.0.0.1:8080:8080` | Loopback only. The server terminates no TLS and knows no users; put your own gateway in front before publishing wider, and add `--allowed-host <name>` to the command for any name the UI is reached by. |
 | `volumes: ./project:/data` | The project and, under `models/`, the state store. One mount carries both. |
-| `stop_grace_period: 90s` | `docker compose stop` sends `SIGTERM`; the server drains requests and a running scheduled child (up to `--drain-timeout-seconds`, default 60). The grace stays above that. |
+| `stop_grace_period: 125s` | `docker compose stop` sends `SIGTERM`; the server drains requests and a running scheduled child (up to `--drain-timeout-seconds`, default 60). A child still running then gets its own `SIGTERM` and a further fixed 60 s before `SIGKILL`, so the grace must exceed the drain **plus 60**. |
 | `deploy.replicas: 1` | One scheduler per project. Two instances on one volume would both run what is due. Never `--scale rocky=2`; run one service per project. |
 
 There is no `healthcheck`. A Compose health check runs inside the container, and the image has no shell or HTTP client. Probe from the host instead:
@@ -75,7 +75,7 @@ The run and the server share the state store on the volume, so the server's next
 
 ```bash
 docker compose logs -f rocky       # JSON lines on stderr, the UI address on stdout
-docker compose stop                # SIGTERM, then the drain, inside the 90 s grace
+docker compose stop                # SIGTERM, then the drain, inside the 125 s grace
 docker compose down                # also removes the container; the volume is your directory, untouched
 ```
 

--- a/deploy/rocky/compose.yaml
+++ b/deploy/rocky/compose.yaml
@@ -54,8 +54,13 @@ services:
 
     # `docker compose stop` sends SIGTERM and the server drains: in-flight
     # requests, then a running scheduled child (up to the server's
-    # --drain-timeout-seconds, default 60). Keep this above that.
-    stop_grace_period: 90s
+    # --drain-timeout-seconds, default 60).
+    #
+    # A child still running when the drain runs out gets its own SIGTERM and a
+    # FURTHER FIXED 60 s before SIGKILL. So the floor is the drain plus 60,
+    # which is 120 s with the defaults. 90 s was short enough to kill a child
+    # mid-write.
+    stop_grace_period: 125s
 
     restart: unless-stopped
 

--- a/docs/src/content/docs/advanced/deployment-contract.md
+++ b/docs/src/content/docs/advanced/deployment-contract.md
@@ -73,7 +73,18 @@ This is why the rule says persistent volume. The state backend does not change i
 
 A rolling update runs the old pod and the new pod at the same time, on separate volumes or on one. On one volume it is the overlap above, one winner per tick, with the new pod contending until the old one drains. On separate volumes it is two schedulers for the length of the rollout. Neither is the rule. Use `Recreate`: stop the old pod, let it drain, start the new one on the same volume.
 
-The drain: `SIGTERM` makes `rocky serve` stop accepting connections, finish in-flight requests, and wait for a running scheduled child up to `--drain-timeout-seconds` (default 60). The pod's `terminationGracePeriodSeconds`, or the container's stop grace, must sit above that number, or the child is killed mid-run and its occurrence is recorded as a failure.
+The drain: `SIGTERM` makes `rocky serve` stop accepting connections, finish in-flight requests, and wait for a running scheduled child up to `--drain-timeout-seconds` (default 60).
+
+A child that is still running when the drain runs out is not killed at once. The server sends it `SIGTERM`, then waits a further fixed 60 seconds before `SIGKILL`. So the worst case is the drain plus 60, not the drain.
+
+```
+  SIGTERM ──▶ drain the child ──▶ SIGTERM the child ──▶ SIGKILL
+              --drain-timeout-seconds   60s, fixed
+              default 60                not configurable
+              └────────────── worst case 120s ──────────────┘
+```
+
+**The pod's `terminationGracePeriodSeconds`, or the container's stop grace, must exceed `--drain-timeout-seconds` plus 60.** With the defaults that is more than 120 seconds. A grace inside that window lets the supervisor `SIGKILL` the pod while the child is still writing, and the occurrence is recorded as a failure.
 
 Closing the tiered-backend seams tracked as issue 1242 does not make a rolling update safe. The double fire lives in the scheduler tables that never sync, not in the sync.
 
@@ -106,7 +117,7 @@ The persistent volume is required on every row. The backend chooses the blast ra
 ## What the engine does not promise
 
 - A webhook demand claimed by a reconciler that then dies, whose child also dies before recording a run, is lost. At most once.
-- A scheduled run killed by a stop grace shorter than the drain is recorded as a failure, not retried.
+- A scheduled run killed by a stop grace shorter than the drain plus 60 seconds is recorded as a failure, not retried.
 - Two schedulers on two volumes both run. No backend prevents it; `cas` only makes the second one fail at the end.
 - `flock` on network storage is unprobed.
 

--- a/docs/src/content/docs/guides/run-the-image.md
+++ b/docs/src/content/docs/guides/run-the-image.md
@@ -107,10 +107,18 @@ The image carries no `HEALTHCHECK` instruction, and you cannot add one: a Docker
 Docker waits 10 seconds by default, then sends `SIGKILL`. A scheduled run can need longer. Set the grace on the container:
 
 ```bash
-docker run --stop-timeout 90 ...
+docker run --stop-timeout 125 ...
 ```
 
-In Kubernetes the same knob is `terminationGracePeriodSeconds`. `--drain-timeout-seconds` (default 60) caps how long the server waits for the child; keep the container's grace above it.
+125, not 90. `--drain-timeout-seconds` (default 60) caps how long the server waits for the child. A child still running when that runs out gets its own `SIGTERM` and a **further fixed 60 seconds** before `SIGKILL`, so the worst case is the drain plus 60.
+
+```
+  drain the child   --drain-timeout-seconds, default 60
+  then SIGTERM it   a further 60s, fixed, not configurable
+  worst case        120s with the defaults
+```
+
+**Set the grace above `--drain-timeout-seconds` + 60.** In Kubernetes the same knob is `terminationGracePeriodSeconds`. A shorter grace kills the child mid-write and records its occurrence as a failure.
 
 ## Run the scheduler
 
@@ -143,7 +151,7 @@ The repository ships [`deploy/rocky/`](https://github.com/rocky-data/rocky/tree/
 
 ## A minikube example
 
-This is an example, not a supported deployment. It follows the rules above: one replica, replaced in place, on a persistent volume, with the health probe from the kubelet and a drain grace above the server's own.
+This is an example, not a supported deployment. It follows the rules above: one replica, replaced in place, on a persistent volume, with the health probe from the kubelet and a stop grace above the drain plus 60.
 
 ```yaml
 apiVersion: v1
@@ -179,7 +187,9 @@ spec:
       labels:
         app: rocky
     spec:
-      terminationGracePeriodSeconds: 90
+      # Above --drain-timeout-seconds (default 60) plus the fixed 60 s the
+      # server allows the child after its own SIGTERM. 90 is not enough.
+      terminationGracePeriodSeconds: 125
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532


### PR DESCRIPTION
Every shipped example sets a 90-second stop grace. The worst case is 120.

## What the code does

On shutdown the server waits `--drain-timeout-seconds` (default 60) for a running scheduled child. A child still running when that runs out is **not** killed at once. The server sends it `SIGTERM`, then waits a **further fixed 60 seconds** before `SIGKILL`.

```
  SIGTERM ──▶ drain the child ──▶ SIGTERM the child ──▶ SIGKILL
              --drain-timeout-seconds   60s, fixed
              default 60                not configurable
              └────────────── worst case 120s ──────────────┘
```

| Where | What it is |
|---|---|
| `engine/crates/rocky-core/src/schedule/spawn.rs:24` | `DEFAULT_DRAIN_TIMEOUT = 60s` |
| `engine/crates/rocky-core/src/schedule/spawn.rs:182` | `KILL_GRACE = 60s` |
| `engine/crates/rocky-core/src/schedule/spawn.rs:318-337` | drain, then `terminate_gracefully` |
| `engine/crates/rocky-core/src/schedule/spawn.rs:372-398` | `wait_with_grace`, then `start_kill` |

So the floor is `--drain-timeout-seconds` **+ 60**.

## Why it matters

A 90-second grace lets the supervisor `SIGKILL` the pod or container while the child is still writing to the warehouse. The occurrence is then recorded as a failure and is not retried — the exact loss the deployment contract says this setting prevents. The pages promised the protection and gave a number too small to deliver it.

## What changed

Five statements of the rule, all wrong, in four files:

| File | Was | Now |
|---|---|---|
| `docs/.../advanced/deployment-contract.md` | "must sit above that number" | must exceed the drain **plus 60**, with the sequence drawn |
| `docs/.../guides/run-the-image.md` | `docker run --stop-timeout 90` | `125`, and the reason |
| `docs/.../guides/run-the-image.md` | `terminationGracePeriodSeconds: 90` | `125`, with a comment |
| `deploy/rocky/compose.yaml` | `stop_grace_period: 90s` | `125s` |
| `deploy/rocky/README.md` | "the grace stays above that" | above the drain plus 60 |

The contract's "what the engine does not promise" list said a run killed by "a stop grace shorter than the drain" is recorded as a failure. That now reads "shorter than the drain plus 60 seconds".

## No CHANGELOG entry

Deliberate. An engine release PR is open in the same window, and two `Unreleased` entries conflict every time. This changes no code.

## How it was found

While proving the Helm chart for self-hosting on Kubernetes. That chart now refuses any `terminationGracePeriodSeconds` at or below `drainTimeoutSeconds + 60`, and prints the arithmetic.
