### PR TITLE
fix(engine): a check that could not run still gates, and cell_as_u64 stops fabricating counts

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -475,16 +475,10 @@ fn merge_replication_compile_and_copy_errors(output: &mut RunOutput, table_error
 /// advisory and `fail_on_error = false` keeps every check advisory — neither
 /// may change a status or an exit code.
 ///
-/// A check the engine could not evaluate and therefore FAILED is not advisory
-/// at all: it reaches the error bucket whatever its severity says (#1741), so
-/// a broken check gates exactly as a violated one does instead of reading as
-/// clean. The `*_not_evaluated` constructors set `passed: false` for that
-/// reason (#1602 / #1595).
-///
-/// `not_evaluated` alone does not mean failed. `cross_source_overlap_not_applicable`
-/// carries a reason with `passed: true` — a group the FR says is not
-/// applicable, which must NOT gate — and the bucketer skips it because it
-/// passed. See [`RunOutput::check_failures_by_severity`] for the rule itself.
+/// A FAILED check carrying `not_evaluated` reaches the error bucket whatever
+/// its severity says, so it gates like an error-severity violation (#1741 /
+/// #1602 / #1595). `not_evaluated` with `passed: true` is not a failure and
+/// reaches neither bucket. See [`RunOutput::check_failures_by_severity`].
 fn replication_check_gate_failed(
     output: &RunOutput,
     checks: &rocky_core::config::ChecksConfig,

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -7016,8 +7016,18 @@ async fn run_batched_checks(
                 // (#1666). `check_row_count` hard-codes `Error`, so
                 // `severity = "warning"` on a replication pipeline parsed and
                 // was discarded — the operator's own escape hatch did nothing.
-                // Same shape the freshness check already uses below.
-                check.severity = pipeline.checks.row_count.severity();
+                //
+                // Only for a check that RAN (#1871). Severity grades a
+                // measurement: an operator writing `warning` means "a row
+                // count that does not match is advisory", not "a row count I
+                // could not obtain is advisory". `row_count_not_evaluated`
+                // chooses `Error` and `check_failures_by_severity` buckets on
+                // severity alone, so overwriting it here is what decides
+                // whether the run gates. Same guard the freshness and
+                // null-rate sites use.
+                if check.not_evaluated.is_none() {
+                    check.severity = pipeline.checks.row_count.severity();
+                }
                 let entry =
                     pending_checks
                         .entry(target_key.clone())
@@ -13822,8 +13832,13 @@ async fn process_table(
             &task.column_match_exclude,
         );
         // The configured severity, not `check_column_match`'s hard-coded
-        // `Error` (#1666).
-        check.severity = column_match_severity;
+        // `Error` (#1666) — and only for a check that RAN (#1871). A column
+        // probe that failed is `column_match_not_evaluated`, which chooses
+        // `Error`; downgrading that to the configured `warning` cleared the
+        // gate on a run that had compared nothing.
+        if check.not_evaluated.is_none() {
+            check.severity = column_match_severity;
+        }
         probe_rate_limited = rate_limited;
         Some(check)
     } else {
@@ -33985,6 +34000,52 @@ table = "fct_events"
         assert!(
             gated,
             "an unevaluated null-rate check gates: {checks:?}",
+            checks = pending.get(&fx.target_key()).map(|p| &p.checks)
+        );
+        assert!(matches!(
+            status,
+            rocky_core::state::RunStatus::PartialFailure
+        ));
+        assert_eq!(
+            result.severity,
+            rocky_core::tests::TestSeverity::Error,
+            "a check the engine could not evaluate keeps its own severity: {result:?}"
+        );
+    }
+
+    /// #1871 regressed the row-count arm of the same invariant the null-rate
+    /// test above pins: a check the engine COULD NOT RUN is never advisory.
+    ///
+    /// `row_count_not_evaluated` chooses `TestSeverity::Error`, and
+    /// `check_failures_by_severity` buckets on severity alone, so the gate's
+    /// correctness rests entirely on that choice surviving. The site
+    /// overwrote it with the configured severity for BOTH arms, so
+    /// `severity = "warning"` downgraded a row-count query that failed and
+    /// the run exited 0 with `status: "Success"`. 1.73.0 always gated it.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn a_failed_row_count_query_gates_even_when_the_configured_severity_is_warning() {
+        let inner = seeded_duckdb().await;
+        let fx = BatchedCheckFixture::new("row_count = { enabled = true, severity = \"warning\" }");
+
+        let failing = InterceptingDuckDb {
+            inner: &inner,
+            prefix: "SELECT COUNT(*) FROM tgt.orders",
+            reply: Intercept::Fail("injected row-count failure"),
+        };
+        let (pending, _) = fx.run(&failing, None, None).await;
+
+        let result = the_result(&pending, &fx.target_key(), "row_count");
+        assert!(
+            result.not_evaluated.is_some(),
+            "the row count must be unevaluated for this test to mean anything: {result:?}"
+        );
+        // The gate first: it is the user-visible consequence, so a regression
+        // prints the exit code it changed rather than a field.
+        let (gated, status) = run_status_for(&fx, &pending);
+        assert!(
+            gated,
+            "an unevaluated row count gates: {checks:?}",
             checks = pending.get(&fx.target_key()).map(|p| &p.checks)
         );
         assert!(matches!(

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -475,11 +475,16 @@ fn merge_replication_compile_and_copy_errors(output: &mut RunOutput, table_error
 /// advisory and `fail_on_error = false` keeps every check advisory — neither
 /// may change a status or an exit code.
 ///
-/// A check the engine could NOT evaluate is not advisory at all. It sets
-/// `passed: false` (#1602 / #1595) and reaches the error bucket whatever its
-/// severity says (#1741), so a broken check gates exactly as a violated one
-/// does instead of reading as clean. See
-/// [`RunOutput::check_failures_by_severity`] for the bucketing rule itself.
+/// A check the engine could not evaluate and therefore FAILED is not advisory
+/// at all: it reaches the error bucket whatever its severity says (#1741), so
+/// a broken check gates exactly as a violated one does instead of reading as
+/// clean. The `*_not_evaluated` constructors set `passed: false` for that
+/// reason (#1602 / #1595).
+///
+/// `not_evaluated` alone does not mean failed. `cross_source_overlap_not_applicable`
+/// carries a reason with `passed: true` — a group the FR says is not
+/// applicable, which must NOT gate — and the bucketer skips it because it
+/// passed. See [`RunOutput::check_failures_by_severity`] for the rule itself.
 fn replication_check_gate_failed(
     output: &RunOutput,
     checks: &rocky_core::config::ChecksConfig,

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -22161,6 +22161,78 @@ timestamp_column = "ts"
         }
     }
 
+    /// A warehouse that copies normally and then refuses to describe the
+    /// TARGET — the post-copy probe failure `post_copy_column_match` turns into
+    /// `column_match_not_evaluated`.
+    ///
+    /// Shared by the two tests that need that failure. It used to live inside
+    /// one of them; a second copy is how the three materialized-table call
+    /// sites drifted in #1718.
+    #[cfg(feature = "duckdb")]
+    struct FailPostCopyDescribe<'a> {
+        inner: &'a rocky_duckdb::adapter::DuckDbWarehouseAdapter,
+        copied: std::sync::atomic::AtomicBool,
+    }
+
+    #[cfg(feature = "duckdb")]
+    #[async_trait::async_trait]
+    impl rocky_core::traits::WarehouseAdapter for FailPostCopyDescribe<'_> {
+        fn dialect(&self) -> &dyn rocky_core::traits::SqlDialect {
+            self.inner.dialect()
+        }
+
+        async fn execute_statement(&self, sql: &str) -> rocky_core::traits::AdapterResult<()> {
+            self.inner.execute_statement(sql).await
+        }
+
+        async fn execute_query(
+            &self,
+            sql: &str,
+        ) -> rocky_core::traits::AdapterResult<rocky_core::traits::QueryResult> {
+            self.inner.execute_query(sql).await
+        }
+
+        async fn describe_table(
+            &self,
+            table: &rocky_ir::TableRef,
+        ) -> rocky_core::traits::AdapterResult<Vec<rocky_ir::ColumnInfo>> {
+            use std::sync::atomic::Ordering;
+            if table.schema == "tgt" && self.copied.load(Ordering::SeqCst) {
+                return Err(rocky_core::traits::AdapterError::msg(
+                    "injected post-copy probe failure",
+                ));
+            }
+            self.inner.describe_table(table).await
+        }
+
+        async fn execute_statement_with_stats(
+            &self,
+            sql: &str,
+        ) -> rocky_core::traits::AdapterResult<rocky_core::traits::ExecutionStats> {
+            use std::sync::atomic::Ordering;
+            let stats = self.inner.execute_statement_with_stats(sql).await?;
+            self.copied.store(true, Ordering::SeqCst);
+            Ok(stats)
+        }
+    }
+
+    /// `src.events` seeded with two rows, plus the empty `tgt` schema the copy
+    /// writes into. Both column_match probe-failure tests start here.
+    #[cfg(feature = "duckdb")]
+    async fn seeded_src_events() -> rocky_duckdb::adapter::DuckDbWarehouseAdapter {
+        use rocky_core::traits::WarehouseAdapter;
+        let inner = rocky_duckdb::adapter::DuckDbWarehouseAdapter::in_memory().unwrap();
+        for sql in [
+            "CREATE SCHEMA src",
+            "CREATE SCHEMA tgt",
+            "CREATE TABLE src.events (event_id INTEGER, user_id INTEGER)",
+            "INSERT INTO src.events VALUES (1, 7), (2, 8)",
+        ] {
+            inner.execute_statement(sql).await.unwrap();
+        }
+        inner
+    }
+
     /// The `(missing, extra)` a `column_match` result reports, sorted so the
     /// assertion does not depend on set iteration order.
     #[cfg(feature = "duckdb")]
@@ -22508,63 +22580,9 @@ timestamp_column = "ts"
     #[cfg(feature = "duckdb")]
     #[tokio::test]
     async fn column_match_records_a_reason_when_the_post_copy_probe_fails() {
-        use std::sync::atomic::{AtomicBool, Ordering};
-
-        use async_trait::async_trait;
         use rocky_core::state::StateStore;
-        use rocky_core::traits::{
-            AdapterError, AdapterResult, ExecutionStats, QueryResult, SqlDialect, WarehouseAdapter,
-        };
-        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
 
-        struct FailPostCopyDescribe<'a> {
-            inner: &'a DuckDbWarehouseAdapter,
-            copied: AtomicBool,
-        }
-
-        #[async_trait]
-        impl WarehouseAdapter for FailPostCopyDescribe<'_> {
-            fn dialect(&self) -> &dyn SqlDialect {
-                self.inner.dialect()
-            }
-
-            async fn execute_statement(&self, sql: &str) -> AdapterResult<()> {
-                self.inner.execute_statement(sql).await
-            }
-
-            async fn execute_query(&self, sql: &str) -> AdapterResult<QueryResult> {
-                self.inner.execute_query(sql).await
-            }
-
-            async fn describe_table(
-                &self,
-                table: &rocky_ir::TableRef,
-            ) -> AdapterResult<Vec<rocky_ir::ColumnInfo>> {
-                if table.schema == "tgt" && self.copied.load(Ordering::SeqCst) {
-                    return Err(AdapterError::msg("injected post-copy probe failure"));
-                }
-                self.inner.describe_table(table).await
-            }
-
-            async fn execute_statement_with_stats(
-                &self,
-                sql: &str,
-            ) -> AdapterResult<ExecutionStats> {
-                let stats = self.inner.execute_statement_with_stats(sql).await?;
-                self.copied.store(true, Ordering::SeqCst);
-                Ok(stats)
-            }
-        }
-
-        let inner = DuckDbWarehouseAdapter::in_memory().unwrap();
-        for sql in [
-            "CREATE SCHEMA src",
-            "CREATE SCHEMA tgt",
-            "CREATE TABLE src.events (event_id INTEGER, user_id INTEGER)",
-            "INSERT INTO src.events VALUES (1, 7), (2, 8)",
-        ] {
-            inner.execute_statement(sql).await.unwrap();
-        }
+        let inner = seeded_src_events().await;
 
         let dir = tempfile::tempdir().unwrap();
         let state = Arc::new(StateStore::open(&dir.path().join("state.redb")).unwrap());
@@ -22573,7 +22591,7 @@ timestamp_column = "ts"
 
         let adapter = FailPostCopyDescribe {
             inner: &inner,
-            copied: AtomicBool::new(false),
+            copied: std::sync::atomic::AtomicBool::new(false),
         };
         let outcome = process_table(&adapter, &state, &pipeline, &task, false)
             .await
@@ -22599,6 +22617,92 @@ timestamp_column = "ts"
             "unexpected reason: {reason}"
         );
         assert!(!check.passed, "an unevaluated check never passes");
+    }
+
+    /// #1871's column_match half, and the last of the four replication check
+    /// sites. FAILS before the guard at `process_table`: the probe failure is
+    /// reported as a `warning`, the gate reads zero errors, and a run that
+    /// compared no columns at all exits 0 with `status: "Success"`.
+    ///
+    /// ```text
+    ///   copy succeeds -> post-copy probe of tgt FAILS
+    ///     -> column_match_not_evaluated  (severity Error, by construction)
+    ///     -> site writes the configured `warning` over it   <- the defect
+    ///     -> gate counts a warning, not an error
+    ///     -> Success
+    /// ```
+    ///
+    /// `column_match_carries_the_configured_severity` pins the other half:
+    /// a probe that ANSWERS still reports at the configured severity. Both
+    /// must hold, and asserting only this one would pass against code that
+    /// ignored the configured severity entirely — which is #1666 again.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn a_failed_column_match_probe_gates_even_when_the_configured_severity_is_warning() {
+        use rocky_core::state::StateStore;
+        use rocky_core::tests::TestSeverity;
+
+        let inner = seeded_src_events().await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let state = Arc::new(StateStore::open(&dir.path().join("state.redb")).unwrap());
+        // The `[checks]` table is declared, not defaulted: see `gate_for`.
+        // `column_match = true` is what a replication pipeline writes to turn
+        // this check on, and `severity` is the escape hatch under test — the
+        // task carries the resolved value, so it is set below.
+        let pipeline = parse_pipeline(
+            "strategy = \"full_refresh\"\n\n[pipeline.bronze.checks]\ncolumn_match = true\n",
+        );
+        assert!(
+            pipeline.checks.fail_on_error,
+            "the fixture must run under the default gate"
+        );
+        let mut task = column_match_task(vec![], vec![]);
+        task.column_match = Some(TestSeverity::Warning);
+
+        let adapter = FailPostCopyDescribe {
+            inner: &inner,
+            copied: std::sync::atomic::AtomicBool::new(false),
+        };
+        let outcome = process_table(&adapter, &state, &pipeline, &task, false)
+            .await
+            .expect("a failed metadata read must not fail a table that copied");
+        let TableOutcome::Materialized(result) = outcome else {
+            panic!("table should be materialized");
+        };
+
+        let check = result
+            .column_match_check
+            .clone()
+            .expect("the task enables column_match");
+        assert!(
+            check.not_evaluated.is_some(),
+            "the probe must have failed for this test to mean anything: {check:?}"
+        );
+
+        // The gate first: it is the user-visible consequence, so a regression
+        // prints the exit code it changed rather than a field.
+        let pending = HashMap::from([(
+            result.target_full_name.clone(),
+            PendingCheck {
+                asset_key: result.asset_key.clone(),
+                checks: vec![check.clone()],
+            },
+        )]);
+        let (gated, status) = gate_for(&pending, &pipeline.checks);
+        assert!(
+            gated,
+            "a column_match that compared nothing gates: {check:?}"
+        );
+        assert!(matches!(
+            status,
+            rocky_core::state::RunStatus::PartialFailure
+        ));
+        assert_eq!(
+            check.severity,
+            TestSeverity::Error,
+            "a check the engine could not evaluate keeps its own severity: {check:?}"
+        );
     }
 
     /// The other side of the same read. The source is probed after the copy
@@ -35144,24 +35248,46 @@ value = "'{source}'"
         fx: &BatchedCheckFixture,
         pending: &HashMap<String, PendingCheck>,
     ) -> (bool, rocky_core::state::RunStatus) {
-        let mut out = crate::output::RunOutput::new(String::new(), 0, 1);
-        out.tables_copied = 1;
-        for (table, bag) in pending {
-            out.check_results.push(crate::output::TableCheckOutput {
-                asset_key: vec![table.clone()],
-                checks: bag.checks.clone(),
-            });
-        }
         // The FIXTURE's own checks config, which is what the runner reads at
         // `output.check_gate_failed = replication_check_gate_failed(&output,
         // &pipeline.checks)`. Reparsing a different config here would let this
-        // helper answer a question the runner never asks. `fail_on_error`
-        // defaults to `true`, so this is the default gate.
+        // helper answer a question the runner never asks.
+        gate_for(pending, &fx.pipeline.checks)
+    }
+
+    /// The same verdict for a check bag that did not come from
+    /// `BatchedCheckFixture` — `column_match` is produced per table, not in
+    /// the batch phase, so it has no fixture to hang off.
+    ///
+    /// Builds the bag the way run.rs:5741 builds it, field for field, so the
+    /// gate reads the shape production hands it. What is NOT re-proved here is
+    /// that `column_match` reaches `pending_checks` at all; that wire is
+    /// pinned by `a_retried_table_contributes_its_column_match_and_freshness`
+    /// and by the inline-drain test beside it.
+    #[cfg(feature = "duckdb")]
+    fn gate_for(
+        pending: &HashMap<String, PendingCheck>,
+        checks: &rocky_core::config::ChecksConfig,
+    ) -> (bool, rocky_core::state::RunStatus) {
+        // Every caller is asking about the DEFAULT gate, so a config with the
+        // gate switched off would make any of them pass for a reason it never
+        // states. `ChecksConfig` derives `Default`, which ignores
+        // `#[serde(default = "default_fail_on_error")]` — so a pipeline whose
+        // TOML omits `[checks]` entirely arrives here with `fail_on_error`
+        // FALSE, and this assertion is what says so out loud.
         assert!(
-            fx.pipeline.checks.fail_on_error,
-            "these tests are about the DEFAULT gate; fail_on_error must be on"
+            checks.fail_on_error,
+            "these tests are about the default gate; fail_on_error must be on"
         );
-        out.check_gate_failed = super::replication_check_gate_failed(&out, &fx.pipeline.checks);
+        let mut out = crate::output::RunOutput::new(String::new(), 0, 1);
+        out.tables_copied = 1;
+        for bag in pending.values() {
+            out.check_results.push(crate::output::TableCheckOutput {
+                asset_key: bag.asset_key.clone(),
+                checks: bag.checks.clone(),
+            });
+        }
+        out.check_gate_failed = super::replication_check_gate_failed(&out, checks);
         out.status = out.derive_run_status();
         (out.check_gate_failed, out.status)
     }

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -471,12 +471,15 @@ fn merge_replication_compile_and_copy_errors(output: &mut RunOutput, table_error
 /// never read the flag, so a pipeline that copied violating data exited 0
 /// (#1598). This is the missing read, not a new policy.
 ///
-/// Error severity only, so a `severity = "warning"` check stays advisory and
-/// `fail_on_error = false` keeps every check advisory — neither may change a
-/// status or an exit code. A check the engine could NOT evaluate counts as a
-/// failure at its own severity: every `*_not_evaluated` constructor sets
-/// `passed: false` (#1602 / #1595), so a broken check gates exactly as a
-/// violated one does instead of reading as clean.
+/// Error severity only, so a MEASURED `severity = "warning"` check stays
+/// advisory and `fail_on_error = false` keeps every check advisory — neither
+/// may change a status or an exit code.
+///
+/// A check the engine could NOT evaluate is not advisory at all. It sets
+/// `passed: false` (#1602 / #1595) and reaches the error bucket whatever its
+/// severity says (#1741), so a broken check gates exactly as a violated one
+/// does instead of reading as clean. See
+/// [`RunOutput::check_failures_by_severity`] for the bucketing rule itself.
 fn replication_check_gate_failed(
     output: &RunOutput,
     checks: &rocky_core::config::ChecksConfig,
@@ -7021,10 +7024,9 @@ async fn run_batched_checks(
                 // measurement: an operator writing `warning` means "a row
                 // count that does not match is advisory", not "a row count I
                 // could not obtain is advisory". `row_count_not_evaluated`
-                // chooses `Error` and `check_failures_by_severity` buckets on
-                // severity alone, so overwriting it here is what decides
-                // whether the run gates. Same guard the freshness and
-                // null-rate sites use.
+                // chooses `Error`; overwriting that here is what sent an
+                // unrunnable check to the warning bucket. Same guard the
+                // freshness and null-rate sites use.
                 if check.not_evaluated.is_none() {
                     check.severity = pipeline.checks.row_count.severity();
                 }
@@ -34120,9 +34122,7 @@ table = "fct_events"
     /// #1871 regressed the row-count arm of the same invariant the null-rate
     /// test above pins: a check the engine COULD NOT RUN is never advisory.
     ///
-    /// `row_count_not_evaluated` chooses `TestSeverity::Error`, and
-    /// `check_failures_by_severity` buckets on severity alone, so the gate's
-    /// correctness rests entirely on that choice surviving. The site
+    /// `row_count_not_evaluated` chooses `TestSeverity::Error`. The site
     /// overwrote it with the configured severity for BOTH arms, so
     /// `severity = "warning"` downgraded a row-count query that failed and
     /// the run exited 0 with `status: "Success"`. 1.73.0 always gated it.

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -411,25 +411,33 @@ fn quality_row_count_check(
     use rocky_core::checks::{CheckDetails, CheckResult};
 
     match queried {
+        // A query that ANSWERED still has to answer with a number. `unwrap_or(0)`
+        // read an empty row set, a missing cell and a non-numeric cell as a
+        // measured count of zero, so the check claimed `not_evaluated: None` at
+        // the configured severity and a `warning` pipeline exited 0 having
+        // counted nothing — the same shape as the failed-query arm below, which
+        // this function already fixed for `Err`.
+        //
+        // `cell_as_u64` is the shared reader; it also accepts an integral JSON
+        // float, which the hand-rolled chain here did not, so an adapter
+        // returning `5.0` reported a populated table as EMPTY.
         Ok(result) => {
-            let count: u64 = result
-                .rows
-                .first()
-                .and_then(|r| r.first())
-                .and_then(|v| {
-                    v.as_u64()
-                        .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
-                })
-                .unwrap_or(0);
-            CheckResult {
-                name: "row_count".into(),
-                passed: count > 0,
-                severity: configured,
-                not_evaluated: None,
-                details: CheckDetails::RowCount {
-                    source_count: count,
-                    target_count: count,
+            match rocky_core::checks::cell_as_u64(result.rows.first().and_then(|r| r.first())) {
+                Some(count) => CheckResult {
+                    name: "row_count".into(),
+                    passed: count > 0,
+                    severity: configured,
+                    not_evaluated: None,
+                    details: CheckDetails::RowCount {
+                        source_count: count,
+                        target_count: count,
+                    },
                 },
+                // A measured `0` is a different answer and keeps the configured
+                // severity: the table really did report zero rows.
+                None => rocky_core::checks::row_count_not_evaluated(
+                    "the row count query returned no readable count",
+                ),
             }
         }
         Err(e) => {
@@ -2677,6 +2685,108 @@ auto_create_schemas = true
             check.severity,
             TestSeverity::Warning,
             "a measured result takes the configured severity: {check:?}"
+        );
+    }
+
+    /// The OTHER unreadable shape, found by review of #1923. The query
+    /// SUCCEEDS and the cell cannot be read — an empty row set, or a cell that
+    /// is not a number. `unwrap_or(0)` turned both into a measured count of
+    /// zero, so the check reported `not_evaluated: None` at the configured
+    /// severity and a `warning` pipeline exited 0 having counted nothing.
+    ///
+    /// ```text
+    ///   query OK, cell unreadable
+    ///     before -> count 0, passed false, not_evaluated None, Warning
+    ///               -> warning bucket -> gate clear -> exit 0
+    ///     after  -> row_count_not_evaluated -> Error -> gate trips
+    /// ```
+    ///
+    /// This is the same class as #1871 but NOT reachable from it, and the gate
+    /// guard in `output.rs` cannot catch it: this path sets
+    /// `not_evaluated: None`, so the gate never sees an unevaluated check.
+    /// The fix has to be here, at the producer.
+    ///
+    /// `cell_as_u64` is the shared reader every other count in the engine uses.
+    /// The hand-rolled chain it replaces also missed an integral JSON float, so
+    /// an adapter returning `5.0` reported the table as EMPTY. That case is
+    /// asserted below too.
+    #[test]
+    fn a_quality_row_count_that_cannot_be_read_is_not_a_measured_zero() {
+        use rocky_core::checks::CheckDetails;
+        use rocky_core::tests::TestSeverity;
+        use rocky_core::traits::QueryResult;
+
+        let ok = |rows: Vec<Vec<serde_json::Value>>| {
+            Ok(QueryResult {
+                columns: vec!["count".into()],
+                rows,
+            })
+        };
+
+        // Three shapes of "the query answered, but not with a count".
+        for (label, rows) in [
+            ("no rows", vec![]),
+            ("no cell in the row", vec![vec![]]),
+            (
+                "a cell that is not a number",
+                vec![vec![serde_json::json!("n/a")]],
+            ),
+        ] {
+            let check = super::quality_row_count_check(ok(rows), TestSeverity::Warning);
+            assert!(!check.passed, "{label}: {check:?}");
+            assert_eq!(
+                check.severity,
+                TestSeverity::Error,
+                "{label}: declared advisory, but nothing was counted, so it \
+                 gates (#1741): {check:?}"
+            );
+            assert!(
+                check.not_evaluated.is_some(),
+                "{label}: an unreadable count must not claim it ran: {check:?}"
+            );
+            assert!(
+                matches!(check.details, CheckDetails::RowCount { .. }),
+                "{label}: {check:?}"
+            );
+        }
+
+        // An integral JSON float IS a readable count. The chain this replaces
+        // handled only integers and numeric strings, so `5.0` fell through to
+        // `unwrap_or(0)` and a populated table reported as empty.
+        let check = super::quality_row_count_check(
+            ok(vec![vec![serde_json::json!(5.0)]]),
+            TestSeverity::Warning,
+        );
+        assert!(check.passed, "5.0 is five rows, not zero: {check:?}");
+        assert!(check.not_evaluated.is_none(), "{check:?}");
+        assert_eq!(check.severity, TestSeverity::Warning, "{check:?}");
+        assert!(
+            matches!(
+                check.details,
+                CheckDetails::RowCount {
+                    target_count: 5,
+                    ..
+                }
+            ),
+            "{check:?}"
+        );
+
+        // The measured-zero case is a DIFFERENT answer and must stay measured:
+        // an empty table really did report 0, and the operator's `warning`
+        // still applies to it.
+        let check = super::quality_row_count_check(
+            ok(vec![vec![serde_json::json!(0)]]),
+            TestSeverity::Warning,
+        );
+        assert!(!check.passed, "zero rows is a failing row count: {check:?}");
+        assert!(
+            check.not_evaluated.is_none(),
+            "a real zero was measured: {check:?}"
+        );
+        assert_eq!(
+            check.severity,
+            TestSeverity::Warning,
+            "a MEASURED violation still takes the configured severity: {check:?}"
         );
     }
 

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -2707,15 +2707,9 @@ auto_create_schemas = true
     /// `not_evaluated: None`, so the gate never sees an unevaluated check.
     /// The fix has to be here, at the producer.
     ///
-    /// `cell_as_u64` is the shared reader the other CHECK counts go through —
-    /// replication row counts, null-rate, custom checks, assertions and
-    /// `compare`. It is not universal: `count_rows`, which reports quarantine
-    /// row counts, still has its own parser.
-    ///
-    /// The hand-rolled chain it replaces also missed an integral JSON float, so
-    /// an adapter returning `5.0` reported the table as EMPTY. That case is
-    /// asserted below, along with the fractional and out-of-range floats that
-    /// `cell_as_u64` itself used to accept (#1923).
+    /// Reads the cell with `cell_as_u64`, so an integral float counts and a
+    /// fraction or out-of-range float does not (#1923). The Databricks BATCH
+    /// row-count path parses its own cell and is not covered by this (#1926).
     #[test]
     fn a_quality_row_count_that_cannot_be_read_is_not_a_measured_zero() {
         use rocky_core::checks::CheckDetails;

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -2698,7 +2698,8 @@ auto_create_schemas = true
     ///   query OK, cell unreadable
     ///     before -> count 0, passed false, not_evaluated None, Warning
     ///               -> warning bucket -> gate clear -> exit 0
-    ///     after  -> row_count_not_evaluated -> Error -> gate trips
+    ///     after  -> row_count_not_evaluated -> Error -> error bucket
+    ///               -> gates, under the default `fail_on_error = true`
     /// ```
     ///
     /// This is the same class as #1871 but NOT reachable from it, and the gate
@@ -2706,10 +2707,15 @@ auto_create_schemas = true
     /// `not_evaluated: None`, so the gate never sees an unevaluated check.
     /// The fix has to be here, at the producer.
     ///
-    /// `cell_as_u64` is the shared reader every other count in the engine uses.
+    /// `cell_as_u64` is the shared reader the other CHECK counts go through —
+    /// replication row counts, null-rate, custom checks, assertions and
+    /// `compare`. It is not universal: `count_rows`, which reports quarantine
+    /// row counts, still has its own parser.
+    ///
     /// The hand-rolled chain it replaces also missed an integral JSON float, so
     /// an adapter returning `5.0` reported the table as EMPTY. That case is
-    /// asserted below too.
+    /// asserted below, along with the fractional and out-of-range floats that
+    /// `cell_as_u64` itself used to accept (#1923).
     #[test]
     fn a_quality_row_count_that_cannot_be_read_is_not_a_measured_zero() {
         use rocky_core::checks::CheckDetails;
@@ -2723,7 +2729,10 @@ auto_create_schemas = true
             })
         };
 
-        // Three shapes of "the query answered, but not with a count".
+        // Shapes of "the query answered, but not with a count". The last two
+        // are the ones `cell_as_u64` itself used to accept: it truncated a
+        // fraction and saturated an out-of-range float, so both arrived here
+        // wearing `Some` as a fabricated row count (#1923).
         for (label, rows) in [
             ("no rows", vec![]),
             ("no cell in the row", vec![vec![]]),
@@ -2731,6 +2740,8 @@ auto_create_schemas = true
                 "a cell that is not a number",
                 vec![vec![serde_json::json!("n/a")]],
             ),
+            ("a fraction", vec![vec![serde_json::json!(5.5)]]),
+            ("an out-of-range float", vec![vec![serde_json::json!(1e30)]]),
         ] {
             let check = super::quality_row_count_check(ok(rows), TestSeverity::Warning);
             assert!(!check.passed, "{label}: {check:?}");

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -5336,13 +5336,30 @@ impl RunOutput {
     /// Failed checks across every table result, bucketed as
     /// `(error_severity, warning_severity)`.
     ///
-    /// A check the engine could not evaluate is a failure here: every
-    /// `*_not_evaluated` constructor in `rocky_core::checks` sets
-    /// `passed: false`, so it lands in its own severity's bucket rather than
-    /// vanishing from the tally. Severity is the check's own — a
-    /// `not_evaluated` assertion declared `severity = "warning"` counts as a
-    /// warning, because a check the user made advisory does not become
-    /// gating by failing to run.
+    /// A check the engine could not evaluate is a failure here, and always an
+    /// ERROR one. Severity grades a MEASUREMENT: `severity = "warning"` means
+    /// "a violation is advisory", never "a check I could not run is advisory"
+    /// (#1741). Only a check that RAN and failed reaches the warning bucket.
+    ///
+    /// ```text
+    ///   passed   not_evaluated   declared     bucket
+    ///   false    Some(reason)    warning  ->  error     <- never advisory
+    ///   false    Some(reason)    error    ->  error
+    ///   false    None            warning  ->  warning
+    ///   false    None            error    ->  error
+    ///   true     -               -        ->  neither
+    /// ```
+    ///
+    /// Two locks hold row one. Every `*_not_evaluated` constructor in
+    /// `rocky_core::checks` hard-codes `Error` (pinned exhaustively by
+    /// `not_evaluated_constructors_fail_and_round_trip_through_json`), and the
+    /// `not_evaluated` arm below reads the field directly. The second lock is
+    /// there because the first one is not enough on its own: #1871 overwrote
+    /// that severity AFTER construction at two call sites in `commands/run.rs`,
+    /// and this function — reading severity alone — let the run through.
+    ///
+    /// Pinned by `check_failures_by_severity_buckets_every_unevaluated_check_as_an_error`
+    /// and `the_gate_buckets_an_unevaluated_failure_as_an_error_whatever_its_severity`.
     ///
     /// Shared by the replication gate (`commands/run.rs`) and the quality
     /// runner (`commands/run_local.rs`) so both bucket identically.
@@ -5353,6 +5370,13 @@ impl RunOutput {
         for table in &self.check_results {
             for check in &table.checks {
                 if check.passed {
+                    continue;
+                }
+                // Read before severity, not after: this is the whole point of
+                // the second lock. A result whose severity was overwritten
+                // after construction still gates (#1871).
+                if check.not_evaluated.is_some() {
+                    error += 1;
                     continue;
                 }
                 match check.severity {
@@ -7064,6 +7088,43 @@ mod run_record_tests {
             ],
         ));
         assert_eq!(out.check_failures_by_severity(), (2, 1));
+    }
+
+    /// The same rule, asserted where the site guards cannot mask it (#1871).
+    ///
+    /// The test above builds its unevaluated checks from the constructors, so
+    /// it passes whether the gate reads `not_evaluated` or only the `Error`
+    /// those constructors chose. It proves the CONSTRUCTORS are right, not the
+    /// gate. This one hand-builds the state no constructor can produce —
+    /// `not_evaluated` set AND `Warning` — which is exactly what #1871
+    /// produced by overwriting severity after construction.
+    ///
+    /// So this is the only test that fails when the gate's `not_evaluated`
+    /// arm is removed. Delete that arm and the count below is `(0, 1)`: the
+    /// run reports one warning, the gate reads zero errors, and a replication
+    /// run that measured nothing exits 0 with `status: "Success"`.
+    #[test]
+    fn the_gate_buckets_an_unevaluated_failure_as_an_error_whatever_its_severity() {
+        use rocky_core::tests::TestSeverity;
+
+        // The #1871 shape, built the way #1871 built it.
+        let mut downgraded =
+            rocky_core::checks::row_count_not_evaluated("the row count query failed");
+        downgraded.severity = TestSeverity::Warning;
+        assert!(
+            downgraded.not_evaluated.is_some() && !downgraded.passed,
+            "the fixture must carry the unevaluated shape: {downgraded:?}"
+        );
+
+        let mut out = RunOutput::new(String::new(), 0, 1);
+        out.check_results
+            .push(checks_for("orders", vec![downgraded]));
+
+        assert_eq!(
+            out.check_failures_by_severity(),
+            (1, 0),
+            "a check that did not run gates however its severity was written"
+        );
     }
 
     /// The whole point of the gate being a separate field: the persisted

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -5339,7 +5339,9 @@ impl RunOutput {
     /// A check the engine could not evaluate is a failure here, and always an
     /// ERROR one. Severity grades a MEASUREMENT: `severity = "warning"` means
     /// "a violation is advisory", never "a check I could not run is advisory"
-    /// (#1741). Only a check that RAN and failed reaches the warning bucket.
+    /// (#1741). A failure carrying `not_evaluated` is bucketed as an error
+    /// whatever its severity says; a failure without it is bucketed at its
+    /// declared severity.
     ///
     /// ```text
     ///   passed   not_evaluated   declared     bucket
@@ -5351,9 +5353,11 @@ impl RunOutput {
     /// ```
     ///
     /// Two locks hold row one. Every `*_not_evaluated` constructor in
-    /// `rocky_core::checks` hard-codes `Error` (pinned exhaustively by
-    /// `not_evaluated_constructors_fail_and_round_trip_through_json`), and the
-    /// `not_evaluated` arm below reads the field directly. The second lock is
+    /// `rocky_core::checks` hard-codes `Error`;
+    /// `not_evaluated_constructors_fail_and_round_trip_through_json` asserts
+    /// that for the seven it lists BY HAND, so an eighth constructor would not
+    /// fail it automatically. The `not_evaluated` arm below reads the field
+    /// directly and does not depend on that list. The second lock is
     /// there because the first one is not enough on its own: #1871 overwrote
     /// that severity AFTER construction at two call sites in `commands/run.rs`,
     /// and this function — reading severity alone — let the run through.

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -5336,12 +5336,16 @@ impl RunOutput {
     /// Failed checks across every table result, bucketed as
     /// `(error_severity, warning_severity)`.
     ///
-    /// A check the engine could not evaluate is a failure here, and always an
-    /// ERROR one. Severity grades a MEASUREMENT: `severity = "warning"` means
-    /// "a violation is advisory", never "a check I could not run is advisory"
-    /// (#1741). A failure carrying `not_evaluated` is bucketed as an error
-    /// whatever its severity says; a failure without it is bucketed at its
-    /// declared severity.
+    /// Severity grades a MEASUREMENT: `severity = "warning"` means "a violation
+    /// is advisory", not "a check I could not run is advisory" (#1741). A
+    /// FAILURE carrying `not_evaluated` is bucketed as an error whatever its
+    /// severity says; a failure without it is bucketed at its declared
+    /// severity.
+    ///
+    /// `not_evaluated` on its own is not a failure. A passing check is skipped
+    /// before severity is read at all, which is what keeps
+    /// `cross_source_overlap_not_applicable` — a reason carried with
+    /// `passed: true` — out of both buckets.
     ///
     /// ```text
     ///   passed   not_evaluated   declared     bucket
@@ -7103,8 +7107,8 @@ mod run_record_tests {
     /// `not_evaluated` set AND `Warning` — which is exactly what #1871
     /// produced by overwriting severity after construction.
     ///
-    /// So this is the only test that fails when the gate's `not_evaluated`
-    /// arm is removed. Delete that arm and the count below is `(0, 1)`: the
+    /// So this test is what fails when the gate's `not_evaluated` arm is
+    /// removed. Delete that arm and the count below is `(0, 1)`: the
     /// run reports one warning, the gate reads zero errors, and a replication
     /// run that measured nothing exits 0 with `status: "Success"`.
     #[test]

--- a/engine/crates/rocky-core/src/checks.rs
+++ b/engine/crates/rocky-core/src/checks.rs
@@ -165,14 +165,26 @@ pub fn null_rate_check_name(column: &str) -> String {
 /// Returns `None` when the cell is absent or not a non-negative integer — the
 /// caller decides whether that is a skip, an error, or a default, rather than a
 /// silent `0` masking a parse failure as a real count.
+///
+/// The float branch checks integrality and range before casting (#1923). It
+/// used to check only `is_finite` and `>= 0.0`, and `f as u64` in Rust
+/// truncates toward zero and SATURATES at the bounds — so `5.5` was returned
+/// as a measured `5`, `0.5` as a measured `0`, and `1e30` as `u64::MAX`. Every
+/// caller reads this as a row count and treats `None` as "could not evaluate",
+/// so a fabricated `Some` is the one failure this function must not produce.
 pub fn cell_as_u64(cell: Option<&serde_json::Value>) -> Option<u64> {
     cell.and_then(|v| {
         v.as_u64()
             .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
             .or_else(|| {
-                v.as_f64()
-                    .filter(|f| f.is_finite() && *f >= 0.0)
-                    .map(|f| f as u64)
+                v.as_f64().filter(|f| f.is_finite()).and_then(|f| {
+                    // `fract() == 0.0` rejects a fraction; the range check
+                    // rejects a value the cast would saturate. `u64::MAX` is
+                    // not exactly representable as an `f64`, so the bound is
+                    // written as a strict `<` against 2^64.
+                    (f.fract() == 0.0 && f >= 0.0 && f < 18_446_744_073_709_551_616.0)
+                        .then_some(f as u64)
+                })
             })
     })
 }
@@ -674,6 +686,27 @@ mod tests {
         assert_eq!(cell_as_u64(Some(&json!("abc"))), None);
         assert_eq!(cell_as_u64(Some(&json!(-1.0))), None);
         assert_eq!(cell_as_u64(Some(&serde_json::Value::Null)), None);
+
+        // A FRACTION is not a count. `f as u64` truncates, so 5.5 used to be
+        // returned as a measured 5 and 0.5 as a measured 0 — a fabricated
+        // count wearing `Some`, which is the one thing this function exists to
+        // prevent. Found reviewing #1923.
+        assert_eq!(cell_as_u64(Some(&json!(5.5))), None);
+        assert_eq!(cell_as_u64(Some(&json!(0.5))), None);
+
+        // OUT OF RANGE is not a count either. A float-to-int `as` cast
+        // saturates rather than wrapping, so 1e30 came back as u64::MAX —
+        // the largest possible row count, from a cell that held no usable
+        // number.
+        assert_eq!(cell_as_u64(Some(&json!(1e30))), None);
+
+        // Still accepted, because these ARE integers: the boundary itself,
+        // and a float that happens to be whole.
+        assert_eq!(cell_as_u64(Some(&json!(0.0))), Some(0));
+        assert_eq!(
+            cell_as_u64(Some(&json!(9007199254740992.0))),
+            Some(9007199254740992)
+        );
     }
 
     /// Test dialect that mirrors Databricks behavior for rocky-core tests.

--- a/engine/crates/rocky-core/src/checks.rs
+++ b/engine/crates/rocky-core/src/checks.rs
@@ -170,8 +170,9 @@ pub fn null_rate_check_name(column: &str) -> String {
 /// used to check only `is_finite` and `>= 0.0`, and `f as u64` in Rust
 /// truncates toward zero and SATURATES at the bounds — so `5.5` was returned
 /// as a measured `5`, `0.5` as a measured `0`, and `1e30` as `u64::MAX`. Every
-/// caller reads this as a row count and treats `None` as "could not evaluate",
-/// so a fabricated `Some` is the one failure this function must not produce.
+/// caller treats `None` as "could not evaluate" — these are row counts, null
+/// and sample counts, custom-check counts and assertion counts — so a
+/// fabricated `Some` is the one failure this function must not produce.
 pub fn cell_as_u64(cell: Option<&serde_json::Value>) -> Option<u64> {
     cell.and_then(|v| {
         v.as_u64()

--- a/engine/crates/rocky-core/src/checks.rs
+++ b/engine/crates/rocky-core/src/checks.rs
@@ -166,23 +166,16 @@ pub fn null_rate_check_name(column: &str) -> String {
 /// caller decides whether that is a skip, an error, or a default, rather than a
 /// silent `0` masking a parse failure as a real count.
 ///
-/// The float branch checks integrality and range before casting (#1923). It
-/// used to check only `is_finite` and `>= 0.0`, and `f as u64` in Rust
-/// truncates toward zero and SATURATES at the bounds — so `5.5` was returned
-/// as a measured `5`, `0.5` as a measured `0`, and `1e30` as `u64::MAX`. Every
-/// caller treats `None` as "could not evaluate" — these are row counts, null
-/// and sample counts, custom-check counts and assertion counts — so a
-/// fabricated `Some` is the one failure this function must not produce.
+/// A float is accepted only when it is integral and in `[0, 2^64)` (#1923).
 pub fn cell_as_u64(cell: Option<&serde_json::Value>) -> Option<u64> {
     cell.and_then(|v| {
         v.as_u64()
             .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
             .or_else(|| {
                 v.as_f64().filter(|f| f.is_finite()).and_then(|f| {
-                    // `fract() == 0.0` rejects a fraction; the range check
-                    // rejects a value the cast would saturate. `u64::MAX` is
-                    // not exactly representable as an `f64`, so the bound is
-                    // written as a strict `<` against 2^64.
+                    // 2^64 exclusive: `u64::MAX` has no exact `f64`. The cast
+                    // is eager (clippy refuses `then` here) and saturating, so
+                    // it runs on a rejected value and the result is dropped.
                     (f.fract() == 0.0 && (0.0..18_446_744_073_709_551_616.0).contains(&f))
                         .then_some(f as u64)
                 })
@@ -688,25 +681,35 @@ mod tests {
         assert_eq!(cell_as_u64(Some(&json!(-1.0))), None);
         assert_eq!(cell_as_u64(Some(&serde_json::Value::Null)), None);
 
-        // A FRACTION is not a count. `f as u64` truncates, so 5.5 used to be
-        // returned as a measured 5 and 0.5 as a measured 0 — a fabricated
-        // count wearing `Some`, which is the one thing this function exists to
-        // prevent. Found reviewing #1923.
+        // A float must be integral and in `[0, 2^64)` (#1923).
         assert_eq!(cell_as_u64(Some(&json!(5.5))), None);
         assert_eq!(cell_as_u64(Some(&json!(0.5))), None);
-
-        // OUT OF RANGE is not a count either. A float-to-int `as` cast
-        // saturates rather than wrapping, so 1e30 came back as u64::MAX —
-        // the largest possible row count, from a cell that held no usable
-        // number.
         assert_eq!(cell_as_u64(Some(&json!(1e30))), None);
-
-        // Still accepted, because these ARE integers: the boundary itself,
-        // and a float that happens to be whole.
         assert_eq!(cell_as_u64(Some(&json!(0.0))), Some(0));
+        assert_eq!(cell_as_u64(Some(&json!(-0.0))), Some(0));
         assert_eq!(
             cell_as_u64(Some(&json!(9007199254740992.0))),
             Some(9007199254740992)
+        );
+
+        // The bound itself. 2^64 is the first REJECTED value and
+        // 2^64 - 2048 the last accepted one. An inclusive bound would admit
+        // 2^64 and cast it to `u64::MAX`, and no other assertion here would
+        // notice.
+        assert_eq!(
+            cell_as_u64(Some(&json!(18_446_744_073_709_551_616.0_f64))),
+            None
+        );
+        assert_eq!(
+            cell_as_u64(Some(&json!(18_446_744_073_709_549_568.0_f64))),
+            Some(18_446_744_073_709_549_568)
+        );
+
+        // `u64::MAX` is reachable only as an integer or a string.
+        assert_eq!(cell_as_u64(Some(&json!(u64::MAX))), Some(u64::MAX));
+        assert_eq!(
+            cell_as_u64(Some(&json!("18446744073709551615"))),
+            Some(u64::MAX)
         );
     }
 

--- a/engine/crates/rocky-core/src/checks.rs
+++ b/engine/crates/rocky-core/src/checks.rs
@@ -182,7 +182,7 @@ pub fn cell_as_u64(cell: Option<&serde_json::Value>) -> Option<u64> {
                     // rejects a value the cast would saturate. `u64::MAX` is
                     // not exactly representable as an `f64`, so the bound is
                     // written as a strict `<` against 2^64.
-                    (f.fract() == 0.0 && f >= 0.0 && f < 18_446_744_073_709_551_616.0)
+                    (f.fract() == 0.0 && (0.0..18_446_744_073_709_551_616.0).contains(&f))
                         .then_some(f as u64)
                 })
             })


### PR DESCRIPTION
A check that **could not run** stopped failing the run. A configured
`severity = "warning"` silenced it, and the run exited 0 with
`status: "Success"` having measured nothing.

> **Scope beyond #1871.** This also tightens the shared `cell_as_u64` reader,
> which fabricated counts from fractional and out-of-range floats. That reader
> is used by six call sites, so the change reaches replication row counts,
> null-rate, custom checks, assertions and `compare` as well as the quality row
> count this PR started from. Details in "A fifth defect" below.
>
> | caller | reads | on `None` |
> |---|---|---|
> | `run.rs:6792` | replication row count | records the table unevaluated |
> | `run.rs:7610`, `:7614` | null-rate sample + null counts | check reported not-evaluated |
> | `run_local.rs:895` | custom check count | `custom_not_evaluated` |
> | `run_local.rs:1093` | assertion count | `None` → "could not evaluate" |
> | `run_local.rs:425` | quality row count | `row_count_not_evaluated` |
> | `compare.rs:357` | compare row count | returns an error |
>
> Every one was already fail-closed on `None`, so no caller changed.

**User-visible changes**

- A replication `row_count` or `column_match` check whose query or probe failed
  now gates the run, even when the pipeline configures
  `severity = "warning"`. It previously reported a warning and exited 0.
- A quality `row_count` whose query returns **no row, no cell, or a
  non-numeric cell** is now reported as not-evaluated and gates the run. It
  previously read as a measured count of zero.
- A quality `row_count` whose adapter returns an integral float (`5.0`) is now
  counted as 5. It previously read as 0, so a populated table reported as
  empty.
- Any check count whose cell is a **fraction** (`5.5`) or an **out-of-range
  float** (`1e30`) is now not-evaluated. `cell_as_u64` previously truncated the
  first to `5` and saturated the second to `u64::MAX`, and that reader is
  shared by replication row counts, null-rate, custom checks, assertions and
  `compare`.

Exit code moves from 0 to 2 in the first two cases. A pipeline relying on the
old silent pass will start failing — which is the point.

```
    a row-count query FAILS

    before                             after
    not_evaluated, severity Error      not_evaluated, severity Error
    severity := warning                severity kept
    gate counts 1 warning              gate counts 1 error
    exit 0   "Success"                 exit 2   "PartialFailure"
```

## Why it happened

Severity grades a **measurement**. An operator writing `warning` means "a row
count that does not match is advisory". It does not mean "a row count I could
not obtain is advisory".

The seven `*_not_evaluated` constructors in `rocky_core::checks` all hard-code
`Error` for that reason. #1871 wrote a configured severity over the result
AFTER the constructor ran, at two sites, and did not separate the two arms.
The check that was measured and the check that could not run both took the
configured value.

The freshness and null-rate sites were already guarded. These two were not.

## What changed

**Two site guards** (`commands/run.rs`) — the same `not_evaluated.is_none()`
guard the other two sites use.

**One gate guard** (`output.rs`) — `check_failures_by_severity` now reads
`not_evaluated` before severity:

```
    passed  not_evaluated  declared     bucket
    false   Some(reason)   warning  ->  error     <- the shipped defect
    false   Some(reason)   error    ->  error
    false   None           warning  ->  warning
    false   None           error    ->  error
```

The site guards fix this regression. The gate guard makes the **replication**
gate independent of call-site severity writes.

It does not fix the whole class, and review proved that: a producer that sets
`not_evaluated: None` is invisible to the gate by construction. One such
producer was found and is fixed below, at the producer.

**The doc** on that function said the opposite — that an advisory check stays
advisory when it fails to run. That is the pre-#1741 rule, and it sat directly
above a test asserting the current one. A stale doc is worse than none here: it
describes severity-only bucketing as intended, which is what makes overwriting
severity at a call site look harmless.

## Evidence

Each guard was reverted on its own and the matching test failed:

| reverted | test that failed |
|---|---|
| `row_count` site guard | `a_failed_row_count_query_gates_even_when_the_configured_severity_is_warning` |
| `column_match` site guard | `a_failed_column_match_probe_gates_even_when_the_configured_severity_is_warning` |
| gate guard | `the_gate_buckets_an_unevaluated_failure_as_an_error_whatever_its_severity` |

The gate guard needed its own test to be measurable at all. With the site
guards in place, no check can reach the gate holding `not_evaluated` **and**
`Warning`, so the end-to-end tests cannot see that arm. The existing
`check_failures_by_severity_buckets_every_unevaluated_check_as_an_error` builds
its checks from the constructors, so it proves the **constructors** are right,
not the gate. The new test hand-builds the state no constructor can produce —
which is exactly the state #1871 shipped.

**Is the gate guard load-bearing, or dead code behind the site guards?**
Reverting two guards at once answers it:

```
  A  row_count site guard reverted, gate guard KEPT
     -> gate assertion PASSES, severity assertion fails
     -> the run still gates

  B  row_count site guard reverted, gate guard ALSO reverted
     -> gate assertion FAILS
     -> "an unevaluated row count gates: severity: Warning,
         not_evaluated: Some("target: the row count query failed...")"
```

A and B differ, so the guard does real work: **the gate guard alone would have
stopped #1871 from shipping a silent pass.** The site guards correct the
reported severity; the gate guard corrects the exit code.

Full `rocky-cli` suite: 1996 passed, 0 failed. Clippy and fmt clean. `just
codegen` produces no binding changes.

## A fourth defect, found by review

Not part of #1871 and pre-existing. `quality_row_count_check` handled a FAILED
query correctly and a SUCCESSFUL one carelessly:

```
    query OK, cell unreadable (no rows / no cell / not a number)
      before -> unwrap_or(0) -> count 0, passed false,
                not_evaluated None, Warning -> gate clear -> exit 0
      after  -> row_count_not_evaluated -> Error -> gate trips
```

A `severity = "warning"` quality pipeline exited 0 having counted nothing, and
every consumer read `not_evaluated: None` as "this check ran".

**The gate guard cannot catch this**, which is the precise limit of the second
lock: the path sets `not_evaluated: None`, so the gate never sees an
unevaluated check. The fix is at the producer, using `cell_as_u64` — the shared
reader every other count in the engine already goes through. That reader also
accepts an integral JSON float, which the hand-rolled chain did not, so an
adapter returning `5.0` reported a populated table as **empty**. Asserted too.

A measured `0` stays measured and keeps the configured severity.

Mutation-checked on its own:
`a_quality_row_count_that_cannot_be_read_is_not_a_measured_zero`.

## Four prose corrections

Every one was an absolute I could not support, and two were sentences in this
PR's own first commit that its second commit then falsified:

| claim | why it was wrong |
|---|---|
| "Only a check that RAN and failed reaches the warning bucket" | false — the quality path above. The doc now says what the function does instead of asserting a property of producers it cannot see. |
| "pinned exhaustively" | that test lists seven constructors **by hand**; an eighth would not fail it. Its own doc records once claiming "every" while covering six. |
| gate doc: an unevaluated check counts "at its own severity" | the pre-#1741 rule. |
| two call-site comments: the bucketer "buckets on severity alone" | written in commit 1, falsified by commit 2. They now point at the function that owns the rule rather than restating it. |

## Found while testing, not fixed here

The first draft of the `column_match` test failed on a config detail, not on
the defect. `ChecksConfig` derives `Default`, which cannot see its own
`#[serde(default = "default_fail_on_error")]`. The `checks` field is
`#[serde(default)]`, so:

```
  [pipeline.X.checks] declared, empty  ->  fail_on_error=true   anomaly=50
  [pipeline.X.checks] absent           ->  fail_on_error=false  anomaly=0
```

Declaring an empty table gives different behaviour from omitting it. It does
not appear to change any run today, because a config with no `[checks]` table
also has every check switched off, so the gate has nothing to miss.
`ChecksConfig` is the only struct in `config.rs` with this shape — the other
eleven with serde field defaults all carry a manual `impl Default`. Not
verified: whether each of those manual impls actually *matches* its serde
defaults. A manual impl removes this failure mode but can still disagree its
own way.

Filed as #1924. `gate_for` asserts `fail_on_error`, so no future test can
measure the wrong gate quietly.

## A fifth defect, found reviewing the fourth

The commit above started routing the quality row count through `cell_as_u64`.
Review of that commit found `cell_as_u64` does not do what its own doc says.

The doc promises `None` for anything "not a non-negative integer". The float
branch checked only `is_finite` and `>= 0.0`, then cast — and in Rust
`f as u64` truncates toward zero **and saturates** at the bounds:

```
    cell      before             after
    5.0   ->  Some(5)        ->  Some(5)     unchanged, it is an integer
    5.5   ->  Some(5)        ->  None        a fraction is not a count
    0.5   ->  Some(0)        ->  None        and neither is this
    1e30  ->  Some(u64::MAX) ->  None        the cast saturated
    -1.0  ->  None           ->  None        unchanged
```

A cell holding no usable number came back as a **measured** row count. `1e30`
reported the largest possible one. Verified by probe, not inferred from cast
semantics.

Pre-existing and shared: replication row counts, null-rate, custom checks,
assertions, `compare`, and now the quality row count all read through it. Every
one of them already treats `None` as "could not evaluate", and two document the
contract as "a non-negative integer" in their own words — so this moves them
from a silently wrong number to an unevaluated check, the fail-closed
direction, with no caller change. 4368 tests across both crates pass.

Mutation-checked twice: the unit test and the caller test each independently
fail when the guard is reverted.

## Three more prose corrections

Found in the commit that fixed the previous three. Same failure, same shape:

| claim | why it was wrong |
|---|---|
| a check that could not be evaluated "sets `passed: false`" | `cross_source_overlap_not_applicable` carries a reason with `passed: true` — its own doc calls it the one `CheckResult` that does. The doc now separates "unevaluated" from "failed". |
| "the shared reader **every other count** in the engine uses" | `count_rows`, for quarantine counts, still has its own parser. |
| a diagram showing the fix makes "the gate trip" | gating also requires `fail_on_error`. |

## Review

Independent red team: **Codex** (`gpt-5.6-codex-max`), which in turn used
GPT-5.6 Terra as its own second lens. Verdict: **No** — correct and complete
for the two #1871 sites, but the invariant was not fully enforced.

Accepted, all four:

- the quality unreadable-count defect (fixed above)
- "Only a check that RAN and failed reaches the warning bucket" — false
- "pinned exhaustively" — overstated
- three stale comments contradicting the new implementation

Confirmed by the review, and worth recording because they were my claims:

- the four replication severity writes plus one quality write are the complete
  production set; the other two matches are test-only
- `cross_source_overlap_not_applicable` is the one non-Error `not_evaluated`
  producer, and the bucketer skips it because `passed` is true
- `gate_for` mirrors the production shape at run.rs:5725
- the #1924 reachability conclusion holds for replication

One premise of mine it corrected: I wrote "each pipeline" uses a serde-defaulted
`checks`. `QualityPipelineConfig.checks` is **required** — a quality pipeline
omitting the table fails deserialization rather than silently getting the
derived defaults.

### Round 3 (`ee5b424d..e590e4d5`): BLOCK, closed without a fourth round

Two items, both taken:

- **No assertion at the `2^64` bound.** Widening the range to `[0, 2^64]`
  would admit it, cast to `u64::MAX`, and every existing assertion would still
  pass. Now pinned from both sides and mutation-checked with exactly that
  widening.
- **Five more false or overbroad prose claims**, listed above.

A new assertion plus deleted prose is behaviour-neutral, so this was closed as
a deliberate disposition rather than a fourth review round.

Round 3 also found a comment of mine claiming replication row counts go through
`cell_as_u64`. Only the unbatched path does — the Databricks batch path parses
its own cell and ends `.unwrap_or(0)`. That is a separate live defect, filed as
**#1926** and fixed in its own PR, not here.

### The pattern, recorded

Three review rounds, and each round's fix commit introduced new false
absolutes — round 3 found five, one of them a re-break of something round 2 had
just corrected. Every false claim in this package was in explanatory prose
added voluntarily, never in a rule the code forced.

Convention from here: a doc comment states the rule and the issue number. No
"why" narrative. The tests carry the evidence.

Not adopted: a full drain-to-exit end-to-end test. The unchanged drain is
already covered by a real-binary test at
`engine/rocky/tests/replication_check_gate.rs:99`, and the reviewer agreed this
is coverage strengthening rather than a shape defect. Worth doing, not here.

Note on validation: the reviewer's sandbox could not execute the column-match
test (`tempfile` hit `Operation not permitted`). I ran it locally; the three
other focused tests it did execute passed in its environment.

Refs #1871
Refs #1780
Refs #1741
Refs #1924
