### PR TITLE
fix(engine/rocky-databricks): an unreadable batched row count is not a measured zero

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -34379,7 +34379,11 @@ table = "fct_events"
     /// reported failure. (The row-count analogue — a leg that answers but
     /// leaves a table out — is pinned by
     /// `a_table_the_batch_row_count_left_out_is_not_evaluated`, whose reason
-    /// text says "returned no result", never "failed".)
+    /// text says "returned no readable count", never "failed".)
+    ///
+    /// This pins the EMPTY case only. `max_timestamp: None` also carries
+    /// "the cell was unreadable", which reaches the same arm and emits no
+    /// check either — a fail-open tracked as #1929.
     #[cfg(feature = "duckdb")]
     #[tokio::test]
     async fn a_batched_freshness_leg_that_answers_null_emits_no_check() {

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -7100,11 +7100,8 @@ async fn run_batched_checks(
         // answered and left a table out records none, so iterating the
         // results is the only way to notice that one.
         //
-        // `None` emits no check. That is right for an empty table and wrong
-        // for everything else `None` carries: a non-empty table whose `ts` is
-        // all NULL reaches the same NULL `MAX(ts)`, as does a missing cell, a
-        // non-string cell and an unparseable string. `MAX` alone cannot
-        // separate them — that needs `COUNT(*)` (#1929).
+        // `None` emits no check. That is correct for an empty table and wrong
+        // for the other states that reach the same `None` (#1929).
         let measured = freshness_batch_refs.iter().filter_map(|tref| {
             let key = tref.full_name();
             match freshness_results.iter().find(|fr| fr.table == *tref) {

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -7098,10 +7098,13 @@ async fn run_batched_checks(
         // exactly the silent gap this change closes for row counts. A batch
         // leg that FAILS does record a reason per table (#1655); a leg that
         // answered and left a table out records none, so iterating the
-        // results is the only way to notice that one. A returned `None` is an empty
-        // table and still emits no check: `MAX(ts)` over no rows is NULL
-        // because there is no row to be fresh, which is not the same as a
-        // query that could not answer.
+        // results is the only way to notice that one.
+        //
+        // `None` emits no check. That is right for an empty table and wrong
+        // for everything else `None` carries: a non-empty table whose `ts` is
+        // all NULL reaches the same NULL `MAX(ts)`, as does a missing cell, a
+        // non-string cell and an unparseable string. `MAX` alone cannot
+        // separate them — that needs `COUNT(*)` (#1929).
         let measured = freshness_batch_refs.iter().filter_map(|tref| {
             let key = tref.full_name();
             match freshness_results.iter().find(|fr| fr.table == *tref) {
@@ -34381,9 +34384,11 @@ table = "fct_events"
     /// `a_table_the_batch_row_count_left_out_is_not_evaluated`, whose reason
     /// text says "returned no readable count", never "failed".)
     ///
-    /// This pins the EMPTY case only. `max_timestamp: None` also carries
-    /// "the cell was unreadable", which reaches the same arm and emits no
-    /// check either — a fail-open tracked as #1929.
+    /// `None` does NOT mean the table is empty. `MAX(ts)` is NULL over no
+    /// rows AND over rows whose `ts` is all NULL, and the query returns no
+    /// `COUNT(*)` to tell them apart. `None` also carries a missing cell, a
+    /// non-string cell and an unparseable string. Every one of those emits no
+    /// check (#1929).
     #[cfg(feature = "duckdb")]
     #[tokio::test]
     async fn a_batched_freshness_leg_that_answers_null_emits_no_check() {

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -6718,7 +6718,7 @@ async fn run_batched_checks(
     // path names the one table whose own query failed, the batch path names
     // every table the failed leg was handed (#1655). A table that a leg
     // answered WITHOUT leaving a row for is not recorded — there is no reason
-    // to give, and it is reported as "returned no result for this table".
+    // to give, and it is reported as "returned no readable count for this table".
     let mut source_count_failures: HashMap<String, String> = HashMap::new();
     let mut target_count_failures: HashMap<String, String> = HashMap::new();
     // In table order, so the emitted results are deterministic.
@@ -6992,7 +6992,7 @@ async fn run_batched_checks(
                         let missing_side = |label: &str, reason: Option<&String>| match reason {
                             Some(reason) => format!("{label}: {reason}"),
                             None => format!(
-                                "{label}: the batch row count query returned no result for this table"
+                                "{label}: the batch row count query returned no readable count for this table"
                             ),
                         };
                         let mut parts = Vec::new();
@@ -33890,8 +33890,8 @@ table = "fct_events"
         assert_eq!(
             result.not_evaluated.as_deref(),
             Some(
-                "source: the batch row count query returned no result for this table; \
-                 target: the batch row count query returned no result for this table"
+                "source: the batch row count query returned no readable count for this table; \
+                 target: the batch row count query returned no readable count for this table"
             ),
             "{result:?}"
         );

--- a/engine/crates/rocky-databricks/src/batch.rs
+++ b/engine/crates/rocky-databricks/src/batch.rs
@@ -191,7 +191,8 @@ pub async fn execute_batch_row_counts(
 /// Parse the `(catalog, schema, table, count)` rows of a batched row-count
 /// query. A row whose count cell does not read as a non-negative integer is
 /// OMITTED, so the caller reports the table as not evaluated rather than as a
-/// measured zero (#1926).
+/// measured zero (#1926). The reason goes to the log: the trait returns only
+/// results (#1928).
 fn parse_row_count_rows(rows: &[Vec<serde_json::Value>]) -> Vec<RowCountResult> {
     let mut results = Vec::with_capacity(rows.len());
     for row in rows {

--- a/engine/crates/rocky-databricks/src/batch.rs
+++ b/engine/crates/rocky-databricks/src/batch.rs
@@ -182,41 +182,53 @@ pub async fn execute_batch_row_counts(
         let sql = generate_batch_row_count_sql(chunk)?;
         let query_result: QueryResult = connector.execute_sql(&sql).await?;
 
-        for row in &query_result.rows {
-            let catalog = row
-                .first()
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string();
-            let schema = row
-                .get(1)
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string();
-            let table = row
-                .get(2)
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string();
-            let count = row
-                .get(3)
-                .and_then(|v| {
-                    v.as_str()
-                        .and_then(|s| s.parse::<u64>().ok())
-                        .or_else(|| v.as_u64())
-                })
-                .unwrap_or(0);
-
-            results.push(RowCountResult {
-                catalog,
-                schema,
-                table,
-                count,
-            });
-        }
+        results.extend(parse_row_count_rows(&query_result.rows));
     }
 
     Ok(results)
+}
+
+/// Parse the `(catalog, schema, table, count)` rows of a batched row-count
+/// query. A row whose count cell does not read as a non-negative integer is
+/// OMITTED, so the caller reports the table as not evaluated rather than as a
+/// measured zero (#1926).
+fn parse_row_count_rows(rows: &[Vec<serde_json::Value>]) -> Vec<RowCountResult> {
+    let mut results = Vec::with_capacity(rows.len());
+    for row in rows {
+        let catalog = row
+            .first()
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let schema = row
+            .get(1)
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let table = row
+            .get(2)
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let Some(count) = rocky_core::checks::cell_as_u64(row.get(3)) else {
+            // The reason lives in the log because the trait returns only
+            // results — `run.rs` sees the absence, not the cause (#1926).
+            tracing::warn!(
+                table = format!("{catalog}.{schema}.{table}"),
+                cell = ?row.get(3),
+                "row count cell was not a non-negative integer — reporting the table as not evaluated"
+            );
+            continue;
+        };
+
+        results.push(RowCountResult {
+            catalog,
+            schema,
+            table,
+            count,
+        });
+    }
+    results
 }
 
 /// Result of a batched freshness query.
@@ -314,6 +326,48 @@ pub async fn execute_batch_freshness(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #1926. A count cell that does not read as a non-negative integer is
+    /// omitted, so `run.rs` reports the table not evaluated. It used to become
+    /// `count: 0`, indistinguishable from an empty table — and when BOTH sides
+    /// were unreadable, `0 == 0` passed a check that measured nothing.
+    #[test]
+    fn an_unreadable_count_cell_is_omitted_not_reported_as_zero() {
+        use serde_json::json;
+
+        let row = |count: serde_json::Value| vec![json!("cat"), json!("sch"), json!("tbl"), count];
+
+        for (label, cell) in [
+            ("null", json!(null)),
+            ("a non-numeric string", json!("n/a")),
+            ("a fraction", json!(5.5)),
+            ("an out-of-range float", json!(1e30)),
+            ("a bool", json!(true)),
+        ] {
+            let parsed = parse_row_count_rows(&[row(cell)]);
+            assert!(
+                parsed.is_empty(),
+                "{label}: an unreadable count must not become a measured row: {parsed:?}"
+            );
+        }
+
+        // A missing cell entirely.
+        let parsed = parse_row_count_rows(&[vec![json!("cat"), json!("sch"), json!("tbl")]]);
+        assert!(parsed.is_empty(), "missing cell: {parsed:?}");
+
+        // The shapes that ARE counts still parse, including a real zero.
+        for (label, cell, expected) in [
+            ("integer", json!(7), 7u64),
+            ("numeric string", json!("7"), 7),
+            ("integral float", json!(7.0), 7),
+            ("a real zero", json!(0), 0),
+        ] {
+            let parsed = parse_row_count_rows(&[row(cell)]);
+            assert_eq!(parsed.len(), 1, "{label}: {parsed:?}");
+            assert_eq!(parsed[0].count, expected, "{label}: {parsed:?}");
+            assert_eq!(parsed[0].table, "tbl", "{label}");
+        }
+    }
 
     #[test]
     fn test_single_table_row_count() {

--- a/engine/crates/rocky-databricks/tests/wiremock_tests.rs
+++ b/engine/crates/rocky-databricks/tests/wiremock_tests.rs
@@ -2347,3 +2347,67 @@ async fn breaker_trip_without_recovery_timeout_emits_none_cooldown() {
         }
     }
 }
+
+/// #1926, through the production path. The unit test beside
+/// `parse_row_count_rows` cannot see the call site, so it stays green if the
+/// guard is reverted inside `execute_batch_row_counts`. This one does not.
+///
+/// Three tables, one readable count each — except `bad`, whose count cell is
+/// a JSON null. `bad` must be ABSENT from the results, not present with 0,
+/// and the other two must be unaffected by its removal.
+#[tokio::test]
+async fn an_unreadable_batched_row_count_cell_is_omitted_from_the_results() {
+    use rocky_databricks::batch::{BatchTableRef, execute_batch_row_counts};
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statement_id": "stmt-rowcount",
+            "status": { "state": "SUCCEEDED" },
+            "manifest": {
+                "schema": {
+                    "columns": [
+                        {"name": "c", "type_name": "STRING", "position": 0},
+                        {"name": "s", "type_name": "STRING", "position": 1},
+                        {"name": "t", "type_name": "STRING", "position": 2},
+                        {"name": "cnt", "type_name": "LONG", "position": 3}
+                    ]
+                },
+                "total_row_count": 3
+            },
+            "result": {
+                "data_array": [
+                    ["cat", "sch", "before", 11],
+                    ["cat", "sch", "bad", null],
+                    ["cat", "sch", "after", 22]
+                ]
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let tref = |table: &str| BatchTableRef {
+        catalog: "cat".into(),
+        schema: "sch".into(),
+        table: table.into(),
+    };
+    let tables = vec![tref("before"), tref("bad"), tref("after")];
+
+    let results = execute_batch_row_counts(&test_connector(&server), &tables)
+        .await
+        .expect("a readable response is not an error");
+
+    let named: Vec<(&str, u64)> = results
+        .iter()
+        .map(|r| (r.table.as_str(), r.count))
+        .collect();
+
+    assert!(
+        !named.iter().any(|(t, _)| *t == "bad"),
+        "an unreadable count must not reach the caller as a measured row: {named:?}"
+    );
+    // The rows on either side are untouched, so the omission is not a
+    // truncation and does not shift the ones that follow it.
+    assert_eq!(named, vec![("before", 11), ("after", 22)], "{named:?}");
+}


### PR DESCRIPTION
On Databricks, a batched row-count cell that could not be read was reported as
a **measured count of zero**.

```
    source cell unreadable -> 0    target real 1000  -> false MISMATCH
    target cell unreadable -> 0    source real 1000  -> false MISMATCH
    both cells unreadable  -> 0 = 0                  -> PASSES, "measured"
```

The last row is the one that matters. A check that measured nothing reported a
clean pass with `not_evaluated: None`, so every consumer read it as "this check
ran".

**User-visible change**: on Databricks, an unreadable batched row count is now
not-evaluated and gates the run, where it previously read as a measured zero.
Exit code moves from 0 to 2 in the both-unreadable case.

This is the **preferred** path for Databricks, not a fallback — `run.rs` uses
the `BatchCheckAdapter` whenever it reports it can batch that leg.

## The fix

Read the cell with `cell_as_u64` and **omit** the row when it will not read.
`run.rs` already derives the right answer from an absent table
(`run.rs:6983-7012`): it reports `row_count_not_evaluated`, naming the side.

`RowCountResult` and the `BatchCheckAdapter` trait are both unchanged.

## Where the reason lives, and why

The trait returns only results, so `run.rs` can see that a table is **absent**
but not **why**. Two halves:

- The **specific** reason goes to the adapter's log, which is the only place
  that knows it: `row count cell was not a non-negative integer`, with the
  table and the offending cell.
- The **generic** missing-side reason is reworded from `returned no result for
  this table` to `returned no readable count for this table`. That is true of
  both a missing row and a bad cell, and it stops pointing an operator at the
  query when the query was fine and the cell was bad.

A per-table reason channel on the trait would be better, and is filed as a
follow-up rather than done here — it changes a core trait across seven
implementations, which is not what a release branch wants.

## Freshness: my rationale here was wrong

I originally wrote that the freshness leg "needs none of this" because
`FreshnessResult.max_timestamp` is already `Option<String>`. Review disproved
it. **I checked the shape of the struct and never checked what `None` means to
its consumer.**

`None` is polymorphic across three causes:

```
    MAX(ts) genuinely NULL  -> None   empty table, emit nothing   (intended)
    cell is not a string    -> None   batch.rs:309
    string will not parse   -> None   adapter.rs:447
```

`run.rs:7107` does `let ts = fr.max_timestamp?` inside a `filter_map`, so the
table leaves the iterator — and because the row **was** returned, the "absent
from results" arm below never fires. An unreadable timestamp emits **no check
at all**.

Same root cause as this PR wearing the opposite sign: here the unreadable state
was not representable and got invented as `0`; there it is representable but
collapses into a state that means something else. Pre-existing, filed as
**#1929**, fixed separately.

The freshness path's identical `returned no result for this table` wording is
still deliberately **left alone**: for the genuinely-absent row the phrase is
accurate, and #1929 is the right place to change what reaches it.

## Evidence

Committed failing first. Before the fix, `null` produced
`RowCountResult { table: "tbl", count: 0 }`.

Mutation-checked: restoring `.unwrap_or(0)` fails
`an_unreadable_count_cell_is_omitted_not_reported_as_zero`.

The test covers `null`, a non-numeric string, a fraction, an out-of-range
float, a bool, and an absent cell — and asserts the shapes that ARE counts
still parse, including a real `0`, which must stay a measured zero.

`parse_row_count_rows` is extracted so the parse is a pure function. The
extraction is behaviour-neutral and was committed in the failing state.

**The unit test alone was not enough, and I claimed it was.** It calls the
helper directly, so reverting the *call site* — inlining `.unwrap_or(0)` back
into `execute_batch_row_counts` — leaves it green. Nothing proved the
production function still routes through the guard. There is now a WireMock
regression driving `execute_batch_row_counts` over a mocked response, and the
call-site mutation fails it.

I had also justified the extraction by saying the concrete connector "needs
credentials". That was false: `connector.rs:313` has `with_base_url` and this
crate already had the WireMock harness. I asserted an obstacle without looking
for the seam.

`rocky-databricks` 226 passed, `rocky-cli` 1996 passed. Clippy and fmt clean.

One existing test asserted the old reason text on both sides and is updated
with the reword — the same change, not a separate one.

Refs #1926
Refs #1923
