### PR TITLE
fix(vscode): re-export the four generated output types missing from the barrel

### DIFF
--- a/editors/vscode/src/types/generated/index.ts
+++ b/editors/vscode/src/types/generated/index.ts
@@ -60,6 +60,25 @@ export type {
   ScheduleThrottleKind,
   TickLockState,
 } from "./schedule_status";
+export type {
+  ScheduleSpoolOutput,
+  SpoolCounts,
+  SpoolPendingEntry,
+  SpoolSkippedEntry,
+} from "./schedule_spool";
+export type {
+  PolicyRulesOutput,
+  PolicyAutonomyBudgetOutput,
+  PolicyRuleScopeOutput,
+  PolicyRuleEntry,
+  PolicyFreezeInForce,
+  PolicyFreezeSources,
+  PolicyLedgerSource,
+  PolicyMarkerSource,
+  PolicyEffect,
+  PolicyPrincipal,
+  PolicyCapability,
+} from "./policy_show";
 
 // serve HTTP API — the five estate routes (typed, no CLI counterpart)
 export type { HealthOutput } from "./health";


### PR DESCRIPTION
Four generated output types are unreachable from the VS Code barrel. Split out of #1907 so a release cut does not have to wait on it.

## What is missing

`editors/vscode/src/types/generated/index.ts` is hand-maintained: `just codegen` writes `types/generated/<command>.ts` but never the barrel. So an output's interface can be generated, committed, and still be unreachable by anyone importing from the barrel.

```text
  policy_show.ts     PolicyRulesOutput            #1874
                     PolicyAutonomyBudgetOutput
                     PolicyRuleScopeOutput
  schedule_spool.ts  ScheduleSpoolOutput          #1899
```

Both of those PRs were mine, and both landed their generated `.ts` without the barrel entry.

The nested and enum types from the same two modules are exported alongside them, so a consumer can name what the outputs actually contain.

## The guard exists and has never run

`src/__tests__/generatedBarrelCompleteness.test.ts` was added in #1853 for exactly this failure, and it does catch it:

```text
  before   2 failed | 108 passed
  after    110 passed
```

It has never gated anything. `vscode-ci` runs `npm test`, which is `node ./out/test/runTest.js`. The vitest suite is `npm run test:unit`, and **no workflow invokes `vitest` or `test:unit`**:

```bash
$ grep -rn 'vitest\|test:unit' .github/workflows/
  (nothing)
```

So the whole vitest suite — 318 tests — is inert in CI, and this guard has been decorative since it was written. That is the more useful finding here; wiring `test:unit` into `vscode-ci` is a follow-up, not this PR.

## Verification

- `npm run test:unit` — 318 passed.
- `npm run compile` (`tsc -p ./`) — clean.
- Before/after on the guard as above, so the change is load-bearing rather than assumed.

## Scope

Barrel only, one file, no generated output changed. `SettingsOutput` is deliberately absent: `settings.ts` does not exist on `main` yet, and its barrel entry travels with #1907.
