### PR TITLE
docs(engine): remove the minikube example, whose copy step cannot work

### DIFF
--- a/docs/src/content/docs/advanced/deployment-contract.md
+++ b/docs/src/content/docs/advanced/deployment-contract.md
@@ -123,7 +123,7 @@ The persistent volume is required on every row. The backend chooses the blast ra
 
 ## Related pages
 
-- [Run the Container Image](/guides/run-the-image/): the image, `docker run`, and the minikube example that follows this contract.
+- [Run the Container Image](/guides/run-the-image/): the image, `docker run`, and the Compose example that follows this contract.
 - [State management](/concepts/state-management/#remote-state-persistence): the backends and the sync lifecycle.
 - [Configuration](/reference/configuration/#concurrent-writers): `concurrency_control`, `on_schema_mismatch`, `catchup`.
 - [Failure modes](/advanced/failure-modes/): what a failed run looks like from the outside.

--- a/docs/src/content/docs/guides/run-the-image.md
+++ b/docs/src/content/docs/guides/run-the-image.md
@@ -1,11 +1,11 @@
 ---
 title: Run the Container Image
-description: "Run Rocky from the container image that ships with every engine release: docker run, the volume, the token, the health probe, the drain, upgrades, and a minikube example."
+description: "Run Rocky from the container image that ships with every engine release: docker run, the volume, the token, the health probe, the drain, upgrades, and a Compose example."
 sidebar:
   order: 5.6
 ---
 
-Every engine release publishes one container image, `ghcr.io/rocky-data/rocky`. The image holds the release's own `rocky` binary and nothing else. This guide shows you how to run it with `docker run`, what to mount, how to probe it, how to stop it, and how to upgrade it. A minikube example closes the page. Kubernetes is not a supported target; the example is a starting point, not a contract.
+Every engine release publishes one container image, `ghcr.io/rocky-data/rocky`. The image holds the release's own `rocky` binary and nothing else. This guide shows you how to run it with `docker run`, what to mount, how to probe it, how to stop it, and how to upgrade it. A Compose example and a build recipe close the page.
 
 ## What the image is
 
@@ -98,7 +98,7 @@ The state store is written under `/data/models`, so the next run picks up the wa
 curl -fsS http://127.0.0.1:8080/api/v1/health
 ```
 
-The image carries no `HEALTHCHECK` instruction, and you cannot add one: a Docker health check runs inside the container, and the image has no shell or HTTP client. The same limit applies to a Compose `healthcheck`. A Kubernetes `httpGet` probe comes from the kubelet, outside the container, so it works; the example below uses it. The health route answers whatever `Host` the probe sends, so `--ui` needs no `--allowed-host` for a probe; every other route holds the rule.
+The image carries no `HEALTHCHECK` instruction, and you cannot add one: a Docker health check runs inside the container, and the image has no shell or HTTP client. The same limit applies to a Compose `healthcheck`. A Kubernetes `httpGet` probe comes from the kubelet, outside the container, so it works. The health route answers whatever `Host` the probe sends, so `--ui` needs no `--allowed-host` for a probe; every other route holds the rule.
 
 ## Stop and drain
 
@@ -124,7 +124,7 @@ docker run --stop-timeout 125 ...
 
 `serve --scheduler` runs every pipeline's `[schedule]` in-process, like `rocky tick` on a cron. Two rules:
 
-- **One instance per project directory.** Two containers with `--scheduler` on one mount would both run what is due. Run one replica, and replace it in place rather than side by side; the example below sets `replicas: 1` and `strategy: Recreate` for that reason.
+- **One instance per project directory.** Two containers with `--scheduler` on one mount would both run what is due. Run one replica, and replace it in place rather than side by side. In Kubernetes terms that is `replicas: 1` and `strategy: Recreate`.
 - **`--ui` with `--scheduler` needs `ROCKY_WEBHOOK_SECRET`**, so the scheduler's webhook route cannot be reached with the read-only browser token.
 
 ## Verify what you pull
@@ -148,92 +148,6 @@ Rolling back is running the previous tag. When the upgrade crossed a state-schem
 ## A Compose example
 
 The repository ships [`deploy/rocky/`](https://github.com/rocky-data/rocky/tree/main/deploy/rocky): one `compose.yaml` that runs the image as a long-lived process with the UI and the scheduler, an `.env.example` for the two secrets, and a README that walks the three steps to start it. It encodes the rules on this page, one line each: the pinned tag, the loopback port, the volume, the drain grace, one replica. It is community-supported: an example to start from, not a supported deployment.
-
-## A minikube example
-
-This is an example, not a supported deployment. It follows the rules above: one replica, replaced in place, on a persistent volume, with the health probe from the kubelet and a stop grace above the drain plus 60.
-
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: rocky-serve
-stringData:
-  token: replace-me-with-openssl-rand-hex-32
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: rocky-data
-spec:
-  accessModes: [ReadWriteOnce]
-  resources:
-    requests:
-      storage: 1Gi
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: rocky
-spec:
-  replicas: 1
-  strategy:
-    type: Recreate
-  selector:
-    matchLabels:
-      app: rocky
-  template:
-    metadata:
-      labels:
-        app: rocky
-    spec:
-      # Above --drain-timeout-seconds (default 60) plus the fixed 60 s the
-      # server allows the child after its own SIGTERM. 90 is not enough.
-      terminationGracePeriodSeconds: 125
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65532
-        fsGroup: 65532
-      containers:
-        - name: rocky
-          image: ghcr.io/rocky-data/rocky:1.74.0
-          args: ["serve", "--host", "0.0.0.0", "--ui", "--token-scope", "read-only"]
-          env:
-            - name: ROCKY_SERVE_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: rocky-serve
-                  key: token
-          ports:
-            - containerPort: 8080
-          readinessProbe:
-            httpGet:
-              path: /api/v1/health
-              port: 8080
-          livenessProbe:
-            httpGet:
-              path: /api/v1/health
-              port: 8080
-            periodSeconds: 30
-          volumeMounts:
-            - name: data
-              mountPath: /data
-      volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: rocky-data
-```
-
-Copy a project into the volume, then reach the UI through a port-forward, which presents the `localhost` host the server allows:
-
-```bash
-kubectl apply -f rocky.yaml
-kubectl cp ./my-project "$(kubectl get pod -l app=rocky -o name | cut -d/ -f2):/data"
-kubectl port-forward deploy/rocky 8080:8080
-# open http://localhost:8080/ui/#token=<the secret's token>
-```
-
-`fsGroup: 65532` makes the volume writable by the server's user. The pod has one container and one replica because the scheduler, and the state store, allow one writer per project.
 
 ## Build the image yourself
 


### PR DESCRIPTION
The minikube example's only instruction for getting a project onto the volume is `kubectl cp` into the Rocky pod. That cannot work.

```
$ kubectl cp ./my-project ns/rocky-pod:/data
OCI runtime exec failed: exec failed: unable to start container process:
exec: "tar": executable file not found in $PATH: unknown
command terminated with exit code 126
```

`kubectl cp` is not a protocol — it runs `tar` **inside the target container** and streams an archive to it. The image is `gcr.io/distroless/cc-debian12:nonroot`, which by design ships no shell, no package manager and no `tar`. No flag avoids it. Full diagnosis in #1915.

## Why delete it now, before the tag

The page arrived in bc208dc2 (#1693), which is **not** an ancestor of `engine-v1.73.0`:

```
$ git merge-base --is-ancestor bc208dc2 engine-v1.73.0; echo $?
1
```

No image has been published yet, so no reader has been able to reach this recipe. The next engine release is the first one where someone can find the page, follow it, and fail. Removing it before the tag closes that window instead of opening it.

## Why no replacement here

A working recipe lands with the Helm chart, along with a pointer from this page to the new Kubernetes guide. Adding the pointer now would link to a directory that does not exist on `main` yet.

So for the window between this and the chart, the page carries **no** Kubernetes example rather than a broken one. That is a real loss of coverage, not a free deletion — it is the trade Hugo picked, on the grounds that nothing beats a recipe that fails.

## What changed

The section alone leaves five dangling references, two of them pointing at the manifest that is gone:

| Where | Was |
|---|---|
| `run-the-image.md` | the `## A minikube example` section, 86 lines |
| `run-the-image.md:3` | frontmatter description ending "and a minikube example" |
| `run-the-image.md:8` | "A minikube example closes the page." |
| `run-the-image.md:101` | of the `httpGet` probe — "the example below uses it" |
| `run-the-image.md:127` | "the example below sets `replicas: 1` and `strategy: Recreate`" |
| `advanced/deployment-contract.md` | "the minikube example that follows this contract" |

No anchor links point into the removed section anywhere in `docs/`, so nothing 404s.

## One thing worth knowing

This deletes the `terminationGracePeriodSeconds: 125` that #1914 corrected in that manifest an hour ago. The rule itself stays on the page — #1914 also put it in the drain section, with the reasoning — so nothing about the grace guidance is lost.

Refs #1915. The chart PR closes it, when it adds the pointer.
