### PR TITLE
docs(engine/rocky-cli): max_downstreams is a post-match ceiling, not a scope predicate

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -13324,7 +13324,7 @@
         "type": "object"
       },
       "PolicyRuleScopeOutput": {
-        "description": "What a rule matches. Every field is as authored; an empty list or `None` means the field does not narrow the rule.",
+        "description": "A rule's scope as authored. An empty list or `None` means the field does not narrow the rule.\n\nEvery field here is a matching predicate EXCEPT `max_downstreams`, which is evaluated after the rule matches.",
         "properties": {
           "any": {
             "type": "boolean"
@@ -13354,7 +13354,7 @@
             ]
           },
           "max_downstreams": {
-            "description": "The blast-radius ceiling: the rule matches only a model with at most this many downstreams.",
+            "description": "The blast-radius ceiling, applied AFTER the rule matches: an `allow` degrades to `require_review` when the target's transitive downstream count exceeds this, or cannot be computed. `deny` and `require_review` rules are unaffected, and the rule still matches either way.",
             "format": "uint64",
             "minimum": 0.0,
             "type": [

--- a/editors/vscode/src/types/generated/policy_show.ts
+++ b/editors/vscode/src/types/generated/policy_show.ts
@@ -167,7 +167,9 @@ export interface PolicyAutonomyBudgetOutput {
   [k: string]: unknown;
 }
 /**
- * What a rule matches. Every field is as authored; an empty list or `None` means the field does not narrow the rule.
+ * A rule's scope as authored. An empty list or `None` means the field does not narrow the rule.
+ *
+ * Every field here is a matching predicate EXCEPT `max_downstreams`, which is evaluated after the rule matches.
  */
 export interface PolicyRuleScopeOutput {
   any: boolean;
@@ -176,7 +178,7 @@ export interface PolicyRuleScopeOutput {
   exclude_classifications: string[];
   layer?: string | null;
   /**
-   * The blast-radius ceiling: the rule matches only a model with at most this many downstreams.
+   * The blast-radius ceiling, applied AFTER the rule matches: an `allow` degrades to `require_review` when the target's transitive downstream count exceeds this, or cannot be computed. `deny` and `require_review` rules are unaffected, and the rule still matches either way.
    */
   max_downstreams?: number | null;
   models: string[];

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -8125,8 +8125,11 @@ pub struct PolicyRuleEntry {
     pub autonomy_budget: Option<PolicyAutonomyBudgetOutput>,
 }
 
-/// What a rule matches. Every field is as authored; an empty list or `None`
-/// means the field does not narrow the rule.
+/// A rule's scope as authored. An empty list or `None` means the field does
+/// not narrow the rule.
+///
+/// Every field here is a matching predicate EXCEPT `max_downstreams`, which is
+/// evaluated after the rule matches.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct PolicyRuleScopeOutput {
     pub any: bool,
@@ -8138,8 +8141,10 @@ pub struct PolicyRuleScopeOutput {
     pub contracted: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub layer: Option<String>,
-    /// The blast-radius ceiling: the rule matches only a model with at most
-    /// this many downstreams.
+    /// The blast-radius ceiling, applied AFTER the rule matches: an `allow`
+    /// degrades to `require_review` when the target's transitive downstream
+    /// count exceeds this, or cannot be computed. `deny` and `require_review`
+    /// rules are unaffected, and the rule still matches either way.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_downstreams: Option<u64>,
 }

--- a/schemas/policy_show.schema.json
+++ b/schemas/policy_show.schema.json
@@ -343,7 +343,7 @@
       "type": "object"
     },
     "PolicyRuleScopeOutput": {
-      "description": "What a rule matches. Every field is as authored; an empty list or `None` means the field does not narrow the rule.",
+      "description": "A rule's scope as authored. An empty list or `None` means the field does not narrow the rule.\n\nEvery field here is a matching predicate EXCEPT `max_downstreams`, which is evaluated after the rule matches.",
       "properties": {
         "any": {
           "type": "boolean"
@@ -373,7 +373,7 @@
           ]
         },
         "max_downstreams": {
-          "description": "The blast-radius ceiling: the rule matches only a model with at most this many downstreams.",
+          "description": "The blast-radius ceiling, applied AFTER the rule matches: an `allow` degrades to `require_review` when the target's transitive downstream count exceeds this, or cannot be computed. `deny` and `require_review` rules are unaffected, and the rule still matches either way.",
           "format": "uint64",
           "minimum": 0.0,
           "type": [

--- a/sdk/python/src/rocky_sdk/types_generated/policy_show_schema.py
+++ b/sdk/python/src/rocky_sdk/types_generated/policy_show_schema.py
@@ -211,7 +211,9 @@ class PolicyPrincipal12(StrEnum):
 
 class PolicyRuleScopeOutput(BaseModel):
     """
-    What a rule matches. Every field is as authored; an empty list or `None` means the field does not narrow the rule.
+    A rule's scope as authored. An empty list or `None` means the field does not narrow the rule.
+
+    Every field here is a matching predicate EXCEPT `max_downstreams`, which is evaluated after the rule matches.
     """
 
     any: bool
@@ -221,7 +223,7 @@ class PolicyRuleScopeOutput(BaseModel):
     layer: str | None = None
     max_downstreams: conint(ge=0) | None = None
     """
-    The blast-radius ceiling: the rule matches only a model with at most this many downstreams.
+    The blast-radius ceiling, applied AFTER the rule matches: an `allow` degrades to `require_review` when the target's transitive downstream count exceeds this, or cannot be computed. `deny` and `require_review` rules are unaffected, and the rule still matches either way.
     """
     models: list[str]
     tags: dict[str, str]


### PR DESCRIPTION
**Audited the policy-show projection for further redaction. Nothing further
qualifies.** The audit found one doc comment that is wrong on the schema
source, which this PR fixes.

## The test applied

A field qualifies for removal when **both** hold:

- **(a)** the engine parses it but no gate or evaluator reads it — if the only
  consumer is the output struct, it qualifies
- **(b)** its shape is author-controlled, not a closed set

## Per-field evidence

Every field fails **(a)**. `rocky-core/src/policy.rs` is the evaluator.

**`PolicyRuleScopeOutput`** — every field is read:

| field | read at |
|---|---|
| `any` | `policy.rs:184` |
| `models` | `policy.rs:189-190` (glob match) |
| `tags` | `policy.rs:196` |
| `classifications` | `policy.rs:207` |
| `exclude_classifications` | `policy.rs:218` |
| `contracted` | `policy.rs:229` |
| `layer` | `policy.rs:236` |
| `max_downstreams` | `policy.rs:363`, via `degrade_for_ceiling` |

**`PolicyRuleEntry`**:

| field | read at |
|---|---|
| `principal` | `policy.rs:341` |
| `capability` | `policy.rs:344`, `:350` |
| `effect` | `policy.rs:356` |
| `scope` | above |
| `verify_after` | governs post-apply verification — must stay |
| `autonomy_budget.failures` | `policy.rs:661` |
| `autonomy_budget.window` | must stay |

**`PolicyFreezeInForce`**:

| field | evidence |
|---|---|
| `scope` | `policy.rs:850` — `scope_selector_matches` decides whether the freeze **binds** |
| `principal` | closed enum (`Human` / `Agent`) — fails (b) |
| `source`, `plan_id`, `freeze_id`, `since` | engine-generated — fails (b) |
| `reason` | see below |

**`PolicyRulesOutput`** top level — `version`, `command`, `configured`,
`policy_version`, `default_agent_effect`: engine-controlled or closed enums,
all fail (b).

## `freeze.reason`: author-controlled, deliberately kept

It is free text, so it passes (b). But the #1874 vector does not reach it.
`${VAR}` is resolved before **config** parse, and a freeze reason comes from
the operator's `--reason` CLI argument (`policy.rs:1036`), never from
`rocky.toml`. There is no resolved-secret path, and if a resolved value did
reach one anyway the #1920 filter still covers it.

It is also the only field that says **why** the plane is frozen. Dropping it
would remove the answer to the first question a reader asks.

## The doc defect

`PolicyRuleScopeOutput.max_downstreams` said:

> The blast-radius ceiling: the rule matches **only** a model with at most this
> many downstreams.

False. The rule still matches. The ceiling applies **after** matching: an
`allow` degrades to `require_review` when the target's transitive downstream
count exceeds it, or cannot be computed. `deny` and `require_review` rules are
unaffected.

Sources: `config.rs:3115-3120`, `policy.rs:178-181`, and `degrade_for_ceiling`
at `policy.rs:283-301`.

A reader of `openapi.json` would have concluded a rule with
`max_downstreams = 5` does not apply to a model with 10 downstreams. It does
apply, and it downgrades.

The struct doc said "What a rule matches", wrong for the one field that does
not participate in matching.

## Cascade

A `///` change to `output.rs` drives the codegen cascade even though it is
prose. Regenerated and committed together: `schemas/policy_show.schema.json`,
the Pydantic model, the TypeScript interface, and `docs/public/openapi.json`.

`just regen-fixtures` produces **zero** drift — no dagster fixture embeds this
text.

## Follow-up, not done here

The optional sweep for similar author-controlled unbounded fields on the other
config-projection routes (`/project`, `/schedule`, `/models/{name}`) is **not**
part of this PR.

Refs #1874
